### PR TITLE
fix(infra): Neon free-tier compatibility — org_id + single RW endpoint + 6h retention

### DIFF
--- a/infra/terraform/db.tf
+++ b/infra/terraform/db.tf
@@ -1,37 +1,35 @@
 resource "neon_project" "birdwatch" {
+  org_id     = var.neon_org_id
   name       = "bird-watch"
   region_id  = "aws-us-west-2" # close to gcp_region
   pg_version = 16
-}
 
-resource "neon_branch" "main" {
-  project_id = neon_project.birdwatch.id
-  name       = "main"
+  # Neon Free tier caps history retention at 6h (21600s). Exceeding this
+  # causes the Neon API to reject the project-create request.
+  # See: https://neon.tech/docs/introduction/plans
+  history_retention_seconds = 21600
 }
 
 resource "neon_database" "main" {
   project_id = neon_project.birdwatch.id
-  branch_id  = neon_branch.main.id
+  branch_id  = neon_project.birdwatch.default_branch_id
   name       = "birdwatch"
   owner_name = neon_project.birdwatch.database_user
 }
 
-# Endpoint with pooled connection enabled — required for serverless.
-resource "neon_endpoint" "main" {
-  project_id     = neon_project.birdwatch.id
-  branch_id      = neon_branch.main.id
-  type           = "read_write"
-  pooler_enabled = true
-}
+# Neon Free tier permits ONE read_write endpoint per branch; the project's
+# auto-created default endpoint occupies that slot. Defining a second
+# `neon_endpoint` of type `read_write` here would cause Neon to reject the
+# apply. We rely on the default endpoint exposed via `database_host` /
+# `database_host_pooler` on the project resource (added in kislerdm/neon
+# v0.7.0), so no separate endpoint resource is needed.
 
-# neon_project exposes database_host_pooler directly (added in provider v0.7.0),
-# so no regex manipulation is needed.
 locals {
   neon_pooled_url = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_project.birdwatch.database_host_pooler}/${neon_database.main.name}?sslmode=require"
 }
 
 output "neon_db_url" {
-  value     = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_endpoint.main.host}/${neon_database.main.name}?sslmode=require"
+  value     = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_project.birdwatch.database_host}/${neon_database.main.name}?sslmode=require"
   sensitive = true
 }
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,6 +1,7 @@
 gcp_project_id        = "REPLACE_ME"
 gcp_region            = "us-west1"
 neon_api_key          = "REPLACE_ME"
+neon_org_id           = "REPLACE_ME"
 cloudflare_account_id = "REPLACE_ME"
 cloudflare_api_token  = "REPLACE_ME"
 cloudflare_zone_id    = "REPLACE_ME"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -15,6 +15,11 @@ variable "neon_api_key" {
   description = "Neon API key (Neon dashboard → Settings → API keys)."
 }
 
+variable "neon_org_id" {
+  type        = string
+  description = "Neon organization ID (visible in console URL after sign-in, e.g. org-green-boat-15736536)."
+}
+
 variable "cloudflare_account_id" {
   type        = string
   description = "Cloudflare account ID (used for Pages + DNS only)."

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     neon = {
       source  = "kislerdm/neon"
-      version = "~> 0.6"
+      version = "~> 0.7"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph TF["infra/terraform/db.tf (new)"]
      NP["neon_project.birdwatch<br/>org_id = var.neon_org_id<br/>history_retention_seconds = 21600"]
      ND["neon_database.main<br/>branch_id = NP.default_branch_id"]
      NP -->|default branch + default RW endpoint| ND
    end

    subgraph LIVE["bird-maps-prod (live, manually bootstrapped 2026-04-19)"]
      NPL["neon_project (existing)"]
      NBL["default branch + default endpoint (pre-existing)"]
      NPL --> NBL
    end

    TF -. "Option C: fresh workspace only — live state untouched" .-> LIVE
```

```mermaid
flowchart TB
    A["Fresh Neon free-tier account"] --> B{"terraform apply"}
    B -->|"OLD db.tf"| X1["FAIL: org_id required"]
    B -->|"OLD db.tf"| X2["FAIL: 2nd read_write endpoint rejected"]
    B -->|"OLD db.tf"| X3["FAIL: history_retention exceeds 6h cap"]
    B -->|"NEW db.tf (this PR)"| OK["SUCCESS: project + default branch + default endpoint + database"]
```

## Summary

- Neon free-tier now rejects the Plan-5 `db.tf` for three reasons — missing `org_id`, a second `read_write` endpoint (only one allowed per branch), and a history-retention value that exceeds the 6h cap. This PR fixes all three in one go so a brand-new Neon account can `terraform apply` cleanly.
- Drops the standalone `neon_branch.main` and `neon_endpoint.main` in favor of the project's auto-created defaults (surfaced via `default_branch_id`, `database_host`, and `database_host_pooler` on `neon_project` as of kislerdm/neon v0.7.0). Bumps the `versions.tf` pin from `~> 0.6` to `~> 0.7` — identified as a BLOCKER by the Wave 0.5 bot spec review.
- Adds `neon_org_id` as a new required Terraform variable (plus matching `.tfvars.example` entry) and documents the 6h retention cap inline with a link to the Neon plans page so the next reader can verify if Neon ever changes the cap.

## Screenshots

N/A — infra-only, no UI changes.

## Test plan

- [x] `terraform init -upgrade` — providers resolve cleanly with the new `~> 0.7` constraint (kislerdm/neon v0.13.0 selected from the compatible range).
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform plan` against the live `bird-maps-prod` state — zero drift on Neon resources (`neon_project.birdwatch`, `neon_database.main` both refresh as "No changes" when targeted). Remaining drift in the full plan (`cloudflare_record.api`, `cloudflare_record.root`, `google_cloud_run_domain_mapping.api`, `google_cloud_run_v2_service.read_api`) is pre-existing and unrelated to this issue.
- [ ] `terraform apply` against a fresh Neon free-tier account — **not executed.** No clean Neon account available to the implementer; verification stops at `validate` + targeted `plan`. The three failure modes were reproduced on the bootstrap run of 2026-04-19 (see commit `d32bc34` era notes) and are the reason this PR exists; the fixes are the direct inverse of those errors.

### Migration strategy

**Option C — fresh-workspace-only.** The live `bird-maps-prod` Neon project (`shiny-recipe-46896370`) was bootstrapped manually on 2026-04-19 rather than via the Plan-5 Terraform config, so it is **already** structured as a project with a default branch + default read-write endpoint (no standalone `neon_branch` / `neon_endpoint` resources). The targeted `terraform plan` above confirms the new config matches live state exactly — no destroy-and-recreate, no state surgery required. This PR therefore applies cleanly to brand-new workspaces AND to the existing live workspace; Options A (`moved {}`) and B (`terraform state rm` + import) were unnecessary. Future fresh Neon free-tier accounts will succeed on the first `terraform apply` where the Plan-5 original would have failed.

Note: this is the safest possible rollout — live infra stays untouched, and the test surface is only the fresh-account path that was previously broken.

## Plan reference

Out of plan — #50. Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1 Task 1.4).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
