### PR TITLE
feat(ci): deploy-migrations workflow + bundled #52 -d flag fix

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -1,0 +1,65 @@
+name: deploy-migrations
+
+# Partial-failure contract: if any `-- Up Migration` statement errors, this
+# workflow exits non-zero and leaves Neon in whatever state the runner reached
+# up to the last committed migration. It does NOT auto-rollback. A human must
+# inspect and either fix-forward with a new migration or manually revert.
+#
+# Ordering with app code: if a schema-changing migration ships alongside a
+# read-api or ingestor code change that depends on the new column, (1) ship
+# the migration PR, (2) wait for this workflow to succeed, (3) ship the code
+# in a follow-up PR. Not enforced in YAML — developer discipline.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'migrations/**'
+      - 'scripts/migrate-deploy.sh'
+      - '.github/workflows/deploy-migrations.yml'
+  workflow_dispatch:
+
+concurrency:
+  # NEVER cancel mid-migration — DB transactions don't always roll back cleanly
+  # on CI cancellation, and `node-pg-migrate`'s per-migration lock doesn't
+  # protect against a SIGKILL'd runner leaving a half-applied `-- Up` block.
+  group: deploy-migrations-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # No id-token: write needed — Neon auth is via DATABASE_URL password,
+      # not GCP WIF like the read-api / ingestor workflows.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Verify DATABASE_URL uses Neon pooled endpoint
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [[ -z "${DATABASE_URL:-}" ]]; then
+            echo "::error::DATABASE_URL secret is not set"
+            exit 1
+          fi
+          if [[ ! "$DATABASE_URL" =~ -pooler ]]; then
+            echo "::error::DATABASE_URL must use Neon pooled endpoint (-pooler suffix). See infra/terraform/db.tf locals.neon_pooled_url."
+            exit 1
+          fi
+          echo "DATABASE_URL points at a pooled endpoint (host contains '-pooler')."
+
+      - name: Apply migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: ./scripts/migrate-deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,8 +7,7 @@ echo "[1/6] terraform apply..."
 (cd infra/terraform && terraform apply -auto-approve)
 
 echo "[2/6] migrations..."
-DB_URL=$(cd infra/terraform && terraform output -raw neon_db_url)
-DATABASE_URL="$DB_URL" ./scripts/migrate-deploy.sh
+echo "migrations deploy handled by .github/workflows/deploy-migrations.yml"
 
 echo "[3/6] read-api deploy handled by .github/workflows/deploy-read-api.yml"
 

--- a/scripts/migrate-deploy.sh
+++ b/scripts/migrate-deploy.sh
@@ -10,9 +10,15 @@ if [ -z "${DATABASE_URL:-}" ]; then
 fi
 
 echo "Enabling PostGIS on Neon..."
+# NOTE: redundant with migrations/1700000001000_enable_postgis.sql, which runs
+# CREATE EXTENSION IF NOT EXISTS postgis via the migrations ledger. Kept for
+# belt-and-suspenders on brand-new Neon branches where the ledger is empty.
+# Safe to delete in a follow-up cleanup (see issue #65 Gotchas, "optional").
 psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 echo "Running migrations..."
-npx node-pg-migrate up -m migrations -d "$DATABASE_URL"
+# -d (a.k.a. --database-url-var) takes the NAME of the env var, not the URL value.
+# (salsita.github.io/node-pg-migrate/cli)
+npx node-pg-migrate up -m migrations -d DATABASE_URL
 
 echo "Done."


### PR DESCRIPTION
Closes #65
Closes #52

## Diagrams

```mermaid
sequenceDiagram
    participant Dev
    participant GH as GitHub (main)
    participant Actions as deploy-migrations workflow
    participant Neon as Neon (pooled endpoint)

    Dev->>GH: push commit touching migrations/**
    GH->>Actions: trigger (paths filter matched)
    Actions->>Actions: actions/checkout@v4
    Actions->>Actions: setup-node@v4 (node 20, npm cache)
    Actions->>Actions: npm ci
    Actions->>Actions: Verify DATABASE_URL =~ -pooler (fail-fast)
    Actions->>Neon: scripts/migrate-deploy.sh<br/>(npx node-pg-migrate up -d DATABASE_URL)
    Neon-->>Actions: pgmigrations ledger advanced
    Actions-->>GH: job green
```

## Summary

- Auto-applies Postgres migrations on every push to `main` whose diff touches `migrations/**`, replacing the manual `scripts/migrate-deploy.sh` invocation previously invoked from `scripts/deploy.sh` step [2/6] (now a stub).
- Enforces the Neon pooled-endpoint invariant with a pre-flight `[[ "$DATABASE_URL" =~ -pooler ]]` check so a misconfigured secret fails fast with a clear error rather than silently hitting the direct endpoint that cannot handle CI's short-lived connection pattern.
- Bundles #52's one-line fix: `node-pg-migrate -d` takes the NAME of the env var, not the URL value. Prior form `-d "$DATABASE_URL"` was silently looking for an env var literally named `postgres://...`, which never existed.

## Screenshots

N/A — not UI (CI / infra config).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-migrations.yml'))"` parses cleanly.
- [x] `bash -n scripts/migrate-deploy.sh` clean.
- [x] `bash -n scripts/deploy.sh` clean.
- [x] `gh secret list` confirms `DATABASE_URL` exists (set from `terraform output -raw neon_pooled_url`).
- [ ] First live validation: the next merge that touches `migrations/**` triggers this workflow end-to-end. On success the `pgmigrations` ledger in Neon advances; on failure the workflow exits non-zero and leaves Neon in whatever partial state the migration reached (documented as the partial-failure contract in the workflow header).
- [ ] `workflow_dispatch` manual run on this branch is a safe dry-run once merged, since all current migrations are already applied and `node-pg-migrate` skips them via the `pgmigrations` ledger.

## Plan reference

Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 1.5 Task 1.5.4). Bundles issue #52 (see closure footers). Part of the CD-setup set alongside frontend (#55/#56/#57), read-api (#58/#72), and ingestor (#59/#74) deploy workflows.

---

Generated with [Claude Code](https://claude.com/claude-code)
