### PR TITLE
fix(frontend): visible count labels + label-bar spacing + Jan clip on PhenologyChart

### DIFF
--- a/frontend/e2e/phenology.spec.ts
+++ b/frontend/e2e/phenology.spec.ts
@@ -53,6 +53,15 @@ test.describe('phenology chart on species detail (#356)', () => {
         await expect(chart.locator('text.phenology-label')).toHaveCount(12);
         await expect(chart.locator('text.phenology-label').first()).toHaveText('Jan');
 
+        // Visible count labels above each non-zero bar (#365). The full
+        // fixture has 12 non-zero months → 12 count labels render.
+        await expect(chart.locator('text.phenology-count')).toHaveCount(12);
+
+        // SVG `overflow="visible"` attribute is the actual fix for Jan
+        // label clipping — CSS overflow alone does not override SVG's
+        // intrinsic viewBox clipping (#365).
+        await expect(chart).toHaveAttribute('overflow', 'visible');
+
         // Accessible label is present (role="img" + aria-label).
         await expect(chart).toHaveAttribute('role', 'img');
         await expect(chart).toHaveAttribute('aria-label', /phenology/i);
@@ -76,6 +85,9 @@ test.describe('phenology chart on species detail (#356)', () => {
         await expect(chart.locator('rect')).toHaveCount(12);
         // Placeholder bars carry the muted class.
         await expect(chart.locator('rect.phenology-bar-empty')).toHaveCount(12);
+        // Empty fixture has no non-zero counts — zero count labels render
+        // (#365 — count labels are skipped when count === 0).
+        await expect(chart.locator('text.phenology-count')).toHaveCount(0);
       });
 
       test('error path — no chart element but surface text still present', async ({ page, apiStub }) => {

--- a/frontend/src/components/PhenologyChart.test.tsx
+++ b/frontend/src/components/PhenologyChart.test.tsx
@@ -63,6 +63,27 @@ describe('PhenologyChart', () => {
     // against the SVG's aria-label and per-bar <title> tooltips.
     const counts = container.querySelectorAll('text.phenology-count');
     expect(counts.length).toBe(12);
+
+    // Tallest bar's count label (count=24, barTop=0) is clamped to y=8 by
+    // Math.max(barTop-2, 8), placing it INSIDE the dark bar fill. The
+    // .phenology-count-on-bar variant flips the fill to white so the number
+    // remains readable (>= 7:1 against --color-text-strong=#1a1a1a). All
+    // shorter bars keep the default --color-text-body fill above the bar.
+    const countTexts = Array.from(
+      container.querySelectorAll<SVGTextElement>('text.phenology-count'),
+    );
+    // Find the count label that renders the max value (24).
+    const tallestCount = countTexts.find(t => t.textContent === '24');
+    expect(tallestCount).toBeDefined();
+    expect(tallestCount!.getAttribute('class')).toContain(
+      'phenology-count-on-bar',
+    );
+    // Non-tallest bars (e.g. count=2) render above the bar — no on-bar class.
+    const shorterCount = countTexts.find(t => t.textContent === '2');
+    expect(shorterCount).toBeDefined();
+    expect(shorterCount!.getAttribute('class')).not.toContain(
+      'phenology-count-on-bar',
+    );
   });
 
   it('zero-fills sparse responses to exactly 12 bars', async () => {

--- a/frontend/src/components/PhenologyChart.test.tsx
+++ b/frontend/src/components/PhenologyChart.test.tsx
@@ -34,6 +34,11 @@ describe('PhenologyChart', () => {
     const svg = container.querySelector('svg.phenology-chart');
     expect(svg).not.toBeNull();
     expect(svg).toHaveAttribute('viewBox', '0 0 216 108');
+    // SVG attribute `overflow="visible"` is the actual fix for the Jan
+    // label clipping at the left edge (#365). The CSS rule on
+    // .phenology-chart provides defense-in-depth, but SVG's intrinsic
+    // viewBox clipping is only overridden by the SVG attribute itself.
+    expect(svg).toHaveAttribute('overflow', 'visible');
 
     // Tallest bar should match the value with the highest count (24 in this
     // dataset). Smallest non-zero bar is for count=2 → 1/12 of full height.
@@ -51,6 +56,13 @@ describe('PhenologyChart', () => {
     const labels = container.querySelectorAll('text.phenology-label');
     expect(labels.length).toBe(12);
     expect(labels[0]?.textContent).toBe('Jan');
+
+    // Visible count labels — one <text class="phenology-count"> per non-zero
+    // bar (issue #365). All 12 fixture entries are non-zero so all 12 count
+    // labels render. aria-hidden so assistive tech doesn't double-announce
+    // against the SVG's aria-label and per-bar <title> tooltips.
+    const counts = container.querySelectorAll('text.phenology-count');
+    expect(counts.length).toBe(12);
   });
 
   it('zero-fills sparse responses to exactly 12 bars', async () => {
@@ -78,6 +90,11 @@ describe('PhenologyChart', () => {
     // Exactly three bars should be non-zero.
     const nonZero = heights.filter(h => h > 0);
     expect(nonZero.length).toBe(3);
+
+    // One <text class="phenology-count"> per non-zero bar — sparse fixture
+    // has 3 non-zero months, so 3 count labels should render (issue #365).
+    const counts = container.querySelectorAll('text.phenology-count');
+    expect(counts.length).toBe(3);
   });
 
   it('renders muted placeholder bars (10% height) for an empty response', async () => {
@@ -93,8 +110,15 @@ describe('PhenologyChart', () => {
     // All 12 bars rendered, all the same height (placeholder), all muted.
     const rects = Array.from(container.querySelectorAll('rect'));
     const heights = rects.map(r => Number(r.getAttribute('height')));
-    // Placeholder height is 10% of 108 viewport height = 10.8 → rounded to 11.
-    expect(heights.every(h => h === 11)).toBe(true);
+    // Placeholder height is 10% of BAR_AREA_HEIGHT (70 after #365 spacing
+    // fix) = 7. Bar area shrank from 80 → 70 to widen the gutter so the
+    // rotated month labels no longer overlap the bar floor.
+    expect(heights.every(h => h === 7)).toBe(true);
+
+    // Empty fixture: zero bars are non-zero, so zero count labels render
+    // (issue #365 — count labels are skipped when count === 0).
+    const counts = container.querySelectorAll('text.phenology-count');
+    expect(counts.length).toBe(0);
   });
 
   it('returns null on getPhenology error so the surrounding surface is unaffected', async () => {

--- a/frontend/src/components/PhenologyChart.tsx
+++ b/frontend/src/components/PhenologyChart.tsx
@@ -17,16 +17,17 @@ const MONTH_ABBRS = [
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ];
 const VIEWBOX_WIDTH = 216; // 12 months × 18px slot width
-// 80px bar area + 28px label gutter (24px to fit a rotated 3-letter string at
-// font-size="9" plus a 4px gap between bar floor and label baseline).
+// 70px bar area + 38px label gutter (24px to fit a rotated 3-letter string
+// at font-size="9" plus a 14px gap between bar floor and label baseline so
+// the rotated label's top-right corner doesn't intrude into the bar zone —
+// issue #365 task 2).
 const VIEWBOX_HEIGHT = 108;
-const BAR_AREA_HEIGHT = 80; // bars scale within this; gutter sits below
+const BAR_AREA_HEIGHT = 70; // bars scale within this; gutter sits below
 const SLOT_WIDTH = 18;
 const BAR_PADDING = 2; // each side; bar width = SLOT_WIDTH - 2*BAR_PADDING
-// 10% of viewBox height — the formula keeps the historical "muted bars are
-// ~one tenth of the chart" relationship intact even though the absolute
-// pixel value moves from 8 → 11 with the gutter addition.
-const PLACEHOLDER_HEIGHT = Math.round(VIEWBOX_HEIGHT * 0.1);
+// 10% of bar area height — keeps muted placeholder bars at ~one tenth of
+// their drawable region. With BAR_AREA_HEIGHT=70 this rounds to 7px.
+const PLACEHOLDER_HEIGHT = Math.round(BAR_AREA_HEIGHT * 0.1);
 
 /**
  * Zero-fills a server's sparse phenology response (only months with non-zero
@@ -62,8 +63,9 @@ function zeroFill(
  *
  * Bar heights scale to `max(count)` per dataset (not a global cap), so the
  * shape of the seasonality curve is what the eye reads — not the absolute
- * volume across species. Bars occupy the top 80 viewBox units; the bottom
- * 28 are reserved for the month-label gutter.
+ * volume across species. Bars occupy the top 70 viewBox units; the bottom
+ * 38 are reserved for the month-label gutter (#365 widened the gutter
+ * from 28 → 38 so rotated labels no longer overlap the bar floor).
  */
 export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
   const { speciesCode, apiClient } = props;
@@ -118,6 +120,12 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
       role="img"
       aria-label="Monthly phenology — observations per month"
       focusable="false"
+      // The Jan label rotates -45° around slot-center x=9 and extends ~1px
+      // past the viewBox's x=0. The CSS `overflow: visible` rule on
+      // .phenology-chart alone is not sufficient — SVG has intrinsic
+      // viewBox clipping that CSS doesn't override. The SVG attribute is
+      // the actual fix; the CSS rule remains as defense-in-depth (#365).
+      overflow="visible"
     >
       {filled.map((d, i) => {
         const x = i * SLOT_WIDTH + BAR_PADDING;
@@ -129,9 +137,9 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
           className = 'phenology-bar phenology-bar-empty';
         } else {
           // Scale bar height to dataset max within the bar area (the top
-          // 80px). count=0 months render at height=0 (no bar drawn), which
+          // 70px). count=0 months render at height=0 (no bar drawn), which
           // is the desired "this month had zero observations" affordance
-          // against the active months. The bottom 28px is reserved for the
+          // against the active months. The bottom 38px is reserved for the
           // month-label gutter and is not available to bars.
           height = max === 0 ? 0 : Math.round((d.count / max) * BAR_AREA_HEIGHT);
           className = 'phenology-bar';
@@ -152,13 +160,45 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
           </rect>
         );
       })}
+      {/* Visible count labels — one per non-zero bar. Sighted-only
+          enhancement (aria-hidden); the chart's aria-label and per-bar
+          <title> already cover assistive tech. 0-count bars get no label
+          (12 zeros would be visual noise; the empty-state placeholder
+          bars also stay number-free). For the tallest bar (count=max,
+          barTop=0), a y of barTop-2 = -2 would render above the viewBox
+          — the Math.max(..., 8) clamp prevents that off-screen
+          rendering (#365 task 1). */}
+      {filled.map((d, i) => {
+        if (d.count === 0) return null;
+        const x = i * SLOT_WIDTH + SLOT_WIDTH / 2;
+        const barTop =
+          max === 0
+            ? BAR_AREA_HEIGHT
+            : BAR_AREA_HEIGHT - Math.round((d.count / max) * BAR_AREA_HEIGHT);
+        const y = Math.max(barTop - 2, 8);
+        return (
+          <text
+            key={`count-${d.month}`}
+            className="phenology-count"
+            x={x}
+            y={y}
+            textAnchor="middle"
+            fontSize="7"
+            aria-hidden="true"
+          >
+            {d.count}
+          </text>
+        );
+      })}
       {/* Visible month labels — 3-letter abbreviations rotated -45° so they
           fit at 18px slot width without horizontal overlap. aria-hidden so
           axe and screen readers don't double-announce against the SVG's
-          aria-label and the per-bar <title> tooltips. */}
+          aria-label and the per-bar <title> tooltips. y=BAR_AREA_HEIGHT+12
+          places the rotated label baseline 12px below the bar floor — the
+          rotated label's top-right corner clears the bar zone (#365). */}
       {filled.map((d, i) => {
         const x = i * SLOT_WIDTH + SLOT_WIDTH / 2;
-        const y = BAR_AREA_HEIGHT + 2; // 2px gap below bar floor
+        const y = BAR_AREA_HEIGHT + 12;
         return (
           <text
             key={`label-${d.month}`}

--- a/frontend/src/components/PhenologyChart.tsx
+++ b/frontend/src/components/PhenologyChart.tsx
@@ -176,10 +176,21 @@ export function PhenologyChart(props: PhenologyChartProps): JSX.Element | null {
             ? BAR_AREA_HEIGHT
             : BAR_AREA_HEIGHT - Math.round((d.count / max) * BAR_AREA_HEIGHT);
         const y = Math.max(barTop - 2, 8);
+        // When the label is clamped inside the bar (y >= barTop) — the
+        // tallest bar reaches barTop=0 so y=8 sits inside the dark fill —
+        // the default --color-text-body (#444) on --color-text-strong
+        // (#1a1a1a) drops to ~1.7:1 contrast (WCAG AA fails 4.5:1). Flip
+        // to a white fill via .phenology-count-on-bar so the count label
+        // remains readable. Shorter bars keep the dark fill above the bar.
+        const labelInsideBar = y >= barTop;
         return (
           <text
             key={`count-${d.month}`}
-            className="phenology-count"
+            className={
+              labelInsideBar
+                ? 'phenology-count phenology-count-on-bar'
+                : 'phenology-count'
+            }
             x={x}
             y={y}
             textAnchor="middle"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -455,14 +455,15 @@ body {
   color: var(--color-text-body);
 }
 .species-detail-loading { color: var(--color-text-muted); font-size: 13px; margin: 8px 0 0 0; }
-/* Phenology chart (#356, #363). 12 monthly observation-count bars rendered
-   as inline SVG inside the species detail body. Sits below
+/* Phenology chart (#356, #363, #365). 12 monthly observation-count bars
+   rendered as inline SVG inside the species detail body. Sits below
    .species-detail-family. The SVG uses width:100% with a max-width cap so
    the chart scales cleanly on both the 390×844 mobile and 1440×900 desktop
    release-1 viewports without ballooning past the surface's 760px content
    cap. The viewBox keeps the internal 216×108 coordinate space stable
-   across viewports — bars occupy the top 80 units, the bottom 28 are the
-   month-label gutter, and 18px slots stay 18px slots in their own
+   across viewports — bars occupy the top 70 units, the bottom 38 are the
+   month-label gutter (widened from 28 → 38 in #365 so rotated labels
+   clear the bar floor), and 18px slots stay 18px slots in their own
    coordinate system regardless of rendered width. */
 .phenology-chart {
   display: block;
@@ -489,6 +490,15 @@ body {
    sighted readers only — the SVG's aria-label still names the chart. */
 .phenology-label {
   fill: var(--color-text-muted);
+  font-family: inherit;
+}
+/* Visible count labels above each non-zero bar (#365). Uses the body-text
+   color (rather than text-muted on .phenology-label) for higher contrast —
+   these numbers are the chart's primary data signal. font-family: inherit
+   matches the .phenology-label rule so both axis surfaces use the same
+   font stack. */
+.phenology-count {
+  fill: var(--color-text-body);
   font-family: inherit;
 }
 .phenology-chart-loading {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -501,6 +501,16 @@ body {
   fill: var(--color-text-body);
   font-family: inherit;
 }
+/* Variant for the tallest bar's count label, whose y is clamped to 8 inside
+   the bar zone (y=0..70) so the label overlaps the dark bar fill. The
+   default --color-text-body (#444) on --color-text-strong (#1a1a1a) is only
+   ~1.7:1 — WCAG AA needs 4.5:1. Pure white pushes contrast to ~16:1, well
+   into AAA territory. Hard-coded #ffffff (rather than --color-text-white,
+   which carries a "text on dark backgrounds" semantic anyway) keeps the
+   intent self-evident at the rule. */
+.phenology-count-on-bar {
+  fill: #ffffff;
+}
 .phenology-chart-loading {
   color: var(--color-text-muted);
   font-size: 13px;


### PR DESCRIPTION
## Diagrams

N/A — pure visual change to existing PhenologyChart SVG geometry.

## Summary

- Sighted users now see observation counts above each non-zero bar (count was previously only in the hover `<title>` tooltip — anonymous to anyone not hovering).
- Label gutter widened (bar area 80→70px, gutter 28→38px) so the rotated month labels no longer overlap the bar floor at production render dimensions.
- SVG `overflow="visible"` attribute added — the existing CSS `overflow: visible` rule alone does not override SVG's intrinsic viewBox clipping, so "Jan" was rendering as "an" at the left edge in production. CSS rule retained as defense-in-depth.

## Screenshots

| Desktop (1440×900) | Mobile (390×844) |
| --- | --- |
| <img alt="PhenologyChart fixed at desktop 1440x900: 12 count labels above bars, Jan label fully visible at left edge, month labels clear bar floor" src="https://github.com/user-attachments/assets/38dd10f7-2bcf-4387-9955-78a010989069" width="640" /> | <img alt="PhenologyChart fixed at mobile 390x844: 12 count labels above bars, Jan label fully visible at left edge, month labels clear bar floor" src="https://github.com/user-attachments/assets/ef705e84-d6e8-45a8-8abd-baabfdda9780" width="320" /> |

Both views show: count labels above each non-zero bar (8, 6, 14, 37, 5, 12, 18, 22, 16, 11, 9, 7), "Jan" rendering completely at the left edge (not "an"), and month labels (Jan…Dec) sitting clear of the bar floor with a 12px gutter.

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 419 passed (38 files)
- [x] Updated unit assertions in `PhenologyChart.test.tsx` — count-label count per fixture, `overflow="visible"` SVG attribute, placeholder height now 7px (was 11px)
- [x] Extended e2e spec `frontend/e2e/phenology.spec.ts` — count label count per branch (12 happy / 0 empty), SVG `overflow="visible"` attribute
- [x] `npm run build --workspace @bird-watch/frontend` — clean tsc + vite build
- [x] `npx knip` — clean
- [x] Playwright MCP smoke at 390×844 and 1440×900 — drove `?detail=norcar&view=detail` against a local mock API matching production phenology shape (12 non-zero counts, max=37); all 12 count labels visible above bars, "Jan" renders fully at left edge, month labels clear bar floor, zero console errors/warnings (favicon 404 filtered as preexisting dev-server noise)

## Plan reference

`docs/plans/2026-05-02-phenology-analytics-execution.md` — chart fixes follow-up (#365). Out of plan in the strict sense (the plan tracks ingestor + endpoint work; this PR closes a visible-rendering gap observed against production).

Closes #365

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)