### PR TITLE
feat(ingestor): wire 'photos' ScheduledKind in handler.ts

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -88,7 +88,7 @@ export interface FamilySilhouette {
 
 export interface IngestRun {
   id: number;
-  kind: 'recent' | 'notable' | 'backfill' | 'hotspots' | 'taxonomy';
+  kind: 'recent' | 'notable' | 'backfill' | 'hotspots' | 'taxonomy' | 'photos';
   startedAt: string;
   finishedAt: string | null;
   obsFetched: number | null;

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -15,6 +15,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): CliDeps {
     runHotspotIngest: vi.fn(),
     runBackfill: vi.fn(),
     runTaxonomy: vi.fn(),
+    runPhotos: vi.fn(),
     ...overrides,
   };
 }

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -18,6 +18,10 @@ import {
   runTaxonomy as realRunTaxonomy,
   type RunTaxonomySummary,
 } from './run-taxonomy.js';
+import {
+  runPhotos as realRunPhotos,
+  type RunPhotosSummary,
+} from './run-photos.js';
 
 /**
  * Every run summary discriminates on `status`. `RunBackfillSummary` can also be
@@ -28,7 +32,8 @@ type AnyRunSummary =
   | RunSummary
   | RunHotspotSummary
   | RunBackfillSummary
-  | RunTaxonomySummary;
+  | RunTaxonomySummary
+  | RunPhotosSummary;
 
 /**
  * Injectable dependencies for `runCli`. In production `cli.ts`'s IIFE passes
@@ -42,6 +47,7 @@ export interface CliDeps {
   runHotspotIngest: typeof realRunHotspotIngest;
   runBackfill: typeof realRunBackfill;
   runTaxonomy: typeof realRunTaxonomy;
+  runPhotos: typeof realRunPhotos;
 }
 
 /**
@@ -74,8 +80,10 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       summary = await deps.runBackfill({ pool, apiKey, regionCode: 'US-AZ', days: 30 });
     } else if (kind === 'taxonomy') {
       summary = await deps.runTaxonomy({ pool, apiKey });
+    } else if (kind === 'photos') {
+      summary = await deps.runPhotos({ pool });
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | taxonomy`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | taxonomy | photos`);
     }
     console.log(JSON.stringify(summary, null, 2));
     if (summary.status === 'failure') {
@@ -111,6 +119,7 @@ if (isEntrypoint) {
     runHotspotIngest: realRunHotspotIngest,
     runBackfill: realRunBackfill,
     runTaxonomy: realRunTaxonomy,
+    runPhotos: realRunPhotos,
   }).catch(err => {
     console.error(err);
     process.exit(1);

--- a/services/ingestor/src/handler.test.ts
+++ b/services/ingestor/src/handler.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock module boundaries BEFORE importing handler. The handler's job is to
+// dispatch ScheduledKind → the right runner; the runners themselves are
+// covered by their own test suites. Stubbing at the module level lets us
+// assert that the dispatch routes the kind correctly and forwards env-derived
+// args (apiKey, regionCode, pool) to the chosen runner.
+const POOL_SENTINEL = Symbol('pool') as unknown as import('@bird-watch/db-client').Pool;
+
+const createPoolMock = vi.fn();
+const closePoolMock = vi.fn();
+const runIngestMock = vi.fn();
+const runHotspotIngestMock = vi.fn();
+const runBackfillMock = vi.fn();
+const runTaxonomyMock = vi.fn();
+const runPhotosMock = vi.fn();
+
+vi.mock('@bird-watch/db-client', () => ({
+  createPool: (...args: unknown[]) => createPoolMock(...args),
+  closePool: (...args: unknown[]) => closePoolMock(...args),
+}));
+
+vi.mock('./run-ingest.js', () => ({
+  runIngest: (...args: unknown[]) => runIngestMock(...args),
+}));
+
+vi.mock('./run-hotspots.js', () => ({
+  runHotspotIngest: (...args: unknown[]) => runHotspotIngestMock(...args),
+}));
+
+vi.mock('./run-backfill.js', () => ({
+  runBackfill: (...args: unknown[]) => runBackfillMock(...args),
+}));
+
+vi.mock('./run-taxonomy.js', () => ({
+  runTaxonomy: (...args: unknown[]) => runTaxonomyMock(...args),
+}));
+
+vi.mock('./run-photos.js', () => ({
+  runPhotos: (...args: unknown[]) => runPhotosMock(...args),
+}));
+
+import { handleScheduled, type HandlerEnv } from './handler.js';
+
+const ENV: HandlerEnv = {
+  DATABASE_URL: 'postgres://test',
+  EBIRD_API_KEY: 'test-key',
+};
+
+describe('handleScheduled', () => {
+  beforeEach(() => {
+    createPoolMock.mockReset().mockReturnValue(POOL_SENTINEL);
+    closePoolMock.mockReset().mockResolvedValue(undefined);
+    runIngestMock.mockReset();
+    runHotspotIngestMock.mockReset();
+    runBackfillMock.mockReset();
+    runTaxonomyMock.mockReset();
+    runPhotosMock.mockReset();
+  });
+
+  it("dispatches to runIngest when kind is 'recent'", async () => {
+    const summary = { status: 'success', fetched: 1, upserted: 1 };
+    runIngestMock.mockResolvedValue(summary);
+
+    const result = await handleScheduled('recent', ENV);
+
+    expect(runIngestMock).toHaveBeenCalledWith({
+      pool: POOL_SENTINEL,
+      apiKey: 'test-key',
+      regionCode: 'US-AZ',
+    });
+    expect(result).toBe(summary);
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it("dispatches to runHotspotIngest when kind is 'hotspots'", async () => {
+    const summary = { status: 'success', fetched: 5, upserted: 5 };
+    runHotspotIngestMock.mockResolvedValue(summary);
+
+    const result = await handleScheduled('hotspots', ENV);
+
+    expect(runHotspotIngestMock).toHaveBeenCalledWith({
+      pool: POOL_SENTINEL,
+      apiKey: 'test-key',
+      regionCode: 'US-AZ',
+    });
+    expect(result).toBe(summary);
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it("dispatches to runBackfill when kind is 'backfill'", async () => {
+    const summary = { status: 'success', daysProcessed: 30 };
+    runBackfillMock.mockResolvedValue(summary);
+
+    const result = await handleScheduled('backfill', ENV);
+
+    expect(runBackfillMock).toHaveBeenCalledWith({
+      pool: POOL_SENTINEL,
+      apiKey: 'test-key',
+      regionCode: 'US-AZ',
+      days: 30,
+    });
+    expect(result).toBe(summary);
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it("dispatches to runTaxonomy when kind is 'taxonomy'", async () => {
+    const summary = { status: 'success', totalFetched: 0, speciesInserted: 0, nonSpeciesFiltered: 0, reconciled: 0 };
+    runTaxonomyMock.mockResolvedValue(summary);
+
+    const result = await handleScheduled('taxonomy', ENV);
+
+    expect(runTaxonomyMock).toHaveBeenCalledWith({
+      pool: POOL_SENTINEL,
+      apiKey: 'test-key',
+    });
+    expect(result).toBe(summary);
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it("dispatches to runPhotos when kind is 'photos'", async () => {
+    const summary = {
+      speciesCount: 0,
+      photosFetched: 0,
+      photosSkipped: 0,
+      photosFailed: 0,
+      errors: [],
+    };
+    runPhotosMock.mockResolvedValue(summary);
+
+    const result = await handleScheduled('photos', ENV);
+
+    // runPhotos's only required arg is `pool`; it must NOT be called with
+    // EBIRD_API_KEY (iNat is its upstream, not eBird).
+    expect(runPhotosMock).toHaveBeenCalledTimes(1);
+    const call = runPhotosMock.mock.calls[0]?.[0];
+    expect(call).toMatchObject({ pool: POOL_SENTINEL });
+    expect(call).not.toHaveProperty('apiKey');
+    expect(result).toBe(summary);
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it('closes the pool even when the runner throws', async () => {
+    runTaxonomyMock.mockRejectedValue(new Error('boom'));
+
+    await expect(handleScheduled('taxonomy', ENV)).rejects.toThrow('boom');
+    expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+});

--- a/services/ingestor/src/handler.ts
+++ b/services/ingestor/src/handler.ts
@@ -3,13 +3,14 @@ import { runIngest, type RunSummary } from './run-ingest.js';
 import { runHotspotIngest, type RunHotspotSummary } from './run-hotspots.js';
 import { runBackfill, type RunBackfillSummary } from './run-backfill.js';
 import { runTaxonomy, type RunTaxonomySummary } from './run-taxonomy.js';
+import { runPhotos, type RunPhotosSummary } from './run-photos.js';
 
 export interface HandlerEnv {
   DATABASE_URL: string;
   EBIRD_API_KEY: string;
 }
 
-export type ScheduledKind = 'recent' | 'hotspots' | 'backfill' | 'taxonomy';
+export type ScheduledKind = 'recent' | 'hotspots' | 'backfill' | 'taxonomy' | 'photos';
 
 /**
  * Platform-agnostic handler: invoked by the Cloud Run Job entry point
@@ -19,7 +20,13 @@ export type ScheduledKind = 'recent' | 'hotspots' | 'backfill' | 'taxonomy';
 export async function handleScheduled(
   kind: ScheduledKind,
   env: HandlerEnv
-): Promise<RunSummary | RunHotspotSummary | RunBackfillSummary | RunTaxonomySummary> {
+): Promise<
+  | RunSummary
+  | RunHotspotSummary
+  | RunBackfillSummary
+  | RunTaxonomySummary
+  | RunPhotosSummary
+> {
   const pool = createPool({ databaseUrl: env.DATABASE_URL });
   try {
     switch (kind) {
@@ -33,6 +40,10 @@ export async function handleScheduled(
         });
       case 'taxonomy':
         return await runTaxonomy({ pool, apiKey: env.EBIRD_API_KEY });
+      case 'photos':
+        // runPhotos's upstream is iNat (no eBird key needed). Wired via the
+        // Cloud Run job + monthly Scheduler cron in task-8b (#327).
+        return await runPhotos({ pool });
     }
   } finally {
     await closePool(pool);

--- a/services/ingestor/src/run-photos.ts
+++ b/services/ingestor/src/run-photos.ts
@@ -19,6 +19,14 @@ export interface RunPhotosArgs {
 }
 
 export interface RunPhotosSummary {
+  /**
+   * Discriminator for the AnyRunSummary union in cli.ts. 'failure' iff every
+   * species hit an error (zero forward progress) — anything else (full success,
+   * mixed success/failure, all-skipped, empty species list) is 'success'. cli.ts
+   * uses this to set process.exitCode; Cloud Run Jobs see exitCode=1 only on
+   * total-failure runs, not on partial-progress ones.
+   */
+  status: 'success' | 'failure';
   /** Total rows iterated from species_meta. */
   speciesCount: number;
   /** Successful end-to-end (iNat hit + R2 uploaded + species_photos row written). */
@@ -67,6 +75,7 @@ export async function runPhotos(args: RunPhotosArgs): Promise<RunPhotosSummary> 
   );
 
   const summary: RunPhotosSummary = {
+    status: 'success',
     speciesCount: rows.length,
     photosFetched: 0,
     photosSkipped: 0,
@@ -134,6 +143,9 @@ export async function runPhotos(args: RunPhotosArgs): Promise<RunPhotosSummary> 
     }
   }
 
+  if (summary.photosFailed > 0 && summary.photosFetched === 0) {
+    summary.status = 'failure';
+  }
   return summary;
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Scheduler[Cloud Scheduler<br/>monthly cron]
    CRJob[Cloud Run Job<br/>kind=photos]
    Handler[handleScheduled<br/>switch dispatch]
    RunPhotos[runPhotos]
    iNat[iNaturalist API]
    R2[Cloudflare R2]
    DB[(species_photos)]

    Scheduler -->|task-8b| CRJob
    CRJob --> Handler
    Handler -->|case 'photos'| RunPhotos
    RunPhotos --> iNat
    RunPhotos --> R2
    RunPhotos --> DB
```

## Summary

- Extends `ScheduledKind` union with `'photos'` and adds the dispatch case so task-8b's monthly Cloud Run Job + Scheduler cron has a handler entry point to invoke. Without this wiring, task-8b cannot ship — the job would have nothing to dispatch to.
- Calls `runPhotos({ pool })` only, deliberately omitting `apiKey`: `runPhotos`'s upstream is iNaturalist (no auth header in the documented client) and the eBird key is irrelevant. The new dispatch test pins this contract so a future copy-paste from `runIngest` cannot silently re-add an unused `apiKey` arg.
- Low-cost defensive type widening: `IngestRun['kind']` in `packages/shared-types` gains `'photos'` so a follow-up change to wire `startIngestRun`/`finishIngestRun` into `run-photos.ts` (flagged on PR #336) surfaces in `getRecentIngestRuns` without needing a second type bump. The DB column is `TEXT` with no `CHECK` constraint, so the type widening is purely additive.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build --workspace @bird-watch/ingestor` — clean (this is the project's typecheck — no separate `typecheck` script exists; production `tsc` covers it)
- [x] `npm run build --workspace @bird-watch/shared-types` + db-client + read-api — all clean (verifies the shared-types union widening doesn't break any consumer)
- [x] `npm run test --workspace @bird-watch/ingestor -- handler.test.ts cli.test.ts transform.test.ts` — 15 passed, 0 failed (the new `handler.test.ts` module-mocks all five runners and asserts each kind dispatches to the right one; the `'photos'` case asserts only `pool` is forwarded — no `apiKey`)
- [x] `npx tsc --noEmit -p tsconfig.test.json` (services/ingestor) — clean
- [x] DB-dependent tests (run-ingest, run-hotspots, run-backfill, run-taxonomy, run-photos) skipped locally (no Docker daemon for testcontainers); will run green in CI which has Docker

## Plan reference

Part of issue #327, task-8a (handler ScheduledKind wiring). Prerequisite for task-8b (Cloud Run Job + monthly Scheduler cron).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)