### PR TITLE
feat(frontend): visible month labels on PhenologyChart

### DIFF
--- a/frontend/e2e/phenology.spec.ts
+++ b/frontend/e2e/phenology.spec.ts
@@ -48,6 +48,11 @@ test.describe('phenology chart on species detail (#356)', () => {
         await expect(chart).toBeVisible();
         await expect(chart.locator('rect')).toHaveCount(12);
 
+        // Visible month labels — 12 rotated <text> elements below the bars.
+        // First one reads 'Jan' (calendar order).
+        await expect(chart.locator('text.phenology-label')).toHaveCount(12);
+        await expect(chart.locator('text.phenology-label').first()).toHaveText('Jan');
+
         // Accessible label is present (role="img" + aria-label).
         await expect(chart).toHaveAttribute('role', 'img');
         await expect(chart).toHaveAttribute('aria-label', /phenology/i);

--- a/frontend/src/components/PhenologyChart.test.tsx
+++ b/frontend/src/components/PhenologyChart.test.tsx
@@ -33,7 +33,7 @@ describe('PhenologyChart', () => {
 
     const svg = container.querySelector('svg.phenology-chart');
     expect(svg).not.toBeNull();
-    expect(svg).toHaveAttribute('viewBox', '0 0 216 80');
+    expect(svg).toHaveAttribute('viewBox', '0 0 216 108');
 
     // Tallest bar should match the value with the highest count (24 in this
     // dataset). Smallest non-zero bar is for count=2 → 1/12 of full height.
@@ -43,6 +43,14 @@ describe('PhenologyChart', () => {
     // Bar 12 (count=24) is the max — height should be largest
     const maxIdx = heights.indexOf(Math.max(...heights));
     expect(maxIdx).toBe(11);
+
+    // Visible month labels — one <text class="phenology-label"> per slot,
+    // 3-letter abbreviations starting at 'Jan'. Marked aria-hidden so the
+    // SVG's aria-label and per-bar <title> tooltips remain the only
+    // semantic surface for assistive tech.
+    const labels = container.querySelectorAll('text.phenology-label');
+    expect(labels.length).toBe(12);
+    expect(labels[0]?.textContent).toBe('Jan');
   });
 
   it('zero-fills sparse responses to exactly 12 bars', async () => {
@@ -85,8 +93,8 @@ describe('PhenologyChart', () => {
     // All 12 bars rendered, all the same height (placeholder), all muted.
     const rects = Array.from(container.querySelectorAll('rect'));
     const heights = rects.map(r => Number(r.getAttribute('height')));
-    // Placeholder height is 10% of 80 viewport height = 8.
-    expect(heights.every(h => h === 8)).toBe(true);
+    // Placeholder height is 10% of 108 viewport height = 10.8 → rounded to 11.
+    expect(heights.every(h => h === 11)).toBe(true);
   });
 
   it('returns null on getPhenology error so the surrounding surface is unaffected', async () => {

--- a/frontend/src/components/PhenologyChart.tsx
+++ b/frontend/src/components/PhenologyChart.tsx
@@ -12,12 +12,21 @@ interface PhenologyState {
   data: Array<{ month: number; count: number }> | null;
 }
 
-const MONTH_LABELS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
+const MONTH_ABBRS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
 const VIEWBOX_WIDTH = 216; // 12 months × 18px slot width
-const VIEWBOX_HEIGHT = 80;
+// 80px bar area + 28px label gutter (24px to fit a rotated 3-letter string at
+// font-size="9" plus a 4px gap between bar floor and label baseline).
+const VIEWBOX_HEIGHT = 108;
+const BAR_AREA_HEIGHT = 80; // bars scale within this; gutter sits below
 const SLOT_WIDTH = 18;
 const BAR_PADDING = 2; // each side; bar width = SLOT_WIDTH - 2*BAR_PADDING
-const PLACEHOLDER_HEIGHT = Math.round(VIEWBOX_HEIGHT * 0.1); // 10% → 8
+// 10% of viewBox height — the formula keeps the historical "muted bars are
+// ~one tenth of the chart" relationship intact even though the absolute
+// pixel value moves from 8 → 11 with the gutter addition.
+const PLACEHOLDER_HEIGHT = Math.round(VIEWBOX_HEIGHT * 0.1);
 
 /**
  * Zero-fills a server's sparse phenology response (only months with non-zero
@@ -45,13 +54,16 @@ function zeroFill(
  * Rendering branches:
  *   - loading: <p role="status">Loading phenology…</p>
  *   - error:   returns null (the surrounding surface stays usable)
- *   - empty:   12 muted placeholder bars at 10% viewport height — gives the
- *              user a visible "no data" affordance without a textual stub
- *   - data:    12 <rect>s with heights scaled to max(count) in the dataset
+ *   - empty:   12 muted placeholder bars at 10% viewBox height — gives the
+ *              user a visible "no data" affordance without a textual stub.
+ *              Month labels still render under the bars for orientation.
+ *   - data:    12 <rect>s with heights scaled to max(count) in the dataset,
+ *              plus 12 rotated <text> labels (Jan…Dec) below the bar area
  *
  * Bar heights scale to `max(count)` per dataset (not a global cap), so the
  * shape of the seasonality curve is what the eye reads — not the absolute
- * volume across species.
+ * volume across species. Bars occupy the top 80 viewBox units; the bottom
+ * 28 are reserved for the month-label gutter.
  */
 export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
   const { speciesCode, apiClient } = props;
@@ -116,13 +128,15 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
           height = PLACEHOLDER_HEIGHT;
           className = 'phenology-bar phenology-bar-empty';
         } else {
-          // Scale bar height to dataset max. count=0 months render at height=0
-          // (no bar drawn), which is the desired "this month had zero
-          // observations" affordance against the active months.
-          height = max === 0 ? 0 : Math.round((d.count / max) * VIEWBOX_HEIGHT);
+          // Scale bar height to dataset max within the bar area (the top
+          // 80px). count=0 months render at height=0 (no bar drawn), which
+          // is the desired "this month had zero observations" affordance
+          // against the active months. The bottom 28px is reserved for the
+          // month-label gutter and is not available to bars.
+          height = max === 0 ? 0 : Math.round((d.count / max) * BAR_AREA_HEIGHT);
           className = 'phenology-bar';
         }
-        const y = VIEWBOX_HEIGHT - height;
+        const y = BAR_AREA_HEIGHT - height;
         return (
           <rect
             key={d.month}
@@ -133,9 +147,31 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
             height={height}
           >
             <title>
-              {`${MONTH_LABELS[i]}: ${d.count} observation${d.count === 1 ? '' : 's'}`}
+              {`${MONTH_ABBRS[i]}: ${d.count} observation${d.count === 1 ? '' : 's'}`}
             </title>
           </rect>
+        );
+      })}
+      {/* Visible month labels — 3-letter abbreviations rotated -45° so they
+          fit at 18px slot width without horizontal overlap. aria-hidden so
+          axe and screen readers don't double-announce against the SVG's
+          aria-label and the per-bar <title> tooltips. */}
+      {filled.map((d, i) => {
+        const x = i * SLOT_WIDTH + SLOT_WIDTH / 2;
+        const y = BAR_AREA_HEIGHT + 2; // 2px gap below bar floor
+        return (
+          <text
+            key={`label-${d.month}`}
+            className="phenology-label"
+            x={x}
+            y={y}
+            textAnchor="end"
+            fontSize="9"
+            transform={`rotate(-45, ${x}, ${y})`}
+            aria-hidden="true"
+          >
+            {MONTH_ABBRS[i]}
+          </text>
         );
       })}
     </svg>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -470,6 +470,11 @@ body {
   max-width: 432px;            /* 2× the 216 viewBox width — keeps bars crisp */
   height: auto;
   margin: 12px 0 0 0;
+  /* The Jan label rotates -45° around slot-center x=9 with text-anchor=end,
+     so its top-left corner extends ~1px past the viewBox's x=0. Allow the
+     overflow rather than padding the viewBox — keeps the bar geometry
+     identical and avoids a layout shift inside the parent container. */
+  overflow: visible;
 }
 .phenology-bar {
   fill: var(--color-text-strong);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -455,13 +455,15 @@ body {
   color: var(--color-text-body);
 }
 .species-detail-loading { color: var(--color-text-muted); font-size: 13px; margin: 8px 0 0 0; }
-/* Phenology chart (#356). 12 monthly observation-count bars rendered as
-   inline SVG inside the species detail body. Sits below .species-detail-family.
-   The SVG uses width:100% with a max-width cap so the chart scales cleanly on
-   both the 390×844 mobile and 1440×900 desktop release-1 viewports without
-   ballooning past the surface's 760px content cap. The viewBox keeps the
-   internal 216×80 coordinate space stable across viewports — bars stay 18px
-   slots in their own coordinate system regardless of rendered width. */
+/* Phenology chart (#356, #363). 12 monthly observation-count bars rendered
+   as inline SVG inside the species detail body. Sits below
+   .species-detail-family. The SVG uses width:100% with a max-width cap so
+   the chart scales cleanly on both the 390×844 mobile and 1440×900 desktop
+   release-1 viewports without ballooning past the surface's 760px content
+   cap. The viewBox keeps the internal 216×108 coordinate space stable
+   across viewports — bars occupy the top 80 units, the bottom 28 are the
+   month-label gutter, and 18px slots stay 18px slots in their own
+   coordinate system regardless of rendered width. */
 .phenology-chart {
   display: block;
   width: 100%;
@@ -474,6 +476,15 @@ body {
 }
 .phenology-bar-empty {
   fill: var(--color-border-subtle);
+}
+/* Visible month-axis labels under each bar. #555 on #f4f1ea (page background)
+   = 7.46:1 contrast — well above WCAG 4.5:1 for small text. font-family:
+   inherit so the SVG <text> picks up the body stack rather than the SVG
+   default sans-serif. aria-hidden on the elements means contrast is for
+   sighted readers only — the SVG's aria-label still names the chart. */
+.phenology-label {
+  fill: var(--color-text-muted);
+  font-family: inherit;
 }
 .phenology-chart-loading {
   color: var(--color-text-muted);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[ApiClient.getPhenology] --> B[PhenologyChart state]
    B -->|loading| C[role=status paragraph]
    B -->|error / null data| D[returns null]
    B -->|data or empty| E[svg.phenology-chart]
    E --> F[12 rect bars in top 80px]
    E --> G[12 text.phenology-label in 28px gutter]
    F -.->|aria-hidden=false, has title| H[per-bar tooltip]
    G -.->|aria-hidden=true| I[visible only]
```

The viewBox grows from 216×80 to 216×108 to add a 28px label gutter. Bars now scale within `BAR_AREA_HEIGHT=80`; labels render in the gutter at `y=82+` and are `aria-hidden` so axe and screen readers don't double-announce against the SVG's `aria-label` and the per-bar `<title>` tooltips.

## Summary

- The 12-month chart on the species-detail surface previously exposed month names only inside `<title>` tooltips — invisible without hovering. This PR adds rotated 3-letter month abbreviations (`Jan`…`Dec`) below each bar so the calendar axis is readable at a glance.
- No chart library, no new package dependency. Constants update in `PhenologyChart.tsx` (12 abbreviations + viewBox 80→108 + `BAR_AREA_HEIGHT=80`); a second `filled.map(...)` block emits one `<text>` per slot with `text-anchor="end"` and `transform="rotate(-45, x, y)"`. CSS adds `.phenology-label { fill: var(--color-text-muted); font-family: inherit; }` (7.46:1 contrast on the page background).
- One follow-on tweak: the Jan label rotates ~1px past the viewBox's left edge, so `.phenology-chart` gets `overflow: visible` to avoid clipping. Bar geometry stays identical.

## Screenshots

| Desktop (1440×900) | Mobile (390×844) |
|---|---|
| <img width="640" alt="Species detail surface at 1440×900 — phenology chart with all 12 month labels visible below the bars" src="https://github.com/user-attachments/assets/a5daf09f-cea9-407e-be47-bfe7c20ee838" /> | <img width="320" alt="Species detail surface at 390×844 — phenology chart with all 12 month labels visible below the bars" src="https://github.com/user-attachments/assets/2f7ea048-fb45-4bde-b56c-738f0ffbd950" /> |

Both shots taken via Playwright MCP against `?detail=verfly&view=detail` with the dev server pointed at `https://api.bird-maps.com`. Zero console errors / warnings at each viewport. All 12 labels (Jan…Dec) visible and unclipped; the rotated Jan label sits 1px past the viewBox's left edge but renders cleanly thanks to the new `overflow: visible` rule on `.phenology-chart`.

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 419 passed
- [x] Unit-test assertions updated: `viewBox` now `0 0 216 108` (line 36); empty-state placeholder height now `h === 11` (line 89, computed from `Math.round(108 * 0.1)`); two new assertions check `text.phenology-label` count is 12 and first label reads `Jan`.
- [x] E2E happy-path adds `await expect(chart.locator('text.phenology-label')).toHaveCount(12)` and a `Jan`-text assertion. The 6 console-cleanliness specs pass through unchanged.
- [x] `npm run build --workspace @bird-watch/frontend` — clean (`tsc -b && vite build`).
- [x] `npx knip` — clean.
- [x] Playwright MCP smoke — drove `?detail=verfly&view=detail` (real prod species code; the issue's `vermfly` is a test-fixture key) at 1440×900 and 390×844 against `VITE_API_BASE_URL=https://api.bird-maps.com`. Zero console errors / warnings at both viewports. All 12 labels visible, no clipping, no overlap with the bar area.

## Plan reference

`docs/plans/2026-05-02-phenology-analytics-execution.md` — chart label follow-up (#363)

Closes #363

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)