### PR TITLE
feat(shared-types): add optional photo fields to SpeciesMeta

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "echo 'no tests'"
+    "test": "tsc -p tsconfig.test.json"
   }
 }

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -1,0 +1,70 @@
+import type { SpeciesMeta } from './index.js';
+
+// Compile-time-only tests for the optional photo projection fields added
+// to SpeciesMeta in issue #327, task-3. These fields are derived at read
+// time via JOIN to species_photos and are NEVER stored on species_meta
+// itself. The package-level "test" script runs `tsc -p tsconfig.test.json`
+// — passing means the type-level expectations below all hold.
+//
+// No runtime assertions live here: the file is intentionally a "type
+// laboratory" and exists only to fail compilation if SpeciesMeta drifts
+// off-spec. The package has no runtime, so a runtime test runner would add
+// only ceremony.
+
+// Case 1: photo fields are optional — a SpeciesMeta literal can omit them.
+const _noPhoto: SpeciesMeta = {
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus',
+  familyCode: 'tyrann1',
+  familyName: 'Tyrant Flycatchers',
+  taxonOrder: 12345,
+};
+void _noPhoto;
+
+// Case 2: when set, photo fields accept strings.
+const _withPhoto: SpeciesMeta = {
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus',
+  familyCode: 'tyrann1',
+  familyName: 'Tyrant Flycatchers',
+  taxonOrder: 12345,
+  photoUrl: 'https://photos.bird-maps.com/vermfly.jpg',
+  photoAttribution: '(c) photographer, some rights reserved (CC BY)',
+  photoLicense: 'CC BY 4.0',
+};
+void _withPhoto;
+
+// Case 3: photo field accessors carry `string | undefined`. The narrow
+// re-assignments below would fail to compile if the fields were typed as
+// anything other than optional strings.
+const _photoUrl: string | undefined = _withPhoto.photoUrl;
+const _photoAttribution: string | undefined = _withPhoto.photoAttribution;
+const _photoLicense: string | undefined = _withPhoto.photoLicense;
+void _photoUrl;
+void _photoAttribution;
+void _photoLicense;
+
+// Case 4: non-string values are rejected. The @ts-expect-error directives
+// are load-bearing — if any of the fields stops rejecting non-strings,
+// tsc will flag the directive as "unused" and fail the test build.
+const _bad1: SpeciesMeta = {
+  speciesCode: 'x', comName: 'x', sciName: 'x',
+  familyCode: 'x', familyName: 'x', taxonOrder: null,
+  // @ts-expect-error — photoUrl must be a string when set
+  photoUrl: 42,
+};
+const _bad2: SpeciesMeta = {
+  speciesCode: 'x', comName: 'x', sciName: 'x',
+  familyCode: 'x', familyName: 'x', taxonOrder: null,
+  // @ts-expect-error — photoAttribution must be a string when set
+  photoAttribution: false,
+};
+const _bad3: SpeciesMeta = {
+  speciesCode: 'x', comName: 'x', sciName: 'x',
+  familyCode: 'x', familyName: 'x', taxonOrder: null,
+  // @ts-expect-error — photoLicense must be a string when set
+  photoLicense: { label: 'CC BY 4.0' },
+};
+void _bad1; void _bad2; void _bad3;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -44,6 +44,17 @@ export interface SpeciesMeta {
   familyCode: string;
   familyName: string;
   taxonOrder: number | null;
+  // Optional photo projection fields. These are derived at read time
+  // (issue #327) from a LEFT JOIN to species_photos and are NEVER stored
+  // on the species_meta table itself. The Read API populates them on
+  // /api/species/:code when a row exists in species_photos with
+  // purpose='detail-panel' for the species; absent otherwise. Cache caveat:
+  // stale CDN responses predating these fields deserialize with all three
+  // === undefined, which the frontend treats as "no photo" (Phylopic
+  // silhouette fallback) — no Cache-Control bump is required.
+  photoUrl?: string;
+  photoAttribution?: string;
+  photoLicense?: string;
 }
 
 export interface FamilySilhouette {

--- a/packages/shared-types/tsconfig.test.json
+++ b/packages/shared-types/tsconfig.test.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Diagrams

```mermaid
classDiagram
    class SpeciesMeta {
        +string speciesCode
        +string comName
        +string sciName
        +string familyCode
        +string familyName
        +number? taxonOrder
        +string? photoUrl
        +string? photoAttribution
        +string? photoLicense
    }

    class species_meta_table {
        species_code TEXT
        com_name TEXT
        sci_name TEXT
        family_code TEXT
        family_name TEXT
        taxon_order INT
    }

    class species_photos_table {
        species_code TEXT FK
        purpose TEXT
        url TEXT
        attribution TEXT
        license TEXT
    }

    species_meta_table --> SpeciesMeta : direct columns
    species_photos_table --> SpeciesMeta : LEFT JOIN at read time
    note for SpeciesMeta "photo* fields are NEVER stored on species_meta;\nthey are projections from species_photos\n(purpose='detail-panel') populated by /api/species/:code"
```

## Summary

- Extends `SpeciesMeta` with three optional photo fields (`photoUrl?`, `photoAttribution?`, `photoLicense?`) for issue #327's iNaturalist photo projection. The fields are derived projections from the new `species_photos` table (added by task-2, already on main) and are NEVER stored on `species_meta` itself.
- Optional rather than nullable so stale CDN responses predating these fields deserialize with `=== undefined` — downstream surfaces (SpeciesDetailSurface in task-10, AttributionModal in task-11) treat `undefined` as "no photo" and fall back to the Phylopic silhouette. No `Cache-Control` bump is required.
- Adds a compile-time-only test (`src/index.test.ts`) and a `tsconfig.test.json` so `npm run test --workspace @bird-watch/shared-types` runs `tsc -p tsconfig.test.json` and pins optionality, string acceptance, accessor types, and three load-bearing `@ts-expect-error` rejections of non-string values. The build tsconfig now excludes `*.test.ts` so the test file does not bleed into the published `dist/`.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/shared-types` — green (the new compile-time `tsc -p tsconfig.test.json` test); was previously `echo 'no tests'`
- [x] Confirmed the test FAILS before the type change (TS2353 + TS2339 errors against the un-extended interface), then PASSES after adding the three fields — TDD discipline observed
- [x] `npm run build --workspace @bird-watch/shared-types` — green; `dist/` contains only `index.{js,d.ts,*.map}` (no `index.test.*` leakage)
- [x] `npm run build` for the four downstream workspaces (`@bird-watch/db-client`, `@bird-watch/ingestor`, `@bird-watch/read-api`, `@bird-watch/frontend`) — all green; the new optional fields do not break any existing `SpeciesMeta` consumer
- [x] No new runtime deps added; only a `test` script + a sibling `tsconfig.test.json`. Lockfile unchanged.
- [ ] New unit / integration tests added (if behavior changed) — N/A; type-only change
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A; type-only change
- [ ] (UI only) Playwright MCP smoke — N/A; not UI

## Plan reference

Part of issue #327 (per-species photos via R2 + iNaturalist), task-3. The plan inlines all 14 tasks in the issue body — no separate `docs/plans/<file>.md` for this work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)