### PR TITLE
feat(frontend): single-column FamilyLegend at all viewports

### DIFF
--- a/frontend/src/components/FamilyLegend.test.tsx
+++ b/frontend/src/components/FamilyLegend.test.tsx
@@ -289,4 +289,21 @@ describe('FamilyLegend', () => {
     );
     expect(screen.queryAllByTestId('family-legend-entry')).toHaveLength(0);
   });
+
+  it('entries list does not have inline grid-template-columns: 1fr 1fr override', () => {
+    const { container } = render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={() => {}}
+        defaultExpanded={true}
+      />
+    );
+    const list = container.querySelector('.family-legend-entries') as HTMLElement;
+    expect(list).not.toBeNull();
+    // Guard against accidental inline-style re-introduction of a 2-column
+    // layout — visual contract is enforced by Playwright at PR review time.
+    expect(list.style.gridTemplateColumns).not.toBe('1fr 1fr');
+  });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -693,7 +693,7 @@ body {
   box-shadow: var(--shadow-listbox);
   font-size: 13px;
   color: var(--color-text-strong);
-  max-width: 320px;
+  max-width: 240px;
 }
 .family-legend-toggle {
   display: flex;
@@ -730,9 +730,9 @@ body {
   margin: 0;
   padding: var(--space-xs) var(--space-xs) var(--space-sm) var(--space-xs);
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 2px;
-  max-height: 320px;
+  max-height: 400px;
   overflow-y: auto;
   border-top: 1px solid var(--color-border-subtle);
 }
@@ -799,7 +799,6 @@ body {
     max-width: calc(100vw - 2 * var(--space-md));
   }
   .family-legend-entries {
-    grid-template-columns: 1fr;
     max-height: 240px;
   }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  subgraph Before["Before (desktop)"]
    A1[".family-legend<br/>max-width: 320px"]
    A2[".family-legend-entries<br/>grid-template-columns: 1fr 1fr<br/>max-height: 320px"]
    A1 --> A2
    A2 -. side-by-side, ~9 rows .-> A3[("entries 2-up")]
  end
  subgraph After["After (desktop)"]
    B1[".family-legend<br/>max-width: 240px"]
    B2[".family-legend-entries<br/>grid-template-columns: 1fr<br/>max-height: 400px"]
    B1 --> B2
    B2 -. single column, ~11 rows .-> B3[("entries stacked")]
  end
  Before --> After
```

```mermaid
flowchart TB
  M["@media (max-width: 760px)"]
  M --> M1[".family-legend<br/>max-width: calc(100vw - 2*--space-md)<br/>(unchanged)"]
  M --> M2[".family-legend-entries<br/>max-height: 240px<br/>(unchanged)"]
  M --> M3["grid-template-columns: 1fr override<br/>REMOVED — base rule already 1fr"]
```

## Summary

- The desktop FamilyLegend's 2-column CSS grid (`grid-template-columns: 1fr 1fr`) created a feel of horizontal navigation that users described as confusing for a top-to-bottom list of bird family names — single-column matches user expectation and matches the mobile layout already in place.
- Compensating dimensional tweaks: desktop max-height grows 320px to 400px (keeps ~11 rows in frame before scrolling); desktop max-width shrinks 320px to 240px — single-column at 240px gives the label more horizontal space than each cell in the old 320px 2-column layout, while also taking less map real estate.
- Mobile is already single-column via the `@media (max-width: 760px)` override; that override's now-redundant `grid-template-columns: 1fr` line is dropped.

## Screenshots

Captured locally during browser-driven verification at the two viewports the release-1 exit criteria name (`browser_console_messages` returned 0 errors / 0 warnings at both):

- Desktop 1440×900: `family-legend-single-column-desktop-1440x900.png` — single column, panel ~240px wide, 10 rows visible before scroll, list height=400px (matches new `max-height: 400px`); confirmed via accessibility snapshot box dimensions `[box=28,390,240,433]`.
- Mobile 390×844: `family-legend-single-column-mobile-390x844.png` — single column, panel ~243px wide, 6 rows visible within mobile max-height=240px (matches preserved mobile constraint).

To upload via the `user-attachments` paste flow (chrome-devtools-mcp was held by another active session in the implementer's runtime; the paste flow requires a logged-in browser the implementer subagent could not reach):

```
/Users/jul/repos/bird-sight-system/family-legend-single-column-desktop-1440x900.png
/Users/jul/repos/bird-sight-system/family-legend-single-column-mobile-390x844.png
```

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend -- FamilyLegend.test` — 14 passed (13 existing + 1 new contract guard)
- [x] New unit test added (`FamilyLegend.test.tsx`): guards against accidental inline-style re-introduction of a 2-column layout
- [x] No new e2e spec — existing behavioral coverage in `family-legend.spec.ts` and `family-legend-viewport.spec.ts` is sufficient (zero layout/dimension assertions per issue D1, D2, D3)
- [x] `npm run build --workspace @bird-watch/frontend` — exit 0, clean production build
- [x] (UI only) Playwright MCP smoke — drove `http://localhost:5173/?view=map` at 1440×900 and 390×844 with stubbed `/api/silhouettes` (13 families) + `/api/observations` (36 obs across all 13). Verified single-column entries via accessibility snapshot box dimensions: `.family-legend` width=240px (desktop) / 243px (mobile), list `[box=29,422,238,400]` (desktop, 400px high), list `[box=29,526,241,240]` (mobile, 240px high). Overflow-y functional. No horizontal scrollbar. `browser_console_messages` returns 0 errors / 0 warnings at both viewports.

## Plan reference

Out of plan — Closes #353 (issue includes its own task list and decision matrix; bot pre-approved the plan with two SUGGESTIONs, both applied: in-code test comment rephrased to "guard against accidental inline-style re-introduction"; commit message dimensional math reworded to qualitative).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)