### PR TITLE
feat(read-api): CORS middleware for cross-origin frontend

### DIFF
--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -2,12 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('production build smoke', () => {
   test('map renders 9 regions when served by vite preview', async ({ page }) => {
-    // Still expected to fail after the #48 baseUrl fix: the preview bundle
-    // now fetches http://localhost:8787/api/* cross-origin, but the read-api
-    // has no CORS middleware yet (tracked as #49 — paired with this PR).
-    // Delete test.fail() once #49 lands and the preflight/ACAO headers are
-    // in place.
-    test.fail();
+    // Preview bundle fetches http://localhost:8787/api/* cross-origin; the
+    // read-api's CORS middleware (#49) ships the required preflight + ACAO
+    // headers so this now passes end-to-end against a live read-api.
     await page.goto('/');
     const regions = page.locator('[data-region-id]');
     await expect(regions).toHaveCount(9, { timeout: 15_000 });

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -141,3 +141,91 @@ describe('GET /api/species/:code', () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe('CORS middleware', () => {
+  // Save + restore FRONTEND_ORIGINS around tests that mutate it so other
+  // describe blocks stay deterministic.
+  const ORIGINAL_FRONTEND_ORIGINS = process.env.FRONTEND_ORIGINS;
+  afterAll(() => {
+    if (ORIGINAL_FRONTEND_ORIGINS === undefined) {
+      delete process.env.FRONTEND_ORIGINS;
+    } else {
+      process.env.FRONTEND_ORIGINS = ORIGINAL_FRONTEND_ORIGINS;
+    }
+  });
+
+  it('returns Access-Control-Allow-Origin for an allow-listed origin', async () => {
+    delete process.env.FRONTEND_ORIGINS; // use default allowlist
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/regions', {
+      headers: { Origin: 'https://bird-maps.com' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin'))
+      .toBe('https://bird-maps.com');
+  });
+
+  it('omits Access-Control-Allow-Origin for a disallowed origin', async () => {
+    delete process.env.FRONTEND_ORIGINS;
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/regions', {
+      headers: { Origin: 'https://evil.example' },
+    });
+    // Hono's cors omits the ACAO header entirely (rather than echoing) for
+    // origins not in the allowlist — browsers treat the absence as a block.
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('responds 204 to an OPTIONS preflight with allow-methods: GET', async () => {
+    delete process.env.FRONTEND_ORIGINS;
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://bird-maps.com',
+        'Access-Control-Request-Method': 'GET',
+      },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin'))
+      .toBe('https://bird-maps.com');
+    // Header value may be a single method or CSV; assert GET is present.
+    expect(res.headers.get('access-control-allow-methods') ?? '')
+      .toMatch(/GET/);
+  });
+
+  it('trims whitespace when parsing FRONTEND_ORIGINS', async () => {
+    // Leading/trailing whitespace in each comma-separated entry must be
+    // stripped; otherwise Hono's array-origin matcher (strict .includes)
+    // silently rejects the browser's exact Origin header.
+    process.env.FRONTEND_ORIGINS = ' https://a.test , https://b.test ';
+    const app = createApp({ pool: db.pool });
+    const resA = await app.request('/api/regions', {
+      headers: { Origin: 'https://a.test' },
+    });
+    const resB = await app.request('/api/regions', {
+      headers: { Origin: 'https://b.test' },
+    });
+    expect(resA.headers.get('access-control-allow-origin')).toBe('https://a.test');
+    expect(resB.headers.get('access-control-allow-origin')).toBe('https://b.test');
+  });
+
+  it('sets Vary: Origin on a cached route so CDN keys per-origin', async () => {
+    // `/api/regions` is served with `Cache-Control: public, immutable`. With
+    // `Vary: Origin`, a spec-compliant CDN caches a separate entry per
+    // Origin. That multiplies the cache namespace N× for N allowed origins
+    // (trivial at 3, callable-out if that grows) but keeps the ACAO header
+    // correct for each cached response. The body itself is Origin-agnostic.
+    delete process.env.FRONTEND_ORIGINS;
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/regions', {
+      headers: { Origin: 'https://bird-maps.com' },
+    });
+    expect(res.status).toBe(200);
+    const vary = res.headers.get('vary') ?? '';
+    expect(vary.toLowerCase()).toContain('origin');
+    // Coexists with route-level Cache-Control.
+    expect(res.headers.get('cache-control'))
+      .toBe('public, max-age=604800, immutable');
+  });
+});

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 import type { Pool } from '@bird-watch/db-client';
 import { getRegions, getHotspots, getObservations, getSpeciesMeta } from '@bird-watch/db-client';
 import { cacheControlFor } from './cache-headers.js';
@@ -9,6 +10,33 @@ export interface AppDeps {
 
 export function createApp(deps: AppDeps): Hono {
   const app = new Hono();
+
+  // Parse the CORS allowlist. `trim` + `filter(Boolean)` so that a value like
+  // "https://a.test, https://b.test" (comma-space) and stray empty entries
+  // ("a,,b") both round-trip correctly; Hono's array-origin matcher uses
+  // strict `.includes(origin)` against the browser's exact Origin header, so
+  // any leftover whitespace silently breaks CORS for that entry.
+  const origins = (process.env.FRONTEND_ORIGINS ??
+    'https://bird-maps.com,https://www.bird-maps.com,http://localhost:5173,http://localhost:4173'
+  ).split(',').map(s => s.trim()).filter(Boolean);
+
+  // CORS must be registered BEFORE route handlers — otherwise preflight
+  // requests (OPTIONS without a matching route handler) 404.
+  //
+  // Interaction with route-level `Cache-Control: public, immutable` on
+  // /api/regions and /api/species/:code: Hono sets `Vary: Origin`, so a
+  // spec-compliant CDN keys the cache per-Origin. That means the identical
+  // JSON body is stored N× for N allowed origins (currently 3 — trivial).
+  // Uptime probes and plain `curl` hit these routes without an Origin
+  // header, so the CDN also caches a no-ACAO entry; browsers never see that
+  // entry because Cloud CDN honors Vary. The cached bodies contain no
+  // Origin-derived data, so serving any cached entry across origins would
+  // still be correct — `Vary: Origin` is purely for header correctness.
+  app.use('*', cors({
+    origin: origins,
+    allowMethods: ['GET'],
+    maxAge: 86400,
+  }));
 
   app.get('/health', c => c.json({ ok: true }));
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser as Browser<br/>(bird-maps.com)
    participant CDN as Cloud CDN
    participant API as Read API<br/>(api.bird-maps.com)

    Browser->>CDN: OPTIONS /api/regions<br/>Origin: https://bird-maps.com
    CDN->>API: OPTIONS /api/regions
    API-->>CDN: 204<br/>ACAO: https://bird-maps.com<br/>Allow-Methods: GET<br/>Max-Age: 86400
    CDN-->>Browser: 204 (cached 86400s)

    Browser->>CDN: GET /api/regions<br/>Origin: https://bird-maps.com
    CDN->>API: GET /api/regions
    API-->>CDN: 200<br/>Cache-Control: public, immutable<br/>Vary: Origin<br/>ACAO: https://bird-maps.com
    CDN-->>Browser: 200 (keyed per-Origin)
```

## Summary

- Install `hono/cors` on `services/read-api/src/app.ts` so the CF-Pages frontend at `bird-maps.com` can actually talk to `api.bird-maps.com` cross-origin — without this, every browser request is blocked and the map never loads.
- Allowlist parsed with `split.trim.filter` because Hono's array-origin matcher uses strict `.includes`, and `FRONTEND_ORIGINS=" a , b "` (comma-space, leading/trailing whitespace) would silently reject both origins without the trim step.
- Documents the `Vary: Origin` × `Cache-Control: public, immutable` interaction in-code: the CDN cache namespace fragments N× per allowed origin, which is trivial at 3 but worth flagging for future growth. Cached bodies are Origin-agnostic.
- Also removes the `test.fail()` marker on `frontend/e2e/prod-smoke.preview.spec.ts` that PR #66 left in with a pointer at #49 — the preview-build project now passes end-to-end.

## Screenshots

N/A — not UI. Read API middleware only.

## Test plan

- [x] `npm test -w @bird-watch/read-api` — 20/20 pass (4 new CORS tests: allowed origin, disallowed origin, OPTIONS preflight 204, whitespace-trim, Vary: Origin)
- [x] `npm run build -w @bird-watch/read-api` — clean
- [x] `npx playwright test --project=preview-build` — 1/1 pass with `test.fail()` removed (run locally against live read-api + vite preview on ports 8787/4173)
- [x] Manual curl verification: allowed Origin receives ACAO header echoed, disallowed Origin receives no ACAO header, OPTIONS preflight returns 204 with `Access-Control-Allow-Methods: GET`

Concrete run (CORS tests only, full file runs 20/20):

```
 ✓ src/app.test.ts > CORS middleware > returns Access-Control-Allow-Origin for an allow-listed origin
 ✓ src/app.test.ts > CORS middleware > omits Access-Control-Allow-Origin for a disallowed origin
 ✓ src/app.test.ts > CORS middleware > responds 204 to an OPTIONS preflight with allow-methods: GET
 ✓ src/app.test.ts > CORS middleware > trims whitespace when parsing FRONTEND_ORIGINS
 ✓ src/app.test.ts > CORS middleware > sets Vary: Origin on a cached route so CDN keys per-origin
```

## Plan reference

Out of plan — #49 (deployment cleanup). Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1 Task 1.3).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
