### PR TITLE
feat(ci): deploy-read-api.yml — Cloud Run auto-deploy via WIF

### DIFF
--- a/.github/workflows/deploy-read-api.yml
+++ b/.github/workflows/deploy-read-api.yml
@@ -1,0 +1,71 @@
+name: deploy-read-api
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/read-api/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/deploy-read-api.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-read-api-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: bird-maps-prod
+  GCP_REGION: us-west1          # matches var.gcp_region default
+  AR_REPO: birdwatch            # matches google_artifact_registry_repository.birdwatch.repository_id (no hyphen)
+  IMAGE_NAME: read-api          # matches the image path Terraform pins in read-api.tf:40 (…/birdwatch/read-api)
+  SERVICE_NAME: bird-read-api   # Cloud Run service name from read-api.tf:28
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write   # required for WIF
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure docker for Artifact Registry
+        run: gcloud auth configure-docker ${GCP_REGION}-docker.pkg.dev --quiet
+
+      - name: Build and push image
+        run: |
+          IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:${GITHUB_SHA}"
+          docker build -f services/read-api/Dockerfile -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run services update "$SERVICE_NAME" \
+            --region="$GCP_REGION" \
+            --image="$IMAGE" \
+            --quiet
+
+      - name: Smoke test
+        run: |
+          # Retry to absorb DNS / Cloud LB / custom-domain propagation after a revision swap.
+          # `gcloud run services update` returns when the new revision serves on its .run.app URL,
+          # but api.bird-maps.com goes through a Cloud LB + custom domain mapping with its own
+          # warm-up window. --retry 5 --retry-delay 3 covers up to ~15s of propagation lag without
+          # masking a genuinely broken deploy.
+          curl -sSfv --retry 5 --retry-delay 3 --retry-all-errors \
+            "https://api.bird-maps.com/health" | tee /tmp/health.json
+          grep -q '"ok":true' /tmp/health.json

--- a/infra/terraform/read-api.tf
+++ b/infra/terraform/read-api.tf
@@ -64,6 +64,14 @@ resource "google_cloud_run_v2_service" "read_api" {
     percent = 100
   }
 
+  # The image tag is rolled forward by .github/workflows/deploy-read-api.yml
+  # (Cloud Run service update on every push to main touching read-api).
+  # Without this, `terraform apply` would revert the service to the :latest
+  # tag pinned above and silently roll back the CD deploy.
+  lifecycle {
+    ignore_changes = [template[0].containers[0].image]
+  }
+
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.read_api_db,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,8 +10,7 @@ echo "[2/6] migrations..."
 DB_URL=$(cd infra/terraform && terraform output -raw neon_db_url)
 DATABASE_URL="$DB_URL" ./scripts/migrate-deploy.sh
 
-echo "[3/6] build + push read-api image..."
-./scripts/build-push.sh read-api latest
+echo "[3/6] read-api deploy handled by .github/workflows/deploy-read-api.yml"
 
 echo "[4/6] build + push ingestor image..."
 ./scripts/build-push.sh ingestor latest
@@ -19,9 +18,6 @@ echo "[4/6] build + push ingestor image..."
 echo "[5/6] roll Cloud Run to new revisions..."
 REGION=$(cd infra/terraform && terraform output -raw gcp_region)
 REGISTRY=$(cd infra/terraform && terraform output -raw artifact_registry_url)
-gcloud run services update bird-read-api \
-  --region="$REGION" \
-  --image="$REGISTRY/read-api:latest"
 gcloud run jobs update bird-ingestor \
   --region="$REGION" \
   --image="$REGISTRY/ingestor:latest"


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Dev as git push main
    participant GH as GitHub Actions
    participant WIF as GCP WIF Pool
    participant SA as gh-deploy SA
    participant AR as Artifact Registry<br/>us-west1 / birdwatch
    participant CR as Cloud Run<br/>bird-read-api
    participant Domain as api.bird-maps.com

    Dev->>GH: push touches services/read-api/** or packages/**
    GH->>WIF: OIDC token (repo=julianken/bird-sight-system)
    WIF->>SA: impersonate gh-deploy@bird-maps-prod
    GH->>AR: docker push read-api:<sha>
    GH->>CR: gcloud run services update --image=...:<sha>
    CR-->>GH: new revision serves traffic
    GH->>Domain: curl /health (retry 5x 3s)
    Domain-->>GH: {"ok":true}
```

```mermaid
flowchart LR
    subgraph Before
      A1[merge to main] --> A2[human runs<br/>scripts/deploy.sh]
      A2 --> A3[docker build+push]
      A3 --> A4[gcloud run services update]
    end
    subgraph After
      B1[merge to main] --> B2[deploy-read-api.yml]
      B2 --> B3[docker build+push :sha]
      B3 --> B4[gcloud run services update]
      B4 --> B5[smoke test<br/>api.bird-maps.com/health]
    end
    Before -. replaces .-> After
```

## Summary

- Adds `.github/workflows/deploy-read-api.yml`. On push to `main` touching `services/read-api/**`, `packages/**`, `package-lock.json`, `tsconfig.base.json`, or the workflow itself, GitHub Actions authenticates to GCP via Workload Identity Federation (no long-lived SA keys), builds the image tagged with `${{ github.sha }}`, pushes to `us-west1-docker.pkg.dev/bird-maps-prod/birdwatch/read-api:<sha>`, updates Cloud Run service `bird-read-api`, then smoke-tests `https://api.bird-maps.com/health`.
- Adds `lifecycle { ignore_changes = [template[0].containers[0].image] }` to `google_cloud_run_v2_service.read_api` in `infra/terraform/read-api.tf`. Without this, the next `terraform apply` would revert the service to the `:latest` tag hardcoded in `read-api.tf` and silently roll back the CD deploy.
- Strips the read-api build-push-update block from `scripts/deploy.sh` (leaves ingestor and migrations blocks in place until their respective CD issues land).

## Screenshots

N/A — CI workflow, no UI changes.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-read-api.yml'))"` parses clean
- [x] `cd infra/terraform && terraform validate` — `Success! The configuration is valid.`
- [x] `bash -n scripts/deploy.sh` — no syntax errors
- [x] WIF bootstrap pre-verified out-of-band (pool `github-pool`, provider `github-provider`, SA `gh-deploy@bird-maps-prod`, roles `run.admin` + `artifactregistry.writer` + `iam.serviceAccountUser`, `workloadIdentityUser` binding for `repository_owner/julianken`)
- [x] GitHub Actions secrets `GCP_WIF_PROVIDER` + `GCP_DEPLOY_SA_EMAIL` set
- [ ] First live validation is the next merge to `main` touching `services/read-api/**` — workflow runs end-to-end, pushes `:<sha>` tag, Cloud Run serves new revision, `/health` returns `{"ok":true}`. Intentionally not exercised pre-merge: `workflow_dispatch` would push an image tagged with a branch SHA that Terraform's ignore-changes then leaves stranded, and a path-filtered dry run is impossible without merging first.

## Plan reference

Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1.5 Task 1.5.2). Prereqs done: WIF bootstrap + secrets.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
