### PR TITLE
feat(ingestor): iNaturalist photo client (#327, task-5)

### DIFF
--- a/services/ingestor/src/inat/client.test.ts
+++ b/services/ingestor/src/inat/client.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fetchInatPhoto } from './client.js';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const INAT_OBSERVATIONS_URL = 'https://api.inaturalist.org/v1/observations';
+
+describe('fetchInatPhoto', () => {
+  it('fetchBestPhoto returns InatPhoto for cc-licensed research-grade hit', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        // Verify the full query-param contract from the issue spec.
+        expect(url.searchParams.get('taxon_name')).toBe('Pyrocephalus rubinus');
+        expect(url.searchParams.get('place_id')).toBe('40'); // Arizona
+        expect(url.searchParams.get('quality_grade')).toBe('research');
+        expect(url.searchParams.get('photo_license')).toBe('cc-by,cc-by-sa,cc0');
+        expect(url.searchParams.get('order_by')).toBe('votes');
+        expect(url.searchParams.get('per_page')).toBe('1');
+        expect(url.searchParams.get('photos')).toBe('true');
+        // iNat recommended-practices doc requires a meaningful UA.
+        expect(request.headers.get('User-Agent')).toMatch(/bird-maps\.com/);
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              photos: [
+                {
+                  url: 'https://inaturalist-open-data.s3.amazonaws.com/photos/12345/square.jpg',
+                  attribution: '(c) Jane Doe, some rights reserved (CC BY)',
+                  license_code: 'cc-by',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Pyrocephalus rubinus');
+
+    expect(photo).not.toBeNull();
+    expect(photo).toEqual({
+      url: 'https://inaturalist-open-data.s3.amazonaws.com/photos/12345/medium.jpg',
+      attribution: '(c) Jane Doe, some rights reserved (CC BY)',
+      license: 'cc-by',
+    });
+    // Defensive: the size substitution must replace 'square', not produce a
+    // 75px thumbnail in the detail panel.
+    expect(photo?.url).not.toContain('square');
+    expect(photo?.url).toContain('medium');
+  });
+
+  it('fetchBestPhoto returns null on zero results', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () => {
+        return HttpResponse.json({
+          total_results: 0,
+          page: 1,
+          per_page: 1,
+          results: [],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Imaginarius nonexistens');
+    expect(photo).toBeNull();
+  });
+
+  it('fetchBestPhoto retries once on 429', async () => {
+    let calls = 0;
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () => {
+        calls++;
+        if (calls === 1) {
+          return new HttpResponse('rate limited', { status: 429 });
+        }
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              photos: [
+                {
+                  url: 'https://example.org/photos/1/square.jpg',
+                  attribution: '(c) Bob, CC0',
+                  license_code: 'cc0',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Pyrocephalus rubinus', {
+      retryBaseMs: 1,
+    });
+
+    expect(calls).toBe(2);
+    expect(photo).not.toBeNull();
+    expect(photo?.license).toBe('cc0');
+    expect(photo?.url).toContain('medium.jpg');
+  });
+});

--- a/services/ingestor/src/inat/client.ts
+++ b/services/ingestor/src/inat/client.ts
@@ -1,0 +1,166 @@
+import type {
+  InatObservationsResponse,
+  InatPhoto,
+} from './types.js';
+
+// User-Agent header value identifying the app to iNaturalist's API. iNat's
+// API recommended-practices doc (https://www.inaturalist.org/pages/api+recommended+practices)
+// asks for meaningful UA strings so they can contact the app maintainer if a
+// problem is observed. Anonymous UAs may be throttled or blocked outright.
+const USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
+
+// place_id=40 is iNaturalist's canonical "Arizona" Place. Confirmed via
+// `GET https://api.inaturalist.org/v1/places/40` returning `name='Arizona'`,
+// `place_type=8` (state), `admin_level=10`. Source of truth — do not change
+// without re-verifying. Other AZ-shaped places (county, NWR, etc.) have
+// different IDs and would silently narrow or skew the photo pool.
+const ARIZONA_PLACE_ID = '40';
+
+// CC license codes accepted by `photo_license`. CC-BY-NC* variants are
+// excluded because they forbid commercial use; while bird-maps.com is
+// non-commercial today, a future donations/grants tier could change that
+// classification, and re-licensing every backfilled photo would be painful.
+const CC_LICENSES = 'cc-by,cc-by-sa,cc0';
+
+const INAT_BASE_URL = 'https://api.inaturalist.org/v1';
+
+export interface FetchInatPhotoOptions {
+  baseUrl?: string;
+  /** Total attempts on transient failures (429 / 5xx). Default 1 retry => 2 total attempts. */
+  maxRetries?: number;
+  retryBaseMs?: number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Fetches a single best-quality, CC-licensed, research-grade observation
+ * photo from iNaturalist for the given binomial taxonomic name. Returns null
+ * when iNat reports zero hits — callers (run-photos.ts) treat null as "skip
+ * this species, log, continue".
+ *
+ * Retries once on transient failures (429, 5xx, network/timeout). 4xx other
+ * than 429 throws immediately — those represent malformed requests, not
+ * iNat-side flakiness, and retrying would only obscure the bug.
+ */
+export async function fetchInatPhoto(
+  taxonName: string,
+  opts: FetchInatPhotoOptions = {}
+): Promise<InatPhoto | null> {
+  const baseUrl = opts.baseUrl ?? INAT_BASE_URL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+
+  const url = new URL(`${baseUrl}/observations`);
+  url.searchParams.set('taxon_name', taxonName);
+  url.searchParams.set('place_id', ARIZONA_PLACE_ID);
+  url.searchParams.set('quality_grade', 'research');
+  url.searchParams.set('photo_license', CC_LICENSES);
+  url.searchParams.set('order_by', 'votes'); // best-rated first
+  url.searchParams.set('per_page', '1');
+  url.searchParams.set('photos', 'true'); // only observations that include photos
+
+  const body = await getJsonWithRetry<InatObservationsResponse>(
+    url,
+    maxRetries,
+    retryBaseMs,
+    requestTimeoutMs
+  );
+
+  const firstResult = body.results[0];
+  if (!firstResult) return null;
+
+  const firstPhoto = firstResult.photos[0];
+  if (!firstPhoto) return null;
+
+  // iNat's `photo.url` returns a 75px square thumbnail by convention. The URL
+  // contains the literal segment 'square' (e.g. .../photos/12345/square.jpg);
+  // substituting 'medium' yields the ~500-800px variant suitable for a detail
+  // panel. iNat publishes the size token convention at
+  // https://www.inaturalist.org/pages/help#photos — supported values are
+  // square, small, medium, large, original.
+  const mediumUrl = firstPhoto.url.replace('square', 'medium');
+
+  // photo_license filtering at the API level guarantees a non-null code, but
+  // defend against a malformed payload by falling back to an empty string —
+  // upstream consumers store the license in a NOT NULL column, so an empty
+  // string surfaces "schema violation" loudly rather than crashing here.
+  const license = firstPhoto.license_code ?? '';
+
+  return {
+    url: mediumUrl,
+    attribution: firstPhoto.attribution,
+    license,
+  };
+}
+
+async function getJsonWithRetry<T>(
+  url: URL,
+  maxRetries: number,
+  retryBaseMs: number,
+  requestTimeoutMs: number
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          'User-Agent': USER_AGENT,
+          accept: 'application/json',
+        },
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
+      // 429 is treated as transient (rate-limited) — retry. 5xx is also
+      // transient — retry. Other 4xx is a programming error and surfaces
+      // immediately; retrying would just delay the failure.
+      if (res.status === 429 || res.status >= 500) {
+        throw new InatTransientError(res.status, await res.text());
+      }
+      if (!res.ok) {
+        throw new InatClientError(res.status, await res.text());
+      }
+      return (await res.json()) as T;
+    } catch (err) {
+      lastError = err;
+      if (err instanceof InatClientError) throw err; // 4xx (non-429) — don't retry
+      if (attempt === maxRetries) break;
+      // Full-jitter exponential backoff (AWS write-up variant).
+      const backoff = retryBaseMs * Math.pow(2, attempt);
+      const withJitter = Math.floor(Math.random() * backoff);
+      await sleep(withJitter);
+    }
+  }
+  if (isAbortError(lastError)) {
+    throw new InatTransientError(
+      0,
+      `Request timed out after ${requestTimeoutMs}ms`
+    );
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+export class InatClientError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`iNat client error ${status}: ${body}`);
+    this.name = 'InatClientError';
+  }
+}
+
+export class InatTransientError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`iNat transient error ${status}: ${body}`);
+    this.name = 'InatTransientError';
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** True for both manual AbortController aborts and AbortSignal.timeout() expirations. */
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'AbortError' || err.name === 'TimeoutError')
+  );
+}

--- a/services/ingestor/src/inat/types.ts
+++ b/services/ingestor/src/inat/types.ts
@@ -1,0 +1,29 @@
+// Public type contract for the iNaturalist photo client. Consumers (e.g.
+// run-photos.ts orchestrator) depend only on this shape — nothing about the
+// raw iNat API response leaks across the module boundary.
+
+export interface InatPhoto {
+  url: string; // ~800px medium-sized JPEG (size substituted from 'square' → 'medium')
+  attribution: string; // e.g. "(c) Jane Doe, some rights reserved (CC BY)"
+  license: string; // e.g. "cc-by", "cc-by-sa", "cc0"
+}
+
+// Minimal shape of the iNat /v1/observations response we care about. The real
+// payload has many more fields (taxon, location, observed_on, etc.) — we only
+// project the photo subset, so anything else is intentionally absent here.
+export interface InatObservationPhoto {
+  url: string; // 75px square thumbnail; size token must be substituted for the larger variant
+  attribution: string;
+  license_code: string | null; // null when license is ARR (filtered out at the API level via photo_license)
+}
+
+export interface InatObservation {
+  photos: InatObservationPhoto[];
+}
+
+export interface InatObservationsResponse {
+  total_results: number;
+  page: number;
+  per_page: number;
+  results: InatObservation[];
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Caller as run-photos.ts (task-7)
    participant Client as fetchInatPhoto
    participant iNat as api.inaturalist.org

    Caller->>Client: fetchInatPhoto("Pyrocephalus rubinus")
    Client->>iNat: GET /v1/observations<br/>?taxon_name=&place_id=40<br/>&quality_grade=research<br/>&photo_license=cc-by,cc-by-sa,cc0<br/>&order_by=votes&per_page=1&photos=true
    alt 200 with results
        iNat-->>Client: { results: [{ photos: [{ url: ".../square.jpg", attribution, license_code }] }] }
        Client-->>Caller: { url: ".../medium.jpg", attribution, license }
    else 200 zero results
        iNat-->>Client: { results: [] }
        Client-->>Caller: null
    else 429 / 5xx / timeout
        iNat-->>Client: 429
        Client->>iNat: retry once (full-jitter backoff)
        iNat-->>Client: 200 OK
        Client-->>Caller: { url, attribution, license }
    end
```

## Summary

- Adds `fetchInatPhoto(taxonName)` so the upcoming `run-photos.ts` orchestrator (task-7) can backfill one CC-licensed, research-grade Arizona photo per species without re-deriving the iNat query contract from scratch.
- `place_id=40` is hard-coded (verified Arizona via `/v1/places/40`) and `photo_license` excludes CC-BY-NC variants — keeps the donations/grants tier optionality the issue calls out.
- Size-token rewrite (`square` -> `medium`) gets the detail panel a ~800px image instead of iNat's default 75px thumbnail; documented inline so the substitution doesn't read as magic.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor -- src/inat/client.test.ts` — 3/3 passing locally
- [x] `npm run build --workspace @bird-watch/ingestor` — clean
- [x] New unit tests added: `fetchBestPhoto returns InatPhoto for cc-licensed research-grade hit`, `fetchBestPhoto returns null on zero results`, `fetchBestPhoto retries once on 429`
- [ ] Playwright e2e — N/A (ingestor module, no user-visible behavior change yet; e2e arrives with task-10/11 frontend wiring)
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Part of #327, task-5 (iNaturalist photo client). The umbrella issue tracks the 14 tasks for `feat(photos): per-species bird photos via R2 + iNaturalist`; this PR implements only the iNat client surface, no orchestration or storage yet.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)