### PR TITLE
ci(infra): nightly terraform plan drift-check + 2-week grace allowlist

### DIFF
--- a/.github/drift-allowlist.yml
+++ b/.github/drift-allowlist.yml
@@ -1,0 +1,46 @@
+# Known-drifted Terraform resources suppressed from nightly drift-check alerts.
+#
+# Each entry expires on `expires`. After expiry, the nightly workflow
+# (.github/workflows/terraform-plan-drift-check.yml) treats drift on these
+# resources as real and opens a drift:automated issue. An entry firing a
+# warning within 7 days of expiry emits a GitHub Actions annotation so the
+# grace window does not silently lapse.
+#
+# Format:
+#   - address: "<terraform_resource_type.name>"
+#     action: "create" | "update" | "delete" | "read"
+#     expires: "YYYY-MM-DD"      # ISO-8601 date; UTC-midnight boundary
+#     reason:  "<one line, reference the reconciliation issue #>"
+#
+# See filter-tf-drift.py for parsing semantics. When editing by hand, keep
+# the list alphabetised by `address` for easier diffs.
+allowlist:
+  - address: "cloudflare_r2_bucket.pmtiles"
+    action: "create"
+    expires: "2026-05-08"
+    reason: "Live in Cloudflare since PR #164; tf import pending in #235"
+
+  - address: "cloudflare_record.tiles"
+    action: "create"
+    expires: "2026-05-08"
+    reason: "Live in Cloudflare since PR #164; tf import pending in #235"
+
+  - address: "cloudflare_workers_route.map_tiles"
+    action: "create"
+    expires: "2026-05-08"
+    reason: "Live in Cloudflare since PR #164; tf import pending in #235"
+
+  - address: "cloudflare_workers_script.map_server"
+    action: "create"
+    expires: "2026-05-08"
+    reason: "Live in Cloudflare since PR #164; tf import pending in #235"
+
+  - address: "google_cloud_run_v2_job.ingestor"
+    action: "update"
+    expires: "2026-05-08"
+    reason: "Cosmetic client/client_version metadata null-out from gcloud CLI deploys; harmonized in #235"
+
+  - address: "google_cloud_run_v2_service.read_api"
+    action: "update"
+    expires: "2026-05-08"
+    reason: "Cosmetic client/client_version metadata null-out from gcloud CLI deploys; harmonized in #235"

--- a/.github/scripts/filter-tf-drift.py
+++ b/.github/scripts/filter-tf-drift.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Filter `terraform show -json` plan output against a checked-in allowlist.
+
+Wired into `.github/workflows/terraform-plan-drift-check.yml`. Reads plan JSON
+from stdin (pipe from `terraform show -json <plan.bin>`), reads the allowlist
+from `.github/drift-allowlist.yml`, and decides whether nightly drift is
+all-suppressed, novel, or sitting on an expired suppression.
+
+Exit codes (the workflow branches on these):
+  0  all planned changes are covered by unexpired allowlist entries
+     (no issue opened)
+  1  novel drift is present — changes not covered by any allowlist entry.
+     A GitHub-Flavored-Markdown issue body is written to stdout; the workflow
+     pipes it into `gh issue create`.
+  2  expired allowlist entries still have drift active. A meta-alert issue
+     body is written to stdout; the workflow flags this as "grace window
+     lapsed — either import the resource or renew the suppression".
+
+Also emits GitHub Actions warning annotations when any allowlist entry
+expires in <=7 days (stdout, prefixed `::warning::`). The workflow surfaces
+these in the job summary.
+
+Design notes:
+- Security: the `terraform show -json` output contains provider-supplied
+  secrets (DB passwords, API keys) under `variables[].value` and resource
+  `values[]`. This script MUST NOT echo any field from those subtrees. The
+  issue body only emits resource address + action tuples. Run locally to
+  confirm before trusting in CI.
+- Determinism: allowlist entries are keyed on (address, action). A plan
+  change with a compound action list ["delete","create"] counts as two
+  discrete matches (one per action); both must be allowlisted.
+- Fail-loud: an unparseable allowlist or JSON is exit code 3 with a
+  readable error on stderr — never exit 0 silently.
+
+Standard library only plus PyYAML (available on ubuntu-latest's stock
+Python). No pip install needed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import pathlib
+import sys
+from typing import Iterable
+
+try:
+    import yaml  # PyYAML
+except ImportError:  # pragma: no cover — runner always has it
+    print(
+        "::error::PyYAML not available. Install via `pip install pyyaml` or "
+        "ensure the runner has it pre-installed.",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+ALLOWLIST_PATH = REPO_ROOT / ".github" / "drift-allowlist.yml"
+EXPIRY_WARNING_DAYS = 7
+
+# `terraform show -json` emits these action tokens in change.actions[]. Only
+# these cause drift from a CI-watcher perspective; no-op is ignored.
+DRIFT_ACTIONS = {"create", "update", "delete", "read"}
+
+
+def load_allowlist(path: pathlib.Path) -> list[dict]:
+    """Return the list under `allowlist:` in drift-allowlist.yml.
+
+    Each entry is validated for the four required keys. Missing keys are a
+    hard failure — we will not silently drop entries.
+    """
+    if not path.exists():
+        print(f"::error::allowlist file not found: {path}", file=sys.stderr)
+        sys.exit(3)
+
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        print(f"::error::allowlist YAML parse failed: {exc}", file=sys.stderr)
+        sys.exit(3)
+
+    entries = (raw or {}).get("allowlist") or []
+    required = {"address", "action", "expires", "reason"}
+    for i, entry in enumerate(entries):
+        missing = required - entry.keys()
+        if missing:
+            print(
+                f"::error::allowlist entry {i} missing keys: "
+                f"{sorted(missing)}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        # normalise
+        if isinstance(entry["expires"], _dt.date):
+            entry["expires_date"] = entry["expires"]
+        else:
+            try:
+                entry["expires_date"] = _dt.date.fromisoformat(
+                    str(entry["expires"])
+                )
+            except ValueError as exc:
+                print(
+                    f"::error::allowlist entry {i} ({entry['address']}) "
+                    f"`expires` is not ISO-8601 YYYY-MM-DD: {exc}",
+                    file=sys.stderr,
+                )
+                sys.exit(3)
+    return entries
+
+
+def extract_drift(plan: dict) -> list[tuple[str, str]]:
+    """Return (address, action) pairs for every non-no-op resource change.
+
+    Security note: we read only address + actions from each entry, never
+    `values` or `before`/`after` content, because those can contain live
+    secrets that terraform-show-json surfaces in full.
+    """
+    drift: list[tuple[str, str]] = []
+    for rc in plan.get("resource_changes", []):
+        actions = rc.get("change", {}).get("actions") or []
+        for action in actions:
+            if action in DRIFT_ACTIONS:
+                drift.append((rc["address"], action))
+    return drift
+
+
+def match_key(entry: dict) -> tuple[str, str]:
+    return (entry["address"], entry["action"])
+
+
+def classify(
+    drift: list[tuple[str, str]],
+    allowlist: list[dict],
+    today: _dt.date,
+) -> tuple[list[tuple[str, str]], list[dict], list[dict]]:
+    """Split drift and allowlist into three bins.
+
+    Returns:
+        novel:   drift tuples NOT covered by any allowlist entry (any state)
+        expired: allowlist entries whose drift IS still active AND expires<today
+        warning: allowlist entries expiring within EXPIRY_WARNING_DAYS days
+    """
+    allow_active: dict[tuple[str, str], dict] = {}
+    allow_expired: dict[tuple[str, str], dict] = {}
+    warning: list[dict] = []
+
+    for entry in allowlist:
+        key = match_key(entry)
+        if entry["expires_date"] < today:
+            allow_expired[key] = entry
+        else:
+            allow_active[key] = entry
+            days_left = (entry["expires_date"] - today).days
+            if 0 <= days_left <= EXPIRY_WARNING_DAYS:
+                warning.append(entry)
+
+    novel: list[tuple[str, str]] = []
+    expired_hit: list[dict] = []
+    for d in drift:
+        if d in allow_active:
+            continue
+        if d in allow_expired:
+            expired_hit.append(allow_expired[d])
+            continue
+        novel.append(d)
+
+    return novel, expired_hit, warning
+
+
+def emit_warning_annotations(warnings: Iterable[dict], today: _dt.date) -> None:
+    for entry in warnings:
+        days_left = (entry["expires_date"] - today).days
+        print(
+            f"::warning title=drift allowlist expiring::"
+            f"{entry['address']} ({entry['action']}) expires in "
+            f"{days_left} day(s) on {entry['expires']}. Reconcile before "
+            f"then or the next drift-check run will open an issue.",
+            file=sys.stderr,
+        )
+
+
+def novel_issue_body(
+    novel: list[tuple[str, str]],
+    run_url: str | None,
+) -> str:
+    lines = [
+        "Nightly `terraform plan` surfaced drift that is **not** covered by "
+        "`.github/drift-allowlist.yml`.",
+        "",
+        "## Novel drift",
+        "",
+        "| Resource address | Planned action |",
+        "| --- | --- |",
+    ]
+    for address, action in sorted(novel):
+        lines.append(f"| `{address}` | `{action}` |")
+    lines += [
+        "",
+        "## Next steps",
+        "",
+        "1. Decide: is this intentional drift (someone applied out-of-band) "
+        "or unintentional (`terraform apply` would recover it)?",
+        "2. If intentional, add a dated entry to `.github/drift-allowlist.yml` "
+        "with a reconciliation-issue reference and an `expires:` date.",
+        "3. If unintentional, open a follow-up issue to run `terraform "
+        "import` or `terraform apply` on the affected resource(s).",
+        "",
+        "Security note: full `terraform show -json` output is **intentionally "
+        "not pasted** here — it contains live DB/provider credentials under "
+        "`variables[].value`. Run `terraform plan` locally (or re-run the "
+        "nightly workflow and read the action logs under the `terraform plan` "
+        "step's stderr, which is also credential-redacted) to inspect "
+        "`before`/`after` values.",
+    ]
+    if run_url:
+        lines += ["", f"Source: {run_url}"]
+    return "\n".join(lines)
+
+
+def expired_issue_body(
+    expired: list[dict],
+    run_url: str | None,
+) -> str:
+    lines = [
+        "Drift allowlist entries have **expired** with their drift still "
+        "active. The 2-week grace window has lapsed; either reconcile the "
+        "resource (terraform import/apply) or renew the suppression with a "
+        "fresh `expires:` date and a rationale update.",
+        "",
+        "## Expired entries (still drifted)",
+        "",
+        "| Resource address | Action | Expired | Reason |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entry in sorted(expired, key=lambda e: (e["address"], e["action"])):
+        lines.append(
+            f"| `{entry['address']}` | `{entry['action']}` | "
+            f"{entry['expires']} | {entry['reason']} |"
+        )
+    lines += [
+        "",
+        "Renew via edit to `.github/drift-allowlist.yml`; reconcile via "
+        "`terraform import` + PR against `infra/terraform/**`.",
+    ]
+    if run_url:
+        lines += ["", f"Source: {run_url}"]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        plan = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(
+            f"::error::terraform plan JSON parse failed: {exc}",
+            file=sys.stderr,
+        )
+        return 3
+
+    today = _dt.date.today()
+    allowlist = load_allowlist(ALLOWLIST_PATH)
+    drift = extract_drift(plan)
+
+    novel, expired_hit, warning = classify(drift, allowlist, today)
+    emit_warning_annotations(warning, today)
+
+    run_url = None
+    import os
+
+    server = os.environ.get("GITHUB_SERVER_URL")
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and repo and run_id:
+        run_url = f"{server}/{repo}/actions/runs/{run_id}"
+
+    if novel:
+        print(novel_issue_body(novel, run_url))
+        return 1
+    if expired_hit:
+        print(expired_issue_body(expired_hit, run_url))
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/terraform-plan-drift-check.yml
+++ b/.github/workflows/terraform-plan-drift-check.yml
@@ -1,0 +1,181 @@
+name: terraform-plan-drift-check
+
+# Nightly read-only drift watcher. Runs `terraform plan` against the GCS-backed
+# state (`gs://bird-maps-tfstate`) and pipes the JSON plan through
+# `.github/scripts/filter-tf-drift.py` with `.github/drift-allowlist.yml`.
+#
+# This is Phase 2 of #183 -- Phase 1 was Julian's local baseline-plan run on
+# 2026-04-24. Allowlist entries suppress the 6 known-drifted items (4 Cloudflare
+# map-v1 resources + 2 Cloud Run cosmetic metadata) for 2 weeks while
+# reconciliation lands in #235.
+#
+# Outcomes:
+#   plan exit 0 -> no drift at all; workflow success, no issue.
+#   plan exit 1 -> real terraform error; workflow failure (not drift-related).
+#   plan exit 2 -> drift detected; filter script decides:
+#                    - all covered by unexpired allowlist -> success, no issue
+#                    - novel drift -> open a drift:automated issue
+#                    - expired allowlist entries -> open a drift:automated issue
+#                      flagged "grace window lapsed"
+#
+# Security invariants:
+#   1. Never upload the raw `terraform show -json` output as an artifact or
+#      echo it to logs -- the JSON contains live DB passwords, Neon/CF/eBird
+#      API tokens under `variables[].value` and resource `values[]`.
+#   2. Issue bodies emit only (address, action) tuples, never `before`/`after`
+#      values. Enforced in `filter-tf-drift.py`.
+#   3. `pull_request` is deliberately NOT a trigger; this workflow uses
+#      repo-scoped secrets that must not be reachable from fork PRs.
+#      (If drift-check ever needs PR-time validation, use `pull_request` with
+#      the no-secrets subset, not `pull_request_target` -- see the drift
+#      analysis R-H6 finding.)
+#   4. No `github.event.*` fields are substituted into `run:` blocks; only
+#      controlled step outputs (filter_exitcode) and literal values from env.
+
+on:
+  schedule:
+    # 11:00 UTC = 03:00 America/Phoenix (MST, no DST). Matches GCP billing /
+    # observability windows Julian already watches in the morning.
+    - cron: '0 11 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: terraform-plan-drift-check
+  cancel-in-progress: true
+
+permissions:
+  contents: read        # checkout
+  id-token: write       # WIF -> GCP (for GCS backend + google provider reads)
+  issues: write         # gh issue create on novel/expired drift
+
+env:
+  # Hardcodeable (not secrets -- see #183 acceptance criteria).
+  TF_VAR_domain: bird-maps.com
+  TF_VAR_gcp_project_id: bird-maps-prod
+  TF_VAR_gcp_region: us-west1
+  # Suppress provider output colourisation for cleaner log parsing.
+  TF_CLI_ARGS: "-no-color"
+  # Telemetry opt-out -- nothing about this CI run should phone HashiCorp.
+  CHECKPOINT_DISABLE: "1"
+
+jobs:
+  plan:
+    name: terraform plan (read-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: infra/terraform
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          # Matches infra/terraform/versions.tf required_version (>= 1.6.0)
+          # and Julian's local 1.14.8 used for Phase 1. Pinning here keeps
+          # nightly plans deterministic if HashiCorp ships a minor that
+          # changes plan output shape.
+          terraform_version: "1.14.8"
+          terraform_wrapper: false  # we shell out to `terraform show -json`
+
+      - name: terraform init
+        run: terraform init -input=false -lock-timeout=60s
+
+      - name: terraform plan
+        id: plan
+        env:
+          # Secrets that must reach provider blocks. The 4 Phase-2 new secrets
+          # (NEON_API_KEY, NEON_ORG_ID, CLOUDFLARE_ZONE_ID, EBIRD_API_KEY) plus
+          # the 2 already-deployed-by-other-workflows (CLOUDFLARE_API_TOKEN,
+          # CLOUDFLARE_ACCOUNT_ID). If any are unset, terraform plan errors
+          # loudly -- desired. The workflow exits non-zero; no drift issue opens.
+          TF_VAR_neon_api_key: ${{ secrets.NEON_API_KEY }}
+          TF_VAR_neon_org_id: ${{ secrets.NEON_ORG_ID }}
+          TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          TF_VAR_ebird_api_key: ${{ secrets.EBIRD_API_KEY }}
+        run: |
+          set +e
+          terraform plan -detailed-exitcode -input=false -lock-timeout=60s \
+            -out=/tmp/tf-plan.bin
+          ec=$?
+          set -e
+          echo "plan_exitcode=${ec}" >> "$GITHUB_OUTPUT"
+          # detailed-exitcode semantics:
+          #   0 = no changes
+          #   1 = terraform errored
+          #   2 = changes detected
+          case "${ec}" in
+            0) echo "No drift." ;;
+            1) echo "::error::terraform plan errored"; exit 1 ;;
+            2) echo "Drift detected; filter step will classify." ;;
+            *) echo "::error::unexpected exit ${ec}"; exit 1 ;;
+          esac
+
+      - name: Classify drift against allowlist
+        id: classify
+        if: steps.plan.outputs.plan_exitcode == '2'
+        run: |
+          set +e
+          terraform show -json /tmp/tf-plan.bin \
+            | python3 ../../.github/scripts/filter-tf-drift.py \
+              > /tmp/drift-issue-body.md
+          ec=$?
+          set -e
+          echo "filter_exitcode=${ec}" >> "$GITHUB_OUTPUT"
+          # filter-tf-drift.py exit codes:
+          #   0 = all drift covered by unexpired allowlist -> no issue
+          #   1 = novel drift -> open issue
+          #   2 = expired allowlist entries with active drift -> open issue
+          #   3 = parse error -> workflow failure
+          case "${ec}" in
+            0) echo "All drift suppressed by allowlist." ;;
+            1|2) echo "Novel or expired drift -- opening issue." ;;
+            3) echo "::error::filter script parse error"; exit 1 ;;
+            *) echo "::error::unexpected filter exit ${ec}"; exit 1 ;;
+          esac
+          # Surface the issue body in the job summary for quick eyeballing
+          # (safe -- filter script never emits secrets).
+          if [ -s /tmp/drift-issue-body.md ]; then
+            {
+              echo "## Drift issue body preview"
+              echo
+              cat /tmp/drift-issue-body.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+        # Python3 + PyYAML are pre-installed on ubuntu-latest. No pip install.
+
+      - name: Open drift issue
+        if: steps.classify.outputs.filter_exitcode == '1' || steps.classify.outputs.filter_exitcode == '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_EC: ${{ steps.classify.outputs.filter_exitcode }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "${FILTER_EC}" = "2" ]; then
+            title="drift:automated -- allowlist grace lapsed ($(date -u +%Y-%m-%d))"
+          else
+            title="drift:automated -- novel terraform drift ($(date -u +%Y-%m-%d))"
+          fi
+          # `gh issue create` is idempotent-hostile (opens a new issue every
+          # run). That's deliberate -- nightly cadence means at-most-one new
+          # issue per day, and stale duplicates are cheaper than a missed
+          # alert. If this becomes noisy we can switch to `gh issue list`
+          # + comment-on-existing in a follow-up.
+          gh issue create \
+            --repo "${GH_REPO}" \
+            --title "${title}" \
+            --label "drift:automated" \
+            --label "area:infra" \
+            --body-file /tmp/drift-issue-body.md


### PR DESCRIPTION
## Diagrams

```
Nightly 11:00 UTC (03:00 America/Phoenix)
   |
   v
checkout --> google-github-actions/auth@v2 (WIF) --> setup-gcloud@v2
   |
   v
hashicorp/setup-terraform@v3 (pinned 1.14.8)
   |
   v
terraform init (GCS backend: gs://bird-maps-tfstate)
   |
   v
terraform plan -detailed-exitcode -out=/tmp/tf-plan.bin
   |
   +-- exit 0 ------> pass, no issue
   |
   +-- exit 1 ------> workflow fail (terraform error, not drift)
   |
   +-- exit 2 ------> terraform show -json | filter-tf-drift.py
                         |
                         +-- exit 0: all drift allowlisted + unexpired -> pass
                         +-- exit 1: novel drift           -> gh issue create
                         +-- exit 2: expired allowlist hit -> gh issue create
                         +-- exit 3: parse error           -> workflow fail
```

## Summary

- Adds `.github/workflows/terraform-plan-drift-check.yml` -- cron `0 11 * * *` + `workflow_dispatch`; 15-min timeout; WIF-auth against the existing `GCP_WIF_PROVIDER` + `GCP_DEPLOY_SA_EMAIL` secrets; read-only (plan never applies).
- Adds `.github/drift-allowlist.yml` suppressing the 6 known-drifted resources from Phase 1 (4 Cloudflare map-v1 resources from PR #164 + 2 Cloud Run cosmetic metadata null-outs) until `2026-05-08`. Each entry references reconciliation issue #235.
- Adds `.github/scripts/filter-tf-drift.py` (stdlib + PyYAML, both pre-installed on ubuntu-latest) that classifies plan output into covered / novel / expired, emits GitHub Actions `::warning::` annotations 7 days before expiry, and never echoes the plan JSON's `values[]` or `variables[]` subtrees (they contain live DB / Neon / Cloudflare / eBird secrets).
- Closes #183.

## Screenshots

N/A -- CI workflow; no UI changes.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/drift-allowlist.yml'))"` -- parses clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/terraform-plan-drift-check.yml'))"` -- parses clean.
- [x] `python3 -c "import ast; ast.parse(open('.github/scripts/filter-tf-drift.py').read())"` -- filter script syntax valid.
- [x] Smoke test against `/tmp/tf-plan.bin` from Phase 1's 2026-04-24 run -> exit 0 (all 6 planned changes are allowlisted, unexpired).
- [x] Synthetic "novel drift" plan -> exit 1 with issue body listing only the novel row; allowlisted rows filtered out; no secrets in body.
- [x] Synthetic "expired allowlist" scenario -> exit 2 with grace-lapsed body.
- [x] Synthetic "expiring within 7 days" scenario -> exit 0 + `::warning title=drift allowlist expiring::` annotation on stderr.
- [x] No `github.event.*` substitutions in `run:` blocks (workflow-injection surface).
- [x] `terraform.tfvars` already gitignored via `infra/terraform/.gitignore` (not newly committed).
- [x] No backslash-escaped backticks in any of the 3 files.
- [x] All 4 required CI gates (`test`, `lint`, `build`, `e2e`) expected green -- workflow file + allowlist YAML + stdlib Python script; no product code touched.

**Acceptance criteria mapping (issue #183):**

- 4 new GitHub Secrets: the workflow references `NEON_API_KEY`, `NEON_ORG_ID`, `CLOUDFLARE_ZONE_ID`, `EBIRD_API_KEY` via `secrets.*`. Julian must add these at repo settings before the nightly run will succeed; without them `terraform plan` errors and the workflow exits 1 (no issue opened).
- 2 hardcoded env vars: `TF_VAR_domain: bird-maps.com`, `TF_VAR_gcp_project_id: bird-maps-prod` live as plain `env:` in the workflow YAML.
- GCP SA scope decision: reuses the existing deploy SA (`GCP_DEPLOY_SA_EMAIL`). Read-only plan works today because the deploy SA already has `storage.objectViewer` on the tfstate bucket and `run.developer`-implied read perms. If CI plan starts erring on `permission denied` for resources outside deploy-scope, the follow-up is Option (a) from the issue: a separate `GCP_PLAN_SA_EMAIL` with broader read-only roles.
- Context7 callout: providers referenced (`google`, `cloudflare`, `neon`) are already pinned via `infra/terraform/versions.tf`; this PR does not edit provider blocks. Noise-filter shape is structural (address + action tuples), not attribute-level, so it is immune to provider attribute churn.
- Noise-filter strategy: documented per-entry rationale in `.github/drift-allowlist.yml` (each of the 6 entries names the reconciliation issue and the root cause: 4 are PR #164 post-merge-import-pending, 2 are `gcloud` CLI metadata null-outs). No bare TODOs.

## Plan reference

Dispatch plan `/Users/j/.claude/plans/use-subagent-driven-development-giggly-blum.md`, Wave 4. Implements #183 Phase 2.

Closes #183.