### PR TITLE
chore(deps): node-pg-migrate 7→8 (parent #179)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "node-pg-migrate": "^7.4.0",
+        "node-pg-migrate": "^8.0.4",
         "pg": "^8.11.3",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
@@ -4239,16 +4239,16 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -5417,22 +5417,20 @@
       }
     },
     "node_modules/node-pg-migrate": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-7.9.1.tgz",
-      "integrity": "sha512-6z4OSN27ye8aYdX9ZU7NN2PTI5pOp34hTr+22Ej12djIYECq++gT7LPLZVOQXEeVCBOZQLqf87kC3Y36G434OQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
+      "integrity": "sha512-HTlJ6fOT/2xHhAUtsqSN85PGMAqSbfGJNRwQF8+ZwQ1+sVGNUTl/ZGEshPsOI3yV22tPIyHXrKXr3S0JxeYLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "~11.0.0",
+        "glob": "~11.1.0",
         "yargs": "~17.7.0"
       },
       "bin": {
-        "node-pg-migrate": "bin/node-pg-migrate.js",
-        "node-pg-migrate-cjs": "bin/node-pg-migrate.js",
-        "node-pg-migrate-esm": "bin/node-pg-migrate.mjs"
+        "node-pg-migrate": "bin/node-pg-migrate.js"
       },
       "engines": {
-        "node": ">=18.19.0"
+        "node": ">=20.11.0"
       },
       "peerDependencies": {
         "@types/pg": ">=6.0.0 <9.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "node-pg-migrate": "^7.4.0",
+    "node-pg-migrate": "^8.0.4",
     "pg": "^8.11.3",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Diagrams

N/A — dep bump.

## Summary

- Bumps `node-pg-migrate` from `^7.4.0` → `^8.0.4` in root `package.json`.
- `scripts/migrate-deploy.sh` unchanged — v8 preserves the CLI flags our deploy script uses (`up`, `-m migrations`, `-d DATABASE_URL`).
- Migration marker semantics (`-- Up Migration` / `-- Down Migration`) preserved — no migration file rewrites.

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm run test -w @bird-watch/db-client` green under v8 (Testcontainers applies all 14 migrations cleanly; 35 tests across 8 files).
- [x] Full up → down (14 rollbacks) → up cycle clean against `postgis/postgis:16-3.4` via `docker compose` (DATABASE_URL → v8 CLI).
- [x] `npx node-pg-migrate --help` verifies `-d`, `-m`, `up`, `down` all still supported.
- [x] All 4 CI gates green (test, lint, build, e2e).

## Plan reference

Dispatch plan `/Users/j/.claude/plans/use-subagent-driven-development-giggly-blum.md`, Wave 3. Parent meta-issue #179.

Closes #187.