### PR TITLE
ci(lockfile-consistency): pin GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/lockfile-consistency.yml
+++ b/.github/workflows/lockfile-consistency.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   lockfile-consistency:
     name: lockfile-consistency


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[lockfile-consistency workflow] --> B{GITHUB_TOKEN scope}
    B -->|"Before: repo default"| C[read + write permissions<br/>on contents, issues, PRs, etc.]
    B -->|"After: explicit block"| D[contents: read only]
    D --> E[checkout + npm ci --dry-run<br/>no writes, no metadata reads]
```

## Summary

- Pins the `lockfile-consistency` workflow's `GITHUB_TOKEN` to `contents: read` — the minimum scope it actually uses (`actions/checkout` + `npm ci --dry-run`).
- Matches GitHub Actions least-privilege hardening guidance. No behavior change; the workflow already does nothing beyond reading the repo.
- Follow-up to #227, flagged by `julianken-bot` review as a low-priority hygiene improvement that was punted to avoid invalidating that PR's approval.

## Screenshots

N/A — not UI.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Diff is exactly two lines added (`permissions:` + `  contents: read`) inserted after the `concurrency:` block, before `jobs:` — verified via `git diff`
- [ ] `npm run typecheck && npm run test` — N/A (workflow-only change, no application code)
- [ ] `npm run build` — N/A (workflow-only change)
- [ ] Playwright MCP smoke — N/A (not UI)
- [x] The `lockfile-consistency` check itself will not run on this PR (path filter only matches `**/package.json` and `package-lock.json`), which is correct — the workflow file is not in-scope for its own check.

## Plan reference

Out of plan — follow-up hygiene from #227 bot review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)