### PR TITLE
chore: require Playwright MCP UI smoke for frontend PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -55,7 +55,14 @@ on a ready-to-merge PR. -->
 - [ ] New unit / integration tests added (if behavior changed)
 - [ ] New Playwright e2e spec added (if user-visible behavior changed)
 - [ ] `npm run build` — clean production build
-- [ ] (UI only) Manual smoke via `npm run dev` — feature works in the browser
+- [ ] (UI only) Playwright MCP smoke — ran `npm run dev --workspace
+      @bird-watch/frontend` (or hit a preview URL), drove the feature via
+      `mcp__plugin_playwright_playwright__browser_*` at ≥1 mobile (390×844) and
+      ≥1 desktop (1440×900) viewport, `browser_console_messages` returns no
+      errors/warnings, and the Screenshots section was captured from those
+      runs. Human-authored PRs may substitute direct browser interaction.
+      Reviewers repeat the drive + console check against the PR head SHA
+      before approving.
 
 ## Plan reference
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,13 +56,13 @@ on a ready-to-merge PR. -->
 - [ ] New Playwright e2e spec added (if user-visible behavior changed)
 - [ ] `npm run build` — clean production build
 - [ ] (UI only) Playwright MCP smoke — ran `npm run dev --workspace
-      @bird-watch/frontend` (or hit a preview URL), drove the feature via
+      @bird-watch/frontend`, drove the feature via
       `mcp__plugin_playwright_playwright__browser_*` at ≥1 mobile (390×844) and
       ≥1 desktop (1440×900) viewport, `browser_console_messages` returns no
       errors/warnings, and the Screenshots section was captured from those
       runs. Human-authored PRs may substitute direct browser interaction.
-      Reviewers repeat the drive + console check against the PR head SHA
-      before approving.
+      Reviewers repeat the drive + console check via `gh pr checkout <N>` +
+      `npm run dev` against the PR head SHA before approving.
 
 ## Plan reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,30 @@ Conventional commits style with scope where useful: `feat(scope):`, `chore:`, `c
 
 ## Testing
 
+### UI verification (agents + reviewers)
+
+Any PR that touches `frontend/**` gets driven live through Playwright MCP before
+it is opened (by the implementer) and before it is approved (by the reviewer).
+Passing e2e specs and `npm run build` are necessary but not sufficient — they
+don't catch console warnings, viewport-specific layout breaks, or interactions
+that only surface when you actually use the feature.
+
+Protocol:
+
+1. `npm run dev --workspace @bird-watch/frontend` locally, or hit the latest
+   Cloudflare Pages preview URL for the PR (review pass).
+2. `mcp__plugin_playwright_playwright__browser_navigate` to each touched
+   surface; `browser_resize` to at least one mobile (390×844) and one desktop
+   (1440×900) viewport — the two viewports the release-1 exit criteria name.
+3. Interact with the feature the way a user would (clicks, form fills, URL
+   round-trips). `browser_console_messages` must return zero errors and zero
+   warnings. A dirty console is a Tier-1 finding at review time.
+4. `browser_take_screenshot` per viewport per touched surface; those feed the
+   PR's Screenshots section (implementer only — reviewers don't re-capture).
+
+`.playwright-mcp/` is already gitignored so per-call snapshot YAMLs never land
+in git. Do not remove it from `.gitignore`.
+
 ### Spec authoring conventions
 
 E2E specs live in `frontend/e2e/*.spec.ts` and run under `@playwright/test`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,16 +68,21 @@ Conventional commits style with scope where useful: `feat(scope):`, `chore:`, `c
 
 ### UI verification (agents + reviewers)
 
-Any PR that touches `frontend/**` gets driven live through Playwright MCP before
-it is opened (by the implementer) and before it is approved (by the reviewer).
-Passing e2e specs and `npm run build` are necessary but not sufficient — they
-don't catch console warnings, viewport-specific layout breaks, or interactions
-that only surface when you actually use the feature.
+Any PR that adds or modifies visible UI under `frontend/**` gets driven live
+through Playwright MCP before it is opened (by the implementer) and before it
+is approved (by the reviewer). Test-only, type-only, and comment-only PRs
+under `frontend/**` are exempt — use the Screenshots section's `N/A — not UI`
+marker and skip this step. Passing e2e specs and `npm run build` are necessary
+but not sufficient for real UI change — they don't catch console warnings,
+viewport-specific layout breaks, or interactions that only surface when you
+actually use the feature.
 
 Protocol:
 
-1. `npm run dev --workspace @bird-watch/frontend` locally, or hit the latest
-   Cloudflare Pages preview URL for the PR (review pass).
+1. `npm run dev --workspace @bird-watch/frontend` locally. Reviewers run the
+   same command after `gh pr checkout <N>` against the PR head SHA — no
+   per-PR preview URLs are configured on this repo yet (Pages deploys only on
+   merge to `main`).
 2. `mcp__plugin_playwright_playwright__browser_navigate` to each touched
    surface; `browser_resize` to at least one mobile (390×844) and one desktop
    (1440×900) viewport — the two viewports the release-1 exit criteria name.


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[Implementer] -->|1. npm run dev| B[Local dev server]
    A -->|2. browser_navigate + resize| C["MCP drive: 390×844 + 1440×900"]
    C -->|3. browser_console_messages| D{console clean?}
    D -->|no| A
    D -->|yes| E[browser_take_screenshot]
    E --> F[Open PR with screenshots]
    F --> G[Reviewer]
    G -->|repeat 1–3 vs head SHA| C
    G -->|console clean + matches screenshots| H[Approve]
```

## Summary

- The existing "Manual smoke via `npm run dev`" line in the PR template was ambiguous for subagent workflows that don't have a human browser, so UI PRs were shipping without an interactive smoke. This codifies Playwright MCP as the explicit mechanism for both implementers and reviewers.
- `CLAUDE.md` §Testing gains a `UI verification (agents + reviewers)` subsection with the 4-step protocol (dev server → navigate + resize → interact + `browser_console_messages` clean → screenshot) pinned to the 390×844 and 1440×900 viewports the Plan 6 release-1 exit criteria already name.
- Ordered ahead of the Plan 6 frontend wave (#113 onward) so the deletion and surface-build PRs land under the new rule from day one.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — N/A (docs + template only)
- [x] New unit / integration tests added — N/A (no code)
- [x] New Playwright e2e spec added — N/A (no user-visible behavior)
- [x] `npm run build` — N/A (no code)
- [x] (UI only) Playwright MCP smoke — N/A (not UI; this PR is the rule that future UI PRs run the smoke)

## Plan reference

Out of plan — tooling convention that supports Plan 6's frontend wave. Companion comment on #125 will point child-issue executors at the new protocol once this merges.