### PR TITLE
test(e2e): preview-build Playwright project + prod smoke spec (#23)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,8 +85,13 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
         working-directory: frontend
-      - name: Run Playwright E2E
-        run: npm run test:e2e --workspace @bird-watch/frontend
+      - name: Run Playwright E2E (dev-server)
+        run: npm run test:e2e --workspace @bird-watch/frontend -- --project=dev-server
+        env:
+          DATABASE_URL: postgres://birdwatch:birdwatch@localhost:5432/birdwatch
+          CI: "true"
+      - name: Run Playwright E2E (preview-build)
+        run: npm run test:e2e --workspace @bird-watch/frontend -- --project=preview-build
         env:
           DATABASE_URL: postgres://birdwatch:birdwatch@localhost:5432/birdwatch
           CI: "true"

--- a/frontend/e2e/manual-test.md
+++ b/frontend/e2e/manual-test.md
@@ -3,7 +3,7 @@
 Step-by-step instructions for a Claude agent to execute the E2E test suite manually
 using the Playwright MCP tools. Each flow maps 1:1 to a `happy-path.spec.ts` assertion.
 
-> **preview-build project:** A second Playwright project (`preview-build`) runs `vite build && vite preview` on port 4173 (no `/api` proxy) to catch the production baseUrl bug. Its spec is `prod-smoke.preview.spec.ts` and uses `test.fail()` until the baseUrl fix lands.
+> **preview-build project:** A second Playwright project (`preview-build`) runs `vite build && vite preview` on port 4173 with `proxy: {}` explicitly set, catching the production routing gap where `/api` is on a different subdomain. Uses `test.fail()` until the baseUrl fix lands.
 
 ---
 

--- a/frontend/e2e/manual-test.md
+++ b/frontend/e2e/manual-test.md
@@ -3,6 +3,8 @@
 Step-by-step instructions for a Claude agent to execute the E2E test suite manually
 using the Playwright MCP tools. Each flow maps 1:1 to a `happy-path.spec.ts` assertion.
 
+> **preview-build project:** A second Playwright project (`preview-build`) runs `vite build && vite preview` on port 4173 (no `/api` proxy) to catch the production baseUrl bug. Its spec is `prod-smoke.preview.spec.ts` and uses `test.fail()` until the baseUrl fix lands.
+
 ---
 
 ## Prerequisites

--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -2,7 +2,10 @@ import { test, expect } from '@playwright/test';
 
 test.describe('production build smoke', () => {
   test('map renders 9 regions when served by vite preview', async ({ page }) => {
-    test.fail(); // Expected: preview server has no /api proxy; remove when baseUrl fix lands
+    // Expected to fail today: preview has no /api proxy.
+    // When the baseUrl fix lands, this will start PASSING, which
+    // fails test.fail() — that's your cue to delete this line.
+    test.fail();
     await page.goto('/');
     const regions = page.locator('[data-region-id]');
     await expect(regions).toHaveCount(9, { timeout: 15_000 });

--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -2,9 +2,11 @@ import { test, expect } from '@playwright/test';
 
 test.describe('production build smoke', () => {
   test('map renders 9 regions when served by vite preview', async ({ page }) => {
-    // Expected to fail today: preview has no /api proxy.
-    // When the baseUrl fix lands, this will start PASSING, which
-    // fails test.fail() — that's your cue to delete this line.
+    // Expected to fail today: preview runs with proxy: {} (vite.config.ts)
+    // so /api hits the static origin (no handler). The baseUrl fix will
+    // switch App.tsx to an env-driven absolute URL — when that lands, this
+    // test will start PASSING, which fails test.fail(). That's your cue
+    // to delete the annotation.
     test.fail();
     await page.goto('/');
     const regions = page.locator('[data-region-id]');

--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('production build smoke', () => {
+  test('map renders 9 regions when served by vite preview', async ({ page }) => {
+    test.fail(); // Expected: preview server has no /api proxy; remove when baseUrl fix lands
+    await page.goto('/');
+    const regions = page.locator('[data-region-id]');
+    await expect(regions).toHaveCount(9, { timeout: 15_000 });
+    await expect(page.locator('.map-wrap'))
+      .toHaveAttribute('aria-busy', 'false', { timeout: 15_000 });
+    await expect(page.locator('.error-screen')).toHaveCount(0);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,14 +9,29 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 60_000,
   use: {
-    baseURL: 'http://localhost:5173',
     headless: true,
     screenshot: 'only-on-failure',
   },
   outputDir: '.playwright-out',
+  projects: [
+    {
+      name: 'dev-server',
+      testIgnore: /.*\.preview\.spec\.ts$/,
+      use: {
+        baseURL: 'http://localhost:5173',
+      },
+    },
+    {
+      name: 'preview-build',
+      testMatch: /.*\.preview\.spec\.ts$/,
+      use: {
+        baseURL: 'http://localhost:4173',
+      },
+    },
+  ],
   webServer: [
     {
-      // Start read-api on port 8787
+      // Start read-api on port 8787 (shared by both projects)
       command: `DATABASE_URL=${process.env.DATABASE_URL ?? 'postgres://birdwatch:birdwatch@localhost:5433/birdwatch'} npm run dev --workspace @bird-watch/read-api`,
       cwd: ROOT,
       url: 'http://localhost:8787/api/regions',
@@ -30,6 +45,14 @@ export default defineConfig({
       url: 'http://localhost:5173',
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
+    },
+    {
+      // Build and start Vite preview on port 4173 (no /api proxy — surfaces the baseUrl bug)
+      command: 'npm run build && npm run preview -- --port 4173 --strictPort',
+      cwd: __dirname,
+      url: 'http://localhost:4173',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
     },
   ],
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
@@ -8,6 +8,15 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:8787',
     },
+  },
+  preview: {
+    port: 4173,
+    // Intentionally empty: vite preview inherits server.proxy by default
+    // in Vite 5. Overriding with {} makes /api requests hit the static
+    // origin (no proxy), simulating the production Cloudflare Pages
+    // deploy where API lives on a different subdomain.
+    // prod-smoke.preview.spec.ts depends on this to reproduce the bug.
+    proxy: {},
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "Playwright projects"
        DEV[dev-server<br/>port 5173<br/>vite dev] -->|testMatch *.spec.ts<br/>testIgnore *.preview.spec.ts| HP[happy-path.spec.ts]
        PRV[preview-build<br/>port 4173<br/>vite build + preview] -->|testMatch *.preview.spec.ts| PS[prod-smoke.preview.spec.ts]
    end

    subgraph "Shared webServer"
        API[read-api on 8787]
    end

    DEV -.->|proxy /api| API
    PRV -.->|NO proxy — surfaces bug| API
```

```mermaid
stateDiagram-v2
    [*] --> TestFails: main today (baseUrl bug)
    TestFails --> CIGreen: test.fail() inverts
    CIGreen --> FutureFix: follow-up PR fixes baseUrl
    FutureFix --> TestPasses: spec runs cleanly
    TestPasses --> CIRed: test.fail() inversion
    CIRed --> RemoveAnnotation: delete test.fail()
    RemoveAnnotation --> [*]
```

## Summary

- Adds a second Playwright project (`preview-build`) that runs against `vite build && vite preview` on port 4173, where Vite's `/api` dev proxy does NOT run. Hardcoded `baseUrl: ''` in `App.tsx` means the client hits `/api/...` on the origin serving the HTML — fine in dev (proxied) but broken in production. This is the fail-fast regression test.
- Scope is test-only per issue #23 (`"This issue is for the test, not the fix"`). A follow-up issue will wire `VITE_API_BASE_URL` or a `_worker.js` redirect. Until then, `test.fail()` inverts the result so CI stays green.
- CI e2e job splits into two named steps (`dev-server`, `preview-build`) so a failing job's step name identifies which server reproduced the bug.

## Screenshots

N/A — not UI. Test-only change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean (no type errors)
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 unit tests pass
- [x] `frontend/e2e/happy-path.spec.ts` untouched — `dev-server` project still runs baseline suite
- [x] `dev-server` project's `testIgnore: /.*\.preview\.spec\.ts$/` scopes preview specs away from it
- [x] `preview-build` project's `testMatch: /.*\.preview\.spec\.ts$/` scopes only preview specs to it
- [ ] Local E2E verification deferred — requires running Postgres + read-api; CI is authoritative

## Plan reference

Closes #23. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)