### PR TITLE
docs: replace gh pr merge with Mergify queue workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,13 @@ Direct push to `main` is blocked by branch protection. Workflow:
 1. Make changes on a feature branch.
 2. Open a PR (`gh pr create`).
 3. Dispatch the bot for review via the `julianken-bot` Agent subagent (it loads its credentials from macOS Keychain and posts as the `@julianken-bot` collaborator). Do NOT use `gh pr review` from the main session — that would post under Julian's identity.
-4. Once `reviewDecision == APPROVED`, squash-merge with `gh pr merge <N> --squash --delete-branch`.
+4. Once `reviewDecision == APPROVED` and all checks are green, enter the Mergify queue by posting a comment on the PR: `@Mergifyio queue`. Mergify squash-merges and deletes the branch automatically. **Do NOT use `gh pr merge`.**
+
+**Mergify queue comment rules (critical):**
+- The comment body must be exactly `@Mergifyio queue` — no prose before or after. Mergify silently ignores prose-prefixed comments.
+- If you need to leave explanatory context (e.g. "addressed the SUGGESTION in commit X"), post it as a separate comment first, then post `@Mergifyio queue` as its own standalone comment.
+
+**Until CI lands (Plan 1):** `.mergify.yml` requires `check-success` on `test`, `lint`, `build`, and `e2e`. The queue will stall on any PR opened before those workflows exist. Once CI is wired up, re-apply branch protection's `required_status_checks` via `gh api -X PUT repos/julianken/bird-sight-system/branches/main/protection`.
 
 The bot is a `push` collaborator on the repo; its APPROVE counts toward the 1-review requirement. `enforce_admins=true` means even repo owners can't bypass.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,10 @@ Direct push to `main` is blocked by branch protection. Workflow:
 1. Make changes on a feature branch.
 2. Open a PR (`gh pr create`).
 3. Dispatch the bot for review via the `julianken-bot` Agent subagent (it loads its credentials from macOS Keychain and posts as the `@julianken-bot` collaborator). Do NOT use `gh pr review` from the main session — that would post under Julian's identity.
-4. Once `reviewDecision == APPROVED` and all checks are green, enter the Mergify queue by posting a comment on the PR: `@Mergifyio queue`. Mergify squash-merges and deletes the branch automatically. **Do NOT use `gh pr merge`.**
+4. Once `reviewDecision == APPROVED`, post a comment on the PR: `@Mergifyio queue`. Mergify enters the queue and waits asynchronously for checks to pass, then squash-merges and deletes the branch. **Do NOT use `gh pr merge`.**
 
 **Mergify queue comment rules (critical):**
-- The comment body must be exactly `@Mergifyio queue` — no prose before or after. Mergify silently ignores prose-prefixed comments.
+- The comment body must be exactly `@Mergifyio queue` — no prose before or after. Mergify's command parser matches the comment body against a literal string; a comment like "Looks good, @Mergifyio queue" does not match and is silently skipped. Validated in the ear-training-station workflow (17+ review cycles).
 - If you need to leave explanatory context (e.g. "addressed the SUGGESTION in commit X"), post it as a separate comment first, then post `@Mergifyio queue` as its own standalone comment.
 
 **Until CI lands (Plan 1):** `.mergify.yml` requires `check-success` on `test`, `lint`, `build`, and `e2e`. The queue will stall on any PR opened before those workflows exist. Once CI is wired up, re-apply branch protection's `required_status_checks` via `gh api -X PUT repos/julianken/bird-sight-system/branches/main/protection`.


### PR DESCRIPTION
## Diagrams

N/A — documentation-only change, no logic or data flow to diagram

## Summary

- Replaces step 4 of the PR workflow in CLAUDE.md: `gh pr merge` → `@Mergifyio queue` comment
- Documents the standalone-comment rule (prose-prefixed comments are silently ignored by Mergify)
- Notes the CI-stall condition: `.mergify.yml` requires `test`/`lint`/`build`/`e2e` checks which don't exist until Plan 1 lands

## Test plan

- [ ] `npm run typecheck && npm run test` — green
- [ ] New unit / integration tests added (if behavior changed)
- [ ] New Playwright e2e spec added (if user-visible behavior changed)
- [ ] `npm run build` — clean production build
- [ ] (UI only) Manual smoke via `npm run dev` — feature works in the browser

## Plan reference

Out of plan — housekeeping correction before plan execution begins.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)