### PR TITLE
test(e2e): @axe-core/playwright WCAG scans on key states (#28)

### DIFF
--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
 test.describe('axe-core WCAG scans', () => {
   test('initial load has no WCAG 2/2.1 A/AA violations', async ({ page }) => {

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+async function scan(page: Page) {
+  return new AxeBuilder({ page })
+    .withTags(WCAG_TAGS)
+    .analyze();
+}
+
+test.describe('axe-core WCAG scans', () => {
+  test('initial load has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    const results = await scan(page);
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+
+  test('region expanded has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    await page.locator('.region-shape[aria-label="Sky Islands — Santa Ritas"]').focus();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-region-id="sky-islands-santa-ritas"]'))
+      .toHaveClass(/region-expanded/);
+    const results = await scan(page);
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+
+  test('error screen has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
+    await page.route('**/api/regions', async route => { await route.abort(); });
+    await page.goto('/');
+    await expect(page.locator('.error-screen h2'))
+      .toHaveText("Couldn't load map data", { timeout: 10_000 });
+    const results = await scan(page);
+    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+  });
+});

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -1,20 +1,20 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
-
-async function scan(page: Page) {
-  return new AxeBuilder({ page })
-    .withTags(WCAG_TAGS)
-    .analyze();
-}
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
 
 test.describe('axe-core WCAG scans', () => {
   test('initial load has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
     await page.goto('/');
     await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
-    const results = await scan(page);
-    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    if (results.violations.length) {
+      await test.info().attach('axe-violations', {
+        body: JSON.stringify(results.violations, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(results.violations).toEqual([]);
   });
 
   test('region expanded has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
@@ -24,8 +24,14 @@ test.describe('axe-core WCAG scans', () => {
     await page.keyboard.press('Enter');
     await expect(page.locator('[data-region-id="sky-islands-santa-ritas"]'))
       .toHaveClass(/region-expanded/);
-    const results = await scan(page);
-    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    if (results.violations.length) {
+      await test.info().attach('axe-violations', {
+        body: JSON.stringify(results.violations, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(results.violations).toEqual([]);
   });
 
   test('error screen has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
@@ -33,7 +39,13 @@ test.describe('axe-core WCAG scans', () => {
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
-    const results = await scan(page);
-    expect(results.violations, JSON.stringify(results.violations, null, 2)).toEqual([]);
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    if (results.violations.length) {
+      await test.info().attach('axe-violations', {
+        body: JSON.stringify(results.violations, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(results.violations).toEqual([]);
   });
 });

--- a/frontend/e2e/manual-test.md
+++ b/frontend/e2e/manual-test.md
@@ -5,6 +5,8 @@ using the Playwright MCP tools. Each flow maps 1:1 to a `happy-path.spec.ts` ass
 
 > **preview-build project:** A second Playwright project (`preview-build`) runs `vite build && vite preview` on port 4173 with `proxy: {}` explicitly set, catching the production routing gap where `/api` is on a different subdomain. Uses `test.fail()` until the baseUrl fix lands.
 
+> **axe-core scans:** `npm run test:e2e --workspace @bird-watch/frontend -- axe.spec.ts` runs three WCAG 2/2.1 A/AA scans (initial load, region expanded, error screen) via @axe-core/playwright. Open a tagged follow-up issue for any rule you disable.
+
 ---
 
 ## Prerequisites

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.41.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.41.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.0",
@@ -70,6 +71,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2609,6 +2623,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/b4a": {


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "Three states scanned"
        S1[initial load<br/>9 regions rendered] --> AXE1[axe analyze]
        S2[Santa Ritas expanded<br/>Enter keyboard activation] --> AXE2[axe analyze]
        S3[error screen<br/>route abort /api/regions] --> AXE3[axe analyze]
    end

    AXE1 --> T1{violations empty?}
    AXE2 --> T2{violations empty?}
    AXE3 --> T3{violations empty?}

    T1 -.-> R[attach JSON to test.info report<br/>only when violations present]
    T2 -.-> R
    T3 -.-> R
```

## Summary

- Adds `@axe-core/playwright ^4.x` as a frontend devDependency and `frontend/e2e/axe.spec.ts` with three WCAG 2/2.1 A/AA scans (initial load, region expanded, error screen). Catches the 30–57% of WCAG violations that automated scanners detect (color contrast, missing alt, duplicate IDs, bad label associations) without requiring a visual-regression setup.
- Intentionally does NOT disable any rules — per the issue spec, if CI surfaces pre-existing violations we'll open tagged follow-up issues and add targeted `.disableRules()` with `TODO(#<issue>):` pointers in a follow-up commit. Silent suppression is explicitly not allowed.
- Uses `test.info().attach()` for violation details on failure (appears in the Playwright HTML report as a JSON attachment) instead of stringifying into the `expect` message — cleaner CI artifacts.
- Inlines the `AxeBuilder` chain at each callsite per code review — keeps the scan configuration visible where reviewers look first, avoids premature abstraction before a second variation forces it.

## Screenshots

N/A — not UI. Test-only change + new devDependency.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 passing
- [x] `@axe-core/playwright` resolved to `^4.11.2` (latest `^4.x`, per CLAUDE.md axe-core drift note)
- [x] Lockfile delta scoped to axe + its single transitive `axe-core@~4.11.3` — no incidental deps
- [x] Tag set pinned to `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa` — excludes opinionated `best-practice` rules
- [x] Error-path test reuses the `**/api/regions` abort idiom from #26, with `async route => { await route.abort(); }`
- [x] Manual-test.md gains a blockquote callout on running axe scans locally + the "open a tagged follow-up issue" protocol
- [x] No source files (App.tsx, components/**, etc.) touched
- [ ] Local Playwright E2E deferred — CI will tell us if pre-existing WCAG violations exist; will iterate on disableRules in a follow-up commit if needed

## Plan reference

Closes #28. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)