### PR TITLE
feat(db-client): add insertSpeciesPhoto / getSpeciesPhotos helpers

### DIFF
--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -5,7 +5,14 @@ export {
   getObservations, upsertObservations, runReconcileStamping,
   type ObservationInput,
 } from './observations.js';
-export { getSpeciesMeta, upsertSpeciesMeta } from './species.js';
+export {
+  getSpeciesMeta,
+  upsertSpeciesMeta,
+  insertSpeciesPhoto,
+  getSpeciesPhotos,
+  type SpeciesPhoto,
+  type SpeciesPhotoInput,
+} from './species.js';
 export { getSilhouettes } from './silhouettes.js';
 export {
   startIngestRun, finishIngestRun, getRecentIngestRuns,

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -134,6 +134,11 @@ describe('species photos', () => {
         'https://photos.bird-maps.com/v-old.jpg',
       ]);
     } finally {
+      // Drop the off-list rows BEFORE restoring the CHECK — ALTER TABLE
+      // ADD CONSTRAINT validates existing rows and would error otherwise.
+      await db.pool.query(
+        `DELETE FROM species_photos WHERE purpose IN ('gallery-old', 'gallery-new')`
+      );
       // Restore the CHECK so subsequent tests see the production schema.
       await db.pool.query(
         `ALTER TABLE species_photos

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from './test-helpers.js';
-import { getSpeciesMeta, upsertSpeciesMeta } from './species.js';
+import {
+  getSpeciesMeta,
+  upsertSpeciesMeta,
+  insertSpeciesPhoto,
+  getSpeciesPhotos,
+} from './species.js';
 
 let db: TestDb;
 beforeAll(async () => { db = await startTestDb(); }, 90_000);
@@ -34,5 +39,209 @@ describe('species meta', () => {
     expect(meta).toBeDefined();
     expect(typeof meta!.taxonOrder).toBe('number');
     expect(meta!.taxonOrder).toBe(30501);
+  });
+});
+
+describe('species photos', () => {
+  beforeEach(async () => {
+    // Photos FK to species_meta; seed a parent so inserts succeed.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+  });
+
+  it('insertSpeciesPhoto inserts; second call with same (species_code, purpose) upserts', async () => {
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/vermfly-v1.jpg',
+      attribution: 'Photo by A',
+      license: 'CC-BY-4.0',
+    });
+
+    // Second call with the same (species_code, purpose) replaces the existing row.
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/vermfly-v2.jpg',
+      attribution: 'Photo by B',
+      license: 'CC-BY-NC-4.0',
+    });
+
+    const photos = await getSpeciesPhotos(db.pool, 'vermfly');
+    expect(photos).toHaveLength(1);
+    expect(photos[0]?.url).toBe('https://photos.bird-maps.com/vermfly-v2.jpg');
+    expect(photos[0]?.attribution).toBe('Photo by B');
+    expect(photos[0]?.license).toBe('CC-BY-NC-4.0');
+    expect(photos[0]?.purpose).toBe('detail-panel');
+  });
+
+  it('getSpeciesPhotos returns all rows for that species ordered by created_at DESC', async () => {
+    // Seed a second species so we can assert the helper filters by species_code.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 12345 },
+    ]);
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/vermfly.jpg',
+      attribution: 'Photo by A',
+      license: 'CC-BY-4.0',
+    });
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'annhum',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/annhum.jpg',
+      attribution: 'Photo by C',
+      license: 'CC-BY-4.0',
+    });
+
+    // Filter contract: only the requested species's rows are returned.
+    const vermPhotos = await getSpeciesPhotos(db.pool, 'vermfly');
+    expect(vermPhotos).toHaveLength(1);
+    expect(vermPhotos[0]?.speciesCode).toBe('vermfly');
+    expect(vermPhotos[0]?.url).toBe('https://photos.bird-maps.com/vermfly.jpg');
+
+    // Ordering contract: when there are multiple rows for a species (which
+    // can only happen today by inserting raw rows under additional purpose
+    // values; the public CHECK currently restricts to 'detail-panel' only),
+    // the helper returns them with the newest first. We exercise this by
+    // temporarily disabling the CHECK constraint so we can write two rows
+    // under the same species_code with distinct purposes and explicit
+    // created_at, then assert the helper orders DESC by created_at.
+    await db.pool.query(`ALTER TABLE species_photos DROP CONSTRAINT species_photos_purpose_check`);
+    try {
+      await db.pool.query(
+        `INSERT INTO species_photos (species_code, purpose, url, attribution, license, created_at)
+         VALUES ('vermfly', 'gallery-old',  'https://photos.bird-maps.com/v-old.jpg',  'A', 'CC-BY-4.0', NOW() - INTERVAL '2 hours'),
+                ('vermfly', 'gallery-new',  'https://photos.bird-maps.com/v-new.jpg',  'A', 'CC-BY-4.0', NOW() - INTERVAL '1 hour')`
+      );
+      const ordered = await getSpeciesPhotos(db.pool, 'vermfly');
+      // Three rows now: detail-panel (newest, just upserted), gallery-new (1h ago),
+      // gallery-old (2h ago). Newest first.
+      expect(ordered).toHaveLength(3);
+      // url for detail-panel is the one inserted earliest in this test
+      // (NOW()), gallery-new is NOW() - 1h, gallery-old is NOW() - 2h, so
+      // strict DESC = [detail-panel, gallery-new, gallery-old].
+      const urls = ordered.map(p => p.url);
+      expect(urls).toEqual([
+        'https://photos.bird-maps.com/vermfly.jpg',
+        'https://photos.bird-maps.com/v-new.jpg',
+        'https://photos.bird-maps.com/v-old.jpg',
+      ]);
+    } finally {
+      // Restore the CHECK so subsequent tests see the production schema.
+      await db.pool.query(
+        `ALTER TABLE species_photos
+         ADD CONSTRAINT species_photos_purpose_check
+         CHECK (purpose IN ('detail-panel'))`
+      );
+    }
+  });
+
+  it('insertSpeciesPhoto does not clobber taxonomy columns on conflict', async () => {
+    // (a) Seed a complete species_meta row so we can prove the upsert
+    //     in (b) doesn't touch any of these columns.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+
+    // (b) Insert a photo for the same species. A careless impl that
+    //     UPSERTed into species_meta with EXCLUDED defaults (e.g. NULL
+    //     com_name) would silently overwrite the taxonomy columns.
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/vermfly.jpg',
+      attribution: 'Photo by Jane Doe',
+      license: 'CC-BY-4.0',
+    });
+
+    // (c) SINGLE SELECT joining species_meta + species_photos. Verify
+    //     BOTH photo columns AND taxonomy columns are intact.
+    const { rows } = await db.pool.query<{
+      species_code: string;
+      com_name: string;
+      sci_name: string;
+      family_code: string;
+      family_name: string;
+      taxon_order: number | null;
+      photo_url: string | null;
+      photo_attribution: string | null;
+      photo_license: string | null;
+    }>(
+      `SELECT sm.species_code, sm.com_name, sm.sci_name, sm.family_code,
+              sm.family_name, sm.taxon_order,
+              sp.url AS photo_url,
+              sp.attribution AS photo_attribution,
+              sp.license AS photo_license
+         FROM species_meta sm
+         LEFT JOIN species_photos sp
+           ON sp.species_code = sm.species_code
+          AND sp.purpose = 'detail-panel'
+        WHERE sm.species_code = 'vermfly'`
+    );
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    // Photo columns landed correctly.
+    expect(row.photo_url).toBe('https://photos.bird-maps.com/vermfly.jpg');
+    expect(row.photo_attribution).toBe('Photo by Jane Doe');
+    expect(row.photo_license).toBe('CC-BY-4.0');
+    // Taxonomy columns are UNCHANGED from step (a).
+    expect(row.com_name).toBe('Vermilion Flycatcher');
+    expect(row.sci_name).toBe('Pyrocephalus rubinus');
+    expect(row.family_code).toBe('tyrannidae');
+    expect(row.family_name).toBe('Tyrant Flycatchers');
+    expect(row.taxon_order).toBe(30501);
+  });
+
+  it('getSpeciesMeta returns photoUrl/photoAttribution/photoLicense when a detail-panel photo exists', async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly',
+      purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/vermfly.jpg',
+      attribution: 'Photo by Jane Doe',
+      license: 'CC-BY-4.0',
+    });
+
+    const meta = await getSpeciesMeta(db.pool, 'vermfly');
+    expect(meta).not.toBeNull();
+    expect(meta!.photoUrl).toBe('https://photos.bird-maps.com/vermfly.jpg');
+    expect(meta!.photoAttribution).toBe('Photo by Jane Doe');
+    expect(meta!.photoLicense).toBe('CC-BY-4.0');
+    // Taxonomy fields still populated.
+    expect(meta!.comName).toBe('Vermilion Flycatcher');
+    expect(meta!.familyCode).toBe('tyrannidae');
+  });
+
+  it('getSpeciesMeta returns undefined for the three photo fields when no detail-panel photo exists', async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+
+    const meta = await getSpeciesMeta(db.pool, 'vermfly');
+    expect(meta).not.toBeNull();
+    // Three photo fields are undefined (not present, not null, not empty).
+    expect(meta!.photoUrl).toBeUndefined();
+    expect(meta!.photoAttribution).toBeUndefined();
+    expect(meta!.photoLicense).toBeUndefined();
+    // exactOptionalPropertyTypes is on, so verify the keys aren't present
+    // on the object at all (the spec says "not present, not null").
+    expect(Object.prototype.hasOwnProperty.call(meta, 'photoUrl')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(meta, 'photoAttribution')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(meta, 'photoLicense')).toBe(false);
   });
 });

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -1,6 +1,101 @@
 import type { Pool } from './pool.js';
 import type { SpeciesMeta } from '@bird-watch/shared-types';
 
+/**
+ * One row of `species_photos`. Mirrors the column shape verbatim — used by
+ * `getSpeciesPhotos` to return a typed array of photo rows. The photo
+ * projection on `SpeciesMeta` (issue #327, set by the LEFT JOIN in
+ * `getSpeciesMeta`) is the wire-facing shape; this type is the row-facing
+ * one and stays inside db-client.
+ */
+export interface SpeciesPhoto {
+  id: number;
+  speciesCode: string;
+  purpose: string;
+  url: string;
+  attribution: string;
+  license: string;
+  createdAt: Date;
+}
+
+export interface SpeciesPhotoInput {
+  speciesCode: string;
+  purpose: string;
+  url: string;
+  attribution: string;
+  license: string;
+}
+
+/**
+ * Insert a row into `species_photos`. Idempotent on `(species_code, purpose)`:
+ * a second call with the same pair upserts (replaces) the existing row's
+ * url/attribution/license and bumps `created_at`. Returns the row id.
+ *
+ * The taxonomy on `species_meta` is NOT touched here — issue #327's plan
+ * critic flagged that a careless impl could clobber `com_name`/`sci_name`/
+ * `family_code`/`family_name`/`taxon_order` if it tried to upsert into
+ * `species_meta` instead. The locking test in species.test.ts
+ * ('insertSpeciesPhoto does not clobber taxonomy columns on conflict') is
+ * the contractual guarantee against that regression.
+ */
+export async function insertSpeciesPhoto(
+  pool: Pool,
+  input: SpeciesPhotoInput
+): Promise<number> {
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO species_photos (species_code, purpose, url, attribution, license)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (species_code, purpose) DO UPDATE SET
+       url = EXCLUDED.url,
+       attribution = EXCLUDED.attribution,
+       license = EXCLUDED.license,
+       created_at = NOW()
+     RETURNING id`,
+    [input.speciesCode, input.purpose, input.url, input.attribution, input.license]
+  );
+  // BIGSERIAL comes back as string from pg by default; cast to number for the
+  // public return type. The id range here is well under Number.MAX_SAFE_INTEGER.
+  return Number(rows[0]!.id);
+}
+
+/**
+ * Return all `species_photos` rows for the given species, newest first.
+ * Today the (species_code, purpose) UNIQUE means a species has at most one
+ * row per purpose and only `'detail-panel'` is permitted, so this returns
+ * 0 or 1 row in practice. The contract is forward-looking: when additional
+ * purpose values land (`marker`, `gallery`, etc.), the ORDER BY clause keeps
+ * consumers correct.
+ */
+export async function getSpeciesPhotos(
+  pool: Pool,
+  speciesCode: string
+): Promise<SpeciesPhoto[]> {
+  const { rows } = await pool.query<{
+    id: string;
+    species_code: string;
+    purpose: string;
+    url: string;
+    attribution: string;
+    license: string;
+    created_at: Date;
+  }>(
+    `SELECT id, species_code, purpose, url, attribution, license, created_at
+       FROM species_photos
+      WHERE species_code = $1
+      ORDER BY created_at DESC`,
+    [speciesCode]
+  );
+  return rows.map(r => ({
+    id: Number(r.id),
+    speciesCode: r.species_code,
+    purpose: r.purpose,
+    url: r.url,
+    attribution: r.attribution,
+    license: r.license,
+    createdAt: r.created_at,
+  }));
+}
+
 export async function getSpeciesMeta(
   pool: Pool,
   speciesCode: string
@@ -12,14 +107,35 @@ export async function getSpeciesMeta(
     family_code: string;
     family_name: string;
     taxon_order: number | null;
+    photo_url: string | null;
+    photo_attribution: string | null;
+    photo_license: string | null;
   }>(
-    `SELECT species_code, com_name, sci_name, family_code, family_name, taxon_order
-     FROM species_meta WHERE species_code = $1`,
+    // LEFT JOIN species_photos so the species row is returned regardless of
+    // whether a detail-panel photo exists. The (species_code, purpose) UNIQUE
+    // guarantees at most one matching row, so no LIMIT/aggregation needed.
+    `SELECT sm.species_code, sm.com_name, sm.sci_name, sm.family_code,
+            sm.family_name, sm.taxon_order,
+            sp.url         AS photo_url,
+            sp.attribution AS photo_attribution,
+            sp.license     AS photo_license
+       FROM species_meta sm
+       LEFT JOIN species_photos sp
+         ON sp.species_code = sm.species_code
+        AND sp.purpose = 'detail-panel'
+      WHERE sm.species_code = $1`,
     [speciesCode]
   );
   const r = rows[0];
   if (!r) return null;
-  return {
+  // Build the result with the taxonomy fields always populated and the
+  // optional photo fields ONLY set when present. Under
+  // exactOptionalPropertyTypes, assigning `undefined` to an optional
+  // string-typed property is a type error — so omit the keys outright when
+  // the JOIN produced NULLs. Consumers see `meta.photoUrl === undefined`
+  // because the property is missing, which is the contract spec'd in
+  // species.test.ts ("not present, not null, not empty").
+  const meta: SpeciesMeta = {
     speciesCode: r.species_code,
     comName: r.com_name,
     sciName: r.sci_name,
@@ -27,6 +143,10 @@ export async function getSpeciesMeta(
     familyName: r.family_name,
     taxonOrder: r.taxon_order,
   };
+  if (r.photo_url !== null) meta.photoUrl = r.photo_url;
+  if (r.photo_attribution !== null) meta.photoAttribution = r.photo_attribution;
+  if (r.photo_license !== null) meta.photoLicense = r.photo_license;
+  return meta;
 }
 
 export async function upsertSpeciesMeta(


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Caller["caller (run-photos.ts, read-api)"]
    DBC["@bird-watch/db-client"]
    SM[("species_meta")]
    SP[("species_photos<br/>UNIQUE (species_code, purpose)")]

    Caller -- "insertSpeciesPhoto({speciesCode, purpose='detail-panel', url, attribution, license})" --> DBC
    DBC -- "INSERT ... ON CONFLICT (species_code, purpose) DO UPDATE" --> SP

    Caller -- "getSpeciesPhotos(speciesCode)" --> DBC
    DBC -- "SELECT ... ORDER BY created_at DESC" --> SP

    Caller -- "getSpeciesMeta(speciesCode)" --> DBC
    DBC -- "sm LEFT JOIN sp ON sp.species_code = sm.species_code AND sp.purpose='detail-panel'" --> SM
    SM -.-> SP
    DBC -- "SpeciesMeta { ..., photoUrl?, photoAttribution?, photoLicense? }" --> Caller
```

## Summary

- Land the read/write surface for `species_photos` (issue #327 task-4): `insertSpeciesPhoto` (upsert on `(species_code, purpose)`) and `getSpeciesPhotos` (newest first). Unblocks task-7 (run-photos.ts), task-9 (read-api), and downstream consumers.
- Extend `getSpeciesMeta` with a `LEFT JOIN species_photos` filtered to `purpose='detail-panel'`, projecting the three photo columns into the optional `photoUrl`/`photoAttribution`/`photoLicense` fields task-3 added to `SpeciesMeta`. Under `exactOptionalPropertyTypes`, the keys are OMITTED when the JOIN produces NULLs — that's the only correct way to represent "no photo" given the type contract.
- Includes the load-bearing `'insertSpeciesPhoto does not clobber taxonomy columns on conflict'` regression locker the plan-critic loop required: a single SELECT joining `species_meta` and `species_photos` after the upsert, asserting both photo columns landed AND `com_name`/`sci_name`/`family_code`/`family_name`/`taxon_order` are unchanged.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build --workspace @bird-watch/db-client` — clean (db-client + shared-types + ingestor + read-api all build cleanly; frontend's pre-existing `maplibre-gl` install issue in this worktree is unrelated to this PR)
- [x] New integration tests added in `packages/db-client/src/species.test.ts` covering all five required cases (insert+upsert, ordering+filter, no-clobber, JOIN populated, JOIN absent)
- [x] `tsc -p packages/db-client/tsconfig.json` and `tsc -p packages/db-client/tsconfig.test.json` — both clean
- [ ] `npm run test --workspace @bird-watch/db-client` — local Docker is not available in this implementing agent's environment; tests skip cleanly at testcontainer startup with "Could not find a working container runtime strategy". CI runs the full suite against a real PostGIS testcontainer.
- [x] No new e2e (no user-visible behavior changed; this is a db-client change consumed only by services/ingestor and services/read-api)

## Plan reference

Part of issue #327, task-4. See https://github.com/julianken/bird-sight-system/issues/327.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)