### PR TITLE
test(e2e): error screen via page.route interception (#26)

### DIFF
--- a/frontend/e2e/error-states.spec.ts
+++ b/frontend/e2e/error-states.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('error screen', () => {
+  test('renders when /api/regions aborts', async ({ page }) => {
+    await page.route('**/api/regions', route => route.abort());
+    await page.goto('/');
+    await expect(page.locator('.error-screen h2'))
+      .toHaveText("Couldn't load map data", { timeout: 10_000 });
+    await expect(page.locator('.error-screen p')).not.toBeEmpty();
+  });
+
+  test('renders on 500 from /api/regions', async ({ page }) => {
+    await page.route('**/api/regions', route =>
+      route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' })
+    );
+    await page.goto('/');
+    await expect(page.locator('.error-screen h2'))
+      .toHaveText("Couldn't load map data", { timeout: 10_000 });
+  });
+
+  test('renders when /api/observations fails even if regions+hotspots succeed', async ({ page }) => {
+    await page.route('**/api/observations**', route => route.abort());
+    await page.goto('/');
+    await expect(page.locator('.error-screen h2'))
+      .toHaveText("Couldn't load map data", { timeout: 10_000 });
+  });
+
+  test('does not hang with aria-busy=true when API aborts', async ({ page }) => {
+    await page.route('**/api/regions', route => route.abort());
+    await page.goto('/');
+    // Either the error screen appeared, OR aria-busy went false. Both are acceptable;
+    // an infinite-loading state would be the bug we guard against.
+    await expect(async () => {
+      const errorVisible = await page.locator('.error-screen').isVisible();
+      const ariaBusy = await page.locator('.map-wrap').getAttribute('aria-busy');
+      expect(errorVisible || ariaBusy === 'false' || ariaBusy === null).toBeTruthy();
+    }).toPass({ timeout: 10_000 });
+  });
+});

--- a/frontend/e2e/error-states.spec.ts
+++ b/frontend/e2e/error-states.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('error screen', () => {
   test('renders when /api/regions aborts', async ({ page }) => {
-    await page.route('**/api/regions', route => route.abort());
+    await page.route('**/api/regions', async route => { await route.abort(); });
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
@@ -10,30 +10,30 @@ test.describe('error screen', () => {
   });
 
   test('renders on 500 from /api/regions', async ({ page }) => {
-    await page.route('**/api/regions', route =>
-      route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' })
-    );
+    await page.route('**/api/regions', async route => {
+      await route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' });
+    });
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
+    await expect(page.locator('.error-screen p')).not.toBeEmpty();
   });
 
   test('renders when /api/observations fails even if regions+hotspots succeed', async ({ page }) => {
-    await page.route('**/api/observations**', route => route.abort());
+    await page.route('**/api/observations**', async route => { await route.abort(); });
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
   });
 
   test('does not hang with aria-busy=true when API aborts', async ({ page }) => {
-    await page.route('**/api/regions', route => route.abort());
+    await page.route('**/api/regions', async route => { await route.abort(); });
     await page.goto('/');
-    // Either the error screen appeared, OR aria-busy went false. Both are acceptable;
-    // an infinite-loading state would be the bug we guard against.
-    await expect(async () => {
-      const errorVisible = await page.locator('.error-screen').isVisible();
-      const ariaBusy = await page.locator('.map-wrap').getAttribute('aria-busy');
-      expect(errorVisible || ariaBusy === 'false' || ariaBusy === null).toBeTruthy();
-    }).toPass({ timeout: 10_000 });
+    // Either the error screen renders, or the map-wrap stops reporting busy.
+    // Race them with Promise.race — first acceptable resolution wins.
+    await Promise.race([
+      expect(page.locator('.error-screen')).toBeVisible({ timeout: 10_000 }),
+      expect(page.locator('.map-wrap')).toHaveAttribute('aria-busy', 'false', { timeout: 10_000 }),
+    ]);
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph FAIL_MODES["Route fail modes"]
        R1["regions aborts"] --> E["&lt;.error-screen&gt;"]
        R2["regions 500"] --> E
        R3["observations aborts<br/>regions+hotspots succeed"] --> E
    end

    subgraph NO_HANG["No-hang guard (test 4)"]
        G0["regions aborts"] --> G1{"Promise.race"}
        G1 -->|"leg A"| GA[".error-screen toBeVisible"]
        G1 -->|"leg B"| GB[".map-wrap aria-busy=false"]
    end

    E --> H["h2 pinned: Couldn't load map data"]
    E --> P["p: error.message non-empty"]
```

## Summary

- Adds `frontend/e2e/error-states.spec.ts` with 4 Playwright tests that exercise the `.error-screen` render path via `page.route()` interception — deterministic, no server shutdown, no flake window.
- Pins the user-visible error copy (`Couldn't load map data`) so a future refactor of the heading fails this test before it fails users.
- Covers three trigger paths (abort on regions, 500 on regions, abort on observations-only) plus a no-hang guard that races `toBeVisible` on `.error-screen` with `toHaveAttribute('aria-busy', 'false')` on `.map-wrap`.
- Hardened per internal code review: all route handlers use `async/await` (so Playwright surfaces rejections as test failures), and the no-hang guard uses web-first assertions under `Promise.race` instead of the `isVisible`/`getAttribute` anti-pattern inside `toPass`.

## Screenshots

N/A — not UI. Test-only change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 passing
- [x] Route pattern uses `**/api/regions` glob (matches both direct and proxied requests); observations test uses `**/api/observations**` trailing-wildcard
- [x] All four route handlers are `async route => { await route.X(); }` — no bare callbacks
- [x] Test 4 races `expect().toBeVisible` and `expect().toHaveAttribute` via `Promise.race` — no `isVisible`/`getAttribute` inside `toPass`
- [x] `App.tsx`, `use-bird-data.ts`, `playwright.config.ts`, `e2e.yml` all untouched — spec locks current error-resolution behavior without changing it
- [x] No `test.fail()` — tests expected to pass on current main
- [ ] Local Playwright E2E deferred — CI is authoritative

## Plan reference

Closes #26. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)