### PR TITLE
fix(ci): build workspace deps before frontend build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -26,6 +26,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - name: Build workspace dependencies
+        run: |
+          npm run build -w @bird-watch/shared-types
+          npm run build -w @bird-watch/family-mapping
       - name: Build frontend
         env:
           VITE_API_BASE_URL: https://api.bird-maps.com


### PR DESCRIPTION
## Diagrams

N/A — CI workflow change only; no runtime/architectural impact.

## Summary

- Adds a `Build workspace dependencies` step before `Build frontend` in `.github/workflows/deploy-frontend.yml` that runs `npm run build -w @bird-watch/shared-types` then `npm run build -w @bird-watch/family-mapping`, mirroring the ordering in `.github/workflows/e2e.yml`.

## Screenshots

N/A — CI config change, no UI.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-frontend.yml'))"` — parses OK
- [x] Local chain: `npm ci && npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/family-mapping && npm run build -w @bird-watch/frontend` — all three workspaces build cleanly (vite output: `dist/assets/index-*.js` 154.41 kB)
- [x] Reproduction of the failure addressed here: https://github.com/julianken/bird-sight-system/actions/runs/24637046972 — `tsc` emitted `error TS2307: Cannot find module '@bird-watch/family-mapping'` and `Cannot find module '@bird-watch/shared-types'` because those workspace packages had not been built yet. With this fix, they are built first and `dist/` resolves the imports.
- [ ] Post-merge: next push to `main` touching `frontend/**` or `packages/**` should trigger `deploy-frontend` and complete the `Build frontend` + Cloudflare Pages deploy + bundle-hash check steps successfully.

## Plan reference

Follow-up fix to #62 (Wave 1.5 Task 1.5.1). Parent plan: `docs/plans/2026-04-19-execute-issues-47-59.md`.
