### PR TITLE
chore: remove redundant shared-types dep from read-api + dead *Color exports

### DIFF
--- a/frontend/src/components/map/observation-layers.ts
+++ b/frontend/src/components/map/observation-layers.ts
@@ -62,17 +62,17 @@ function readToken(name: string, fallback: string): string {
 }
 
 /** Resolve --color-accent-notable-fg (dark amber) for notable dots. */
-export function notableColor(): string {
+function notableColor(): string {
   return readToken('--color-accent-notable-fg', '#b8860b');
 }
 
 /** Resolve --color-text-body for common (non-notable) dots. */
-export function commonColor(): string {
+function commonColor(): string {
   return readToken('--color-text-body', '#444');
 }
 
 /** Resolve --color-text-white for text on cluster circles. */
-export function clusterTextColor(): string {
+function clusterTextColor(): string {
   return readToken('--color-text-white', '#fff');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8392,7 +8392,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@bird-watch/db-client": "*",
-        "@bird-watch/shared-types": "*",
         "@hono/node-server": "^1.7.0",
         "hono": "^4.0.0"
       },

--- a/services/read-api/package.json
+++ b/services/read-api/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@bird-watch/db-client": "*",
-    "@bird-watch/shared-types": "*",
     "@hono/node-server": "^1.7.0",
     "hono": "^4.0.0"
   },


### PR DESCRIPTION
## Diagrams

N/A — small cleanup.

## Summary

- Removes `@bird-watch/shared-types` from `services/read-api/package.json` dependencies (unused; types flow transitively via `@bird-watch/db-client`).
- Removes three dead exports from `frontend/src/components/map/observation-layers.ts`: `notableColor`, `commonColor`, `clusterTextColor` (only internally referenced).
- Retains `FAMILY_COLOR_FALLBACK` (live via `family-color.ts`).
- Dockerfile's `shared-types` build step retained — `db-client` still transitively depends on it.

## Screenshots

N/A — not UI.

## Test plan

- [x] `grep -n "@bird-watch/shared-types" services/read-api/src/` returns zero matches.
- [x] `grep -rn "notableColor\|commonColor\|clusterTextColor" frontend/` returns zero external usages.
- [x] `npm run build --workspaces` green.
- [x] `npm run test --workspaces` green.
- [x] e2e + lint CI gates green.

## Plan reference

Dispatch plan `/Users/j/.claude/plans/use-subagent-driven-development-giggly-blum.md`, Wave 1.

Closes #180.