### PR TITLE
fix(infra): scheduler needs run.jobsExecutorWithOverrides, not run.invoker (#106)

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -91,10 +91,15 @@ resource "google_service_account" "scheduler" {
   display_name = "bird-watch Cloud Scheduler invoker"
 }
 
+# The scheduler job body sends containerOverrides (to pick the CLI subcommand —
+# "recent", "backfill", "hotspots", "taxonomy" — on a single shared image), so
+# the API call is run.jobs.runWithOverrides, not run.jobs.run. roles/run.invoker
+# grants only the latter and 403s the former; roles/run.jobsExecutorWithOverrides
+# is the predefined role that grants both. See issue #106.
 resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke" {
   name     = google_cloud_run_v2_job.ingestor.name
   location = google_cloud_run_v2_job.ingestor.location
-  role     = "roles/run.invoker"
+  role     = "roles/run.jobsExecutorWithOverrides"
   member   = "serviceAccount:${google_service_account.scheduler.email}"
 }
 


### PR DESCRIPTION
## Diagrams

PR #107 fixed link 1 (OAuth token mint). This PR fixes link 2 — the Cloud Run API-method authorization check. The error was always HTTP 403, but the *source* of the 403 shifted after #107 landed:

\`\`\`mermaid
sequenceDiagram
    participant CSA as Cloud Scheduler<br/>service agent
    participant Inv as bird-scheduler@<br/>(invoker SA)
    participant Run as Cloud Run v2 API
    participant Job as bird-ingestor<br/>(job)

    Note over CSA,Inv: LINK 1 — fixed by #107 (tokenCreator)
    CSA->>Inv: GenerateAccessToken
    Inv-->>CSA: OAuth token for bird-scheduler@

    rect rgb(255, 230, 230)
    Note over CSA,Run: LINK 2 — THIS PR
    CSA->>Run: POST .../jobs/bird-ingestor:run<br/>body: {"overrides":{"containerOverrides":[{"args":["recent"]}]}}
    Run->>Run: check bird-scheduler@ holds<br/>run.jobs.runWithOverrides on the job
    Run-->>CSA: 403 — role was run.invoker,<br/>which grants only run.jobs.run
    end

    Note right of Run: With new role, this check passes<br/>and execution proceeds to the job.
\`\`\`

## Summary

- The scheduler HTTP body sends \`{"overrides":{"containerOverrides":[{"args":["recent"]}]}}\` because we invoke one shared ingestor image with different CLI subcommands for each cron (recent / backfill / hotspots / taxonomy). A request with overrides is \`run.jobs.runWithOverrides\`, not \`run.jobs.run\`.
- \`roles/run.invoker\` has exactly two permissions: \`run.jobs.run\`, \`run.routes.invoke\`. It does **not** include \`run.jobs.runWithOverrides\`. \`bird-scheduler@\` was being denied at Cloud Run's IAM check for every tick, even after #107 landed and the token mint started succeeding.
- Proof of the asymmetry: \`gh-deploy@\` (who has \`roles/run.admin\` at project level, which *does* include \`run.jobs.runWithOverrides\`) can invoke \`bird-ingestor\` manually. Manual invocations in the issue log are the only successful executions on record.
- Fix: swap the role on \`google_cloud_run_v2_job_iam_member.scheduler_invoke\` from \`roles/run.invoker\` → \`roles/run.jobsExecutorWithOverrides\`. The latter's entire permission set is \`{run.jobs.run, run.jobs.runWithOverrides, run.executions.cancel}\` — tight least-privilege match for the scheduler's call pattern.
- Comment on the resource explains why this role was chosen, so future maintainers don't "simplify" it back to the more familiar \`run.invoker\`.

## Screenshots

N/A — not UI.

## Test plan

- [x] \`terraform fmt\` — no diff
- [x] \`terraform validate\` — Success
- [x] \`terraform plan\` — shows exactly one replacement (destroy + create) of \`scheduler_invoke\` with the new role; nothing else drifts
- [ ] After \`terraform apply\`, the next \`*/30\` tick of \`bird-ingest-recent\` returns \`status.code\` unset / 0
- [ ] \`gcloud run jobs executions list --job=bird-ingestor --region=us-west1 --project=bird-maps-prod --limit=3\` — shows a new execution tied to the scheduler timestamp
- [ ] eventual first successful end-to-end ingest lands rows in the \`observations\` table

## Plan reference

Out of plan — resolves #106 (Cloud Scheduler 403 on every run since 2026-04-19). Third IAM link in a three-link auth chain; the issue diagnosis caught link 3 (serviceAccountUser on runtime SA), PR #107 caught link 1 (tokenCreator on invoker SA), and this PR catches link 2 (the API-method role on the job).