### PR TITLE
feat(ingestor): eBird client + observation transform (Plan 2 tasks 1–6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,10 @@
       "resolved": "packages/family-mapping",
       "link": true
     },
+    "node_modules/@bird-watch/ingestor": {
+      "resolved": "services/ingestor",
+      "link": true
+    },
     "node_modules/@bird-watch/shared-types": {
       "resolved": "packages/shared-types",
       "link": true
@@ -544,6 +548,93 @@
         "node": ">=6"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
+      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -584,6 +675,56 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1089,6 +1230,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ssh2": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
@@ -1123,6 +1274,13 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1870,6 +2028,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1941,6 +2109,20 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2302,6 +2484,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2432,6 +2641,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2479,6 +2709,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -2737,6 +2974,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.4.tgz",
+      "integrity": "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.26.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
@@ -2857,6 +3149,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -2906,6 +3205,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -3318,6 +3624,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
+      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -3388,6 +3701,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3507,6 +3827,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -3525,6 +3855,13 @@
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -3618,6 +3955,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tar-fs": {
@@ -3719,6 +4069,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -3727,6 +4097,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tsx": {
@@ -3764,6 +4147,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3806,6 +4205,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -4605,6 +5014,21 @@
     "packages/shared-types": {
       "name": "@bird-watch/shared-types",
       "version": "0.0.1"
+    },
+    "services/ingestor": {
+      "name": "@bird-watch/ingestor",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bird-watch/db-client": "*",
+        "@bird-watch/shared-types": "*"
+      },
+      "devDependencies": {
+        "@testcontainers/postgresql": "^10.7.0",
+        "msw": "^2.1.0",
+        "testcontainers": "^10.7.0",
+        "tsx": "^4.7.0",
+        "vitest": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/family-mapping && npm run build -w @bird-watch/db-client",
+    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/family-mapping && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/ingestor",
     "lint": "npm run lint --workspaces --if-present",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/services/ingestor/package.json
+++ b/services/ingestor/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@bird-watch/ingestor",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "ingest:local": "tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@bird-watch/db-client": "*",
+    "@bird-watch/shared-types": "*"
+  },
+  "devDependencies": {
+    "@testcontainers/postgresql": "^10.7.0",
+    "msw": "^2.1.0",
+    "testcontainers": "^10.7.0",
+    "tsx": "^4.7.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { EbirdClient } from './client.js';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const SAMPLE_OBS = [
+  {
+    speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+    sciName: 'Pyrocephalus rubinus', locId: 'L101234', locName: 'Madera Canyon',
+    obsDt: '2026-04-15 08:00', howMany: 2, lat: 31.72, lng: -110.88,
+    obsValid: true, obsReviewed: false, locationPrivate: false, subId: 'S100',
+  },
+];
+
+describe('EbirdClient.fetchRecent', () => {
+  it('returns observations for a region', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('back')).toBe('14');
+        expect(request.headers.get('x-ebirdapitoken')).toBe('test-key');
+        return HttpResponse.json(SAMPLE_OBS);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'test-key' });
+    const obs = await client.fetchRecent('US-AZ', { back: 14 });
+    expect(obs).toHaveLength(1);
+    expect(obs[0]?.speciesCode).toBe('vermfly');
+  });
+});

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -33,3 +33,34 @@ describe('EbirdClient.fetchRecent', () => {
     expect(obs[0]?.speciesCode).toBe('vermfly');
   });
 });
+
+describe('EbirdClient.fetchNotable', () => {
+  it('returns notable observations only', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => {
+        return HttpResponse.json([{ ...SAMPLE_OBS[0], speciesCode: 'eltrog' }]);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k' });
+    const obs = await client.fetchNotable('US-AZ');
+    expect(obs[0]?.speciesCode).toBe('eltrog');
+  });
+});
+
+describe('EbirdClient.fetchHotspots', () => {
+  it('returns hotspots for a region', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/hotspot/US-AZ', () => {
+        return HttpResponse.json([
+          { locId: 'L1', locName: 'Sweetwater', countryCode: 'US',
+            subnational1Code: 'US-AZ', lat: 32.30, lng: -110.99,
+            numSpeciesAllTime: 280 },
+        ]);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k' });
+    const h = await client.fetchHotspots('US-AZ');
+    expect(h[0]?.locId).toBe('L1');
+    expect(h[0]?.numSpeciesAllTime).toBe(280);
+  });
+});

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
-import { EbirdClient } from './client.js';
+import { EbirdClient, EbirdServerError } from './client.js';
 
 const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -105,5 +105,19 @@ describe('EbirdClient retries', () => {
     const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 2 });
     await expect(client.fetchRecent('US-AZ')).rejects.toThrow(/502/);
     expect(calls).toBe(3); // 1 initial + 2 retries
+  });
+
+  it('retries on request timeout then throws EbirdServerError', async () => {
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', async () => {
+        calls++;
+        await new Promise(r => setTimeout(r, 50));
+        return HttpResponse.json([]);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', maxRetries: 1, retryBaseMs: 1, requestTimeoutMs: 5 });
+    await expect(client.fetchRecent('US-AZ')).rejects.toThrow(EbirdServerError);
+    expect(calls).toBe(2); // initial + 1 retry
   });
 });

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -64,3 +64,46 @@ describe('EbirdClient.fetchHotspots', () => {
     expect(h[0]?.numSpeciesAllTime).toBe(280);
   });
 });
+
+describe('EbirdClient retries', () => {
+  it('retries on 5xx and eventually succeeds', async () => {
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => {
+        calls++;
+        if (calls < 3) return new HttpResponse('boom', { status: 503 });
+        return HttpResponse.json(SAMPLE_OBS);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    const obs = await client.fetchRecent('US-AZ');
+    expect(calls).toBe(3);
+    expect(obs).toHaveLength(1);
+  });
+
+  it('throws immediately on 4xx (no retry)', async () => {
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => {
+        calls++;
+        return new HttpResponse('forbidden', { status: 403 });
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    await expect(client.fetchRecent('US-AZ')).rejects.toThrow(/403/);
+    expect(calls).toBe(1);
+  });
+
+  it('throws after exhausting retries on 5xx', async () => {
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => {
+        calls++;
+        return new HttpResponse('always broken', { status: 502 });
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 2 });
+    await expect(client.fetchRecent('US-AZ')).rejects.toThrow(/502/);
+    expect(calls).toBe(3); // 1 initial + 2 retries
+  });
+});

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -5,6 +5,7 @@ export interface EbirdClientOptions {
   baseUrl?: string;
   maxRetries?: number;
   retryBaseMs?: number;
+  requestTimeoutMs?: number;
 }
 
 export interface FetchRecentOptions {
@@ -17,12 +18,14 @@ export class EbirdClient {
   private readonly baseUrl: string;
   private readonly maxRetries: number;
   private readonly retryBaseMs: number;
+  private readonly requestTimeoutMs: number;
 
   constructor(opts: EbirdClientOptions) {
     this.apiKey = opts.apiKey;
     this.baseUrl = opts.baseUrl ?? 'https://api.ebird.org/v2';
     this.maxRetries = opts.maxRetries ?? 3;
     this.retryBaseMs = opts.retryBaseMs ?? 250;
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
   }
 
   async fetchRecent(
@@ -68,6 +71,7 @@ export class EbirdClient {
       try {
         const res = await fetch(url, {
           headers: { 'x-ebirdapitoken': this.apiKey, accept: 'application/json' },
+          signal: AbortSignal.timeout(this.requestTimeoutMs),
         });
         if (res.status >= 500) {
           throw new EbirdServerError(res.status, await res.text());
@@ -81,9 +85,16 @@ export class EbirdClient {
         lastError = err;
         if (err instanceof EbirdClientError) throw err; // 4xx — don't retry
         if (attempt === this.maxRetries) break;
-        const delay = this.retryBaseMs * 2 ** attempt;
-        await sleep(delay);
+        // Full-jitter exponential backoff (AWS write-up variant).
+        // Timeouts (AbortError) are treated as transient — same retry path as 5xx.
+        const backoff = this.retryBaseMs * Math.pow(2, attempt);
+        const withJitter = Math.floor(Math.random() * backoff);
+        await sleep(withJitter);
       }
+    }
+    // If the final error is a timeout, surface a clear EbirdServerError.
+    if (isAbortError(lastError)) {
+      throw new EbirdServerError(0, `Request timed out after ${this.requestTimeoutMs}ms`);
     }
     throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
@@ -103,3 +114,7 @@ export class EbirdServerError extends Error {
 }
 
 function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+/** True for both manual AbortController aborts and AbortSignal.timeout() expirations. */
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+}

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -1,0 +1,105 @@
+import type { EbirdObservation, EbirdHotspot } from './types.js';
+
+export interface EbirdClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  maxRetries?: number;
+  retryBaseMs?: number;
+}
+
+export interface FetchRecentOptions {
+  back?: number;       // 1–30 days; default 14
+  maxResults?: number; // default 10000
+}
+
+export class EbirdClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly maxRetries: number;
+  private readonly retryBaseMs: number;
+
+  constructor(opts: EbirdClientOptions) {
+    this.apiKey = opts.apiKey;
+    this.baseUrl = opts.baseUrl ?? 'https://api.ebird.org/v2';
+    this.maxRetries = opts.maxRetries ?? 3;
+    this.retryBaseMs = opts.retryBaseMs ?? 250;
+  }
+
+  async fetchRecent(
+    regionCode: string,
+    o: FetchRecentOptions = {}
+  ): Promise<EbirdObservation[]> {
+    const url = new URL(`${this.baseUrl}/data/obs/${regionCode}/recent`);
+    url.searchParams.set('back', String(o.back ?? 14));
+    url.searchParams.set('maxResults', String(o.maxResults ?? 10_000));
+    return this.getJson<EbirdObservation[]>(url);
+  }
+
+  async fetchNotable(
+    regionCode: string,
+    o: FetchRecentOptions = {}
+  ): Promise<EbirdObservation[]> {
+    const url = new URL(`${this.baseUrl}/data/obs/${regionCode}/recent/notable`);
+    url.searchParams.set('back', String(o.back ?? 14));
+    url.searchParams.set('detail', 'simple');
+    return this.getJson<EbirdObservation[]>(url);
+  }
+
+  async fetchHotspots(regionCode: string): Promise<EbirdHotspot[]> {
+    const url = new URL(`${this.baseUrl}/ref/hotspot/${regionCode}`);
+    url.searchParams.set('fmt', 'json');
+    return this.getJson<EbirdHotspot[]>(url);
+  }
+
+  async fetchHistoric(
+    regionCode: string,
+    y: number, m: number, d: number
+  ): Promise<EbirdObservation[]> {
+    const url = new URL(
+      `${this.baseUrl}/data/obs/${regionCode}/historic/${y}/${m}/${d}`
+    );
+    url.searchParams.set('maxResults', '10000');
+    return this.getJson<EbirdObservation[]>(url);
+  }
+
+  private async getJson<T>(url: URL): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const res = await fetch(url, {
+          headers: { 'x-ebirdapitoken': this.apiKey, accept: 'application/json' },
+        });
+        if (res.status >= 500) {
+          throw new EbirdServerError(res.status, await res.text());
+        }
+        if (!res.ok) {
+          const body = await res.text();
+          throw new EbirdClientError(res.status, body);
+        }
+        return (await res.json()) as T;
+      } catch (err) {
+        lastError = err;
+        if (err instanceof EbirdClientError) throw err; // 4xx — don't retry
+        if (attempt === this.maxRetries) break;
+        const delay = this.retryBaseMs * 2 ** attempt;
+        await sleep(delay);
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+}
+
+export class EbirdClientError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`eBird client error ${status}: ${body}`);
+    this.name = 'EbirdClientError';
+  }
+}
+export class EbirdServerError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`eBird server error ${status}: ${body}`);
+    this.name = 'EbirdServerError';
+  }
+}
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }

--- a/services/ingestor/src/ebird/types.ts
+++ b/services/ingestor/src/ebird/types.ts
@@ -1,0 +1,32 @@
+// Shapes returned by https://api.ebird.org/v2/data/obs/{regionCode}/recent
+// Reference: https://documenter.getpostman.com/view/664302/S1ENwy59
+
+export interface EbirdObservation {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  locId: string;
+  locName: string;
+  obsDt: string;            // "YYYY-MM-DD HH:MM"
+  howMany?: number;
+  lat: number;
+  lng: number;
+  obsValid: boolean;
+  obsReviewed: boolean;
+  locationPrivate: boolean;
+  subId: string;
+  subnational1Code?: string;
+  subnational2Code?: string;
+}
+
+export interface EbirdHotspot {
+  locId: string;
+  locName: string;
+  countryCode: string;
+  subnational1Code: string;
+  subnational2Code?: string;
+  lat: number;
+  lng: number;
+  latestObsDt?: string;     // ISO-ish or absent
+  numSpeciesAllTime?: number;
+}

--- a/services/ingestor/src/transform.test.ts
+++ b/services/ingestor/src/transform.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { toObservationInput } from './transform.js';
+import type { EbirdObservation } from './ebird/types.js';
+
+const sample: EbirdObservation = {
+  speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus', locId: 'L1', locName: 'Madera',
+  obsDt: '2026-04-15 08:00', howMany: 2, lat: 31.72, lng: -110.88,
+  obsValid: true, obsReviewed: false, locationPrivate: false, subId: 'S100',
+};
+
+describe('toObservationInput', () => {
+  it('maps fields and parses obsDt to ISO', () => {
+    const out = toObservationInput(sample, new Set());
+    expect(out.subId).toBe('S100');
+    expect(out.speciesCode).toBe('vermfly');
+    expect(out.lat).toBe(31.72);
+    expect(out.lng).toBe(-110.88);
+    expect(out.obsDt).toBe('2026-04-15T08:00:00.000Z');
+    expect(out.howMany).toBe(2);
+    expect(out.isNotable).toBe(false);
+  });
+
+  it('marks is_notable=true when sub_id is in the notable set', () => {
+    const notableKeys = new Set(['S100|vermfly']);
+    const out = toObservationInput(sample, notableKeys);
+    expect(out.isNotable).toBe(true);
+  });
+
+  it('handles missing howMany (defaults to null)', () => {
+    const { howMany, ...rest } = sample;
+    const out = toObservationInput(rest as EbirdObservation, new Set());
+    expect(out.howMany).toBeNull();
+  });
+});

--- a/services/ingestor/src/transform.ts
+++ b/services/ingestor/src/transform.ts
@@ -1,0 +1,40 @@
+import type { EbirdObservation } from './ebird/types.js';
+import type { ObservationInput } from '@bird-watch/db-client';
+
+/**
+ * eBird returns obsDt as "YYYY-MM-DD HH:MM" in local time of the observation.
+ * For MVP we treat as UTC — accuracy to the hour is fine for "what was seen recently".
+ */
+export function toObservationInput(
+  o: EbirdObservation,
+  notableKeys: ReadonlySet<string>
+): ObservationInput {
+  const key = `${o.subId}|${o.speciesCode}`;
+  const obsDtIso = parseEbirdDate(o.obsDt);
+  return {
+    subId: o.subId,
+    speciesCode: o.speciesCode,
+    comName: o.comName,
+    lat: o.lat,
+    lng: o.lng,
+    obsDt: obsDtIso,
+    locId: o.locId,
+    locName: o.locName,
+    howMany: typeof o.howMany === 'number' ? o.howMany : null,
+    isNotable: notableKeys.has(key),
+  };
+}
+
+export function notableKeyset(obs: EbirdObservation[]): Set<string> {
+  return new Set(obs.map(o => `${o.subId}|${o.speciesCode}`));
+}
+
+function parseEbirdDate(s: string): string {
+  // "2026-04-15 08:00" → "2026-04-15T08:00:00.000Z"
+  const normalized = s.replace(' ', 'T') + ':00.000Z';
+  const d = new Date(normalized);
+  if (isNaN(d.getTime())) {
+    throw new Error(`Invalid eBird obsDt: ${s}`);
+  }
+  return d.toISOString();
+}

--- a/services/ingestor/tsconfig.json
+++ b/services/ingestor/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/services/ingestor/tsconfig.test.json
+++ b/services/ingestor/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/services/ingestor/vitest.config.ts
+++ b/services/ingestor/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

Scaffolds `services/ingestor` and lands the eBird-facing half: typed API responses, a retrying `EbirdClient` (fetchRecent / fetchNotable / fetchHotspots / fetchHistoric), and the pure `toObservationInput` transform. MSW v2 drives all HTTP tests — zero real network calls in CI.

## Commits

| # | SHA | What |
|---|---|---|
| 1 | `db13f43` | `chore(ingestor): scaffold package` — `services/ingestor/{package.json,tsconfig.json,tsconfig.test.json,vitest.config.ts}`. Root build script now chains `ingestor` after db-client. |
| 2 | `ce35527` | `feat(ingestor): define eBird response types` |
| 3 | `b00f5e9` | `feat(ingestor): EbirdClient.fetchRecent with retry skeleton` + 1 MSW test |
| 4 | `df3493f` | `test(ingestor): cover fetchNotable + fetchHotspots` — +2 tests |
| 5 | `a1097ab` | `test(ingestor): cover retry + 4xx + exhaustion paths` — +3 tests |
| 6 | `e264827` | `feat(ingestor): transform eBird obs to ObservationInput` + 3 tests |
| — | `fde41bc` | `fix(ingestor): add fetch timeout + backoff jitter to EbirdClient` — review-feedback hardening |

## Test plan

- [x] `npm test` across all workspaces — 4 family-mapping + 19 db-client + 10 ingestor = **33 tests**, all green
- [x] `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.test.json`
- [x] `npm run build` chains shared-types → family-mapping → db-client → ingestor; each package produces `dist/`
- [ ] CI `test`/`lint`/`build`/`e2e` all green

## Plan-vs-reality notes

- **`tsconfig.references`** block removed from the plan-prescribed tsconfig (matches earlier PR 1c/1d decision; `composite: true` isn't set on library packages so `tsc --build` would fail).
- **`tsconfig.test.json` added** — plan doesn't include it, but it keeps `dist/` clean and resolves editor vitest types cleanly. Same pattern as `packages/db-client`.
- **Review hardening** — added `requestTimeoutMs` (default 30s) + full-jitter exponential backoff on top of the plan's retry logic. The plan anticipated retry but didn't specify either detail.

## Contract for PR 2b

- `EbirdClient#fetchRecent(regionCode, {back, maxResults})` → `EbirdObservation[]`
- `EbirdClient#fetchNotable(regionCode, {back})` → notable subset of the above
- `EbirdClient#fetchHotspots(regionCode)` → `EbirdHotspot[]`
- `toObservationInput(obs, {isNotable})` → `ObservationInput` ready for `db-client#upsertObservations`
- `notableKeyset(notables)` → the `Set<string>` PR 2b will use to compute `is_notable` during upsert