### PR TITLE
chore(frontend): release-2 polish sweep — dead code, stale docs, TS18048

### DIFF
--- a/docs/analyses/2026-04-20-frontend-map-analysis/STATUS.md
+++ b/docs/analyses/2026-04-20-frontend-map-analysis/STATUS.md
@@ -1,33 +1,28 @@
 # Analysis Funnel Status
 
 ## Current State
-- **Phase:** 4
-- **Sub-state:** Phase 0 in-progress (framing)
-- **Last updated:** 2026-04-21T03:46:37Z
+- **Phase:** Final (complete)
+- **Last updated:** 2026-04-21
 - **Artifact root:** /Users/j/repos/bird-watch/docs/analyses/2026-04-20-frontend-map-analysis
 
 ## Analysis Question
 Why is the map-based bird-watch frontend failing, and what evidence should inform a map-less reimagining?
 
 ## Analysis Conclusion
-_Filled after Phase 4._
-
-## Domain Tags
-_To be filled during Phase 0._
+The map rendering chain was the root cause: SVG-based region expansion was
+too complex, viewport-sensitive, and unmaintainable to sustain past Release 1.
+The evidence (prototype timing data, console error audit, rendering-chain
+complexity) justified a complete DISCARD-and-reimagine. Path A (three surface
+views: Feed / Species / Hotspots with URL-driven navigation) was selected and
+implemented as Plan 6. See `docs/plans/2026-04-21-plan-6-path-a-reimagine.md`.
 
 ## Phase Completion
 - [x] Phase 0: Frame
-- [x] Phase 1: _(in progress)_ Investigate (5 areas)
-- [x] Phase 2: _(in progress)_ Iterate (5 iterators)
-- [x] Phase 3: _(in progress)_ Synthesize (3 synthesizers)
-- [x] Phase 4: _(in progress)_ Final report
+- [x] Phase 1: Investigate (5 areas)
+- [x] Phase 2: Iterate (5 iterators)
+- [x] Phase 3: Synthesize (3 synthesizers)
+- [x] Phase 4: Final report
 
-## Context Packets Available
-_None yet._
-
-## Recovery Instructions
-To resume from this state:
-1. Read this STATUS.md
-2. Read the context packet for the current phase
-3. Read any incomplete artifacts for the sub-state
-4. Continue from where the sub-state indicates
+## Outcome
+Plan 6 shipped. PR #125 tracker closed. Path A is live at bird-maps.com.
+Context packets and phase artifacts are in this directory.

--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -61,7 +61,7 @@ test.describe('Path A happy path', () => {
       .poll(() => app.getUrlParams().get('notable'), { timeout: 5_000 })
       .toBe('true');
     // Wait for data refetch + re-render before measuring again.
-    await expect(page.locator('main[aria-busy="false"]')).toBeVisible({ timeout: 10_000 });
+    await app.waitForAppReady();
 
     const filteredCount = await page.locator('.feed-row').count();
 

--- a/frontend/e2e/manual-test.md
+++ b/frontend/e2e/manual-test.md
@@ -3,272 +3,223 @@
 Step-by-step instructions for a Claude agent to execute the E2E test suite manually
 using the Playwright MCP tools. Each flow maps 1:1 to a `happy-path.spec.ts` assertion.
 
-> **preview-build project:** A second Playwright project (`preview-build`) runs `vite build && vite preview` on port 4173 with `proxy: {}` explicitly set, catching the production routing gap where `/api` is on a different subdomain. Uses `test.fail()` until the baseUrl fix lands.
+> **Readiness gate:** The `<main id="main-surface">` element flips
+> `data-render-complete="true"` once `useBirdData` finishes its initial load.
+> All flows that require data must wait for this attribute before asserting.
 
-> **axe-core scans:** `npm run test:e2e --workspace @bird-watch/frontend -- axe.spec.ts` runs three WCAG 2/2.1 A/AA scans (initial load, region expanded, error screen) via @axe-core/playwright. Open a tagged follow-up issue for any rule you disable.
-
-> **Page Object Model:** Shared selectors live in `frontend/e2e/pages/*.ts` — `AppPage` (goto, waitForMapLoad, expandRegion, regionById, getUrlParams) and `FiltersBar` (timeWindow/notableOnly/family/species locators + selectTimeWindow/toggleNotable/selectFamily/setSpecies). New specs should use the POM; selectors don't belong in spec files.
+> **Page Object Model:** Shared selectors live in `frontend/e2e/pages/*.ts`:
+> `AppPage` (`goto`, `waitForAppReady`, `getUrlParams`) and `FiltersBar`
+> (`toggleNotable`, `selectTimeWindow`, etc.). New specs must use the POM.
 
 ---
 
 ## Prerequisites
 
-Before starting, both servers must be running. If they are not, ask the user to start them:
+Both servers must be running before starting:
 
 ```
 # Terminal 1 — read-api on port 8787
 DATABASE_URL=postgres://birdwatch:birdwatch@localhost:5433/birdwatch npm run dev --workspace @bird-watch/read-api
 
 # Terminal 2 — Vite dev server on port 5173
-cd frontend && npm run dev
+npm run dev --workspace @bird-watch/frontend
 ```
 
-Verify the API is up by navigating to `http://localhost:8787/api/regions` and confirming
-a JSON array is returned. Verify the frontend is up by navigating to `http://localhost:5173`
-and confirming the page loads without a network error.
+Confirm the API: navigate to `http://localhost:8787/api/observations` — a JSON
+array must be returned.
+Confirm the frontend: navigate to `http://localhost:5173` — the page loads and
+`<main data-render-complete="true">` appears within a few seconds.
 
 ---
 
-## Flow 1 — Initial page load renders all 9 regions
+## Flow 1 — Feed surface loads by default
 
-**What the automated test asserts:** `expect(regions).toHaveCount(9)`
+**What the automated test asserts:** at least one `.feed-row` is visible;
+the Feed tab has `aria-selected="true"`.
 
 ### Steps
 
 1. Navigate to the app:
-   - Tool: `browser_navigate`
-   - URL: `http://localhost:5173`
+   - Tool: `browser_navigate` → `http://localhost:5173`
 
-2. Take a snapshot to see the page structure:
-   - Tool: `browser_snapshot`
-
-3. Wait up to 15 seconds for the SVG map to finish loading, then verify exactly
-   9 elements with a `data-region-id` attribute are present in the DOM:
+2. Wait for render completion:
    - Tool: `browser_evaluate`
-   - Script: `document.querySelectorAll('[data-region-id]').length`
-   - **Pass:** result is `9`
-   - **Fail:** result is `0` (API unreachable or CORS error) or any number other than 9
+   - Script: `document.querySelector('main[data-render-complete="true"]') !== null`
+   - **Pass:** `true` (retry up to ~10 s)
 
-4. Verify the map-wrap is no longer in a loading state:
+3. Verify at least one feed row is visible:
    - Tool: `browser_evaluate`
-   - Script: `document.querySelector('.map-wrap')?.getAttribute('aria-busy')`
-   - **Pass:** result is `"false"` or `null`
+   - Script: `document.querySelectorAll('.feed-row').length`
+   - **Pass:** result ≥ 1
+
+4. Verify the Feed tab is selected:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelector('[role="tab"][aria-label="Feed view"]')?.getAttribute('aria-selected')`
+   - **Pass:** `"true"`
+
+5. Take a screenshot at desktop (1440×900) and mobile (390×844).
 
 ---
 
-## Flow 2 — Keyboard expand of the Santa Ritas region
+## Flow 2 — Notable-only filter narrows feed and updates URL
 
-**What the automated test asserts:** region receives focus → Enter key triggers expansion →
-element gets `region-expanded` class → `transform` attribute is non-empty.
-
-### Steps
-
-1. Locate the Santa Ritas region shape and confirm it exists:
-   - Tool: `browser_evaluate`
-   - Script: `!!document.querySelector('.region-shape[aria-label="Sky Islands — Santa Ritas"]')`
-   - **Pass:** `true`
-
-2. Focus the element using its aria-label:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('.region-shape[aria-label="Sky Islands — Santa Ritas"]').focus()`
-
-3. Press Enter to trigger keyboard activation:
-   - Tool: `browser_press_key`
-   - Key: `Enter`
-
-4. Take a screenshot to visually confirm the region expanded on the canvas:
-   - Tool: `browser_take_screenshot`
-
----
-
-## Flow 3 — URL updates with region param after expansion
-
-**What the automated test asserts:** `page.url()` contains `region=sky-islands-santa-ritas`
+**What the automated test asserts:** after toggling "Notable only", the URL
+gains `notable=true` and the row count decreases (or stays equal if all seeded
+observations are notable).
 
 ### Steps
 
-1. Immediately after Flow 2 Step 3, read the current URL:
-   - Tool: `browser_evaluate`
-   - Script: `window.location.href`
-   - **Pass:** URL contains `region=sky-islands-santa-ritas`
-   - **Fail:** URL does not change (replaceState bug) or contains a different region id
+1. Navigate to `http://localhost:5173` and wait for render completion.
 
----
+2. Count baseline feed rows:
+   - Tool: `browser_evaluate` → `document.querySelectorAll('.feed-row').length`
 
-## Flow 4 — Expanded region has `region-expanded` class and non-empty transform
+3. Click the Notable only checkbox:
+   - Tool: `browser_click` → `input[aria-label="Notable only"]`
 
-**What the automated test asserts:** `toHaveClass(/region-expanded/)` and `transformAttr` is truthy
-
-### Steps
-
-1. Check the class list on the expanded region `<g>`:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('[data-region-id="sky-islands-santa-ritas"]')?.className`
-   - **Pass:** returned string contains `region-expanded`
-
-2. Check the transform attribute (set by `computeExpandTransform`):
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('[data-region-id="sky-islands-santa-ritas"]')?.getAttribute('transform')`
-   - **Pass:** result is a non-empty string such as `"translate(123.4, 56.7) scale(2.1)"`
-   - **Fail:** result is `null` or `""` (region did not physically expand on the canvas)
-
----
-
-## Flow 5 — "Notable only" checkbox updates URL
-
-**What the automated test asserts:** checking the Notable only input appends `notable=true`
-to the URL.
-
-### Steps
-
-1. Locate the Notable only checkbox and confirm it is currently unchecked:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('input[aria-label="Notable only"]')?.checked`
-   - **Pass:** `false`
-
-2. Click the checkbox to check it:
-   - Tool: `browser_click`
-   - Use the aria-label selector: `input[aria-label="Notable only"]`
-
-3. Read the URL to confirm it updated:
-   - Tool: `browser_evaluate`
-   - Script: `window.location.href`
+4. Verify URL updated:
+   - Tool: `browser_evaluate` → `window.location.href`
    - **Pass:** URL contains `notable=true`
-   - **Fail:** URL unchanged (state is not being persisted)
 
-4. Confirm the checkbox is now visually checked:
+5. Wait for re-render:
    - Tool: `browser_evaluate`
-   - Script: `document.querySelector('input[aria-label="Notable only"]')?.checked`
-   - **Pass:** `true`
+   - Script: `document.querySelector('main[data-render-complete="true"]') !== null`
+
+6. Count rows after filter:
+   - Tool: `browser_evaluate` → `document.querySelectorAll('.feed-row').length`
+   - **Pass:** count ≤ baseline count
 
 ---
 
-## Flow 6 — Deep-link restore: reload recovers expanded region and filter state
+## Flow 3 — Species deep link cold-loads to search surface with panel open
 
-**What the automated test asserts:** after `page.reload()`, the region is still expanded
-and the Notable only checkbox is still checked — proving URL state is read on mount.
+**What the automated test asserts:** navigating to `?species=<code>` without
+an explicit `?view=` lands on the Species tab and opens the SpeciesPanel.
 
 ### Steps
 
-1. Note the URL before reloading (should contain both `region=sky-islands-santa-ritas`
-   and `notable=true` from previous flows):
-   - Tool: `browser_evaluate`
-   - Script: `window.location.search`
+1. Navigate with a species code (use any code seeded in `species_meta`; e.g. `vermfly`):
+   - Tool: `browser_navigate` → `http://localhost:5173?species=vermfly`
 
-2. Navigate to the same URL (simulates a reload / deep link):
-   - Tool: `browser_navigate`
-   - URL: `http://localhost:5173` + the query string from Step 1
-     (e.g. `http://localhost:5173?region=sky-islands-santa-ritas&notable=true`)
+2. Wait for render completion.
 
-3. Wait for the map to finish loading (9 regions present, aria-busy false):
+3. Verify the Species tab is selected:
    - Tool: `browser_evaluate`
-   - Script: `document.querySelectorAll('[data-region-id]').length`
-   - **Pass:** `9` (wait and retry if still `0`)
+   - Script: `document.querySelector('[role="tab"][aria-label="Species view"]')?.getAttribute('aria-selected')`
+   - **Pass:** `"true"`
 
-4. Confirm the Santa Ritas region is expanded without any user interaction:
+4. Verify the SpeciesPanel (`<aside role="complementary">`) is visible:
    - Tool: `browser_evaluate`
-   - Script: `document.querySelector('[data-region-id="sky-islands-santa-ritas"]')?.className`
-   - **Pass:** contains `region-expanded`
-   - **Fail:** no `region-expanded` class (URL state is not being read on mount)
-
-5. Confirm the Notable only checkbox is checked without any user interaction:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('input[aria-label="Notable only"]')?.checked`
+   - Script: `document.querySelector('aside[role="complementary"]') !== null`
    - **Pass:** `true`
-   - **Fail:** `false` (filter state is not restored from URL on mount)
 
-6. Take a screenshot to document the restored state:
-   - Tool: `browser_take_screenshot`
+5. Verify `?species=vermfly` is still in the URL (mount effect must not strip it):
+   - Tool: `browser_evaluate` → `new URLSearchParams(window.location.search).get('species')`
+   - **Pass:** `"vermfly"`
 
 ---
 
-## Additional flows (not covered by current automated tests)
+## Flow 4 — SpeciesPanel opens as drawer on mobile; tap overlay dismisses
 
-These cover UI surfaces present in the codebase that `happy-path.spec.ts` does not exercise.
-Run them when those areas change.
+**What the automated test asserts:** at 390×844, the panel has
+`data-layout="drawer"` and a `.species-panel-overlay` sibling; clicking the
+overlay dismisses the panel and strips `?species=` from the URL.
 
-### Flow 7 — Time window filter changes URL param
+### Steps
 
-1. Navigate to `http://localhost:5173`
-2. Wait for 9 regions.
-3. Change the Time window select to "Today":
-   - Tool: `browser_select_option`
-   - Selector: `select[aria-label="Time window"]`
-   - Value: `1d`
-4. Verify URL contains `since=1d`:
-   - Tool: `browser_evaluate` → `window.location.href`
-   - **Pass:** contains `since=1d`
-5. Change back to "14 days" (the default):
+1. Resize viewport to 390×844:
+   - Tool: `browser_resize` → `{ width: 390, height: 844 }`
+
+2. Navigate to `http://localhost:5173?species=vermfly` and wait for render completion.
+
+3. Verify the panel has `data-layout="drawer"`:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelector('aside[role="complementary"]')?.getAttribute('data-layout')`
+   - **Pass:** `"drawer"`
+
+4. Verify the overlay is present:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelector('.species-panel-overlay') !== null`
+   - **Pass:** `true`
+
+5. Click the overlay to dismiss:
+   - Tool: `browser_click` → `.species-panel-overlay`
+
+6. Verify the panel is gone:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelector('aside[role="complementary"]') === null || getComputedStyle(document.querySelector('aside[role="complementary"]')).display === 'none'`
+   - **Pass:** `true`
+
+7. Verify `?species=` was stripped from the URL:
+   - Tool: `browser_evaluate` → `new URLSearchParams(window.location.search).get('species')`
+   - **Pass:** `null`
+
+---
+
+## Flow 5 — SpeciesPanel opens as sidebar on desktop; ESC dismisses
+
+**What the automated test asserts:** at 1440×900, the panel has
+`data-layout="sidebar"` (no overlay); pressing ESC dismisses and strips
+`?species=`.
+
+### Steps
+
+1. Resize viewport to 1440×900:
+   - Tool: `browser_resize` → `{ width: 1440, height: 900 }`
+
+2. Navigate to `http://localhost:5173?species=vermfly` and wait for render completion.
+
+3. Verify `data-layout="sidebar"`:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelector('aside[role="complementary"]')?.getAttribute('data-layout')`
+   - **Pass:** `"sidebar"`
+
+4. Verify no overlay is present:
+   - Tool: `browser_evaluate`
+   - Script: `document.querySelectorAll('.species-panel-overlay').length`
+   - **Pass:** `0`
+
+5. Press ESC to dismiss:
+   - Tool: `browser_press_key` → `Escape`
+
+6. Verify the panel is gone and `?species=` stripped (same checks as Flow 4, Steps 6–7).
+
+---
+
+## Additional flows (supplementary, not covered by automated specs)
+
+### Flow 6 — Time window filter changes URL param
+
+1. Navigate to `http://localhost:5173` and wait for render completion.
+2. Change the Time window select to "Today":
+   - Tool: `browser_select_option` → `select[aria-label="Time window"]`, value `1d`
+3. Verify URL contains `since=1d`.
+4. Change back to "14 days" (the default):
    - Tool: `browser_select_option` → value `14d`
-6. Verify `since` param is removed from URL (default is omitted):
-   - Tool: `browser_evaluate` → `window.location.href`
-   - **Pass:** URL does NOT contain `since=`
+5. Verify `since` param is absent from URL (default is omitted).
 
-### Flow 8 — Family filter updates URL param
+### Flow 7 — Error screen renders when API is unreachable
 
-1. Navigate to `http://localhost:5173`
-2. Wait for 9 regions.
-3. Open the Family select and check whether any options besides "All families" are present:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('select[aria-label="Family"]')?.options.length`
-   - **Note:** if result is `1`, `species_meta` is empty (known issue) — log and skip to Step 6.
-4. Select the first non-"All families" option:
-   - Tool: `browser_evaluate`
-   - Script: `document.querySelector('select[aria-label="Family"] option:nth-child(2)')?.value`
-   - Then: `browser_select_option` with that value.
-5. Verify URL contains `family=<code>`:
-   - Tool: `browser_evaluate` → `window.location.href`
-   - **Pass:** URL contains `family=`
-6. Reset to "All families":
-   - Tool: `browser_select_option` → value `""`
-   - Verify `family` param removed from URL.
-
-### Flow 9 — Species text input commits on blur
-
-1. Navigate to `http://localhost:5173`
-2. Wait for 9 regions.
-3. Focus the Species input:
-   - Tool: `browser_evaluate` → `document.querySelector('input[aria-label="Species"]').focus()`
-4. Type a species common name (type something and check the datalist — or use a known value):
-   - Tool: `browser_type`
-   - Selector: `input[aria-label="Species"]`
-   - Text: partial name (e.g. `"Vermilion"`)
-5. Take a snapshot to see datalist suggestions.
-6. Press Tab to blur the input (which triggers `onBlur → commitSpeciesDraft`):
-   - Tool: `browser_press_key` → `Tab`
-7. Verify URL contains `species=<code>` if an exact match was found, or no `species=` param
-   if no match:
-   - Tool: `browser_evaluate` → `window.location.href`
-
-### Flow 10 — Error screen renders when API is unreachable
-
-1. Navigate to a URL that forces an API failure:
-   - Tool: `browser_navigate`
-   - URL: `http://localhost:5173` with no read-api running (stop the read-api server first,
-     or navigate directly to the app while the API is down).
-2. Wait a few seconds, then check for the error screen:
+1. Stop the read-api server, then navigate to `http://localhost:5173`.
+2. Wait a few seconds and check:
    - Tool: `browser_evaluate`
    - Script: `document.querySelector('.error-screen h2')?.textContent`
-   - **Pass:** `"Couldn't load map data"`
-   - **Fail:** page hangs with `aria-busy=true` indefinitely
+   - **Pass:** `"Couldn't load bird data"`
 
 ---
 
 ## Reporting results
 
-After completing all flows, summarise findings in this format:
+After completing all flows, summarise findings:
 
 ```
-Flow 1 — Initial load:        PASS / FAIL
-Flow 2 — Keyboard expand:     PASS / FAIL
-Flow 3 — URL on expand:       PASS / FAIL
-Flow 4 — Class + transform:   PASS / FAIL
-Flow 5 — Notable filter URL:  PASS / FAIL
-Flow 6 — Deep-link restore:   PASS / FAIL
-Flow 7 — Time window param:   PASS / FAIL (optional)
-Flow 8 — Family param:        PASS / FAIL / SKIP (species_meta empty)
-Flow 9 — Species input blur:  PASS / FAIL (optional)
-Flow 10 — Error screen:       PASS / FAIL (optional)
+Flow 1 — Feed surface default load:           PASS / FAIL
+Flow 2 — Notable filter narrows + URL:        PASS / FAIL
+Flow 3 — Species deep link → search surface:  PASS / FAIL
+Flow 4 — Mobile drawer + overlay dismiss:     PASS / FAIL
+Flow 5 — Desktop sidebar + ESC dismiss:       PASS / FAIL
+Flow 6 — Time window param (optional):        PASS / FAIL
+Flow 7 — Error screen (optional):             PASS / FAIL
 ```
 
 Any FAIL should include the evaluate script result and a screenshot.

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -19,9 +19,8 @@ export class AppPage {
   /**
    * Wait for the app to finish its initial data load. The `<main>`
    * landmark flips `data-render-complete="true"` once `useBirdData`'s
-   * `loading` settles to `false` and `observations` is no longer
-   * null. Replaces the legacy `[data-region-id]` count=9 gate that
-   * disappeared when the map chain was deleted in #113.
+   * `loading` settles to `false`. Replaces the legacy `[data-region-id]`
+   * count=9 gate that disappeared when the map chain was deleted in #113.
    */
   async waitForAppReady(timeout = 10_000) {
     await this.page

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,7 @@ export function App() {
     );
   }
 
-  const renderComplete = !loading && observations !== null ? 'true' : 'false';
+  const renderComplete = !loading ? 'true' : 'false';
 
   return (
     <div className="app">

--- a/frontend/src/components/MigrationBanner.test.tsx
+++ b/frontend/src/components/MigrationBanner.test.tsx
@@ -53,8 +53,8 @@ describe('MigrationBanner', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss migration notice' }));
     // Last replaceState call must not include region=
     const calls = (window.history.replaceState as ReturnType<typeof vi.fn>).mock.calls;
-    const lastCall = calls[calls.length - 1];
-    const urlArg = lastCall[2] as string;
+    const lastCall = calls.at(-1);
+    const urlArg = lastCall?.[2] as string;
     expect(urlArg).not.toContain('region=');
   });
 });

--- a/frontend/src/components/SpeciesAutocomplete.test.tsx
+++ b/frontend/src/components/SpeciesAutocomplete.test.tsx
@@ -103,10 +103,10 @@ describe('SpeciesAutocomplete', () => {
     // Auto-highlight already selects the first option; confirm it before
     // pressing any arrow key.
     const listbox = screen.getByRole('listbox');
-    const firstOption = within(listbox).getAllByRole('option')[0];
+    const [firstOption] = within(listbox).getAllByRole('option');
     expect(firstOption).toHaveAttribute('aria-selected', 'true');
     // aria-activedescendant on the input points at the auto-highlighted option.
-    expect(input.getAttribute('aria-activedescendant')).toBe(firstOption.id);
+    expect(input.getAttribute('aria-activedescendant')).toBe(firstOption!.id);
     // ArrowDown advances from the first option to the second.
     await user.keyboard('{ArrowDown}');
     const secondOption = within(listbox).getAllByRole('option')[1];
@@ -401,9 +401,10 @@ describe('SpeciesAutocomplete', () => {
       const options = within(listbox).getAllByRole('option');
 
       // First visible option must be Cooper's Hawk (Accipitridae has lowest taxonOrder).
-      expect(options[0].textContent).toMatch(/Cooper/i);
+      const [firstOpt] = options;
+      expect(firstOpt!.textContent).toMatch(/Cooper/i);
       // Auto-highlight must be on the first VISIBLE option.
-      expect(options[0]).toHaveAttribute('aria-selected', 'true');
+      expect(firstOpt).toHaveAttribute('aria-selected', 'true');
       // Enter must commit the visually-highlighted option (Cooper's Hawk), NOT Common Loon.
       await user.keyboard('{Enter}');
       expect(onSelectSpecies).toHaveBeenCalledTimes(1);
@@ -435,24 +436,25 @@ describe('SpeciesAutocomplete', () => {
       expect(options.length).toBeGreaterThanOrEqual(2);
 
       // Auto-highlight: first option (Cooper's Hawk, Accipitridae) is selected.
-      expect(options[0]).toHaveAttribute('aria-selected', 'true');
-      expect(options[0].textContent).toMatch(/Cooper/i);
+      const [opt0, opt1] = options;
+      expect(opt0).toHaveAttribute('aria-selected', 'true');
+      expect(opt0!.textContent).toMatch(/Cooper/i);
 
       // Verify groups: flat-sentinel pattern uses <li role="presentation" class="autocomplete-group-header">.
       // First group must be Accipitridae (lower taxonOrder), second must be Picidae.
       const groupHeaders = container.querySelectorAll('.autocomplete-group-header');
       expect(groupHeaders.length).toBeGreaterThanOrEqual(2);
-      expect(groupHeaders[0].textContent).toMatch(/Accipitridae/i);
-      expect(groupHeaders[1].textContent).toMatch(/Picidae/i);
+      expect(groupHeaders[0]!.textContent).toMatch(/Accipitridae/i);
+      expect(groupHeaders[1]!.textContent).toMatch(/Picidae/i);
 
       // ArrowDown crosses the group boundary: Accipitridae → Picidae.
       // The group header (<li role="presentation">) must NOT receive aria-selected.
       await user.keyboard('{ArrowDown}');
       // options[1] = Downy Woodpecker (first option in Picidae group) is now selected.
-      expect(options[1]).toHaveAttribute('aria-selected', 'true');
-      expect(options[1].textContent).toMatch(/Downy Woodpecker/i);
+      expect(opt1).toHaveAttribute('aria-selected', 'true');
+      expect(opt1!.textContent).toMatch(/Downy Woodpecker/i);
       // The previously-selected option is no longer selected.
-      expect(options[0]).toHaveAttribute('aria-selected', 'false');
+      expect(opt0).toHaveAttribute('aria-selected', 'false');
 
       // Group headers are <li role="presentation"> and must never carry aria-selected.
       for (const header of Array.from(groupHeaders)) {

--- a/frontend/src/release-1-assertions.test.ts
+++ b/frontend/src/release-1-assertions.test.ts
@@ -39,9 +39,6 @@ function collectProductionFiles(dir: string): string[] {
     }
     if (!/\.(ts|tsx)$/.test(entry)) continue;
     if (/\.test\.(ts|tsx)$/.test(entry)) continue;
-    // Exclude this file itself — the patterns appear in its own string
-    // literals, which would produce self-referential matches.
-    if (full.endsWith('release-1-assertions.test.ts')) continue;
     out.push(full);
   }
   return out;

--- a/frontend/src/tokens.test.ts
+++ b/frontend/src/tokens.test.ts
@@ -43,7 +43,7 @@ describe('tokens', () => {
         zIndex.modal,
       ];
       ranks.forEach((v, i) => {
-        if (i > 0) expect(v).toBeGreaterThan(ranks[i - 1]);
+        if (i > 0) expect(v).toBeGreaterThan(ranks[i - 1]!);
       });
     });
     it('panel is above overlay', () => {
@@ -69,7 +69,7 @@ describe('tokens', () => {
     it('scale is monotonic', () => {
       const ranks = [spacing.xs, spacing.sm, spacing.md, spacing.lg, spacing.xl];
       ranks.forEach((v, i) => {
-        if (i > 0) expect(v).toBeGreaterThan(ranks[i - 1]);
+        if (i > 0) expect(v).toBeGreaterThan(ranks[i - 1]!);
       });
     });
     it('values are multiples of 4px', () => {

--- a/frontend/src/tokens.ts
+++ b/frontend/src/tokens.ts
@@ -110,7 +110,7 @@ export const spacing = {
   sm: 8,
   /** Medium gap — panel internal spacing (species name → sci name). */
   md: 12,
-  /** Large gap — map-wrap padding, filters-bar gap. */
+  /** Large gap — filters-bar gap, surface padding. */
   lg: 16,
   /** X-large gap — panel top padding. */
   xl: 24,
@@ -121,7 +121,7 @@ export const duration = {
   fast: 200,
   /** Default transitions. 250ms. */
   base: 250,
-  /** Region-expand transition. 350ms. */
+  /** Slow panel/drawer transitions. 350ms. */
   slow: 350,
 } as const;
 


### PR DESCRIPTION
## Diagrams

N/A — no architectural change. Batch of 8 SUGGESTION-tier cleanups from Plan 6 PR reviews, grouped into 4 commits:

| Commit | Scope |
|---|---|
| `6102b28` | Dead code: App.tsx null check, release-1-assertions.test.ts dead branch, tokens.ts stale comments, TS18048 fixes in 3 test files |
| `7b05de7` | Doc rewrite: manual-test.md (Path A), STATUS.md final-state |
| `15346b7` | E2E: happy-path.spec.ts aria-busy → waitForAppReady |
| `84dc1e8` | Docs: waitForAppReady JSDoc synced with post-sweep gate |

## Summary

- **Dead code removed:** App.tsx dropped `observations !== null` guard (useBirdData initializes as `[]`, never null); release-1-assertions.test.ts self-exclusion branch; tokens.ts comments referencing deleted `.map-wrap` / `region-expand`.
- **TS hygiene:** `tsc --noEmit -p frontend/tsconfig.test.json` now returns 0 errors (was 8). Fixes use destructuring + non-null assertions in SpeciesAutocomplete.test.tsx, MigrationBanner.test.tsx (`.at(-1)` + optional chain), and tokens.test.ts (`!` on loop-indexed access TS can't infer through `.forEach`).
- **Stale docs:** `frontend/e2e/manual-test.md` rewritten around Path A surfaces (feed / species / hotspots + `[data-render-complete="true"]` gate); STATUS.md of the pre-Path-A analysis updated to final state (Path A selected, Plan 6 shipped).
- **E2E pattern consistency:** happy-path.spec.ts's lone `main[aria-busy="false"]` locator replaced with canonical `app.waitForAppReady()`. Viewport ordering audit showed all specs already set viewport before `goto` — no changes needed.
- **One carry-over:** `url-state.ts` bare `p.get('region')` was already commented adequately on main (from the #133 migration-banner PR) — no diff needed.

## Screenshots

N/A — no visible behavior change. Playwright MCP smoke would only capture already-verified states; each earlier PR in this batch (#146–#149) carries its own before/after screenshots.

## Test plan

- [x] `npx tsc --noEmit -p frontend/tsconfig.test.json` → 0 errors
- [x] `npm test --workspace @bird-watch/frontend` → 183/183 green (no count change, no assertion weakening)
- [x] `npm run build --workspace @bird-watch/frontend` → tsc + vite clean (162.99 kB JS, 323ms)
- [x] `npm run lint` → clean
- [x] `grep -c 'data-region-id\|region-expanded' frontend/e2e/manual-test.md` → 0 (all stale selectors removed)

## Plan reference

Out of plan — release-2 polish sweep bundling Plan 6 PR-review deferrals, resolves issue #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)