### PR TITLE
chore(read-api): drop immutable from /api/silhouettes Cache-Control + cache-purge runbook

### DIFF
--- a/docs/runbooks/cache-purge.md
+++ b/docs/runbooks/cache-purge.md
@@ -1,0 +1,71 @@
+# Cache purge — `/api/silhouettes`
+
+## When to run
+
+Run `scripts/purge-silhouettes-cache.sh` after **any** change that mutates
+the `family_silhouettes` table reaches production. Common triggers:
+
+- A migration in the epic #251 series (#244, #245, #246, #249) lands on
+  `main` and is applied to the production DB.
+- An ad-hoc curation pass updates an SVG, color, or attribution row.
+- A Phylopic seed-expansion script adds new `family_code` rows.
+
+`/api/silhouettes` is served with `Cache-Control: public, max-age=604800`
+(see `services/read-api/src/cache-headers.ts`). Without `immutable`,
+browsers re-validate at expiry — but they still serve cached bytes for
+up to a week before that. A Cloudflare edge purge invalidates both
+the CDN copy *and* (via the next conditional revalidation) the browser
+copy, so updated silhouettes reach users on their next request.
+
+## How to run
+
+The script is a one-liner around the Cloudflare zone-purge API:
+
+```bash
+CLOUDFLARE_ZONE_ID=... CLOUDFLARE_API_TOKEN=... \
+  ./scripts/purge-silhouettes-cache.sh
+```
+
+Optional override for staging or alternate hosts:
+
+```bash
+API_HOST=staging-api.bird-maps.com ./scripts/purge-silhouettes-cache.sh
+```
+
+Use `--dry-run` to confirm the request shape without calling the API
+(this is the path CI exercises so the script can't rot silently):
+
+```bash
+CLOUDFLARE_ZONE_ID=... CLOUDFLARE_API_TOKEN=... \
+  ./scripts/purge-silhouettes-cache.sh --dry-run
+```
+
+## Where the secrets live
+
+`CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` are not yet wired into a
+shared secret store for ops use. **TODO:** add them to GitHub Actions
+repository secrets (under Settings → Secrets and variables → Actions)
+once the credential plumbing for #251 follow-ups lands. Until then,
+operators pull the values from the Cloudflare dashboard:
+
+- Zone ID: dashboard → `bird-maps.com` → Overview → right sidebar.
+- API token: dashboard → My Profile → API Tokens → create a token with
+  scope `Zone | Cache Purge | bird-maps.com`. Rotate after any
+  individual operator rotation.
+
+## Branch-merge ordering (epic #251 → version-one → main)
+
+This runbook ships in the same PR as the `cache-headers.ts` `immutable`
+removal (issue #252, base branch `version-one`). Both are
+documentation-grade changes — order **into** `version-one` doesn't
+matter relative to the DB migrations from #244, #245, #246, and #249.
+
+The constraint is on the *outbound* side: when `version-one` is merged
+into `main` for a release that includes any of those migrations, the
+`cache-headers.ts` change **must be in the same merge**. Otherwise the
+new silhouette rows land in production but get masked by the still-
+`immutable` Cache-Control directive for up to seven days.
+
+In practice this means: do not split the epic across two
+`version-one → main` merges. Either ship the whole epic together, or
+back this PR out of the partial release.

--- a/scripts/purge-silhouettes-cache.sh
+++ b/scripts/purge-silhouettes-cache.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Purge the /api/silhouettes response from Cloudflare's edge cache.
+#
+# Run this after merging a `family_silhouettes` migration so the new
+# rows reach users immediately, instead of waiting up to 7 days for
+# the browser cache to expire (max-age=604800).
+#
+# See docs/runbooks/cache-purge.md for the full ops procedure and the
+# secret-store layout for CLOUDFLARE_ZONE_ID / CLOUDFLARE_API_TOKEN.
+#
+# Flags:
+#   --dry-run   Print the request that would be sent and exit 0 without
+#               calling the Cloudflare API. Used by CI to keep this
+#               script from rotting silently.
+set -euo pipefail
+: "${CLOUDFLARE_ZONE_ID:?required}"
+: "${CLOUDFLARE_API_TOKEN:?required}"
+API_HOST="${API_HOST:-api.bird-maps.com}"
+PURGE_URL="https://${API_HOST}/api/silhouettes"
+PAYLOAD="$(jq -nc --arg url "$PURGE_URL" '{files: [$url]}')"
+if [[ "${1:-}" == "--dry-run" ]]; then
+  echo "DRY RUN — would POST to https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache"
+  echo "Payload: ${PAYLOAD}"
+  exit 0
+fi
+curl -fsSL -X POST \
+  "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "${PAYLOAD}"

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -128,8 +128,10 @@ describe('GET /api/silhouettes', () => {
     // Must come from cacheControlFor('silhouettes') — NOT a hardcoded string.
     // Both sides of the equality reference the same TTL table entry; if that
     // entry ever changes this test will flag both the route and the table.
+    // No `immutable` directive: silhouette payload drifts between deploys
+    // (curation, Phylopic seed expansion); see cache-headers.ts comment.
     expect(res.headers.get('cache-control'))
-      .toBe('public, max-age=604800, immutable');
+      .toBe('public, max-age=604800');
     const body = await res.json() as Array<{
       familyCode: string; color: string; svgData: string | null;
       source: string | null; license: string | null;

--- a/services/read-api/src/cache-headers.test.ts
+++ b/services/read-api/src/cache-headers.test.ts
@@ -14,11 +14,14 @@ describe('cacheControlFor', () => {
     expect(cacheControlFor('species'))
       .toBe('public, max-age=604800, immutable');
   });
-  it('returns 7d immutable for /silhouettes', () => {
-    // Family-color mapping is static per deploy (changes only via seed
-    // migrations), so it rides the same immutable-1-week profile as the
-    // region and species-meta endpoints.
+  it('returns 7d max-age (revalidatable) for /silhouettes', () => {
+    // Family silhouettes legitimately drift between deploys (curation,
+    // Phylopic seed expansion). The 1-week max-age is still aggressive
+    // enough not to hammer the API, but dropping `immutable` lets browsers
+    // re-validate with the CDN at expiry — and a Cloudflare cache-purge
+    // (see scripts/purge-silhouettes-cache.sh) reaches users on the next
+    // request rather than waiting up to 7 days.
     expect(cacheControlFor('silhouettes'))
-      .toBe('public, max-age=604800, immutable');
+      .toBe('public, max-age=604800');
   });
 });

--- a/services/read-api/src/cache-headers.ts
+++ b/services/read-api/src/cache-headers.ts
@@ -4,10 +4,13 @@ const TABLE: Record<Endpoint, string> = {
   observations: 'public, max-age=1800, stale-while-revalidate=600',
   hotspots:     'public, max-age=86400, stale-while-revalidate=3600',
   species:      'public, max-age=604800, immutable',
-  // Family-color/silhouette mapping is static per deploy (rows land via
-  // seed migrations, not at runtime), so a 1-week immutable TTL matches
-  // the species profile. Callers should bust by redeploying.
-  silhouettes:  'public, max-age=604800, immutable',
+  // Family-color/silhouette payload genuinely drifts between deploys
+  // (curation, Phylopic seed expansion), so we keep the 1-week max-age
+  // (cheap on the read path) but DROP `immutable` — browsers will
+  // re-validate at expiry, and an out-of-band Cloudflare cache purge
+  // (scripts/purge-silhouettes-cache.sh) reaches users on the next
+  // request rather than waiting up to 7 days.
+  silhouettes:  'public, max-age=604800',
 };
 
 export function cacheControlFor(endpoint: Endpoint): string {

--- a/services/read-api/src/purge-silhouettes-cache.test.ts
+++ b/services/read-api/src/purge-silhouettes-cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// scripts/purge-silhouettes-cache.sh wraps the Cloudflare cache-purge curl.
+// We can't safely test the live POST, but the --dry-run flag is the contract
+// CI relies on to keep the script from rotting. This spec asserts:
+//   1. The script file exists and is executable.
+//   2. Required env-vars are enforced (the unset-env case errors out).
+//   3. --dry-run with both env-vars set exits 0 and prints the expected lines.
+// Resolve from the workspace dir up to the repo root so the test stays
+// portable whether vitest is invoked from the workspace or the root.
+const SCRIPT = resolve(__dirname, '../../../scripts/purge-silhouettes-cache.sh');
+
+describe('scripts/purge-silhouettes-cache.sh', () => {
+  it('exists and is executable', () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+    // 0o111 = any execute bit (owner|group|other). Stricter than checking
+    // the user-execute bit alone — the script must run for CI's runner UID,
+    // which is not necessarily the file owner.
+    const mode = statSync(SCRIPT).mode;
+    expect((mode & 0o111) !== 0).toBe(true);
+  });
+
+  it('errors when CLOUDFLARE_ZONE_ID is missing', () => {
+    const r = spawnSync(SCRIPT, ['--dry-run'], {
+      // Strip the two required vars from the inherited env.
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([k]) => k !== 'CLOUDFLARE_ZONE_ID' && k !== 'CLOUDFLARE_API_TOKEN',
+        ),
+      ) as NodeJS.ProcessEnv,
+      encoding: 'utf8',
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/CLOUDFLARE_ZONE_ID/);
+  });
+
+  it('--dry-run prints the would-be POST and exits 0 without calling the API', () => {
+    const r = spawnSync(SCRIPT, ['--dry-run'], {
+      env: {
+        ...process.env,
+        CLOUDFLARE_ZONE_ID: 'test_zone',
+        CLOUDFLARE_API_TOKEN: 'test_token',
+      } as NodeJS.ProcessEnv,
+      encoding: 'utf8',
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('DRY RUN');
+    expect(r.stdout).toContain(
+      'https://api.cloudflare.com/client/v4/zones/test_zone/purge_cache',
+    );
+    expect(r.stdout).toContain('https://api.bird-maps.com/api/silhouettes');
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant B as Browser
    participant E as Edge (CDN)
    participant API as Read API
    Note over B,API: Before — `Cache-Control: public, max-age=604800, immutable`
    B->>E: GET /api/silhouettes
    E-->>B: 200 (cached for 7d, never re-validates)
    Note over B: stuck on stale payload<br/>for up to 7d after migration
    Note over B,API: After — `Cache-Control: public, max-age=604800`
    B->>E: GET /api/silhouettes
    E-->>B: 200 (cached for 7d)
    Note over B: at expiry, re-validates<br/>+ Cloudflare purge<br/>(scripts/purge-silhouettes-cache.sh)<br/>can force-fresh post-deploy
```

## Summary

- The \`immutable\` directive told browsers never to revalidate the silhouettes payload for the entire 7-day window. That's the wrong contract: \`family_silhouettes\` genuinely mutates (seed expansions in #244, real Phylopic SVGs in #245, common_name in #249, _FALLBACK in #246, creator in #245). Without this fix, those changes wouldn't reach users for up to 7 days regardless of CDN purge.
- Adds \`scripts/purge-silhouettes-cache.sh\` (with \`--dry-run\` mode tested in CI) so ops can force-purge the Cloudflare cache after the version-one → main release. Documented in \`docs/runbooks/cache-purge.md\`.
- Critical pitfall avoided: \`app.test.ts\` has three identical \`'public, max-age=604800, immutable'\` assertions — at lines 134, 165, 316. **Only line 134** (silhouettes) is updated; lines 165 and 316 (\`/api/species\` and \`/api/species/:code\`) remain unchanged because those endpoints' contract is still genuinely immutable.

## Screenshots

N/A — not UI

## Test plan

- [x] \`cacheControlFor('silhouettes')\` returns \`'public, max-age=604800'\` (no \`immutable\`) — \`cache-headers.test.ts\` 4/4 pass.
- [x] \`scripts/purge-silhouettes-cache.sh --dry-run\` exits 0 and prints expected output — \`purge-silhouettes-cache.test.ts\` 3/3 pass.
- [x] \`app.test.ts\` lines 165 and 316 (\`/api/species\` and \`/api/species/:code\`) **unchanged** — still assert the immutable string for those endpoints.
- [x] \`scripts/purge-silhouettes-cache.sh\` is executable (\`-rwxr-xr-x\`).
- [x] \`npm run build\` clean across all 5 workspaces.
- [ ] CI gates (\`test\`, \`lint\`, \`build\`, \`e2e\`) green — testcontainer-backed suites in read-api / ingestor were Docker-gated locally but will run on CI.

## Plan reference

Part of epic #251, Issue #252. See \`docs/plans/2026-04-25-phylopic-silhouettes-epic-251/plan.md\`, Task 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)