### PR TITLE
refactor(frontend): extract auto-spider effect into useAutoSpider hook (#293)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -36,48 +36,11 @@ import {
   type MosaicTile,
 } from './cluster-mosaic.js';
 import {
-  SPIDER_LEADER_COLOR,
-  SPIDER_LEADER_WIDTH,
-} from './spiderfy.js';
-import {
   MapMarkerHitLayer,
   type HitTargetMarker,
 } from './MapMarkerHitLayer.js';
-import {
-  groupOverlapping,
-  fanPositions,
-  type StackInput,
-} from './stack-fanout.js';
 import { StackedSilhouetteMarker } from './StackedSilhouetteMarker.js';
-
-/** Source / layer ids for the auto-spider leader lines. */
-const AUTO_SPIDER_SOURCE_ID = 'auto-spider-leader-lines';
-const AUTO_SPIDER_LAYER_ID = 'auto-spider-leader-lines-layer';
-
-/**
- * One leaf in the auto-spider state — carries the data needed to render a
- * StackedSilhouetteMarker at the fanned position.
- */
-interface AutoSpiderLeaf {
-  subId: string;
-  lngLat: [number, number];
-  silhouette: { svgData: string | null; color: string };
-  comName: string;
-  familyCode: string | null;
-  locName: string | null;
-  obsDt: string;
-  isNotable: boolean;
-}
-
-/**
- * One auto-spider stack — a group of co-located observations with their
- * fanned leaf positions.
- */
-interface AutoSpiderStack {
-  stackId: string;
-  centerLngLat: [number, number];
-  leaves: AutoSpiderLeaf[];
-}
+import { useAutoSpider } from './use-auto-spider.js';
 
 export interface MapCanvasProps {
   observations: Observation[];
@@ -284,13 +247,19 @@ export function MapCanvas({
 
   /**
    * Auto-spider stacks (issue #277, Spider v2 Task 3). Reconciled on every
-   * map `idle` by the auto-spider reconciler effect below. Each entry holds
-   * one fanned stack: the center lngLat, and the fanned leaves with their
-   * projected marker positions. Cleared to [] when no stacks are visible.
+   * map `idle` by the `useAutoSpider` hook (extracted from MapCanvas in
+   * #293). Each entry holds one fanned stack: the center lngLat, and the
+   * fanned leaves with their projected marker positions. The hook owns the
+   * effect, internal state, and the leader-line source/layer lifecycle;
+   * MapCanvas just consumes the returned stacks and renders one
+   * `<Marker>+<StackedSilhouetteMarker>` per leaf.
    */
-  const [autoSpiderStacks, setAutoSpiderStacks] = useState<AutoSpiderStack[]>(
-    [],
-  );
+  const autoSpiderStacks = useAutoSpider({
+    map: mapReady ? mapRef.current?.getMap() ?? null : null,
+    mapReady,
+    spritesReady,
+    silhouettes,
+  });
 
   // Issue #277 (Spider v2 Task 4): derive the set of subIds that belong to
   // any active auto-spider stack. These features get inStack: true in the
@@ -653,300 +622,6 @@ export function MapCanvas({
     // reads the live silhouettes array via silhouettesRef so per-row
     // updates don't need a re-registration.
   }, [silhouettes.length, mapReady]);
-
-  /**
-   * Auto-spider reconciler — issue #277, Spider v2 Task 3.
-   *
-   * On every map `idle` (and once immediately on mount when the map is
-   * ready), query the rendered unclustered-point features, project them to
-   * screen coords, detect co-located stacks via `groupOverlapping`, and fan
-   * each stack's members to distinct positions via `fanPositions`. Fanned
-   * positions are unprojected back to lngLat so `<Marker>` placements stay
-   * anchored to map coordinates across pan/zoom. The resulting
-   * AutoSpiderStack array drives the `<Marker>+<StackedSilhouetteMarker>`
-   * render below and the `auto-spider-leader-lines` GeoJSON source update.
-   *
-   * Short-circuit: when `silhouettes` is empty the effect returns early —
-   * same guard as the mosaic reconciler. Pan/zoom does NOT close
-   * auto-spider (it re-computes on the next idle). Escape only applies to
-   * the click-driven spiderfy path; auto-spider has no concept of "closing".
-   *
-   * Source/layer lifecycle:
-   *   - Source + layer are added once on the first reconcile that finds a
-   *     non-empty stacks result (idempotent `getLayer` check before
-   *     `addLayer`).
-   *   - On subsequent reconciles the source is updated via `setData` rather
-   *     than removed + re-added (avoids a flicker frame).
-   *   - When no stacks are detected the source data is set to an empty
-   *     FeatureCollection so leader lines disappear without removing the
-   *     source.
-   */
-  // Architectural note: this useEffect is a candidate for extraction into a useAutoSpider hook if MapCanvas grows further. Not blocking — current size is manageable.
-  useEffect(() => {
-    // AC #2: short-circuit when silhouettes aren't loaded yet.
-    if (silhouettes.length === 0) return undefined;
-    if (!mapReady) return undefined;
-    // The auto-spider reconciler queries the 'unclustered-point' layer, which
-    // is JSX-conditioned on spritesReady. Calling queryRenderedFeatures with a
-    // layers filter that names a not-yet-mounted layer raises
-    // "layer does not exist in the map's style". Wait until spritesReady flips.
-    if (!spritesReady) return undefined;
-    const map = mapRef.current?.getMap();
-    if (!map) return undefined;
-
-    // Build once per effect pass (dep array: [silhouettes.length, mapReady,
-    // spritesReady]). Silhouettes change at most once per session (empty →
-    // populated), so rebuilding on every idle would be wasteful at
-    // production obs counts.
-    const silByFamily = new Map<string, { svgData: string | null; color: string }>();
-    for (const s of silhouettesRef.current) {
-      silByFamily.set(s.familyCode.toLowerCase(), {
-        svgData: s.svgData,
-        color: s.color,
-      });
-    }
-
-    // Defensive — protects against future async yields in `reconcile`.
-    // Today reconcile is synchronous so this flag never fires; kept for
-    // forward-compatibility.
-    let cancelled = false;
-
-    const reconcile = () => {
-      if (cancelled) return;
-      const currentSilhouettes = silhouettesRef.current;
-      if (currentSilhouettes.length === 0) return;
-
-      // Defensive belt-and-suspenders: catch the case where the layer is
-      // removed between effect runs (style reload, hot-module replacement).
-      // querySourceFeatures itself doesn't throw on a missing layer (it
-      // queries the source, not the layer), but the source-readiness
-      // lifecycle still depends on the symbol layer having mounted, so we
-      // keep this check as a proxy for "rendering pipeline is alive".
-      if (!map.getLayer('unclustered-point')) return;
-
-      // Query the underlying GeoJSON source directly — NOT the rendered
-      // layer. The unclustered-point layer carries an
-      // `['!=', ['get', 'inStack'], true]` filter (Task 4) so once the
-      // reconciler stamps `inStack=true` on a feature, queryRenderedFeatures
-      // would stop returning it on subsequent idles, causing the reconciler
-      // to "forget" the stack and unstack it on the next idle, which then
-      // re-stacks it, and so on — a feedback loop that flickered the
-      // viewport (issue #277). querySourceFeatures bypasses layer filters
-      // and reads the raw source data, so the reconciler always sees the
-      // originally-stacked features.
-      const rawFeatures = (map.querySourceFeatures('observations', {
-        // Match the unclustered-point layer's first clause — return only
-        // unclustered features. We then apply the viewport filter manually
-        // below to preserve queryRenderedFeatures' viewport-only semantic
-        // (querySourceFeatures returns features in all rendered TILES, which
-        // can extend beyond the visible viewport).
-        filter: ['!', ['has', 'point_count']],
-      }) ?? []) as Array<{
-        properties?: Record<string, unknown>;
-        geometry?: { type: string; coordinates: unknown };
-      }>;
-
-      // querySourceFeatures returns one feature per tile boundary a feature
-      // crosses; dedupe by subId so the same obs doesn't end up in multiple
-      // stacks (which would produce React duplicate-key warnings on the
-      // stacked-silhouette-marker JSX). Same shape as the mosaic
-      // reconciler's dedupe on cluster_id above.
-      const seenSubIds = new Set<string>();
-      const features = rawFeatures.filter((f) => {
-        const subId = f.properties?.['subId'];
-        if (typeof subId !== 'string') return false;
-        if (seenSubIds.has(subId)) return false;
-        seenSubIds.add(subId);
-        return true;
-      });
-
-      // Compute viewport bounds for the manual filter below. getContainer()
-      // returns the map's wrapper div; getBoundingClientRect gives device-
-      // pixel dimensions that match map.project's screen-coord output.
-      const container = map.getContainer();
-      const { width: viewportWidth, height: viewportHeight } =
-        container.getBoundingClientRect();
-
-      // Build StackInput array — one per feature with screen projection.
-      const inputs: StackInput[] = [];
-      for (const f of features) {
-        const props = f.properties;
-        if (!props) continue;
-        const geom = f.geometry;
-        if (!geom || geom.type !== 'Point') continue;
-        const coords = geom.coordinates as [number, number];
-        if (!Array.isArray(coords) || coords.length < 2) continue;
-
-        const subId = props.subId as string | undefined;
-        if (!subId) continue;
-
-        const comName = (props.comName as string | undefined) ?? '';
-        const familyCode = (props.familyCode as string | null | undefined) ?? null;
-        const locName = (props.locName as string | null | undefined) ?? null;
-        const obsDt = (props.obsDt as string | undefined) ?? '';
-        const isNotable = Boolean(props.isNotable);
-        const silhouetteId = (props.silhouetteId as string | undefined) ?? '';
-        const color = (props.color as string | undefined) ?? '#888888';
-
-        // Project lngLat → screen coords.
-        const screen = map.project([coords[0], coords[1]]);
-
-        // Viewport filter — querySourceFeatures returns features in all
-        // rendered tiles (which extend beyond the visible viewport on
-        // tile boundaries). queryRenderedFeatures(undefined, ...) only
-        // returned viewport-visible features, so we replicate that here.
-        if (
-          screen.x < 0 ||
-          screen.x > viewportWidth ||
-          screen.y < 0 ||
-          screen.y > viewportHeight
-        ) {
-          continue;
-        }
-
-        inputs.push({
-          subId,
-          comName,
-          familyCode,
-          silhouetteId,
-          color,
-          isNotable,
-          obsDt,
-          locName,
-          screen: { x: screen.x, y: screen.y },
-          lngLat: [coords[0], coords[1]],
-        });
-      }
-
-      // Detect co-located stacks.
-      const stacks = groupOverlapping(inputs);
-
-      if (cancelled) return;
-
-      // Build AutoSpiderStack array from detected stacks.
-      const nextStacks: AutoSpiderStack[] = [];
-      const leaderFeatures: Array<{
-        type: 'Feature';
-        geometry: { type: 'LineString'; coordinates: [[number, number], [number, number]] };
-        properties: Record<string, string>;
-      }> = [];
-
-      for (const [si, stack] of stacks.entries()) {
-        const stackId = `stack-${si}`;
-        const fanned = fanPositions(stack);
-        const leaves: AutoSpiderLeaf[] = [];
-
-        for (const fan of fanned) {
-          // Find the matching input member.
-          const member = stack.members.find((m) => m.subId === fan.subId);
-          if (!member) continue;
-
-          // Unproject screen → lngLat for the Marker placement.
-          const unprojected = map.unproject({ x: fan.screen.x, y: fan.screen.y });
-          const leafLng = 'lng' in unprojected ? (unprojected as { lng: number }).lng : (unprojected as [number, number])[0];
-          const leafLat = 'lat' in unprojected ? (unprojected as { lat: number }).lat : (unprojected as [number, number])[1];
-          const leafLngLat: [number, number] = [leafLng, leafLat];
-
-          // Resolve silhouette svgData from silhouettesRef (NOT from feature
-          // properties — silhouetteId is a sprite name, not svgData).
-          const familyKey = member.familyCode?.toLowerCase() ?? null;
-          const sil = familyKey ? silByFamily.get(familyKey) : undefined;
-          const silhouette = {
-            svgData: sil?.svgData ?? null,
-            color: sil?.color ?? member.color,
-          };
-
-          leaves.push({
-            subId: member.subId,
-            lngLat: leafLngLat,
-            silhouette,
-            comName: member.comName,
-            familyCode: member.familyCode,
-            locName: member.locName,
-            obsDt: member.obsDt,
-            isNotable: member.isNotable,
-          });
-
-          // One LineString per leaf: origin = stack center lngLat → leaf lngLat.
-          leaderFeatures.push({
-            type: 'Feature',
-            geometry: {
-              type: 'LineString',
-              coordinates: [stack.centerLngLat, leafLngLat],
-            },
-            properties: { subId: member.subId, stackId },
-          });
-        }
-
-        if (leaves.length > 0) {
-          nextStacks.push({ stackId, centerLngLat: stack.centerLngLat, leaves });
-        }
-      }
-
-      if (cancelled) return;
-
-      // Update leader-line source. The source persists across reconcile
-      // passes; add it once (idempotent getLayer check) then use setData.
-      const leaderGeoJson = {
-        type: 'FeatureCollection' as const,
-        features: leaderFeatures,
-      };
-
-      const rawSource = map.getSource(AUTO_SPIDER_SOURCE_ID);
-      const existingSource =
-        rawSource != null &&
-        typeof (rawSource as { setData?: unknown }).setData === 'function'
-          ? (rawSource as { setData: (data: unknown) => void })
-          : null;
-
-      if (!existingSource) {
-        // First reconcile that touches the source (or mock returned a non-
-        // GeoJSON source without setData — treat as absent). Add source + layer.
-        // Guard against double-add on re-render by checking getLayer first.
-        if (!rawSource) {
-          map.addSource(AUTO_SPIDER_SOURCE_ID, {
-            type: 'geojson',
-            data: leaderGeoJson,
-          });
-        }
-        if (!map.getLayer(AUTO_SPIDER_LAYER_ID)) {
-          map.addLayer({
-            id: AUTO_SPIDER_LAYER_ID,
-            type: 'line',
-            source: AUTO_SPIDER_SOURCE_ID,
-            paint: {
-              'line-color': SPIDER_LEADER_COLOR,
-              'line-width': SPIDER_LEADER_WIDTH,
-            },
-          });
-        }
-      } else {
-        existingSource.setData(leaderGeoJson);
-      }
-
-      setAutoSpiderStacks((prev) =>
-        prev.length === 0 && nextStacks.length === 0 ? prev : nextStacks,
-      );
-    };
-
-    const onLoad = () => { reconcile(); };
-    const onIdle = () => { reconcile(); };
-    map.on('load', onLoad);
-    map.on('idle', onIdle);
-    // Run once immediately for maps already at rest.
-    reconcile();
-
-    return () => {
-      cancelled = true;
-      map.off('load', onLoad);
-      map.off('idle', onIdle);
-    };
-    // Re-register when silhouettes flip empty↔populated, when the map first
-    // becomes ready, OR when sprites finish registering (spritesReady is the
-    // gate that lets the unclustered-point layer mount; we must wait for it
-    // before querying that layer). The closure reads live silhouettes via
-    // silhouettesRef.
-  }, [silhouettes.length, mapReady, spritesReady]);
 
   /**
    * Mosaic-marker click handler:

--- a/frontend/src/components/map/use-auto-spider.test.ts
+++ b/frontend/src/components/map/use-auto-spider.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type maplibregl from 'maplibre-gl';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
+import { useAutoSpider } from './use-auto-spider.js';
+
+/* ── Smoke tests for the extracted useAutoSpider hook (issue #293) ─────
+   The full behavioral coverage lives in MapCanvas.test.tsx — those tests
+   render the parent and exercise the reconciler end-to-end through the
+   `idle` and `load` event handlers. These hook-level smokes only pin two
+   short-circuit paths so a regression that breaks them surfaces in
+   isolation. Anything more elaborate would duplicate the integration
+   coverage in MapCanvas.test.tsx. */
+
+const SILHOUETTES: FamilySilhouette[] = [
+  {
+    familyCode: 'tyrannidae',
+    color: '#C77A2E',
+    svgData: 'M0 0L1 1Z',
+    source: 'placeholder',
+    license: 'CC0',
+    commonName: 'Tyrant Flycatchers',
+    creator: null,
+  },
+];
+
+describe('useAutoSpider', () => {
+  it('returns [] initially when map is null', () => {
+    const { result } = renderHook(() =>
+      useAutoSpider({
+        map: null,
+        mapReady: false,
+        spritesReady: false,
+        silhouettes: SILHOUETTES,
+      }),
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it('short-circuits without side effects when silhouettes is empty', () => {
+    // A fully-stocked map mock — every method is a spy. With silhouettes
+    // empty the effect must return early before invoking anything on the
+    // map. This protects the AC #2 short-circuit (ingest cache miss /
+    // API failure on cold load).
+    const map = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getLayer: vi.fn(),
+      getSource: vi.fn(),
+      addSource: vi.fn(),
+      addLayer: vi.fn(),
+      querySourceFeatures: vi.fn(),
+      queryRenderedFeatures: vi.fn(),
+      project: vi.fn(),
+      unproject: vi.fn(),
+      getContainer: vi.fn(),
+    } as unknown as maplibregl.Map;
+
+    const { result } = renderHook(() =>
+      useAutoSpider({
+        map,
+        mapReady: true,
+        spritesReady: true,
+        silhouettes: [],
+      }),
+    );
+    expect(result.current).toEqual([]);
+    // No listener registration — no `idle`/`load` `on()` call, no source
+    // / layer mutation. If the short-circuit regresses, every spy below
+    // would record at least one invocation.
+    expect((map.on as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect((map.off as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect((map.addSource as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect((map.addLayer as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect((map.querySourceFeatures as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('does NOT register listeners when mapReady is false', () => {
+    // Mirror of the silhouettes-empty case for the mapReady gate.
+    const map = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getLayer: vi.fn(),
+      getSource: vi.fn(),
+      addSource: vi.fn(),
+      addLayer: vi.fn(),
+      querySourceFeatures: vi.fn(),
+      queryRenderedFeatures: vi.fn(),
+      project: vi.fn(),
+      unproject: vi.fn(),
+      getContainer: vi.fn(),
+    } as unknown as maplibregl.Map;
+
+    const { result } = renderHook(() =>
+      useAutoSpider({
+        map,
+        mapReady: false,
+        spritesReady: true,
+        silhouettes: SILHOUETTES,
+      }),
+    );
+    expect(result.current).toEqual([]);
+    expect((map.on as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('does NOT register listeners when spritesReady is false', () => {
+    // Mirror of the silhouettes-empty case for the spritesReady gate —
+    // pins the cold-load guard that prevents the reconciler from
+    // querying a not-yet-mounted symbol layer.
+    const map = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getLayer: vi.fn(),
+      getSource: vi.fn(),
+      addSource: vi.fn(),
+      addLayer: vi.fn(),
+      querySourceFeatures: vi.fn(),
+      queryRenderedFeatures: vi.fn(),
+      project: vi.fn(),
+      unproject: vi.fn(),
+      getContainer: vi.fn(),
+    } as unknown as maplibregl.Map;
+
+    const { result } = renderHook(() =>
+      useAutoSpider({
+        map,
+        mapReady: true,
+        spritesReady: false,
+        silhouettes: SILHOUETTES,
+      }),
+    );
+    expect(result.current).toEqual([]);
+    expect((map.on as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/use-auto-spider.ts
+++ b/frontend/src/components/map/use-auto-spider.ts
@@ -1,0 +1,404 @@
+import { useEffect, useRef, useState } from 'react';
+import type maplibregl from 'maplibre-gl';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
+import {
+  SPIDER_LEADER_COLOR,
+  SPIDER_LEADER_WIDTH,
+} from './spiderfy.js';
+import {
+  groupOverlapping,
+  fanPositions,
+  type StackInput,
+} from './stack-fanout.js';
+
+/** Source / layer ids for the auto-spider leader lines. */
+export const AUTO_SPIDER_SOURCE_ID = 'auto-spider-leader-lines';
+export const AUTO_SPIDER_LAYER_ID = 'auto-spider-leader-lines-layer';
+
+/**
+ * One leaf in the auto-spider state — carries the data needed to render a
+ * StackedSilhouetteMarker at the fanned position.
+ */
+export interface AutoSpiderLeaf {
+  subId: string;
+  lngLat: [number, number];
+  silhouette: { svgData: string | null; color: string };
+  comName: string;
+  familyCode: string | null;
+  locName: string | null;
+  obsDt: string;
+  isNotable: boolean;
+}
+
+/**
+ * One auto-spider stack — a group of co-located observations with their
+ * fanned leaf positions.
+ */
+export interface AutoSpiderStack {
+  stackId: string;
+  centerLngLat: [number, number];
+  leaves: AutoSpiderLeaf[];
+}
+
+export interface UseAutoSpiderArgs {
+  /** Underlying maplibre-gl Map instance. `null` until the map mounts. */
+  map: maplibregl.Map | null;
+  /** Flips true after the map fires its initial `load` event. */
+  mapReady: boolean;
+  /**
+   * Flips true after sprite registration (`map.addImage` Promise.all)
+   * resolves — gates the unclustered-point symbol layer mount in
+   * MapCanvas. The reconciler must wait for it before calling
+   * `queryRenderedFeatures(..., { layers: ['unclustered-point'] })`,
+   * which would otherwise throw "layer does not exist in the map's
+   * style".
+   */
+  spritesReady: boolean;
+  /**
+   * Family silhouettes from `/api/silhouettes`. The reconciler reads
+   * `svgData` + `color` per family to populate each leaf's silhouette
+   * payload. When the array is empty the reconciler short-circuits — same
+   * guard as the mosaic reconciler.
+   */
+  silhouettes: readonly FamilySilhouette[];
+}
+
+/**
+ * Auto-spider reconciler — issue #277, Spider v2 Task 3 (extracted from
+ * MapCanvas in #293).
+ *
+ * On every map `idle` (and once immediately on mount when the map is
+ * ready), query the rendered unclustered-point features, project them to
+ * screen coords, detect co-located stacks via `groupOverlapping`, and fan
+ * each stack's members to distinct positions via `fanPositions`. Fanned
+ * positions are unprojected back to lngLat so `<Marker>` placements stay
+ * anchored to map coordinates across pan/zoom. The returned
+ * AutoSpiderStack array drives the `<Marker>+<StackedSilhouetteMarker>`
+ * render in MapCanvas and the `auto-spider-leader-lines` GeoJSON source
+ * update.
+ *
+ * Short-circuit: when `silhouettes` is empty the effect returns early —
+ * same guard as the mosaic reconciler. Pan/zoom does NOT close
+ * auto-spider (it re-computes on the next idle). Escape only applies to
+ * the click-driven spiderfy path; auto-spider has no concept of "closing".
+ *
+ * Source/layer lifecycle:
+ *   - Source + layer are added once on the first reconcile that finds a
+ *     non-empty stacks result (idempotent `getLayer` check before
+ *     `addLayer`).
+ *   - On subsequent reconciles the source is updated via `setData` rather
+ *     than removed + re-added (avoids a flicker frame).
+ *   - When no stacks are detected the source data is set to an empty
+ *     FeatureCollection so leader lines disappear without removing the
+ *     source.
+ */
+export function useAutoSpider({
+  map,
+  mapReady,
+  spritesReady,
+  silhouettes,
+}: UseAutoSpiderArgs): AutoSpiderStack[] {
+  /**
+   * Auto-spider stacks. Reconciled on every map `idle` by the effect
+   * below. Each entry holds one fanned stack: the center lngLat, and the
+   * fanned leaves with their projected marker positions. Cleared to []
+   * when no stacks are visible.
+   */
+  const [autoSpiderStacks, setAutoSpiderStacks] = useState<AutoSpiderStack[]>(
+    [],
+  );
+
+  // The reconciler reads `silhouettes` on every pass. A ref keeps the
+  // closure fresh without re-registering the map listeners (registration
+  // is keyed only on the map instance + readiness flags, NOT on the
+  // silhouettes array contents).
+  const silhouettesRef = useRef(silhouettes);
+  silhouettesRef.current = silhouettes;
+
+  useEffect(() => {
+    // AC #2: short-circuit when silhouettes aren't loaded yet.
+    if (silhouettes.length === 0) return undefined;
+    if (!mapReady) return undefined;
+    // The auto-spider reconciler queries the 'unclustered-point' layer, which
+    // is JSX-conditioned on spritesReady. Calling queryRenderedFeatures with a
+    // layers filter that names a not-yet-mounted layer raises
+    // "layer does not exist in the map's style". Wait until spritesReady flips.
+    if (!spritesReady) return undefined;
+    if (!map) return undefined;
+
+    // Build once per effect pass (dep array: [silhouettes.length, mapReady,
+    // spritesReady, map]). Silhouettes change at most once per session
+    // (empty → populated), so rebuilding on every idle would be wasteful at
+    // production obs counts.
+    const silByFamily = new Map<string, { svgData: string | null; color: string }>();
+    for (const s of silhouettesRef.current) {
+      silByFamily.set(s.familyCode.toLowerCase(), {
+        svgData: s.svgData,
+        color: s.color,
+      });
+    }
+
+    // Defensive — protects against future async yields in `reconcile`.
+    // Today reconcile is synchronous so this flag never fires; kept for
+    // forward-compatibility.
+    let cancelled = false;
+
+    const reconcile = () => {
+      if (cancelled) return;
+      const currentSilhouettes = silhouettesRef.current;
+      if (currentSilhouettes.length === 0) return;
+
+      // Defensive belt-and-suspenders: catch the case where the layer is
+      // removed between effect runs (style reload, hot-module replacement).
+      // querySourceFeatures itself doesn't throw on a missing layer (it
+      // queries the source, not the layer), but the source-readiness
+      // lifecycle still depends on the symbol layer having mounted, so we
+      // keep this check as a proxy for "rendering pipeline is alive".
+      if (!map.getLayer('unclustered-point')) return;
+
+      // Query the underlying GeoJSON source directly — NOT the rendered
+      // layer. The unclustered-point layer carries an
+      // `['!=', ['get', 'inStack'], true]` filter (Task 4) so once the
+      // reconciler stamps `inStack=true` on a feature, queryRenderedFeatures
+      // would stop returning it on subsequent idles, causing the reconciler
+      // to "forget" the stack and unstack it on the next idle, which then
+      // re-stacks it, and so on — a feedback loop that flickered the
+      // viewport (issue #277). querySourceFeatures bypasses layer filters
+      // and reads the raw source data, so the reconciler always sees the
+      // originally-stacked features.
+      const rawFeatures = (map.querySourceFeatures('observations', {
+        // Match the unclustered-point layer's first clause — return only
+        // unclustered features. We then apply the viewport filter manually
+        // below to preserve queryRenderedFeatures' viewport-only semantic
+        // (querySourceFeatures returns features in all rendered TILES, which
+        // can extend beyond the visible viewport).
+        filter: ['!', ['has', 'point_count']],
+      }) ?? []) as Array<{
+        properties?: Record<string, unknown>;
+        geometry?: { type: string; coordinates: unknown };
+      }>;
+
+      // querySourceFeatures returns one feature per tile boundary a feature
+      // crosses; dedupe by subId so the same obs doesn't end up in multiple
+      // stacks (which would produce React duplicate-key warnings on the
+      // stacked-silhouette-marker JSX). Same shape as the mosaic
+      // reconciler's dedupe on cluster_id above.
+      const seenSubIds = new Set<string>();
+      const features = rawFeatures.filter((f) => {
+        const subId = f.properties?.['subId'];
+        if (typeof subId !== 'string') return false;
+        if (seenSubIds.has(subId)) return false;
+        seenSubIds.add(subId);
+        return true;
+      });
+
+      // Compute viewport bounds for the manual filter below. getContainer()
+      // returns the map's wrapper div; getBoundingClientRect gives device-
+      // pixel dimensions that match map.project's screen-coord output.
+      const container = map.getContainer();
+      const { width: viewportWidth, height: viewportHeight } =
+        container.getBoundingClientRect();
+
+      // Build StackInput array — one per feature with screen projection.
+      const inputs: StackInput[] = [];
+      for (const f of features) {
+        const props = f.properties;
+        if (!props) continue;
+        const geom = f.geometry;
+        if (!geom || geom.type !== 'Point') continue;
+        const coords = geom.coordinates as [number, number];
+        if (!Array.isArray(coords) || coords.length < 2) continue;
+
+        const subId = props.subId as string | undefined;
+        if (!subId) continue;
+
+        const comName = (props.comName as string | undefined) ?? '';
+        const familyCode = (props.familyCode as string | null | undefined) ?? null;
+        const locName = (props.locName as string | null | undefined) ?? null;
+        const obsDt = (props.obsDt as string | undefined) ?? '';
+        const isNotable = Boolean(props.isNotable);
+        const silhouetteId = (props.silhouetteId as string | undefined) ?? '';
+        const color = (props.color as string | undefined) ?? '#888888';
+
+        // Project lngLat → screen coords.
+        const screen = map.project([coords[0], coords[1]]);
+
+        // Viewport filter — querySourceFeatures returns features in all
+        // rendered tiles (which extend beyond the visible viewport on
+        // tile boundaries). queryRenderedFeatures(undefined, ...) only
+        // returned viewport-visible features, so we replicate that here.
+        if (
+          screen.x < 0 ||
+          screen.x > viewportWidth ||
+          screen.y < 0 ||
+          screen.y > viewportHeight
+        ) {
+          continue;
+        }
+
+        inputs.push({
+          subId,
+          comName,
+          familyCode,
+          silhouetteId,
+          color,
+          isNotable,
+          obsDt,
+          locName,
+          screen: { x: screen.x, y: screen.y },
+          lngLat: [coords[0], coords[1]],
+        });
+      }
+
+      // Detect co-located stacks.
+      const stacks = groupOverlapping(inputs);
+
+      if (cancelled) return;
+
+      // Build AutoSpiderStack array from detected stacks.
+      const nextStacks: AutoSpiderStack[] = [];
+      const leaderFeatures: Array<{
+        type: 'Feature';
+        geometry: { type: 'LineString'; coordinates: [[number, number], [number, number]] };
+        properties: Record<string, string>;
+      }> = [];
+
+      for (const [si, stack] of stacks.entries()) {
+        const stackId = `stack-${si}`;
+        const fanned = fanPositions(stack);
+        const leaves: AutoSpiderLeaf[] = [];
+
+        for (const fan of fanned) {
+          // Find the matching input member.
+          const member = stack.members.find((m) => m.subId === fan.subId);
+          if (!member) continue;
+
+          // Unproject screen → lngLat for the Marker placement. The
+          // `{ x, y }` literal is a structural match for maplibre's
+          // `PointLike`, but the strict typing from `maplibregl.Map.unproject`
+          // expects a class-instance `Point`. Cast widens the param to the
+          // looser `PointLike` semantic the runtime actually accepts —
+          // matches the `as any` pattern MapCanvas uses elsewhere on this
+          // intra-package boundary. The return is also widened so the
+          // `'lng' in ...` runtime branch (which handles both maplibre's
+          // LngLat and the `[lng, lat]` tuple shape returned by some test
+          // mocks) typechecks.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const unprojected = (map.unproject as (p: any) => any)({
+            x: fan.screen.x,
+            y: fan.screen.y,
+          }) as { lng: number; lat: number } | [number, number];
+          const leafLng =
+            'lng' in unprojected
+              ? (unprojected as { lng: number }).lng
+              : (unprojected as [number, number])[0];
+          const leafLat =
+            'lat' in unprojected
+              ? (unprojected as { lat: number }).lat
+              : (unprojected as [number, number])[1];
+          const leafLngLat: [number, number] = [leafLng, leafLat];
+
+          // Resolve silhouette svgData from silhouettesRef (NOT from feature
+          // properties — silhouetteId is a sprite name, not svgData).
+          const familyKey = member.familyCode?.toLowerCase() ?? null;
+          const sil = familyKey ? silByFamily.get(familyKey) : undefined;
+          const silhouette = {
+            svgData: sil?.svgData ?? null,
+            color: sil?.color ?? member.color,
+          };
+
+          leaves.push({
+            subId: member.subId,
+            lngLat: leafLngLat,
+            silhouette,
+            comName: member.comName,
+            familyCode: member.familyCode,
+            locName: member.locName,
+            obsDt: member.obsDt,
+            isNotable: member.isNotable,
+          });
+
+          // One LineString per leaf: origin = stack center lngLat → leaf lngLat.
+          leaderFeatures.push({
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates: [stack.centerLngLat, leafLngLat],
+            },
+            properties: { subId: member.subId, stackId },
+          });
+        }
+
+        if (leaves.length > 0) {
+          nextStacks.push({ stackId, centerLngLat: stack.centerLngLat, leaves });
+        }
+      }
+
+      if (cancelled) return;
+
+      // Update leader-line source. The source persists across reconcile
+      // passes; add it once (idempotent getLayer check) then use setData.
+      const leaderGeoJson = {
+        type: 'FeatureCollection' as const,
+        features: leaderFeatures,
+      };
+
+      const rawSource = map.getSource(AUTO_SPIDER_SOURCE_ID);
+      const existingSource =
+        rawSource != null &&
+        typeof (rawSource as unknown as { setData?: unknown }).setData ===
+          'function'
+          ? (rawSource as unknown as { setData: (data: unknown) => void })
+          : null;
+
+      if (!existingSource) {
+        // First reconcile that touches the source (or mock returned a non-
+        // GeoJSON source without setData — treat as absent). Add source + layer.
+        // Guard against double-add on re-render by checking getLayer first.
+        if (!rawSource) {
+          map.addSource(AUTO_SPIDER_SOURCE_ID, {
+            type: 'geojson',
+            data: leaderGeoJson,
+          });
+        }
+        if (!map.getLayer(AUTO_SPIDER_LAYER_ID)) {
+          map.addLayer({
+            id: AUTO_SPIDER_LAYER_ID,
+            type: 'line',
+            source: AUTO_SPIDER_SOURCE_ID,
+            paint: {
+              'line-color': SPIDER_LEADER_COLOR,
+              'line-width': SPIDER_LEADER_WIDTH,
+            },
+          });
+        }
+      } else {
+        existingSource.setData(leaderGeoJson);
+      }
+
+      setAutoSpiderStacks((prev) =>
+        prev.length === 0 && nextStacks.length === 0 ? prev : nextStacks,
+      );
+    };
+
+    const onLoad = () => { reconcile(); };
+    const onIdle = () => { reconcile(); };
+    map.on('load', onLoad);
+    map.on('idle', onIdle);
+    // Run once immediately for maps already at rest.
+    reconcile();
+
+    return () => {
+      cancelled = true;
+      map.off('load', onLoad);
+      map.off('idle', onIdle);
+    };
+    // Re-register when silhouettes flip empty↔populated, when the map first
+    // becomes ready, OR when sprites finish registering (spritesReady is the
+    // gate that lets the unclustered-point layer mount; we must wait for it
+    // before querying that layer). The closure reads live silhouettes via
+    // silhouettesRef.
+  }, [silhouettes.length, mapReady, spritesReady, map]);
+
+  return autoSpiderStacks;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    MapCanvas["MapCanvas.tsx"] -- "{ map, mapReady, spritesReady, silhouettes }" --> useAutoSpider["useAutoSpider hook"]
    useAutoSpider -- "AutoSpiderStack[]" --> MapCanvas
    useAutoSpider -- "addSource / addLayer / setData" --> maplibre["maplibre-gl Map"]
    useAutoSpider -- "on('load' | 'idle')" --> maplibre
    MapCanvas -- "<Marker>+<StackedSilhouetteMarker> per leaf" --> dom["DOM"]
```

The hook owns the effect, the internal `autoSpiderStacks` state, and the leader-line source/layer lifecycle. MapCanvas just consumes the returned stacks and renders one `<Marker>+<StackedSilhouetteMarker>` per leaf. No public surface changes.

## Summary

- **Why:** MapCanvas was ~1100 lines; the auto-spider reconciler (post-Spider v2) was ~200 lines of dense projection / grouping / fan-position math + source/layer lifecycle, plus a `// Architectural note: this useEffect is a candidate for extraction into a useAutoSpider hook` TODO at the top. Per the final reviewer of #280, this was the single biggest readability liability left in MapCanvas.
- **What:** Extracted to `frontend/src/components/map/use-auto-spider.ts`. MapCanvas drops from 1181 -> 856 lines (-325). All `AUTO_SPIDER_*` constants, `AutoSpiderStack`/`AutoSpiderLeaf` interfaces, the `setAutoSpiderStacks` state, the `silhouettesRef` indirection (the hook's own copy — MapCanvas keeps a separate ref for the mosaic reconciler), and the entire reconciler `useEffect` (gates, idle/load handlers, projection -> grouping -> fan -> state pipeline, source/layer lifecycle) move into the hook.
- **Behavior-preserving:** All 30 existing MapCanvas tests pass unchanged (including the 6 Spider-v2 integration tests: silhouettes-empty short-circuit, no-overlap no-stacks, 5-coincident-obs -> 5 markers, tile-boundary subId dedupe, second-idle no-oscillation, listener cleanup). Added 4 new hook-level smoke tests in `use-auto-spider.test.ts` to pin the short-circuit paths in isolation.

## Screenshots

N/A — behavior-preserving refactor verified by full Spider v2 e2e + integration tests. Live browser-drive at zoom 16 over the Tucson hotspot (`-110.9, 32.45`) confirmed 5 fanned silhouette markers + 5 leader lines + working ObservationPopover (Northern Cardinal click); `panBy([10, 10])` -> markers stayed at 5 (no oscillation); `jumpTo([-112.0, 33.5])` zoom 8 -> 0 stacks (correctly absent); 0 console errors. (Pre-existing 4 maplibre-internal `Expected value to be of type number` warnings on cluster expressions — same on `main`, not introduced here.)

## Test plan

- [x] `npx tsc -p frontend/tsconfig.json --noEmit` — clean
- [x] `npm run test --workspace @bird-watch/frontend` — 384/384 pass (was 380/380 baseline; +4 new hook smoke tests)
- [x] `npm run test --workspace @bird-watch/frontend -- --run MapCanvas use-auto-spider` — 34/34 pass
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] Browser-drive at 1440x900 via chrome-devtools-mcp:
  - `jumpTo([-110.9, 32.45])` zoom 16 (Tucson Sweetwater Wetlands hotspot) -> 5 stacked-silhouette markers + 14 leader-line features (one per leaf, with tile-boundary repeats) -> auto-spider source + layer present
  - Cardinal marker click -> ObservationPopover for "Northern Cardinal" opens
  - `panBy([10, 10])` -> markers stay at 5 (no oscillation)
  - `jumpTo([-112.0, 33.5])` zoom 8 (Phoenix area, clustered) -> 0 stacked markers, 0 leader features (correctly absent)

## Plan reference

Spider v2 follow-up. See `docs/plans/.../come-up-with-a-agile-bear.md` Wave 4 Bundle F and follow-up issue #293.

Closes #293.