### PR TITLE
fix(infra): apex DNS + Cloud Run domain mapping for api subdomain

### DIFF
--- a/infra/terraform/frontend.tf
+++ b/infra/terraform/frontend.tf
@@ -10,15 +10,54 @@ resource "cloudflare_pages_domain" "root" {
   domain       = var.domain
 }
 
-# Subdomain "api" → CNAME to the Cloud Run service URL (proxied through Cloudflare for caching).
+# Apex "@" → CNAME to the Pages project's auto-assigned pages.dev subdomain.
+# cloudflare_pages_domain binds the domain on the Pages side but does NOT
+# create the DNS record; without this resource the zone serves NXDOMAIN for
+# the apex. Reference the provider-exposed `subdomain` attribute rather than
+# hardcoding "birdwatch-1xe.pages.dev" — if the project is ever recreated,
+# Cloudflare may assign a different pages.dev suffix. proxied=true lets CF
+# auto-flatten the apex CNAME.
+resource "cloudflare_record" "root" {
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  type    = "CNAME"
+  content = cloudflare_pages_project.frontend.subdomain
+  proxied = true
+  ttl     = 1
+}
+
+# Subdomain "api" → CNAME to Cloud Run's documented CNAME target.
+# Cloud Run rejects requests whose Host header is not a registered domain
+# mapping, so pointing straight at the run.app URL returns 404. The canonical
+# path is a CNAME to ghs.googlehosted.com plus a google_cloud_run_domain_mapping
+# below; proxied MUST be false so Cloud Run's own Let's Encrypt cert serves
+# (proxying through Cloudflare breaks the SSL handshake).
 resource "cloudflare_record" "api" {
   zone_id = var.cloudflare_zone_id
   name    = "api"
   type    = "CNAME"
-  # Strip protocol; CF wants just the host
-  value   = trimprefix(google_cloud_run_v2_service.read_api.uri, "https://")
-  proxied = true
+  content = "ghs.googlehosted.com"
+  proxied = false
   ttl     = 1
+}
+
+# NOTE: google_cloud_run_domain_mapping is the v1-Knative resource. The rest
+# of the infra uses google_cloud_run_v2_service, but the v2 provider does
+# not yet expose a domain-mapping resource; the v1 resource is the canonical
+# path and the v1/v2 mix is intentional here. Prerequisite: the operator
+# must verify `var.domain` in Google Search Console (one-time out-of-band
+# TXT record) before `terraform apply` — otherwise this resource fails.
+resource "google_cloud_run_domain_mapping" "api" {
+  location = var.gcp_region
+  name     = "api.${var.domain}"
+
+  metadata {
+    namespace = var.gcp_project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.read_api.name
+  }
 }
 
 output "api_url" {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Browser -->|https://bird-maps.com| CF1[Cloudflare apex<br/>CNAME @ → pages.dev<br/>proxied=true]
    CF1 --> Pages[Cloudflare Pages<br/>birdwatch project]

    Browser2[Browser] -->|https://api.bird-maps.com| CF2[Cloudflare api<br/>CNAME → ghs.googlehosted.com<br/>proxied=false]
    CF2 --> GHS[ghs.googlehosted.com]
    GHS --> Mapping[google_cloud_run_domain_mapping.api<br/>v1 Knative]
    Mapping --> Run[google_cloud_run_v2_service.read_api]
```

```mermaid
flowchart TB
    subgraph Before[Before - both broken]
        B1[apex bird-maps.com] -.->|no DNS record| NX[NXDOMAIN]
        B2[api.bird-maps.com] -->|CNAME proxied to run.app| R404[Cloud Run 404<br/>unknown host header]
    end
    subgraph After[After]
        A1[apex bird-maps.com] -->|CNAME to pages.dev| OK1[Pages 200]
        A2[api.bird-maps.com] -->|CNAME ghs.googlehosted.com + domain mapping| OK2[Cloud Run 200]
    end
```

## Summary

- Add `cloudflare_record.root` so the apex actually resolves — `cloudflare_pages_domain` only binds the hostname on the Pages side, it does not create a DNS record. Content sources from `cloudflare_pages_project.frontend.subdomain` (not a hardcoded `birdwatch-1xe.pages.dev`) so recreating the project does not silently break the apex.
- Flip `cloudflare_record.api` to target `ghs.googlehosted.com` with `proxied = false`, and register the mapping via `google_cloud_run_domain_mapping.api`. Cloud Run 404s on unknown Host headers, and CF-proxying breaks its Let's Encrypt handshake — both undoing the previous configuration.
- The v1-Knative `google_cloud_run_domain_mapping` is used intentionally; the v2 provider does not yet expose a domain-mapping resource, so the v1/v2 mix is canonical for now (noted inline).

## Screenshots

N/A — not UI (Terraform config only).

## Test plan

- [x] `terraform init` — OK (providers: cloudflare ~> 4.52, google ~> 5.45 already in lock file)
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform plan` — shows no changes to the three resources touched here (they already exist in state from the on-disk patch); only drift is an unrelated `client`/`client_version` scrub on `google_cloud_run_v2_service.read_api`:

  ```
  Plan: 0 to add, 1 to change, 0 to destroy.
    # google_cloud_run_v2_service.read_api will be updated in-place
    ~ resource "google_cloud_run_v2_service" "read_api" {
        - client                  = "gcloud" -> null
        - client_version          = "565.0.0" -> null
      }
  ```

- [ ] **Operator prerequisite (one-time, out-of-band):** verify `bird-maps.com` in [Google Search Console](https://search.google.com/search-console) via TXT record BEFORE `terraform apply` — `google_cloud_run_domain_mapping` fails otherwise with `Domain is not verified for the given caller`.
- [ ] After apply: `curl -sI https://bird-maps.com` returns 200
- [ ] After apply: `curl -sI https://api.bird-maps.com/health` returns 200 with `{ok:true}`
- [ ] Note: Cloud Run + Let's Encrypt cert provisioning for `api.bird-maps.com` can take 5–15 minutes post-apply; first hit may 502/SSL-fail during that window.

## Plan reference

Out of plan — #51. Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1 Task 1.5).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
