### PR TITLE
infra: configure Terraform remote state backend on GCS

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,72 @@
+# Infrastructure
+
+Terraform configuration for the bird-watch system, managing GCP (Cloud Run,
+Artifact Registry, Secret Manager, Cloud Scheduler), Neon (Postgres), and
+Cloudflare (Pages, DNS).
+
+## Remote state
+
+Terraform state is stored in a GCS bucket to keep sensitive values (DB
+passwords, API tokens) off local disk and to enable state locking for safe
+concurrent operations.
+
+| Property | Value |
+|---|---|
+| Bucket | `gs://bird-maps-tfstate` |
+| Prefix | `terraform/state` |
+| Location | `us-central1` |
+| Versioning | Enabled |
+| Public access | Prevented (uniform bucket-level access) |
+
+## Getting started
+
+### 1. Authenticate with GCP
+
+```bash
+gcloud auth application-default login
+```
+
+This writes Application Default Credentials that both `gcloud` and the
+Terraform GCS backend use automatically. You must have at least
+`roles/storage.objectUser` on the `bird-maps-tfstate` bucket.
+
+### 2. Initialize Terraform
+
+```bash
+cd infra/terraform
+terraform init
+```
+
+This downloads providers and connects to the remote GCS backend. No local
+`terraform.tfstate` file is created.
+
+### 3. Create a `terraform.tfvars` file
+
+Copy the example and fill in real values:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars` is gitignored (contains secrets). See `variables.tf` for
+descriptions of each variable.
+
+### 4. Plan and apply
+
+```bash
+terraform plan   # review changes
+terraform apply  # apply (requires confirmation)
+```
+
+## Migrating from local state
+
+If you previously ran `terraform apply` with local state, migrate it to GCS:
+
+```bash
+cd infra/terraform
+terraform init -migrate-state
+```
+
+Terraform will prompt you to confirm moving the state to the GCS backend.
+After migration, delete the local `terraform.tfstate` and
+`terraform.tfstate.backup` files.

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,4 +1,9 @@
 terraform {
+  backend "gcs" {
+    bucket = "bird-maps-tfstate"
+    prefix = "terraform/state"
+  }
+
   required_version = ">= 1.6.0"
   required_providers {
     google = {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before
        A[Developer laptop] -->|terraform apply| B[local terraform.tfstate]
        B -.->|contains| C[Neon DB password\nCloudflare API token\neBird API key]
        B -.->|no locking| D[concurrent corruption risk]
    end

    subgraph After
        E[Developer laptop] -->|terraform init| F[GCS: bird-maps-tfstate]
        F -->|versioned objects| G[terraform/state/default.tfstate]
        F -->|native locking| H[safe concurrent access]
        F -->|uniform bucket-level access\npublic access prevention| I[credentials stay in GCP]
    end
```

## Summary

- **Why:** Local `terraform.tfstate` contained sensitive credentials (Neon DB password, Cloudflare API token) with no locking and no recovery path. `.gitignore` prevented git commits (#47) but state on a single laptop is a bus-factor-1 risk.
- **What:** Created GCS bucket `bird-maps-tfstate` in `us-central1` with versioning, uniform bucket-level access, and public access prevention. Added `backend "gcs"` block to `versions.tf`. Confirmed `terraform init` and `terraform validate` pass cleanly against the new backend.
- **Docs:** Added `infra/README.md` with authentication, initialization, and state-migration instructions for new developers.

**Credential rotation note:** The Neon DB password and Cloudflare API token were embedded in the old local `terraform.tfstate` files generated during the 2026-04-19 deploy. If those local files were ever exposed (e.g. on an unencrypted laptop backup), both secrets should be rotated. This is not blocking for this PR but should be tracked as a follow-up hygiene task.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean (no formatting drift)
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform init` — successfully connected to GCS backend, providers installed
- [x] GCS bucket verified: versioning enabled, uniform bucket-level access, public access prevention enforced, location `us-central1`

## Plan reference

Out of plan — infrastructure hygiene; unblocks multi-dev workflow and pre-plan-7 credential safety.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)