### PR TITLE
chore: ignore MCP snapshots, onboarding screenshots, tfstate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,18 @@ coverage/
 # Playwright output (screenshots, traces from local runs)
 frontend/.playwright-out/
 frontend/playwright-report/
+
+# Playwright MCP runtime artifacts — may contain page snapshots of credential
+# flows (API key creation, OAuth callbacks). Never commit.
+.playwright-mcp/
+cf-*.png
+page-*.png
+gcp-*.png
+
+# Terraform state (contains DB passwords + API tokens). Use remote state
+# instead; local tfstate should never be committed.
+terraform.tfstate
+terraform.tfstate.backup
+
+# Per-user Claude Code workspace
+.claude/


### PR DESCRIPTION
## Diagrams

```
local working tree                         .gitignore
──────────────────────────                 ──────────────
terraform.tfstate  ────────── rm ────┐
.playwright-mcp/   ─── (keep, ignore) │
cf-*.png (16 files)─── rm ────────────┼──► add patterns:
gcp-*.png (6 files)─── rm ────────────┤    .playwright-mcp/
.claude/           ─── (keep, ignore) ┤    cf-*.png, page-*.png, gcp-*.png
                                      │    terraform.tfstate(.backup)
                                      │    .claude/
                                      └──► secrets no longer committable
```

Two of the five patterns (`terraform.tfstate`, `.playwright-mcp/`) can contain credentials; the other three (`cf-*.png`, `gcp-*.png`, `.claude/`) are noise but the same rule keeps them from dirtying the tree on the next onboarding run.

## Summary

- Add five patterns to `.gitignore` so that local artifacts generated during the 2026-04-19 live deploy (tfstate, MCP snapshots, onboarding PNGs, per-user Claude Code workspace) cannot be accidentally staged.
- Remove 16 `cf-*.png`, 6 `gcp-*.png`, and `terraform.tfstate` from the working tree. All three were untracked — plain `rm` sufficed, no `git rm` needed.
- Deliberately leave `.claude/` on disk (it backs active git worktrees per issue #47 gotcha). The directory is ignored; not deleted.

## Screenshots

N/A — not UI.

## Test plan

- [x] `.gitignore` contains the five new pattern blocks. Verified by reading the file (see diff — lines 24–37).
- [x] Untracked files removed. Before: 16 cf-*.png + 6 gcp-*.png + terraform.tfstate at repo root. After:
  ```
  $ rm cf-*.png gcp-*.png terraform.tfstate
  $ ls cf-*.png gcp-*.png terraform.tfstate 2>/dev/null
  (no output — all missing)
  ```
- [x] `git status --short` no longer lists any of the four issue-flagged patterns:
  ```
  $ git status --short
   M .gitignore
  ?? docs/plans/2026-04-19-execute-issues-47-59.md
  ?? frontend/src/vite-env.d.ts
  ```
  (The two remaining untracked entries are out-of-scope: `docs/plans/...` is committed separately; `frontend/src/vite-env.d.ts` belongs to #48.)
- [x] `.claude/` directory not touched — its `worktrees/` subdir backs active git worktrees and must not be `rm -rf`'d.
- [x] Terraform remote backend check. `grep -n backend infra/terraform/*.tf` returned no matches, so no remote backend is configured. Opened follow-up issue #60 tagged `area:infra` to track configuring GCS as the remote state backend and rotating any credentials that previously lived in local tfstate.

## Plan reference

Out of plan — #47 (deployment cleanup). Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1 Task 1.1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
