### PR TITLE
feat(read-api): Hono read API service — Plan 3 (all 9 tasks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,10 @@
       "resolved": "services/ingestor",
       "link": true
     },
+    "node_modules/@bird-watch/read-api": {
+      "resolved": "services/read-api",
+      "link": true
+    },
     "node_modules/@bird-watch/shared-types": {
       "resolved": "packages/shared-types",
       "link": true
@@ -546,6 +550,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -2660,6 +2677,15 @@
       "dependencies": {
         "@types/set-cookie-parser": "^2.4.10",
         "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/human-signals": {
@@ -5025,6 +5051,22 @@
       "devDependencies": {
         "@testcontainers/postgresql": "^10.7.0",
         "msw": "^2.1.0",
+        "testcontainers": "^10.7.0",
+        "tsx": "^4.7.0",
+        "vitest": "^1.2.0"
+      }
+    },
+    "services/read-api": {
+      "name": "@bird-watch/read-api",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bird-watch/db-client": "*",
+        "@bird-watch/shared-types": "*",
+        "hono": "^4.0.0"
+      },
+      "devDependencies": {
+        "@hono/node-server": "^1.7.0",
+        "@testcontainers/postgresql": "^10.7.0",
         "testcontainers": "^10.7.0",
         "tsx": "^4.7.0",
         "vitest": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/family-mapping && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/ingestor",
+    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/family-mapping && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api",
     "lint": "npm run lint --workspaces --if-present",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/services/read-api/package.json
+++ b/services/read-api/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bird-watch/read-api",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "dev": "tsx src/local.ts"
+  },
+  "dependencies": {
+    "@bird-watch/db-client": "*",
+    "@bird-watch/shared-types": "*",
+    "hono": "^4.0.0"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^1.7.0",
+    "@testcontainers/postgresql": "^10.7.0",
+    "testcontainers": "^10.7.0",
+    "tsx": "^4.7.0",
+    "vitest": "^1.2.0"
+  }
+}

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -107,6 +107,22 @@ describe('GET /api/observations', () => {
   });
 });
 
+describe('error handling', () => {
+  it('returns 503 when DB query throws a connection error', async () => {
+    const pg = await import('pg');
+    const badPool = new pg.default.Pool({
+      connectionString: 'postgres://nope:nope@127.0.0.1:1/none',
+      max: 1,
+      connectionTimeoutMillis: 200,
+    });
+    const app = createApp({ pool: badPool as unknown as Parameters<typeof createApp>[0]['pool'] });
+    const res = await app.request('/api/regions');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'database unavailable' });
+    await badPool.end();
+  });
+});
+
 describe('GET /api/species/:code', () => {
   it('returns species meta for a known code', async () => {
     const app = createApp({ pool: db.pool });

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -106,3 +106,22 @@ describe('GET /api/observations', () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe('GET /api/species/:code', () => {
+  it('returns species meta for a known code', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/vermfly');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control'))
+      .toBe('public, max-age=604800, immutable');
+    const body = await res.json() as { speciesCode: string; comName: string };
+    expect(body.speciesCode).toBe('vermfly');
+    expect(body.comName).toBe('Vermilion Flycatcher');
+  });
+
+  it('returns 404 for unknown species', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/notreal');
+    expect(res.status).toBe(404);
+  });
+});

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
+import { createApp } from './app.js';
+
+let db: TestDb;
+beforeAll(async () => { db = await startTestDb(); }, 90_000);
+afterAll(async () => { await db?.stop(); });
+
+describe('GET /api/regions', () => {
+  it('returns the 9 seeded regions with the correct cache header', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/regions');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control'))
+      .toBe('public, max-age=604800, immutable');
+    const body = await res.json() as Array<{ id: string }>;
+    expect(body).toHaveLength(9);
+    expect(body.find(r => r.id === 'sky-islands-santa-ritas')).toBeTruthy();
+  });
+});

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -40,3 +40,69 @@ describe('GET /api/hotspots', () => {
     expect(body[0]?.regionId).toBe('sonoran-tucson');
   });
 });
+
+describe('GET /api/observations', () => {
+  beforeAll(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+    ]);
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, [
+      { subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: new Date(Date.now() - 5*86400_000).toISOString(),
+        locId: 'L1', locName: 'X', howMany: 1, isNotable: false },
+      { subId: 'S2', speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        lat: 32.30, lng: -110.99, obsDt: new Date(Date.now() - 20*86400_000).toISOString(),
+        locId: 'L2', locName: 'Y', howMany: 1, isNotable: true },
+    ]);
+  });
+
+  it('returns observations with correct cache header', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control'))
+      .toBe('public, max-age=1800, stale-while-revalidate=600');
+    const body = await res.json() as Array<unknown>;
+    expect(body).toHaveLength(2);
+  });
+
+  it('filters by since=14d', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=14d');
+    const body = await res.json() as Array<{ subId: string }>;
+    expect(body.map(o => o.subId)).toEqual(['S1']);
+  });
+
+  it('filters by notable=true', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d&notable=true');
+    const body = await res.json() as Array<{ subId: string }>;
+    expect(body.map(o => o.subId)).toEqual(['S2']);
+  });
+
+  it('filters by species code', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d&species=vermfly');
+    const body = await res.json() as Array<{ subId: string }>;
+    expect(body.map(o => o.subId)).toEqual(['S1']);
+  });
+
+  it('filters by family code', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d&family=trochilidae');
+    const body = await res.json() as Array<{ subId: string }>;
+    expect(body.map(o => o.subId)).toEqual(['S2']);
+  });
+
+  it('rejects invalid since values with 400', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=banana');
+    expect(res.status).toBe(400);
+  });
+});

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
+import {
+  upsertHotspots,
+  upsertSpeciesMeta,
+  upsertObservations,
+} from '@bird-watch/db-client';
 import { createApp } from './app.js';
 
 let db: TestDb;
@@ -16,5 +21,22 @@ describe('GET /api/regions', () => {
     const body = await res.json() as Array<{ id: string }>;
     expect(body).toHaveLength(9);
     expect(body.find(r => r.id === 'sky-islands-santa-ritas')).toBeTruthy();
+  });
+});
+
+describe('GET /api/hotspots', () => {
+  it('returns hotspots with the correct cache header', async () => {
+    await upsertHotspots(db.pool, [
+      { locId: 'L207118', locName: 'Sweetwater Wetlands',
+        lat: 32.30, lng: -110.99, numSpeciesAlltime: 280, latestObsDt: '2026-04-15T12:00:00Z' },
+    ]);
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/hotspots');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control'))
+      .toBe('public, max-age=86400, stale-while-revalidate=3600');
+    const body = await res.json() as Array<{ locId: string; regionId: string | null }>;
+    expect(body[0]?.locId).toBe('L207118');
+    expect(body[0]?.regionId).toBe('sonoran-tucson');
   });
 });

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -55,11 +55,18 @@ export function createApp(deps: AppDeps): Hono {
   });
 
   app.onError((err, c) => {
-    const msg = (err as { code?: string }).code ?? '';
-    if (['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'].includes(msg)) {
+    const code = (err as { code?: string }).code ?? '';
+    // OS-level connection errors
+    if (['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'].includes(code)) {
       return c.json({ error: 'database unavailable' }, 503);
     }
+    // pg-pool timeout (no .code, matched by name/message)
     if (err.name === 'TimeoutError' || /timeout/i.test(err.message)) {
+      return c.json({ error: 'database unavailable' }, 503);
+    }
+    // Postgres server-side connection errors: 53xxx class (insufficient resources)
+    // 53300 = too_many_connections, 53200 = out_of_memory, 53100 = disk_full
+    if (code.startsWith('53')) {
       return c.json({ error: 'database unavailable' }, 503);
     }
     console.error('Unhandled error', err);

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Pool } from '@bird-watch/db-client';
-import { getRegions } from '@bird-watch/db-client';
+import { getRegions, getHotspots } from '@bird-watch/db-client';
 import { cacheControlFor } from './cache-headers.js';
 
 export interface AppDeps {
@@ -15,6 +15,12 @@ export function createApp(deps: AppDeps): Hono {
   app.get('/api/regions', async c => {
     const rows = await getRegions(deps.pool);
     c.header('Cache-Control', cacheControlFor('regions'));
+    return c.json(rows);
+  });
+
+  app.get('/api/hotspots', async c => {
+    const rows = await getHotspots(deps.pool);
+    c.header('Cache-Control', cacheControlFor('hotspots'));
     return c.json(rows);
   });
 

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,0 +1,34 @@
+import { Hono } from 'hono';
+import type { Pool } from '@bird-watch/db-client';
+import { getRegions } from '@bird-watch/db-client';
+import { cacheControlFor } from './cache-headers.js';
+
+export interface AppDeps {
+  pool: Pool;
+}
+
+export function createApp(deps: AppDeps): Hono {
+  const app = new Hono();
+
+  app.get('/health', c => c.json({ ok: true }));
+
+  app.get('/api/regions', async c => {
+    const rows = await getRegions(deps.pool);
+    c.header('Cache-Control', cacheControlFor('regions'));
+    return c.json(rows);
+  });
+
+  app.onError((err, c) => {
+    const msg = (err as { code?: string }).code ?? '';
+    if (['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'].includes(msg)) {
+      return c.json({ error: 'database unavailable' }, 503);
+    }
+    if (err.name === 'TimeoutError' || /timeout/i.test(err.message)) {
+      return c.json({ error: 'database unavailable' }, 503);
+    }
+    console.error('Unhandled error', err);
+    return c.json({ error: 'internal' }, 500);
+  });
+
+  return app;
+}

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -25,20 +25,23 @@ export function createApp(deps: AppDeps): Hono {
   });
 
   app.get('/api/observations', async c => {
-    const since = c.req.query('since') as '1d' | '7d' | '14d' | '30d' | undefined;
-    if (since !== undefined && !['1d', '7d', '14d', '30d'].includes(since)) {
+    const sinceRaw = c.req.query('since');
+    const validSince = ['1d', '7d', '14d', '30d'] as const;
+    if (sinceRaw !== undefined && !(validSince as readonly string[]).includes(sinceRaw)) {
       return c.json({ error: 'invalid since' }, 400);
     }
+    const since = sinceRaw as '1d' | '7d' | '14d' | '30d' | undefined;
     const notableParam = c.req.query('notable');
     const speciesCode = c.req.query('species');
     const familyCode = c.req.query('family');
 
-    const rows = await getObservations(deps.pool, {
-      since,
-      notable: notableParam === 'true',
-      speciesCode,
-      familyCode,
-    });
+    const filters: Parameters<typeof getObservations>[1] = {};
+    if (since !== undefined) filters.since = since;
+    if (notableParam === 'true') filters.notable = true;
+    if (speciesCode !== undefined) filters.speciesCode = speciesCode;
+    if (familyCode !== undefined) filters.familyCode = familyCode;
+
+    const rows = await getObservations(deps.pool, filters);
     c.header('Cache-Control', cacheControlFor('observations'));
     return c.json(rows);
   });

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Pool } from '@bird-watch/db-client';
-import { getRegions, getHotspots, getObservations } from '@bird-watch/db-client';
+import { getRegions, getHotspots, getObservations, getSpeciesMeta } from '@bird-watch/db-client';
 import { cacheControlFor } from './cache-headers.js';
 
 export interface AppDeps {
@@ -41,6 +41,14 @@ export function createApp(deps: AppDeps): Hono {
     });
     c.header('Cache-Control', cacheControlFor('observations'));
     return c.json(rows);
+  });
+
+  app.get('/api/species/:code', async c => {
+    const code = c.req.param('code');
+    const meta = await getSpeciesMeta(deps.pool, code);
+    if (!meta) return c.json({ error: 'not found' }, 404);
+    c.header('Cache-Control', cacheControlFor('species'));
+    return c.json(meta);
   });
 
   app.onError((err, c) => {

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import type { Pool } from '@bird-watch/db-client';
-import { getRegions, getHotspots } from '@bird-watch/db-client';
+import { getRegions, getHotspots, getObservations } from '@bird-watch/db-client';
 import { cacheControlFor } from './cache-headers.js';
 
 export interface AppDeps {
@@ -21,6 +21,25 @@ export function createApp(deps: AppDeps): Hono {
   app.get('/api/hotspots', async c => {
     const rows = await getHotspots(deps.pool);
     c.header('Cache-Control', cacheControlFor('hotspots'));
+    return c.json(rows);
+  });
+
+  app.get('/api/observations', async c => {
+    const since = c.req.query('since') as '1d' | '7d' | '14d' | '30d' | undefined;
+    if (since !== undefined && !['1d', '7d', '14d', '30d'].includes(since)) {
+      return c.json({ error: 'invalid since' }, 400);
+    }
+    const notableParam = c.req.query('notable');
+    const speciesCode = c.req.query('species');
+    const familyCode = c.req.query('family');
+
+    const rows = await getObservations(deps.pool, {
+      since,
+      notable: notableParam === 'true',
+      speciesCode,
+      familyCode,
+    });
+    c.header('Cache-Control', cacheControlFor('observations'));
     return c.json(rows);
   });
 

--- a/services/read-api/src/cache-headers.test.ts
+++ b/services/read-api/src/cache-headers.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { cacheControlFor, type Endpoint } from './cache-headers.js';
+
+describe('cacheControlFor', () => {
+  it('returns 30-min TTL with SWR for /observations', () => {
+    expect(cacheControlFor('observations'))
+      .toBe('public, max-age=1800, stale-while-revalidate=600');
+  });
+  it('returns 24h TTL with SWR for /hotspots', () => {
+    expect(cacheControlFor('hotspots'))
+      .toBe('public, max-age=86400, stale-while-revalidate=3600');
+  });
+  it('returns 7d immutable for /regions', () => {
+    expect(cacheControlFor('regions'))
+      .toBe('public, max-age=604800, immutable');
+  });
+  it('returns 7d immutable for /species', () => {
+    expect(cacheControlFor('species'))
+      .toBe('public, max-age=604800, immutable');
+  });
+});

--- a/services/read-api/src/cache-headers.ts
+++ b/services/read-api/src/cache-headers.ts
@@ -1,0 +1,12 @@
+export type Endpoint = 'observations' | 'hotspots' | 'regions' | 'species';
+
+const TABLE: Record<Endpoint, string> = {
+  observations: 'public, max-age=1800, stale-while-revalidate=600',
+  hotspots:     'public, max-age=86400, stale-while-revalidate=3600',
+  regions:      'public, max-age=604800, immutable',
+  species:      'public, max-age=604800, immutable',
+};
+
+export function cacheControlFor(endpoint: Endpoint): string {
+  return TABLE[endpoint];
+}

--- a/services/read-api/src/index.ts
+++ b/services/read-api/src/index.ts
@@ -1,0 +1,2 @@
+export { createApp, type AppDeps } from './app.js';
+export { cacheControlFor, type Endpoint } from './cache-headers.js';

--- a/services/read-api/src/local.ts
+++ b/services/read-api/src/local.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env tsx
+import { serve } from '@hono/node-server';
+import { createPool } from '@bird-watch/db-client';
+import { createApp } from './app.js';
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error('DATABASE_URL not set');
+
+  const pool = createPool({ databaseUrl: dbUrl });
+  const app = createApp({ pool });
+  const port = Number(process.env.PORT ?? 8787);
+  serve({ fetch: app.fetch, port });
+  console.log(`Read API listening on http://localhost:${port}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/read-api/tsconfig.json
+++ b/services/read-api/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/services/read-api/tsconfig.test.json
+++ b/services/read-api/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts", "vitest.config.ts"]
+}

--- a/services/read-api/vitest.config.ts
+++ b/services/read-api/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Scaffolds `services/read-api` as a platform-agnostic Hono app that serves four JSON endpoints (`/api/regions`, `/api/hotspots`, `/api/observations`, `/api/species/:code`)
- Each endpoint applies spec-mandated `Cache-Control` TTLs via a `cacheControlFor()` helper
- Routes read from Postgres via `@bird-watch/db-client` — no PostGIS geometry math on the read path
- 503 returned on DB connection failures (`ECONNREFUSED`, `ETIMEDOUT`, timeout); 400 for invalid `since` param; 404 for unknown species
- Local dev server (`src/local.ts`) via `@hono/node-server` on `:8787`
- Root `build` script extended to chain `@bird-watch/read-api` last

## Test plan

- [ ] `npm test --workspace @bird-watch/read-api` — 15 tests pass (11 app + 4 cache-headers) across Testcontainers Postgres
- [ ] `npm run build` from repo root — all five packages build in dep order (shared-types → family-mapping → db-client → ingestor → read-api)
- [ ] `npm run dev --workspace @bird-watch/read-api` — listens on :8787, `curl localhost:8787/api/regions | jq 'length'` returns 9
- [ ] `npx tsc --noEmit` (both `tsconfig.json` and `tsconfig.test.json`) exit 0
- [ ] `git log --oneline HEAD~10..HEAD` — 10 commits (9 task commits + root build script)

## Cache-Control values per route

| Route | Header value |
|---|---|
| `/api/regions` | `public, max-age=604800, immutable` |
| `/api/hotspots` | `public, max-age=86400, stale-while-revalidate=3600` |
| `/api/observations` | `public, max-age=1800, stale-while-revalidate=600` |
| `/api/species/:code` | `public, max-age=604800, immutable` |

## Plan-vs-reality notes

- **`exactOptionalPropertyTypes` TS error** — the plan's inline `getObservations(pool, { since, ... })` pattern fails with `exactOptionalPropertyTypes: true` (optional properties can't receive `undefined` explicitly). Fixed by building the filters object conditionally before passing it.
- **`onError` added at Task 3** — added proactively during `createApp` scaffolding so all subsequent routes benefit from it; the Task 7 test still confirms the 503 behavior.
- **Extra root-build commit** — the 9 task commits are clean; the root `package.json` update was committed separately as `chore:` since it isn't part of any single task's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)