### PR TITLE
test(e2e): keyboard nav, aria-busy, aria-label guardrails (#27)

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -15,10 +15,11 @@ test.describe('accessibility', () => {
     await page.goto('/');
     await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
 
-    // Collect the first 8 focused elements after tabbing from body.
+    // Collect the first 20 focused elements after tabbing from body.
+    // Budget is wide enough to survive seed changes that shift region-badge tab positions.
     await page.locator('body').focus();
     const visited: string[] = [];
-    for (let i = 0; i < 8; i++) {
+    for (let i = 0; i < 20; i++) {
       await page.keyboard.press('Tab');
       const tag = await page.evaluate(() => {
         const el = document.activeElement as HTMLElement | null;
@@ -29,20 +30,29 @@ test.describe('accessibility', () => {
       visited.push(tag);
     }
 
-    // The four filters must all appear before we hit any region-shape.
-    const firstRegionIdx = visited.findIndex(s => s.startsWith('path[') || s.includes('Sky Islands'));
+    // Positively identify filters; everything else is map-side by process of elimination.
+    // Robust to Badge tags (<g role="button">), overflow pips, hotspot dots, or any future
+    // map-side interactive element.
+    const FILTER_SIGNATURES = ['Time window', 'Notable only', 'Family', 'Species'];
+
+    const isFilter = (s: string) => FILTER_SIGNATURES.some(sig => s.includes(sig));
+    const firstNonFilterIdx = visited.findIndex(s => s !== 'body[]' && !isFilter(s));
+
     const timeWindowIdx = visited.findIndex(s => s.includes('Time window'));
     const notableIdx = visited.findIndex(s => s.includes('Notable only'));
     const familyIdx = visited.findIndex(s => s.includes('Family'));
     const speciesIdx = visited.findIndex(s => s.includes('Species'));
 
-    expect(timeWindowIdx).toBeGreaterThanOrEqual(0);
-    expect(notableIdx).toBeGreaterThanOrEqual(0);
-    expect(familyIdx).toBeGreaterThanOrEqual(0);
-    expect(speciesIdx).toBeGreaterThanOrEqual(0);
-    if (firstRegionIdx >= 0) {
-      expect(Math.max(timeWindowIdx, notableIdx, familyIdx, speciesIdx))
-        .toBeLessThan(firstRegionIdx);
+    expect(timeWindowIdx, 'Time window filter must be tabbable').toBeGreaterThanOrEqual(0);
+    expect(notableIdx, 'Notable only filter must be tabbable').toBeGreaterThanOrEqual(0);
+    expect(familyIdx, 'Family filter must be tabbable').toBeGreaterThanOrEqual(0);
+    expect(speciesIdx, 'Species filter must be tabbable').toBeGreaterThanOrEqual(0);
+
+    if (firstNonFilterIdx >= 0) {
+      expect(
+        Math.max(timeWindowIdx, notableIdx, familyIdx, speciesIdx),
+        'all four filters must come before any map-side tabbable (region path, badge, etc.)'
+      ).toBeLessThan(firstNonFilterIdx);
     }
   });
 
@@ -56,17 +66,19 @@ test.describe('accessibility', () => {
     ).toBe('false');
   });
 
-  test('every interactive control has an aria-label or associated label', async ({ page }) => {
+  test('every input, select, button, role=button, link, or textarea has an accessible label', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
 
     const unlabelled = await page.evaluate(() => {
-      const roots = Array.from(document.querySelectorAll('.app input, .app select, .app [role="button"]'));
+      const roots = Array.from(document.querySelectorAll('.app input, .app select, .app button, .app [role="button"], .app a[href], .app textarea'));
       return roots
         .filter((el): el is HTMLElement => el instanceof HTMLElement)
         .filter(el => {
           const aria = el.getAttribute('aria-label');
           if (aria && aria.trim()) return false;
+          const labelledBy = el.getAttribute('aria-labelledby');
+          if (labelledBy && labelledBy.split(/\s+/).some(id => document.getElementById(id))) return false;
           const id = el.id;
           if (id && document.querySelector(`label[for="${id}"]`)) return false;
           if (el.closest('label')) return false;

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('accessibility', () => {
+  test('Space key also expands a region (not only Enter)', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    const region = page.locator('.region-shape[aria-label="Sky Islands — Santa Ritas"]');
+    await region.focus();
+    await page.keyboard.press('Space');
+    await expect(page.locator('[data-region-id="sky-islands-santa-ritas"]'))
+      .toHaveClass(/region-expanded/);
+  });
+
+  test('Tab reaches all four filters before any map region', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+
+    // Collect the first 8 focused elements after tabbing from body.
+    await page.locator('body').focus();
+    const visited: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press('Tab');
+      const tag = await page.evaluate(() => {
+        const el = document.activeElement as HTMLElement | null;
+        if (!el) return 'NONE';
+        const label = el.getAttribute('aria-label') ?? '';
+        return `${el.tagName.toLowerCase()}[${label}]`;
+      });
+      visited.push(tag);
+    }
+
+    // The four filters must all appear before we hit any region-shape.
+    const firstRegionIdx = visited.findIndex(s => s.startsWith('path[') || s.includes('Sky Islands'));
+    const timeWindowIdx = visited.findIndex(s => s.includes('Time window'));
+    const notableIdx = visited.findIndex(s => s.includes('Notable only'));
+    const familyIdx = visited.findIndex(s => s.includes('Family'));
+    const speciesIdx = visited.findIndex(s => s.includes('Species'));
+
+    expect(timeWindowIdx).toBeGreaterThanOrEqual(0);
+    expect(notableIdx).toBeGreaterThanOrEqual(0);
+    expect(familyIdx).toBeGreaterThanOrEqual(0);
+    expect(speciesIdx).toBeGreaterThanOrEqual(0);
+    if (firstRegionIdx >= 0) {
+      expect(Math.max(timeWindowIdx, notableIdx, familyIdx, speciesIdx))
+        .toBeLessThan(firstRegionIdx);
+    }
+  });
+
+  test('aria-busy flips from true to false when data loads', async ({ page }) => {
+    await page.goto('/');
+    // Race: the mount effect kicks off a fetch, and we may miss the `true` state
+    // if the network is very fast. Accept either ordering, but we MUST end on 'false'.
+    await expect.poll(
+      () => page.locator('.map-wrap').getAttribute('aria-busy'),
+      { timeout: 15_000 }
+    ).toBe('false');
+  });
+
+  test('every interactive control has an aria-label or associated label', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+
+    const unlabelled = await page.evaluate(() => {
+      const roots = Array.from(document.querySelectorAll('.app input, .app select, .app [role="button"]'));
+      return roots
+        .filter((el): el is HTMLElement => el instanceof HTMLElement)
+        .filter(el => {
+          const aria = el.getAttribute('aria-label');
+          if (aria && aria.trim()) return false;
+          const id = el.id;
+          if (id && document.querySelector(`label[for="${id}"]`)) return false;
+          if (el.closest('label')) return false;
+          return true;
+        })
+        .map(el => el.outerHTML.slice(0, 200));
+    });
+    expect(unlabelled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph KBD["Keyboard activation"]
        K1["focus .region-shape"] --> K2["keyboard.press Space"]
        K2 --> K3{"region-expanded class?"}
    end

    subgraph TAB["Tab order (robust)"]
        T0["focus body"] --> T1["loop 20 tabs, collect activeElement"]
        T1 --> T2["positive filter identification"]
        T2 --> T3{"all 4 filters have findIndex ≥ 0?"}
        T3 --> T4{"max filter idx < firstNonFilterIdx?"}
    end

    subgraph BUSY["aria-busy"]
        A1["page.goto"] --> A2["expect.poll aria-busy"]
        A2 --> A3{"resolves to 'false' within 15s?"}
    end

    subgraph LABELS["Label enumeration"]
        L0["query .app input/select/button/role=button/a/textarea"] --> L1{"each has one of:"}
        L1 -->|"or"| L2["non-empty aria-label"]
        L1 -->|"or"| L3["aria-labelledby → exists"]
        L1 -->|"or"| L4["label[for=id]"]
        L1 -->|"or"| L5["closest label wraps"]
    end
```

## Summary

- Adds `frontend/e2e/a11y.spec.ts` with 4 lightweight Playwright guards (no axe dependency — that's issue #28):
  - Space-key region expansion (Region.tsx listens for both Enter and Space)
  - Tab order: all four filters tabbable before any map-side element
  - aria-busy flips true → false when data loads (accepts any ordering, asserts terminal state only)
  - Accessible-label presence on every input/select/button/role=button/a/textarea in `.app`
- Hardened per internal code review: tab-loop budget widened to 20 (so the test survives future E2E seed changes that might shift Badge tab positions); positive filter identification (catches Badge `<g role=button>` tabbables the prior path-only predicate missed); `aria-labelledby` added as a fourth valid labeling mechanism; selector broadened to include native `<button>`, `<a href>`, and `<textarea>` for future-proofing.

## Screenshots

N/A — not UI. Test-only change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 passing
- [x] Region.tsx confirmed to handle `e.key === ' '` for Space; FiltersBar.tsx confirmed to have aria-labels on all four controls (Time window, Notable only, Family, Species)
- [x] Tab-budget of 20 > current maximum (4 filters + 4 regions + 4 badges = 12 worst case); future seed changes safe
- [x] Positive filter-signature matching via `FILTER_SIGNATURES` const treats anything else as map-side — robust to new tabbables
- [x] `aria-labelledby` honored alongside aria-label, `label[for=id]`, and implicit `closest('label')`
- [x] No `test.fail()`, no source changes, no CI config changes
- [ ] Local Playwright E2E deferred — CI is authoritative

## Plan reference

Closes #27. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)