### PR TITLE
ci: consolidate Dependabot npm to root + lockfile-drift check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,17 @@
 version: 2
 updates:
-  # Root npm (workspace root — devDependencies, tooling)
+  # Single npm entry for the whole monorepo.
+  #
+  # npm workspaces keeps one package-lock.json at the root. A per-workspace
+  # Dependabot entry would edit a workspace's package.json without touching
+  # the root lockfile, breaking `npm ci`. Pointing the single entry at "/"
+  # lets Dependabot walk every workspace and emit a PR that updates every
+  # affected package.json *and* the root lockfile in one atomic change.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -13,86 +19,9 @@ updates:
       # node-pg-migrate major bump tracked separately by #187
       - dependency-name: "node-pg-migrate"
         update-types: ["version-update:semver-major"]
-    labels:
-      - "area:infra"
-
-  # Frontend workspace
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-    ignore:
       # maplibre-gl major bump tracked separately by #188
       - dependency-name: "maplibre-gl"
         update-types: ["version-update:semver-major"]
-      # vitest major bump tracked separately by #186
-      - dependency-name: "vitest"
-        update-types: ["version-update:semver-major"]
-    labels:
-      - "area:frontend"
-
-  # Read API workspace
-  - package-ecosystem: "npm"
-    directory: "/services/read-api"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-    ignore:
-      # vitest major bump tracked separately by #186
-      - dependency-name: "vitest"
-        update-types: ["version-update:semver-major"]
-    labels:
-      - "area:read-api"
-
-  # Ingestor workspace
-  - package-ecosystem: "npm"
-    directory: "/services/ingestor"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-    ignore:
-      # vitest major bump tracked separately by #186
-      - dependency-name: "vitest"
-        update-types: ["version-update:semver-major"]
-    labels:
-      - "area:ingestor"
-
-  # DB client workspace
-  - package-ecosystem: "npm"
-    directory: "/packages/db-client"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-    ignore:
-      # vitest major bump tracked separately by #186
-      - dependency-name: "vitest"
-        update-types: ["version-update:semver-major"]
-    labels:
-      - "area:infra"
-
-  # Shared types workspace
-  - package-ecosystem: "npm"
-    directory: "/packages/shared-types"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    groups:
-      minor-and-patch:
-        update-types: ["minor", "patch"]
-    ignore:
       # vitest major bump tracked separately by #186
       - dependency-name: "vitest"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/lockfile-consistency.yml
+++ b/.github/workflows/lockfile-consistency.yml
@@ -1,0 +1,29 @@
+name: lockfile-consistency
+on:
+  pull_request:
+    paths:
+      - '**/package.json'
+      - 'package-lock.json'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lockfile-consistency:
+    name: lockfile-consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Verify package-lock.json is in sync with all workspace package.json files
+        run: |
+          if ! npm ci --dry-run --ignore-scripts; then
+            echo ""
+            echo "::error::package-lock.json is out of sync with one or more package.json files."
+            echo "::error::This typically happens when a PR edits a workspace package.json without regenerating the root lockfile."
+            echo "::error::Fix: run 'npm install' at the repo root and commit the updated package-lock.json."
+            exit 1
+          fi


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph Before["Before: per-workspace npm entries"]
        direction TB
        A1["Dependabot points at<br/>/services/ingestor"] --> A2[Edits services/ingestor/package.json]
        A2 --> A3[Looks for sibling lockfile]
        A3 --> A4["None found<br/>(lives at repo root)"]
        A4 --> A5["PR: package.json only"]
        A5 --> A6["❌ npm ci fails<br/>Missing: X from lock file"]
    end
    subgraph After["After: single root npm entry"]
        direction TB
        B1["Dependabot points at /"] --> B2[Walks all workspaces]
        B2 --> B3["Edits every affected<br/>workspace package.json"]
        B3 --> B4[Regenerates root lockfile]
        B4 --> B5["PR: all package.jsons + lockfile"]
        B5 --> B6["✅ npm ci succeeds"]
    end
```

## Summary

- **Bug:** Six open Dependabot PRs (#204, #206, #210, #211, #212, #215) red across all four required checks with identical `npm ci` "Missing: X from lock file" errors. Every workspace testcontainers bump had a duplicate: one from the root entry (#218 — works) and one from each per-workspace entry (broken).
- **Root cause:** npm workspaces keeps a single `package-lock.json` at the repo root. Dependabot's lockfile regeneration only fires on a lockfile sitting next to the `package.json` it's editing. Pointing Dependabot at `/services/ingestor` therefore produces a PR that edits the workspace's `package.json` but never touches the root lockfile.
- **Fix:** Collapse five per-workspace npm entries into the single root `"/"` entry. Migrate `vitest`/`maplibre-gl`/`node-pg-migrate` major-version ignores to the root entry. PR #218 already proves the root-only path produces the correct atomic "workspace package.jsons + root lockfile" diff.
- **Defense-in-depth:** new `lockfile-consistency` workflow runs `npm ci --dry-run --ignore-scripts` on PRs that touch any `package.json` or the root lockfile. Same pre-check `npm ci` already runs, but surfaced as a single labeled red check with a fix-it message instead of four generic failures across `test`/`lint`/`build`/`e2e`.

## Screenshots

N/A — not UI (CI config + workflow file).

## Test plan

- [x] `npm ci --dry-run --ignore-scripts` locally on clean branch — exit 0 (check passes at current state)
- [x] Negative case: temporarily added `testcontainers@11.14.0` to `services/ingestor/package.json` — command exits nonzero with the same `Missing: testcontainers@11.14.0 from lock file` error that failing Dependabot PRs show. Restored immediately.
- [x] Both YAML files parse via `python3 -c "import yaml; yaml.safe_load(open(...))"`
- [x] `git diff --stat` confirms only `.github/dependabot.yml` (−79/+8) and `.github/workflows/lockfile-consistency.yml` (new) changed — no source, test, or lockfile churn
- [ ] `npm run typecheck && npm run test` — N/A (no application code touched)
- [ ] `npm run build` — N/A (no application code touched)
- [ ] Playwright MCP smoke — N/A (not UI)

## Plan reference

Out of plan — incident response for broken Dependabot PRs observed 2026-04-24. Follow-up: close the six broken duplicate PRs (#204, #206, #210, #211, #212, #215) after this merges — they will never go green, and Dependabot's next run with the fixed config will re-emit any still-needed bumps as correctly-lockfiled root-level PRs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)