### PR TITLE
fix(frontend): render child regions after parents for correct SVG z-order

### DIFF
--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -40,6 +40,12 @@ function groupBy<T, K>(arr: T[], key: (t: T) => K): globalThis.Map<K, T[]> {
 
 export function Map(props: MapProps) {
   const observationsByRegion = groupBy(props.observations, o => o.regionId ?? 'unknown');
+  // Render parents (parent_id === null) before children so child polygons (e.g. sky islands)
+  // paint on top of their parent — otherwise alphabetical id order causes the parent's <path>
+  // to cover child polygons and intercept clicks. Fixes #80.
+  const orderedRegions = [...props.regions].sort((a, b) =>
+    (a.parentId === null ? 0 : 1) - (b.parentId === null ? 0 : 1)
+  );
 
   return (
     <svg
@@ -57,7 +63,7 @@ export function Map(props: MapProps) {
         if (e.target === e.currentTarget) props.onSelectRegion(null);
       }}
     >
-      {props.regions.map(r => {
+      {orderedRegions.map(r => {
         const isExpanded = props.expandedRegionId === r.id;
         const isDimmed = props.expandedRegionId !== null && !isExpanded;
         return (


### PR DESCRIPTION
## Diagrams

N/A

## Summary

- Regions iterated in alphabetical id order, causing sky-island children (`sky-islands-*`, all with `parentId='sonoran-tucson'`) to paint before their parent; `sonoran-tucson`'s `<path>` then covered their polygons and badges and intercepted clicks.
- Sort regions so `parentId === null` entries render first, children render after — child polygons sit on top of the parent fill in SVG z-order and receive pointer events correctly.

## Screenshots

N/A — programmatic test + CI e2e (PR #79) will validate

## Test plan

- [x] `npm run build -w @bird-watch/frontend` — clean (158.66 kB bundle, 292 ms)
- [x] `npm test -w @bird-watch/frontend` — 10 files, 59 tests, all green
- [x] Local e2e skipped (flaky environment per task brief); PR #79's e2e suite will validate the interactivity end-to-end once it rebases after this merges — specifically, PR #79 can drop its `force: true` click kludge since sky-island targets will now receive real clicks.

## Plan reference

Out of plan — unblocks PR #79. Parent: `docs/plans/2026-04-19-execute-issues-47-59.md`
