### PR TITLE
test(e2e): shared API stub fixture + migrate 2 consumers (#32)

### DIFF
--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 import AxeBuilder from '@axe-core/playwright';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
@@ -34,8 +34,8 @@ test.describe('axe-core WCAG scans', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('error screen has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
-    await page.route('**/api/regions', async route => { await route.abort(); });
+  test('error screen has no WCAG 2/2.1 A/AA violations', async ({ page, apiStub }) => {
+    await apiStub.stubApiAbort('regions');
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });

--- a/frontend/e2e/error-states.spec.ts
+++ b/frontend/e2e/error-states.spec.ts
@@ -1,33 +1,31 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures.js';
 
 test.describe('error screen', () => {
-  test('renders when /api/regions aborts', async ({ page }) => {
-    await page.route('**/api/regions', async route => { await route.abort(); });
+  test('renders when /api/regions aborts', async ({ page, apiStub }) => {
+    await apiStub.stubApiAbort('regions');
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
     await expect(page.locator('.error-screen p')).not.toBeEmpty();
   });
 
-  test('renders on 500 from /api/regions', async ({ page }) => {
-    await page.route('**/api/regions', async route => {
-      await route.fulfill({ status: 500, contentType: 'text/plain', body: 'boom' });
-    });
+  test('renders on 500 from /api/regions', async ({ page, apiStub }) => {
+    await apiStub.stubApiFailure('regions', 500);
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
     await expect(page.locator('.error-screen p')).not.toBeEmpty();
   });
 
-  test('renders when /api/observations fails even if regions+hotspots succeed', async ({ page }) => {
-    await page.route('**/api/observations**', async route => { await route.abort(); });
+  test('renders when /api/observations fails even if regions+hotspots succeed', async ({ page, apiStub }) => {
+    await apiStub.stubApiAbort('observations');
     await page.goto('/');
     await expect(page.locator('.error-screen h2'))
       .toHaveText("Couldn't load map data", { timeout: 10_000 });
   });
 
-  test('does not hang with aria-busy=true when API aborts', async ({ page }) => {
-    await page.route('**/api/regions', async route => { await route.abort(); });
+  test('does not hang with aria-busy=true when API aborts', async ({ page, apiStub }) => {
+    await apiStub.stubApiAbort('regions');
     await page.goto('/');
     // Either the error screen renders, or the map-wrap stops reporting busy.
     // Race them with Promise.race — first acceptable resolution wins.

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,6 +1,9 @@
 import { test as base } from '@playwright/test';
 import type { Observation } from '@bird-watch/shared-types';
 
+/** Read API endpoints that can be stubbed. Keep in sync with services/read-api/src/app.ts. */
+export type StubbableEndpoint = 'regions' | 'hotspots' | 'observations' | 'species';
+
 /**
  * Playwright route stubs for the Read API. Each helper registers a single
  * `page.route` handler; route handlers are LIFO, so a later registration
@@ -22,13 +25,13 @@ export interface ApiStub {
    * The trailing `**` tolerates query strings and sub-paths — endpoints
    * must not share a prefix with a sibling endpoint.
    */
-  stubApiFailure(endpoint: string, status: number): Promise<void>;
+  stubApiFailure(endpoint: StubbableEndpoint, status: number): Promise<void>;
   /**
    * Aborts `**\/api/${endpoint}**` at the network layer (no response).
    * Use for fetch-rejection paths (CORS, offline, DNS failure). For an
    * HTTP-level failure, use `stubApiFailure` instead.
    */
-  stubApiAbort(endpoint: string): Promise<void>;
+  stubApiAbort(endpoint: StubbableEndpoint): Promise<void>;
 }
 
 export const test = base.extend<{ apiStub: ApiStub }>({

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,10 +1,33 @@
 import { test as base } from '@playwright/test';
 import type { Observation } from '@bird-watch/shared-types';
 
+/**
+ * Playwright route stubs for the Read API. Each helper registers a single
+ * `page.route` handler; route handlers are LIFO, so a later registration
+ * wins over an earlier one for the same glob.
+ */
 export interface ApiStub {
+  /**
+   * Stubs the three list endpoints (`/api/regions`, `/api/hotspots`,
+   * `/api/observations`) to return `200 []`. Does NOT stub
+   * `/api/species/{code}` — add that route manually if your test
+   * exercises species detail lookup.
+   */
   stubEmpty(): Promise<void>;
+  /** Stubs `/api/observations` to return `200` with the provided list. */
   stubObservations(obs: Observation[]): Promise<void>;
+  /**
+   * Stubs `**\/api/${endpoint}**` to respond with HTTP `status` and a
+   * `text/plain` body. Use for HTTP-level error paths (500, 401, etc.).
+   * The trailing `**` tolerates query strings and sub-paths — endpoints
+   * must not share a prefix with a sibling endpoint.
+   */
   stubApiFailure(endpoint: string, status: number): Promise<void>;
+  /**
+   * Aborts `**\/api/${endpoint}**` at the network layer (no response).
+   * Use for fetch-rejection paths (CORS, offline, DNS failure). For an
+   * HTTP-level failure, use `stubApiFailure` instead.
+   */
   stubApiAbort(endpoint: string): Promise<void>;
 }
 

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,53 @@
+import { test as base } from '@playwright/test';
+import type { Observation } from '@bird-watch/shared-types';
+
+export interface ApiStub {
+  stubEmpty(): Promise<void>;
+  stubObservations(obs: Observation[]): Promise<void>;
+  stubApiFailure(endpoint: string, status: number): Promise<void>;
+  stubApiAbort(endpoint: string): Promise<void>;
+}
+
+export const test = base.extend<{ apiStub: ApiStub }>({
+  apiStub: async ({ page }, use) => {
+    const stub: ApiStub = {
+      async stubEmpty() {
+        await page.route('**/api/regions', async route => {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+        });
+        await page.route('**/api/hotspots', async route => {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+        });
+        await page.route('**/api/observations**', async route => {
+          await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+        });
+      },
+      async stubObservations(obs) {
+        await page.route('**/api/observations**', async route => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(obs),
+          });
+        });
+      },
+      async stubApiFailure(endpoint, status) {
+        await page.route(`**/api/${endpoint}**`, async route => {
+          await route.fulfill({
+            status,
+            contentType: 'text/plain',
+            body: `stubbed ${status}`,
+          });
+        });
+      },
+      async stubApiAbort(endpoint) {
+        await page.route(`**/api/${endpoint}**`, async route => {
+          await route.abort();
+        });
+      },
+    };
+    await use(stub);
+  },
+});
+
+export { expect } from '@playwright/test';


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "Fixture API"
        F[fixtures.ts] --> M1[stubEmpty<br/>regions/hotspots/observations → 200 array empty]
        F --> M2[stubObservations list<br/>observations → 200 provided JSON]
        F --> M3[stubApiFailure endpoint status<br/>HTTP-level fault 500/401/etc]
        F --> M4[stubApiAbort endpoint<br/>network-level fault CORS/offline]
    end

    subgraph Consumers
        E[error-states.spec.ts<br/>4 tests] -->|uses| M3
        E -->|uses| M4
        A[axe.spec.ts<br/>1 test] -->|uses| M4
    end

    Other[7 unmigrated specs<br/>happy-path, history-nav, filters,<br/>a11y, deep-link, region-collapse,<br/>prod-smoke.preview] -.->|import @playwright/test<br/>no fixture dependency| PW[real read-api]
```

## Summary

- Adds `frontend/e2e/fixtures.ts` exporting a custom `test` that extends Playwright's base with an `apiStub` fixture. Four methods: `stubEmpty`, `stubObservations(list)`, `stubApiFailure(endpoint, status)`, `stubApiAbort(endpoint)`. `stubApiAbort` is an addition beyond the issue spec because existing consumers use `route.abort()` (network fault) in addition to `route.fulfill` (HTTP fault) — each fault mode gets its own helper.
- Migrates 2 consumers: `error-states.spec.ts` (all 4 tests, replaces all 5 `page.route` calls) and `axe.spec.ts`'s error-screen test (replaces its 1 `page.route` call).
- Fixture is strictly additive. The 7 other specs continue to import from `@playwright/test` and hit the real read-api via the `webServer` block.
- Route handlers inside the fixture use `async route => { await route.X(); }` — matches the house style established in #26 (async/await on route handlers so rejections surface as test failures, not unhandled promise rejections).
- `Observation` type imported from `@bird-watch/shared-types` — first cross-workspace import in `frontend/e2e/`. Works because `frontend/package.json` already lists `@bird-watch/shared-types` as a prod dep.
- Glob widens from `**/api/regions` to `**/api/regions**` inside `stubApiFailure`/`stubApiAbort` for caller convenience. Verified against Playwright's urlMatch impl: no production URL matches the new glob that didn't match the old one — endpoints today have no subpaths and no query-string callers hit `/api/regions`.
- JSDoc added to the `ApiStub` interface per internal code review: documents `stubEmpty`'s exact scope (explicitly calls out the `/api/species/{code}` gap), disambiguates `stubApiFailure` (HTTP status) from `stubApiAbort` (network fault), and notes the glob-widening caveat.

## Screenshots

N/A — not UI. Test infrastructure only.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 33/33 unit tests pass
- [x] `Observation` type resolves from `@bird-watch/shared-types` — verified via `tsc` and `npx playwright test --list`
- [x] All 4 route handlers in `fixtures.ts` use `async route => { await route.X(); }` — rejections surface as test failures
- [x] Migrated `error-states.spec.ts` preserves semantics exactly: 4 tests, same assertions, same `Promise.race` in test 4
- [x] Migrated `axe.spec.ts` third test uses `apiStub.stubApiAbort('regions')`; first two tests unchanged (destructure only `{ page }`)
- [x] Unmigrated specs zero-diff (`git diff main..HEAD -- frontend/e2e/happy-path.spec.ts frontend/e2e/history-nav.spec.ts frontend/e2e/filters.spec.ts frontend/e2e/a11y.spec.ts frontend/e2e/deep-link.spec.ts frontend/e2e/region-collapse.spec.ts frontend/e2e/prod-smoke.preview.spec.ts` returns empty)
- [x] No source changes, no `playwright.config.ts` / `package.json` / `e2e.yml` changes — no new runtime deps
- [ ] Local Playwright E2E deferred — CI is authoritative

## Plan reference

Closes #32. Part of tracking issue #34 (E2E Playwright test suite expansion).
Execution plan: `/Users/j/.claude/plans/i-want-you-to-nifty-petal.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)