### PR TITLE
feat(ci): deploy-frontend.yml — auto-deploy to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,60 @@
+name: deploy-frontend
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+concurrency:
+  group: deploy-frontend-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Build frontend
+        env:
+          VITE_API_BASE_URL: https://api.bird-maps.com
+        run: npm run build -w @bird-watch/frontend
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy frontend/dist --project-name=birdwatch --branch=main --commit-dirty=true
+      - name: Post-deploy bundle-hash check
+        run: |
+          set -euo pipefail
+          # Fetch the live site, extract the first /assets/*.js path, fetch that
+          # bundle, grep for the production API base URL. If the deployed bundle
+          # does not bake in api.bird-maps.com, the build env did not propagate
+          # and the site is broken - fail the workflow so the previous CF Pages
+          # deployment stays live (fail-forward).
+          HTML=$(curl -sSf --retry 5 --retry-delay 3 --retry-all-errors https://bird-maps.com/)
+          ASSET=$(printf '%s' "$HTML" | grep -oE '/assets/[^"]+\.js' | head -1)
+          if [ -z "$ASSET" ]; then
+            echo "ERROR: no /assets/*.js found in served HTML" >&2
+            printf '%s\n' "$HTML" | head -40 >&2
+            exit 1
+          fi
+          echo "Checking bundle: $ASSET"
+          COUNT=$(curl -sSf --retry 5 --retry-delay 3 --retry-all-errors "https://bird-maps.com$ASSET" | grep -c 'api.bird-maps.com' || true)
+          echo "api.bird-maps.com occurrences in bundle: $COUNT"
+          if [ "$COUNT" -lt 1 ]; then
+            echo "ERROR: deployed bundle does not contain api.bird-maps.com" >&2
+            exit 1
+          fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,13 +26,10 @@ gcloud run jobs update bird-ingestor \
   --region="$REGION" \
   --image="$REGISTRY/ingestor:latest"
 
-echo "[6/6] build + deploy frontend..."
-DOMAIN=$(cd infra/terraform && terraform output -raw root_domain)
-echo "VITE_API_BASE_URL=https://api.$DOMAIN" > frontend/.env.production
-CLOUDFLARE_API_TOKEN=$(cd infra/terraform && terraform output -raw cloudflare_api_token)
-export CLOUDFLARE_API_TOKEN
-(cd frontend && npm run build && npx wrangler pages deploy dist --project-name=birdwatch --branch=main)
+echo "[6/6] frontend deploy..."
+echo "frontend deploy handled by .github/workflows/deploy-frontend.yml"
 
+DOMAIN=$(cd infra/terraform && terraform output -raw root_domain)
 echo
 echo "Deployed."
 echo "  Frontend:  https://$DOMAIN"


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Dev as developer
    participant GH as GitHub (main)
    participant GA as GitHub Actions
    participant CF as Cloudflare Pages
    participant Site as bird-maps.com

    Dev->>GH: merge PR touching frontend/**
    GH->>GA: push event (paths filter matches)
    GA->>GA: npm ci + npm run build -w @bird-watch/frontend<br/>VITE_API_BASE_URL=https://api.bird-maps.com
    GA->>CF: wrangler pages deploy frontend/dist<br/>--project-name=birdwatch --branch=main
    CF->>Site: promote new deployment
    GA->>Site: GET / → extract /assets/*.js
    GA->>Site: GET /assets/<hash>.js → grep api.bird-maps.com
    Note over GA: fail if count < 1<br/>(previous deploy stays live)
```

## Summary

- Adds `.github/workflows/deploy-frontend.yml` that rebuilds and deploys the frontend to Cloudflare Pages (`birdwatch`) whenever a `main` push touches `frontend/**`, `packages/**`, or root `package.json` / `package-lock.json`. Uses `cloudflare/wrangler-action@v3` with `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` repo secrets already provisioned 2026-04-19.
- Bakes `VITE_API_BASE_URL=https://api.bird-maps.com` at build time, then runs a post-deploy smoke check that fetches the live bundle and greps for that base URL — if it is missing, the job fails and CF Pages keeps the prior deployment live (fail-forward, no rollback logic needed).
- Replaces the `wrangler pages deploy` block in `scripts/deploy.sh` (step 6/6) with a pointer stub, closing the race window where a human `deploy.sh` run could race CI for the same Pages project.

## Screenshots

N/A — CI config only.

## Test plan

- [x] YAML syntax — `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-frontend.yml'))"` parses cleanly.
- [x] Shell syntax — `bash -n scripts/deploy.sh` passes.
- [x] Project name verified `birdwatch` (matches `infra/terraform/frontend.tf` and previous manual `scripts/deploy.sh` invocation).
- [x] Path filter matches `frontend/**`, `packages/**`, `package.json`, `package-lock.json`, and the workflow file itself; shared-infra-only changes (e.g. `docs/**`, `.github/**` non-workflow) do NOT trigger.
- [ ] Live validation: the next merge to `main` that touches `frontend/**` is the end-to-end test. Expected: workflow goes green, `curl -sSf https://bird-maps.com` returns 200, and the post-deploy smoke step reports `api.bird-maps.com occurrences in bundle: 1` (or more).
- [ ] Negative path (future merge that only touches `services/read-api/**`) — `deploy-frontend` should NOT run; verify in Actions UI.

## Plan reference

Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1.5 Task 1.5.1). Prereqs: WIF bootstrap (done) + CLOUDFLARE_{ACCOUNT_ID,API_TOKEN} secrets (done 2026-04-19).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
