### PR TITLE
chore: stale-comment / dead-export sweep across workspaces [G13 / SUGGESTION-bundle]

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -396,7 +396,7 @@ export function MapCanvas({
         // MapLibre 5.x: `getClusterExpansionZoom` (and `getClusterChildren`,
         // `getClusterLeaves`) returns a Promise and no longer invokes the
         // legacy callback argument. Passing a callback silently no-ops —
-        // which is how this regression shipped (see PR #165 / issue #166).
+        // so we always call .then() on the returned Promise instead.
         const src = source as {
           getClusterExpansionZoom: (id: number) => Promise<number>;
         };

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -7,9 +7,9 @@
  * MapLibre warnings at zoom >7, but those are cosmetic upstream issues, not
  * crashes. Acceptable for v1 ship.
  *
- * Future: self-hosted PMTiles at tiles.bird-maps.com (R2 bucket + CF Worker
- * already provisioned by Plan 7 S2, but the one-time build-basemap.sh upload
- * hasn't run yet, and a full style spec with land/water/road layers + glyphs
- * still needs authoring).
+ * Future work (tracked in #312): self-hosted PMTiles at tiles.bird-maps.com.
+ * R2 bucket + CF Worker provisioned by Plan 7 Decision 5, but the one-time
+ * build-basemap.sh upload hasn't run yet, and a full style spec with
+ * land/water/road layers + glyphs still needs authoring.
  */
 export const basemapStyle = 'https://tiles.openfreemap.org/styles/positron';

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -7,9 +7,10 @@
  * MapLibre warnings at zoom >7, but those are cosmetic upstream issues, not
  * crashes. Acceptable for v1 ship.
  *
- * Future work (tracked in #312): self-hosted PMTiles at tiles.bird-maps.com.
- * R2 bucket + CF Worker provisioned by Plan 7 Decision 5, but the one-time
- * build-basemap.sh upload hasn't run yet, and a full style spec with
- * land/water/road layers + glyphs still needs authoring.
+ * Future: self-hosted PMTiles at tiles.bird-maps.com (tracked in #156 — Plan 7
+ * Decision 3 / S2 infra issue, now closed). R2 bucket + CF Worker already
+ * provisioned by Plan 7 S2, but the one-time build-basemap.sh upload hasn't
+ * run yet, and a full style spec with land/water/road layers + glyphs still
+ * needs authoring.
  */
 export const basemapStyle = 'https://tiles.openfreemap.org/styles/positron';

--- a/frontend/src/components/map/fan-layout.test.ts
+++ b/frontend/src/components/map/fan-layout.test.ts
@@ -3,7 +3,6 @@ import {
   computeSpiderfyLayout,
   SPIDERFY_RADIUS_PX,
   SPIDERFY_MAX_LEAVES,
-  SPIDERFY_DURATION_MS,
 } from './fan-layout.js';
 
 /* ── Pure layout helpers ──────────────────────────────────────────────────
@@ -62,7 +61,4 @@ describe('exported constants', () => {
     expect(SPIDERFY_MAX_LEAVES).toBe(8);
   });
 
-  it('SPIDERFY_DURATION_MS matches issue spec (200ms)', () => {
-    expect(SPIDERFY_DURATION_MS).toBe(200);
-  });
 });

--- a/frontend/src/components/map/fan-layout.ts
+++ b/frontend/src/components/map/fan-layout.ts
@@ -2,7 +2,8 @@
  * Fan-layout geometry — pure circle and Archimedean spiral math used by the
  * Spider v2 auto-fan reconciler (`stack-fanout.ts` + `MapCanvas.tsx`).
  *
- * Renamed from `spiderfy.ts` after Spider v2 (#280) deleted the click-driven
+ * Renamed from `spiderfy.ts` in PR #295 (`refactor(frontend): rename
+ * spiderfy.ts → fan-layout.ts`), which also deleted the click-driven
  * spider. The old name was a misnomer — what remains is just per-leaf offset
  * geometry plus the leader-line paint constants the auto-spider layer reads
  * (the auto-spider is no longer a "click to spider out" interaction; it's a
@@ -31,7 +32,6 @@
 
 export const SPIDERFY_RADIUS_PX = 70;
 export const SPIDERFY_MAX_LEAVES = 8;
-export const SPIDERFY_DURATION_MS = 200;
 /** Shared with auto-spider reconciler in MapCanvas.tsx — keep in sync. */
 export const SPIDER_LEADER_COLOR = '#444';
 export const SPIDER_LEADER_WIDTH = 2;

--- a/frontend/src/components/map/use-auto-spider.ts
+++ b/frontend/src/components/map/use-auto-spider.ts
@@ -12,8 +12,8 @@ import {
 } from './stack-fanout.js';
 
 /** Source / layer ids for the auto-spider leader lines. */
-export const AUTO_SPIDER_SOURCE_ID = 'auto-spider-leader-lines';
-export const AUTO_SPIDER_LAYER_ID = 'auto-spider-leader-lines-layer';
+const AUTO_SPIDER_SOURCE_ID = 'auto-spider-leader-lines';
+const AUTO_SPIDER_LAYER_ID = 'auto-spider-leader-lines-layer';
 
 /**
  * One leaf in the auto-spider state — carries the data needed to render a

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -14,10 +14,13 @@ import { useEffect, useState } from 'react';
  *   hook returns `false` and registers no listeners. It does NOT crash.
  * - The effect cleans up its listener on unmount and on query change.
  *
- * Originally introduced for SpeciesPanel (#115, since deleted). Currently
- * referenced in MapMarkerHitLayer for pointer-coarse detection. Retained
- * for any future responsive-layout work that needs React-state-driven
- * conditional DOM (e.g. `data-layout` attributes, conditional siblings).
+ * Originally introduced for SpeciesPanel (#115, since deleted). Currently has
+ * zero production callers — MapMarkerHitLayer mentions the hook only in its
+ * own JSDoc advice, and MapCanvas inlines `window.matchMedia` directly rather
+ * than calling this hook. Retained for future responsive-layout work that
+ * needs React-state-driven conditional DOM (e.g. `data-layout` attributes,
+ * conditional siblings). TODO: delete if no caller materialises by the time
+ * the map-v1 surface is complete.
  */
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState<boolean>(() => {

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -14,9 +14,10 @@ import { useEffect, useState } from 'react';
  *   hook returns `false` and registers no listeners. It does NOT crash.
  * - The effect cleans up its listener on unmount and on query change.
  *
- * Originally used by SpeciesPanel (#115) to drive its drawer-vs-sidebar
- * layout. Retained for future responsive-layout hooks that need React-state-
- * driven conditional DOM (e.g. `data-layout` attributes, conditional siblings).
+ * Originally introduced for SpeciesPanel (#115, since deleted). Currently
+ * referenced in MapMarkerHitLayer for pointer-coarse detection. Retained
+ * for any future responsive-layout work that needs React-state-driven
+ * conditional DOM (e.g. `data-layout` attributes, conditional siblings).
  */
 export function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = useState<boolean>(() => {

--- a/frontend/src/hooks/use-scroll-restore.ts
+++ b/frontend/src/hooks/use-scroll-restore.ts
@@ -3,7 +3,11 @@ import { useEffect, useRef } from 'react';
 /**
  * Scroll position capture-and-restore tied to an `active` boolean.
  *
- * Contract (per issue #115):
+ * Originally introduced for SpeciesPanel (#115, since deleted). Retained for
+ * any future panel or drawer component that needs the same scroll-restore
+ * contract.
+ *
+ * Contract:
  *   - false → true: capture `window.scrollY` as the "pre-open" position.
  *   - true  → false: if the user has NOT scrolled materially since capture
  *     (|current - captured| ≤ 2px), restore to the captured position.

--- a/frontend/src/tokens.ts
+++ b/frontend/src/tokens.ts
@@ -64,11 +64,7 @@ export const iconSize = {
 export const zIndex = {
   /** Default stacking (reserved — no rule uses this today). */
   base: 0,
-  /**
-   * Region polygon layer. Reserved for future CSS-stacked layers; note that
-   * SVG interiors paint in document order, NOT CSS z-index. The region
-   * polygons today are SVG children, so this value never applies to them.
-   */
+  /** Reserved for future map layers (CSS-stacked overlays). */
   shapes: 10,
   /** Badge layer (reserved). */
   badges: 20,
@@ -89,9 +85,7 @@ export const opacity = {
    */
   subtle: 0.08,
   /**
-   * Dim non-selected regions on expand. Was `0.2` inline in Map.tsx.
-   * Stays on the `<g>` wrapper so badges/labels dim together with the
-   * region fill.
+   * Low opacity for de-emphasised elements. Was `0.2` inline in Map.tsx.
    */
   dimmed: 0.2,
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,9 +9,9 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      // Issue #258: `@vis.gl/react-maplibre` does a dynamic
+      // Issue #258: `react-map-gl/maplibre` (^8.1.1) does a dynamic
       // `import('maplibre-gl')` at runtime. npm workspaces hoists
-      // `@vis.gl/react-maplibre` to the root `node_modules/`, but
+      // `react-map-gl` to the root `node_modules/`, but
       // `maplibre-gl` is declared only as a frontend dep so it stays in
       // `frontend/node_modules/`. Vite's bundler can't resolve from one
       // to the other, and ships a chunk whose body is `throw Error(...)`.

--- a/packages/db-client/src/__tests__/region-topology.test.ts
+++ b/packages/db-client/src/__tests__/region-topology.test.ts
@@ -1,3 +1,6 @@
+// Geometry-contract tests: these verify PostGIS state in the live DB after
+// migrations run. They do not test exported db-client functions — they assert
+// spatial invariants that would otherwise be invisible to the unit test suite.
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from '../test-helpers.js';
 

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -4,6 +4,12 @@ import type { Observation, ObservationFilters } from '@bird-watch/shared-types';
 export interface ObservationInput {
   subId: string;
   speciesCode: string;
+  // comName is populated by toObservationInput() but intentionally NOT
+  // inserted into the observations table. The read path derives com_name
+  // from a species_meta JOIN (SELECT sm.com_name FROM species_meta sm …),
+  // so storing it in observations would be redundant and could diverge if
+  // taxonomy is updated. The field is kept here so the transform function
+  // can produce a complete record from the eBird response without surgery.
   comName: string;
   lat: number;
   lng: number;
@@ -75,14 +81,16 @@ export async function upsertObservations(
 }
 
 /**
- * Re-runs the region/silhouette stamping UPDATE across ALL observations whose
- * region_id or silhouette_id is still NULL. Idempotent.
+ * Backfills region_id / silhouette_id on observations that are still NULL
+ * because species_meta was empty at ingest time (e.g. prod pre-#83).
+ * Idempotent — safe to call repeatedly; only touches rows whose stamps are
+ * still NULL. Intended to run once after a taxonomy load, not as a
+ * continuous stamping path.
  *
- * upsertObservations only stamps rows it just touched (via its WHERE filter,
- * which in practice catches the current batch). When species_meta is empty
- * at ingest time (as on prod pre-#83), the silhouette JOIN finds no row and
- * silhouette_id stays NULL — even after the batch is stamped. Running this
- * after a taxonomy job is loaded backfills every orphaned row.
+ * Ongoing per-run stamping (normal case) happens inside `upsertObservations`
+ * via an inline UPDATE that covers only the batch just inserted. This
+ * function handles the historical backfill for rows that pre-date the first
+ * successful taxonomy run.
  *
  * Returns the number of rows updated.
  */

--- a/packages/db-client/src/region-boundaries.test.ts
+++ b/packages/db-client/src/region-boundaries.test.ts
@@ -1,3 +1,6 @@
+// Geometry-contract tests: these verify PostGIS state in the live DB after
+// migrations run. They do not test exported db-client functions — they assert
+// spatial invariants that would otherwise be invisible to the unit test suite.
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from './test-helpers.js';
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -40,9 +40,10 @@ export interface Observation {
   // with familyCode === undefined. Consumers treat undefined the same as
   // null (skip / fallback), so no Cache-Control bump is required.
   familyCode: string | null;
-  // taxonOrder remains optional: it's sourced from SpeciesMeta and only
-  // lands on the wire when the read-api projects it. Consumers default
-  // to null when absent.
+  // taxonOrder is present only on /api/species/:code responses (projected
+  // from SpeciesMeta). It is never included in /api/observations payloads
+  // (getObservations SELECT omits taxon_order). Consumers default to null
+  // when absent.
   taxonOrder?: number | null;
 }
 
@@ -86,7 +87,7 @@ export interface FamilySilhouette {
 
 export interface IngestRun {
   id: number;
-  kind: 'recent' | 'notable' | 'backfill' | 'hotspots' | 'taxonomy';
+  kind: 'recent' | 'backfill' | 'hotspots' | 'taxonomy';
   startedAt: string;
   finishedAt: string | null;
   obsFetched: number | null;

--- a/services/ingestor/src/ebird/types.ts
+++ b/services/ingestor/src/ebird/types.ts
@@ -1,6 +1,6 @@
 // eBird API response shapes used by the ingestor:
 //   EbirdObservation — https://api.ebird.org/v2/data/obs/{regionCode}/recent
-//   EbirdHotspot    — https://api.ebird.org/v2/ref/hotspot/geo
+//   EbirdHotspot    — https://api.ebird.org/v2/ref/hotspot/{regionCode}
 //   EbirdTaxon      — https://api.ebird.org/v2/ref/taxonomy/ebird
 // Reference: https://documenter.getpostman.com/view/664302/S1ENwy59
 

--- a/services/ingestor/src/ebird/types.ts
+++ b/services/ingestor/src/ebird/types.ts
@@ -1,4 +1,7 @@
-// Shapes returned by https://api.ebird.org/v2/data/obs/{regionCode}/recent
+// eBird API response shapes used by the ingestor:
+//   EbirdObservation — https://api.ebird.org/v2/data/obs/{regionCode}/recent
+//   EbirdHotspot    — https://api.ebird.org/v2/ref/hotspot/geo
+//   EbirdTaxon      — https://api.ebird.org/v2/ref/taxonomy/ebird
 // Reference: https://documenter.getpostman.com/view/664302/S1ENwy59
 
 export interface EbirdObservation {

--- a/services/ingestor/src/index.ts
+++ b/services/ingestor/src/index.ts
@@ -2,3 +2,4 @@ export { handleScheduled, type HandlerEnv, type ScheduledKind } from './handler.
 export { runIngest, type RunSummary } from './run-ingest.js';
 export { runHotspotIngest, type RunHotspotSummary } from './run-hotspots.js';
 export { runBackfill, type RunBackfillSummary } from './run-backfill.js';
+export { runTaxonomy, type RunTaxonomySummary } from './run-taxonomy.js';

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -140,6 +140,8 @@ describe('GET /api/silhouettes', () => {
     // 15 rows from migration 9000 + 10 AZ-family expansion rows from
     // migration 15000 (issue #244) + the `_FALLBACK` row from migration
     // 18000 (issue #246) → 26 total.
+    // Fields exercised below also cover: creator (migrations 1700000016000 +
+    // 1700000017000), commonName (migration 1700000019500, issue #249).
     expect(body).toHaveLength(26);
     // Spot-check the _FALLBACK row round-trips through the Hono response
     // so the frontend's symbol-layer fallback path can rely on it.

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -29,7 +29,7 @@ export function createApp(deps: AppDeps): Hono {
   // Interaction with route-level `Cache-Control: public, immutable` on
   // /api/species/:code: Hono sets `Vary: Origin`, so a
   // spec-compliant CDN keys the cache per-Origin. That means the identical
-  // JSON body is stored N× for N allowed origins (currently 3 — trivial).
+  // JSON body is stored N× for N allowed origins (currently 4 — trivial).
   // Uptime probes and plain `curl` hit these routes without an Origin
   // header, so the CDN also caches a no-ACAO entry; browsers never see that
   // entry because Cloud CDN honors Vary. The cached bodies contain no


### PR DESCRIPTION
## Diagrams

N/A — comment-only and dead-export deletions; no data flow, state machine, or component tree changes.

## Summary

- **frontend**: 9 fixes — alias comment (react-map-gl, not @vis.gl), fan-layout PR ref (#295), dead `SPIDERFY_DURATION_MS` export removed, PMTiles tracking-issue ref added, stale `#165/#166` ref replaced with neutral zoom-guard description, `AUTO_SPIDER_SOURCE_ID`/`_LAYER_ID` unexported (no external callers), `zIndex.shapes`/`opacity.dimmed` comments de-referenced deleted SVG renderer, scroll-restore and media-query JSDoc updated to reflect SpeciesPanel deletion.
- **services**: 4 fixes — read-api CORS count comment (3→4), app.test.ts migration coverage comment extended to all exercised migrations, ingestor `runTaxonomy`/`RunTaxonomySummary` added to package index, ebird/types.ts header broadened to cover all three shapes.
- **packages**: 4 fixes — `IngestRun.kind` dead `'notable'` value removed, `taxonOrder` scoped to `/api/species/:code` only, `ObservationInput.comName` silent-drop documented, `runReconcileStamping` comment scoped to backfill-only (not ongoing stamping), geometry-contract headers added to both region test files.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build` — passes for all non-frontend workspaces; frontend has a pre-existing `maplibre-gl` type resolution error unrelated to this PR (confirmed pre-existing via `git stash` check)
- [x] `npm run lint --workspaces --if-present` — green
- [x] `npm test -w frontend` — 346 tests pass (1 pre-existing `MapCanvas.test.tsx` failure from missing `maplibre-gl` in test env, unchanged)
- [x] `npm test -w services/ingestor` — green
- [x] Acceptance-criteria greps all pass:
  - `grep -rn "vis.gl/react-maplibre" frontend/src/` → no output ✓
  - `grep -rn "currently 3" services/read-api/src/app.ts` → no output ✓
  - `grep -n "'notable'" packages/shared-types/src/index.ts` → no output ✓
  - `grep -rn "SPIDERFY_DURATION_MS" frontend/src/` → no output ✓

## Plan reference

Closes #310. Implements G13/Wave-2b of dispatch plan.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)