### PR TITLE
test(e2e): filter flows — time window, family, species (#25)

### DIFF
--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -36,7 +36,7 @@ test.describe('filter flows', () => {
     // Draft only — URL should not have species param yet.
     await expect.poll(() => page.url(), { timeout: 3_000 }).not.toContain('species=');
 
-    await page.keyboard.press('Tab');
+    await input.blur();
     // After blur with no exact match, URL still has no species param.
     await expect.poll(() => page.url(), { timeout: 5_000 }).not.toContain('species=');
   });
@@ -44,14 +44,16 @@ test.describe('filter flows', () => {
   test('species input commits exact match on blur', async ({ page }) => {
     const input = page.getByLabel('Species');
     await input.focus();
+    await expect(page.locator('datalist#species-options option').first()).toBeAttached({ timeout: 10_000 });
     await input.fill('Vermilion Flycatcher');
-    await page.keyboard.press('Tab');
+    await input.blur();
     await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('species=vermfly');
   });
 
   test('species input commits on Enter', async ({ page }) => {
     const input = page.getByLabel('Species');
     await input.focus();
+    await expect(page.locator('datalist#species-options option').first()).toBeAttached({ timeout: 10_000 });
     await input.fill('Vermilion Flycatcher');
     await page.keyboard.press('Enter');
     await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('species=vermfly');

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('filter flows', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+  });
+
+  test('time window select updates URL and respects default-omit', async ({ page }) => {
+    const sel = page.getByLabel('Time window');
+    await sel.selectOption('1d');
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('since=1d');
+    await sel.selectOption('14d');
+    await expect.poll(() => page.url(), { timeout: 5_000 }).not.toContain('since=');
+  });
+
+  test('family select updates URL when options exist', async ({ page }) => {
+    const sel = page.getByLabel('Family');
+    const count = await sel.locator('option').count();
+    test.skip(count <= 1, 'species_meta is empty — no families to filter by');
+
+    const firstValue = await sel.locator('option').nth(1).getAttribute('value');
+    expect(firstValue).toBeTruthy();
+    await sel.selectOption(firstValue!);
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain(`family=${firstValue}`);
+
+    await sel.selectOption({ label: 'All families' });
+    await expect.poll(() => page.url(), { timeout: 5_000 }).not.toContain('family=');
+  });
+
+  test('species input does not commit on keystroke (draft isolation + no-match blur)', async ({ page }) => {
+    const input = page.getByLabel('Species');
+    await input.focus();
+    await input.fill('Vermilio'); // partial, no match
+
+    // Draft only — URL should not have species param yet.
+    await expect.poll(() => page.url(), { timeout: 3_000 }).not.toContain('species=');
+
+    await page.keyboard.press('Tab');
+    // After blur with no exact match, URL still has no species param.
+    await expect.poll(() => page.url(), { timeout: 5_000 }).not.toContain('species=');
+  });
+
+  test('species input commits exact match on blur', async ({ page }) => {
+    const input = page.getByLabel('Species');
+    await input.focus();
+    await input.fill('Vermilion Flycatcher');
+    await page.keyboard.press('Tab');
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('species=vermfly');
+  });
+
+  test('species input commits on Enter', async ({ page }) => {
+    const input = page.getByLabel('Species');
+    await input.focus();
+    await input.fill('Vermilion Flycatcher');
+    await page.keyboard.press('Enter');
+    await expect.poll(() => page.url(), { timeout: 5_000 }).toContain('species=vermfly');
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph Time window
        T1[select 1d] --> T2{URL has since=1d?}
        T3[select 14d] --> T4{URL has no since=?}
    end

    subgraph Family
        F0[count options] -->|count ≤ 1| Fskip[test.skip 'species_meta empty']
        F0 -->|count > 1| F1[pick first non-default option]
        F1 --> F2{URL has family=code?}
        F2 --> F3[select All families]
        F3 --> F4{URL has no family=?}
    end

    subgraph Species
        S0[type 'Vermilio'] --> S1{URL has no species= while focused?}
        S1 --> S2[input.blur] --> S3{URL still has no species=?}

        M0[type 'Vermilion Flycatcher'] --> M1[wait for datalist populated]
        M1 --> M2a[input.blur] --> M3a{URL has species=vermfly?}
        M1 --> M2b[press Enter] --> M3b{URL has species=vermfly?}
    end
```

## Summary

- Adds `frontend/e2e/filters.spec.ts` covering the three filter flows (time window default-omit, family null-round-trip, species draft isolation + commit-on-blur/Enter) that are currently only documented in `manual-test.md` Flows 7-9.
- Uses `getByLabel(...)` throughout — matches the house style from `happy-path.spec.ts` and `history-nav.spec.ts`, and relies on aria-labels already on every FiltersBar control (`Time window`, `Family`, `Notable only`, `Species`).
- Graceful-skip on sparse seed data: the Family test `test.skip`s when only "All families" is present, so the PR doesn't couple test reliability to the `species_meta` table's cardinality.
- Hardening applied from code review: `input.blur()` instead of `page.keyboard.press('Tab')` (immune to DOM tab-chain changes), and an explicit `datalist#species-options option` wait before species commit tests to prevent a data-race flake where commits fire before `speciesIndex` populates from observations.

## Screenshots

N/A — not UI. Test-only change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 passing
- [x] Selectors match `happy-path.spec.ts` + `history-nav.spec.ts` house style (`getByLabel`, no CSS)
- [x] All `expect.poll` calls explicit `{ timeout: 5_000 }` (draft-isolation check uses 3_000 — short enough to catch keystroke-commit regressions, long enough to pass on main)
- [x] No `test.fail()` anywhere — tests expected to pass on current main
- [x] `FiltersBar.tsx`, `playwright.config.ts`, `e2e.yml` untouched — spec runs under the existing `dev-server` project
- [x] Species commit tests await `<datalist>` population before fill (deterministic against observation-arrival timing)
- [ ] Local Playwright E2E deferred — CI is authoritative

## Plan reference

Closes #25. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)