### PR TITLE
fix(infra): grant tokenCreator to Cloud Scheduler service agent (#106)

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -98,6 +98,19 @@ resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke" {
   member   = "serviceAccount:${google_service_account.scheduler.email}"
 }
 
+# Scheduler's http_target uses oauth_token { service_account_email = scheduler }.
+# Before the HTTP call fires, the Cloud Scheduler service agent must mint an
+# OAuth token on behalf of that SA — which requires tokenCreator on the SA
+# itself. Without this binding the request 403s before reaching Cloud Run, so
+# the invoker-side bindings above never come into play. See issue #106.
+data "google_project" "current" {}
+
+resource "google_service_account_iam_member" "scheduler_token_creator" {
+  service_account_id = google_service_account.scheduler.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
+}
+
 locals {
   # Cloud Run Jobs v2 REST endpoint. v2 is the current API surface for
   # google_cloud_run_v2_job and uses a cleaner path than the v1 Knative


### PR DESCRIPTION
## Diagrams

The scheduler → job invocation is a 3-link auth chain. #106 repaired links 2 and 3; link 1 was never bound, so every request 403s before leaving Cloud Scheduler. This PR adds the missing link-1 binding.

```mermaid
sequenceDiagram
    participant CSA as Cloud Scheduler<br/>service agent<br/>(gcp-sa-cloudscheduler)
    participant Inv as bird-scheduler@<br/>(invoker SA)
    participant Run as Cloud Run v2 API
    participant Job as bird-ingestor@<br/>(runtime SA)

    rect rgb(255, 230, 230)
    Note over CSA,Inv: LINK 1 — missing before this PR
    CSA->>Inv: GenerateAccessToken<br/>(needs tokenCreator on Inv)
    Inv-->>CSA: OAuth token "I am bird-scheduler"
    end
    rect rgb(230, 255, 230)
    Note over CSA,Run: LINK 2 — fixed by #106
    CSA->>Run: POST .../jobs/bird-ingestor:run<br/>(needs run.invoker on job)
    end
    rect rgb(230, 255, 230)
    Note over Run,Job: LINK 3 — fixed by #106
    Run->>Job: start execution<br/>(needs serviceAccountUser on Job)
    end
```

## Summary

- Root cause of ongoing #106 outage: the Cloud Scheduler service agent (\`service-{project_number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com\`) lacked \`roles/iam.serviceAccountTokenCreator\` on the invoker SA \`bird-scheduler@\`, so the OAuth-token mint at the start of every scheduled HTTP call failed. Evidence: \`get-iam-policy bird-scheduler@\` returned etag \`ACAB\` (zero bindings); Cloud Run audit log had zero requests with \`principalEmail=bird-scheduler@\` — i.e. the call never arrived, consistent with a pre-send token denial rather than an invoker-side denial.
- Adds a single \`google_service_account_iam_member\` binding the scheduler service agent to tokenCreator on the invoker SA. Uses a stock \`data.google_project.current\` to resolve the project number at apply time.
- Comment in the file documents why this binding exists, so future maintainers don't look at the three scheduler-adjacent IAM resources and assume one is redundant.

## Screenshots

N/A — not UI.

## Test plan

- [x] \`terraform fmt\` — no diff
- [x] \`terraform validate\` — Success
- [ ] \`terraform plan\` — Julian previews locally before apply; expect exactly one add (\`google_service_account_iam_member.scheduler_token_creator\`) and one data-source read (\`data.google_project.current\`)
- [ ] After \`terraform apply\`, the next \`*/30\` tick of \`bird-ingest-recent\` completes with \`status.code\` unset / 0 instead of 7
- [ ] \`gcloud scheduler jobs describe bird-ingest-recent --location=us-west1 --project=bird-maps-prod --format='value(lastAttemptTime,status.code)'\` — confirms post-apply success
- [ ] \`gcloud run jobs executions list --job=bird-ingestor --region=us-west1 --project=bird-maps-prod --limit=3\` — shows a new execution tied to the scheduler timestamp

Not running CI suites — this is an infra-only change under \`infra/terraform/\`; \`test\` / \`lint\` / \`build\` / \`e2e\` are unaffected but will run per branch protection.

## Plan reference

Out of plan — fixes #106 (Cloud Scheduler 403 on every run since 2026-04-19). Supersedes the fix prescribed in the issue body, which addressed two of three auth links but not the token-mint link.