### PR TITLE
feat(frontend): render species photo in SpeciesDetailSurface with silhouette fallback

### DIFF
--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { SpeciesDetailSurface } from './SpeciesDetailSurface.js';
 import { ApiClient } from '../api/client.js';
-import type { SpeciesMeta } from '@bird-watch/shared-types';
+import type { SpeciesMeta, FamilySilhouette } from '@bird-watch/shared-types';
+import { __resetSilhouettesCache } from '../data/use-silhouettes.js';
 
 const VERMFLY: SpeciesMeta = {
   speciesCode: 'vermfly',
@@ -13,14 +14,36 @@ const VERMFLY: SpeciesMeta = {
   taxonOrder: 4400,
 };
 
+const VERMFLY_WITH_PHOTO: SpeciesMeta = {
+  ...VERMFLY,
+  photoUrl: 'https://photos.bird-maps.com/vermfly.jpg',
+  photoAttribution: 'Jane Smith',
+  photoLicense: 'CC-BY-4.0',
+};
+
+const TYRANNIDAE_SILHOUETTE: FamilySilhouette = {
+  familyCode: 'tyrannidae',
+  color: '#C77A2E',
+  svgData: 'M0 0L1 1Z',
+  source: 'https://www.phylopic.org/i/x',
+  license: 'CC-BY-3.0',
+  commonName: 'Tyrant Flycatchers',
+  creator: 'Test Creator',
+};
+
 function makeClient(overrides: Partial<ApiClient>): ApiClient {
   return Object.assign(new ApiClient(), overrides);
 }
 
 describe('SpeciesDetailSurface', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+  });
+
   it('renders common, scientific, and family names when data resolves', async () => {
     const client = makeClient({
       getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
     render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
     await waitFor(() =>
@@ -34,6 +57,7 @@ describe('SpeciesDetailSurface', () => {
   it('shows loading state initially', () => {
     const client = makeClient({
       getSpecies: vi.fn().mockReturnValue(new Promise(() => {})),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
     render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
     expect(screen.getByText('Loading species details…')).toBeInTheDocument();
@@ -42,6 +66,7 @@ describe('SpeciesDetailSurface', () => {
   it('shows error state on fetch failure', async () => {
     const client = makeClient({
       getSpecies: vi.fn().mockRejectedValue(new Error('boom')),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
     render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
     await waitFor(() =>
@@ -58,6 +83,7 @@ describe('SpeciesDetailSurface', () => {
   it('renders in-flow (no role=complementary, no close button)', async () => {
     const client = makeClient({
       getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
     render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
     await waitFor(() =>
@@ -67,5 +93,71 @@ describe('SpeciesDetailSurface', () => {
     expect(screen.queryByRole('complementary')).toBeNull();
     // No close button — user navigates away via back button or SurfaceNav.
     expect(screen.queryByRole('button', { name: 'Close species details' })).toBeNull();
+  });
+
+  // ─── Photo rendering (issue #327 task-10) ─────────────────────────────
+  //
+  // The Read API LEFT-JOINs species_photos onto /api/species/:code (task-9)
+  // and projects optional photoUrl/photoAttribution/photoLicense fields onto
+  // SpeciesMeta. Frontend renders a <img> for the photo when present and
+  // falls back to the existing Phylopic silhouette path on absence OR on
+  // image-load error. Behavioral spec verbatim from issue #327 task-10.
+
+  it('renders <img src={photoUrl} alt="X photo"> when photoUrl is present', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY_WITH_PHOTO),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    const photo = await screen.findByAltText('Vermilion Flycatcher photo');
+    expect(photo.tagName).toBe('IMG');
+    expect(photo).toHaveAttribute('src', 'https://photos.bird-maps.com/vermfly.jpg');
+  });
+
+  it('does not render the photo img when photoUrl is undefined/null', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
+    );
+    // No photo img — the silhouette is the only visual.
+    expect(screen.queryByAltText('Vermilion Flycatcher photo')).toBeNull();
+    // Silhouette fallback IS rendered (SVG with the family color).
+    const silhouette = screen.getByTestId('species-detail-silhouette');
+    expect(silhouette).toBeInTheDocument();
+  });
+
+  it('onError on the photo img triggers fallback to silhouette', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY_WITH_PHOTO),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    const photo = await screen.findByAltText('Vermilion Flycatcher photo');
+    // Silhouette is NOT rendered while the photo img is in the tree.
+    expect(screen.queryByTestId('species-detail-silhouette')).toBeNull();
+    // Simulate an image-load failure (404, ECONNRESET, etc.).
+    fireEvent.error(photo);
+    // Photo img is gone; silhouette fallback is now visible.
+    expect(screen.queryByAltText('Vermilion Flycatcher photo')).toBeNull();
+    expect(screen.getByTestId('species-detail-silhouette')).toBeInTheDocument();
+  });
+
+  it('alt text uses {comName} photo format for accessibility', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue({
+        ...VERMFLY_WITH_PHOTO,
+        comName: 'Anna’s Hummingbird',
+        speciesCode: 'annhum',
+        photoUrl: 'https://photos.bird-maps.com/annhum.jpg',
+      }),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="annhum" apiClient={client} />);
+    const photo = await screen.findByAltText('Anna’s Hummingbird photo');
+    expect(photo.tagName).toBe('IMG');
   });
 });

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -1,9 +1,108 @@
+import { useEffect, useMemo, useState } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
+import { useSilhouettes } from '../data/use-silhouettes.js';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
 
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
   apiClient: ApiClient;
+}
+
+/**
+ * Renders the per-species visual: the iNaturalist photo when SpeciesMeta
+ * carries a non-null `photoUrl`, falling back to the family Phylopic
+ * silhouette otherwise (and on photo-load failure via `onError`). The
+ * silhouette payload comes from `useSilhouettes` (cached at module level
+ * across the app, so this is essentially free to mount alongside the
+ * App-level mount); the lookup keys on `data.familyCode`.
+ *
+ * Two rendering branches:
+ *   - `<img src={photoUrl}>` — issue #327 task-10 happy path
+ *   - SVG silhouette — fallback. Mirrors FamilyLegend's SilhouetteGlyph
+ *     (svgData → <path>; null svgData → <circle>) so the visual language
+ *     stays consistent across the app.
+ *
+ * Edge cases:
+ *   - silhouettes still loading → render nothing (caller's "loading
+ *     species details…" copy is already showing for the data fetch).
+ *   - silhouette absent from the response (uncurated family) → render the
+ *     null-svgData circle fallback in a neutral muted color.
+ */
+function SpeciesDetailVisual({
+  comName,
+  familyCode,
+  photoUrl,
+  silhouettes,
+}: {
+  comName: string;
+  familyCode: string;
+  photoUrl: string | undefined;
+  silhouettes: FamilySilhouette[];
+}) {
+  // Reset photo-error state when speciesCode changes (the consumer remounts
+  // this subtree implicitly via the parent's `data` prop change, but the
+  // state-reset is explicit here so a future refactor that reuses the
+  // component across species codes doesn't silently leak the prior species'
+  // error state).
+  const [photoErrored, setPhotoErrored] = useState<boolean>(false);
+  useEffect(() => {
+    setPhotoErrored(false);
+  }, [photoUrl]);
+
+  const silhouette = useMemo(
+    () => silhouettes.find(s => s.familyCode === familyCode),
+    [silhouettes, familyCode],
+  );
+
+  const showPhoto = !!photoUrl && !photoErrored;
+
+  if (showPhoto && photoUrl) {
+    return (
+      <img
+        className="species-detail-photo"
+        src={photoUrl}
+        alt={`${comName} photo`}
+        onError={() => setPhotoErrored(true)}
+      />
+    );
+  }
+
+  // Silhouette fallback — render an SVG matching FamilyLegend's
+  // SilhouetteGlyph. Use a fixed 96px box so the detail panel reads at
+  // a usable size (vs the 28px legend glyph). When svgData is null the
+  // fallback is a colored circle; when the family isn't in the silhouettes
+  // payload at all (uncurated row), render a muted neutral circle so the
+  // surface never holds an empty visual hole.
+  const size = 96;
+  if (silhouette?.svgData) {
+    return (
+      <svg
+        data-testid="species-detail-silhouette"
+        className="species-detail-silhouette"
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d={silhouette.svgData} fill={silhouette.color} />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      data-testid="species-detail-silhouette"
+      className="species-detail-silhouette"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle cx={12} cy={12} r={6} fill={silhouette?.color ?? 'var(--color-text-muted)'} />
+    </svg>
+  );
 }
 
 /**
@@ -14,10 +113,18 @@ export interface SpeciesDetailSurfaceProps {
  * Shows: common name, scientific name, and family name fetched via
  * `useSpeciesDetail`. No ESC dismiss, no overlay, no close button —
  * the user navigates away via the browser back button or SurfaceNav.
+ *
+ * Photo (issue #327 task-10): when SpeciesMeta carries `photoUrl`, render
+ * the photo as the surface's primary visual. Falls back to the family
+ * Phylopic silhouette via `<SpeciesDetailVisual>` on photoUrl absence OR
+ * on `<img onError>`. Silhouette payload comes from `useSilhouettes`
+ * (module-level cache shared with the App-mounted hook in App.tsx — no
+ * second network round-trip).
  */
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   const { speciesCode, apiClient } = props;
   const { loading, error, data } = useSpeciesDetail(apiClient, speciesCode);
+  const { silhouettes } = useSilhouettes(apiClient);
 
   return (
     <div className="species-detail-surface">
@@ -35,6 +142,12 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
 
       {data && (
         <div className="species-detail-body">
+          <SpeciesDetailVisual
+            comName={data.comName}
+            familyCode={data.familyCode}
+            photoUrl={data.photoUrl}
+            silhouettes={silhouettes}
+          />
           <h2 className="species-detail-common-name">{data.comName}</h2>
           <p className="species-detail-sci-name"><em>{data.sciName}</em></p>
           <p className="species-detail-family">{data.familyName}</p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -420,9 +420,18 @@ body {
    and scaling it to the photo's footprint would invent visual weight the
    silhouette path doesn't carry. */
 .species-detail-photo {
+  /* Width caps at 480px on desktop, fills container on mobile.
+     aspect-ratio + object-fit reserve a stable 4:3 box BEFORE the photo
+     loads — eliminates the CLS (Cumulative Layout Shift) that would
+     otherwise happen as comName/sciName/familyName text below the photo
+     reflows downward when the image swaps in. iNaturalist's medium
+     variant returns photos at varied native ratios; cover-cropping to
+     4/3 trades a small framing compromise for layout stability. */
   display: block;
-  max-width: min(100%, 480px);
-  height: auto;
+  width: 100%;
+  max-width: 480px;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
   margin: 0 0 12px 0;
   border-radius: 4px;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -413,6 +413,23 @@ body {
   margin-inline: auto;
 }
 .species-detail-body { margin-top: var(--space-sm); }
+/* Photo / silhouette visual (#327 task-10). The photo renders at full
+   container width capped at 480px so it stays usable on 1440×900 desktop
+   without ballooning past the surface's 760px content cap. The silhouette
+   fallback sits at a fixed 96px square — it's a glyph, not a hero image,
+   and scaling it to the photo's footprint would invent visual weight the
+   silhouette path doesn't carry. */
+.species-detail-photo {
+  display: block;
+  max-width: min(100%, 480px);
+  height: auto;
+  margin: 0 0 12px 0;
+  border-radius: 4px;
+}
+.species-detail-silhouette {
+  display: block;
+  margin: 0 0 12px 0;
+}
 .species-detail-common-name {
   margin: 0 0 4px 0;
   font-size: 20px;


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A[useSpeciesDetail] -->|data with photoUrl?| B{SpeciesDetailVisual}
    C[useSilhouettes] -->|FamilySilhouette array| B
    B -->|photoUrl set AND not errored| D["&lt;img src=photoUrl alt='${comName} photo'&gt;"]
    B -->|photoUrl unset OR errored| E[SVG silhouette fallback]
    D -.->|onError fires| F[setPhotoErrored true]
    F -.->|re-render| B
    E -->|svgData present| G["&lt;path d=svgData fill=color/&gt;"]
    E -->|svgData null| H["&lt;circle fill=color/&gt;"]
```

## Summary

- Surfaces the optional `photoUrl` projection that read-api task-9 (#335) added to `/api/species/:code` — when set, the species detail page now leads with a real iNaturalist bird photo instead of a generic silhouette.
- Falls back to the family Phylopic silhouette via SVG (mirroring `FamilyLegend.SilhouetteGlyph`) when `photoUrl` is absent OR when `<img onError>` fires — the silhouette is the always-available baseline, never a broken-image icon.
- Photo-error state is local to a new `SpeciesDetailVisual` subcomponent and resets on `photoUrl` change so a future refactor that reuses the component across species codes won't leak the prior species' error state.

## Screenshots

PENDING — `user-attachments` paste-flow upload requires the `chrome-devtools-mcp` server connected to a GitHub-logged-in browser profile. That MCP server is not connected in this dispatch session (only `playwright`, `context7` are connected), and the Playwright MCP browser instance does not persist GitHub auth.

The four expected screenshots were captured locally during the Playwright MCP UI verification step (see Test plan). Reviewer can reproduce them by running `npm run dev --workspace @bird-watch/frontend` after `gh pr checkout 338` and visiting `?detail=rethaw&view=detail` at 390x844 and 1440x900. The four states verified:

1. Photo path 1440x900 — `<img class="species-detail-photo">` rendering above the heading (stubbed via page.route to return a CC0 picsum.photos image).
2. Photo path 390x844 — same, mobile.
3. Silhouette fallback 1440x900 — Red-tailed Hawk Phylopic SVG path glyph (live API, no photos seeded yet).
4. Silhouette fallback 390x844 — same, mobile.

Local screenshot paths in this worktree (NOT committed — repo CLAUDE.md retired the commit-and-link convention on 2026-04-27 via PR #313):
- `desktop-photo-rendered.png`
- `desktop-silhouette-fallback.png`
- `mobile-photo-rendered.png`
- `mobile-silhouette-fallback.png`

A follow-up turn (or the human reviewer) with `chrome-devtools-mcp` connected can run the paste flow per `~/.claude/skills/pr-screenshots-via-user-attachments/paste-procedure.md` to attach the captures to this section before merge.

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (375 tests, including 4 new SpeciesDetailSurface RTL cases for the photo paths)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] New unit tests added — 4 new RTL cases extending `SpeciesDetailSurface.test.tsx`: photo IMG renders with right src+alt; absent photoUrl renders only the silhouette; `fireEvent.error(img)` swaps to silhouette; alt text follows `{comName} photo` format
- [ ] New Playwright e2e spec — deferred to task-12 per issue #327 plan
- [x] (UI only) Playwright MCP smoke — drove the surface at 390x844 and 1440x900 via `mcp__plugin_playwright_playwright__browser_*`. Photo path verified via `page.route` stub returning a CC0 picsum.photos image. Silhouette path verified against the live API (no photos yet — task-7 ingest hasn't run). `<img onError>` fallback verified by stubbing a 404 photoUrl and observing the silhouette swap. Zero console errors / warnings on the photo and silhouette paths.

## Plan reference

Part of issue #327, task-10. See [issue #327](https://github.com/julianken/bird-sight-system/issues/327) — `feat(photos): per-species bird photos via R2 + iNaturalist`. This is the first frontend task in the photo epic; downstream tasks-11 (AttributionModal threading) and task-12 (e2e specs + axe) build on this surface.

---

Generated with [Claude Code](https://claude.com/claude-code)
