### PR TITLE
fix(frontend): alias maplibre-gl in vite config (P0 prod map regression #258)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,26 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // Issue #258: `@vis.gl/react-maplibre` does a dynamic
+      // `import('maplibre-gl')` at runtime. npm workspaces hoists
+      // `@vis.gl/react-maplibre` to the root `node_modules/`, but
+      // `maplibre-gl` is declared only as a frontend dep so it stays in
+      // `frontend/node_modules/`. Vite's bundler can't resolve from one
+      // to the other, and ships a chunk whose body is `throw Error(...)`.
+      // The alias pins the resolution to the frontend's local copy and
+      // is robust against future hoist drift (e.g. when a peer-dep'd
+      // sibling package gets installed at root).
+      'maplibre-gl': path.resolve(__dirname, 'node_modules/maplibre-gl'),
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before-broken
        V1[vite build] --> CK1[react-maplibre-Dt35Kf9b.js<br/>0.13 KB<br/>throw Error 'Could not resolve maplibre-gl'<br/>**fires on every prod page load of /?view=map**]
    end
    subgraph After-fix
        V2[vite build<br/>+ resolve.alias<br/>'maplibre-gl' → frontend/node_modules] --> CK2[maplibre-gl-CxlP_mE2.js<br/>1027 KB<br/>real library bundled]
        V2 --> CK3[MapCanvas-*.js<br/>imports the real chunk]
    end
```

## Summary

- **P0 production fix.** The map view at https://bird-maps.com/?view=map currently throws \`Could not resolve "maplibre-gl"\` at runtime — verified live via Chrome DevTools console. Root cause is npm-workspaces hoist drift: \`@vis.gl/react-maplibre\` ends up at root \`node_modules/\` while \`maplibre-gl\` lives only in \`frontend/node_modules/\`, so vite's bundler can't resolve the dynamic \`import('maplibre-gl')\` and ships a throwing stub chunk.
- **Fix is a Vite \`resolve.alias\`** pinning \`maplibre-gl\` to the frontend's local copy. Robust against future hoist drift (e.g. when a peer-dep'd sibling pkg gets installed at root), unlike "just declare maplibre-gl at root" which only works while versions happen to align across consumers.
- **Closes #258.** Once this lands and Cloudflare Pages deploys, queue the epic release PR #275.

## Screenshots

N/A — config-only fix; user-visible verification is the post-deploy live check on bird-maps.com (the map will load again instead of throwing).

## Test plan

- [x] **Reproduced live**: `mcp__plugin_chrome-devtools-mcp_chrome-devtools__new_page` on https://bird-maps.com/?view=map → console shows the throw.
- [x] **Reproduced locally**: `npm run build --workspace @bird-watch/frontend` on \`origin/main\` produces \`dist/assets/react-maplibre-Dt35Kf9b.js\` whose body is \`throw Error("Could not resolve...")\`.
- [x] **Fixed locally**: with the alias added, \`npm run build\` now emits \`dist/assets/maplibre-gl-CxlP_mE2.js\` (1.0 MB, the real library) and no throwing react-maplibre chunk.
- [x] **Frontend unit tests**: \`npm run test --workspace @bird-watch/frontend\` — 203/203 pass.
- [ ] CI gates (\`test\`, \`lint\`, \`build\`, \`e2e\`) green.
- [ ] **Post-merge verification**: after Cloudflare Pages deploys, re-probe https://bird-maps.com/?view=map via Chrome DevTools → confirm zero \`maplibre-gl\` resolve errors in console.

## Plan reference

Out of plan — P0 hotfix discovered during execution of \`docs/plans/2026-04-25-phylopic-silhouettes-epic-251/plan.md\`. **Blocks epic release PR #275** (the epic ships on top of this fix; merging #275 first would deploy the entire silhouette feature on a known-broken bundle). Closes follow-up #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)