### PR TITLE
test(frontend): gate accname fallback + dedupe map-view axe scan (#260, #263)

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -91,7 +91,17 @@ test.describe('accessibility', () => {
           // text content per the HTML AccName algorithm. Adding the
           // SurfaceFooter eBird credit (#243) introduced the first such
           // text-only link in the app, exposing this gap. Allow non-empty
-          // text content as a valid accname source.
+          // text content as a valid accname source — but ONLY for the
+          // interactive roles where AccName treats textContent as valid.
+          // For <select>, <input>, <textarea>, textContent is NOT a valid
+          // accname source (#260): <select>.textContent returns concatenated
+          // option text, <textarea>.textContent returns initial content —
+          // both are truthy even for unlabelled controls.
+          const isAccnameTextRole =
+            el.tagName === 'A' ||
+            el.tagName === 'BUTTON' ||
+            el.getAttribute('role') === 'button';
+          if (!isAccnameTextRole) return true;
           const text = (el.textContent ?? '').trim();
           if (text) return false;
           return true;

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -31,6 +31,14 @@ test.describe('axe-core WCAG scans', () => {
   // Map view scans the FamilyLegend overlay (#249) at desktop and mobile
   // viewports. Replaces the historical `region expanded` skip (the
   // pre-#113 map's region-expand axe scan no longer has a target).
+  // The maplibre AttributionControl needs WebGL to render and headless
+  // Chromium (CI + local) ships without it. We scan the chrome around
+  // the map (filters bar, surface nav, the map-canvas wrapper) — that's
+  // the part axe actually has DOM for. The attribution markup is unit-
+  // tested at the customAttribution-array level, so dropping the canvas
+  // contents from the axe scan does not mask a WCAG regression in the
+  // map's own controls (those are MapLibre-owned and out of our axe
+  // jurisdiction anyway).
   test('map view has no WCAG 2/2.1 A/AA violations (desktop)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('view=map');
@@ -223,38 +231,15 @@ test.describe('axe-core WCAG scans', () => {
     });
   });
 
-  // Extend the axe coverage to include feed (initial-load already covers
-  // this path, but assert explicitly for ?view=feed) and map. Existing
-  // species/detail/error scans above continue to cover the other surfaces.
+  // Feed view explicit scan. Initial-load above also covers ?view=feed
+  // by default, but assert explicitly for the URL-driven path.
+  // (Map view is covered above at desktop + mobile — see lines ~34 and
+  // ~146. The earlier duplicate `map view` test at the bottom of this
+  // describe was removed in #263 as functionally redundant.)
   test('feed view has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('view=feed');
     await app.waitForAppReady();
-    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
-    if (results.violations.length) {
-      await test.info().attach('axe-violations', {
-        body: JSON.stringify(results.violations, null, 2),
-        contentType: 'application/json',
-      });
-    }
-    expect(results.violations).toEqual([]);
-  });
-
-  test('map view has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
-    const app = new AppPage(page);
-    await app.goto('view=map');
-    await app.waitForAppReady();
-    // The maplibre AttributionControl needs WebGL to render and headless
-    // Chromium (CI + local) ships without it. We scan the chrome around
-    // the map (filters bar, surface nav, the map-canvas wrapper) — that's
-    // the part axe actually has DOM for. The attribution markup is unit-
-    // tested at the customAttribution-array level, so dropping the canvas
-    // contents from the axe scan does not mask a WCAG regression in the
-    // map's own controls (those are MapLibre-owned and out of our axe
-    // jurisdiction anyway).
-    await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({
-      timeout: 15_000,
-    });
     const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
     if (results.violations.length) {
       await test.info().attach('axe-violations', {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before
        A1["a11y.spec — accname check<br/>matches input/select/button/a/textarea"] --> B1["fallback: any textContent → labelled<br/>(false negative on select/textarea)"]
        A2["axe.spec — map view scan"] --> B2["line 34 (desktop) ✓"]
        A2 --> B3["line 258 (no viewport tag)<br/>functionally redundant ✗"]
    end
    subgraph After
        C1["a11y.spec — accname check<br/>same selector"] --> D1["fallback gated to A / BUTTON / role=button<br/>only (per HTML AccName)"]
        C2["axe.spec — map view scan"] --> D2["line 42 (desktop) ✓"]
        C2 --> D3["line 154 (mobile) ✓"]
    end
```

## Summary

- #260: a11y.spec.ts's textContent accname fallback was applying to ANY element with text — silently masking aria-label gaps on `<select>` (returns concatenated option text) and `<textarea>` (returns initial content). Gate it to interactive roles where AccName actually treats textContent as a name source: `<a>`, `<button>`, `[role=button]`.
- #263: axe.spec.ts ran the map view through axe twice — once at line ~34 and again at line ~258. Both ran at the default desktop viewport with the same WCAG tags; the only material difference was the explanatory comment block on the bottom one. Folded that comment into the line-34 site (kept) and removed the duplicate.

## Screenshots

N/A — test-only.

## Test plan

- [x] `npx playwright test --list` parses cleanly. `axe.spec.ts` test count: 15 → 14 (one map-view duplicate removed). `a11y.spec.ts` test count unchanged at 4.
- [x] Diff confined to the two target files (`frontend/e2e/a11y.spec.ts` +12/-1, `frontend/e2e/axe.spec.ts` +12/-28).
- [x] Manual logic check: gated fallback returns `true` (unlabelled) immediately for non-interactive controls; preserves prior behaviour on `<a>`/`<button>`/`[role=button]`.
- [ ] CI green: `test`, `lint`, `build`, `e2e`.

(Full e2e suite not run in-dispatch — no dev server available in this environment; `--list` parse + manual reading is the agreed substitute for test-only spec edits.)

## Plan reference

Follow-up to epic #251. See docs/plans/2026-04-25-phylopic-silhouettes-epic-251/plan.md and follow-up issues #260 + #263.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)