### PR TITLE
feat(frontend): add iNat photo credit to AttributionModal

### DIFF
--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -208,3 +208,91 @@ test.describe('AttributionModal — mobile viewport', () => {
     expect(await rows.count()).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Issue #327 task-11 — iNaturalist photo credit in the AttributionModal.
+ *
+ * Two viewports (390×844 mobile, 1440×900 desktop) confirm the credit
+ * surfaces in the modal Photos section after navigating to a species
+ * detail surface and opening Credits. Stubbing /api/species/:code via
+ * `apiStub.stubSpecies` is required because the live read-api may not
+ * yet have R2 photo data populated for arbitrary species; the test
+ * deliberately picks deterministic photoAttribution + photoLicense
+ * fixtures so the credit is observable.
+ */
+
+const VERMFLY_WITH_PHOTO = {
+  ...VERMFLY,
+  photoUrl: 'https://photos.bird-maps.com/vermfly.jpg',
+  photoAttribution: 'Jane Photographer',
+  photoLicense: 'cc-by',
+} as const;
+
+test.describe('AttributionModal — iNat photo credit (#327 task-11)', () => {
+  for (const viewport of [
+    { width: 1440, height: 900, label: 'desktop' },
+    { width: 390, height: 844, label: 'mobile' },
+  ] as const) {
+    test.describe(`${viewport.label} (${viewport.width}x${viewport.height})`, () => {
+      test.use({ viewport: { width: viewport.width, height: viewport.height } });
+
+      test('shows iNat photo credit when SpeciesDetailSurface has a photo', async ({ page, apiStub }) => {
+        // Stub the species lookup with the photo fixture. The detail
+        // surface mounts on view=detail+detail=vermfly and the App
+        // threads photoAttribution + photoLicense through to the modal.
+        await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+        const app = new AppPage(page);
+        await app.goto('detail=vermfly&view=detail');
+        await app.waitForAppReady();
+        // Wait for the species detail surface to render (heading is the
+        // canonical post-fetch indicator).
+        await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
+          .toBeVisible({ timeout: 10_000 });
+
+        // Open the Credits modal.
+        const trigger = page.locator('footer.app-footer').getByRole('button', { name: /credits/i });
+        await trigger.click();
+        const dialog = page.locator('dialog.attribution-modal');
+        await expect(dialog).toHaveAttribute('open', '');
+
+        // Photos section is present with an <h3>Photos</h3>.
+        const photosSection = dialog.locator('[data-testid=attribution-photos-section]');
+        await expect(photosSection).toBeVisible();
+        await expect(photosSection.getByRole('heading', { level: 3, name: /^photos$/i }))
+          .toBeVisible();
+
+        // Photographer attribution is rendered.
+        await expect(photosSection.getByText(/Jane Photographer/)).toBeVisible();
+
+        // CC license link surfaces with the canonical creativecommons.org
+        // deed URL. The cc-by code resolves to "CC BY 4.0" + /licenses/by/4.0/.
+        const licenseLink = photosSection.getByRole('link', { name: /CC BY 4\.0/i });
+        await expect(licenseLink).toBeVisible();
+        await expect(licenseLink).toHaveAttribute('href', 'https://creativecommons.org/licenses/by/4.0/');
+        await expect(licenseLink).toHaveAttribute('target', '_blank');
+        await expect(licenseLink).toHaveAttribute('rel', 'noopener noreferrer');
+      });
+
+      test('omits the Photos section when species has no photo metadata', async ({ page, apiStub }) => {
+        // VERMFLY (no photoAttribution / photoLicense) — the section
+        // must NOT render. Verifies the omit path that protects the
+        // user's experience on every other view + every species without
+        // a curated detail-panel photo.
+        await apiStub.stubSpecies('vermfly', VERMFLY);
+        const app = new AppPage(page);
+        await app.goto('detail=vermfly&view=detail');
+        await app.waitForAppReady();
+        await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
+          .toBeVisible({ timeout: 10_000 });
+
+        const trigger = page.locator('footer.app-footer').getByRole('button', { name: /credits/i });
+        await trigger.click();
+        const dialog = page.locator('dialog.attribution-modal');
+        await expect(dialog).toHaveAttribute('open', '');
+        // No Photos heading; no photos section testid.
+        await expect(dialog.locator('[data-testid=attribution-photos-section]'))
+          .toHaveCount(0);
+      });
+    });
+  }
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ApiClient, ApiError } from './api/client.js';
 import { useUrlState } from './state/url-state.js';
 import { useBirdData } from './data/use-bird-data.js';
 import { useSilhouettes } from './data/use-silhouettes.js';
+import { useSpeciesDetail } from './data/use-species-detail.js';
 import { FiltersBar } from './components/FiltersBar.js';
 import { FeedSurface } from './components/FeedSurface.js';
 import { MapSurface } from './components/MapSurface.js';
@@ -42,6 +43,19 @@ export function App() {
     loading: silhouettesLoading,
     error: silhouettesError,
   } = useSilhouettes(apiClient);
+
+  // Active species meta for the detail view (issue #327 task-11). The
+  // hook fires only when state.view === 'detail' AND state.detail is set
+  // — passing `null` is a clean no-op. The Read API serves /api/species/:code
+  // with `Cache-Control: max-age=31536000, immutable`, so the parallel
+  // mount in SpeciesDetailSurface (which has its own per-instance cache)
+  // hits the browser HTTP cache on the second fetch — no duplicate
+  // network round-trip in practice. The threading exists to feed the
+  // photo credit into AttributionModal's Photos section without forcing
+  // a refactor of either the hook or SpeciesDetailSurface.
+  const activeDetailCode =
+    state.view === 'detail' && state.detail ? state.detail : null;
+  const { data: activeSpeciesMeta } = useSpeciesDetail(apiClient, activeDetailCode);
 
   // FamilyLegend toggle: clear when the active family is clicked again,
   // otherwise set. Single source of truth for URL-state writes lives here;
@@ -187,11 +201,21 @@ export function App() {
           misses or API failures (issue #274). Without these props the
           modal would render an empty list while the fetch is in flight
           — looks like silhouettes don't exist.
+
+          iNat photo credit (issue #327 task-11): the active SpeciesMeta
+          carries optional `photoAttribution` + `photoLicense` fields
+          when the detail-panel photo exists. Both must be present for
+          the Photos section to render; either-absent collapses it.
+          When `view !== 'detail'` or no species is selected,
+          `activeSpeciesMeta` is null — both props pass `undefined`, so
+          the section omits cleanly on every other view.
         */}
         <AttributionModal
           silhouettes={silhouettes}
           loading={silhouettesLoading}
           error={silhouettesError}
+          photoAttribution={activeSpeciesMeta?.photoAttribution}
+          photoLicense={activeSpeciesMeta?.photoLicense}
         />
       </footer>
     </div>

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -475,4 +475,129 @@ describe('AttributionModal', () => {
     await user.click(screen.getByRole('button', { name: /close/i }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  /*
+   * iNaturalist photo credit (issue #327 task-11).
+   *
+   * SpeciesDetailSurface (#327 task-10) renders an iNat-mirrored photo
+   * when SpeciesMeta carries a non-null `photoUrl`. Per CC license terms
+   * (specifically iNat's CC-BY / CC-BY-SA / CC-BY-NC variants on
+   * uploaded observations), the photographer must be credited and the
+   * license URL surfaced on the same page as the photo. We surface that
+   * credit in the AttributionModal — already the canonical credits
+   * surface — so the prominence requirement is met without crowding
+   * the SpeciesDetailSurface itself.
+   *
+   * Render contract:
+   *   - Both `photoAttribution` AND `photoLicense` present → render the
+   *     "Photos" section. The section sits below Family Silhouettes, above
+   *     Map Tiles, mirroring the existing CC-credit pattern (label by
+   *     creator — license link).
+   *   - Either prop absent (or both) → omit the section entirely. No
+   *     empty heading; no "no photo credit" placeholder. Silently
+   *     dropping is correct because not every species has a photo.
+   *   - Unknown license code → render the code as plain text rather than
+   *     a broken link (mirrors the unknown-Phylopic-license behavior
+   *     above).
+   */
+
+  it('renders a Photos section when photoAttribution + photoLicense are both present', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoAttribution="Jane Photographer"
+        photoLicense="cc-by"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    // Section heading appears as <h3> (consistent with the other sections).
+    expect(
+      screen.getByRole('heading', { level: 3, name: /^photos$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the photographer name + license link in the Photos section', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoAttribution="Jane Photographer"
+        photoLicense="cc-by"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const photosHeading = screen.getByRole('heading', { level: 3, name: /^photos$/i });
+    const section = photosHeading.closest('section');
+    expect(section).not.toBeNull();
+    // Photographer attribution surfaces.
+    expect(within(section!).getByText(/Jane Photographer/)).toBeInTheDocument();
+    // License is rendered as a link to the matching CC URL.
+    const licenseLink = within(section!).getByRole('link', { name: /CC BY 4\.0/i });
+    expect(licenseLink).toHaveAttribute('href', 'https://creativecommons.org/licenses/by/4.0/');
+    // Same noopener-noreferrer + _blank contract as every other modal link.
+    expect(licenseLink).toHaveAttribute('target', '_blank');
+    expect(licenseLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('omits the Photos section when both photoAttribution and photoLicense are absent', async () => {
+    const user = userEvent.setup();
+    render(<AttributionModal silhouettes={SILHOUETTES} />);
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    // No <h3>Photos</h3> in the modal.
+    expect(
+      screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
+    ).toBeNull();
+  });
+
+  it('omits the Photos section when only photoAttribution is present (no license)', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoAttribution="Jane Photographer"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    expect(
+      screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
+    ).toBeNull();
+  });
+
+  it('omits the Photos section when only photoLicense is present (no attribution)', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoLicense="cc-by"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    expect(
+      screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
+    ).toBeNull();
+  });
+
+  it('renders an unknown photo license code as plain text (no link)', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoAttribution="Jane Photographer"
+        photoLicense="cc-mystery-9.9"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const photosHeading = screen.getByRole('heading', { level: 3, name: /^photos$/i });
+    const section = photosHeading.closest('section');
+    expect(section).not.toBeNull();
+    // Unknown identifier surfaces as plain text — verify by walking the
+    // text content; getByText alone on a string fragment may partial-match.
+    expect(section!.textContent).toMatch(/cc-mystery-9\.9/i);
+    // ...and there's no anchor in the section pointing at creativecommons.
+    const ccLinks = within(section!).queryAllByRole('link');
+    for (const link of ccLinks) {
+      expect(link.getAttribute('href') ?? '').not.toMatch(/creativecommons\.org/);
+    }
+  });
 });

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -50,6 +50,75 @@ const LICENSE_URLS: Record<string, string> = {
   'CC-BY-SA-3.0': 'https://creativecommons.org/licenses/by-sa/3.0/',
 };
 
+/**
+ * Mapping for iNaturalist photo license codes (issue #327 task-11).
+ *
+ * Two shapes co-exist in the data path:
+ *   - iNat-native lowercase codes from the photos ingest: `cc-by`,
+ *     `cc-by-sa`, `cc0`, etc. (services/ingestor/src/inat/types.ts).
+ *   - Legacy CC formal labels (`CC-BY-4.0`, `CC-BY-NC`) some test
+ *     fixtures + handcurated rows carry. Normalize via lowercase lookup
+ *     so the same modal serves both.
+ *
+ * `name` is the human-readable label the modal renders inline ("CC BY 4.0");
+ * `url` is the deed page on creativecommons.org. The lookup is
+ * case-insensitive — see `lookupPhotoLicense` below.
+ */
+const PHOTO_LICENSE_INFO: Record<string, { name: string; url: string }> = {
+  'cc0': {
+    name: 'CC0 1.0',
+    url: 'https://creativecommons.org/publicdomain/zero/1.0/',
+  },
+  'cc-by': {
+    name: 'CC BY 4.0',
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+  },
+  'cc-by-sa': {
+    name: 'CC BY-SA 4.0',
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+  },
+  'cc-by-nc': {
+    name: 'CC BY-NC 4.0',
+    url: 'https://creativecommons.org/licenses/by-nc/4.0/',
+  },
+  'cc-by-nd': {
+    name: 'CC BY-ND 4.0',
+    url: 'https://creativecommons.org/licenses/by-nd/4.0/',
+  },
+  'cc-by-nc-sa': {
+    name: 'CC BY-NC-SA 4.0',
+    url: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+  },
+  'cc-by-nc-nd': {
+    name: 'CC BY-NC-ND 4.0',
+    url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+  },
+  // Legacy CC formal codes (some seeded test rows + ingestor variants
+  // store these). Mapped to the same deed pages.
+  'cc-by-4.0': {
+    name: 'CC BY 4.0',
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+  },
+  'cc-by-sa-4.0': {
+    name: 'CC BY-SA 4.0',
+    url: 'https://creativecommons.org/licenses/by-sa/4.0/',
+  },
+  'cc-by-nc-4.0': {
+    name: 'CC BY-NC 4.0',
+    url: 'https://creativecommons.org/licenses/by-nc/4.0/',
+  },
+};
+
+/**
+ * Resolves an iNaturalist license code to a `{ name, url }` pair, or
+ * returns `null` when the code isn't in the map. The component falls
+ * back to rendering the raw code as plain text on `null` (mirrors the
+ * Phylopic `LICENSE_URLS` fail-soft behavior).
+ */
+function lookupPhotoLicense(code: string): { name: string; url: string } | null {
+  return PHOTO_LICENSE_INFO[code.toLowerCase()] ?? null;
+}
+
 export interface AttributionModalProps {
   /**
    * Phylopic per-silhouette credits sourced from `useSilhouettes()` in
@@ -85,6 +154,29 @@ export interface AttributionModalProps {
    * fires once per state change with the new `open` boolean.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * iNaturalist photographer attribution string for the currently-active
+   * SpeciesDetailSurface photo (issue #327 task-11). Sourced from
+   * `SpeciesMeta.photoAttribution`. Threaded by App.tsx from the active
+   * detail-view species and `undefined` when `view !== 'detail'` or no
+   * species is selected. The Photos credit section renders only when
+   * BOTH `photoAttribution` AND `photoLicense` are present; either-
+   * absent / both-absent collapses the section entirely.
+   *
+   * The explicit `| undefined` is required under
+   * `exactOptionalPropertyTypes: true` so call sites can pass
+   * `activeSpeciesMeta?.photoAttribution` (which may be `undefined`)
+   * directly without TypeScript complaining. Mirrors `SpeciesDetailVisual`'s
+   * `photoUrl` convention.
+   */
+  photoAttribution?: string | undefined;
+  /**
+   * iNaturalist license code for the active species photo (issue #327
+   * task-11). iNat-native lowercase codes (`cc-by`, `cc-by-sa`, `cc0`)
+   * and legacy CC formal codes (`CC-BY-4.0`) are both accepted via
+   * case-insensitive lookup. Unknown codes render as plain text.
+   */
+  photoLicense?: string | undefined;
 }
 
 export function AttributionModal({
@@ -92,6 +184,8 @@ export function AttributionModal({
   loading = false,
   error = null,
   onOpenChange,
+  photoAttribution,
+  photoLicense,
 }: AttributionModalProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -320,6 +414,54 @@ export function AttributionModal({
               </>
             )}
           </section>
+          {/*
+            iNat photo credit (issue #327 task-11). Renders only when
+            BOTH `photoAttribution` and `photoLicense` are present —
+            no "Photos" heading appears for species with a Phylopic-only
+            visual. Section sits between Family Silhouettes and Map Tiles
+            so the credit ordering follows the visual hierarchy on the
+            detail surface (photo → silhouette fallback → map context).
+          */}
+          {photoAttribution && photoLicense && (() => {
+            const licenseInfo = lookupPhotoLicense(photoLicense);
+            return (
+              <section
+                className="attribution-modal-section"
+                data-testid="attribution-photos-section"
+              >
+                <h3>Photos</h3>
+                <p>
+                  Species photos by{' '}
+                  <span className="attribution-modal-photographer">
+                    {photoAttribution}
+                  </span>
+                  {' — '}
+                  {licenseInfo ? (
+                    <a
+                      href={licenseInfo.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {licenseInfo.name}
+                    </a>
+                  ) : (
+                    <span className="attribution-modal-license-text">
+                      {photoLicense}
+                    </span>
+                  )}
+                  {'. Photos sourced from '}
+                  <a
+                    href="https://www.inaturalist.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    iNaturalist
+                  </a>
+                  .
+                </p>
+              </section>
+            );
+          })()}
           <section className="attribution-modal-section">
             <h3>Map Tiles</h3>
             <p>


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[App.tsx] -->|state.view==detail<br/>state.detail| B[useSpeciesDetail]
    B -->|/api/species/:code<br/>cache: immutable| C[species_meta + photo JOIN]
    C -->|photoAttribution<br/>photoLicense| A
    A -->|threaded props| D[AttributionModal]
    D -->|both present?| E{render Photos section}
    E -->|yes| F[photographer + CC license link]
    E -->|no| G[section omitted]
```

## Summary

- Extends `AttributionModalProps` with optional `photoAttribution` + `photoLicense` and renders a new "Photos" credit section between Family Silhouettes and Map Tiles when BOTH props are present (either-absent / both-absent collapses cleanly).
- Threads the props from the active SpeciesMeta in `App.tsx` via a new mount of `useSpeciesDetail` gated on `view === 'detail'` AND a non-null `detail` code; non-detail views pass `undefined` so the section omits everywhere except the species detail surface.
- License lookup is case-insensitive and accepts iNat-native lowercase codes (`cc-by`, `cc-by-sa`, `cc0`, plus -nc / -nd variants) and legacy CC formal labels (`CC-BY-4.0`); unknown codes fail-soft to plain text rather than rendering a broken anchor — mirrors the existing Phylopic `LICENSE_URLS` pattern.

## Screenshots

PENDING — chrome-devtools-mcp not available in this dispatch session, so the `pr-screenshots-via-user-attachments` paste flow can't run. Local PNGs were captured via Playwright MCP at both required viewports and live at:

- Desktop (1440×900): `/Users/jul/repos/bird-sight-system/attribution-modal-photo-credit-desktop-1440x900.png`
- Mobile (390×844): `/Users/jul/repos/bird-sight-system/attribution-modal-photo-credit-mobile-390x844.png`

Reproduce locally with: `npm run db:up && npm run db:migrate`, then `INSERT INTO species_photos (species_code, purpose, url, attribution, license) VALUES ('annhum', 'detail-panel', '<a real image url>', 'Anna Schmidt', 'cc-by-sa');`, then `npm run dev --workspace @bird-watch/frontend` and visit `http://localhost:5173/?detail=annhum&view=detail`. Click Credits — the Photos section reads "Species photos by Anna Schmidt — CC BY-SA 4.0. Photos sourced from iNaturalist." (license linking to the canonical CC deed page). Mirrors the precedent set by PR #338 (issue #327 task-10) — bot-approved with the same caveat.

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — clean (typecheck via `tsc -b` + vite build)
- [x] `npx vitest run` — 381/381 frontend unit + integration tests pass (was 375 before this PR; +6 new AttributionModal tests)
- [x] `npx playwright test --project=dev-server attribution-modal` — 18/18 attribution-modal e2e tests pass (was 14 before; +4 new iNat-photo-credit tests at both 390x844 and 1440x900 viewports)
- [x] New unit tests added (renders / omits photo credit, renders link to CC URL, unknown-license-as-plaintext fail-soft)
- [x] New Playwright e2e spec added (`AttributionModal — iNat photo credit (#327 task-11)` describe block, parametrized over both viewports, with stubbed species lookup via `apiStub.stubSpecies`)
- [x] Playwright MCP smoke drive — opened detail view with seeded photo data at 1440×900 and 390×844, clicked Credits, verified Photos section renders with photographer + CC link; `browser_console_messages` returns 0 errors and 0 warnings on both viewports

## Plan reference

Part of issue #327, task-11. See issue body for the full task list (eBird → iNat photo enrichment epic).

---

Generated with [Claude Code](https://claude.com/claude-code)