### PR TITLE
fix(ingestor): taxonomy ingestor populates species_meta (#83)

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -174,3 +174,30 @@ resource "google_cloud_scheduler_job" "ingest_hotspots" {
 
   depends_on = [google_project_service.scheduler]
 }
+
+# Monthly refresh of species_meta from eBird's taxonomy endpoint. eBird ships a
+# new taxonomy version yearly, so monthly is comfortably ahead of drift. After
+# upsert, the job also reconciles region_id / silhouette_id across observations
+# that lacked a species_meta row at original ingest time (the #83 fix path).
+resource "google_cloud_scheduler_job" "ingest_taxonomy" {
+  name      = "bird-ingest-taxonomy"
+  region    = var.gcp_region
+  schedule  = "0 6 1 * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["taxonomy"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -3,7 +3,8 @@ export type { Pool, PoolOptions } from './pool.js';
 export { getRegions } from './regions.js';
 export { getHotspots, upsertHotspots, type HotspotInput } from './hotspots.js';
 export {
-  getObservations, upsertObservations, type ObservationInput,
+  getObservations, upsertObservations, runReconcileStamping,
+  type ObservationInput,
 } from './observations.js';
 export { getSpeciesMeta, upsertSpeciesMeta } from './species.js';
 export {

--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from './test-helpers.js';
-import { upsertObservations, getObservations, type ObservationInput } from './observations.js';
+import {
+  upsertObservations, getObservations, runReconcileStamping,
+  type ObservationInput,
+} from './observations.js';
 
 let db: TestDb;
 beforeAll(async () => {
@@ -105,5 +108,57 @@ describe('getObservations filters', () => {
   it('filters by family code', async () => {
     const rows = await getObservations(db.pool, { familyCode: 'trochilidae' });
     expect(rows.map(r => r.subId)).toEqual(['S201']);
+  });
+});
+
+describe('runReconcileStamping', () => {
+  it('fills NULL silhouette_id / region_id on existing rows after species_meta lands', async () => {
+    // Wipe species_meta so the initial upsert leaves silhouette_id NULL (the
+    // exact prod shape in #83: observations ingested before species_meta was
+    // populated).
+    await db.pool.query('TRUNCATE species_meta CASCADE');
+
+    await upsertObservations(db.pool, [
+      {
+        subId: 'S900', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: '2026-04-15T08:00:00Z',
+        locId: 'L1', locName: 'Madera', howMany: 1, isNotable: false,
+      },
+    ]);
+    const before = await getObservations(db.pool, {});
+    expect(before[0]?.silhouetteId).toBeNull();
+    // region_id comes from the geometry JOIN which is independent of species_meta,
+    // so it is already populated. Null it out to prove reconcile fills it too.
+    await db.pool.query("UPDATE observations SET region_id = NULL WHERE sub_id = 'S900'");
+
+    // Populate species_meta (simulating a successful runTaxonomy) and reconcile.
+    await db.pool.query(
+      `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+       VALUES ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers')`
+    );
+    const touched = await runReconcileStamping(db.pool);
+    expect(touched).toBeGreaterThanOrEqual(1);
+
+    const after = await getObservations(db.pool, {});
+    expect(after[0]?.silhouetteId).toBe('tyrannidae');
+    expect(after[0]?.regionId).toBe('sky-islands-santa-ritas');
+  });
+
+  it('is idempotent — a second run touches no rows', async () => {
+    await db.pool.query(
+      `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+       VALUES ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers')
+       ON CONFLICT (species_code) DO UPDATE SET family_code = EXCLUDED.family_code`
+    );
+    await upsertObservations(db.pool, [
+      {
+        subId: 'S901', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: '2026-04-15T08:00:00Z',
+        locId: 'L1', locName: 'Madera', howMany: 1, isNotable: false,
+      },
+    ]);
+    // Everything already stamped — reconcile should find nothing to update.
+    const touched = await runReconcileStamping(db.pool);
+    expect(touched).toBe(0);
   });
 });

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -74,6 +74,40 @@ export async function upsertObservations(
   return inputs.length;
 }
 
+/**
+ * Re-runs the region/silhouette stamping UPDATE across ALL observations whose
+ * region_id or silhouette_id is still NULL. Idempotent.
+ *
+ * upsertObservations only stamps rows it just touched (via its WHERE filter,
+ * which in practice catches the current batch). When species_meta is empty
+ * at ingest time (as on prod pre-#83), the silhouette JOIN finds no row and
+ * silhouette_id stays NULL — even after the batch is stamped. Running this
+ * after a taxonomy job is loaded backfills every orphaned row.
+ *
+ * Returns the number of rows updated.
+ */
+export async function runReconcileStamping(pool: Pool): Promise<number> {
+  const { rowCount } = await pool.query(`
+    UPDATE observations o
+    SET
+      region_id = COALESCE(o.region_id, (
+        SELECT r.id FROM regions r
+        WHERE ST_Contains(r.geom, o.geom)
+        ORDER BY ST_Area(r.geom) ASC
+        LIMIT 1
+      )),
+      silhouette_id = COALESCE(o.silhouette_id, (
+        SELECT fs.id
+        FROM species_meta sm
+        JOIN family_silhouettes fs ON fs.family_code = sm.family_code
+        WHERE sm.species_code = o.species_code
+        LIMIT 1
+      ))
+    WHERE o.region_id IS NULL OR o.silhouette_id IS NULL
+  `);
+  return rowCount ?? 0;
+}
+
 export async function getObservations(
   pool: Pool,
   f: ObservationFilters

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -51,7 +51,7 @@ export interface FamilySilhouette {
 
 export interface IngestRun {
   id: number;
-  kind: 'recent' | 'notable' | 'backfill' | 'hotspots';
+  kind: 'recent' | 'notable' | 'backfill' | 'hotspots' | 'taxonomy';
   startedAt: string;
   finishedAt: string | null;
   obsFetched: number | null;

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -3,6 +3,7 @@ import { createPool, closePool } from '@bird-watch/db-client';
 import { runIngest } from './run-ingest.js';
 import { runHotspotIngest } from './run-hotspots.js';
 import { runBackfill } from './run-backfill.js';
+import { runTaxonomy } from './run-taxonomy.js';
 
 const KIND = process.argv[2] ?? 'recent';
 
@@ -21,8 +22,10 @@ async function main() {
       summary = await runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (KIND === 'backfill') {
       summary = await runBackfill({ pool, apiKey, regionCode: 'US-AZ', days: 30 });
+    } else if (KIND === 'taxonomy') {
+      summary = await runTaxonomy({ pool, apiKey });
     } else {
-      throw new Error(`Unknown kind: ${KIND}. Try recent | hotspots | backfill`);
+      throw new Error(`Unknown kind: ${KIND}. Try recent | hotspots | backfill | taxonomy`);
     }
     console.log(JSON.stringify(summary, null, 2));
   } finally {

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -65,6 +65,45 @@ describe('EbirdClient.fetchHotspots', () => {
   });
 });
 
+describe('EbirdClient.fetchTaxonomy', () => {
+  it('returns the full eBird taxonomy with species and non-species categories', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('cat')).toBe('species');
+        expect(url.searchParams.get('fmt')).toBe('json');
+        expect(url.searchParams.get('locale')).toBe('en');
+        expect(url.searchParams.get('version')).toBe('latest');
+        expect(request.headers.get('x-ebirdapitoken')).toBe('test-key');
+        return HttpResponse.json([
+          {
+            sciName: 'Pyrocephalus rubinus',
+            comName: 'Vermilion Flycatcher',
+            speciesCode: 'verfly',
+            category: 'species',
+            taxonOrder: 30501,
+            bandingCodes: ['VEFL'],
+            comNameCodes: ['VEFL'],
+            sciNameCodes: ['PYRU'],
+            order: 'Passeriformes',
+            familyCode: 'tyrann1',
+            familyComName: 'Tyrant Flycatchers',
+            familySciName: 'Tyrannidae',
+          },
+        ]);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'test-key' });
+    const taxa = await client.fetchTaxonomy();
+    expect(taxa).toHaveLength(1);
+    expect(taxa[0]?.speciesCode).toBe('verfly');
+    expect(taxa[0]?.familyComName).toBe('Tyrant Flycatchers');
+    expect(taxa[0]?.familyCode).toBe('tyrann1');
+    expect(taxa[0]?.taxonOrder).toBe(30501);
+    expect(taxa[0]?.category).toBe('species');
+  });
+});
+
 describe('EbirdClient retries', () => {
   it('retries on 5xx and eventually succeeds', async () => {
     let calls = 0;

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -1,4 +1,4 @@
-import type { EbirdObservation, EbirdHotspot } from './types.js';
+import type { EbirdObservation, EbirdHotspot, EbirdTaxon } from './types.js';
 
 export interface EbirdClientOptions {
   apiKey: string;
@@ -63,6 +63,21 @@ export class EbirdClient {
     );
     url.searchParams.set('maxResults', '10000');
     return this.getJson<EbirdObservation[]>(url);
+  }
+
+  /**
+   * Fetches the full eBird taxonomy (~17k rows including issf/spuh/slash/form/
+   * hybrid sub-categories). The `cat=species` parameter is an eBird server-side
+   * hint but does not actually restrict the response — callers MUST still filter
+   * to `category === 'species'` before writing to species_meta.
+   */
+  async fetchTaxonomy(): Promise<EbirdTaxon[]> {
+    const url = new URL(`${this.baseUrl}/ref/taxonomy/ebird`);
+    url.searchParams.set('cat', 'species');
+    url.searchParams.set('fmt', 'json');
+    url.searchParams.set('locale', 'en');
+    url.searchParams.set('version', 'latest');
+    return this.getJson<EbirdTaxon[]>(url);
   }
 
   private async getJson<T>(url: URL): Promise<T> {

--- a/services/ingestor/src/ebird/types.ts
+++ b/services/ingestor/src/ebird/types.ts
@@ -30,3 +30,22 @@ export interface EbirdHotspot {
   latestObsDt?: string;     // ISO-ish or absent
   numSpeciesAllTime?: number;
 }
+
+// Shape returned by https://api.ebird.org/v2/ref/taxonomy/ebird
+// The taxonomy includes species AND non-species categories (issf, spuh, slash,
+// form, hybrid, domestic) — consumers must filter to category === 'species'
+// before upserting into species_meta.
+export interface EbirdTaxon {
+  sciName: string;
+  comName: string;
+  speciesCode: string;
+  category: 'species' | 'issf' | 'spuh' | 'slash' | 'form' | 'hybrid' | 'domestic';
+  taxonOrder: number;
+  bandingCodes?: string[];
+  comNameCodes?: string[];
+  sciNameCodes?: string[];
+  order?: string;
+  familyCode?: string;
+  familyComName?: string;
+  familySciName?: string;
+}

--- a/services/ingestor/src/handler.ts
+++ b/services/ingestor/src/handler.ts
@@ -2,13 +2,14 @@ import { createPool, closePool } from '@bird-watch/db-client';
 import { runIngest, type RunSummary } from './run-ingest.js';
 import { runHotspotIngest, type RunHotspotSummary } from './run-hotspots.js';
 import { runBackfill, type RunBackfillSummary } from './run-backfill.js';
+import { runTaxonomy, type RunTaxonomySummary } from './run-taxonomy.js';
 
 export interface HandlerEnv {
   DATABASE_URL: string;
   EBIRD_API_KEY: string;
 }
 
-export type ScheduledKind = 'recent' | 'hotspots' | 'backfill';
+export type ScheduledKind = 'recent' | 'hotspots' | 'backfill' | 'taxonomy';
 
 /**
  * Platform-agnostic handler: invoked by the Cloud Run Job entry point
@@ -18,7 +19,7 @@ export type ScheduledKind = 'recent' | 'hotspots' | 'backfill';
 export async function handleScheduled(
   kind: ScheduledKind,
   env: HandlerEnv
-): Promise<RunSummary | RunHotspotSummary | RunBackfillSummary> {
+): Promise<RunSummary | RunHotspotSummary | RunBackfillSummary | RunTaxonomySummary> {
   const pool = createPool({ databaseUrl: env.DATABASE_URL });
   try {
     switch (kind) {
@@ -30,6 +31,8 @@ export async function handleScheduled(
         return await runBackfill({
           pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ', days: 30,
         });
+      case 'taxonomy':
+        return await runTaxonomy({ pool, apiKey: env.EBIRD_API_KEY });
     }
   } finally {
     await closePool(pool);

--- a/services/ingestor/src/run-taxonomy.test.ts
+++ b/services/ingestor/src/run-taxonomy.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
+import {
+  getSpeciesMeta, getObservations, getRecentIngestRuns,
+  upsertObservations,
+} from '@bird-watch/db-client';
+import { runTaxonomy } from './run-taxonomy.js';
+
+const server = setupServer();
+let db: TestDb;
+
+// A realistic mix: 5 species rows + 2 non-species (issf + spuh) that must be
+// dropped. familyComName → familyName is the only rename.
+const TAXONOMY_FIXTURE = [
+  {
+    sciName: 'Pyrocephalus rubinus', comName: 'Vermilion Flycatcher',
+    speciesCode: 'verfly', category: 'species', taxonOrder: 30501,
+    familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
+    familySciName: 'Tyrannidae',
+  },
+  {
+    sciName: 'Calypte anna', comName: "Anna's Hummingbird",
+    speciesCode: 'annhum', category: 'species', taxonOrder: 6000,
+    familyCode: 'trochi1', familyComName: 'Hummingbirds',
+    familySciName: 'Trochilidae',
+  },
+  {
+    sciName: 'Cardinalis cardinalis', comName: 'Northern Cardinal',
+    speciesCode: 'norcar', category: 'species', taxonOrder: 32000,
+    familyCode: 'cardin1', familyComName: 'Cardinals and Allies',
+    familySciName: 'Cardinalidae',
+  },
+  {
+    sciName: 'Megascops trichopsis', comName: 'Whiskered Screech-Owl',
+    speciesCode: 'whsowl1', category: 'species', taxonOrder: 4300,
+    familyCode: 'strigi1', familyComName: 'Owls',
+    familySciName: 'Strigidae',
+  },
+  {
+    sciName: 'Contopus pertinax', comName: 'Greater Pewee',
+    speciesCode: 'grepew1', category: 'species', taxonOrder: 30000,
+    familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
+    familySciName: 'Tyrannidae',
+  },
+  // issf — subspecies form, must be dropped
+  {
+    sciName: 'Junco hyemalis hyemalis/carolinensis',
+    comName: 'Dark-eyed Junco (Slate-colored)',
+    speciesCode: 'daejun1', category: 'issf', taxonOrder: 31000,
+    familyCode: 'passer1', familyComName: 'Old World Sparrows',
+    familySciName: 'Passeridae',
+  },
+  // spuh — genus-level, must be dropped
+  {
+    sciName: 'Empidonax sp.', comName: 'Empidonax flycatcher sp.',
+    speciesCode: 'y00005', category: 'spuh', taxonOrder: 30400,
+    familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
+    familySciName: 'Tyrannidae',
+  },
+];
+
+beforeAll(async () => {
+  db = await startTestDb();
+  server.listen({ onUnhandledRequest: 'error' });
+}, 90_000);
+
+afterEach(() => server.resetHandlers());
+beforeEach(async () => {
+  await db.pool.query('TRUNCATE species_meta CASCADE');
+  await db.pool.query('TRUNCATE observations');
+  await db.pool.query('TRUNCATE ingest_runs RESTART IDENTITY');
+});
+
+afterAll(async () => {
+  server.close();
+  await db?.stop();
+});
+
+describe('runTaxonomy', () => {
+  it('fetches taxonomy, filters to species, upserts species_meta, records success run', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', () =>
+        HttpResponse.json(TAXONOMY_FIXTURE)
+      )
+    );
+
+    const summary = await runTaxonomy({
+      pool: db.pool, apiKey: 'test-key',
+    });
+
+    expect(summary.status).toBe('success');
+    expect(summary.totalFetched).toBe(7);
+    expect(summary.nonSpeciesFiltered).toBe(2);
+    expect(summary.speciesInserted).toBe(5);
+
+    // Verify a real row landed. `family_code` is derived from `familySciName`
+    // (lowercased) — not eBird's `familyCode` — because family_silhouettes is
+    // seeded with lowercased-sci-name keys (migration 1700000009000) and the
+    // stamping JOIN in observations.ts relies on this alignment.
+    const verfly = await getSpeciesMeta(db.pool, 'verfly');
+    expect(verfly).toEqual({
+      speciesCode: 'verfly',
+      comName: 'Vermilion Flycatcher',
+      sciName: 'Pyrocephalus rubinus',
+      familyCode: 'tyrannidae',
+      familyName: 'Tyrant Flycatchers',
+      taxonOrder: 30501,
+    });
+
+    // Non-species rows are not written.
+    expect(await getSpeciesMeta(db.pool, 'daejun1')).toBeNull();
+    expect(await getSpeciesMeta(db.pool, 'y00005')).toBeNull();
+
+    // Ingest run is recorded with kind='taxonomy' and status='success'.
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.kind).toBe('taxonomy');
+    expect(runs[0]?.status).toBe('success');
+    expect(runs[0]?.obsFetched).toBe(7);
+    expect(runs[0]?.obsUpserted).toBe(5);
+  });
+
+  it('reconcile-stamps existing observations — post-run they carry silhouette_id and region_id', async () => {
+    // Seed an observation BEFORE species_meta is populated. With an empty
+    // species_meta, upsertObservations' stamping JOIN finds nothing, so
+    // silhouette_id stays NULL (the exact prod bug in #83).
+    await upsertObservations(db.pool, [
+      {
+        subId: 'S200', speciesCode: 'verfly', comName: 'verfly',
+        lat: 31.72, lng: -110.88,
+        obsDt: '2026-04-15T08:00:00.000Z',
+        locId: 'L1', locName: 'Madera', howMany: 1, isNotable: false,
+      },
+    ]);
+    const before = await getObservations(db.pool, {});
+    expect(before[0]?.silhouetteId).toBeNull();
+
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', () =>
+        HttpResponse.json(TAXONOMY_FIXTURE)
+      )
+    );
+
+    const summary = await runTaxonomy({
+      pool: db.pool, apiKey: 'test-key',
+    });
+    expect(summary.status).toBe('success');
+
+    const after = await getObservations(db.pool, {});
+    // verfly → tyrann1 → silhouette 'tyrannidae' (seeded in migration 9)
+    expect(after[0]?.silhouetteId).toBe('tyrannidae');
+    expect(after[0]?.regionId).toBe('sky-islands-santa-ritas');
+    // comName now resolves through species_meta instead of falling back to code
+    expect(after[0]?.comName).toBe('Vermilion Flycatcher');
+  });
+
+  it('records failure run when eBird is unreachable', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', () =>
+        new HttpResponse('boom', { status: 502 })
+      )
+    );
+
+    const summary = await runTaxonomy({
+      pool: db.pool, apiKey: 'test-key',
+      maxRetries: 0, retryBaseMs: 1,
+    });
+
+    expect(summary.status).toBe('failure');
+    expect(summary.error).toMatch(/502|server/i);
+
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.kind).toBe('taxonomy');
+    expect(runs[0]?.status).toBe('failure');
+  });
+});

--- a/services/ingestor/src/run-taxonomy.ts
+++ b/services/ingestor/src/run-taxonomy.ts
@@ -1,0 +1,114 @@
+import {
+  upsertSpeciesMeta, runReconcileStamping,
+  startIngestRun, finishIngestRun,
+  type Pool,
+} from '@bird-watch/db-client';
+import type { SpeciesMeta } from '@bird-watch/shared-types';
+import { EbirdClient } from './ebird/client.js';
+import type { EbirdTaxon } from './ebird/types.js';
+
+export interface RunTaxonomyOptions {
+  pool: Pool;
+  apiKey: string;
+  /** Test hooks — forwarded to EbirdClient. */
+  maxRetries?: number;
+  retryBaseMs?: number;
+  /** Inject a client for tests; if omitted, one is constructed. */
+  client?: EbirdClient;
+  /** Upsert batch size. pg caps parameter count at ~65k; upsert uses 6 params
+   *  per row so 500 = 3000 params per statement (well under the cap). */
+  batchSize?: number;
+}
+
+export interface RunTaxonomySummary {
+  status: 'success' | 'failure';
+  totalFetched: number;
+  speciesInserted: number;
+  nonSpeciesFiltered: number;
+  reconciled: number;
+  error?: string;
+}
+
+const DEFAULT_BATCH_SIZE = 500;
+
+export async function runTaxonomy(opts: RunTaxonomyOptions): Promise<RunTaxonomySummary> {
+  const clientOpts: import('./ebird/client.js').EbirdClientOptions = {
+    apiKey: opts.apiKey,
+    ...(opts.maxRetries !== undefined && { maxRetries: opts.maxRetries }),
+    ...(opts.retryBaseMs !== undefined && { retryBaseMs: opts.retryBaseMs }),
+  };
+  const client = opts.client ?? new EbirdClient(clientOpts);
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+
+  const runId = await startIngestRun(opts.pool, 'taxonomy');
+  try {
+    const taxonomy = await client.fetchTaxonomy();
+    const speciesOnly = taxonomy.filter(t => t.category === 'species');
+    const nonSpeciesFiltered = taxonomy.length - speciesOnly.length;
+
+    const inputs = speciesOnly.map(toSpeciesMeta);
+    let speciesInserted = 0;
+    for (let i = 0; i < inputs.length; i += batchSize) {
+      const chunk = inputs.slice(i, i + batchSize);
+      speciesInserted += await upsertSpeciesMeta(opts.pool, chunk);
+    }
+
+    // Fill silhouette_id / region_id on rows whose species_meta JOIN previously
+    // found nothing. Idempotent — a no-op on subsequent runs once all rows are
+    // stamped.
+    const reconciled = await runReconcileStamping(opts.pool);
+
+    await finishIngestRun(opts.pool, runId, {
+      status: 'success',
+      obsFetched: taxonomy.length,
+      obsUpserted: speciesInserted,
+    });
+
+    return {
+      status: 'success',
+      totalFetched: taxonomy.length,
+      speciesInserted,
+      nonSpeciesFiltered,
+      reconciled,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await finishIngestRun(opts.pool, runId, {
+      status: 'failure',
+      errorMessage: msg,
+    });
+    return {
+      status: 'failure',
+      totalFetched: 0,
+      speciesInserted: 0,
+      nonSpeciesFiltered: 0,
+      reconciled: 0,
+      error: msg,
+    };
+  }
+}
+
+/**
+ * Maps eBird's taxonomy row to SpeciesMeta.
+ *
+ * family_code conventions: the `family_silhouettes` seed in migration
+ * 1700000009000_seed_family_silhouettes.sql uses lowercased scientific family
+ * names (e.g., 'tyrannidae') as the join key. eBird's own `familyCode` field
+ * is different (e.g., 'tyrann1'), so we derive family_code from
+ * `familySciName.toLowerCase()` to stay aligned with the silhouette schema.
+ * Falls back to eBird's familyCode lowercased if familySciName is absent.
+ *
+ * family_name carries the human-readable English label
+ * (`familyComName`, e.g. 'Tyrant Flycatchers').
+ */
+export function toSpeciesMeta(t: EbirdTaxon): SpeciesMeta {
+  const familyCode = (t.familySciName ?? t.familyCode ?? '').toLowerCase();
+  return {
+    speciesCode: t.speciesCode,
+    comName: t.comName,
+    sciName: t.sciName,
+    familyCode,
+    familyName: t.familyComName ?? '',
+    taxonOrder: typeof t.taxonOrder === 'number' ? t.taxonOrder : null,
+  };
+}


### PR DESCRIPTION
## Diagrams

New monthly `taxonomy` ingestor kind. Runs after deploy once, then monthly via Cloud Scheduler. Fills `species_meta` from eBird's `/ref/taxonomy/ebird` and reconciles `region_id` / `silhouette_id` on every observation that was stamped when `species_meta` was empty.

```mermaid
sequenceDiagram
    participant Scheduler
    participant Job as "Cloud Run Job<br>(ingestor taxonomy)"
    participant eBird
    participant Postgres

    Scheduler->>Job: POST /jobs:run (monthly, 0 6 1 * *)
    Job->>eBird: GET /ref/taxonomy/ebird?cat=species
    eBird-->>Job: ~17k rows (species + issf/spuh/slash/form/hybrid)
    Job->>Job: filter category=='species'
    Job->>Postgres: upsertSpeciesMeta (500-row chunks)
    Job->>Postgres: runReconcileStamping<br>(fills silhouette_id / region_id)
    Job->>Postgres: finishIngestRun(status='success')
```

Data-flow fix (what #83 actually broke on prod):

```mermaid
flowchart LR
    subgraph Before["Before — prod today"]
        B1["observations.species_code"] -->|JOIN| B2["species_meta: EMPTY"]
        B2 --> B3["silhouetteId: NULL<br>comName: speciesCode fallback"]
        B3 --> B4["/api/species/verfly -> 404<br>Family filter: only 'All'"]
    end
    subgraph After["After"]
        A1["observations.species_code"] -->|JOIN| A2["species_meta: ~11k rows<br>(populated by taxonomy ingestor)"]
        A2 --> A3["silhouetteId: tyrannidae<br>comName: 'Vermilion Flycatcher'"]
        A3 --> A4["/api/species/verfly -> 200<br>Family filter: 14 families"]
    end
```

## Summary

- `species_meta` had no writer in prod — this PR adds `taxonomy` as a 4th ingestor kind, mirroring the existing `recent` / `backfill` / `hotspots` pattern. One eBird call, ~17k rows in, ~11k species out after filtering issf/spuh/slash/form/hybrid.
- `family_code` is derived from `familySciName.toLowerCase()`, not eBird's `familyCode` field, because `family_silhouettes` (migration `1700000009000`) keys on lowercased scientific names — this is the join that makes `silhouette_id` resolve during observation stamping.
- After the species upsert succeeds, `runReconcileStamping` does a one-shot UPDATE across every observation whose `region_id` / `silhouette_id` is still NULL. Idempotent on every subsequent run.

## Screenshots

N/A — not UI. No frontend changes. Prod verification (post-merge, post-`gcloud run jobs execute`) will be: `curl https://api.bird-maps.com/api/species/verfly` returns 200, Family filter dropdown populates, observation `comName` / `silhouetteId` fill in.

## Test plan

- [x] `npm test` — 144 passing across 5 workspaces (added 3 `run-taxonomy.test.ts`, 1 `client.test.ts` for `fetchTaxonomy`, 2 `observations.test.ts` for `runReconcileStamping`; existing 138 unchanged)
- [x] New integration tests added — `run-taxonomy.test.ts` exercises the full cycle on testcontainers Postgres (success, reconcile-stamps-existing-observations, failure-records-ingest-run)
- [x] `npm run build` — clean across all workspaces (shared-types, family-mapping, db-client, ingestor, read-api, frontend)
- [x] `terraform validate` — green in `infra/terraform/`
- [ ] Manual prod backfill — out of scope for this PR. After merge, Julian runs `gcloud run jobs execute bird-ingestor --args=taxonomy --region=us-central1` once; thereafter the Cloud Scheduler cron `0 6 1 * *` handles monthly refresh.

## Plan reference

Out of plan — discovered post-ship; fixes #83. The original plans (Plan 1 scaffolded `species_meta`; Plan 2 only populated it in test setup) never specified a prod writer. This fills that gap.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)