### PR TITLE
feat(read-api): enable gzip compression middleware

### DIFF
--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -142,6 +142,45 @@ describe('GET /api/species/:code', () => {
   });
 });
 
+describe('gzip compression middleware', () => {
+  beforeAll(async () => {
+    // The compress middleware's default threshold is 1024 bytes — responses
+    // below it are returned uncompressed. The /api/observations seed from
+    // the earlier describe leaves ~2 rows (~600 bytes of JSON), so we seed
+    // extra rows here to push /api/observations?since=30d comfortably past
+    // the threshold and get a deterministic compression outcome.
+    const extra = Array.from({ length: 20 }, (_, i) => ({
+      subId: `S-gzip-${i}`,
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 31.72 + i * 0.01,
+      lng: -110.88 + i * 0.01,
+      obsDt: new Date(Date.now() - i * 86400_000).toISOString(),
+      locId: `L-gzip-${i}`,
+      locName: `Gzip Seed Location ${i}`,
+      howMany: 1,
+      isNotable: false,
+    }));
+    await upsertObservations(db.pool, extra);
+  });
+
+  it('returns content-encoding: gzip when client accepts gzip', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d', {
+      headers: { 'Accept-Encoding': 'gzip' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).toBe('gzip');
+  });
+
+  it('omits content-encoding when client does not advertise gzip', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).toBeNull();
+  });
+});
+
 describe('CORS middleware', () => {
   // Save + restore FRONTEND_ORIGINS around tests that mutate it so other
   // describe blocks stay deterministic.

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import type { Pool } from '@bird-watch/db-client';
 import { getRegions, getHotspots, getObservations, getSpeciesMeta } from '@bird-watch/db-client';
@@ -37,6 +38,12 @@ export function createApp(deps: AppDeps): Hono {
     allowMethods: ['GET'],
     maxAge: 86400,
   }));
+
+  // Gzip JSON responses. Default threshold is 1024 bytes, so small routes
+  // (health, single-species lookups) go through uncompressed; big ones
+  // (`/api/observations?since=14d` healthy-baseline payload ~101 KB) drop
+  // below ~20 KB on the wire — load-bearing for mobile on slow-LTE. See #108.
+  app.use('*', compress());
 
   app.get('/health', c => c.json({ ok: true }));
 


### PR DESCRIPTION
## Diagrams

\`\`\`mermaid
flowchart LR
    Client -->|"Request<br/>Accept-Encoding: gzip"| CORS
    CORS --> Compress
    Compress --> Route["/api/observations<br/>/api/hotspots<br/>/api/regions<br/>/api/species/:code<br/>/health"]
    Route -->|"JSON body"| Compress
    Compress -->|"if body > 1024 B<br/>AND client accepted gzip<br/>AND type is compressible"| Out1["Content-Encoding: gzip"]
    Compress -->|"else (health checks,<br/>small responses,<br/>clients without gzip)"| Out2["uncompressed"]
    Out1 --> ClientOut[Client]
    Out2 --> ClientOut
\`\`\`

## Summary

- Register \`compress()\` from \`hono/compress\` as the second global middleware, after \`cors()\` and before the first route handler. Order rationale: CORS preflights (OPTIONS, no body) short-circuit before compression gets involved; once a GET reaches a route handler, the compress middleware wraps \`ctx.res\` on the way out with \`CompressionStream(\`gzip\`)\`.
- The middleware is conservative by default: it skips responses below ~1024 bytes (\`/health\`, \`/api/species/:code\` single-row lookups) and responses that declare \`Cache-Control: no-transform\` (none of ours do). Compressible types include \`application/json\`, which is every route's response.
- Two tests cover the positive case (client sends \`Accept-Encoding: gzip\` on a >1KB payload → \`Content-Encoding: gzip\`) and the negative case (no \`Accept-Encoding\` header → no \`Content-Encoding\`). The positive test seeds ~20 extra observation rows to push the \`/api/observations?since=30d\` body past the default threshold deterministically.
- No response-shape changes, no route changes, no other middleware added. Hono version unchanged.

## Screenshots

N/A — not UI.

## Test plan

- [x] \`npm test -w @bird-watch/read-api\` — 22/22 green (18 in \`app.test.ts\` including two new gzip specs)
- [x] \`npm run build -w @bird-watch/read-api\` — clean \`tsc\`
- [x] Confirmed \`hono/compress\` options shape against the installed package (\`node_modules/hono/dist/types/middleware/compress/index.d.ts\`): \`{ encoding?, threshold? }\`, default threshold 1024
- [ ] After deploy, \`curl -H "accept-encoding: gzip" -sI https://api.bird-maps.com/api/observations?since=14d\` returns \`content-encoding: gzip\`
- [ ] After deploy, \`curl -H "accept-encoding: gzip" -s https://api.bird-maps.com/api/observations?since=14d | wc -c\` is < 20 KB
- [ ] Existing uptime / probe traffic to \`/health\` stays uncompressed (below threshold; verify behavior unchanged)

## Plan reference

Part of Plan 6, Task 1. See \`docs/plans/2026-04-21-plan-6-path-a-reimagine.md#task-1-enable-gzip-compression-on-the-read-api\`. Resolves #108.