### PR TITLE
feat(frontend): wire VITE_API_BASE_URL for prod cross-origin API

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://api.REPLACE_WITH_DOMAIN
+VITE_API_BASE_URL=https://api.bird-maps.com

--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from '@playwright/test';
 
 test.describe('production build smoke', () => {
   test('map renders 9 regions when served by vite preview', async ({ page }) => {
-    // Expected to fail today: preview runs with proxy: {} (vite.config.ts)
-    // so /api hits the static origin (no handler). The baseUrl fix will
-    // switch App.tsx to an env-driven absolute URL — when that lands, this
-    // test will start PASSING, which fails test.fail(). That's your cue
-    // to delete the annotation.
+    // Still expected to fail after the #48 baseUrl fix: the preview bundle
+    // now fetches http://localhost:8787/api/* cross-origin, but the read-api
+    // has no CORS middleware yet (tracked as #49 — paired with this PR).
+    // Delete test.fail() once #49 lands and the preflight/ACAO headers are
+    // in place.
     test.fail();
     await page.goto('/');
     const regions = page.locator('[data-region-id]');

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -50,8 +50,17 @@ export default defineConfig({
       timeout: 30_000,
     },
     {
-      // Build and start Vite preview on port 4173 (no /api proxy — surfaces the baseUrl bug)
-      command: 'npm run build && npm run preview -- --port 4173 --strictPort',
+      // Build and start Vite preview on port 4173.
+      // VITE_API_BASE_URL points at the read-api webServer (8787) so the
+      // preview bundle — which runs without the dev proxy (see preview.proxy
+      // in vite.config.ts) — fetches the API cross-origin, mirroring the
+      // Cloudflare Pages + Cloud Run split in production. This requires CORS
+      // on the read-api; see services/read-api/src/app.ts. Without this
+      // override, `npm run build` would inline .env.production's
+      // https://api.bird-maps.com and the test would hit (or fail to reach)
+      // real production.
+      command:
+        'VITE_API_BASE_URL=http://localhost:8787 npm run build && npm run preview -- --port 4173 --strictPort',
       cwd: __dirname,
       url: 'http://localhost:4173',
       reuseExistingServer: !process.env.CI,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { FiltersBar } from './components/FiltersBar.js';
 import { deriveFamilies, deriveSpeciesIndex } from './derived.js';
 import { colorForFamily } from '@bird-watch/family-mapping';
 
-const apiClient = new ApiClient({ baseUrl: '' });
+const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? '' });
 
 // Generic bird silhouette SVG path used for every badge (MVP).
 // Each family is distinguished by color. A future enhancement can fetch

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Prod[Production]
        CFPages[Cloudflare Pages<br/>bird-maps.com] -- fetch --> CR[Cloud Run<br/>api.bird-maps.com]
    end
    subgraph Dev[Local dev]
        Vite[vite dev :5173] -- /api proxy --> RA[read-api :8787]
    end
    subgraph Preview[Preview-build E2E]
        VitePreview[vite preview :4173] -- cross-origin --> RA2[read-api :8787<br/>needs CORS #49]
    end

    App[App.tsx] -. reads .-> EnvVar[VITE_API_BASE_URL]
    EnvVar -. prod .-> CFPages
    EnvVar -. dev '' .-> Vite
    EnvVar -. preview localhost:8787 .-> VitePreview
```

## Summary

- `App.tsx` now sources `baseUrl` from `import.meta.env.VITE_API_BASE_URL`, falling back to `''` so `npm run dev` keeps using the Vite proxy.
- `frontend/.env.production` sets the real Cloud Run hostname (`https://api.bird-maps.com`); `frontend/src/vite-env.d.ts` types the new env var for tsc.
- Preview-build Playwright webServer now injects `VITE_API_BASE_URL=http://localhost:8787` at build time so the preview bundle hits the local read-api (mirroring the prod cross-origin split) instead of baking in the real prod domain.

## Screenshots

N/A — config plumbing, no visible change. The change affects which origin `fetch` targets; the rendered UI is identical in the dev flow (vite proxy hides the difference).

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — types check, clean prod build

  ```
  > @bird-watch/frontend@0.0.1 build
  > tsc -b && vite build

  vite v5.4.21 building for production...
  transforming...
  ✓ 43 modules transformed.
  dist/index.html                   0.41 kB │ gzip:  0.28 kB
  dist/assets/index-BjDvnfFx.css    1.00 kB │ gzip:  0.54 kB
  dist/assets/index-DCx2e0R7.js   154.41 kB │ gzip: 50.05 kB
  ✓ built in 347ms
  ```

- [x] `npm run dev` boots with no TS errors (Vite v5.4.21 ready in 104 ms).

- [x] `npx playwright test --project=preview-build` — 1 passed (inverts via `test.fail()`; see gotcha below).

- [x] `npx playwright test --project=dev-server` — 21 passed with `.env.local` absent (mirrors CI). 4 failures in `filters.spec.ts` + `deep-link.spec.ts` reproduced on clean `main` and are pre-existing (species input / overflow-pip labeling); unrelated to this PR's scope.

### Gotchas

- **`test.fail()` at `frontend/e2e/prod-smoke.preview.spec.ts:10` is intentionally retained.** Issue #48's acceptance criteria ask for its removal, but empirically removing it causes the preview-build spec to fail because the newly cross-origin preview bundle cannot reach `localhost:8787` until the read-api gains CORS (tracked in #49). The comment has been updated to reference #49 so the next PR deletes `test.fail()` at the same time the preflight/ACAO headers land. This is the "defer and flag" path from the execution instructions, not a silent skip.
- **Local `.env.local` shadows `.env.production` during `vite preview` / `vite dev`.** CI runners don't have `.env.local`; Playwright's preview-build webServer passes `VITE_API_BASE_URL=http://localhost:8787` inline so the build doesn't inline the real `https://api.bird-maps.com`. Developers whose `.env.local` sets `VITE_API_BASE_URL=http://localhost:8787` will see dev-server Playwright runs fail on CORS — remove or set to `''` for local Playwright runs.

## Plan reference

Out of plan — #48 (deployment cleanup). Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1 Task 1.2).

---

Generated with [Claude Code](https://claude.com/claude-code)
