### PR TITLE
fix(read-api): add Vary: Accept-Encoding to gzip responses

### DIFF
--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -179,6 +179,21 @@ describe('gzip compression middleware', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('content-encoding')).toBeNull();
   });
+
+  it('sets Vary: Accept-Encoding on a gzipped response', async () => {
+    // Caches (CloudFlare CDN, browser caches) must vary their stored entry
+    // by Accept-Encoding so they never serve a gzip body to a client that
+    // didn't negotiate it.  See #143.
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations?since=30d', {
+      headers: { 'Accept-Encoding': 'gzip' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).toBe('gzip');
+    expect(
+      res.headers.get('vary')?.toLowerCase().includes('accept-encoding'),
+    ).toBe(true);
+  });
 });
 
 describe('CORS middleware', () => {

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -45,6 +45,20 @@ export function createApp(deps: AppDeps): Hono {
   // below ~20 KB on the wire — load-bearing for mobile on slow-LTE. See #108.
   app.use('*', compress());
 
+  // Tell downstream caches (CloudFlare CDN, browser caches) that the response
+  // body may differ depending on the client's Accept-Encoding value.  Without
+  // this header, a cache keyed only by URL could serve a gzip-encoded body to
+  // a client that never negotiated gzip.  Unconditional is correct per HTTP
+  // semantics: even a response that happened to fall below the compression
+  // threshold (and thus wasn't gzipped) could have been, so the cache must
+  // treat Accept-Encoding as a cache dimension.  Uses append:true so any
+  // existing Vary value (e.g. "Origin" from CORS) is comma-merged, not
+  // replaced.  Closes #143.
+  app.use('*', async (c, next) => {
+    await next();
+    c.header('Vary', 'Accept-Encoding', { append: true });
+  });
+
   app.get('/health', c => c.json({ ok: true }));
 
   app.get('/api/regions', async c => {


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Client
    participant CDN as CloudFlare CDN
    participant API as Read API (Hono)

    Note over API: compress() middleware<br/>gzips body (≥1024 bytes)
    Note over API: new Vary middleware<br/>sets Vary: Accept-Encoding

    Client->>CDN: GET /api/observations<br/>Accept-Encoding: gzip
    CDN->>API: forward
    API-->>CDN: 200, content-encoding: gzip,<br/>vary: Origin, Accept-Encoding
    CDN-->>Client: cache keyed by<br/>(URL, Origin, Accept-Encoding)

    Client->>CDN: GET /api/observations<br/>(no Accept-Encoding)
    Note over CDN: separate cache key →<br/>refetch, no bogus gzip body
```

## Summary

- Unconditional `Vary: Accept-Encoding` middleware registered after Hono's `compress()` in `services/read-api/src/app.ts`. Uses `c.header('Vary', 'Accept-Encoding', { append: true })` so the value comma-merges with the `Origin` that CORS already writes rather than clobbering it.
- Closes the gap flagged by @julianken-bot during PR #130 review — without this header, a downstream cache keyed only by URL can serve a gzipped body to a client that never negotiated gzip. Harmless for modern browsers, breaks the contract for non-browser consumers.
- One new test case asserting `vary` contains `accept-encoding` on a gzipped response. 23/23 read-api tests green.

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm test --workspace @bird-watch/read-api` → 23 passed (23), new case included
- [x] `npm run lint` → clean
- [x] `npm run build --workspace @bird-watch/read-api` → tsc exit 0
- [ ] Post-merge production check: `curl -sI --compressed 'https://api.bird-maps.com/api/observations?since=14d' | grep -i '^vary:'` returns `vary: origin, accept-encoding` (or the other order).

## Plan reference

Out of plan — release-2 correctness follow-up, resolves issue #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)