### PR TITLE
infra: Cloud Run services — read-api Service + ingestor Job + Scheduler (Plan 5 tasks 5–8)

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -91,7 +91,10 @@ resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke" {
 }
 
 locals {
-  job_run_url = "https://${var.gcp_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.gcp_project_id}/jobs/${google_cloud_run_v2_job.ingestor.name}:run"
+  # Cloud Run Jobs v2 REST endpoint. v2 is the current API surface for
+  # google_cloud_run_v2_job and uses a cleaner path than the v1 Knative
+  # alias (/apis/run.googleapis.com/v1/namespaces/...).
+  job_run_url = "https://run.googleapis.com/v2/projects/${var.gcp_project_id}/locations/${var.gcp_region}/jobs/${google_cloud_run_v2_job.ingestor.name}:run"
 }
 
 # Three crons matching the spec: every 30 min, daily 4am UTC, weekly Sun 5am UTC.

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -1,0 +1,165 @@
+resource "google_service_account" "ingestor" {
+  account_id   = "bird-ingestor"
+  display_name = "bird-watch Ingestor"
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_db" {
+  secret_id = google_secret_manager_secret.db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_secret_manager_secret" "ebird_key" {
+  secret_id = "bird-watch-ebird-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "ebird_key" {
+  secret      = google_secret_manager_secret.ebird_key.id
+  secret_data = var.ebird_api_key
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_ebird" {
+  secret_id = google_secret_manager_secret.ebird_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_cloud_run_v2_job" "ingestor" {
+  name     = "bird-ingestor"
+  location = var.gcp_region
+
+  template {
+    template {
+      service_account = google_service_account.ingestor.email
+      timeout         = "300s"
+      max_retries     = 1
+
+      containers {
+        image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/ingestor:latest"
+
+        # Args are appended to ENTRYPOINT. CLI takes "recent" | "hotspots" | "backfill".
+        args = ["recent"]
+
+        resources {
+          limits = { cpu = "1", memory = "512Mi" }
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "EBIRD_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.ebird_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_ebird,
+  ]
+}
+
+# Service account that Scheduler uses to invoke the Job.
+resource "google_service_account" "scheduler" {
+  account_id   = "bird-scheduler"
+  display_name = "bird-watch Cloud Scheduler invoker"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke" {
+  name     = google_cloud_run_v2_job.ingestor.name
+  location = google_cloud_run_v2_job.ingestor.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+locals {
+  job_run_url = "https://${var.gcp_region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.gcp_project_id}/jobs/${google_cloud_run_v2_job.ingestor.name}:run"
+}
+
+# Three crons matching the spec: every 30 min, daily 4am UTC, weekly Sun 5am UTC.
+resource "google_cloud_scheduler_job" "ingest_recent" {
+  name      = "bird-ingest-recent"
+  region    = var.gcp_region
+  schedule  = "*/30 * * * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["recent"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}
+
+resource "google_cloud_scheduler_job" "ingest_backfill" {
+  name      = "bird-ingest-backfill"
+  region    = var.gcp_region
+  schedule  = "0 4 * * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["backfill"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}
+
+resource "google_cloud_scheduler_job" "ingest_hotspots" {
+  name      = "bird-ingest-hotspots"
+  region    = var.gcp_region
+  schedule  = "0 5 * * 0"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["hotspots"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}

--- a/infra/terraform/read-api.tf
+++ b/infra/terraform/read-api.tf
@@ -1,0 +1,83 @@
+# Store the Neon pooled URL in Secret Manager so we don't ship it in plain env.
+resource "google_secret_manager_secret" "db_url" {
+  secret_id = "bird-watch-db-url"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "db_url" {
+  secret      = google_secret_manager_secret.db_url.id
+  secret_data = local.neon_pooled_url
+}
+
+# Service account the Read API runs as.
+resource "google_service_account" "read_api" {
+  account_id   = "bird-read-api"
+  display_name = "bird-watch Read API"
+}
+
+resource "google_secret_manager_secret_iam_member" "read_api_db" {
+  secret_id = google_secret_manager_secret.db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.read_api.email}"
+}
+
+resource "google_cloud_run_v2_service" "read_api" {
+  name     = "bird-read-api"
+  location = var.gcp_region
+
+  template {
+    service_account = google_service_account.read_api.email
+
+    scaling {
+      min_instance_count = 0 # true scale-to-zero
+      max_instance_count = 5
+    }
+
+    containers {
+      image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/read-api:latest"
+
+      ports { container_port = 8080 }
+
+      resources {
+        limits            = { cpu = "1", memory = "256Mi" }
+        cpu_idle          = true # CPU only allocated during requests (cheaper)
+        startup_cpu_boost = true # quicker cold starts
+      }
+
+      env {
+        name = "DATABASE_URL"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_url.secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+  }
+
+  traffic {
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    percent = 100
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.read_api_db,
+  ]
+}
+
+# Allow public access (CDN sits in front).
+resource "google_cloud_run_v2_service_iam_member" "read_api_public" {
+  name     = google_cloud_run_v2_service.read_api.name
+  location = google_cloud_run_v2_service.read_api.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+output "read_api_url" {
+  value = google_cloud_run_v2_service.read_api.uri
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,7 +1034,6 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -7750,10 +7749,10 @@
       "dependencies": {
         "@bird-watch/db-client": "*",
         "@bird-watch/shared-types": "*",
+        "@hono/node-server": "^1.7.0",
         "hono": "^4.0.0"
       },
       "devDependencies": {
-        "@hono/node-server": "^1.7.0",
         "@testcontainers/postgresql": "^10.7.0",
         "testcontainers": "^10.7.0",
         "tsx": "^4.7.0",

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REGISTRY=$(cd infra/terraform && terraform output -raw artifact_registry_url)
+SERVICE="${1:?usage: build-push.sh <service> (read-api | ingestor)}"
+TAG="${2:-latest}"
+
+echo "Building $SERVICE → $REGISTRY/$SERVICE:$TAG ..."
+docker buildx build --platform linux/amd64 \
+  -f "services/$SERVICE/Dockerfile" \
+  -t "$REGISTRY/$SERVICE:$TAG" \
+  --push .
+
+echo "Pushed $REGISTRY/$SERVICE:$TAG"

--- a/services/ingestor/.dockerignore
+++ b/services/ingestor/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.env.local
+src/**/*.test.ts

--- a/services/ingestor/Dockerfile
+++ b/services/ingestor/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS build
+WORKDIR /repo
+
+COPY package.json package-lock.json ./
+COPY tsconfig.base.json ./
+COPY packages ./packages
+COPY services/ingestor ./services/ingestor
+
+RUN npm ci --workspaces --include-workspace-root --include=dev
+RUN npm run build --workspace @bird-watch/shared-types
+RUN npm run build --workspace @bird-watch/db-client
+RUN npm run build --workspace @bird-watch/family-mapping
+RUN npm run build --workspace @bird-watch/ingestor
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /repo/package.json /repo/package-lock.json ./
+COPY --from=build /repo/packages ./packages
+COPY --from=build /repo/services/ingestor/package.json ./services/ingestor/
+COPY --from=build /repo/services/ingestor/dist ./services/ingestor/dist
+
+RUN npm ci --omit=dev --workspaces --include-workspace-root
+
+# The Cloud Run Job invokes this entrypoint with the kind as $1.
+ENTRYPOINT ["node", "services/ingestor/dist/cli.js"]

--- a/services/read-api/.dockerignore
+++ b/services/read-api/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.env
+.env.local
+src/**/*.test.ts

--- a/services/read-api/Dockerfile
+++ b/services/read-api/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage — uses the monorepo root context.
+FROM node:20-alpine AS build
+WORKDIR /repo
+
+# Copy package manifests first for cached install.
+COPY package.json package-lock.json ./
+COPY tsconfig.base.json ./
+COPY packages ./packages
+COPY services/read-api ./services/read-api
+
+RUN npm ci --workspaces --include-workspace-root --include=dev
+RUN npm run build --workspace @bird-watch/shared-types
+RUN npm run build --workspace @bird-watch/db-client
+RUN npm run build --workspace @bird-watch/family-mapping
+RUN npm run build --workspace @bird-watch/read-api
+
+# Runtime stage — copy only what we need.
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8080
+
+COPY --from=build /repo/package.json /repo/package-lock.json ./
+COPY --from=build /repo/packages ./packages
+COPY --from=build /repo/services/read-api/package.json ./services/read-api/
+COPY --from=build /repo/services/read-api/dist ./services/read-api/dist
+
+RUN npm ci --omit=dev --workspaces --include-workspace-root
+
+EXPOSE 8080
+CMD ["node", "services/read-api/dist/local.js"]

--- a/services/read-api/package.json
+++ b/services/read-api/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@bird-watch/db-client": "*",
     "@bird-watch/shared-types": "*",
+    "@hono/node-server": "^1.7.0",
     "hono": "^4.0.0"
   },
   "devDependencies": {
-    "@hono/node-server": "^1.7.0",
     "@testcontainers/postgresql": "^10.7.0",
     "testcontainers": "^10.7.0",
     "tsx": "^4.7.0",


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph GCP[GCP Cloud Run]
        svc[bird-read-api<br/>Service<br/>min=0 max=5<br/>cpu_idle=true<br/>startup_cpu_boost=true<br/>port 8080]
        job[bird-ingestor<br/>Job<br/>timeout=300s<br/>max_retries=1<br/>args=recent default]
    end

    subgraph Secrets[Secret Manager]
        dbsec[bird-watch-db-url]
        ebsec[bird-watch-ebird-key]
    end

    subgraph IAM[Service accounts]
        raSA[bird-read-api SA<br/>secretAccessor: db_url]
        ingSA[bird-ingestor SA<br/>secretAccessor: db_url + ebird_key]
        schSA[bird-scheduler SA<br/>run.invoker on job]
    end

    subgraph Sched[Cloud Scheduler]
        s1[ingest_recent<br/>*/30 * * * *<br/>args=recent]
        s2[ingest_backfill<br/>0 4 * * *<br/>args=backfill]
        s3[ingest_hotspots<br/>0 5 * * 0<br/>args=hotspots]
    end

    Internet -->|roles/run.invoker allUsers| svc
    s1 -->|POST :run<br/>OAuth| job
    s2 -->|POST :run<br/>OAuth| job
    s3 -->|POST :run<br/>OAuth| job

    svc --> raSA --> dbsec
    job --> ingSA --> dbsec
    job --> ingSA --> ebsec
    s1 --> schSA
    s2 --> schSA
    s3 --> schSA
```

```mermaid
graph TB
    subgraph Build[docker build]
        src[services/read-api/src/**/*.ts<br/>services/ingestor/src/**/*.ts<br/>packages/*/src/**/*.ts] --> builder[Node 20 Alpine<br/>npm ci --include=dev<br/>tsc per workspace]
        builder --> dist[dist/ for each<br/>workspace]
    end

    subgraph Runtime[Runtime stage]
        dist --> rt[Node 20 Alpine<br/>npm ci --omit=dev<br/>CMD node dist/local.js<br/>ENTRYPOINT node dist/cli.js]
    end

    subgraph Registry[Artifact Registry]
        rt --> img[us-west1-docker.pkg.dev/.../read-api:latest<br/>us-west1-docker.pkg.dev/.../ingestor:latest]
    end

    img --> svc2[Cloud Run Service]
    img --> job2[Cloud Run Job]
```

## Summary

- Adds Dockerfiles for `read-api` and `ingestor` (multi-stage Node 20 alpine), `scripts/build-push.sh` helper (buildx + linux/amd64), and Terraform for a Cloud Run Service (read-api), a Cloud Run Job (ingestor), three Cloud Scheduler crons (recent / backfill / hotspots), plus Secret Manager secrets for the Neon pooled URL and eBird API key with least-privilege IAM bindings. Everything scales to zero on idle.
- One real bug fix uncovered by the Docker stage: `@hono/node-server` was in \`devDependencies\` on \`main\`, but \`local.ts\` imports it at module top. The runtime stage uses \`npm ci --omit=dev\`, so the container would have crashed on startup. Moved to \`dependencies\` + refreshed lockfile.
- One post-review fix: switched Scheduler → Job \`:run\` URL from the v1 Knative alias to the current v2 REST endpoint (\`run.googleapis.com/v2/projects/…/jobs/…:run\`). Functionally equivalent (v1 also accepts overrides) but v2 is the current API surface for \`google_cloud_run_v2_job\` and drops the confusing \`/apis/run.googleapis.com/v1/namespaces/\` Knative-legacy path.

## Screenshots

N/A — not UI

## Test plan

- [x] \`cd infra/terraform && terraform fmt -check -recursive . && terraform init -backend=false && terraform validate\` → \`Success! The configuration is valid.\`
- [x] \`docker build -f services/read-api/Dockerfile -t bird-read-api:local .\` → image contains \`/app/services/read-api/dist/local.js\` + all three workspace \`dist/\` dirs
- [x] \`docker build -f services/ingestor/Dockerfile -t bird-ingestor:local .\` → image contains \`/app/services/ingestor/dist/cli.js\`
- [x] \`bash -n scripts/build-push.sh\` → exit 0; \`set -euo pipefail\` + \`\${SERVICE:?usage}\` hard-fails when arg missing
- [x] \`git ls-files infra/terraform/\` confirms no \`.terraform/\`, no \`.terraform.lock.hcl\`, no \`terraform.tfvars\`, no real secret values
- [x] All service accounts least-privilege: read-api SA only has \`secretAccessor\` on db_url; ingestor SA on db_url + ebird_key; scheduler SA has \`run.invoker\` scoped to the job (not the whole project)
- [x] \`roles/run.invoker\` for \`allUsers\` is ONLY on the read-api Service (public API), NOT on the ingestor Job
- [ ] \`terraform apply\` against a real GCP project — Julian runs after PR 5a+5b merge (not a merge blocker)
- [ ] Manual \`gcloud run jobs execute bird-ingestor --args=backfill\` after apply — Julian verifies

## Plan reference

\`docs/plans/2026-04-16-plan-5-infra-terraform.md\` — Tasks 5, 6, 7, 8.

Follow-up in PR 5c: Cloudflare Pages + DNS, \`deploy.sh\`, \`smoke-test.sh\`, README Deployment section.