### PR TITLE
chore(infra): provision R2 public-access Worker + DNS CNAME

### DIFF
--- a/infra/terraform/photos.tf
+++ b/infra/terraform/photos.tf
@@ -10,4 +10,52 @@ resource "cloudflare_r2_bucket" "photos" {
   account_id = var.cloudflare_account_id
   name       = "birdwatch-photos"
   location   = "WNAM" # Western North America — closest to AZ users
+
+  # Photos are reconstitutable only via rate-limited iNaturalist re-fetch
+  # (~344 species × monthly cadence). A `terraform destroy` typo would cost
+  # hours of ingest work, not just data — the one-line guard is cheap
+  # insurance and matches the bucket's "treat as durable archive" role.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# ── Public read-only Worker in front of the R2 bucket ────────────────────
+#
+# The bucket has no public ACL; this Worker is the only public ingress.
+# Mirrors the `cloudflare_workers_script.map_server` + `cloudflare_workers_route`
+# + `cloudflare_record` triplet from map-v1.tf — same shape, different
+# binding name (PHOTOS vs TILES) and different hostname.
+#
+# Worker source lives in infra/workers/photo-server.js (kept as a real .js
+# file, not an inline heredoc, so it can be unit-tested with `node --test`).
+
+resource "cloudflare_workers_script" "photo_server" {
+  account_id = var.cloudflare_account_id
+  name       = "birdwatch-photo-server"
+  module     = true
+
+  content = file("${path.module}/../workers/photo-server.js")
+
+  r2_bucket_binding {
+    name        = "PHOTOS"
+    bucket_name = cloudflare_r2_bucket.photos.name
+  }
+}
+
+resource "cloudflare_workers_route" "photos" {
+  zone_id     = var.cloudflare_zone_id
+  pattern     = "photos.${var.domain}/*"
+  script_name = cloudflare_workers_script.photo_server.name
+}
+
+# photos.bird-maps.com CNAME — Worker-routed hostname needs Cloudflare proxy
+# (proxied = true) so the Worker route fires. Same pattern as tiles.
+resource "cloudflare_record" "photos" {
+  zone_id = var.cloudflare_zone_id
+  name    = "photos"
+  type    = "CNAME"
+  content = var.domain
+  proxied = true
+  ttl     = 1
 }

--- a/infra/workers/photo-server.js
+++ b/infra/workers/photo-server.js
@@ -1,0 +1,73 @@
+// ── photo-server: public read-only proxy in front of birdwatch-photos R2 ──
+//
+// Exposes `https://photos.bird-maps.com/<key>` → `r2://birdwatch-photos/<key>`.
+// Bound to the `PHOTOS` R2 binding (see infra/terraform/photos.tf).
+//
+// Key derivation: request.url.pathname.slice(1) — so a request for
+//   https://photos.bird-maps.com/vermfly.webp
+// reads R2 key
+//   vermfly.webp
+//
+// Caching contract: photos are write-once at R2 keys. If a species photo is
+// replaced (e.g. iNaturalist license change → re-fetch), the new photo is
+// uploaded under a NEW key and the species_photos row is updated to point at
+// it; the old key is never overwritten. That makes hit responses safe to mark
+// `immutable` with a one-year max-age. Misses get a short 60s cache to
+// absorb traffic on not-yet-ingested species without pinning a 404 forever.
+
+/**
+ * Resolve the HTTP Content-Type for a given object key (e.g. R2 key, URL
+ * path, filename) based on its extension. Unknown / missing extensions
+ * fall through to `application/octet-stream` per RFC 2046.
+ *
+ * Exported so the unit test can exercise the lookup table without spinning
+ * up the full Worker runtime.
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+export function contentTypeFor(key) {
+  const dot = key.lastIndexOf('.');
+  if (dot === -1) return 'application/octet-stream';
+  const ext = key.slice(dot + 1).toLowerCase();
+  switch (ext) {
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+export default {
+  /**
+   * @param {Request} request
+   * @param {{ PHOTOS: R2Bucket }} env
+   */
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const key = url.pathname.slice(1);
+
+    const object = await env.PHOTOS.get(key);
+
+    if (object === null) {
+      return new Response(null, {
+        status: 404,
+        headers: {
+          'Cache-Control': 'public, max-age=60',
+        },
+      });
+    }
+
+    return new Response(object.body, {
+      headers: {
+        'Content-Type': contentTypeFor(key),
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    });
+  },
+};

--- a/infra/workers/photo-server.test.js
+++ b/infra/workers/photo-server.test.js
@@ -1,0 +1,48 @@
+// Smoke tests for the photo-server Worker's pure helpers.
+//
+// We can't run the full Worker fetch handler here without miniflare/wrangler,
+// but the Content-Type lookup is a pure function — exporting and testing it
+// independently catches the most common bugs (typos in the extension table,
+// case-sensitivity slips, default fallback regressions).
+//
+// Run with:  node --test infra/workers/photo-server.test.js
+// Node 20+'s built-in test runner is sufficient here; no devDeps needed.
+// `infra/` is not an npm workspace, so vitest is not on the PATH at this
+// level.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { contentTypeFor } from './photo-server.js';
+
+describe('contentTypeFor', () => {
+  it('returns image/jpeg for .jpg', () => {
+    assert.equal(contentTypeFor('vermfly.jpg'), 'image/jpeg');
+  });
+
+  it('returns image/jpeg for .jpeg', () => {
+    assert.equal(contentTypeFor('vermfly.jpeg'), 'image/jpeg');
+  });
+
+  it('returns image/png for .png', () => {
+    assert.equal(contentTypeFor('vermfly.png'), 'image/png');
+  });
+
+  it('returns image/webp for .webp', () => {
+    assert.equal(contentTypeFor('vermfly.webp'), 'image/webp');
+  });
+
+  it('returns application/octet-stream for unknown extensions', () => {
+    assert.equal(contentTypeFor('vermfly.gif'), 'application/octet-stream');
+    assert.equal(contentTypeFor('vermfly.tiff'), 'application/octet-stream');
+    assert.equal(contentTypeFor('no-extension'), 'application/octet-stream');
+    assert.equal(contentTypeFor(''), 'application/octet-stream');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    // R2 keys are case-sensitive, but a key like `Vermfly.JPG` should still
+    // get the right Content-Type if it ever lands.
+    assert.equal(contentTypeFor('vermfly.JPG'), 'image/jpeg');
+    assert.equal(contentTypeFor('vermfly.PNG'), 'image/png');
+    assert.equal(contentTypeFor('vermfly.WebP'), 'image/webp');
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    Browser[Browser<br/>SpeciesDetailSurface] -->|GET /vermfly.webp| DNS[cloudflare_record.photos<br/>photos.bird-maps.com<br/>CNAME → bird-maps.com<br/>proxied=true]
    DNS -->|Worker route fires| Route[cloudflare_workers_route.photos<br/>photos.bird-maps.com/*]
    Route -->|invokes| Worker[cloudflare_workers_script.photo_server<br/>infra/workers/photo-server.js<br/>R2 binding: PHOTOS]
    Worker -->|env.PHOTOS.get key| R2[(cloudflare_r2_bucket.photos<br/>birdwatch-photos<br/>WNAM)]

    style R2 fill:#f6ad55,stroke:#7c2d12
    style Worker fill:#fbd38d,stroke:#7c2d12
```

```mermaid
sequenceDiagram
    participant Client
    participant Worker as photo-server
    participant R2 as PHOTOS bucket

    Client->>Worker: GET /vermfly.webp
    Worker->>R2: env.PHOTOS.get("vermfly.webp")
    alt object exists
        R2-->>Worker: R2Object {body, ...}
        Worker-->>Client: 200, image/webp,<br/>Cache-Control: public, max-age=31536000, immutable
    else not found
        R2-->>Worker: null
        Worker-->>Client: 404, empty body,<br/>Cache-Control: public, max-age=60
    end
```

## Summary

- Lands the public-read half of issue #327 task-1b — the Worker, route, and DNS CNAME that put `photos.bird-maps.com` in front of the `birdwatch-photos` R2 bucket created in PR #330. Mirrors the proven `map_server` + `cloudflare_workers_route.map_tiles` + `cloudflare_record.tiles` triplet from `map-v1.tf` exactly; only the binding name (`PHOTOS` vs `TILES`), bucket, hostname, and cache contract differ.
- Worker source kept as a real `.js` file (`infra/workers/photo-server.js`), not an inline `<<-EOT` heredoc as in `map-v1.tf`, so the Content-Type lookup is unit-testable. The lookup is exported and exercised by `infra/workers/photo-server.test.js` (Node's built-in `node:test` runner — `infra/` is not an npm workspace so vitest is unavailable at this level).
- Hit responses are `Cache-Control: public, max-age=31536000, immutable` because photos are write-once at R2 keys: a replacement (e.g. iNat license drift → re-fetch) goes to a new key and updates `species_photos.url`, so the old key is never overwritten. Misses get a short 60s cache to absorb traffic on not-yet-ingested species without pinning a 404 forever.
- Drive-by addition (called out in task-1a's bot review): `lifecycle { prevent_destroy = true }` on `cloudflare_r2_bucket.photos`. Photos are reconstitutable only via rate-limited iNat re-fetch (~344 species × monthly cadence) — a `terraform destroy` typo would cost hours, not lose data. The one-line guard is cheap insurance.

## Screenshots

N/A — not UI

## Test plan

- [x] `node --test infra/workers/photo-server.test.js` — 6/6 green. Covers `.jpg`, `.jpeg`, `.png`, `.webp`, unknown extensions, no-extension, empty key, and uppercase variants.
- [x] `terraform fmt -check -diff infra/terraform/*.tf` — clean.
- [x] `terraform init -backend=false && terraform validate` — `Success! The configuration is valid.` against the full `infra/terraform/` config (Terraform 1.14.8, matching the CI pin in `terraform-plan-drift-check.yml`; cloudflare provider `~> 4.20` resolved to 4.52.7).
- [x] TDD discipline followed: wrote `photo-server.test.js` first, confirmed `ERR_MODULE_NOT_FOUND` failure (no implementation), then added `photo-server.js` with the exported `contentTypeFor` helper and the default `fetch` handler, confirmed pass.
- [x] Resource shape mirrors `cloudflare_workers_script.map_server` + `cloudflare_workers_route.map_tiles` + `cloudflare_record.tiles` from `map-v1.tf` (same provider version, same `account_id`/`zone_id` vars, same `proxied = true` for the CNAME).
- [ ] `terraform plan` against the live GCS backend — out of scope for the PR author (no GCP creds in this environment); the operator runs `terraform apply` manually after merge. The nightly `terraform-plan-drift-check` workflow will surface any post-apply drift.
- [ ] N/A — no UI, no Playwright drive.
- [ ] N/A — no `npm run build` (infra-only; `infra/` is not a workspace).

## Plan reference

Part of issue #327 (\"feat(photos): per-species bird photos via R2 + iNaturalist\"), task-1b — depends on task-1a (PR #330, merged at 6784592). Unblocks task-7 (R2 upload helper) and task-10 (frontend photo render).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)