### PR TITLE
test(e2e): deep-link restore for all 5 URL params (#29)

### DIFF
--- a/frontend/e2e/deep-link.spec.ts
+++ b/frontend/e2e/deep-link.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('deep-link restore', () => {
+  test('multi-param URL restores every filter and region expand', async ({ page }) => {
+    await page.goto('/?region=sky-islands-santa-ritas&notable=true&since=7d');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    await expect(page.locator('[data-region-id="sky-islands-santa-ritas"]'))
+      .toHaveClass(/region-expanded/);
+    await expect(page.getByLabel('Notable only')).toBeChecked();
+    await expect(page.getByLabel('Time window')).toHaveValue('7d');
+  });
+
+  test('invalid since falls back to default (readUrl returns DEFAULTS.since)', async ({ page }) => {
+    await page.goto('/?since=garbage');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    await expect(page.getByLabel('Time window')).toHaveValue('14d');
+    // writeUrl only fires inside set(), never on mount — do NOT assert URL normalization here.
+  });
+
+  test('species param shows common name in input', async ({ page }) => {
+    await page.goto('/?species=vermfly');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    // Skip if dev DB has no observations (speciesIndex will be empty).
+    const familySel = page.getByLabel('Family');
+    const familyOptionCount = await familySel.locator('option').count();
+    test.skip(familyOptionCount <= 1, 'species_meta is empty — no observations to drive speciesIndex, skipping species deep-link test');
+    // speciesDraft is derived from speciesIndex on mount — only populated AFTER
+    // observations come back and the effect in FiltersBar re-runs.
+    await expect(page.getByLabel('Species')).toHaveValue('Vermilion Flycatcher', { timeout: 10_000 });
+  });
+
+  test('family param selects matching option when seeded families exist', async ({ page }) => {
+    await page.goto('/?family=tyrannidae');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    const familySel = page.getByLabel('Family');
+    const optionCount = await familySel.locator('option').count();
+    test.skip(optionCount <= 1, 'species_meta is empty — no families to restore from URL');
+    await expect(familySel).toHaveValue('tyrannidae');
+  });
+});

--- a/frontend/e2e/deep-link.spec.ts
+++ b/frontend/e2e/deep-link.spec.ts
@@ -37,4 +37,14 @@ test.describe('deep-link restore', () => {
     test.skip(optionCount <= 1, 'species_meta is empty — no families to restore from URL');
     await expect(familySel).toHaveValue('tyrannidae');
   });
+
+  test('empty URL leaves all controls at defaults', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('[data-region-id]')).toHaveCount(9, { timeout: 15_000 });
+    await expect(page.getByLabel('Time window')).toHaveValue('14d');
+    await expect(page.getByLabel('Notable only')).not.toBeChecked();
+    await expect(page.getByLabel('Family')).toHaveValue('');
+    await expect(page.getByLabel('Species')).toHaveValue('');
+    await expect(page.locator('.region-expanded')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "Cold-load URLs tested"
        U1["/?region=sky-islands-santa-ritas&notable=true&since=7d"] --> A1[expanded region + checked + 7d]
        U2["/?since=garbage"] --> A2[fallback to 14d default]
        U3["/?species=vermfly"] --> A3[Species input shows 'Vermilion Flycatcher']
        U4["/?family=tyrannidae"] --> A4[Family select value 'tyrannidae']
        U5["/"] --> A5[all controls at DEFAULTS<br/>14d, unchecked, empty, empty]
    end

    A3 --> W[waits for speciesIndex to hydrate<br/>via 10s timeout]
    A4 --> S[test.skip if species_meta empty]
    A3 --> S2[test.skip if Family has ≤1 option]
```

## Summary

- Adds `frontend/e2e/deep-link.spec.ts` with 5 cold-load tests proving URL is the source of truth for all 5 state params (region, notable, since, species, family) plus the `DEFAULTS` constant itself.
- No clicks anywhere — every test starts from a raw `page.goto`. Proves `readUrl → useState` lazy-init path without touching `writeUrl`.
- Covers the `VALID_SINCE` whitelist branch: `since=garbage` falls back to `14d` default. Explicitly does NOT assert URL cleanup — `writeUrl` only fires inside `set()`, never on mount, so the garbage param stays in the URL until a user interaction.
- Empty-URL test (#5, added per internal code review) pins the `DEFAULTS` constant — a refactor that accidentally inverts a default (`notable: false → true`) would be caught by this test before reaching users.
- Graceful `test.skip` on tests 3 & 4 if Family has ≤1 option (matches the pattern from `filters.spec.ts`) — keeps the spec usable locally before anyone has run the ingestor.

## Screenshots

N/A — not UI. Test-only change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 passing
- [x] Preflight verification: `VALID_SINCE = {'1d','7d','14d','30d'}`, `DEFAULTS.since='14d'`, `readUrl` runs on mount, `writeUrl` only fires from `set()`
- [x] `FiltersBar.tsx` Species input binds `speciesDraft` state; seeded via `useState` initializer from `speciesIndex`, re-synced by effect — 10s timeout absorbs the speciesIndex hydration race
- [x] CI seed: `('vermfly', 'Vermilion Flycatcher', ..., 'tyrannidae', ...)` — tests 3 & 4 have real data to match
- [x] Families + speciesIndex derive atomically in the same `useMemo` pass in `App.tsx` — no intermediate-state race
- [x] No source changes (`url-state.ts`, `FiltersBar.tsx`, `App.tsx`, `playwright.config.ts` untouched)
- [x] No `test.fail()`, no `page.reload()` — cold-load only
- [ ] Local Playwright E2E deferred — CI is authoritative

## Plan reference

Closes #29. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)