### PR TITLE
docs(plans): mark plan-4-frontend obsolete; check plan-7 prototype-gate boxes

### DIFF
--- a/docs/plans/2026-04-16-plan-4-frontend.md
+++ b/docs/plans/2026-04-16-plan-4-frontend.md
@@ -1,5 +1,7 @@
 # Frontend Implementation Plan
 
+> **Status:** Obsolete — superseded by Plan 6 (`docs/plans/2026-04-21-plan-6-path-a-reimagine.md`) and Plan 7 (`docs/plans/2026-04-22-plan-7-map-v1.md`). Do not execute.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build the React + Vite frontend that renders Arizona as a stylized SVG of 9 ecoregions, places species-stacked badges with bird-silhouette icons inside each region, expands the selected region inline, supports four filters, and syncs everything to the URL for deep-linking.

--- a/docs/plans/2026-04-22-plan-7-map-v1.md
+++ b/docs/plans/2026-04-22-plan-7-map-v1.md
@@ -115,11 +115,11 @@ Cloudflare provider is already pinned at `~> 4.20` in `versions.tf`. No new prov
 
 Per `CLAUDE.md` §"Prototype gate", no code under this plan may be written until all of:
 
-- [ ] Canned JSON with **≥344 representative observations** drives a local MapLibre prototype.
-- [ ] Rendering verified at **390×844 AND 1440×900** (the two viewports the release-1 exit criteria name).
-- [ ] Every interactive surface exercised: pan, zoom, cluster click, individual point click, filter-change repaint.
-- [ ] **Zero console errors, zero console warnings** at both viewports.
-- [ ] 5-line learnings note committed to `docs/plans/2026-04-22-map-v1-prototype/learnings.md` documenting anything that surprised the prototyper.
+- [x] Canned JSON with **≥344 representative observations** drives a local MapLibre prototype. (PR #163)
+- [x] Rendering verified at **390×844 AND 1440×900** (the two viewports the release-1 exit criteria name). (PR #163)
+- [x] Every interactive surface exercised: pan, zoom, cluster click, individual point click, filter-change repaint. (PR #163)
+- [x] **Zero console errors, zero console warnings** at both viewports. (PR #163)
+- [x] 5-line learnings note committed to `docs/plans/2026-04-22-map-v1-prototype/learnings.md` documenting anything that surprised the prototyper. (PR #163)
 
 The prototype does NOT need a real API, real R2 tiles, or real auth. A local Vite dev server with canned JSON and OpenFreeMap tiles is sufficient for the gate itself — we swap in the R2-hosted PMTiles during implementation. Scope: 2–4 hours.
 


### PR DESCRIPTION
## Diagrams

N/A — text-only doc edit.

## Summary

- Adds a top-of-file OBSOLETE callout to `docs/plans/2026-04-16-plan-4-frontend.md` (superseded by Plan 6 reimagine + Plan 7 map-v1) so agents don't accidentally execute the scrapped plan.
- Ticks the five completed prototype-gate checkboxes in `docs/plans/2026-04-22-plan-7-map-v1.md` — the gate was satisfied by PR #163 + the committed learnings note.

## Screenshots

N/A — not UI.

## Test plan

- [x] `head -20 docs/plans/2026-04-16-plan-4-frontend.md` shows the OBSOLETE callout at top.
- [x] `grep -c '^- \[x\]' docs/plans/2026-04-22-plan-7-map-v1.md` increased by the expected number of ticked boxes.
- [x] `npm run build` + `npm run lint` + `npm run test` all green (doc-only changes, should not regress).

## Plan reference

Part of dispatch plan `/Users/j/.claude/plans/use-subagent-driven-development-giggly-blum.md`, Wave 1.

Closes #175.