### PR TITLE
docs(runbook): clarify CDN-purge vs browser-cache semantics in cache-purge runbook

### DIFF
--- a/docs/runbooks/cache-purge.md
+++ b/docs/runbooks/cache-purge.md
@@ -10,12 +10,42 @@ the `family_silhouettes` table reaches production. Common triggers:
 - An ad-hoc curation pass updates an SVG, color, or attribution row.
 - A Phylopic seed-expansion script adds new `family_code` rows.
 
+## What the purge does (and does not) invalidate
+
+There are two caches between the database and the user's screen. The
+script only touches one of them.
+
+| Tier              | What it is                                            | TTL                        | Touched by `purge-silhouettes-cache.sh`? |
+| ----------------- | ----------------------------------------------------- | -------------------------- | ---------------------------------------- |
+| **Cloudflare CDN** | Edge copy at the colo nearest the requesting user     | Honors `Cache-Control`     | **Yes** — purged within ~30s             |
+| **User browser**   | Per-user copy in each visitor's HTTP cache            | `max-age=604800` (7 days)  | **No** — held until that user's clock ticks |
+
 `/api/silhouettes` is served with `Cache-Control: public, max-age=604800`
-(see `services/read-api/src/cache-headers.ts`). Without `immutable`,
-browsers re-validate at expiry — but they still serve cached bytes for
-up to a week before that. A Cloudflare edge purge invalidates both
-the CDN copy *and* (via the next conditional revalidation) the browser
-copy, so updated silhouettes reach users on their next request.
+(see `services/read-api/src/cache-headers.ts`). Notably, that header
+**no longer carries `immutable`** — issue #252 removed it precisely so
+browsers will revalidate when their per-user `max-age` clock expires
+instead of holding the response untouchably for the full week.
+
+The cause-effect chain for a curation update is therefore:
+
+1. The migration lands; the API now returns the new SVG/color/attribution.
+2. The operator runs `purge-silhouettes-cache.sh`. Within ~30s the
+   Cloudflare edge copy is gone.
+3. The next time a user's browser actually goes to the network for
+   `/api/silhouettes` (either a cold fetch or a conditional revalidation
+   after `max-age` expiry), the request reaches the API and gets the
+   fresh bytes. Without the purge, the edge would still hand back the
+   stale copy until its own TTL ticked.
+4. **Browser caches turn over per response `max-age` regardless of the
+   purge.** Most users see fresh data within hours (whenever their
+   browser's TTL next ticks); a worst-case user who fetched right before
+   the migration holds stale bytes for up to 7 days from their last
+   request, then revalidates and picks up the new copy.
+
+If you need a hard guarantee that every user sees the new data
+immediately, neither the CDN purge nor the existing `max-age` window can
+provide it — that would require a versioned URL (e.g. `/api/silhouettes?v=2`)
+which we deliberately do not use.
 
 ## How to run
 
@@ -64,7 +94,10 @@ The constraint is on the *outbound* side: when `version-one` is merged
 into `main` for a release that includes any of those migrations, the
 `cache-headers.ts` change **must be in the same merge**. Otherwise the
 new silhouette rows land in production but get masked by the still-
-`immutable` Cache-Control directive for up to seven days.
+`immutable` Cache-Control directive for up to seven days — and at that
+point the CDN purge wouldn't help, because `immutable` instructs
+browsers to skip even the conditional revalidation that the purge
+relies on.
 
 In practice this means: do not split the epic across two
 `version-one → main` merges. Either ship the whole epic together, or


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    DB[("Postgres<br/>family_silhouettes")] --> API["Read API<br/>/api/silhouettes<br/>Cache-Control: max-age=604800"]
    API -->|"cached at edge"| CDN["Cloudflare CDN"]
    CDN -->|"cached per user"| B1["Browser A<br/>max-age clock: 2h left"]
    CDN -->|"cached per user"| B2["Browser B<br/>max-age clock: 6d left"]

    PURGE["purge-silhouettes-cache.sh"] -.->|"invalidates within ~30s"| CDN
    PURGE -.->|"does NOT touch"| B1
    PURGE -.->|"does NOT touch"| B2
```

## Summary

- The runbook conflated the Cloudflare edge cache (what `purge-silhouettes-cache.sh` invalidates, ~30s effective) with the per-user browser cache (controlled by response `max-age` + the post-#252 non-`immutable` directive). Operators reading the prior version could plausibly conclude that purging makes every user see fresh data immediately, which is wrong.
- Restructured the "When to run" section with an explicit two-tier table and a four-step cause-effect chain so an operator running the script knows what they ARE invalidating (CDN), what they ARE NOT invalidating (browser caches), and the worst-case stale-data window for any individual user (up to 7 days from their last fetch).

## Screenshots

N/A — docs only.

## Test plan

- [x] runbook reads cleanly; no broken cross-references; CDN/browser distinction visually distinct (table + numbered chain)
- [x] referenced TTL (`max-age=604800`) verified against `services/read-api/src/cache-headers.ts` line 13
- [x] referenced script behavior (Cloudflare zone purge of `/api/silhouettes`) verified against `scripts/purge-silhouettes-cache.sh`
- [x] the #252 `immutable`-removal narrative still flows in the branch-merge-ordering section (extended one sentence to explain why `immutable` would have defeated the purge)

## Plan reference

Follow-up to epic #251. See `docs/plans/2026-04-25-phylopic-silhouettes-epic-251/plan.md` and follow-up issue #257.

Closes #257.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)