### PR TITLE
infra: add ingestor_photos Cloud Run job (600s) + Scheduler cron (#327 task-8b)

### DIFF
--- a/.github/workflows/deploy-ingestor.yml
+++ b/.github/workflows/deploy-ingestor.yml
@@ -52,25 +52,44 @@ jobs:
           docker push "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
-      - name: Deploy to Cloud Run Job
+      - name: Deploy to Cloud Run Jobs
         run: |
-          gcloud run jobs update "$JOB_NAME" \
-            --region="$GCP_REGION" \
-            --image="$IMAGE" \
-            --quiet
+          # Two jobs share this image: bird-ingestor (the original — recent /
+          # hotspots / backfill / taxonomy kinds, 300s timeout) and
+          # bird-ingestor-photos (added in #327 task-8b — photos kind,
+          # 600s timeout). Both dispatch through cli.ts on the kind arg.
+          # If the photos job doesn't exist yet (Terraform apply hasn't been
+          # run since #327 task-8b merged), skip rather than fail the deploy
+          # — the next deploy after apply picks up this image automatically.
+          for JOB in bird-ingestor bird-ingestor-photos; do
+            if gcloud run jobs describe "$JOB" --region="$GCP_REGION" >/dev/null 2>&1; then
+              echo "Updating $JOB to $IMAGE"
+              gcloud run jobs update "$JOB" \
+                --region="$GCP_REGION" \
+                --image="$IMAGE" \
+                --quiet
+            else
+              echo "Job $JOB does not exist yet — skipping (terraform apply pending for #327 task-8b?)"
+            fi
+          done
 
       - name: Verify image pinned
         run: |
           # Cloud Run Jobs aren't HTTP endpoints, so we can't curl a /health URL the way
-          # deploy-read-api does. The closest equivalent is verifying the job resource now
+          # deploy-read-api does. The closest equivalent is verifying each job resource now
           # points at the commit-SHA image tag we just pushed. This confirms the update
           # succeeded end-to-end (auth → AR push → Cloud Run control plane) without burning
-          # a live ingest run on every deploy. The three schedulers (every 30 min, daily
-          # 4am, weekly Sun 5am) bind to the job by name, so they pick up the new image
-          # on their next tick automatically.
-          DEPLOYED=$(gcloud run jobs describe "$JOB_NAME" \
-            --region="$GCP_REGION" \
-            --format='value(spec.template.spec.template.spec.containers[0].image)')
-          echo "Deployed image: $DEPLOYED"
-          echo "Expected image: $IMAGE"
-          test "$DEPLOYED" = "$IMAGE"
+          # a live ingest run on every deploy. Schedulers bind to jobs by name, so they
+          # pick up the new image on their next tick automatically.
+          for JOB in bird-ingestor bird-ingestor-photos; do
+            if gcloud run jobs describe "$JOB" --region="$GCP_REGION" >/dev/null 2>&1; then
+              DEPLOYED=$(gcloud run jobs describe "$JOB" \
+                --region="$GCP_REGION" \
+                --format='value(spec.template.spec.template.spec.containers[0].image)')
+              echo "Deployed image for $JOB: $DEPLOYED"
+              echo "Expected image:        $IMAGE"
+              test "$DEPLOYED" = "$IMAGE"
+            else
+              echo "Job $JOB not provisioned — verification skipped"
+            fi
+          done

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -28,6 +28,59 @@ resource "google_secret_manager_secret_iam_member" "ingestor_ebird" {
   member    = "serviceAccount:${google_service_account.ingestor.email}"
 }
 
+# ── R2 (Cloudflare) credentials for the photos ingest job ────────────────
+#
+# The photos kind (run-photos.ts) downloads iNaturalist images and PUTs them
+# into the `birdwatch-photos` R2 bucket via the S3-compatible endpoint. R2
+# credentials are minted in the Cloudflare R2 dashboard (account-scoped
+# access keys) and live outside Terraform's reach — we declare the secret
+# resources here, but values are populated out-of-band post-`terraform apply`
+# via `gcloud secrets versions add`. This keeps R2 keys off `terraform.tfvars`
+# and out of any plan/state JSON exfiltrated to CI logs. Same shape as
+# `ebird_key` minus the `_version` resource (which would require the value
+# at apply time via a `var.*`).
+resource "google_secret_manager_secret" "r2_endpoint" {
+  secret_id = "bird-watch-r2-endpoint"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret" "r2_access_key_id" {
+  secret_id = "bird-watch-r2-access-key-id"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret" "r2_secret_access_key" {
+  secret_id = "bird-watch-r2-secret-access-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_r2_endpoint" {
+  secret_id = google_secret_manager_secret.r2_endpoint.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_r2_access_key_id" {
+  secret_id = google_secret_manager_secret.r2_access_key_id.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_r2_secret_access_key" {
+  secret_id = google_secret_manager_secret.r2_secret_access_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
 resource "google_cloud_run_v2_job" "ingestor" {
   name     = "bird-ingestor"
   location = var.gcp_region
@@ -210,6 +263,146 @@ resource "google_cloud_scheduler_job" "ingest_taxonomy" {
     body = base64encode(jsonencode({
       overrides = {
         containerOverrides = [{ args = ["taxonomy"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}
+
+# ── Photos ingest job (issue #327) ───────────────────────────────────────
+#
+# Separate Cloud Run Job because the photos kind needs a 600s timeout to
+# walk ~344 species × (iNat fetch + R2 PUT). The other kinds (recent,
+# backfill, hotspots, taxonomy) finish well within 300s and are tuned for
+# that ceiling — bumping the shared job's timeout would mask runtime
+# regressions in the eBird-driven kinds. Mirrors the .ingestor job's shape
+# (image, env, lifecycle.ignore_changes) so deploy-ingestor.yml's image-tag
+# rollout reaches both jobs from a single Artifact Registry push.
+resource "google_cloud_run_v2_job" "ingestor_photos" {
+  name     = "bird-ingestor-photos"
+  location = var.gcp_region
+
+  template {
+    template {
+      service_account = google_service_account.ingestor.email
+      timeout         = "600s"
+      max_retries     = 1
+
+      containers {
+        image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/ingestor:latest"
+
+        # CLI takes the kind as positional arg; Scheduler override below sets it
+        # to "photos", but the baked-in default keeps a manual `gcloud run jobs
+        # execute bird-ingestor-photos` working without overrides.
+        args = ["photos"]
+
+        resources {
+          limits = { cpu = "1", memory = "512Mi" }
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "EBIRD_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.ebird_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "R2_ENDPOINT"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.r2_endpoint.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "R2_ACCESS_KEY_ID"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.r2_access_key_id.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "R2_SECRET_ACCESS_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.r2_secret_access_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # Same rationale as .ingestor: deploy-ingestor.yml rolls the image tag,
+  # Terraform must not reconcile it back to :latest on every apply.
+  lifecycle {
+    ignore_changes = [template[0].template[0].containers[0].image]
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_ebird,
+    google_secret_manager_secret_iam_member.ingestor_r2_endpoint,
+    google_secret_manager_secret_iam_member.ingestor_r2_access_key_id,
+    google_secret_manager_secret_iam_member.ingestor_r2_secret_access_key,
+  ]
+}
+
+# Same role + same scheduler SA as `.scheduler_invoke` — Scheduler still uses
+# containerOverrides to pin args=["photos"] (matches the bake-in default but
+# is explicit at the cron-call site), which routes through runWithOverrides.
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke_photos" {
+  name     = google_cloud_run_v2_job.ingestor_photos.name
+  location = google_cloud_run_v2_job.ingestor_photos.location
+  role     = "roles/run.jobsExecutorWithOverrides"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+locals {
+  # v2 endpoint for the photos-only job — separate URL because the path
+  # includes the job name, not the project + location alone.
+  job_run_url_photos = "https://run.googleapis.com/v2/projects/${var.gcp_project_id}/locations/${var.gcp_region}/jobs/${google_cloud_run_v2_job.ingestor_photos.name}:run"
+}
+
+# Monthly photos refresh. iNat photos rotate slowly (license drift, better
+# observations getting voted up) so monthly is the right cadence — matches the
+# taxonomy cron (also monthly) but offset by one hour to avoid concurrent
+# load on Neon's connection pool. ingest_taxonomy fires at 06:00 UTC on the
+# 1st; photos fires at 07:00 UTC on the 1st.
+resource "google_cloud_scheduler_job" "ingest_photos" {
+  name      = "bird-ingest-photos"
+  region    = var.gcp_region
+  schedule  = "0 7 1 * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url_photos
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["photos"] }]
       }
     }))
     oauth_token {


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "Cloud Scheduler (Etc/UTC)"
      S1["ingest_recent<br/>*/30 * * * *"]
      S2["ingest_backfill<br/>0 4 * * *"]
      S3["ingest_hotspots<br/>0 5 * * 0"]
      S4["ingest_taxonomy<br/>0 6 1 * *"]
      S5["ingest_photos<br/>0 7 1 * * (NEW)"]
    end

    subgraph "Cloud Run Jobs"
      J1["bird-ingestor<br/>timeout=300s<br/>(recent/backfill/hotspots/taxonomy)"]
      J2["bird-ingestor-photos<br/>timeout=600s (NEW)<br/>kind=photos"]
    end

    subgraph "Secret Manager"
      K1[bird-watch-db-url]
      K2[bird-watch-ebird-key]
      K3["bird-watch-r2-endpoint (NEW)"]
      K4["bird-watch-r2-access-key-id (NEW)"]
      K5["bird-watch-r2-secret-access-key (NEW)"]
    end

    S1 -->|args=recent| J1
    S2 -->|args=backfill| J1
    S3 -->|args=hotspots| J1
    S4 -->|args=taxonomy| J1
    S5 -->|args=photos| J2

    J1 --> K1
    J1 --> K2
    J2 --> K1
    J2 --> K2
    J2 --> K3
    J2 --> K4
    J2 --> K5
```

## Summary

- Photos kind walks ~344 species (iNat fetch + R2 PUT) and needs 600s. Other ingest kinds are tuned for the shared 300s ceiling, so a separate `bird-ingestor-photos` Cloud Run Job is the safer split — bumping the existing job's timeout would mask runtime regressions in the eBird-driven kinds (per plan-critic resolution).
- Three new Secret Manager secrets (`bird-watch-r2-endpoint`, `…-r2-access-key-id`, `…-r2-secret-access-key`) are declared with no `_version` resource — operator populates values out-of-band via `gcloud secrets versions add` post-`terraform apply`. Keeps R2 access keys off `terraform.tfvars` and out of any plan/state JSON exfiltrated to CI logs.
- Cron at `0 7 1 * *` (07:00 UTC on the 1st) sits one hour offset from `ingest_taxonomy` (06:00 UTC on the 1st) to avoid concurrent Neon connection-pool load.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -recursive -check` — clean (exit 0)
- [x] `terraform init -backend=false` — clean
- [x] `terraform validate` — `Success! The configuration is valid.`
- [ ] `terraform plan` — not run locally; the nightly `terraform-plan-drift-check` workflow will exercise full plan against live state on the next run. Expected diff: the 9 new resources added in this PR (3 secrets, 3 IAM bindings, 1 job, 1 IAM binding for scheduler invoke, 1 scheduler job) — no other changes.
- [x] R2 secrets shape mirrors the existing `ebird_key` pattern minus the `_version` resource (which would require a `var.*` value at apply time).
- [x] New job's `lifecycle.ignore_changes = [template[0].template[0].containers[0].image]` matches the existing `.ingestor` job, so `deploy-ingestor.yml` rolls both jobs with one image push.
- [x] New IAM binding mirrors `scheduler_invoke` shape — same `roles/run.jobsExecutorWithOverrides` role required because the new scheduler still uses `containerOverrides` (routes through `runWithOverrides`, not `run`).

## Plan reference

Part of issue #327, task-8b. Depends on task-1a (R2 bucket), task-1b (R2 Worker), task-7 (run-photos.ts), task-8a (handler.ts + cli.ts wiring) — all merged.

Post-merge operator action required: populate the three R2 secrets via `gcloud secrets versions add bird-watch-r2-endpoint --data-file=-` etc. before the `0 7 1 * *` schedule fires (or before manually executing the job).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)