### PR TITLE
chore(migrations): fix stale frontend references in migration comments

### DIFF
--- a/migrations/1700000008000_seed_regions.sql
+++ b/migrations/1700000008000_seed_regions.sql
@@ -8,7 +8,9 @@
 --   geom  — WGS84 MULTIPOLYGON (SRID 4326), lng range −114.85…−109.05,
 --            lat range 31.30…37.00 (AZ bounding box).
 --   svg_path — SVG path string for viewBox "0 0 360 380".  Derived from geom
---              using the same linear projection as frontend/src/components/Map.tsx:
+--              using the linear projection below (historically matched a
+--              frontend SVG renderer, removed in #133; the projection is now
+--              a DB-only invariant preserved for any future SVG consumer):
 --                x = ((lng − −114.85) / (−109.05 − −114.85)) × 360
 --                y = ((37.00 − lat)   / (37.00 − 31.30))     × 380
 --              geom and svg_path describe the same shape; they must stay in sync.

--- a/migrations/1700000011000_fix_region_boundaries.sql
+++ b/migrations/1700000011000_fix_region_boundaries.sql
@@ -35,9 +35,11 @@
 --   y = ((37.00 - lat)  / 5.7) * 380
 -- `geom` and `svg_path` describe the same shape; the SVG values below are
 -- deterministically derived from the MULTIPOLYGON coordinates using that
--- formula.  The SVG path uses only absolute M/L/Z verbs — no curves — because
--- the parser in frontend/src/components/Region.tsx and frontend/src/geo/path.ts
--- only understands that subset.
+-- formula.  The `svg_path` column stores only absolute M/L/Z verbs — no
+-- curves — matching the minimal SVG-verb subset that the (now-removed, #133)
+-- frontend parser accepted.  The column is still served by `/api/regions`;
+-- keep the M/L/Z restriction for forward compatibility with any future SVG
+-- consumer.
 --
 -- Ingest contract (smallest-area-wins point-in-polygon) — TWO call sites:
 --   packages/db-client/src/observations.ts:58-59

--- a/migrations/1700000012000_fix_sky_islands_boundaries.sql
+++ b/migrations/1700000012000_fix_sky_islands_boundaries.sql
@@ -45,8 +45,9 @@
 --   y = ((37.00 - lat)  / 5.7) * 380
 -- Rounded to 3 decimals to match 11000's precision exactly; using 8000's
 -- 1-decimal form (239.0) would reintroduce a ~0.034-unit hairline seam.
--- Parsers accept only absolute M/L/Z verbs (frontend/src/geo/path.ts and
--- frontend/src/components/Region.tsx).
+-- `svg_path` stores only absolute M/L/Z verbs (no curves) — matches the
+-- minimal subset the (removed, #133) SVG parser accepted; preserved for
+-- forward compatibility with any future SVG consumer of `/api/regions`.
 --
 -- Ingest contract
 -- ---------------

--- a/migrations/1700000013000_fix_sky_islands_color.sql
+++ b/migrations/1700000013000_fix_sky_islands_color.sql
@@ -8,10 +8,15 @@
 -- without leaving the earth-tone palette").
 --
 -- `display_color` is a column on the `regions` table — the fix lives in
--- the DB seed, NOT in Region.tsx, so that `/api/regions` continues to be
--- the single source of truth for region fill color.  The matching token
--- `color.palette.skyIslands` in `frontend/src/tokens.ts` mirrors this
--- value for parity.
+-- the DB seed because the column is part of the `/api/regions` data
+-- contract (`packages/db-client/src/regions.ts:12`, exposed as
+-- `Region.displayColor` on `packages/shared-types/src/index.ts`).  The
+-- original SVG region-fill renderer that consumed it was removed in #133;
+-- the current MapLibre map does not draw region polygons, so no live
+-- frontend reader exists today.  A static token at
+-- `frontend/src/tokens.ts` (`color.palette.skyIslands`) mirrors this hex
+-- as a forward-compat reference — keep the DB value and the token in sync
+-- if either changes.
 --
 -- Timestamp `1700000013000` is the next slot after the most recent
 -- sky-islands migration (`1700000012000_fix_sky_islands_boundaries.sql`,


### PR DESCRIPTION
## Diagrams

N/A — comment-only changes in 4 SQL files.

## Summary

- Fixes stale frontend references (`Region.tsx`, `Map.tsx`, `frontend/src/geo/`) in migration comments across 4 files, 5 refs.
- Replacements are **invariant-style rewrites** per bot review on #182 (not name-swaps): they describe the DB invariant the migration maintains, rather than pointing at a new consumer that doesn't actually consume the column.
- No schema changes; migrations still apply cleanly against Testcontainers.

## Screenshots

N/A — not UI.

## Test plan

- [x] `grep -nE "Region\.tsx|Map\.tsx|frontend/src/geo/" migrations/*.sql` returns empty.
- [x] `npm run test -w @bird-watch/db-client` green (exercises migrations via Testcontainers).
- [x] All 4 CI gates (test, lint, build, e2e) green.

## Plan reference

Dispatch plan `/Users/j/.claude/plans/use-subagent-driven-development-giggly-blum.md`, Wave 1.

Closes #182.