### PR TITLE
ci(deps): add ignore rules + testcontainers group from 20-PR triage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
+      # @types/node major must track the Node runtime — which is pinned to
+      # LTS via the `node` ignore on the Docker entries below. Without this
+      # rule, Dependabot proposes @types/node majors ahead of the runtime
+      # (e.g., #231 bumped it to 25 while Docker stays on 20).
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "area:infra"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+      # testcontainers core + postgresql adapter are peer-versioned; group
+      # so a v-bump emits one PR instead of two-that-must-coordinate.
+      testcontainers:
+        patterns:
+          - "testcontainers"
+          - "@testcontainers/*"
     ignore:
       # node-pg-migrate major bump tracked separately by #187
       - dependency-name: "node-pg-migrate"
@@ -24,6 +30,18 @@ updates:
         update-types: ["version-update:semver-major"]
       # vitest major bump tracked separately by #186
       - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      # React 19 needs a coordinated bundle (react + react-dom +
+      # @types/react + @types/react-dom in one PR — split bumps break peer
+      # deps). Closed #223, #226 for this reason. Re-enable after the
+      # hand-crafted React 19 upgrade PR lands.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
     labels:
       - "area:infra"
@@ -37,6 +55,13 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # Cloudflare provider v5 requires HCL rewrites via tf-migrate
+      # (cloudflare_record → cloudflare_dns_record, r2_bucket_binding shape,
+      # workers_script attribute renames). Closed #201. Re-enable after a
+      # coordinated v5 migration PR lands.
+      - dependency-name: "cloudflare/cloudflare"
+        update-types: ["version-update:semver-major"]
     labels:
       - "area:infra"
 
@@ -58,6 +83,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # Dependabot picks the latest tag regardless of LTS status, and Node
+      # "Current" (odd-numbered) releases have 6-month support windows.
+      # Closed #202 — it bumped to Node 25, already EOL at review time.
+      # Human judgement required: bump only to the next LTS (24, then 26).
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "area:read-api"
       - "area:infra"
@@ -68,6 +100,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      # Same reasoning as read-api above. Closed #200.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - "area:ingestor"
       - "area:infra"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Closed["Closures from the 20-PR triage"]
        direction TB
        A1["#200, #202<br/>Node 25 (EOL'd)"]
        A2["#201<br/>Cloudflare v5 (needs HCL rewrites)"]
        A3["#223, #226<br/>React 19 (needs bundle)"]
    end
    subgraph Fix["This PR: config guards"]
        direction TB
        B1["ignore node majors<br/>on both Docker entries"]
        B2["ignore cloudflare/cloudflare<br/>majors on terraform entry"]
        B3["ignore react / react-dom /<br/>@types/react / @types/react-dom<br/>majors on root npm entry"]
        B4["group testcontainers +<br/>@testcontainers/postgresql<br/>(hygiene, not a closure)"]
    end
    A1 --> B1
    A2 --> B2
    A3 --> B3
```

## Summary

- Adds Dependabot ignore rules for the three failure modes that today's 20-PR triage identified — each closure (#200, #202, #201, #223, #226) would recur on next week's Dependabot run without these guards.
- Groups `testcontainers` + `@testcontainers/*` so future v-bumps ship as one PR (the pair is peer-versioned; #218/#230 were peer-coordination overhead the next v-bump shouldn't need).
- Comments in the config record *why* each ignore exists and the closed PR number that triggered it, so the rules can be lifted when the coordinated upgrade (React 19 bundle / tf-migrate migration) lands.

## Screenshots

N/A — not UI.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`)
- [x] Diff is additive only (`git diff --stat` shows +36/-0) — no existing rule was removed or modified
- [x] Each new ignore block is anchored to a specific closed-PR number in a comment, so future maintainers can find the context
- [ ] `npm run typecheck && npm run test` — N/A (config-only change)
- [ ] `npm run build` — N/A (config-only change)
- [ ] Playwright MCP smoke — N/A (not UI)

## Plan reference

Out of plan — follow-up from the 2026-04-24 Dependabot backlog triage (which itself was a follow-up to #227's config fix).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)