### PR TITLE
docs(plan-5): sync with actually-shipped code from PRs #47-#51

### DIFF
--- a/docs/plans/2026-04-16-plan-5-infra-terraform.md
+++ b/docs/plans/2026-04-16-plan-5-infra-terraform.md
@@ -338,7 +338,7 @@ npx node-pg-migrate up -m migrations -d "$DATABASE_URL"
 echo "Done."
 ```
 
-> Note (#52 follow-up): `node-pg-migrate`'s `-d` flag takes the **connection string itself**, not the name of an env var — a subtle but important distinction vs. the older `-d DATABASE_URL` usage (which would look up `process.env.DATABASE_URL`). Both happen to work in practice because the env var is also set, but the explicit pass is canonical. The CD workflow that runs this script on every push (issue #65, Wave 1.5 — not yet shipped) is what bundles issue #52's scripted variant. Until then, run locally from a trusted workstation.
+> Note (#52 follow-up): `node-pg-migrate`'s `-d` / `--database-url-var` flag takes the **NAME of an env var** that contains the connection string — NOT the connection string itself (per the CLI docs at salsita.github.io/node-pg-migrate/cli; default value is `DATABASE_URL`). The snippet above writes `-d "$DATABASE_URL"`, which bash expands shell-side into the literal URL; `node-pg-migrate` then treats that URL as an env var name, fails the lookup, and falls back to its default of reading `process.env.DATABASE_URL`. It works by accident. The canonical form is `-d DATABASE_URL` (the literal variable name, unexpanded) — that is what issue #52 tracks and what the Wave 1.5 CD workflow (issue #65, not yet shipped) will ship. Until then, run locally from a trusted workstation and be aware the `"$DATABASE_URL"` form is load-bearing only because the env var is also exported.
 
 - [ ] **Step 2: Make executable + run**
 

--- a/docs/plans/2026-04-16-plan-5-infra-terraform.md
+++ b/docs/plans/2026-04-16-plan-5-infra-terraform.md
@@ -14,6 +14,18 @@
 
 ---
 
+## Prerequisites (one-time manual steps, NOT automatable)
+
+These two steps must be completed out-of-band **before** the first `terraform apply`; otherwise the relevant Terraform resources will fail in ways that aren't obvious from the error message.
+
+1. **Obtain `neon_org_id`.** The `kislerdm/neon` provider v0.7+ requires an organization ID on every `neon_project` — there is no default-org inference. Sign in to [console.neon.tech](https://console.neon.tech) and grab the org id from the URL (e.g. `org-green-boat-15736536`). Put it in `terraform.tfvars` as `neon_org_id`. Without this, `terraform apply` on a fresh Neon free-tier account fails with an opaque API error on the `neon_project` create step — see PR #68 (commit `6b92790`) for the full diagnosis.
+
+2. **Verify `var.domain` in Google Search Console.** The `google_cloud_run_domain_mapping` resource in Task 9 will fail to apply unless Google has verified you own the domain. Go to [search.google.com/search-console](https://search.google.com/search-console), add `var.domain` as a property, and add the TXT record Google shows you to the zone at your DNS provider (Cloudflare, in our case). Wait for Search Console to confirm verification (usually <1 min after the record propagates). Only then run `terraform apply`. See PR #69 (commit `c01924e`).
+
+Both of these are genuinely one-time (per-account, per-domain). They live here because subagents re-executing this plan verbatim will otherwise hit a wall at Task 2 and Task 9 respectively.
+
+---
+
 ### Task 1: Scaffold the `infra/` directory + provider config
 
 **Files:**
@@ -35,7 +47,11 @@ terraform {
     }
     neon = {
       source  = "kislerdm/neon"
-      version = "~> 0.6"
+      # 0.7+ is required: it exposes `database_host` / `database_host_pooler`
+      # attributes on `neon_project` (so we don't need a regex to derive the
+      # pooled host) and adds the now-mandatory `org_id` argument. See Task 2
+      # and PR #68 (commit 6b92790).
+      version = "~> 0.7"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
@@ -67,6 +83,11 @@ variable "neon_api_key" {
   type        = string
   sensitive   = true
   description = "Neon API key (Neon dashboard → Settings → API keys)."
+}
+
+variable "neon_org_id" {
+  type        = string
+  description = "Neon organization ID (visible in console URL after sign-in, e.g. org-green-boat-15736536). Required by kislerdm/neon v0.7+; there is no default-org inference."
 }
 
 variable "cloudflare_account_id" {
@@ -138,6 +159,7 @@ resource "google_project_service" "secretmanager" {
 gcp_project_id        = "REPLACE_ME"
 gcp_region            = "us-west1"
 neon_api_key          = "REPLACE_ME"
+neon_org_id           = "REPLACE_ME"
 cloudflare_account_id = "REPLACE_ME"
 cloudflare_api_token  = "REPLACE_ME"
 cloudflare_zone_id    = "REPLACE_ME"
@@ -147,6 +169,8 @@ domain                = "birdwatch.example.com"
 
 - [ ] **Step 5: Write `.gitignore`**
 
+`infra/terraform/.gitignore` (local to the Terraform dir):
+
 ```
 .terraform/
 .terraform.lock.hcl
@@ -155,6 +179,27 @@ terraform.tfstate.backup
 terraform.tfvars
 *.auto.tfvars
 ```
+
+ALSO append the following to the **repo-root** `.gitignore`. These patterns exist because actively hazardous files leaked into the working tree during the 2026-04-19 live deploy, and subsequent runs will re-create them. Source of truth: PR #61 (commit `86ca45d`).
+
+```
+# Playwright MCP runtime artifacts — may contain page snapshots of credential
+# flows (API key creation, OAuth callbacks). Never commit.
+.playwright-mcp/
+cf-*.png
+page-*.png
+gcp-*.png
+
+# Terraform state (contains DB passwords + API tokens). Use remote state
+# instead; local tfstate should never be committed.
+terraform.tfstate
+terraform.tfstate.backup
+
+# Per-user Claude Code workspace
+.claude/
+```
+
+Why this matters: `terraform.tfstate` contains the Neon DB password and Cloudflare API token in plaintext. `.playwright-mcp/*.yml` snapshots capture DOM of whatever tab is open — including credential-entry flows. The `cf-*.png` / `gcp-*.png` / `page-*.png` patterns block the onboarding screenshots Playwright MCP saves at repo root during CF and GCP setup (22 files during the 2026-04-19 onboarding).
 
 - [ ] **Step 6: Authenticate gcloud and Terraform**
 
@@ -190,44 +235,41 @@ git commit -m "infra: scaffold Terraform with GCP + Neon + Cloudflare providers"
 
 - [ ] **Step 1: Write `db.tf`**
 
+Source of truth: shipped in PR #68 (commit `6b92790`). Three Neon-free-tier landmines are cleared in this version — each is commented inline below. Do not simplify these away without verifying against the current Neon plan limits at https://neon.tech/docs/introduction/plans.
+
 ```hcl
 resource "neon_project" "birdwatch" {
+  org_id     = var.neon_org_id
   name       = "bird-watch"
-  region_id  = "aws-us-west-2"  # close to gcp_region
+  region_id  = "aws-us-west-2" # close to gcp_region
   pg_version = 16
-}
 
-resource "neon_branch" "main" {
-  project_id = neon_project.birdwatch.id
-  name       = "main"
+  # Neon Free tier caps history retention at 6h (21600s). Exceeding this
+  # causes the Neon API to reject the project-create request.
+  # See: https://neon.tech/docs/introduction/plans
+  history_retention_seconds = 21600
 }
 
 resource "neon_database" "main" {
   project_id = neon_project.birdwatch.id
-  branch_id  = neon_branch.main.id
+  branch_id  = neon_project.birdwatch.default_branch_id
   name       = "birdwatch"
-  owner_name = neon_project.birdwatch.default_role_name
+  owner_name = neon_project.birdwatch.database_user
 }
 
-# Endpoint with pooled connection enabled — required for serverless.
-resource "neon_endpoint" "main" {
-  project_id = neon_project.birdwatch.id
-  branch_id  = neon_branch.main.id
-  type       = "read_write"
-  pooler_enabled = true
-}
+# Neon Free tier permits ONE read_write endpoint per branch; the project's
+# auto-created default endpoint occupies that slot. Defining a second
+# `neon_endpoint` of type `read_write` here would cause Neon to reject the
+# apply. We rely on the default endpoint exposed via `database_host` /
+# `database_host_pooler` on the project resource (added in kislerdm/neon
+# v0.7.0), so no separate endpoint resource is needed.
 
-# Neon inserts "-pooler" after the endpoint id (the first dot-separated
-# segment of the host), NOT before ".neon.tech":
-#   ep-cool-xxx.us-east-2.aws.neon.tech         (direct)
-#   ep-cool-xxx-pooler.us-east-2.aws.neon.tech  (pooled)
 locals {
-  neon_pooled_host = replace(neon_endpoint.main.host, "/^([^.]+)\\./", "$1-pooler.")
-  neon_pooled_url  = "postgres://${neon_project.birdwatch.default_role_name}:${neon_project.birdwatch.default_role_password}@${local.neon_pooled_host}/${neon_database.main.name}?sslmode=require"
+  neon_pooled_url = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_project.birdwatch.database_host_pooler}/${neon_database.main.name}?sslmode=require"
 }
 
 output "neon_db_url" {
-  value     = "postgres://${neon_project.birdwatch.default_role_name}:${neon_project.birdwatch.default_role_password}@${neon_endpoint.main.host}/${neon_database.main.name}?sslmode=require"
+  value     = "postgres://${neon_project.birdwatch.database_user}:${neon_project.birdwatch.database_password}@${neon_project.birdwatch.database_host}/${neon_database.main.name}?sslmode=require"
   sensitive = true
 }
 
@@ -237,6 +279,12 @@ output "neon_pooled_url" {
   sensitive = true
 }
 ```
+
+Three hidden landmines for anyone skimming this:
+
+1. **`org_id` is mandatory.** The Neon API requires it as of 2026-04; no default-org inference. Captured in `var.neon_org_id` (see Prerequisites). Previous plan drafts omitted this and failed at `terraform apply` time.
+2. **Do not add a `neon_branch` resource.** Free tier allows one branch; the project auto-creates it. Reference it via `neon_project.birdwatch.default_branch_id`.
+3. **Do not add a `neon_endpoint` resource.** Free tier allows one read_write endpoint per branch; the project's default endpoint already occupies that slot. Using the `database_host_pooler` / `database_host` project attributes replaces the old regex-based pooled-host derivation entirely.
 
 - [ ] **Step 2: Apply**
 
@@ -282,13 +330,15 @@ if [ -z "${DATABASE_URL:-}" ]; then
 fi
 
 echo "Enabling PostGIS on Neon..."
-psql "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 echo "Running migrations..."
 npx node-pg-migrate up -m migrations -d "$DATABASE_URL"
 
 echo "Done."
 ```
+
+> Note (#52 follow-up): `node-pg-migrate`'s `-d` flag takes the **connection string itself**, not the name of an env var — a subtle but important distinction vs. the older `-d DATABASE_URL` usage (which would look up `process.env.DATABASE_URL`). Both happen to work in practice because the env var is also set, but the explicit pass is canonical. The CD workflow that runs this script on every push (issue #65, Wave 1.5 — not yet shipped) is what bundles issue #52's scripted variant. Until then, run locally from a trusted workstation.
 
 - [ ] **Step 2: Make executable + run**
 
@@ -431,6 +481,8 @@ git commit -m "feat(read-api): Dockerfile for Cloud Run"
 - Create: `infra/terraform/read-api.tf`
 - Create: `scripts/build-push.sh`
 
+> **CORS middleware is baked into the Read API as of PR #67 (commit `ce309b0`).** `services/read-api/src/app.ts` registers `hono/cors` before all route handlers — preflight OPTIONS requests would 404 otherwise. The allowlist is driven by the `FRONTEND_ORIGINS` env var (see Step 3 below); defaults to prod + vite dev/preview origins. This is a Plan 3 concern but is mentioned here because the Cloud Run env config has to set `FRONTEND_ORIGINS` correctly for CORS to work in prod. `Vary: Origin` means CDN caches key per-origin; trivial at 3 origins.
+
 - [ ] **Step 1: Write `scripts/build-push.sh`**
 
 ```bash
@@ -517,6 +569,17 @@ resource "google_cloud_run_v2_service" "read_api" {
             version = "latest"
           }
         }
+      }
+
+      # CORS allowlist. The Read API's Hono app (services/read-api/src/app.ts,
+      # shipped in PR #67 / commit ce309b0) installs `hono/cors` and reads this
+      # env var as a comma-separated list, whitespace-trimmed. The default in
+      # app.ts covers prod + vite dev/preview; override here only if you want
+      # to lock it down further. Without CORS the browser blocks every request
+      # from bird-maps.com → api.bird-maps.com and the map never loads.
+      env {
+        name  = "FRONTEND_ORIGINS"
+        value = "https://${var.domain},https://www.${var.domain}"
       }
     }
   }
@@ -830,6 +893,8 @@ git commit -m "infra: deploy ingestor as Cloud Run Job + 3 Scheduler triggers"
 
 - [ ] **Step 1: Write `infra/terraform/frontend.tf`**
 
+Source of truth: shipped in PR #69 (commit `c01924e`). Two independent DNS bugs in the pre-ship draft are fixed here — read the inline comments before simplifying anything.
+
 ```hcl
 resource "cloudflare_pages_project" "frontend" {
   account_id        = var.cloudflare_account_id
@@ -843,21 +908,73 @@ resource "cloudflare_pages_domain" "root" {
   domain       = var.domain
 }
 
-# Subdomain "api" → CNAME to the Cloud Run service URL (proxied through Cloudflare for caching).
+# Apex "@" → CNAME to the Pages project's auto-assigned pages.dev subdomain.
+# cloudflare_pages_domain binds the domain on the Pages side but does NOT
+# create the DNS record; without this resource the zone serves NXDOMAIN for
+# the apex. Reference the provider-exposed `subdomain` attribute rather than
+# hardcoding "birdwatch-1xe.pages.dev" — if the project is ever recreated,
+# Cloudflare may assign a different pages.dev suffix. proxied=true lets CF
+# auto-flatten the apex CNAME.
+#
+# KNOWN FRAGILE: the pages.dev hostname returned by the provider is not
+# guaranteed stable across project re-creates. If the Pages project is ever
+# deleted-and-recreated, this record will update to the new pages.dev host
+# on the next apply — but any manual links to the old pages.dev URL will
+# break. The apex itself (via var.domain) is stable.
+resource "cloudflare_record" "root" {
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  type    = "CNAME"
+  content = cloudflare_pages_project.frontend.subdomain
+  proxied = true
+  ttl     = 1
+}
+
+# Subdomain "api" → CNAME to Cloud Run's documented CNAME target.
+# Cloud Run rejects requests whose Host header is not a registered domain
+# mapping, so pointing straight at the run.app URL returns 404. The canonical
+# path is a CNAME to ghs.googlehosted.com plus a google_cloud_run_domain_mapping
+# below; proxied MUST be false so Cloud Run's own Let's Encrypt cert serves
+# (proxying through Cloudflare breaks the SSL handshake).
 resource "cloudflare_record" "api" {
   zone_id = var.cloudflare_zone_id
   name    = "api"
   type    = "CNAME"
-  # Strip protocol; CF wants just the host
-  value   = trimprefix(google_cloud_run_v2_service.read_api.uri, "https://")
-  proxied = true
+  content = "ghs.googlehosted.com"
+  proxied = false
   ttl     = 1
+}
+
+# NOTE: google_cloud_run_domain_mapping is the v1-Knative resource. The rest
+# of the infra uses google_cloud_run_v2_service, but the v2 provider does
+# not yet expose a domain-mapping resource; the v1 resource is the canonical
+# path and the v1/v2 mix is intentional here. Prerequisite: the operator
+# must verify `var.domain` in Google Search Console (one-time out-of-band
+# TXT record) before `terraform apply` — otherwise this resource fails.
+# See the top-level "Prerequisites" section of this plan.
+resource "google_cloud_run_domain_mapping" "api" {
+  location = var.gcp_region
+  name     = "api.${var.domain}"
+
+  metadata {
+    namespace = var.gcp_project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_v2_service.read_api.name
+  }
 }
 
 output "api_url"       { value = "https://api.${var.domain}" }
 output "frontend_url"  { value = "https://${var.domain}" }
 output "root_domain"   { value = var.domain }
 ```
+
+Three gotchas that cost real hours on 2026-04-19:
+
+1. **`cloudflare_pages_domain` does not create DNS.** It binds the domain on the Pages side only. Without `cloudflare_record.root`, the zone serves NXDOMAIN for the apex. This is not documented prominently anywhere.
+2. **`proxied = true` on `api.*` breaks Cloud Run SSL.** Cloud Run serves its own Let's Encrypt cert; routing through Cloudflare's proxy layer breaks the handshake. The apex CAN be proxied (Cloudflare manages the cert for it via Pages); the api subdomain cannot.
+3. **`ghs.googlehosted.com`, not the run.app URL.** Cloud Run matches the `Host:` header against registered domain mappings — pointing DNS at the raw run.app URL returns 404 even though DNS resolves fine. Must CNAME to `ghs.googlehosted.com` AND register the mapping via `google_cloud_run_domain_mapping`.
 
 - [ ] **Step 2: Apply**
 
@@ -866,6 +983,14 @@ terraform apply
 ```
 
 - [ ] **Step 3: Build + deploy frontend**
+
+`frontend/.env.production` should be checked in with the live production domain as its value (NOT a REPLACE_WITH_DOMAIN placeholder — the pre-ship draft had that, which produced a broken bundle where the frontend fetched from `api.REPLACE_WITH_DOMAIN`). The deploy script overwrites this file per-deploy so the checked-in value is mostly documentation, but keep it accurate. Example committed value (PR #66 / commit `cc6641c`):
+
+```
+VITE_API_BASE_URL=https://api.bird-maps.com
+```
+
+`frontend/src/App.tsx` reads this at build time via `import.meta.env.VITE_API_BASE_URL`; falls back to `''` so the Vite dev-server proxy at `/api` continues to work. `frontend/src/vite-env.d.ts` declares the type (see PR #66).
 
 ```bash
 DOMAIN=$(terraform output -raw root_domain)
@@ -1024,24 +1149,26 @@ This project deploys to **GCP Cloud Run + Neon Postgres + Cloudflare Pages** —
 ### Prerequisites
 
 - GCP account with a project, `gcloud` CLI authenticated, billing enabled (free tier covers our usage)
-- Neon account (Neon dashboard → Settings → API keys)
+- Neon account (Neon dashboard → Settings → API keys) — also grab your `org_id` from the console URL
 - Cloudflare account with a zone you control (used for Pages + DNS only)
 - eBird API key (free at ebird.org/api/keygen)
 - Terraform ≥ 1.6
 - Docker + `docker buildx` for multi-arch builds
 - `psql` on `$PATH`
+- Your domain verified in [Google Search Console](https://search.google.com/search-console) (one-time TXT record) — required before `google_cloud_run_domain_mapping` can apply
 
 ### One-time setup
 
 1. `cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars` and fill in:
    - `gcp_project_id`, `gcp_region`
-   - `neon_api_key`
+   - `neon_api_key`, `neon_org_id`
    - `cloudflare_account_id`, `cloudflare_api_token`, `cloudflare_zone_id`, `domain`
    - `ebird_api_key`
 2. `gcloud auth login && gcloud auth application-default login`
-3. `cd infra/terraform && terraform init`
-4. `./scripts/deploy.sh` — provisions infra, builds + pushes images, deploys frontend
-5. `./scripts/smoke-test.sh`
+3. Verify `domain` in Google Search Console, add the TXT record to Cloudflare, wait for confirmation
+4. `cd infra/terraform && terraform init`
+5. `./scripts/deploy.sh` — provisions infra, builds + pushes images, deploys frontend
+6. `./scripts/smoke-test.sh`
 
 ### Subsequent deploys
 
@@ -1067,16 +1194,33 @@ git commit -m "docs: deployment instructions for GCP Cloud Run"
 ## Self-review checklist (run before declaring Plan 5 done)
 
 - [ ] `terraform init` and `terraform validate` succeed
-- [ ] `terraform apply` provisions: APIs enabled, Neon project + DB + pooled endpoint, Artifact Registry, Read API Cloud Run service, Ingestor Cloud Run Job, 3 Cloud Scheduler triggers, Cloudflare Pages project + custom domain, DNS CNAME for API
+- [ ] `terraform apply` on a fresh account with only the `terraform.tfvars` variables reaches a working deploy with **no manual Terraform edits** (this is the acid test for the Prerequisites section — if you had to hand-tweak `db.tf`, `frontend.tf`, or any other Terraform file during apply, the plan is still wrong)
+- [ ] `terraform apply` provisions: APIs enabled, Neon project + default endpoint (free tier — no separate `neon_branch` or `neon_endpoint` resources), Artifact Registry, Read API Cloud Run service with `FRONTEND_ORIGINS` env var, Ingestor Cloud Run Job, 3 Cloud Scheduler triggers, Cloudflare Pages project + custom domain, DNS records for apex (`@` → pages.dev, proxied) and `api` (→ `ghs.googlehosted.com`, NOT proxied), `google_cloud_run_domain_mapping.api`
 - [ ] `./scripts/deploy.sh` runs end-to-end without errors
 - [ ] `./scripts/smoke-test.sh` passes
-- [ ] Browsing `https://<domain>` renders the live map with real eBird data
+- [ ] Browsing `https://<domain>` renders the live map with real eBird data (confirms: apex DNS correct, Pages deploy reachable, CORS headers present, `api.<domain>` reaches Cloud Run with correct Host header)
 - [ ] After 30 min, a fresh ingest run is visible in `ingest_runs` table and Cloud Logging
 - [ ] Cloud Run Read API revision shows `min_instance_count=0` (verify in console — confirms scale-to-zero)
 - [ ] Monthly bill remains $0 in GCP billing dashboard after a week of normal usage
 - [ ] No secret values committed to git: `git log -p | grep -iE 'api_key|password|secret' | grep -v '\.example'` returns nothing
+- [ ] `terraform.tfstate`, `.playwright-mcp/`, `.claude/`, and `cf-*/gcp-*/page-*.png` are gitignored at repo root (PR #61 patterns)
 
 When all checked: Plan 5 is done. The system is live, truly serverless, scale-to-zero, $0/month.
+
+---
+
+## CD workflows (Wave 1.5, issues #62–#65 — not yet shipped)
+
+This plan describes the **manual `./scripts/deploy.sh` flow**, which is what landed first (shipped live 2026-04-19). Wave 1.5 will replace most of it with GitHub Actions:
+
+| Issue | Workflow | Replaces |
+|---|---|---|
+| #62 | CD: build + push Read API on `main` | Manual `./scripts/build-push.sh read-api` |
+| #63 | CD: build + push Ingestor on `main` | Manual `./scripts/build-push.sh ingestor` |
+| #64 | CD: deploy frontend to Pages on `main` | Manual `wrangler pages deploy` |
+| #65 | CD: run migrations on `main` (bundles #52's scripted `migrate-deploy.sh`) | Manual `./scripts/migrate-deploy.sh` from a workstation |
+
+Once Wave 1.5 merges, `./scripts/deploy.sh` becomes a break-glass tool rather than the happy path. Terraform stays manual (infra changes are rare and deserve a human in the loop); everything downstream of Terraform automates on push.
 
 ---
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    spec["docs/plans/2026-04-16-plan-5-infra-terraform.md<br/>(draft, pre-ship)"] -->|2026-04-19 live deploy<br/>hit 6 landmines| reality["actually-shipped code<br/>PRs #47-#51"]
    reality -->|this PR| synced["docs/plans/2026-04-16-plan-5-infra-terraform.md<br/>(synced)"]

    subgraph patches["6 shipped PRs folded into the plan"]
      p47["#47 / PR #61<br/>gitignore: .tfstate, .playwright-mcp, .claude"]
      p48["#48 / PR #66<br/>VITE_API_BASE_URL wiring"]
      p49["#49 / PR #67<br/>Read-API CORS middleware"]
      p50["#50 / PR #68<br/>Neon org_id + free-tier caps"]
      p51["#51 / PR #69<br/>apex DNS + ghs.googlehosted.com + domain mapping"]
      p52["#52 / future #65 CD<br/>migrate-deploy.sh -d flag (noted)"]
    end

    patches --> reality
```

```mermaid
sequenceDiagram
    participant Operator
    participant GSC as Google Search Console
    participant Neon
    participant TF as terraform apply

    Note over Operator,TF: NEW "Prerequisites" section (one-time, NOT automatable)
    Operator->>GSC: Verify var.domain (TXT record)
    Operator->>Neon: Grab neon_org_id from console URL
    Operator->>TF: terraform apply (fresh account)
    TF-->>Operator: working deploy, no manual Terraform edits
```

## Summary

- Brings `docs/plans/2026-04-16-plan-5-infra-terraform.md` into alignment with the code actually shipped in PRs #47-#51 — every embedded `db.tf` / `frontend.tf` / `migrate-deploy.sh` / `app.ts` / `App.tsx` / `.gitignore` block now matches the merge commits byte-for-byte (modulo whitespace).
- Adds a top-level "Prerequisites" section naming the two one-time out-of-band steps (obtain `neon_org_id`; verify domain in Google Search Console) that gate a clean `terraform apply` on a fresh account — these previously lived only in the memory notes, so a subagent re-executing the plan verbatim would hit walls at Task 2 and Task 9.
- Adds a "CD workflows (Wave 1.5, issues #62-#65 — not yet shipped)" section documenting that GitHub Actions will replace `scripts/deploy.sh` as the happy path, and a self-review checklist item requiring that `terraform apply` on a fresh account with only `terraform.tfvars` reaches a working deploy with no manual Terraform edits.

## Screenshots

N/A — docs-only PR (no frontend or UI changes).

## Test plan

- [x] Task ordering in `grep -n '^##\+ '` output is unchanged (Tasks 1-12 preserved in order; Prerequisites + CD-workflows added as new top-level sections)
- [x] Every code block edit in the plan was cross-checked against `git show <merge-sha>` for the corresponding merged PR:
  - `.gitignore` block ↔ PR #61 / `86ca45d`
  - `frontend/.env.production` + App.tsx wiring ↔ PR #66 / `cc6641c`
  - Read-API CORS + `FRONTEND_ORIGINS` env ↔ PR #67 / `ce309b0`
  - `db.tf` + `variables.tf` + `versions.tf` ↔ PR #68 / `6b92790`
  - `frontend.tf` apex record + `ghs.googlehosted.com` + `google_cloud_run_domain_mapping` ↔ PR #69 / `c01924e`
- [x] All 4 acceptance criteria from issue #53 satisfied:
  - [x] AC #1: embedded code matches shipped files byte-identical (modulo whitespace) at the referenced merge commits
  - [x] AC #2: new "Prerequisites" section lists `neon_org_id` + Google Search Console verification
  - [x] AC #3: each gotcha (free-tier retention cap, `proxied=false` for Cloud Run, pages.dev hostname fragility) is inline-commented in the corresponding task
  - [x] AC #4: self-review checklist adds the fresh-account `terraform apply` acid test
- [x] No secret values in the plan file: `grep -iE 'api_key|password|secret' docs/plans/2026-04-16-plan-5-infra-terraform.md | grep -v REPLACE_ME | grep -v description` returns only comments/env refs
- [x] `wc -l`: 1092 → 1236 lines (+178 / -34 per `git diff --stat`)

Per-change source-of-truth mapping (for reviewer-assisted diffing):

| Plan section | Source PR / commit |
|---|---|
| Prerequisites (new top-level section) | PR #68, PR #69 (composite) |
| Task 1 `versions.tf` neon `~> 0.7` | PR #68 / `6b92790` |
| Task 1 `variables.tf` `neon_org_id` | PR #68 / `6b92790` |
| Task 1 `terraform.tfvars.example` + repo-root `.gitignore` | PR #61 / `86ca45d`, PR #68 / `6b92790` |
| Task 2 `db.tf` (full replacement) | PR #68 / `6b92790` |
| Task 3 `migrate-deploy.sh` note on `-d` flag / #52 bundling | future CD PR #65 (noted) |
| Task 6 `FRONTEND_ORIGINS` env var + CORS callout | PR #67 / `ce309b0` |
| Task 9 `frontend.tf` (apex record, ghs target, domain mapping) | PR #69 / `c01924e` |
| Task 9 Step 3 `VITE_API_BASE_URL` + `vite-env.d.ts` note | PR #66 / `cc6641c` |
| Task 12 README Prerequisites expansion | composite |
| Self-review checklist new items | PR #61, #68, #69 (composite) |
| CD workflows (new section) | Wave 1.5 issues #62-#65 (forward ref) |

## Plan reference

Out of plan (meta — updating Plan 5 itself). Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 2 Task 2.1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
