### PR TITLE
fix(ingestor): scope photos backfill to AZ-observed species

### DIFF
--- a/services/ingestor/src/run-photos.test.ts
+++ b/services/ingestor/src/run-photos.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
-import { upsertSpeciesMeta, getSpeciesPhotos, insertSpeciesPhoto } from '@bird-watch/db-client';
+import {
+  upsertSpeciesMeta,
+  getSpeciesPhotos,
+  insertSpeciesPhoto,
+  upsertObservations,
+} from '@bird-watch/db-client';
 
 // Mock the iNat client and R2 uploader at the module boundary BEFORE importing
 // run-photos. The orchestrator's job is to compose those two side-effects with
@@ -63,10 +68,52 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await db.pool.query('TRUNCATE species_photos RESTART IDENTITY CASCADE');
+  await db.pool.query('TRUNCATE observations CASCADE');
   await db.pool.query('TRUNCATE species_meta CASCADE');
   fetchInatPhotoMock.mockReset();
   uploadToR2Mock.mockReset();
   await upsertSpeciesMeta(db.pool, SPECIES_FIXTURE);
+  // Seed one AZ observation per species so all three are visible to the
+  // photos job. The dedicated "skips species_meta rows with no observations"
+  // test below seeds observations for only one species.
+  await upsertObservations(db.pool, [
+    {
+      subId: 'S100000001',
+      speciesCode: 'verfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.2226,
+      lng: -110.9747,
+      obsDt: '2026-04-30T12:00:00Z',
+      locId: 'L100',
+      locName: 'Tucson',
+      howMany: 1,
+      isNotable: false,
+    },
+    {
+      subId: 'S100000002',
+      speciesCode: 'annhum',
+      comName: "Anna's Hummingbird",
+      lat: 33.4484,
+      lng: -112.0740,
+      obsDt: '2026-04-30T12:00:00Z',
+      locId: 'L101',
+      locName: 'Phoenix',
+      howMany: 1,
+      isNotable: false,
+    },
+    {
+      subId: 'S100000003',
+      speciesCode: 'norcar',
+      comName: 'Northern Cardinal',
+      lat: 32.7,
+      lng: -111.0,
+      obsDt: '2026-04-30T12:00:00Z',
+      locId: 'L102',
+      locName: 'Casa Grande',
+      howMany: 1,
+      isNotable: false,
+    },
+  ]);
 });
 
 afterAll(async () => {
@@ -247,5 +294,59 @@ describe('runPhotos', () => {
     expect(await getSpeciesPhotos(db.pool, 'norcar')).toHaveLength(1);
     expect(await getSpeciesPhotos(db.pool, 'verfly')).toEqual([]);
     expect(await getSpeciesPhotos(db.pool, 'annhum')).toEqual([]);
+  });
+
+  it('runPhotos skips species_meta rows that have no observations in AZ (the iNat client filters by place_id=40, so species never observed in AZ are guaranteed no-op iNat round-trips)', async () => {
+    // Override the beforeEach seed: clear all observations and re-insert
+    // only one for verfly. annhum and norcar are left with species_meta
+    // rows but no observations — they represent the ~24k non-AZ species
+    // the taxonomy ingest writes to species_meta.
+    await db.pool.query('TRUNCATE observations CASCADE');
+    await upsertObservations(db.pool, [
+      {
+        subId: 'S100000001',
+        speciesCode: 'verfly',
+        comName: 'Vermilion Flycatcher',
+        lat: 32.2226,
+        lng: -110.9747,
+        obsDt: '2026-04-30T12:00:00Z',
+        locId: 'L100',
+        locName: 'Tucson',
+        howMany: 1,
+        isNotable: false,
+      },
+    ]);
+
+    fetchInatPhotoMock.mockImplementation(async (sciName: string) => ({
+      url: `https://inat.example.test/${encodeURIComponent(sciName)}/medium.jpg`,
+      attribution: `(c) somebody for ${sciName}, CC BY`,
+      license: 'cc-by',
+    }));
+    uploadToR2Mock.mockImplementation(async (_imageUrl: string, destKey: string) => {
+      return `https://photos.bird-maps.com/${destKey}`;
+    });
+
+    const summary = await runPhotos({ pool: db.pool, paceMs: 0 });
+
+    // Only the species with an observation is iterated.
+    expect(summary.speciesCount).toBe(1);
+    expect(summary.photosFetched).toBe(1);
+    expect(summary.photosSkipped).toBe(0);
+    expect(summary.photosFailed).toBe(0);
+
+    // iNat called exactly once, only for the AZ-observed species.
+    expect(fetchInatPhotoMock).toHaveBeenCalledTimes(1);
+    const sciNamesQueried = fetchInatPhotoMock.mock.calls.map(c => c[0]);
+    expect(sciNamesQueried).toEqual(['Pyrocephalus rubinus']);
+    expect(sciNamesQueried).not.toContain('Calypte anna');
+    expect(sciNamesQueried).not.toContain('Cardinalis cardinalis');
+
+    // R2 called exactly once.
+    expect(uploadToR2Mock).toHaveBeenCalledTimes(1);
+
+    // DB: photo row only for the AZ-observed species.
+    expect(await getSpeciesPhotos(db.pool, 'verfly')).toHaveLength(1);
+    expect(await getSpeciesPhotos(db.pool, 'annhum')).toEqual([]);
+    expect(await getSpeciesPhotos(db.pool, 'norcar')).toEqual([]);
   });
 });

--- a/services/ingestor/src/run-photos.ts
+++ b/services/ingestor/src/run-photos.ts
@@ -56,10 +56,18 @@ export async function runPhotos(args: RunPhotosArgs): Promise<RunPhotosSummary> 
   const paceMs = args.paceMs ?? DEFAULT_PACE_MS;
   const forceRefresh = args.forceRefresh ?? false;
 
-  // Fetch all species rows alongside any existing detail-panel photo URL via
-  // a LEFT JOIN. One round-trip beats N queries for the per-row "do you
-  // already have a photo?" check; the species_meta count is in the low
-  // hundreds today, so the join cost is negligible.
+  // Fetch species rows alongside any existing detail-panel photo URL via a
+  // LEFT JOIN. One round-trip beats N queries for the per-row "do you
+  // already have a photo?" check.
+  //
+  // The EXISTS filter narrows the iteration to species we have actually
+  // observed in Arizona. The taxonomy ingest writes the *full* eBird
+  // taxonomy (~24k species) to species_meta, but the iNat client filters
+  // photo lookups by place_id=40 (Arizona) — so for species never observed
+  // in AZ, every iteration would be a no-op iNat round-trip that returns
+  // null. With the filter, the photos job iterates only the ~344 species
+  // actually present in `observations`, fitting comfortably inside the
+  // 600s Cloud Run job timeout.
   const { rows } = await args.pool.query<{
     species_code: string;
     sci_name: string;
@@ -70,6 +78,10 @@ export async function runPhotos(args: RunPhotosArgs): Promise<RunPhotosSummary> 
        LEFT JOIN species_photos sp
          ON sp.species_code = sm.species_code
         AND sp.purpose = $1
+      WHERE EXISTS (
+        SELECT 1 FROM observations o
+         WHERE o.species_code = sm.species_code
+      )
       ORDER BY sm.species_code`,
     [PURPOSE]
   );


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before
        SM1[species_meta<br/>~24,000 rows<br/>full eBird taxonomy] --> Iter1[run-photos iterates<br/>every row alphabetically]
        Iter1 --> Inat1[iNat call<br/>place_id=40 AZ filter]
        Inat1 -->|null for ~99% of rows| Skip1[skip + log]
        Skip1 -.->|~600s timeout<br/>stuck on a*| Dead[never reaches verfly,<br/>annhum, etc.]
    end

    subgraph After
        SM2[species_meta<br/>~24,000 rows] --> Filter[WHERE EXISTS<br/>SELECT 1 FROM observations<br/>WHERE species_code = sm.species_code]
        Filter -->|~344 rows| Iter2[run-photos iterates<br/>only AZ-observed species]
        Iter2 --> Inat2[iNat call<br/>place_id=40 AZ filter]
        Inat2 -->|photo| Upload[R2 upload + DB write]
    end
```

## Summary

- The `bird-ingestor-photos` Cloud Run job (entry `services/ingestor/src/run-photos.ts`) iterates every row in `species_meta`, but the taxonomy ingest fills that table with the full eBird taxonomy (~24k species) — not just the ~344 species ever observed in Arizona. The iNat client filters by `place_id=40` (AZ), so each non-AZ iteration is a guaranteed no-op iNat round-trip that returns null.
- Real-world impact today (2026-04-30): a live run logged thousands of `[run-photos] afepig1 (Columba unicincta): iNat returned no photo, skipping` lines and timed out covering only the alphabetical prefix `a*` (African / Amazonian / Andean / Angolan species), never reaching actual AZ species like `verfly` or `annhum`.
- The fix is a `WHERE EXISTS (SELECT 1 FROM observations o WHERE o.species_code = sm.species_code)` filter on the SELECT, collapsing iteration from ~24k → ~344 rows so the job fits comfortably inside the 600s timeout. EXISTS is preferred over an inner JOIN because it keeps one row per species when a species has many observations.

## Screenshots

N/A — backend only

## Test plan

- [x] `npm run typecheck && npm run test` — green (`run-photos.test.ts` passes 5/5; full ingestor suite passes 11/11 test files)
- [x] New integration test added: `runPhotos skips species_meta rows that have no observations in AZ` — seeds 3 species into `species_meta`, observations for only 1, asserts `summary.speciesCount === 1` and the orphan rows are skipped without an iNat call.
- [x] Existing tests updated: `beforeEach` now seeds one observation per species so the original 4 tests (which expect all 3 species processed) still see all 3 rows post-filter.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A (backend job, no UI surface)
- [x] `npm run build` — clean
- [ ] (UI only) Playwright MCP smoke — N/A (backend only)

## Plan reference

Out of plan — production bugfix surfaced by a live `bird-ingestor-photos` job run on 2026-04-30 that timed out without reaching most AZ species.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)