### PR TITLE
fix(db): topology-correct AZ ecoregion polygons + sky-island parent_id

### DIFF
--- a/migrations/1700000011000_fix_region_boundaries.sql
+++ b/migrations/1700000011000_fix_region_boundaries.sql
@@ -1,0 +1,218 @@
+-- Up Migration
+--
+-- Fix topology gaps and overlaps at shared boundaries between neighbouring AZ
+-- ecoregion polygons, and populate `parent_id` on the three sky-island rows.
+--
+-- Background
+-- ----------
+-- The 9 polygons seeded in migrations/1700000008000_seed_regions.sql were
+-- hand-authored independently per region, so neighbouring polygons did not
+-- share identical vertex sequences along their common edges.  This left thin
+-- gaps and small overlaps (visible when rendering, and incorrect as a
+-- coverage model) between the following sibling pairs:
+--
+--   lower-colorado   ↔ colorado-plateau      (west edge, lat 35–36 / y≈80–120)
+--   lower-colorado   ↔ mogollon-rim          (west edge, lat 34–35 / y≈133–200)
+--   lower-colorado   ↔ sonoran-phoenix       (west edge, lat 31.7–33.8 / y≈200)
+--   mogollon-rim     ↔ sonoran-tucson        (lat ≈33.2 at lng=-111.5)
+--   sonoran-phoenix  ↔ sonoran-tucson        (lat 31.6–33.5 / SVG y≈233–360, x≈207–239)
+--
+-- Fix strategy
+-- ------------
+-- For every shared edge in the 9-region topology, pick ONE canonical sequence
+-- of vertices and rewrite the neighbour so both polygons quote the same
+-- sequence (in reversed order on one side).  Picked the *lower-colorado*
+-- east-edge vertex sequence as canonical along the entire west side of the
+-- state because those vertices approximate the true AZ western boundary most
+-- faithfully (they have the finest granularity).  Picked the *mogollon-rim*
+-- south edge (through the -110.2 / 33.2 dip) as canonical for the mr↔st
+-- interface, snapping sonoran-tucson's top to match.  Picked the sp↔st 3-way
+-- corners at (-111.5, 33.5) and (-111.0, 31.6) to force both polygons to meet
+-- cleanly along a lng=-111.0 vertical segment (lat 32.6 → 31.6).
+--
+-- Projection contract (unchanged from 1700000008000 header):
+--   x = ((lng + 114.85) / 5.8) * 360
+--   y = ((37.00 - lat)  / 5.7) * 380
+-- `geom` and `svg_path` describe the same shape; the SVG values below are
+-- deterministically derived from the MULTIPOLYGON coordinates using that
+-- formula.  The SVG path uses only absolute M/L/Z verbs — no curves — because
+-- the parser in frontend/src/components/Region.tsx and frontend/src/geo/path.ts
+-- only understands that subset.
+--
+-- Ingest contract (smallest-area-wins point-in-polygon) — TWO call sites:
+--   packages/db-client/src/observations.ts:58-59
+--     SELECT r.id FROM regions r
+--     WHERE ST_Contains(r.geom, o.geom)
+--     ORDER BY ST_Area(r.geom) ASC
+--     LIMIT 1
+--   packages/db-client/src/hotspots.ts:64-71
+--     Same pattern, and duplicated in the re-stamp WHERE clause of the same
+--     UPDATE statement.
+-- Both call sites preserve child-wins-over-parent for sky-island points (a
+-- point inside a sky-island is stamped with the sky-island id because
+-- `ST_Area(sky-island) < ST_Area(sonoran-tucson)`).
+-- (Note: the 1700000008000 header refers to a `services/ingestor/src/upsert.ts`
+-- file that does not exist in the shipped codebase — the real call sites are
+-- the two files above.)
+--
+-- Sky-island parenting (Option A from Wave 0.5 round 3)
+-- -----------------------------------------------------
+-- The three sky-island rows were seeded with parent_id = NULL, but the
+-- `regions.parent_id` column (migrations/1700000002000_regions.sql:5) exists
+-- precisely for this nesting, and `grand-canyon → colorado-plateau` already
+-- uses it.  Populating parent_id = 'sonoran-tucson' on all three sky-islands:
+--   * makes the data model internally consistent,
+--   * lets a sibling-pair overlap check (same parent_id, neither is the
+--     other's parent) correctly exclude the sky-island-inside-parent overlap
+--     that is intentional by design,
+--   * has no impact on the ingest contract because ST_Area(sky-island) is
+--     much smaller than ST_Area(sonoran-tucson), so smallest-area-wins still
+--     routes observations to the sky-island.
+
+-- ---- Boundary fixes: one UPDATE per affected polygon ----
+
+-- colorado-plateau: snap west edge to lower-colorado's east vertices and move
+-- NW corner to lng=-114.85 (matching lc's top-west vertex).
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.85 37.0, -112.0 37.0, -109.05 37.0, -109.05 34.5, '
+    '-110.8 34.3, -112.2 34.4, -113.3 34.6, -114.1 34.5, -114.3 35.2, '
+    '-114.5 35.8, -114.85 36.3, -114.85 37.0)))'
+  ), 4326),
+  svg_path = 'M 0.000 0.000 L 176.897 0.000 L 360.000 0.000 L 360.000 166.667 '
+             'L 251.379 180.000 L 164.483 173.333 L 96.207 160.000 '
+             'L 46.552 166.667 L 34.138 120.000 L 21.724 80.000 L 0.000 46.667 Z'
+WHERE id = 'colorado-plateau';
+
+-- mogollon-rim: snap NW corner to the cp/mr/lc 3-way (-114.1, 34.5) and SW
+-- corner to the mr/sp/lc 3-way (-114.0, 33.8).
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.1 34.5, -113.3 34.6, -112.2 34.4, -110.8 34.3, '
+    '-109.05 34.5, -109.05 33.5, -110.2 33.2, -111.5 33.5, -112.5 33.85, '
+    '-113.3 33.9, -114.0 33.8, -114.1 34.5)))'
+  ), 4326),
+  svg_path = 'M 46.552 166.667 L 96.207 160.000 L 164.483 173.333 '
+             'L 251.379 180.000 L 360.000 166.667 L 360.000 233.333 '
+             'L 288.621 253.333 L 207.931 233.333 L 145.862 210.000 '
+             'L 96.207 206.667 L 52.759 213.333 Z'
+WHERE id = 'mogollon-rim';
+
+-- sonoran-phoenix: snap NW corner to (-114.0, 33.8); on the east side,
+-- replace the (-111.3, 31.8) vertex with a straight lng=-111.0 run from
+-- (-111.0, 32.6) through (-111.0, 32.1) to the sp/st/Mexico 3-way
+-- (-111.0, 31.6).
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.0 33.8, -113.3 33.9, -112.5 33.85, -111.5 33.5, '
+    '-111.0 32.6, -111.0 32.1, -111.0 31.6, -112.5 31.5, -113.2 31.6, '
+    '-114.0 31.7, -114.0 33.8)))'
+  ), 4326),
+  svg_path = 'M 52.759 213.333 L 96.207 206.667 L 145.862 210.000 '
+             'L 207.931 233.333 L 238.966 293.333 L 238.966 326.667 '
+             'L 238.966 360.000 L 145.862 366.667 L 102.414 360.000 '
+             'L 52.759 353.333 Z'
+WHERE id = 'sonoran-phoenix';
+
+-- lower-colorado: the canonical west/east edges are already lc's own
+-- vertices; this UPDATE is essentially a no-op on geometry but closes the
+-- ring on the same vertex used as the NW corner (-114.85, 36.3) and snaps
+-- the southern shared corner (-114.0, 31.7) to match sp's SW corner.  svg
+-- path is refreshed to the canonical 3-decimal form.
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.85 36.3, -114.5 35.8, -114.3 35.2, -114.1 34.5, '
+    '-114.0 33.8, -114.0 32.8, -114.0 31.7, -114.4 31.4, -114.85 31.35, '
+    '-114.85 36.3)))'
+  ), 4326),
+  svg_path = 'M 0.000 46.667 L 21.724 80.000 L 34.138 120.000 '
+             'L 46.552 166.667 L 52.759 213.333 L 52.759 280.000 '
+             'L 52.759 353.333 L 27.931 373.333 L 0.000 376.667 Z'
+WHERE id = 'lower-colorado';
+
+-- sonoran-tucson: snap NW corner to the mr/sp/st 3-way (-111.5, 33.5) —
+-- previously 33.2 — and drop the extra (-110.8, 33.2) vertex so the north
+-- edge matches mr's south edge (a single dip to -110.2, 33.2).
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-111.5 33.5, -110.2 33.2, -109.05 33.5, -109.05 31.3, '
+    '-110.6 31.3, -111.0 31.6, -111.0 32.1, -111.0 32.6, -111.5 33.5)))'
+  ), 4326),
+  svg_path = 'M 207.931 233.333 L 288.621 253.333 L 360.000 233.333 '
+             'L 360.000 380.000 L 263.793 380.000 L 238.966 360.000 '
+             'L 238.966 326.667 L 238.966 293.333 Z'
+WHERE id = 'sonoran-tucson';
+
+-- ---- Sky-island parent_id (Option A, Wave 0.5 round 3) ----
+
+UPDATE regions SET parent_id = 'sonoran-tucson'
+WHERE id IN (
+  'sky-islands-santa-ritas',
+  'sky-islands-huachucas',
+  'sky-islands-chiricahuas'
+);
+
+-- Down Migration
+--
+-- Revert sky-island parent_id first (reverse order of the UP changes).
+
+UPDATE regions SET parent_id = NULL
+WHERE id IN (
+  'sky-islands-santa-ritas',
+  'sky-islands-huachucas',
+  'sky-islands-chiricahuas'
+);
+
+-- Revert each boundary UPDATE by inlining the original polygon + svg_path
+-- values from migrations/1700000008000_seed_regions.sql.
+
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.8 37.0, -112.0 37.0, -109.05 37.0, -109.05 34.5, '
+    '-110.8 34.3, -112.2 34.4, -113.3 34.6, -114.0 35.0, -114.3 35.8, '
+    '-114.8 36.3, -114.8 37.0)))'
+  ), 4326),
+  svg_path = 'M 3.1 0.0 L 176.9 0.0 L 360.0 0.0 L 360.0 166.7 L 251.4 180.0 '
+             'L 164.5 173.3 L 96.2 160.0 L 52.8 133.3 L 34.1 80.0 L 3.1 46.7 Z'
+WHERE id = 'colorado-plateau';
+
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.0 35.0, -113.3 34.6, -112.2 34.4, -110.8 34.3, '
+    '-109.05 34.5, -109.05 33.5, -110.2 33.2, -111.5 33.5, -112.5 33.85, '
+    '-113.3 33.9, -114.0 34.0, -114.0 35.0)))'
+  ), 4326),
+  svg_path = 'M 52.8 133.3 L 96.2 160.0 L 164.5 173.3 L 251.4 180.0 L 360.0 166.7 '
+             'L 360.0 233.3 L 288.6 253.3 L 207.9 233.3 L 145.9 210.0 L 96.2 206.7 '
+             'L 52.8 200.0 Z'
+WHERE id = 'mogollon-rim';
+
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.0 34.0, -113.3 33.9, -112.5 33.85, -111.5 33.5, '
+    '-111.0 32.6, -111.3 31.8, -112.5 31.5, -113.2 31.6, -114.0 31.7, '
+    '-114.0 34.0)))'
+  ), 4326),
+  svg_path = 'M 52.8 200.0 L 96.2 206.7 L 145.9 210.0 L 207.9 233.3 L 239.0 293.3 '
+             'L 220.3 346.7 L 145.9 366.7 L 102.4 360.0 L 52.8 353.3 Z'
+WHERE id = 'sonoran-phoenix';
+
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-114.8 36.3, -114.5 35.8, -114.3 35.2, -114.1 34.5, '
+    '-114.0 33.8, -114.0 32.8, -114.0 31.7, -114.4 31.4, -114.85 31.35, '
+    '-114.8 36.3)))'
+  ), 4326),
+  svg_path = 'M 3.1 46.7 L 21.7 80.0 L 34.1 120.0 L 46.6 166.7 L 52.8 213.3 '
+             'L 52.8 280.0 L 52.8 353.3 L 27.9 373.3 L 0.0 376.7 Z'
+WHERE id = 'lower-colorado';
+
+UPDATE regions SET
+  geom = ST_SetSRID(ST_GeomFromText(
+    'MULTIPOLYGON(((-111.5 33.2, -110.8 33.2, -110.2 33.2, -109.05 33.5, '
+    '-109.05 31.3, -110.6 31.3, -111.0 31.6, -111.0 32.1, -111.0 32.6, '
+    '-111.5 33.2)))'
+  ), 4326),
+  svg_path = 'M 207.9 253.3 L 251.4 253.3 L 288.6 253.3 L 360.0 233.3 L 360.0 380.0 '
+             'L 263.8 380.0 L 239.0 360.0 L 239.0 326.7 L 239.0 293.3 Z'
+WHERE id = 'sonoran-tucson';

--- a/packages/db-client/src/region-boundaries.test.ts
+++ b/packages/db-client/src/region-boundaries.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startTestDb, type TestDb } from './test-helpers.js';
+
+// Topology checks introduced by migrations/1700000011000_fix_region_boundaries.sql.
+// These verify the post-migration state against the AC in issue #58:
+//   - sky-island parent_id populated to 'sonoran-tucson'
+//   - siblings (same parent_id, neither is the other's parent) do NOT overlap
+//   - union of the 6 top-level polygons has no internal gaps (self-consistent:
+//     the external boundary of the union equals the external boundary of the
+//     sum of individual boundaries minus the shared edges)
+//   - smallest-area-wins ingest contract still routes sky-island points to
+//     sky-islands, confirming the parent/child relationship survives the
+//     boundary rewrite.
+//
+// We avoid hard-coding an external AZ-outer-boundary geometry; instead we
+// assert properties of the union directly (no holes, no degenerate area).
+
+let db: TestDb;
+beforeAll(async () => { db = await startTestDb(); }, 90_000);
+afterAll(async () => { await db?.stop(); });
+
+describe('region boundaries: topology', () => {
+  it('populates sky-island parent_id to sonoran-tucson', async () => {
+    const { rows } = await db.pool.query<{ id: string; parent_id: string | null }>(
+      `SELECT id, parent_id FROM regions
+         WHERE id LIKE 'sky-islands-%'
+         ORDER BY id`
+    );
+    expect(rows).toHaveLength(3);
+    for (const r of rows) {
+      expect(r.parent_id).toBe('sonoran-tucson');
+    }
+  });
+
+  it('sibling pairs do not overlap and have zero intersection area', async () => {
+    // Precise sibling-pair filter per AC:
+    //   (a.id < b.id) AND (a.parent_id IS NOT DISTINCT FROM b.parent_id)
+    //   AND (a.id IS DISTINCT FROM b.parent_id)
+    //   AND (b.id IS DISTINCT FROM a.parent_id)
+    //
+    // We must use IS DISTINCT FROM here rather than plain `<>`.  For top-level
+    // rows, `a.parent_id` is NULL, so `b.id <> a.parent_id` evaluates to NULL
+    // (unknown), which causes the WHERE clause to silently drop the pair —
+    // hiding every top-level↔top-level sibling pair from the check.  IS
+    // DISTINCT FROM treats NULL as a distinct value and returns TRUE.
+    //
+    // After the fix we expect 13 sibling pairs: the 10 pairs of top-level
+    // regions (the 5 AZ ecoregions, plus grand-canyon is NOT top-level so we
+    // have 5C2 = 10) and the 3 pairs among the 3 sky-island siblings.
+    const { rows } = await db.pool.query<{
+      a_id: string; b_id: string;
+      overlaps: boolean;
+      inter_area: number;
+    }>(`
+      SELECT a.id AS a_id, b.id AS b_id,
+             ST_Overlaps(a.geom, b.geom) AS overlaps,
+             ST_Area(ST_Intersection(a.geom, b.geom)) AS inter_area
+        FROM regions a JOIN regions b ON a.id < b.id
+       WHERE a.parent_id IS NOT DISTINCT FROM b.parent_id
+         AND a.id IS DISTINCT FROM b.parent_id
+         AND b.id IS DISTINCT FROM a.parent_id
+    `);
+    expect(rows.length).toBe(13);
+    for (const r of rows) {
+      expect({ pair: `${r.a_id}+${r.b_id}`, overlaps: r.overlaps })
+        .toEqual({ pair: `${r.a_id}+${r.b_id}`, overlaps: false });
+      expect({ pair: `${r.a_id}+${r.b_id}`, inter_area: r.inter_area })
+        .toEqual({ pair: `${r.a_id}+${r.b_id}`, inter_area: 0 });
+    }
+  });
+
+  it('expected-neighbour pairs share a positive-length boundary (ST_Touches)', async () => {
+    // This is necessary but not sufficient (a point-touch also satisfies
+    // ST_Touches).  The sibling-overlap assertion above plus the union-area
+    // assertion below together guarantee full edge coverage.
+    const expected: Array<[string, string]> = [
+      ['colorado-plateau', 'mogollon-rim'],
+      ['colorado-plateau', 'lower-colorado'],
+      ['mogollon-rim',    'sonoran-phoenix'],
+      ['mogollon-rim',    'sonoran-tucson'],
+      ['mogollon-rim',    'lower-colorado'],
+      ['sonoran-phoenix', 'sonoran-tucson'],
+      ['sonoran-phoenix', 'lower-colorado'],
+    ];
+    for (const [a, b] of expected) {
+      const { rows } = await db.pool.query<{ touches: boolean; shared_len: number }>(
+        `SELECT ST_Touches(a.geom, b.geom) AS touches,
+                ST_Length(ST_Intersection(ST_Boundary(a.geom), ST_Boundary(b.geom))) AS shared_len
+           FROM regions a, regions b
+          WHERE a.id = $1 AND b.id = $2`,
+        [a, b]
+      );
+      expect({ pair: `${a}+${b}`, touches: rows[0]?.touches }).toEqual({
+        pair: `${a}+${b}`, touches: true,
+      });
+      expect(rows[0]?.shared_len ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it('union of top-level regions forms a single polygon with no holes', async () => {
+    // No hole = no internal gap = no linear gap between sibling polygons.
+    // Combined with the zero-intersection sibling assertion, this gives full
+    // edge coverage for every sibling pair: if any neighbour pair left a
+    // linear gap, ST_Union would retain an interior ring.
+    const { rows } = await db.pool.query<{
+      geom_type: string; area: number; n_interior: number;
+    }>(`
+      WITH u AS (
+        SELECT ST_Union(geom) AS g
+          FROM regions
+         WHERE parent_id IS NULL
+      )
+      SELECT ST_GeometryType(g) AS geom_type,
+             ST_Area(g) AS area,
+             ST_NumInteriorRings(
+               CASE WHEN ST_GeometryType(g) = 'ST_MultiPolygon'
+                    THEN ST_GeometryN(g, 1)
+                    ELSE g END
+             ) AS n_interior
+        FROM u
+    `);
+    expect(rows[0]?.geom_type).toBe('ST_Polygon');
+    expect(rows[0]?.n_interior).toBe(0);
+    expect(rows[0]?.area ?? 0).toBeGreaterThan(30);  // AZ ~32 sq degrees
+  });
+
+  it('ingest contract: smallest-area-wins routes Madera Canyon to sky-islands-santa-ritas', async () => {
+    // Replays the point-in-polygon query used at
+    // packages/db-client/src/observations.ts:58-59 and
+    // packages/db-client/src/hotspots.ts:64-71.
+    const { rows } = await db.pool.query<{ id: string }>(
+      `SELECT r.id FROM regions r
+         WHERE ST_Contains(r.geom, ST_SetSRID(ST_MakePoint($1, $2), 4326))
+         ORDER BY ST_Area(r.geom) ASC
+         LIMIT 1`,
+      [-110.88, 31.72]  // Madera Canyon
+    );
+    expect(rows[0]?.id).toBe('sky-islands-santa-ritas');
+  });
+
+  it('ingest contract: Sweetwater Wetlands routes to sonoran-tucson', async () => {
+    const { rows } = await db.pool.query<{ id: string }>(
+      `SELECT r.id FROM regions r
+         WHERE ST_Contains(r.geom, ST_SetSRID(ST_MakePoint($1, $2), 4326))
+         ORDER BY ST_Area(r.geom) ASC
+         LIMIT 1`,
+      [-110.99, 32.30]  // Sweetwater Wetlands
+    );
+    expect(rows[0]?.id).toBe('sonoran-tucson');
+  });
+});


### PR DESCRIPTION
## Diagrams

Before (shipped 1700000008000 — polygons authored independently, gaps/overlaps at 5 sibling interfaces):

```
 cp.bottom-left: (-114.0 35.0)          mr.top-left: (-114.0 35.0)
  lc.top-right: (-114.85 36.3)          lc.east @ lat 34.5: (-114.1 34.5)
                                        lc.east @ lat 33.8: (-114.0 33.8)
 ─────────────────────────────
   ^ 0.85° horizontal offset             ^ lc dips further west than mr/cp,
     between lc and cp NW edge             leaving a ~0.1–0.5° sliver/gap

 mr.south @ lng=-111.5: (-111.5 33.5)    st.north @ lng=-111.5: (-111.5 33.2)
 sp.top @ lng=-111.5:   (-111.5 33.5)                            ^ 0.3° gap

 sp.east descends (-111.0 32.6) → (-111.3 31.8)
 st.west descends (-111.0 32.6) → (-111.0 32.1) → (-111.0 31.6)
                                   ^ sp wanders west; st stays at -111.0
```

After (1700000011000 snaps all shared edges to the lc east-sequence / mr south-sequence / lng=-111.0 vertical):

```
 cp west = [(-114.85 36.3), (-114.5 35.8), (-114.3 35.2), (-114.1 34.5)]   (== lc east subseq)
 mr west = [(-114.1 34.5), (-114.0 33.8)]                                  (== lc east subseq)
 sp west = [(-114.0 33.8), (-114.0 32.8), (-114.0 31.7)]                   (== lc east subseq)

 mr south (east of -111.5) = [(-111.5 33.5), (-110.2 33.2), (-109.05 33.5)]
 st north                  = [(-111.5 33.5), (-110.2 33.2), (-109.05 33.5)]   (== mr south reversed)

 sp east = [(-111.5 33.5), (-111.0 32.6), (-111.0 32.1), (-111.0 31.6)]
 st west = [(-111.5 33.5), (-111.0 32.6), (-111.0 32.1), (-111.0 31.6)]   (== sp east reversed)
```

## Summary

- **What got fixed.** 5 of the 9 AZ ecoregion polygons (colorado-plateau, mogollon-rim, sonoran-phoenix, lower-colorado, sonoran-tucson) had their shared-edge vertex sequences snapped so every neighbour pair now quotes an identical sequence. Grand Canyon and the 3 sky-island polygons are unchanged.
- **How.** An additive migration (`migrations/1700000011000_fix_region_boundaries.sql`) issues 5 `UPDATE regions SET geom=…, svg_path=…` statements + 1 `UPDATE` that sets `parent_id = 'sonoran-tucson'` on the 3 sky-island rows (Option A from Wave 0.5 round 3). The down-migration inlines the exact original values from `1700000008000_seed_regions.sql` so the seed state is byte-for-byte restorable. No curve commands introduced — the SVG parser in `frontend/src/components/Region.tsx` and `frontend/src/geo/path.ts` only understands `M/L/Z`.
- **Why sky-island parent_id.** The sibling-pair overlap AC needs to filter child-inside-parent overlaps. With `parent_id` populated, `a.parent_id IS NOT DISTINCT FROM b.parent_id` correctly treats sky-islands as siblings of each other (not of the top-level Sonoran regions), and the intentional sky-island-inside-sonoran-tucson overlap is no longer reported as a sibling bug.
- **Ingest contract preserved.** Both call sites (`packages/db-client/src/observations.ts:58-59` and `packages/db-client/src/hotspots.ts:64-71`) keep routing points inside sky-islands to the sky-island because `ST_Area(sky-island) << ST_Area(sonoran-tucson)`. The new migration's header cites both call sites explicitly; the stale `services/ingestor/src/upsert.ts` reference in 1700000008000:16-22 is documented as a known issue — we did not edit the shipped migration.
- **Tests.** New `packages/db-client/src/region-boundaries.test.ts` (6 cases, runs under the existing `@testcontainers/postgresql` harness): sky-island parent_id, sibling-overlap, expected-neighbour share a positive-length boundary, ST_Union forms a single hole-free polygon, and the two existing ingest probes still resolve correctly.

## Screenshots

N/A — not UI. Verification is programmatic (PostGIS queries asserting invariants on the post-migration DB), as discussed in the issue's AC.

## Test plan

- [x] `npm test -w @bird-watch/db-client` — 25 passed (7 files), including the new 6 region-boundaries cases
- [x] `npm test -w @bird-watch/ingestor` — 18 passed (5 files), including run-ingest/run-hotspots region-probe assertions
- [x] `npm test -w @bird-watch/read-api` — 20 passed (2 files)
- [x] `npm run build -w @bird-watch/db-client` — clean

Captured PostGIS verification output (full version via the ephemeral testcontainers run):

```
=== Sky-island parent_id ===
 sky-islands-chiricahuas   parent_id = sonoran-tucson
 sky-islands-huachucas     parent_id = sonoran-tucson
 sky-islands-santa-ritas   parent_id = sonoran-tucson

=== Sibling-pair check (13 pairs, all overlaps=false, inter_area=0) ===
 colorado-plateau        ↔ lower-colorado         shared_len=1.9708
 colorado-plateau        ↔ mogollon-rim           shared_len=5.0892
 colorado-plateau        ↔ sonoran-phoenix        shared_len=0.0000 (not neighbours)
 colorado-plateau        ↔ sonoran-tucson         shared_len=0.0000 (not neighbours)
 lower-colorado          ↔ mogollon-rim           shared_len=0.7071
 lower-colorado          ↔ sonoran-phoenix        shared_len=2.1000
 lower-colorado          ↔ sonoran-tucson         shared_len=0.0000 (not neighbours)
 mogollon-rim            ↔ sonoran-phoenix        shared_len=2.5681
 mogollon-rim            ↔ sonoran-tucson         shared_len=2.5227
 sky-islands-chiricahuas ↔ sky-islands-huachucas  shared_len=0.0000 (not neighbours)
 sky-islands-chiricahuas ↔ sky-islands-santa-ritas shared_len=0.0000 (not neighbours)
 sky-islands-huachucas   ↔ sky-islands-santa-ritas shared_len=0.0000 (touch at a point only)
 sonoran-phoenix         ↔ sonoran-tucson         shared_len=2.0296

=== Union of top-level regions ===
 geom_type = ST_Polygon   area = 32.0363   holes = 0

=== Ingest probes (smallest-area-wins) ===
 Madera Canyon      (31.72, -110.88) -> sky-islands-santa-ritas
 Sweetwater Wetlands (32.30, -110.99) -> sonoran-tucson
```

Down-migration round-trip: applied UP then DOWN of 1700000011000 against a fresh testcontainer and confirmed the resulting `svg_path` and `ST_AsText(geom)` for all 5 modified regions match the 1700000008000 seed byte-for-byte (modulo PostGIS's trailing-zero normalization, e.g. `-112.0` → `-112`).

## Plan reference

Parent: `docs/plans/2026-04-19-execute-issues-47-59.md` (Wave 3 Task 3.1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
