### PR TITLE
feat(frontend): add unwired MapLibre map components (Plan 7 S3)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "@bird-watch/family-mapping": "*",
     "@bird-watch/shared-types": "*",
+    "maplibre-gl": "^4.7.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-map-gl": "^7.1.9"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+export interface ErrorBoundaryProps {
+  /** Fallback UI rendered when a child throws during render. */
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Generic React error boundary. Catches render-phase errors in the subtree
+ * and displays a fallback instead of crashing the entire app.
+ *
+ * Used by MapSurface to isolate MapLibre GL JS failures (WebGL context loss,
+ * tile fetch errors, style parse errors) from the rest of the application.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  override render(): React.ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback != null) return this.props.fallback;
+      return (
+        <div className="error-screen" role="alert">
+          <h2>Something went wrong</h2>
+          <p>{this.state.error?.message ?? 'An unexpected error occurred.'}</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { Observation } from '@bird-watch/shared-types';
+import { ErrorBoundary } from './ErrorBoundary.js';
+
+/**
+ * Lazy-loaded MapCanvas. The React.lazy() boundary lives HERE — not inside
+ * MapCanvas — so the 217 KB maplibre-gl chunk is only fetched when the map
+ * surface is first rendered. Feed and Species tabs never pay for it.
+ */
+const MapCanvas = React.lazy(() =>
+  import('./map/MapCanvas.js').then((m) => ({ default: m.MapCanvas })),
+);
+
+export interface MapSurfaceProps {
+  observations: Observation[];
+}
+
+/**
+ * View-level wrapper for the geographic map surface. Provides:
+ *   1. Code-splitting boundary (React.lazy / Suspense) — keeps MapLibre
+ *      out of the main bundle.
+ *   2. Error boundary — isolates WebGL / tile / style failures.
+ *   3. Loading skeleton while the chunk downloads.
+ *
+ * S4 wires this into App.tsx behind the `?view=map` tab. Until then it
+ * is unreachable in production (tree-shaken since nothing imports it).
+ */
+export function MapSurface({ observations }: MapSurfaceProps) {
+  return (
+    <ErrorBoundary
+      fallback={
+        <div className="error-screen" role="alert">
+          <h2>Map failed to load</h2>
+          <p>The map could not be displayed. Try refreshing the page.</p>
+        </div>
+      }
+    >
+      <React.Suspense
+        fallback={
+          <div
+            className="map-loading-skeleton"
+            role="status"
+            aria-live="polite"
+            style={{
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: '#f4f1ea',
+            }}
+          >
+            Loading map…
+          </div>
+        }
+      >
+        <MapCanvas observations={observations} />
+      </React.Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import type { Observation } from '@bird-watch/shared-types';
+
+/* ── Mock react-map-gl/maplibre ─────────────────���──────────────────────────
+   jsdom has no WebGL context so we stub Map, Source, and Layer as thin
+   pass-through components that expose their props for assertion.
+   Map is wrapped in forwardRef because MapCanvas passes a ref to it. */
+
+let capturedSourceProps: Record<string, unknown> = {};
+
+vi.mock('react-map-gl/maplibre', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Map: forwardRef(function MockMap({ children, ...rest }: any, _ref: any) {
+    return (
+      <div data-testid="mock-map" data-props={JSON.stringify(rest)}>
+        {children}
+      </div>
+    );
+  }),
+  Source: ({ children, ...rest }: Record<string, unknown>) => {
+    capturedSourceProps = rest;
+    return (
+      <div data-testid="mock-source" data-props={JSON.stringify(rest)}>
+        {children as React.ReactNode}
+      </div>
+    );
+  },
+  Layer: (props: Record<string, unknown>) => (
+    <div data-testid="mock-layer" data-layer-id={props.id} />
+  ),
+}));
+
+vi.mock('maplibre-gl/dist/maplibre-gl.css', () => ({}));
+
+/* ── Import after mocks ───────���───────────────────────────────────────── */
+const { MapCanvas } = await import('./MapCanvas.js');
+
+/* ── Helpers ─────────────────��─────────────────────────────────────────── */
+
+function makeObs(partial: Partial<Observation> = {}): Observation {
+  return {
+    subId: partial.subId ?? 'S001',
+    speciesCode: partial.speciesCode ?? 'houfin',
+    comName: partial.comName ?? 'House Finch',
+    lat: partial.lat ?? 32.2,
+    lng: partial.lng ?? -110.9,
+    obsDt: partial.obsDt ?? '2026-04-15T10:00:00Z',
+    locId: partial.locId ?? 'L001',
+    locName: partial.locName ?? 'Sabino Canyon',
+    howMany: partial.howMany ?? 3,
+    isNotable: partial.isNotable ?? false,
+    regionId: null,
+    silhouetteId: null,
+  };
+}
+
+describe('MapCanvas', () => {
+  beforeEach(() => {
+    capturedSourceProps = {};
+  });
+
+  it('renders the map-canvas wrapper with data-testid', () => {
+    const obs = Array.from({ length: 10 }, (_, i) =>
+      makeObs({ subId: `S${String(i).padStart(3, '0')}` }),
+    );
+    render(<MapCanvas observations={obs} />);
+    expect(screen.getByTestId('map-canvas')).toBeInTheDocument();
+  });
+
+  it('passes a GeoJSON FeatureCollection to the Source component', () => {
+    const obs = Array.from({ length: 10 }, (_, i) =>
+      makeObs({ subId: `S${String(i).padStart(3, '0')}` }),
+    );
+    render(<MapCanvas observations={obs} />);
+
+    expect(capturedSourceProps.type).toBe('geojson');
+    expect(capturedSourceProps.cluster).toBe(true);
+    expect(capturedSourceProps.clusterMaxZoom).toBe(14);
+    expect(capturedSourceProps.clusterRadius).toBe(50);
+
+    const data = capturedSourceProps.data as { type: string; features: unknown[] };
+    expect(data.type).toBe('FeatureCollection');
+    expect(data.features).toHaveLength(10);
+  });
+
+  it('renders three Layer components: clusters, cluster-count, unclustered-point', () => {
+    render(<MapCanvas observations={[makeObs()]} />);
+
+    const layers = screen.getAllByTestId('mock-layer');
+    const layerIds = layers.map((el) => el.getAttribute('data-layer-id'));
+
+    expect(layerIds).toContain('clusters');
+    expect(layerIds).toContain('cluster-count');
+    expect(layerIds).toContain('unclustered-point');
+  });
+
+  it('renders the ObservationPopover (initially null / hidden)', () => {
+    render(<MapCanvas observations={[makeObs()]} />);
+    // Popover renders nothing when observation is null.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Map, Source, Layer } from 'react-map-gl/maplibre';
+import type { MapRef } from 'react-map-gl/maplibre';
+import type { MapGeoJSONFeature } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import type { Observation } from '@bird-watch/shared-types';
+import { basemapStyle } from './basemap-style.js';
+import {
+  observationsToGeoJson,
+  buildClusterLayerSpec,
+  buildClusterCountLayerSpec,
+  buildUnclusteredPointLayerSpec,
+  CLUSTER_MAX_ZOOM,
+  CLUSTER_RADIUS,
+} from './observation-layers.js';
+import { ObservationPopover } from './ObservationPopover.js';
+
+export interface MapCanvasProps {
+  observations: Observation[];
+}
+
+/** Arizona center — default initial view. */
+const INITIAL_VIEW = {
+  longitude: -111.0937,
+  latitude: 34.0489,
+  zoom: 6,
+} as const;
+
+/**
+ * MapLibre GL JS map instance wrapped via react-map-gl/maplibre.
+ *
+ * Click handling uses the raw MapLibre `map.on('click', layerId, ...)` API
+ * instead of react-map-gl's `interactiveLayerIds` + `onClick` — the JSX
+ * abstraction doesn't populate `e.features` when layers are added via
+ * `<Source>`/`<Layer>` children (prototype learnings #1, #5).
+ */
+export function MapCanvas({ observations }: MapCanvasProps) {
+  const mapRef = useRef<MapRef>(null);
+  const [selectedObs, setSelectedObs] = useState<Observation | null>(null);
+
+  const geojson = useMemo(
+    () => observationsToGeoJson(observations),
+    [observations],
+  );
+
+  // Build layer specs once — they read CSS tokens at construction time.
+  const clusterLayer = useMemo(() => buildClusterLayerSpec(), []);
+  const clusterCountLayer = useMemo(() => buildClusterCountLayerSpec(), []);
+  const unclusteredLayer = useMemo(() => buildUnclusteredPointLayerSpec(), []);
+
+  // Observation lookup by subId for click handler.
+  const obsLookup = useMemo(() => {
+    const lookup: Record<string, Observation> = Object.create(null);
+    for (const o of observations) lookup[o.subId] = o;
+    return lookup;
+  }, [observations]);
+
+  /**
+   * Wire click handling through the raw MapLibre instance. This avoids the
+   * react-map-gl `e.features` bug (see prototype learnings #1).
+   */
+  const handleLoad = useCallback(() => {
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    map.on('click', 'unclustered-point', (e) => {
+      const features: MapGeoJSONFeature[] = map.queryRenderedFeatures(e.point, {
+        layers: ['unclustered-point'],
+      });
+      const feature = features[0];
+      if (!feature) return;
+
+      const subId = feature.properties?.subId as string | undefined;
+      if (subId) {
+        const obs = obsLookup[subId];
+        if (obs) setSelectedObs(obs);
+      }
+    });
+
+    // Zoom into cluster on click.
+    map.on('click', 'clusters', (e) => {
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: ['clusters'],
+      });
+      const feature = features[0];
+      if (!feature) return;
+
+      const clusterId = feature.properties?.cluster_id as number | undefined;
+      const source = map.getSource('observations');
+      if (clusterId != null && source && 'getClusterExpansionZoom' in source) {
+        (source as { getClusterExpansionZoom: (id: number, cb: (err: unknown, zoom: number) => void) => void })
+          .getClusterExpansionZoom(clusterId, (err, zoom) => {
+            if (err) return;
+            const geom = feature.geometry;
+            if (geom.type === 'Point') {
+              map.easeTo({
+                center: geom.coordinates as [number, number],
+                zoom,
+              });
+            }
+          });
+      }
+    });
+
+    // Change cursor on hover.
+    map.on('mouseenter', 'clusters', () => {
+      map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', 'clusters', () => {
+      map.getCanvas().style.cursor = '';
+    });
+    map.on('mouseenter', 'unclustered-point', () => {
+      map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', 'unclustered-point', () => {
+      map.getCanvas().style.cursor = '';
+    });
+  }, [obsLookup]);
+
+  const handleClosePopover = useCallback(() => setSelectedObs(null), []);
+
+  return (
+    <div data-testid="map-canvas" style={{ width: '100%', height: '100%' }}>
+      <Map
+        ref={mapRef}
+        initialViewState={INITIAL_VIEW}
+        style={{ width: '100%', height: '100%' }}
+        mapStyle={basemapStyle}
+        onLoad={handleLoad}
+      >
+        <Source
+          id="observations"
+          type="geojson"
+          data={geojson}
+          cluster
+          clusterMaxZoom={CLUSTER_MAX_ZOOM}
+          clusterRadius={CLUSTER_RADIUS}
+        >
+          <Layer {...clusterLayer} />
+          <Layer {...clusterCountLayer} />
+          <Layer {...unclusteredLayer} />
+        </Source>
+      </Map>
+      <ObservationPopover
+        observation={selectedObs}
+        onClose={handleClosePopover}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/map/ObservationPopover.tsx
+++ b/frontend/src/components/map/ObservationPopover.tsx
@@ -1,0 +1,60 @@
+import type { Observation } from '@bird-watch/shared-types';
+
+export interface ObservationPopoverProps {
+  observation: Observation | null;
+  onClose: () => void;
+}
+
+/**
+ * Inline popover shown when an unclustered observation point is clicked on
+ * the map. Displays the species common name, location, timestamp, and a
+ * notable badge when applicable.
+ *
+ * No navigation links — that belongs to #151 (species detail wiring).
+ */
+export function ObservationPopover({ observation, onClose }: ObservationPopoverProps) {
+  if (!observation) return null;
+
+  const dateStr = new Date(observation.obsDt).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+  return (
+    <div
+      className="observation-popover"
+      role="dialog"
+      aria-label={`Details for ${observation.comName}`}
+    >
+      <div className="observation-popover-header">
+        <span className="observation-popover-name">
+          {observation.comName}
+        </span>
+        {observation.isNotable && (
+          <span className="observation-popover-badge" aria-label="Notable">
+            !
+          </span>
+        )}
+        <button
+          type="button"
+          className="observation-popover-close"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          &times;
+        </button>
+      </div>
+      {observation.locName && (
+        <div className="observation-popover-location">
+          {observation.locName}
+        </div>
+      )}
+      <div className="observation-popover-time">{dateStr}</div>
+      {observation.howMany != null && (
+        <div className="observation-popover-count">
+          Count: {observation.howMany}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -1,0 +1,31 @@
+import type { StyleSpecification } from 'maplibre-gl';
+
+/**
+ * Minimal basemap style pointing at the S2 tile endpoint.
+ *
+ * Until S2 (tile infrastructure) merges, the URL will 404 — that's expected
+ * for unwired S3. MapLibre renders an empty canvas with the background colour
+ * and logs a fetch error; cluster/point layers still render correctly against
+ * the transparent background, which is all the unit tests need.
+ */
+export const basemapStyle: StyleSpecification = {
+  version: 8,
+  name: 'bird-maps-basemap',
+  sources: {
+    'bird-maps-tiles': {
+      type: 'vector',
+      tiles: ['https://tiles.bird-maps.com/{z}/{x}/{y}.pbf'],
+      minzoom: 0,
+      maxzoom: 14,
+    },
+  },
+  layers: [
+    {
+      id: 'background',
+      type: 'background',
+      paint: {
+        'background-color': '#f4f1ea', // matches --color-bg-page
+      },
+    },
+  ],
+};

--- a/frontend/src/components/map/observation-layers.test.ts
+++ b/frontend/src/components/map/observation-layers.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import type { Observation } from '@bird-watch/shared-types';
+import {
+  observationsToGeoJson,
+  buildClusterLayerSpec,
+  buildClusterCountLayerSpec,
+  buildUnclusteredPointLayerSpec,
+  CLUSTER_MAX_ZOOM,
+  CLUSTER_RADIUS,
+} from './observation-layers.js';
+
+function makeObs(partial: Partial<Observation> = {}): Observation {
+  return {
+    subId: partial.subId ?? 'S001',
+    speciesCode: partial.speciesCode ?? 'houfin',
+    comName: partial.comName ?? 'House Finch',
+    lat: partial.lat ?? 32.2,
+    lng: partial.lng ?? -110.9,
+    obsDt: partial.obsDt ?? '2026-04-15T10:00:00Z',
+    locId: partial.locId ?? 'L001',
+    locName: 'locName' in partial ? (partial.locName as string | null) : 'Sabino Canyon',
+    howMany: 'howMany' in partial ? (partial.howMany as number | null) : 3,
+    isNotable: partial.isNotable ?? false,
+    regionId: null,
+    silhouetteId: null,
+  };
+}
+
+describe('observationsToGeoJson', () => {
+  it('returns a FeatureCollection with the correct number of features', () => {
+    const obs = Array.from({ length: 5 }, (_, i) =>
+      makeObs({ subId: `S00${i}` }),
+    );
+    const result = observationsToGeoJson(obs);
+
+    expect(result.type).toBe('FeatureCollection');
+    expect(result.features).toHaveLength(5);
+  });
+
+  it('maps observation fields to GeoJSON properties', () => {
+    const obs = makeObs({
+      subId: 'S999',
+      comName: 'Vermilion Flycatcher',
+      locName: 'Sweetwater Wetlands',
+      obsDt: '2026-04-16T08:30:00Z',
+      howMany: 2,
+      isNotable: true,
+    });
+    const result = observationsToGeoJson([obs]);
+    const feature = result.features[0]!;
+
+    expect(feature.type).toBe('Feature');
+    expect(feature.geometry.type).toBe('Point');
+    expect(feature.geometry.coordinates).toEqual([-110.9, 32.2]);
+    expect(feature.properties.subId).toBe('S999');
+    expect(feature.properties.comName).toBe('Vermilion Flycatcher');
+    expect(feature.properties.locName).toBe('Sweetwater Wetlands');
+    expect(feature.properties.obsDt).toBe('2026-04-16T08:30:00Z');
+    expect(feature.properties.howMany).toBe(2);
+    expect(feature.properties.isNotable).toBe(true);
+  });
+
+  it('returns an empty FeatureCollection for zero observations', () => {
+    const result = observationsToGeoJson([]);
+    expect(result.type).toBe('FeatureCollection');
+    expect(result.features).toHaveLength(0);
+  });
+
+  it('handles null locName and null howMany', () => {
+    const obs = makeObs({ locName: null, howMany: null });
+    const result = observationsToGeoJson([obs]);
+    const props = result.features[0]!.properties;
+
+    expect(props.locName).toBeNull();
+    expect(props.howMany).toBeNull();
+  });
+});
+
+describe('layer specs', () => {
+  it('unclustered-point paint uses isNotable case expression', () => {
+    const spec = buildUnclusteredPointLayerSpec();
+    expect(spec.id).toBe('unclustered-point');
+    expect(spec.type).toBe('circle');
+
+    // The paint expression should reference 'isNotable' via a case expression.
+    const paint = spec.paint as Record<string, unknown>;
+    const circleColor = paint['circle-color'] as unknown[];
+    expect(circleColor[0]).toBe('case');
+    expect(circleColor[1]).toEqual(['get', 'isNotable']);
+    // Third element is the notable colour (string), fourth is common colour.
+    expect(typeof circleColor[2]).toBe('string');
+    expect(typeof circleColor[3]).toBe('string');
+  });
+
+  it('unclustered-point circle radius is 10-12px for mobile touch targets', () => {
+    const spec = buildUnclusteredPointLayerSpec();
+    const paint = spec.paint as Record<string, unknown>;
+    const radius = paint['circle-radius'] as number;
+    expect(radius).toBeGreaterThanOrEqual(10);
+    expect(radius).toBeLessThanOrEqual(12);
+  });
+
+  it('cluster layer filters to features with point_count', () => {
+    const spec = buildClusterLayerSpec();
+    expect(spec.id).toBe('clusters');
+    expect(spec.type).toBe('circle');
+    expect(spec.filter).toEqual(['has', 'point_count']);
+  });
+
+  it('cluster-count layer renders point_count_abbreviated', () => {
+    const spec = buildClusterCountLayerSpec();
+    expect(spec.id).toBe('cluster-count');
+    expect(spec.type).toBe('symbol');
+    const layout = spec.layout as Record<string, unknown>;
+    expect(layout['text-field']).toEqual(['get', 'point_count_abbreviated']);
+  });
+});
+
+describe('cluster defaults', () => {
+  it('CLUSTER_RADIUS is 50', () => {
+    expect(CLUSTER_RADIUS).toBe(50);
+  });
+
+  it('CLUSTER_MAX_ZOOM is 14', () => {
+    expect(CLUSTER_MAX_ZOOM).toBe(14);
+  });
+});

--- a/frontend/src/components/map/observation-layers.ts
+++ b/frontend/src/components/map/observation-layers.ts
@@ -1,0 +1,162 @@
+import type { Observation } from '@bird-watch/shared-types';
+import type { LayerProps } from 'react-map-gl/maplibre';
+
+/**
+ * GeoJSON FeatureCollection type for observations — narrowed so callers get
+ * geometry + property types without pulling in the full `@types/geojson` dep.
+ */
+export interface ObservationFeatureCollection {
+  type: 'FeatureCollection';
+  features: Array<{
+    type: 'Feature';
+    geometry: { type: 'Point'; coordinates: [number, number] };
+    properties: {
+      subId: string;
+      comName: string;
+      locName: string | null;
+      obsDt: string;
+      howMany: number | null;
+      isNotable: boolean;
+    };
+  }>;
+}
+
+/**
+ * Convert an array of Observations into a GeoJSON FeatureCollection suitable
+ * for a MapLibre GeoJSON source with clustering enabled.
+ */
+export function observationsToGeoJson(
+  observations: Observation[],
+): ObservationFeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: observations.map((o) => ({
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [o.lng, o.lat] as [number, number],
+      },
+      properties: {
+        subId: o.subId,
+        comName: o.comName,
+        locName: o.locName,
+        obsDt: o.obsDt,
+        howMany: o.howMany,
+        isNotable: o.isNotable,
+      },
+    })),
+  };
+}
+
+/* ── Colour helpers ────────────────────────────────────────────────────────
+   MapLibre style specs require concrete colour values (not CSS variables).
+   Read the design tokens at call time so the spec objects stay in sync with
+   the theme without hex literals in this module. */
+
+function readToken(name: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback;
+  const val = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return val || fallback;
+}
+
+/** Resolve --color-accent-notable-fg (dark amber) for notable dots. */
+export function notableColor(): string {
+  return readToken('--color-accent-notable-fg', '#b8860b');
+}
+
+/** Resolve --color-text-body for common (non-notable) dots. */
+export function commonColor(): string {
+  return readToken('--color-text-body', '#444');
+}
+
+/** Resolve --color-text-white for text on cluster circles. */
+export function clusterTextColor(): string {
+  return readToken('--color-text-white', '#fff');
+}
+
+/* ── Cluster source defaults ───────────────────────────────────────────── */
+
+export const CLUSTER_MAX_ZOOM = 14;
+export const CLUSTER_RADIUS = 50;
+
+/* ── Layer specs ───────────────────────────────────────────────────────── */
+
+/**
+ * Build the cluster-circle layer spec. Uses step expressions for graduated
+ * circle sizes based on point_count.
+ */
+export function buildClusterLayerSpec(): LayerProps {
+  return {
+    id: 'clusters',
+    type: 'circle',
+    source: 'observations',
+    filter: ['has', 'point_count'],
+    paint: {
+      'circle-color': [
+        'step',
+        ['get', 'point_count'],
+        '#51bbd6',
+        100,
+        '#f1f075',
+        750,
+        '#f28cb1',
+      ],
+      'circle-radius': [
+        'step',
+        ['get', 'point_count'],
+        20,
+        100,
+        30,
+        750,
+        40,
+      ],
+    },
+  };
+}
+
+/**
+ * Build the cluster-count symbol layer spec — renders the observation count
+ * inside each cluster circle.
+ */
+export function buildClusterCountLayerSpec(): LayerProps {
+  return {
+    id: 'cluster-count',
+    type: 'symbol',
+    source: 'observations',
+    filter: ['has', 'point_count'],
+    layout: {
+      'text-field': ['get', 'point_count_abbreviated'],
+      'text-size': 12,
+    },
+    paint: {
+      'text-color': readToken('--color-text-strong', '#1a1a1a'),
+    },
+  };
+}
+
+/**
+ * Build the unclustered-point layer spec. Notable observations get the accent
+ * colour; common ones get the body-text colour. Circle radius is 11px — large
+ * enough for reliable 390x844 mobile touch targets (prototype learnings #4).
+ */
+export function buildUnclusteredPointLayerSpec(): LayerProps {
+  return {
+    id: 'unclustered-point',
+    type: 'circle',
+    source: 'observations',
+    filter: ['!', ['has', 'point_count']],
+    paint: {
+      'circle-color': [
+        'case',
+        ['get', 'isNotable'],
+        notableColor(),
+        commonColor(),
+      ],
+      'circle-radius': 11,
+      'circle-stroke-width': 1,
+      'circle-stroke-color': clusterTextColor(),
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,10 @@
       "dependencies": {
         "@bird-watch/family-mapping": "*",
         "@bird-watch/shared-types": "*",
+        "maplibre-gl": "^4.7.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-map-gl": "^7.1.9"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.2",
@@ -1227,6 +1229,101 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
@@ -2018,6 +2115,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/mapbox__point-geometry": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+      "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mapbox__vector-tile": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+      "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/mapbox__point-geometry": "*",
+        "@types/pbf": "*"
+      }
+    },
+    "node_modules/@types/mapbox-gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz",
+      "integrity": "sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2027,6 +2165,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
     },
     "node_modules/@types/pg": {
       "version": "8.20.0",
@@ -2121,6 +2265,15 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2551,6 +2704,15 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -2586,6 +2748,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/async": {
@@ -2953,6 +3124,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
       }
     },
     "node_modules/cac": {
@@ -3595,6 +3785,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3832,6 +4028,18 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -3968,6 +4176,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4066,6 +4280,21 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -4089,6 +4318,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+      "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^4.1.3",
+        "kind-of": "^6.0.3",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/global-prefix/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/gopd": {
@@ -4287,7 +4554,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4320,6 +4586,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4434,6 +4709,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4479,6 +4763,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4628,6 +4924,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -4721,6 +5026,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4732,6 +5043,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lazystream": {
@@ -4876,6 +5202,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
+        "@types/geojson-vt": "3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/mapbox__vector-tile": "^1.3.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.0",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "global-prefix": "^4.0.0",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.3.0",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0",
+        "vt-pbf": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4953,6 +5320,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5056,6 +5432,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
@@ -5356,6 +5738,19 @@
         "node": "*"
       }
     },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
@@ -5596,6 +5991,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5702,6 +6103,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -5743,6 +6150,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -5773,6 +6186,55 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-map-gl": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-7.1.9.tgz",
+      "integrity": "sha512-KsCc8Gyn05wVGlHZoopaiiCr0RCAQ6LDISo5sEy1/pV/d7RlozkF946tiX7IgyijJQMRujHol5QdwUPESjh73w==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1",
+        "@types/mapbox-gl": ">=1.0.0"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0 <5.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-map-gl/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/react-map-gl/node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -5904,6 +6366,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -5972,6 +6443,12 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -6090,6 +6567,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/shebang-command": {
@@ -6211,6 +6703,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6227,6 +6754,43 @@
       "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -6441,6 +7005,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6562,6 +7135,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
@@ -6696,6 +7275,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
@@ -6722,6 +7316,21 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -7383,6 +7992,17 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
       }
     },
     "node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph "New components (unwired — S4 connects)"
        MS[MapSurface.tsx] -->|React.lazy| MC[map/MapCanvas.tsx]
        MS -->|wraps| EB[ErrorBoundary.tsx]
        MC --> OL[map/observation-layers.ts]
        MC --> BS[map/basemap-style.ts]
        MC --> OP[map/ObservationPopover.tsx]
    end

    subgraph "Existing (NOT touched)"
        App[App.tsx]
        SN[SurfaceNav.tsx]
        US[url-state.ts]
    end

    App -.->|"S4 wires"| MS
    OL -->|reads| CSS["--color-* CSS tokens"]
    MC -->|"react-map-gl/maplibre"| ML[MapLibre GL JS]
```

## Summary

- Add the full MapLibre map component tree for Plan 7's geographic map surface: `MapSurface` (lazy wrapper + error boundary), `MapCanvas` (MapLibre instance with clustered GeoJSON source), `observation-layers` (pure GeoJSON + layer-spec helpers), `ObservationPopover`, `basemap-style`, and `ErrorBoundary`.
- Components are code-split via `React.lazy` so the ~217 KB MapLibre chunk only loads when S4 wires `MapSurface` into `App.tsx` behind `?view=map`. Until then, the new files are tree-shaken from the production bundle.
- Click handling uses the raw MapLibre `map.on('click', layerId)` API (not react-map-gl's `interactiveLayerIds`) per prototype learnings #1 and #5. Unclustered point radius is 11px for reliable mobile touch targets (learnings #4).

## Screenshots

N/A — components not yet wired into UI; S4 lands user-visible change.

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 202 tests pass (24 suites)
- [x] New unit tests: `observation-layers.test.ts` (10 tests), `MapCanvas.test.tsx` (4 tests)
- [x] `npx tsc -p frontend/tsconfig.json --noEmit` — zero errors
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npm run lint` — green
- [x] Verified `ls frontend/dist/assets/` shows no MapCanvas chunk (tree-shaken)
- [x] No changes to App.tsx, SurfaceNav.tsx, url-state.ts, or HotspotListSurface.tsx

## Plan reference

Part of Plan 7, S3 (issue #157). See `docs/plans/2026-04-22-plan-7-map-v1.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)