### PR TITLE
chore(infra): provision R2 bucket birdwatch-photos

### DIFF
--- a/infra/terraform/photos.tf
+++ b/infra/terraform/photos.tf
@@ -1,0 +1,13 @@
+# ── Storage backend for per-species bird photos ─────────────────────────
+#
+# Cloudflare R2 bucket holding the iNaturalist-sourced JPEG/PNG/WebP photos
+# rendered by SpeciesDetailSurface. Public access is provided by a separate
+# Worker (task-1b) at photos.${var.domain}; the bucket itself stays private.
+# Mirrors the cloudflare_r2_bucket.pmtiles pattern from map-v1.tf.
+# See issue #327 §Approach.
+
+resource "cloudflare_r2_bucket" "photos" {
+  account_id = var.cloudflare_account_id
+  name       = "birdwatch-photos"
+  location   = "WNAM" # Western North America — closest to AZ users
+}


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    Ingestor[ingestor: run-photos.ts<br/>task-7] -->|S3 PUT<br/>via @aws-sdk/client-s3| R2[(cloudflare_r2_bucket.photos<br/>name: birdwatch-photos<br/>location: WNAM)]
    R2 -->|R2 binding PHOTOS| Worker[photo-server Worker<br/>task-1b]
    Worker -->|public reads<br/>at photos.bird-maps.com| Frontend[SpeciesDetailSurface<br/>task-10]

    style R2 fill:#f6ad55,stroke:#7c2d12
```

## Summary

- Lands the storage half of issue #327 task-1a — `cloudflare_r2_bucket.photos` only. The Worker, DNS, and public-access plumbing arrive in task-1b; this PR is a deliberately minimal, single-resource addition so the apply step is safe to run alone.
- Mirrors the proven `cloudflare_r2_bucket.pmtiles` pattern from `map-v1.tf` (same `account_id`, same `WNAM` location, same provider version `~> 4.20`); only the resource label and bucket name differ. No new variables — `var.cloudflare_account_id` already exists.
- Bucket itself stays private. `birdwatch-pmtiles` set the precedent that public access is provided by a Worker, not by R2 ACLs — task-1b extends that pattern at `photos.${var.domain}`.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform validate` — exits 0 against the full `infra/terraform/` config (Terraform 1.14.8, matching the CI pin in `terraform-plan-drift-check.yml`).
- [x] `terraform plan -target=cloudflare_r2_bucket.photos` (against a local backend with stub `TF_VAR_*` values) — shows exactly one `+ create` diff with `name = "birdwatch-photos"`, `location = "WNAM"`, `account_id = var.cloudflare_account_id`. No other resource diffs, destroys, updates, or replaces.
- [x] `git diff main` — only `infra/terraform/photos.tf` (13 lines, new file). No other files touched.
- [ ] N/A — no application code, no unit/integration tests applicable.
- [ ] N/A — no UI, no Playwright drive.
- [ ] N/A — no `npm run build` (infra-only).
- Apply path: out of scope for this PR. The operator runs `terraform apply` manually after merge, then proceeds to task-1b which depends on `cloudflare_r2_bucket.photos.name` being live. The nightly `terraform-plan-drift-check` workflow will surface any post-apply drift.

## Plan reference

Part of issue #327 (\"feat(photos): per-species bird photos via R2 + iNaturalist\"), task-1a — first of three Terraform tasks (1a, 1b, 8b) for that issue.