### PR TITLE
fix(ingestor): cascade iNat photo lookup AZ -> US -> global

### DIFF
--- a/services/ingestor/src/inat/client.test.ts
+++ b/services/ingestor/src/inat/client.test.ts
@@ -58,9 +58,11 @@ describe('fetchInatPhoto', () => {
     expect(photo?.url).toContain('medium');
   });
 
-  it('fetchBestPhoto returns null on zero results', async () => {
+  it('fetchBestPhoto returns null on zero results across all three tiers', async () => {
+    let calls = 0;
     server.use(
       http.get(INAT_OBSERVATIONS_URL, () => {
+        calls++;
         return HttpResponse.json({
           total_results: 0,
           page: 1,
@@ -72,6 +74,141 @@ describe('fetchInatPhoto', () => {
 
     const photo = await fetchInatPhoto('Imaginarius nonexistens');
     expect(photo).toBeNull();
+    // Tier cascade: AZ → US → global, so an exhaustive miss touches iNat 3
+    // times. Anything other than 3 means the cascade is short-circuiting or
+    // looping — both regressions on this PR's contract.
+    expect(calls).toBe(3);
+  });
+
+  it('Tier 1 (place_id=40) hit short-circuits the cascade', async () => {
+    let calls = 0;
+    const placeIds: (string | null)[] = [];
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        calls++;
+        const url = new URL(request.url);
+        placeIds.push(url.searchParams.get('place_id'));
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              photos: [
+                {
+                  url: 'https://example.org/photos/az/square.jpg',
+                  attribution: '(c) AZ Photographer, CC BY',
+                  license_code: 'cc-by',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Pyrocephalus rubinus');
+
+    expect(calls).toBe(1);
+    expect(placeIds).toEqual(['40']);
+    expect(photo?.url).toBe('https://example.org/photos/az/medium.jpg');
+    expect(photo?.license).toBe('cc-by');
+  });
+
+  it('Tier 2 (place_id=1, US) hit when AZ is empty', async () => {
+    let calls = 0;
+    const placeIds: (string | null)[] = [];
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        calls++;
+        const url = new URL(request.url);
+        placeIds.push(url.searchParams.get('place_id'));
+        if (calls === 1) {
+          // AZ tier — empty
+          return HttpResponse.json({
+            total_results: 0,
+            page: 1,
+            per_page: 1,
+            results: [],
+          });
+        }
+        // US tier — hit
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              photos: [
+                {
+                  url: 'https://example.org/photos/us/square.jpg',
+                  attribution: '(c) US Photographer, CC BY-SA',
+                  license_code: 'cc-by-sa',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Anser aegyptiaca');
+
+    expect(calls).toBe(2);
+    // Tier order is documented in the cascade — AZ (40) then US (1). place_id=1
+    // is iNat's canonical "United States" Place per
+    // https://api.inaturalist.org/v1/places/1.
+    expect(placeIds).toEqual(['40', '1']);
+    expect(photo?.url).toBe('https://example.org/photos/us/medium.jpg');
+    expect(photo?.license).toBe('cc-by-sa');
+  });
+
+  it('Tier 3 (no place_id, global) hit when AZ and US are empty', async () => {
+    let calls = 0;
+    const placeIdParams: (string | null)[] = [];
+    const hadPlaceIdKey: boolean[] = [];
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        calls++;
+        const url = new URL(request.url);
+        placeIdParams.push(url.searchParams.get('place_id'));
+        hadPlaceIdKey.push(url.searchParams.has('place_id'));
+        if (calls < 3) {
+          return HttpResponse.json({
+            total_results: 0,
+            page: 1,
+            per_page: 1,
+            results: [],
+          });
+        }
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              photos: [
+                {
+                  url: 'https://example.org/photos/global/square.jpg',
+                  attribution: '(c) Global Photographer, CC0',
+                  license_code: 'cc0',
+                },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    const photo = await fetchInatPhoto('Larus occidentalis');
+
+    expect(calls).toBe(3);
+    expect(placeIdParams.slice(0, 2)).toEqual(['40', '1']);
+    // Tier 3 must omit `place_id` entirely, not pass an empty string. iNat
+    // treats `place_id=` as a malformed filter on some routes.
+    expect(hadPlaceIdKey[2]).toBe(false);
+    expect(photo?.url).toBe('https://example.org/photos/global/medium.jpg');
+    expect(photo?.license).toBe('cc0');
   });
 
   it('fetchBestPhoto retries once on 429', async () => {

--- a/services/ingestor/src/inat/client.ts
+++ b/services/ingestor/src/inat/client.ts
@@ -16,6 +16,25 @@ const USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
 // different IDs and would silently narrow or skew the photo pool.
 const ARIZONA_PLACE_ID = '40';
 
+// place_id=1 is iNaturalist's canonical "United States" Place. Confirmed via
+// `GET https://api.inaturalist.org/v1/places/1` returning `name='United States'`,
+// `place_type=12` (country), `admin_level=0`. Used as Tier 2 in the photo
+// fallback cascade for AZ-rare/vagrant species (e.g. Cave Swallow, Glossy
+// Ibis) that have plenty of US research-grade observations elsewhere but no
+// AZ hits.
+const UNITED_STATES_PLACE_ID = '1';
+
+// Tier cascade for the photo lookup. Tier 1 is the historical AZ-only filter;
+// Tier 2 widens to the US; Tier 3 drops the place filter entirely. Each tier
+// keeps the same quality_grade/license/order_by constraints — only the
+// geographic filter relaxes.
+type Tier = { label: 'az' | 'us' | 'global'; placeId: string | null };
+const TIERS: readonly Tier[] = [
+  { label: 'az', placeId: ARIZONA_PLACE_ID },
+  { label: 'us', placeId: UNITED_STATES_PLACE_ID },
+  { label: 'global', placeId: null },
+];
+
 // CC license codes accepted by `photo_license`. CC-BY-NC* variants are
 // excluded because they forbid commercial use; while bird-maps.com is
 // non-commercial today, a future donations/grants tier could change that
@@ -51,47 +70,64 @@ export async function fetchInatPhoto(
   const retryBaseMs = opts.retryBaseMs ?? 250;
   const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
 
-  const url = new URL(`${baseUrl}/observations`);
-  url.searchParams.set('taxon_name', taxonName);
-  url.searchParams.set('place_id', ARIZONA_PLACE_ID);
-  url.searchParams.set('quality_grade', 'research');
-  url.searchParams.set('photo_license', CC_LICENSES);
-  url.searchParams.set('order_by', 'votes'); // best-rated first
-  url.searchParams.set('per_page', '1');
-  url.searchParams.set('photos', 'true'); // only observations that include photos
+  for (const tier of TIERS) {
+    const url = new URL(`${baseUrl}/observations`);
+    url.searchParams.set('taxon_name', taxonName);
+    if (tier.placeId !== null) {
+      url.searchParams.set('place_id', tier.placeId);
+    }
+    url.searchParams.set('quality_grade', 'research');
+    url.searchParams.set('photo_license', CC_LICENSES);
+    url.searchParams.set('order_by', 'votes'); // best-rated first
+    url.searchParams.set('per_page', '1');
+    url.searchParams.set('photos', 'true'); // only observations that include photos
 
-  const body = await getJsonWithRetry<InatObservationsResponse>(
-    url,
-    maxRetries,
-    retryBaseMs,
-    requestTimeoutMs
-  );
+    const body = await getJsonWithRetry<InatObservationsResponse>(
+      url,
+      maxRetries,
+      retryBaseMs,
+      requestTimeoutMs
+    );
 
-  const firstResult = body.results[0];
-  if (!firstResult) return null;
+    const firstResult = body.results[0];
+    if (!firstResult) continue;
 
-  const firstPhoto = firstResult.photos[0];
-  if (!firstPhoto) return null;
+    const firstPhoto = firstResult.photos[0];
+    if (!firstPhoto) continue;
 
-  // iNat's `photo.url` returns a 75px square thumbnail by convention. The URL
-  // contains the literal segment 'square' (e.g. .../photos/12345/square.jpg);
-  // substituting 'medium' yields the ~500-800px variant suitable for a detail
-  // panel. iNat publishes the size token convention at
-  // https://www.inaturalist.org/pages/help#photos — supported values are
-  // square, small, medium, large, original.
-  const mediumUrl = firstPhoto.url.replace('square', 'medium');
+    // iNat's `photo.url` returns a 75px square thumbnail by convention. The
+    // URL contains the literal segment 'square' (e.g.
+    // .../photos/12345/square.jpg); substituting 'medium' yields the
+    // ~500-800px variant suitable for a detail panel. iNat publishes the size
+    // token convention at https://www.inaturalist.org/pages/help#photos —
+    // supported values are square, small, medium, large, original.
+    const mediumUrl = firstPhoto.url.replace('square', 'medium');
 
-  // photo_license filtering at the API level guarantees a non-null code, but
-  // defend against a malformed payload by falling back to an empty string —
-  // upstream consumers store the license in a NOT NULL column, so an empty
-  // string surfaces "schema violation" loudly rather than crashing here.
-  const license = firstPhoto.license_code ?? '';
+    // photo_license filtering at the API level guarantees a non-null code,
+    // but defend against a malformed payload by falling back to an empty
+    // string — upstream consumers store the license in a NOT NULL column, so
+    // an empty string surfaces "schema violation" loudly rather than crashing
+    // here.
+    const license = firstPhoto.license_code ?? '';
 
-  return {
-    url: mediumUrl,
-    attribution: firstPhoto.attribution,
-    license,
-  };
+    // Surface the tier on Tier 2/3 hits so a future "why is this photo
+    // showing a Maine bird?" investigation can grep the logs. Silent on
+    // Tier 1 (the common case — most species are AZ-photographed).
+    if (tier.label !== 'az') {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[fetchInatPhoto] ${taxonName}: matched at tier=${tier.label}`
+      );
+    }
+
+    return {
+      url: mediumUrl,
+      attribution: firstPhoto.attribution,
+      license,
+    };
+  }
+
+  return null;
 }
 
 async function getJsonWithRetry<T>(


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[fetchInatPhoto sciName] --> T1{Tier 1: place_id=40 AZ}
    T1 -->|hit| R[InatPhoto]
    T1 -->|null| T2{Tier 2: place_id=1 US}
    T2 -->|hit| R
    T2 -->|null| T3{Tier 3: no place_id global}
    T3 -->|hit| R
    T3 -->|null| N[null]
```

## Summary

- **Why:** PR #342 landed photos backfill at 353/383 (92%) coverage. Of the 30 missing species, 10 are real AZ-observed birds (vagrants, rare visitors, naturalized escapees) that have **zero** AZ research-grade iNat observations under our CC license filter but plenty of US or global hits — the hard-coded `place_id=40` filter blocks them unnecessarily.
- **What:** Replace the single-place query with a 3-tier cascade — Tier 1 (`place_id=40`, AZ) -> Tier 2 (`place_id=1`, US, per https://api.inaturalist.org/v1/places/1) -> Tier 3 (no `place_id`, global). All other filters (`quality_grade=research`, `photo_license=cc-by/cc-by-sa/cc0`, `order_by=votes`, `per_page=1`) are unchanged. Function signature is unchanged; cascade is internal.
- **Expected delta after re-run:** the following 10 species should land photos via Tier 2/3: `amgplo`, `cavswa`, `comter`, `egygoo`, `gloibi`, `mutswa`, `purfin`, `shbdow`, `tufduc`, `wesgul`, `whevir`. The remaining 20 missing species are structurally unfixable (10 eBird placeholder/spuh codes like `x00059`; 10 hybrid codes like `bwxtea1`) — they have no row in `species_meta` and are correctly handled by the silhouette fallback in `SpeciesDetailSurface`.

Tier 2/3 hits log a single `[fetchInatPhoto] <sciName>: matched at tier=us|global` line so a future "why is this photo from Maine?" investigation can grep iNat job logs. Tier 1 stays silent (the common case). Worst case adds 2 extra iNat calls per Tier-1-miss species (~20 calls for the 10 species above), negligible against the 100 req/min budget; existing `paceMs` in `run-photos.ts` throttles unchanged.

## Screenshots

N/A - backend only

## Test plan

- [x] `npm run test -w @bird-watch/ingestor` - 11 files / 54 tests pass
- [x] `npm run build -w @bird-watch/ingestor` - clean
- [x] `npm run build` (full repo) - clean
- [x] New unit tests added in `services/ingestor/src/inat/client.test.ts`:
  - Tier 1 hit short-circuits the cascade (1 iNat call)
  - Tier 2 hit when AZ is empty (2 calls; verifies `place_id` order is `40` then `1`)
  - Tier 3 hit when AZ + US are empty (3 calls; verifies Tier 3 omits the `place_id` key entirely rather than passing `place_id=`)
  - All tiers null returns null with exactly 3 calls
  - Existing Tier 1 happy-path + 429 retry tests still pass

## Plan reference

Out of plan - follow-up to PR #342 (photos backfill). Closes the AZ-vagrant photo gap surfaced after that PR's first clean run.

---

Generated with [Claude Code](https://claude.com/claude-code)