### PR TITLE
fix(frontend): map cluster-click + spider-on-first-click + silhouette contrast (blocks #275)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -236,6 +236,17 @@ export function MapCanvas({
   // replaces the prior image), so the layer can stay mounted continuously.
   const [spritesReady, setSpritesReady] = useState(false);
 
+  // Tracks the map's current zoom for hit-target gating. The hit-layer
+  // (#247) renders DOM `<button>` overlays for accessible marker clicks;
+  // those buttons absorb clicks before they reach the underlying maplibre
+  // canvas. At zoom < CLUSTER_MAX_ZOOM, observations are aggregated into
+  // cluster circles and the cluster-circle click handler should win — so
+  // hit-targets must be SUPPRESSED at low zoom to avoid intercepting
+  // cluster clicks (visually, those buttons would otherwise sit on top of
+  // the cluster circles and steal the click). Updated via `zoomend` so
+  // mid-pan-zoom doesn't churn React.
+  const [mapZoom, setMapZoom] = useState<number>(INITIAL_VIEW.zoom);
+
   // Build layer specs once — they read CSS tokens at construction time.
   const clusterLayer = useMemo(() => buildClusterLayerSpec(), []);
   const clusterCountLayer = useMemo(() => buildClusterCountLayerSpec(), []);
@@ -393,6 +404,14 @@ export function MapCanvas({
     // moves under it.
     map.on('zoomstart', () => {
       if (spiderfyRef.current) closeSpiderfy();
+    });
+
+    // Track final zoom for the hit-target gate. Subscribed to `zoomend`
+    // (not `zoom`) so we only re-render React once per zoom gesture, not
+    // on every interpolated frame. Initial zoom is set in useState; this
+    // syncs after every user interaction.
+    map.on('zoomend', () => {
+      setMapZoom(map.getZoom());
     });
 
     // Change cursor on hover.
@@ -655,12 +674,23 @@ export function MapCanvas({
           const currentZoom = map.getZoom();
           const center: [number, number] = [entry.longitude, entry.latitude];
 
-          if (targetZoom > currentZoom) {
-            map.easeTo({ center, zoom: targetZoom });
+          // Spiderfy when current zoom is already at or above clusterMaxZoom.
+          // supercluster returns `clusterMaxZoom + 1` as the expansion zoom
+          // for clusters at the cap, which would otherwise loop us into a
+          // "zoom one level past max → click again → spiderfy" two-click UX.
+          // Match the layer-bound `clusters` click handler's predicate so the
+          // mosaic-click and circle-click code paths agree on the spiderfy
+          // boundary.
+          const atMaxZoom = currentZoom >= CLUSTER_MAX_ZOOM;
+          if (!atMaxZoom && targetZoom > currentZoom) {
+            map.easeTo({
+              center,
+              zoom: Math.min(targetZoom, CLUSTER_MAX_ZOOM),
+            });
             return;
           }
 
-          // Already at supercluster's clusterMaxZoom — spiderfy instead.
+          // At supercluster's clusterMaxZoom — spiderfy instead.
           if (typeof src.getClusterLeaves !== 'function') return;
           if (spiderfyRef.current) {
             try {
@@ -716,14 +746,20 @@ export function MapCanvas({
   }, [closeSpiderfy]);
 
   /* The hit-layer covers two cases:
-     (a) when no spiderfy is active, render hit targets over every
-         currently-rendered unclustered point (so screen-reader users can
-         still reach them). queryRenderedFeatures on every render is
-         expensive; instead we trust the geojson and let the hit layer's
-         re-projection on each map move keep positions accurate.
+     (a) when no spiderfy is active AND zoom >= CLUSTER_MAX_ZOOM, render
+         hit targets over every observation (which by the source's
+         clusterMaxZoom contract means each obs renders as its own
+         unclustered symbol). At zoom < CLUSTER_MAX_ZOOM, observations
+         are aggregated into cluster circles — and the hit-target buttons
+         (real DOM elements with `pointer-events: auto`) would absorb
+         clicks intended for cluster circles, breaking the layer-bound
+         `clusters` click handler that drives zoom-into-cluster + spiderfy.
+         Suppress the hit layer at low zoom; the cluster circles are
+         themselves clickable through maplibre's event system.
      (b) when a spiderfy is active, render hit targets over the spiderfied
-         leaves only. The base unclustered points are still on the map
-         underneath but the hit-layer takes precedence visually. */
+         leaves only — independent of zoom. The base unclustered points
+         are still on the map underneath but the hit-layer takes precedence
+         visually. */
   const hitMarkers: HitTargetMarker[] = useMemo(() => {
     if (spiderfy) {
       return spiderfy.leaves.map((l) => ({
@@ -736,10 +772,12 @@ export function MapCanvas({
         lngLat: l.leafLngLat,
       }));
     }
-    // No spiderfy — render hit targets over every unclustered observation.
-    // (The cluster-circle layer hides observations that are clustered; the
-    // hit-layer over them is harmless because click-throughs would still
-    // hit the cluster layer.)
+    // No spiderfy — only render hit targets when observations are actually
+    // unclustered (zoom >= CLUSTER_MAX_ZOOM). Below that, suppress the
+    // overlay so cluster-circle clicks reach maplibre's event handlers.
+    if (mapZoom < CLUSTER_MAX_ZOOM) {
+      return [];
+    }
     return observations.map((o) => ({
       subId: o.subId,
       comName: o.comName,
@@ -749,7 +787,7 @@ export function MapCanvas({
       isNotable: o.isNotable,
       lngLat: [o.lng, o.lat] as [number, number],
     }));
-  }, [observations, spiderfy]);
+  }, [observations, spiderfy, mapZoom]);
 
   const handleHitSelect = useCallback(
     (subId: string) => {
@@ -832,19 +870,27 @@ export function MapCanvas({
           unmounts disappearing clusters and mounts new ones in a single
           reconciler pass — no orphans, no leaks.
         */}
-        {Array.from(mosaics.values()).map((entry) => (
-          <Marker
-            key={entry.clusterId}
-            longitude={entry.longitude}
-            latitude={entry.latitude}
-          >
-            <MosaicMarker
-              tiles={entry.tiles}
-              totalCount={entry.totalCount}
-              onClick={handleMosaicClick(entry)}
-            />
-          </Marker>
-        ))}
+        {Array.from(mosaics.values())
+          // Suppress the mosaic for the cluster currently being spidered
+          // — otherwise the user sees the mosaic marker layered over the
+          // fanned leader lines and reads "click did nothing." Hiding the
+          // mosaic gives a clean visual swap: mosaic disappears, leader
+          // lines fan out from the same center. (Spider v2, #277, will
+          // also place visible silhouettes at leaf positions.)
+          .filter((entry) => spiderfy?.clusterId !== entry.clusterId)
+          .map((entry) => (
+            <Marker
+              key={entry.clusterId}
+              longitude={entry.longitude}
+              latitude={entry.latitude}
+            >
+              <MosaicMarker
+                tiles={entry.tiles}
+                totalCount={entry.totalCount}
+                onClick={handleMosaicClick(entry)}
+              />
+            </Marker>
+          ))}
       </MapView>
       {/* Issue #247: HTML hit-layer overlay for spiderfied + unclustered
           markers, mounted as a sibling of the maplibre canvas inside the

--- a/frontend/src/components/map/observation-layers.ts
+++ b/frontend/src/components/map/observation-layers.ts
@@ -292,6 +292,16 @@ export function buildUnclusteredPointLayerSpec(): LayerProps {
       // SDF tint: each feature's color property paints its own silhouette.
       // This is what gives the map the same family-color signal as the legend.
       'icon-color': ['get', 'color'],
+      // White halo around each silhouette for contrast against the
+      // light OpenFreeMap positron basemap. Without it, families whose
+      // seed color is naturally low-saturation (accipitridae #222222,
+      // cathartidae #444444, corvidae #222244, strigidae #5A4A2A,
+      // troglodytidae #7A5028, plus _FALLBACK #555 at half opacity)
+      // read as faint smudges. The halo is the same trick maplibre
+      // text-symbol labels use to stand out against varied backgrounds —
+      // see basemap-style.ts text layers for the precedent.
+      'icon-halo-color': '#ffffff',
+      'icon-halo-width': 1.5,
       // Fade _FALLBACK markers so missing-Phylopic families read as
       // distinct from the rest. The condition uses the literal sentinel
       // value — must stay in sync with FALLBACK_SILHOUETTE_ID above.

--- a/frontend/src/components/map/spiderfy.ts
+++ b/frontend/src/components/map/spiderfy.ts
@@ -68,6 +68,11 @@ export interface SpiderfyLeaf {
 }
 
 export interface SpiderfyState {
+  /** The cluster_id whose leaves are currently fanned. Consumers can use
+      this to suppress duplicate visuals (e.g. hide the cluster's own
+      mosaic marker while it's spidered) so the user gets a clean
+      "stack opened" feedback. */
+  clusterId: number;
   leaves: SpiderfyLeaf[];
   /** Removes the transient leader-line layer + source. Idempotent. */
   teardown: () => void;
@@ -301,8 +306,15 @@ export async function spiderfyCluster(
     type: 'line',
     source: SPIDERFY_LEADER_SOURCE_ID,
     paint: {
-      'line-color': '#888',
-      'line-width': 1,
+      // Darker + thicker than the original 1px #888: against the light
+      // OpenFreeMap positron basemap, 1px gray reads as background noise.
+      // 2px #444 gives the user a clear "yes, the cluster fanned" signal
+      // even before they notice the (currently invisible) hit-targets at
+      // the leaf positions. Spider v2 (#277) will add visible silhouettes
+      // at leaf positions; until then, leader-line visibility is the
+      // primary cue.
+      'line-color': '#444',
+      'line-width': 2,
     },
   });
 
@@ -328,6 +340,7 @@ export async function spiderfyCluster(
   }
 
   return {
+    clusterId,
     leaves,
     teardown: () => removeSpiderfyLayer(map),
   };


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph Bugs-found-during-Playwright-drive-of-version-one
      B1[Bug 1: hit-target buttons absorb cluster clicks at all zooms]
      B2[Bug 2: mosaic click at zoom=14 zooms to 15 instead of spider]
      B3[Visual: dark family colors invisible on light basemap]
      B4[Visual: leader-lines invisible 1px gray]
      B5[Visual: mosaic stays drawn over fanned spider]
    end
    subgraph Patches-this-PR
      P1[Gate hitMarkers on mapZoom >= CLUSTER_MAX_ZOOM]
      P2[handleMosaicClick branches on currentZoom >= CLUSTER_MAX_ZOOM]
      P3[icon-halo-color #fff + width 1.5 on SDF symbol layer]
      P4[Leader-line 1px #888 -> 2px #444]
      P5[Hide cluster mosaic when spiderfy.clusterId matches]
    end
    subgraph Deferred
      V2[Spider v2 #277 — auto-fan overlapping silhouettes at any zoom]
    end
    B1 --> P1
    B2 --> P2
    B3 --> P3
    B4 --> P4
    B5 --> P5
    P5 -.next epic.-> V2
```

## Summary

Five small fixes discovered via local Playwright drive of \`version-one\` HEAD before queueing the epic #251 release PR (#275). Each fix has its own one-paragraph "why" in the commit message.

- **Bug 1**: cluster clicks were intercepted by overlapping hit-target buttons → no zoom-into-cluster. Fixed by gating hit-targets on \`mapZoom >= CLUSTER_MAX_ZOOM\`.
- **Bug 2**: mosaic click at the cap zoom (14) routed through \`easeTo(15)\` instead of spider — required two clicks to spider. Fixed by branching on \`currentZoom >= CLUSTER_MAX_ZOOM\` (matching the layer-bound handler).
- **Visual 3**: dark-family silhouettes (hawks, vultures, owls, wrens) washed out on the light basemap. Fixed with white halo on the SDF layer (preserves family colors; legend ↔ map color contract intact).
- **Visual 4**: spider leader-lines invisible at 1px #888. Bumped to 2px #444.
- **Visual 5**: cluster mosaic stayed visible over the fanned spider. Fixed by filtering it out when \`spiderfy.clusterId === entry.clusterId\`.

**Known v1 limitation tracked in #277** (Spider v2): the spider currently fans hit-targets + leader-lines but the SDF silhouette icons stay at original lat/lngs. Real-world co-located obs (multiple sightings at the same hotspot) still visually stack at zoom > clusterMaxZoom. Spider v2 will auto-fan visible icons at any zoom — that's the next epic task after this release.

## Screenshots

Captured at the head SHA via local Playwright drive against the patched build.

| Surface | Before (epic #251 HEAD) | After (this PR) |
|---|---|---|
| Zoom 13 Tucson — silhouettes on basemap | "all gray" — dark colors washed out | Halo lifts every silhouette; family colors clearly visible (red trogon, purple hummingbird, brown wren, dark hawks, yellow finch, etc.) |
| Zoom 6 — cluster click | Tooltip opens (hit-target absorbed click) | Cluster zooms in (correct) |
| Zoom 14 over tight cluster — mosaic click | Map zooms to 15 (no spider) | Spider fires on first click, mosaic disappears, leader lines fan out |

Local screenshots: \`.playwright-mcp/local-z13-tucson-halo-test.png\`, \`.playwright-mcp/local-after-bundle.png\`, \`.playwright-mcp/local-z15-tight-cluster.png\`.

## Test plan

- [x] \`npm run build --workspace @bird-watch/frontend\` — clean (1.0 MB maplibre chunk, no throwing stub).
- [x] \`npm run test --workspace @bird-watch/frontend\` — **319/319 pass**.
- [x] Local Playwright drive at zoom 6, 12, 13, 14, 15 confirms each of the 5 patches lands behaviorally:
  - hit-buttons: 0 at zoom 6, 81 at zoom ≥ 14
  - cluster-click at zoom 6: zoomed 6 → 10
  - mosaic-click at zoom 14: stayed at zoom 14 + spider-leaves-line layer added + 5 leaves
  - halo: dark family silhouettes readable against light basemap
  - mosaic hidden when its cluster is spidered (1 → 0 markers)
- [ ] CI gates (\`test\`, \`lint\`, \`build\`, \`e2e\`) green.

## Plan reference

Out of plan — discovered during local verification of the epic #251 release PR (#275). **#275 should NOT queue until this lands** (otherwise the epic ships with the two cluster-click bugs + the visual contrast issue). Spider v2 (#277) is the next epic task immediately following the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)