### PR TITLE
docs(frontend): freshen MapCanvas.test spritesReady comments post-Spider-v2 (#273)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -552,13 +552,21 @@ describe('MapCanvas', () => {
 
   it('does not call addImage when silhouettes prop is empty', () => {
     render(<MapCanvas observations={[makeObs()]} silhouettes={[]} />);
-    // No silhouettes → no sprite registration. The symbol layer mounts
-    // with `icon-image: ['get', 'silhouetteId']` looking up sprites that
-    // don't exist; that surfaces as a missing-image warning at runtime,
-    // which would be a Tier-1 dirty-console finding. The fix is to mount
-    // MapCanvas only after silhouettes resolve — but that's a caller
-    // concern; this test just confirms the no-silhouettes default is a
-    // no-op (no spurious addImage calls).
+    // No silhouettes → no sprite registration. MapCanvas owns the fix
+    // via the `spritesReady` flag, which gates two sites in
+    // `MapCanvas.tsx`:
+    //   1. JSX: `{spritesReady && <Layer {...unclusteredLayer} />}` —
+    //      the symbol layer is never mounted until sprites are
+    //      registered, so MapLibre never tries to look up a missing
+    //      `icon-image` (would emit a Tier-1 missing-image console
+    //      warning on cold load).
+    //   2. The auto-spider reconciler effect early-returns on
+    //      `if (!spritesReady) return undefined;` (added in #280) so
+    //      `queryRenderedFeatures` never names the not-yet-mounted
+    //      `unclustered-point` layer (would throw
+    //      "layer does not exist in the map's style").
+    // This test just pins the most upstream invariant for the empty
+    // case: no silhouettes → no `map.addImage` calls at all.
     expect(fakeMap.addImage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Diagrams

N/A — comment freshening only

## Summary

- Update the stale doc-comment in `MapCanvas.test.tsx` (the `does not call addImage when silhouettes prop is empty` test) so it accurately describes both `spritesReady` gating sites in `MapCanvas.tsx` after Spider v2 (#280): the JSX gate on the unclustered-point symbol layer (`MapCanvas.tsx:1083`) AND the auto-spider reconciler effect early-return (`MapCanvas.tsx:671`). The prior comment said "the fix is a caller concern", which was wrong even pre-#280 and is now doubly stale.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend -- --run MapCanvas` — 27 tests pass (identical count to `origin/main` 527e3db)
- [x] No production code changes (test-file comment-only diff)

## Plan reference

Follow-up to epic #251. See `docs/plans/2026-04-25-phylopic-silhouettes-epic-251/plan.md` and follow-up issue #273.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)