### PR TITLE
docs+ci: require PR template; mergify inline-check mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,11 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     merge_method: squash
     update_method: merge
+    batch_size: 1
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - base = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ These are non-obvious commitments the plans enforce:
 Direct push to `main` is blocked by branch protection. Workflow:
 
 1. Make changes on a feature branch.
-2. Open a PR (`gh pr create`).
+2. Open a PR (`gh pr create`). **The PR description MUST follow `.github/PULL_REQUEST_TEMPLATE.md`** — all five sections (Summary, Plan/Task reference, Test plan, Review focus, Diagram) are mandatory. GitHub applies the template to UI-created PRs automatically; when using `gh pr create --body`, paste the template body verbatim and fill every section. Skipping sections wastes the bot's review cycles because the diagram-first section is load-bearing for fast architectural review.
 3. Dispatch the bot for review via the `julianken-bot` Agent subagent (it loads its credentials from macOS Keychain and posts as the `@julianken-bot` collaborator). Do NOT use `gh pr review` from the main session — that would post under Julian's identity.
 4. Once `reviewDecision == APPROVED`, post a comment on the PR: `@Mergifyio queue`. Mergify enters the queue and waits asynchronously for checks to pass, then squash-merges and deletes the branch. **Do NOT use `gh pr merge`.**
 
@@ -54,7 +54,9 @@ Direct push to `main` is blocked by branch protection. Workflow:
 - The comment body must be exactly `@Mergifyio queue` — no prose before or after. Mergify's command parser matches the comment body against a literal string; a comment like "Looks good, @Mergifyio queue" does not match and is silently skipped. Validated in the ear-training-station workflow (17+ review cycles).
 - If you need to leave explanatory context (e.g. "addressed the SUGGESTION in commit X"), post it as a separate comment first, then post `@Mergifyio queue` as its own standalone comment.
 
-**Until CI lands (Plan 1):** `.mergify.yml` requires `check-success` on `test`, `lint`, `build`, and `e2e`. The queue will stall on any PR opened before those workflows exist. Once CI is wired up, re-apply branch protection's `required_status_checks` via `gh api -X PUT repos/julianken/bird-sight-system/branches/main/protection`.
+**CI is now live.** `.mergify.yml` requires `check-success` on `test`, `lint`, `build`, and `e2e`, and branch protection enforces the same four as `required_status_checks` (applied 2026-04-17 after PR #9 merged). Every PR blocks on all four being green.
+
+**Mergify config compatibility:** `.mergify.yml` uses `queue_rules[].checks_timeout` and `merge_queue.max_parallel_checks: 1` with `batch_size: 1` so it works with branch protection's `strict: true` (require branches up-to-date). If branch protection's strictness is ever flipped off, those settings can be relaxed.
 
 The bot is a `push` collaborator on the repo; its APPROVE counts toward the 1-review requirement. `enforce_admins=true` means even repo owners can't bypass.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,3 @@ The following libraries change quickly enough that training-data knowledge is of
 | `node-pg-migrate` | 1 | CLI flags and `-- Up/Down Migration` marker semantics |
 
 For everything else (TypeScript, React 18, Vite, `pg`, PostGIS SQL, React Testing Library, Docker, npm workspaces) training data is reliable enough — skip context7 and only fetch if a real failure surfaces.
-
-## CI status
-
-No CI workflows exist yet. `.mergify.yml` references `test`, `lint`, `build`, and `e2e` checks — when the first CI workflow lands (likely as part of Plan 1's followups), those job names must match, and `required_status_checks` on branch protection should be re-applied via `gh api -X PUT repos/julianken/bird-sight-system/branches/main/protection` to actually enforce them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ These are non-obvious commitments the plans enforce:
 Direct push to `main` is blocked by branch protection. Workflow:
 
 1. Make changes on a feature branch.
-2. Open a PR (`gh pr create`). **The PR description MUST follow `.github/PULL_REQUEST_TEMPLATE.md`** — all five sections (Summary, Plan/Task reference, Test plan, Review focus, Diagram) are mandatory. GitHub applies the template to UI-created PRs automatically; when using `gh pr create --body`, paste the template body verbatim and fill every section. Skipping sections wastes the bot's review cycles because the diagram-first section is load-bearing for fast architectural review.
+2. Open a PR (`gh pr create`). **The PR description MUST follow `.github/PULL_REQUEST_TEMPLATE.md`** — all five sections (Diagrams, Summary, Screenshots, Test plan, Plan reference) are mandatory. GitHub applies the template to UI-created PRs automatically; when using `gh pr create --body`, paste the template body verbatim and fill every section. Skipping sections wastes the bot's review cycles because the diagram-first section is load-bearing for fast architectural review. The Screenshots section is REQUIRED on any PR that touches `frontend/**` (otherwise `N/A — not UI`); the Plan reference links the PR back to `docs/plans/<plan-file>.md` or says `Out of plan — <reason>`.
 3. Dispatch the bot for review via the `julianken-bot` Agent subagent (it loads its credentials from macOS Keychain and posts as the `@julianken-bot` collaborator). Do NOT use `gh pr review` from the main session — that would post under Julian's identity.
 4. Once `reviewDecision == APPROVED`, post a comment on the PR: `@Mergifyio queue`. Mergify enters the queue and waits asynchronously for checks to pass, then squash-merges and deletes the branch. **Do NOT use `gh pr merge`.**
 
@@ -56,7 +56,7 @@ Direct push to `main` is blocked by branch protection. Workflow:
 
 **CI is now live.** `.mergify.yml` requires `check-success` on `test`, `lint`, `build`, and `e2e`, and branch protection enforces the same four as `required_status_checks` (applied 2026-04-17 after PR #9 merged). Every PR blocks on all four being green.
 
-**Mergify config compatibility:** `.mergify.yml` uses `queue_rules[].checks_timeout` and `merge_queue.max_parallel_checks: 1` with `batch_size: 1` so it works with branch protection's `strict: true` (require branches up-to-date). If branch protection's strictness is ever flipped off, those settings can be relaxed.
+**Mergify config compatibility:** `.mergify.yml` sets `merge_queue.max_parallel_checks: 1` and `queue_rules[].batch_size: 1` (and does NOT define a separate `merge_conditions` block) so in-place checks work alongside branch protection's `required_status_checks.strict: true` (require branches up-to-date). If branch protection's strictness is ever flipped off, those two settings can be relaxed — but until then, Mergify's queue will error out on any config that defines `merge_conditions` separately from `queue_conditions` or that allows >1 parallel check.
 
 The bot is a `push` collaborator on the repo; its APPROVE counts toward the 1-review requirement. `enforce_admins=true` means even repo owners can't bypass.
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Author
        A[Write PR body]
    end
    A -->|must fill| T[.github/PULL_REQUEST_TEMPLATE.md]
    T --> D[Diagrams section]
    T --> S[Summary]
    T --> TP[Test plan]
    T --> PR[Plan reference]
    A --> CM[CLAUDE.md PR workflow]
    CM -->|rule| T
    C[.mergify.yml] -->|inline checks mode| BP[(Branch protection<br/>strict = true)]
```

## Summary

- CLAUDE.md now mandates filling out every section of `.github/PULL_REQUEST_TEMPLATE.md` on every PR, because the diagram section is load-bearing for fast bot architectural review.
- `.mergify.yml` switches to inline-check mode (`merge_queue.max_parallel_checks: 1`, `batch_size: 1`) — fixes the incompatibility Mergify reported on PR #10 after branch protection's `required_status_checks.strict = true` landed.
- The outdated "Until CI lands (Plan 1)" paragraph in CLAUDE.md is updated to reflect that CI is now live and the four checks are enforced.

## Screenshots

N/A — not UI.

## Test plan

- [x] `.mergify.yml` YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.mergify.yml'))"`)
- [x] `CLAUDE.md` renders clean in markdown preview
- [ ] CI `test`/`lint`/`build`/`e2e` all green on this PR
- [ ] Mergify queues this PR successfully (proves the inline-check mode fix works)

## Plan reference

Out of plan — workflow hardening in response to (a) Julian's request to mandate the PR template and (b) Mergify incompatibility reported on PR #10 after branch protection was tightened.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)