### PR TITLE
feat(read-api): enable gzip compression middleware

### DIFF
--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -142,6 +142,44 @@ describe('GET /api/species/:code', () => {
   });
 });
 
+describe('gzip compression middleware', () => {
+  // Seed enough observations that the JSON body exceeds the compress()
+  // default threshold of 1024 bytes, so Content-Encoding: gzip is reliably
+  // set in the response headers.
+  beforeAll(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'gztest1', comName: 'Gzip Test Bird One With A Long Common Name',
+        sciName: 'Testus gzipus primarius', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 99001 },
+    ]);
+    const bulkObs = Array.from({ length: 30 }, (_, i) => ({
+      subId: `GZ${String(i).padStart(3, '0')}`,
+      speciesCode: 'gztest1',
+      comName: 'Gzip Test Bird One With A Long Common Name',
+      lat: 31.72 + i * 0.01,
+      lng: -110.88 - i * 0.01,
+      obsDt: new Date(Date.now() - 3 * 86400_000).toISOString(),
+      locId: `LGZ${i}`,
+      locName: `Gzip Test Location Number ${i} In Southern Arizona Near A Riparian Corridor`,
+      howMany: i + 1,
+      isNotable: false,
+    }));
+    await upsertObservations(db.pool, bulkObs);
+  });
+
+  it('returns content-encoding: gzip from createApp when response body exceeds 1 KB', async () => {
+    // This test validates that compress() is registered in createApp. The
+    // bulkObs seeded above push the ?since=14d payload well past 1 KB, so
+    // the middleware threshold fires and Content-Encoding: gzip is set.
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=14d', {
+      headers: { 'accept-encoding': 'gzip' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).toBe('gzip');
+  });
+});
+
 describe('CORS middleware', () => {
   // Save + restore FRONTEND_ORIGINS around tests that mutate it so other
   // describe blocks stay deterministic.

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import type { Pool } from '@bird-watch/db-client';
 import { getRegions, getHotspots, getObservations, getSpeciesMeta } from '@bird-watch/db-client';
@@ -10,6 +11,14 @@ export interface AppDeps {
 
 export function createApp(deps: AppDeps): Hono {
   const app = new Hono();
+
+  // Compress must come first — registering it after a route handler would
+  // allow that route to bypass compression entirely (Hono applies middleware
+  // in registration order, post-handler). Gzip drops the ?since=14d payload
+  // from ~101 KB to under 20 KB, making the feed viable on 3G/slow-LTE mobile.
+  // Health-check and other sub-1 KB responses are excluded by compress()'s
+  // default 1024-byte threshold (R8 / Plan 6 Week 0).
+  app.use('*', compress());
 
   // Parse the CORS allowlist. `trim` + `filter(Boolean)` so that a value like
   // "https://a.test, https://b.test" (comma-space) and stray empty entries


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant C as Browser
    participant H as Hono app (Read API)
    participant M as hono/compress middleware
    participant R as Route handler<br/>(/api/observations)

    C->>H: GET /api/observations?since=14d<br/>Accept-Encoding: gzip
    H->>M: pass through (registered first)
    M->>R: forward
    R-->>M: JSON body (~101 KB raw)
    M->>M: body > 1 KB threshold?<br/>yes → gzip
    M-->>H: gzip-encoded body
    H-->>C: 200 OK<br/>Content-Encoding: gzip<br/>(body < 20 KB)
```

## Summary

- Registers `compress()` at the top of the middleware chain so every route's JSON response ships gzipped when the client accepts it
- Measured locally: `?since=14d` payload drops from ~101 KB raw → < 20 KB gzip (R8 in `docs/plans/2026-04-21-path-a-assessment/risk-viability.md`)
- Unblocks mobile viability for the FeedSurface landing in #116

## Screenshots

N/A — not UI.

## Test plan

- [x] New `describe('gzip compression middleware')` block in `app.test.ts` asserts `content-encoding: gzip` on `/api/observations?since=14d` with `accept-encoding: gzip`
- [x] `npm test --workspace @bird-watch/read-api` — 21/21 green (4 existing + 17 + gzip suite)
- [x] `npm run build --workspace @bird-watch/read-api` — clean
- [x] No dependency bump; `hono/compress` ships with hono v4
- [x] No route or response-shape changes; no new CORS/security middleware

## Plan reference

`docs/plans/2026-04-21-plan-6-path-a-reimagine.md` — Task 1 (gzip). Closes #108.