### PR TITLE
ci: fix deploy-ingestor verify step using wrong gcloud format path

### DIFF
--- a/.github/workflows/deploy-ingestor.yml
+++ b/.github/workflows/deploy-ingestor.yml
@@ -70,7 +70,7 @@ jobs:
           # on their next tick automatically.
           DEPLOYED=$(gcloud run jobs describe "$JOB_NAME" \
             --region="$GCP_REGION" \
-            --format='value(template.template.containers[0].image)')
+            --format='value(spec.template.spec.template.spec.containers[0].image)')
           echo "Deployed image: $DEPLOYED"
           echo "Expected image: $IMAGE"
           test "$DEPLOYED" = "$IMAGE"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph before["Before (buggy)"]
    PUSH1[docker push image]
    UPDATE1[gcloud run jobs update]
    VERIFY1["verify: --format='value(template.template.containers[0].image)'"]
    RESULT1[("Deployed: '' (empty)<br/>Expected: image:sha<br/>exit 1 ❌")]
    PUSH1 --> UPDATE1 --> VERIFY1 --> RESULT1
  end
  subgraph after["After (fixed)"]
    PUSH2[docker push image]
    UPDATE2[gcloud run jobs update]
    VERIFY2["verify: --format='value(spec.template.spec.template.spec.containers[0].image)'"]
    RESULT2[("Deployed: image:sha<br/>Expected: image:sha<br/>exit 0 ✅")]
    PUSH2 --> UPDATE2 --> VERIFY2 --> RESULT2
  end
```

## Summary

- One-line fix in `.github/workflows/deploy-ingestor.yml`: the verify step queried `template.template.containers[0].image` (Cloud Run v2 admin-API path), but `gcloud run jobs describe` returns the Knative v1 shape. The attribute path silently resolved to empty, so the final `test "$DEPLOYED" = "$IMAGE"` failed.
- Deploys actually succeeded — Cloud Run was serving the new image on every run. The workflow was just a false negative, which masked real regressions.
- Surfaced while running the taxonomy backfill post-#84 merge: the workflow had been red on every deploy since it landed (confirmed against `gh run list --workflow=deploy-ingestor.yml`), but the `bird-ingestor` Cloud Run Job image tag matched every commit SHA we'd merged.

## Screenshots

N/A — not UI.

## Test plan

- [x] Verified the fixed path against prod: `gcloud run jobs describe bird-ingestor --region=us-west1 --format='value(spec.template.spec.template.spec.containers[0].image)'` returns the full image URL (e.g., `…/ingestor:c84818d3…`).
- [x] Verified the buggy path against prod: same command with `template.template.containers[0].image` returns empty.
- [x] The workflow's touched-paths trigger includes `.github/workflows/deploy-ingestor.yml`, so this PR's merge will itself trigger a new deploy run — that run is the end-to-end test of the fix.

## Plan reference

Out of plan — follow-up to #83/#84; surfaced during taxonomy backfill rollout.