### PR TITLE
infra: Terraform foundation + Neon + Artifact Registry (Plan 5 tasks 1–4)

### DIFF
--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.auto.tfvars

--- a/infra/terraform/db.tf
+++ b/infra/terraform/db.tf
@@ -1,0 +1,42 @@
+resource "neon_project" "birdwatch" {
+  name       = "bird-watch"
+  region_id  = "aws-us-west-2" # close to gcp_region
+  pg_version = 16
+}
+
+resource "neon_branch" "main" {
+  project_id = neon_project.birdwatch.id
+  name       = "main"
+}
+
+resource "neon_database" "main" {
+  project_id = neon_project.birdwatch.id
+  branch_id  = neon_branch.main.id
+  name       = "birdwatch"
+  owner_name = neon_project.birdwatch.database_user
+}
+
+# Endpoint with pooled connection enabled — required for serverless.
+resource "neon_endpoint" "main" {
+  project_id     = neon_project.birdwatch.id
+  branch_id      = neon_branch.main.id
+  type           = "read_write"
+  pooler_enabled = true
+}
+
+# neon_project exposes database_host_pooler directly (added in provider v0.7.0),
+# so no regex manipulation is needed.
+locals {
+  neon_pooled_url = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_project.birdwatch.database_host_pooler}/${neon_database.main.name}?sslmode=require"
+}
+
+output "neon_db_url" {
+  value     = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_endpoint.main.host}/${neon_database.main.name}?sslmode=require"
+  sensitive = true
+}
+
+# Pooled URL — what Cloud Run uses. Each connection is multiplexed via PgBouncer.
+output "neon_pooled_url" {
+  value     = local.neon_pooled_url
+  sensitive = true
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,30 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+provider "neon" {
+  api_key = var.neon_api_key
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# Enable required GCP APIs once
+resource "google_project_service" "run" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_project_service" "scheduler" {
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_project_service" "artifactregistry" {
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}

--- a/infra/terraform/registry.tf
+++ b/infra/terraform/registry.tf
@@ -1,0 +1,12 @@
+resource "google_artifact_registry_repository" "birdwatch" {
+  repository_id = "birdwatch"
+  location      = var.gcp_region
+  format        = "DOCKER"
+  description   = "Container images for bird-watch services"
+
+  depends_on = [google_project_service.artifactregistry]
+}
+
+output "artifact_registry_url" {
+  value = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+gcp_project_id        = "REPLACE_ME"
+gcp_region            = "us-west1"
+neon_api_key          = "REPLACE_ME"
+cloudflare_account_id = "REPLACE_ME"
+cloudflare_api_token  = "REPLACE_ME"
+cloudflare_zone_id    = "REPLACE_ME"
+ebird_api_key         = "REPLACE_ME"
+domain                = "birdwatch.example.com"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,43 @@
+variable "gcp_project_id" {
+  type        = string
+  description = "GCP project ID (create one at console.cloud.google.com)."
+}
+
+variable "gcp_region" {
+  type        = string
+  default     = "us-west1"
+  description = "Cloud Run + Artifact Registry region. us-west1 keeps latency to AZ users low."
+}
+
+variable "neon_api_key" {
+  type        = string
+  sensitive   = true
+  description = "Neon API key (Neon dashboard → Settings → API keys)."
+}
+
+variable "cloudflare_account_id" {
+  type        = string
+  description = "Cloudflare account ID (used for Pages + DNS only)."
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  sensitive   = true
+  description = "Cloudflare API token with Pages + DNS perms."
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for `domain`."
+}
+
+variable "ebird_api_key" {
+  type        = string
+  sensitive   = true
+  description = "eBird API key (ebird.org/api/keygen)."
+}
+
+variable "domain" {
+  type        = string
+  description = "Domain you control on Cloudflare, e.g. birdwatch.example.com"
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.20"
+    }
+    neon = {
+      source  = "kislerdm/neon"
+      version = "~> 0.6"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.20"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/scripts/migrate-deploy.sh
+++ b/scripts/migrate-deploy.sh
@@ -10,7 +10,7 @@ if [ -z "${DATABASE_URL:-}" ]; then
 fi
 
 echo "Enabling PostGIS on Neon..."
-psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 echo "Running migrations..."
 npx node-pg-migrate up -m migrations -d "$DATABASE_URL"

--- a/scripts/migrate-deploy.sh
+++ b/scripts/migrate-deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL not set" >&2
+  echo "Hint: export DATABASE_URL=\$(cd infra/terraform && terraform output -raw neon_db_url)" >&2
+  exit 1
+fi
+
+echo "Enabling PostGIS on Neon..."
+psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+
+echo "Running migrations..."
+npx node-pg-migrate up -m migrations -d "$DATABASE_URL"
+
+echo "Done."


### PR DESCRIPTION
## Diagrams

```mermaid
graph TB
    subgraph infra/terraform
        versions[versions.tf<br/>provider pins]
        main[main.tf<br/>GCP APIs<br/>providers]
        variables[variables.tf<br/>8 variables]
        db[db.tf<br/>neon_project<br/>neon_branch<br/>neon_database<br/>neon_endpoint<br/>pooler_enabled=true]
        registry[registry.tf<br/>artifact_registry_repository<br/>DOCKER format]
    end

    subgraph scripts
        migrate[migrate-deploy.sh<br/>DATABASE_URL guard<br/>CREATE EXTENSION postgis<br/>npx node-pg-migrate up]
    end

    subgraph outputs[Terraform outputs]
        db_url[neon_db_url<br/>sensitive]
        pool_url[neon_pooled_url<br/>sensitive]
        reg_url[artifact_registry_url]
    end

    db --> db_url
    db --> pool_url
    registry --> reg_url
    migrate -.reads.-> db_url

    style db_url fill:#ffe4b5
    style pool_url fill:#ffe4b5
```

```mermaid
sequenceDiagram
    participant Julian
    participant Neon
    participant GCP

    Note over Julian: One-time setup
    Julian->>Julian: cp terraform.tfvars.example terraform.tfvars<br/>fill in 8 values
    Julian->>GCP: gcloud auth login + application-default login
    Julian->>GCP: terraform init + apply<br/>(5a establishes: APIs, Neon, Registry)
    GCP-->>Julian: 4 APIs enabled
    Neon-->>Julian: project + pooled endpoint
    GCP-->>Julian: Artifact Registry ready

    Julian->>Neon: ./scripts/migrate-deploy.sh<br/>(9 migrations + seeds)
    Neon-->>Julian: 9 regions, 15 silhouettes
```

## Summary

- Lays the Terraform foundation for Plan 5 deployment: provider pins, GCP API enablement, Neon Postgres with pooled endpoint, migration runner script, Google Artifact Registry. The stack targets \$0/mo hobbyist free-tier on GCP Cloud Run + Neon + Cloudflare Pages.
- No resource creation in CI — this PR lands config only. Julian applies it himself (he holds GCP + Neon creds). `terraform fmt -check`, `terraform init -backend=false`, and `terraform validate` all pass locally without any credentials, which is the CI-checkable quality bar.
- One plan deviation: `db.tf` uses `kislerdm/neon` v0.13.0 attributes (`database_user`, `database_password`, `database_host_pooler`) instead of the plan's `default_role_name` / `default_role_password` + regex pooled-host construction. The plan's attribute names do not exist in v0.13.0; v0.13.0 exposes the pooled host directly. Spec reviewer verified against provider docs.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check -recursive .` → exit 0
- [x] `terraform init -backend=false` → 4 providers downloaded cleanly (google v5.45.2, neon v0.13.0, cloudflare v4.52.7, docker v3.9.0)
- [x] `terraform validate` → \`Success! The configuration is valid.\`
- [x] `bash -n scripts/migrate-deploy.sh` → exit 0
- [x] `git ls-files infra/terraform/` confirms `terraform.tfvars` and `.terraform*` are gitignored
- [x] `grep -iE 'api_key|password|secret' $(git diff --name-only main..HEAD)` returns no real values (only variable declarations + REPLACE_ME placeholders)
- [x] `migrate-deploy.sh` uses `psql -v ON_ERROR_STOP=1` so privilege errors on Neon do not silently pass (fixed after code-quality review)
- [ ] `terraform apply` against a real GCP project + Neon workspace — Julian runs manually when ready (not a PR-merge blocker)

## Plan reference

`docs/plans/2026-04-16-plan-5-infra-terraform.md` — Tasks 1, 2, 3, 4.

Follow-ups in later PRs:
- PR 5b — Cloud Run Service (read-api) + Cloud Run Job (ingestor) + Cloud Scheduler + Secret Manager
- PR 5c — Cloudflare Pages + DNS + deploy.sh + smoke-test.sh + README Deployment section