### PR TITLE
feat(frontend): six components — Badge, BadgeStack, HotspotDot, Region, Map, FiltersBar (Plan 4 tasks 5–10)

### DIFF
--- a/frontend/src/components/Badge.test.tsx
+++ b/frontend/src/components/Badge.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Badge } from './Badge.js';
+
+describe('Badge', () => {
+  it('renders the species count', () => {
+    render(
+      <svg viewBox="0 0 100 100">
+        <Badge x={50} y={50} count={3} silhouettePath="M0 0 L 10 10" color="#FF0808" comName="Vermilion Flycatcher" />
+      </svg>
+    );
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('uses the family color', () => {
+    const { container } = render(
+      <svg viewBox="0 0 100 100">
+        <Badge x={50} y={50} count={1} silhouettePath="M0 0" color="#7B2D8E" comName="Anna's Hummingbird" />
+      </svg>
+    );
+    const circle = container.querySelector('circle.badge-circle');
+    expect(circle?.getAttribute('fill')).toBe('#7B2D8E');
+  });
+
+  it('does not render the count chip when count is 1', () => {
+    render(
+      <svg viewBox="0 0 100 100">
+        <Badge x={50} y={50} count={1} silhouettePath="M0 0" color="#000" comName="X" />
+      </svg>
+    );
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,0 +1,54 @@
+export interface BadgeProps {
+  x: number;
+  y: number;
+  count: number;
+  silhouettePath: string;
+  color: string;
+  comName: string;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+const RADIUS = 14;
+const CHIP_RADIUS = 7;
+
+export function Badge(props: BadgeProps) {
+  const cursor = props.onClick ? 'pointer' : 'default';
+  return (
+    <g
+      className={`badge${props.selected ? ' badge-selected' : ''}`}
+      transform={`translate(${props.x},${props.y})`}
+      onClick={props.onClick}
+      role={props.onClick ? 'button' : undefined}
+      tabIndex={props.onClick ? 0 : undefined}
+      aria-label={`${props.comName}${props.count > 1 ? ` (${props.count} sightings)` : ''}`}
+      style={{ cursor }}
+    >
+      <circle
+        className="badge-circle"
+        r={RADIUS}
+        fill={props.color}
+        stroke="#fff"
+        strokeWidth={2}
+      />
+      <g transform={`translate(-${RADIUS},-${RADIUS}) scale(${(RADIUS * 2) / 24})`}>
+        <path d={props.silhouettePath} fill="#fff" />
+      </g>
+      {props.count > 1 && (
+        <g transform={`translate(${RADIUS - 2},${-RADIUS + 2})`}>
+          <circle r={CHIP_RADIUS} fill="#1a1a1a" />
+          <text
+            textAnchor="middle"
+            dominantBaseline="central"
+            fill="#fff"
+            fontSize={9}
+            fontWeight="bold"
+            fontFamily="-apple-system, sans-serif"
+          >
+            {props.count}
+          </text>
+        </g>
+      )}
+    </g>
+  );
+}

--- a/frontend/src/components/BadgeStack.test.tsx
+++ b/frontend/src/components/BadgeStack.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BadgeStack, layoutBadges } from './BadgeStack.js';
+import type { Observation } from '@bird-watch/shared-types';
+
+const O = (i: number, sp: string, sil: string): Observation => ({
+  subId: `S${i}`, speciesCode: sp, comName: sp, lat: 32, lng: -111,
+  obsDt: '2026-04-15T08:00:00Z', locId: 'L1', locName: 'X',
+  howMany: 1, isNotable: false, regionId: 'r', silhouetteId: sil,
+});
+
+describe('layoutBadges', () => {
+  it('groups by speciesCode with counts', () => {
+    const obs = [O(1, 'vermfly', 'tyrannidae'), O(2, 'vermfly', 'tyrannidae'), O(3, 'annhum', 'trochilidae')];
+    const groups = layoutBadges(obs);
+    expect(groups).toHaveLength(2);
+    expect(groups.find(g => g.speciesCode === 'vermfly')?.count).toBe(2);
+    expect(groups.find(g => g.speciesCode === 'annhum')?.count).toBe(1);
+  });
+});
+
+describe('BadgeStack', () => {
+  it('renders one Badge per species', () => {
+    const obs = [O(1, 'vermfly', 'tyrannidae'), O(2, 'annhum', 'trochilidae')];
+    render(
+      <svg viewBox="0 0 200 200">
+        <BadgeStack
+          observations={obs}
+          x={0} y={0} width={200} height={200}
+          silhouetteFor={() => 'M0 0'}
+          colorFor={() => '#000'}
+        />
+      </svg>
+    );
+    expect(screen.getByLabelText(/vermfly/)).toBeTruthy();
+    expect(screen.getByLabelText(/annhum/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/BadgeStack.tsx
+++ b/frontend/src/components/BadgeStack.tsx
@@ -52,6 +52,7 @@ export function BadgeStack(props: BadgeStackProps) {
         const row = Math.floor(i / cols);
         const cx = props.x + (col + 0.5) * (BADGE_DIAMETER + PADDING);
         const cy = props.y + (row + 0.5) * (BADGE_DIAMETER + PADDING);
+        const onSelectSpecies = props.onSelectSpecies;
         return (
           <Badge
             key={g.speciesCode}
@@ -62,11 +63,9 @@ export function BadgeStack(props: BadgeStackProps) {
             color={props.colorFor(g.silhouetteId)}
             comName={g.comName}
             selected={props.selectedSpeciesCode === g.speciesCode}
-            onClick={
-              props.onSelectSpecies
-                ? () => props.onSelectSpecies!(g.speciesCode)
-                : undefined
-            }
+            {...(onSelectSpecies !== undefined
+              ? { onClick: () => onSelectSpecies(g.speciesCode) }
+              : {})}
           />
         );
       })}

--- a/frontend/src/components/BadgeStack.tsx
+++ b/frontend/src/components/BadgeStack.tsx
@@ -1,0 +1,75 @@
+import type { Observation } from '@bird-watch/shared-types';
+import { Badge } from './Badge.js';
+
+export interface BadgeGroup {
+  speciesCode: string;
+  comName: string;
+  silhouetteId: string | null;
+  count: number;
+}
+
+export function layoutBadges(observations: Observation[]): BadgeGroup[] {
+  const map = new Map<string, BadgeGroup>();
+  for (const o of observations) {
+    const existing = map.get(o.speciesCode);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      map.set(o.speciesCode, {
+        speciesCode: o.speciesCode,
+        comName: o.comName,
+        silhouetteId: o.silhouetteId,
+        count: 1,
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => b.count - a.count);
+}
+
+export interface BadgeStackProps {
+  observations: Observation[];
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  silhouetteFor: (silhouetteId: string | null) => string;
+  colorFor: (silhouetteId: string | null) => string;
+  onSelectSpecies?: (speciesCode: string) => void;
+  selectedSpeciesCode?: string | null;
+}
+
+const BADGE_DIAMETER = 30;
+const PADDING = 4;
+
+export function BadgeStack(props: BadgeStackProps) {
+  const groups = layoutBadges(props.observations);
+  const cols = Math.max(1, Math.floor(props.width / (BADGE_DIAMETER + PADDING)));
+
+  return (
+    <g className="badge-stack">
+      {groups.map((g, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        const cx = props.x + (col + 0.5) * (BADGE_DIAMETER + PADDING);
+        const cy = props.y + (row + 0.5) * (BADGE_DIAMETER + PADDING);
+        return (
+          <Badge
+            key={g.speciesCode}
+            x={cx}
+            y={cy}
+            count={g.count}
+            silhouettePath={props.silhouetteFor(g.silhouetteId)}
+            color={props.colorFor(g.silhouetteId)}
+            comName={g.comName}
+            selected={props.selectedSpeciesCode === g.speciesCode}
+            onClick={
+              props.onSelectSpecies
+                ? () => props.onSelectSpecies!(g.speciesCode)
+                : undefined
+            }
+          />
+        );
+      })}
+    </g>
+  );
+}

--- a/frontend/src/components/FiltersBar.test.tsx
+++ b/frontend/src/components/FiltersBar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FiltersBar } from './FiltersBar.js';
+
+describe('FiltersBar', () => {
+  it('shows current values', () => {
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        onChange={() => {}}
+      />
+    );
+    const sinceSelect = screen.getByLabelText('Time window') as HTMLSelectElement;
+    expect(sinceSelect.value).toBe('14d');
+  });
+
+  it('calls onChange when time window changes', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        onChange={onChange}
+      />
+    );
+    await user.selectOptions(screen.getByLabelText('Time window'), '7d');
+    expect(onChange).toHaveBeenCalledWith({ since: '7d' });
+  });
+
+  it('calls onChange when notable toggle changes', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('checkbox', { name: /Notable/ }));
+    expect(onChange).toHaveBeenCalledWith({ notable: true });
+  });
+});

--- a/frontend/src/components/FiltersBar.tsx
+++ b/frontend/src/components/FiltersBar.tsx
@@ -1,0 +1,81 @@
+import type { Since } from '../state/url-state.js';
+
+export interface FamilyOption { code: string; name: string; }
+export interface SpeciesOption { code: string; comName: string; }
+
+export interface FiltersBarProps {
+  since: Since;
+  notable: boolean;
+  speciesCode: string | null;
+  familyCode: string | null;
+  families: FamilyOption[];
+  speciesIndex: SpeciesOption[];
+  onChange: (partial: Partial<{
+    since: Since; notable: boolean;
+    speciesCode: string | null; familyCode: string | null;
+  }>) => void;
+}
+
+export function FiltersBar(props: FiltersBarProps) {
+  return (
+    <div className="filters-bar" role="region" aria-label="Filters">
+      <label>
+        Time window
+        <select
+          aria-label="Time window"
+          value={props.since}
+          onChange={e => props.onChange({ since: e.target.value as Since })}
+        >
+          <option value="1d">Today</option>
+          <option value="7d">7 days</option>
+          <option value="14d">14 days</option>
+          <option value="30d">30 days</option>
+        </select>
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          aria-label="Notable only"
+          checked={props.notable}
+          onChange={e => props.onChange({ notable: e.target.checked })}
+        />
+        Notable only
+      </label>
+      <label>
+        Family
+        <select
+          aria-label="Family"
+          value={props.familyCode ?? ''}
+          onChange={e => props.onChange({ familyCode: e.target.value || null })}
+        >
+          <option value="">All families</option>
+          {props.families.map(f =>
+            <option key={f.code} value={f.code}>{f.name}</option>
+          )}
+        </select>
+      </label>
+      <label>
+        Species
+        <input
+          type="search"
+          aria-label="Species"
+          list="species-options"
+          placeholder="Common name"
+          value={props.speciesIndex.find(s => s.code === props.speciesCode)?.comName ?? ''}
+          onChange={e => {
+            const v = e.target.value;
+            const match = props.speciesIndex.find(s =>
+              s.comName.toLowerCase() === v.toLowerCase()
+            );
+            props.onChange({ speciesCode: match?.code ?? null });
+          }}
+        />
+        <datalist id="species-options">
+          {props.speciesIndex.map(s =>
+            <option key={s.code} value={s.comName} />
+          )}
+        </datalist>
+      </label>
+    </div>
+  );
+}

--- a/frontend/src/components/HotspotDot.test.tsx
+++ b/frontend/src/components/HotspotDot.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { HotspotDot } from './HotspotDot.js';
+
+describe('HotspotDot', () => {
+  it('scales radius by activity', () => {
+    const { container, rerender } = render(
+      <svg viewBox="0 0 100 100">
+        <HotspotDot x={10} y={10} numSpeciesAlltime={50} locName="A" />
+      </svg>
+    );
+    const small = container.querySelector('circle.hotspot-dot');
+    const smallR = parseFloat(small!.getAttribute('r')!);
+
+    rerender(
+      <svg viewBox="0 0 100 100">
+        <HotspotDot x={10} y={10} numSpeciesAlltime={500} locName="A" />
+      </svg>
+    );
+    const big = container.querySelector('circle.hotspot-dot');
+    const bigR = parseFloat(big!.getAttribute('r')!);
+    expect(bigR).toBeGreaterThan(smallR);
+  });
+});

--- a/frontend/src/components/HotspotDot.tsx
+++ b/frontend/src/components/HotspotDot.tsx
@@ -1,0 +1,32 @@
+export interface HotspotDotProps {
+  x: number;
+  y: number;
+  numSpeciesAlltime: number | null;
+  locName: string;
+}
+
+const MIN_R = 3;
+const MAX_R = 11;
+
+function radiusFor(species: number | null): number {
+  if (!species || species <= 0) return MIN_R;
+  // log scale: 50 species ≈ MIN_R+1, 500 species ≈ MAX_R
+  const r = MIN_R + Math.log10(species) * 3;
+  return Math.min(MAX_R, Math.max(MIN_R, r));
+}
+
+export function HotspotDot(props: HotspotDotProps) {
+  return (
+    <circle
+      className="hotspot-dot"
+      cx={props.x}
+      cy={props.y}
+      r={radiusFor(props.numSpeciesAlltime)}
+      fill="#00A6F3"
+      stroke="#fff"
+      strokeWidth={1.5}
+    >
+      <title>{props.locName}</title>
+    </circle>
+  );
+}

--- a/frontend/src/components/Map.test.tsx
+++ b/frontend/src/components/Map.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Map } from './Map.js';
+import type { Region, Observation, Hotspot } from '@bird-watch/shared-types';
+
+const regions: Region[] = [
+  { id: 'r1', name: 'R1', parentId: null, displayColor: '#FF0808', svgPath: 'M 0 0 L 100 0 L 100 100 L 0 100 Z' },
+  { id: 'r2', name: 'R2', parentId: null, displayColor: '#00A6F3', svgPath: 'M 200 0 L 300 0 L 300 100 L 200 100 Z' },
+];
+const observations: Observation[] = [];
+const hotspots: Hotspot[] = [];
+
+describe('Map', () => {
+  it('renders one region per region prop', () => {
+    render(
+      <Map
+        regions={regions}
+        observations={observations}
+        hotspots={hotspots}
+        expandedRegionId={null}
+        selectedSpeciesCode={null}
+        onSelectRegion={() => {}}
+        silhouetteFor={() => 'M0 0'}
+        colorFor={() => '#000'}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'R1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'R2' })).toBeInTheDocument();
+  });
+
+  it('marks the expanded region with the region-expanded class', () => {
+    const { container } = render(
+      <Map
+        regions={regions}
+        observations={observations}
+        hotspots={hotspots}
+        expandedRegionId="r1"
+        selectedSpeciesCode={null}
+        onSelectRegion={() => {}}
+        silhouetteFor={() => 'M0 0'}
+        colorFor={() => '#000'}
+      />
+    );
+    const expanded = container.querySelector('[data-region-id="r1"]');
+    expect(expanded?.classList.contains('region-expanded')).toBe(true);
+    const other = container.querySelector('[data-region-id="r2"]');
+    expect(other?.classList.contains('region-expanded')).toBe(false);
+  });
+
+  it('calls onSelectRegion when a region is clicked', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Map
+        regions={regions}
+        observations={observations}
+        hotspots={hotspots}
+        expandedRegionId={null}
+        selectedSpeciesCode={null}
+        onSelectRegion={onSelect}
+        silhouetteFor={() => 'M0 0'}
+        colorFor={() => '#000'}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'R1' }));
+    expect(onSelect).toHaveBeenCalledWith('r1');
+  });
+});

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -9,7 +9,7 @@ export interface MapProps {
   expandedRegionId: string | null;
   selectedSpeciesCode: string | null;
   onSelectRegion: (id: string | null) => void;
-  onSelectSpecies?: (code: string | null) => void;
+  onSelectSpecies?: (code: string) => void;
   silhouetteFor: (silhouetteId: string | null) => string;
   colorFor: (silhouetteId: string | null) => string;
 }
@@ -68,7 +68,9 @@ export function Map(props: MapProps) {
               expanded={isExpanded}
               selectedSpeciesCode={props.selectedSpeciesCode}
               onSelect={() => props.onSelectRegion(isExpanded ? null : r.id)}
-              onSelectSpecies={props.onSelectSpecies}
+              {...(props.onSelectSpecies !== undefined
+                ? { onSelectSpecies: props.onSelectSpecies }
+                : {})}
               silhouetteFor={props.silhouetteFor}
               colorFor={props.colorFor}
             />

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,0 +1,92 @@
+import type { Region as RegionT, Observation, Hotspot } from '@bird-watch/shared-types';
+import { Region } from './Region.js';
+import { HotspotDot } from './HotspotDot.js';
+
+export interface MapProps {
+  regions: RegionT[];
+  observations: Observation[];
+  hotspots: Hotspot[];
+  expandedRegionId: string | null;
+  selectedSpeciesCode: string | null;
+  onSelectRegion: (id: string | null) => void;
+  onSelectSpecies?: (code: string | null) => void;
+  silhouetteFor: (silhouetteId: string | null) => string;
+  colorFor: (silhouetteId: string | null) => string;
+}
+
+const VIEWBOX_W = 360;
+const VIEWBOX_H = 380;
+// Approx geographic bounding box for AZ used to project hotspot lat/lng -> SVG units
+const GEO_MIN_LNG = -114.85;
+const GEO_MAX_LNG = -109.05;
+const GEO_MIN_LAT = 31.30;
+const GEO_MAX_LAT = 37.00;
+
+function project(lat: number, lng: number): { x: number; y: number } {
+  const x = ((lng - GEO_MIN_LNG) / (GEO_MAX_LNG - GEO_MIN_LNG)) * VIEWBOX_W;
+  const y = ((GEO_MAX_LAT - lat) / (GEO_MAX_LAT - GEO_MIN_LAT)) * VIEWBOX_H;
+  return { x, y };
+}
+
+function groupBy<T, K>(arr: T[], key: (t: T) => K): globalThis.Map<K, T[]> {
+  const m = new globalThis.Map<K, T[]>();
+  for (const v of arr) {
+    const k = key(v);
+    const list = m.get(k);
+    if (list) list.push(v); else m.set(k, [v]);
+  }
+  return m;
+}
+
+export function Map(props: MapProps) {
+  const observationsByRegion = groupBy(props.observations, o => o.regionId ?? 'unknown');
+
+  return (
+    <svg
+      className="bird-map"
+      viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+      role="application"
+      aria-label="Arizona ecoregions map"
+      onClick={e => {
+        if (e.target === e.currentTarget) props.onSelectRegion(null);
+      }}
+    >
+      {props.regions.map(r => {
+        const isExpanded = props.expandedRegionId === r.id;
+        const isDimmed = props.expandedRegionId !== null && !isExpanded;
+        return (
+          <g
+            key={r.id}
+            style={{
+              opacity: isDimmed ? 0.2 : 1,
+              transition: 'opacity 250ms ease, transform 350ms ease',
+            }}
+          >
+            <Region
+              region={r}
+              observations={observationsByRegion.get(r.id) ?? []}
+              expanded={isExpanded}
+              selectedSpeciesCode={props.selectedSpeciesCode}
+              onSelect={() => props.onSelectRegion(isExpanded ? null : r.id)}
+              onSelectSpecies={props.onSelectSpecies}
+              silhouetteFor={props.silhouetteFor}
+              colorFor={props.colorFor}
+            />
+          </g>
+        );
+      })}
+      {props.expandedRegionId === null && props.hotspots.map(h => {
+        const { x, y } = project(h.lat, h.lng);
+        return (
+          <HotspotDot
+            key={h.locId}
+            x={x}
+            y={y}
+            numSpeciesAlltime={h.numSpeciesAlltime}
+            locName={h.locName}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/src/components/Region.test.tsx
+++ b/frontend/src/components/Region.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Region } from './Region.js';
+import type { Region as RegionT, Observation } from '@bird-watch/shared-types';
+
+const region: RegionT = {
+  id: 'sky-islands-santa-ritas',
+  name: 'Santa Ritas',
+  parentId: null,
+  displayColor: '#FF0808',
+  svgPath: 'M 200 170 L 340 170 L 340 215 L 200 215 Z',
+};
+
+const obs: Observation[] = [{
+  subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+  lat: 31.7, lng: -110.9, obsDt: '2026-04-15T08:00:00Z', locId: 'L1',
+  locName: 'X', howMany: 1, isNotable: false,
+  regionId: 'sky-islands-santa-ritas', silhouetteId: 'tyrannidae',
+}];
+
+describe('Region', () => {
+  it('renders the polygon with the display color', () => {
+    const { container } = render(
+      <svg viewBox="0 0 360 380">
+        <Region
+          region={region}
+          observations={obs}
+          expanded={false}
+          onSelect={() => {}}
+          silhouetteFor={() => 'M0 0'}
+          colorFor={() => '#000'}
+        />
+      </svg>
+    );
+    const path = container.querySelector('path.region-shape');
+    expect(path?.getAttribute('fill')).toBe('#FF0808');
+  });
+
+  it('calls onSelect when clicked', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <svg viewBox="0 0 360 380">
+        <Region
+          region={region}
+          observations={obs}
+          expanded={false}
+          onSelect={onSelect}
+          silhouetteFor={() => 'M0 0'}
+          colorFor={() => '#000'}
+        />
+      </svg>
+    );
+    await user.click(screen.getByRole('button', { name: /Santa Ritas/ }));
+    expect(onSelect).toHaveBeenCalledWith('sky-islands-santa-ritas');
+  });
+});

--- a/frontend/src/components/Region.tsx
+++ b/frontend/src/components/Region.tsx
@@ -52,8 +52,12 @@ export function Region(props: RegionProps) {
         height={stackH}
         silhouetteFor={props.silhouetteFor}
         colorFor={props.colorFor}
-        onSelectSpecies={props.onSelectSpecies}
-        selectedSpeciesCode={props.selectedSpeciesCode}
+        {...(props.onSelectSpecies !== undefined
+          ? { onSelectSpecies: props.onSelectSpecies }
+          : {})}
+        {...(props.selectedSpeciesCode !== undefined
+          ? { selectedSpeciesCode: props.selectedSpeciesCode }
+          : {})}
       />
     </g>
   );

--- a/frontend/src/components/Region.tsx
+++ b/frontend/src/components/Region.tsx
@@ -1,0 +1,60 @@
+import type { Region as RegionT, Observation } from '@bird-watch/shared-types';
+import { BadgeStack } from './BadgeStack.js';
+import { boundingBoxOfPath } from '../geo/path.js';
+
+export interface RegionProps {
+  region: RegionT;
+  observations: Observation[];
+  expanded: boolean;
+  selectedSpeciesCode?: string | null;
+  onSelect: (regionId: string) => void;
+  onSelectSpecies?: (speciesCode: string) => void;
+  silhouetteFor: (silhouetteId: string | null) => string;
+  colorFor: (silhouetteId: string | null) => string;
+}
+
+export function Region(props: RegionProps) {
+  const bbox = boundingBoxOfPath(props.region.svgPath);
+  const padding = 8;
+  const stackX = bbox.x + padding;
+  const stackY = bbox.y + padding;
+  const stackW = bbox.width - padding * 2;
+  const stackH = bbox.height - padding * 2;
+
+  return (
+    <g
+      className={`region${props.expanded ? ' region-expanded' : ''}`}
+      data-region-id={props.region.id}
+    >
+      <path
+        className="region-shape"
+        d={props.region.svgPath}
+        fill={props.region.displayColor}
+        stroke="#fff"
+        strokeWidth={3}
+        role="button"
+        tabIndex={0}
+        aria-label={props.region.name}
+        onClick={() => props.onSelect(props.region.id)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            props.onSelect(props.region.id);
+          }
+        }}
+        style={{ cursor: 'pointer' }}
+      />
+      <BadgeStack
+        observations={props.observations}
+        x={stackX}
+        y={stackY}
+        width={stackW}
+        height={stackH}
+        silhouetteFor={props.silhouetteFor}
+        colorFor={props.colorFor}
+        onSelectSpecies={props.onSelectSpecies}
+        selectedSpeciesCode={props.selectedSpeciesCode}
+      />
+    </g>
+  );
+}

--- a/frontend/src/geo/path.ts
+++ b/frontend/src/geo/path.ts
@@ -1,0 +1,36 @@
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Parse a flat M/L/Z SVG path (no curves) and return its bounding box.
+ * The seed paths in the DB are all of this form.
+ */
+export function boundingBoxOfPath(d: string): BoundingBox {
+  const tokens = d.split(/[\s,]+/).filter(Boolean);
+  let i = 0;
+  const xs: number[] = [];
+  const ys: number[] = [];
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (t === 'M' || t === 'L') {
+      const x = parseFloat(tokens[i + 1] ?? '0');
+      const y = parseFloat(tokens[i + 2] ?? '0');
+      xs.push(x); ys.push(y);
+      i += 3;
+    } else if (t === 'Z' || t === 'z') {
+      i += 1;
+    } else {
+      i += 1;
+    }
+  }
+  if (xs.length === 0) return { x: 0, y: 0, width: 0, height: 0 };
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,3 +5,10 @@ body {
   background: #f4f1ea;
   color: #1a1a1a;
 }
+
+.bird-map { width: 100%; height: 100%; display: block; }
+.region { transition: transform 350ms ease; transform-origin: center; }
+.region-expanded .region-shape { filter: drop-shadow(0 4px 16px rgba(0,0,0,0.3)); }
+.region-expanded .badge-stack { transform: scale(1.5); transform-origin: center; }
+.badge { transition: transform 200ms ease; }
+.badge-selected .badge-circle { stroke: #1a1a1a; stroke-width: 4; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,3 +12,15 @@ body {
 .region-expanded .badge-stack { transform: scale(1.5); transform-origin: center; }
 .badge { transition: transform 200ms ease; }
 .badge-selected .badge-circle { stroke: #1a1a1a; stroke-width: 4; }
+
+.filters-bar {
+  display: flex;
+  gap: 16px;
+  padding: 12px 16px;
+  background: #fff;
+  border-bottom: 1px solid #d8d3c3;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.filters-bar label { display: flex; gap: 6px; align-items: center; font-size: 13px; }
+.filters-bar select, .filters-bar input { padding: 4px 8px; }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,1 +1,9 @@
 import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Vitest sets globals:false so @testing-library/react cannot detect afterEach
+// as a global. Register cleanup manually so DOM is cleared between tests.
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph components
    direction LR
    F[FiltersBar]
    M[Map]
    R[Region]
    BS[BadgeStack]
    B[Badge]
    HD[HotspotDot]
    M --> R
    R --> BS
    BS --> B
    M --> HD
    F -.-> URL[(?since=14d<br/>&notable=true<br/>&species=verfly<br/>&family=trochilidae)]
  end
  URL -.-> useUrlState[useUrlState hook<br/>from PR #14]
  B -.-> FM[family-mapping:<br/>silhouetteForFamily<br/>colorForFamily]
```

## Summary

- Six composable React components, each unit-tested with `@testing-library/react`. Total 14 new tests (24 with the 10 from PR #14).
- `Badge` is the atomic unit; `BadgeStack` groups observations by species before laying them out; `Region` is a single AZ ecoregion polygon with an overlaid `BadgeStack`; `Map` places all regions on the stylized SVG and handles inline region-expansion; `HotspotDot` renders a log-scaled SVG circle for each hotspot; `FiltersBar` owns the four filter controls.
- App composition + Playwright E2E land in PR 4c — components are exercised only via unit tests in this PR.

## Screenshots

N/A — App composition lands in PR 4c (Plan 4 task 11). The bot's Playwright MCP walk happens there, when components are wired into an interactive page.

## Test plan

- [x] `npm run build` at root — all 6 workspaces build in order; `frontend/dist/` has hashed bundles
- [x] `npm test --workspace @bird-watch/frontend` — 24/24 tests pass across 9 files
- [x] `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.test.json`
- [ ] CI `test`/`lint`/`build`/`e2e` all green on this PR

## Plan reference

Part of Plan 4, Tasks 5–10. See `docs/plans/2026-04-16-plan-4-frontend.md`.

### Commits

| Task | SHA | What |
|---|---|---|
| 5 | `eadeb77` | feat(frontend): Badge (single species + count chip) |
| 6 | `4fdb919` | feat(frontend): BadgeStack (group by species) |
| 7 | `e32ab26` | feat(frontend): HotspotDot (log-scaled radius) |
| 8 | `c65cdd6` | feat(frontend): Region (polygon + BadgeStack + click) |
| 9 | `3b1f6c9` | feat(frontend): Map (inline region expansion) |
| 10 | `0d086a1` | feat(frontend): FiltersBar (time, notable, family, species) |
| — | `2736607` | fix(frontend): satisfy exactOptionalPropertyTypes for optional-prop forwarding |

### Plan-vs-reality drift (applied in this PR)

1. `test-setup.ts` now explicitly imports `afterEach` and calls `cleanup()` — RTL's auto-cleanup only fires when vitest `globals: true`, which this project has set to `false`.
2. `Map` component name shadowed the built-in `Map` constructor in `groupBy`; switched to `globalThis.Map`.
3. `exactOptionalPropertyTypes` required conditional spread (`{...(prop !== undefined ? { key: prop } : {})}`) at BadgeStack → Badge, Region → BadgeStack, Map → Region.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)