### PR TITLE
feat(ci): deploy-ingestor.yml — Cloud Run job auto-deploy via WIF

### DIFF
--- a/.github/workflows/deploy-ingestor.yml
+++ b/.github/workflows/deploy-ingestor.yml
@@ -1,0 +1,76 @@
+name: deploy-ingestor
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/ingestor/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.base.json'
+      - '.github/workflows/deploy-ingestor.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-ingestor-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  GCP_PROJECT: bird-maps-prod
+  GCP_REGION: us-west1          # matches var.gcp_region default
+  AR_REPO: birdwatch            # matches google_artifact_registry_repository.birdwatch.repository_id (no hyphen)
+  IMAGE_NAME: ingestor          # matches the image path Terraform pins in ingestor.tf (…/birdwatch/ingestor)
+  JOB_NAME: bird-ingestor       # Cloud Run job name from ingestor.tf:32
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write   # required for WIF
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure docker for Artifact Registry
+        run: gcloud auth configure-docker ${GCP_REGION}-docker.pkg.dev --quiet
+
+      - name: Build and push image
+        run: |
+          IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:${GITHUB_SHA}"
+          docker build -f services/ingestor/Dockerfile -t "$IMAGE" .
+          docker push "$IMAGE"
+          echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Deploy to Cloud Run Job
+        run: |
+          gcloud run jobs update "$JOB_NAME" \
+            --region="$GCP_REGION" \
+            --image="$IMAGE" \
+            --quiet
+
+      - name: Verify image pinned
+        run: |
+          # Cloud Run Jobs aren't HTTP endpoints, so we can't curl a /health URL the way
+          # deploy-read-api does. The closest equivalent is verifying the job resource now
+          # points at the commit-SHA image tag we just pushed. This confirms the update
+          # succeeded end-to-end (auth → AR push → Cloud Run control plane) without burning
+          # a live ingest run on every deploy. The three schedulers (every 30 min, daily
+          # 4am, weekly Sun 5am) bind to the job by name, so they pick up the new image
+          # on their next tick automatically.
+          DEPLOYED=$(gcloud run jobs describe "$JOB_NAME" \
+            --region="$GCP_REGION" \
+            --format='value(template.template.containers[0].image)')
+          echo "Deployed image: $DEPLOYED"
+          echo "Expected image: $IMAGE"
+          test "$DEPLOYED" = "$IMAGE"

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -70,6 +70,14 @@ resource "google_cloud_run_v2_job" "ingestor" {
     }
   }
 
+  # Once .github/workflows/deploy-ingestor.yml takes over image rollouts, Terraform
+  # must stop reconciling the image tag back to :latest on every apply. Jobs wrap
+  # the pod template in an execution template, hence the double template[0] —
+  # different from google_cloud_run_v2_service which uses single template[0].
+  lifecycle {
+    ignore_changes = [template[0].template[0].containers[0].image]
+  }
+
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,15 +12,9 @@ DATABASE_URL="$DB_URL" ./scripts/migrate-deploy.sh
 
 echo "[3/6] read-api deploy handled by .github/workflows/deploy-read-api.yml"
 
-echo "[4/6] build + push ingestor image..."
-./scripts/build-push.sh ingestor latest
+echo "[4/6] ingestor deploy handled by .github/workflows/deploy-ingestor.yml"
 
-echo "[5/6] roll Cloud Run to new revisions..."
-REGION=$(cd infra/terraform && terraform output -raw gcp_region)
-REGISTRY=$(cd infra/terraform && terraform output -raw artifact_registry_url)
-gcloud run jobs update bird-ingestor \
-  --region="$REGION" \
-  --image="$REGISTRY/ingestor:latest"
+echo "[5/6] Cloud Run revisions rolled by per-service deploy workflows"
 
 echo "[6/6] frontend deploy..."
 echo "frontend deploy handled by .github/workflows/deploy-frontend.yml"


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Dev as push to main
    participant GHA as GitHub Actions
    participant WIF as Workload Identity
    participant AR as Artifact Registry
    participant Run as Cloud Run Job
    participant Sched as Cloud Scheduler

    Dev->>GHA: paths: services/ingestor/** | packages/** | tsconfig.base.json
    GHA->>WIF: id-token exchange (bird-maps-prod deploy SA)
    GHA->>AR: docker push us-west1-docker.pkg.dev/.../ingestor:<sha>
    GHA->>Run: gcloud run jobs update bird-ingestor --image=...:<sha>
    GHA->>Run: gcloud run jobs describe --format=image
    GHA-->>GHA: assert deployed == expected (no HTTP curl for a Job)

    Note over Sched,Run: three schedulers bind to job NAME, not image —<br/>every 30m / daily 04:00 / weekly Sun 05:00 UTC<br/>pick up :<sha> on next tick, no reconfig
```

```mermaid
flowchart LR
    subgraph Before
      dev1["dev laptop"] -->|"./scripts/deploy.sh [4/6][5/6]"| push1["build-push.sh + gcloud run jobs update"]
    end
    subgraph After
      main["push to main"] --> wf["deploy-ingestor.yml"]
      wf --> job["bird-ingestor @ :&lt;sha&gt;"]
      deploy["scripts/deploy.sh"] -->|"[4/6] [5/6]"| stub["stub echo — workflow does the work"]
    end
```

## Summary

- Mirrors the #63 / PR #72 read-api pattern for the Cloud Run **Job**. Pushes to `main` that touch `services/ingestor/**`, `packages/**`, root manifests, or the workflow itself build, push, and roll `bird-ingestor` to the commit-SHA image — no manual `./scripts/deploy.sh` step and no container drift.
- Jobs have no HTTP surface, so the post-deploy check is `gcloud run jobs describe … --format=image` asserting the deployed tag equals `${{ github.sha }}`. Deliberately avoids `gcloud run jobs execute --wait` — that would burn a live eBird ingest on every merge.
- `google_cloud_run_v2_job.ingestor` now ignores `template[0].template[0].containers[0].image` (double `template[0]` — Jobs wrap the pod template in an execution template; different from Services). Prevents Terraform from reconciling back to `:latest` on the next apply.
- Three Cloud Scheduler bindings (every 30 min / daily 04:00 UTC / weekly Sun 05:00 UTC) bind to the job **by name**, not by image, so they transparently pick up the new revision on their next tick — no scheduler churn.

## Screenshots

N/A — not UI

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-ingestor.yml'))"` — parses
- [x] `cd infra/terraform && terraform validate` — Success! The configuration is valid
- [x] `bash -n scripts/deploy.sh` — syntax OK
- [ ] First live validation is the next merge touching `services/ingestor/**` (e.g. a handler change) — workflow will build, push, update the job, and assert the image tag equals the commit SHA before returning green.
- [ ] Subsequent `terraform apply` after merge is a no-op on the job image (covered by `lifecycle.ignore_changes`); run once post-merge to confirm plan diff is empty.

## Plan reference

Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1.5 Task 1.5.3). Prereqs done: WIF + secrets (same as #63).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
