### PR TITLE
feat(ingestor): iNat /v1/taxa client + probe-taxon CLI debug kind

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -16,6 +16,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): CliDeps {
     runBackfill: vi.fn(),
     runTaxonomy: vi.fn(),
     runPhotos: vi.fn(),
+    fetchInatTaxon: vi.fn(),
     ...overrides,
   };
 }
@@ -23,6 +24,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): CliDeps {
 describe('runCli', () => {
   const ORIGINAL_ENV = process.env;
   const ORIGINAL_EXIT_CODE = process.exitCode;
+  const ORIGINAL_ARGV = process.argv;
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -33,6 +35,7 @@ describe('runCli', () => {
   afterEach(() => {
     process.env = ORIGINAL_ENV;
     process.exitCode = ORIGINAL_EXIT_CODE;
+    process.argv = ORIGINAL_ARGV;
     logSpy.mockRestore();
   });
 
@@ -115,5 +118,39 @@ describe('runCli', () => {
     delete process.env.DATABASE_URL;
     const deps = makeDeps();
     await expect(runCli('recent', deps)).rejects.toThrow(/DATABASE_URL/);
+  });
+
+  it('"probe-taxon" runs without EBIRD_API_KEY/DATABASE_URL set (debug kind, no DB)', async () => {
+    // probe-taxon is an operator triage tool — it does not touch the DB and
+    // does not need eBird credentials. The kind must early-return ahead of
+    // the env guards so an operator can run it locally without secrets in
+    // their shell. Regression check: pre-fix, the EBIRD_API_KEY guard fired
+    // first and forced operators to set a junk key just to run a debug.
+    delete process.env.EBIRD_API_KEY;
+    delete process.env.DATABASE_URL;
+    process.argv = ['node', 'cli.ts', 'probe-taxon', 'Setophaga coronata'];
+    const fetchInatTaxonSpy = vi.fn().mockResolvedValue({
+      inatTaxonId: 9083,
+      wikipediaUrl: 'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+    });
+    const deps = makeDeps({ fetchInatTaxon: fetchInatTaxonSpy });
+
+    await runCli('probe-taxon', deps);
+
+    expect(fetchInatTaxonSpy).toHaveBeenCalledWith('Setophaga coronata');
+    // No DB pool was created — the env guards were correctly bypassed and the
+    // probe path never reached the createPool branch.
+    expect(deps.createPool).not.toHaveBeenCalled();
+    expect(deps.closePool).not.toHaveBeenCalled();
+    // Result is logged as JSON for the operator to grep.
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('"probe-taxon" without a binomial argument throws', async () => {
+    process.argv = ['node', 'cli.ts', 'probe-taxon'];
+    const deps = makeDeps();
+    await expect(runCli('probe-taxon', deps)).rejects.toThrow(
+      /probe-taxon requires a binomial/
+    );
   });
 });

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -22,6 +22,7 @@ import {
   runPhotos as realRunPhotos,
   type RunPhotosSummary,
 } from './run-photos.js';
+import { fetchInatTaxon as realFetchInatTaxon } from './inat/taxon-client.js';
 
 /**
  * Every run summary discriminates on `status`. `RunBackfillSummary` can also be
@@ -48,6 +49,7 @@ export interface CliDeps {
   runBackfill: typeof realRunBackfill;
   runTaxonomy: typeof realRunTaxonomy;
   runPhotos: typeof realRunPhotos;
+  fetchInatTaxon: typeof realFetchInatTaxon;
 }
 
 /**
@@ -64,6 +66,18 @@ export interface CliDeps {
  * outer IIFE catches them to print a stack trace and exit 1.
  */
 export async function runCli(kind: string, deps: CliDeps): Promise<void> {
+  // probe-taxon is an operator triage tool that hits iNat's /v1/taxa endpoint
+  // directly — no DB, no eBird auth. Early-return ahead of the env guards so
+  // an operator can `npx tsx services/ingestor/src/cli.ts probe-taxon "..."`
+  // locally without setting EBIRD_API_KEY or DATABASE_URL in their shell.
+  if (kind === 'probe-taxon') {
+    const sciName = process.argv[3];
+    if (!sciName) throw new Error('probe-taxon requires a binomial argument');
+    const taxon = await deps.fetchInatTaxon(sciName);
+    console.log(JSON.stringify(taxon, null, 2));
+    return;
+  }
+
   const apiKey = process.env.EBIRD_API_KEY;
   const dbUrl = process.env.DATABASE_URL;
   if (!apiKey) throw new Error('EBIRD_API_KEY not set');
@@ -107,7 +121,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else if (kind === 'photos') {
       summary = await deps.runPhotos({ pool });
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | probe-taxon`);
     }
     console.log(JSON.stringify(summary, null, 2));
     if (summary.status === 'failure') {
@@ -144,6 +158,7 @@ if (isEntrypoint) {
     runBackfill: realRunBackfill,
     runTaxonomy: realRunTaxonomy,
     runPhotos: realRunPhotos,
+    fetchInatTaxon: realFetchInatTaxon,
   }).catch(err => {
     console.error(err);
     process.exit(1);

--- a/services/ingestor/src/inat/client.ts
+++ b/services/ingestor/src/inat/client.ts
@@ -7,7 +7,9 @@ import type {
 // API recommended-practices doc (https://www.inaturalist.org/pages/api+recommended+practices)
 // asks for meaningful UA strings so they can contact the app maintainer if a
 // problem is observed. Anonymous UAs may be throttled or blocked outright.
-const USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
+// Exported so sibling iNat clients (taxon-client.ts) can present the same
+// identity — iNat's per-UA throttle bucketing depends on it.
+export const INAT_USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
 
 // place_id=40 is iNaturalist's canonical "Arizona" Place. Confirmed via
 // `GET https://api.inaturalist.org/v1/places/40` returning `name='Arizona'`,
@@ -130,7 +132,14 @@ export async function fetchInatPhoto(
   return null;
 }
 
-async function getJsonWithRetry<T>(
+/**
+ * Shared fetch + retry helper for any iNat /v1/* JSON endpoint. Exported so
+ * sibling clients (taxon-client.ts) can use the same retry/UA/timeout
+ * semantics without duplicating the loop. 429 and 5xx are transient and
+ * trigger the configured retry; other 4xx are programmer errors and surface
+ * immediately.
+ */
+export async function getJsonWithRetry<T>(
   url: URL,
   maxRetries: number,
   retryBaseMs: number,
@@ -141,7 +150,7 @@ async function getJsonWithRetry<T>(
     try {
       const res = await fetch(url, {
         headers: {
-          'User-Agent': USER_AGENT,
+          'User-Agent': INAT_USER_AGENT,
           accept: 'application/json',
         },
         signal: AbortSignal.timeout(requestTimeoutMs),

--- a/services/ingestor/src/inat/taxon-client.test.ts
+++ b/services/ingestor/src/inat/taxon-client.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fetchInatTaxon } from './taxon-client.js';
+import { InatClientError } from './client.js';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const INAT_TAXA_URL = 'https://api.inaturalist.org/v1/taxa';
+
+describe('fetchInatTaxon', () => {
+  it('returns { inatTaxonId, wikipediaUrl } on exact-match species', async () => {
+    server.use(
+      http.get(INAT_TAXA_URL, ({ request }) => {
+        const url = new URL(request.url);
+        // Verify the full query-param contract from the issue spec.
+        expect(url.searchParams.get('q')).toBe('Setophaga coronata');
+        expect(url.searchParams.get('rank')).toBe('species');
+        expect(url.searchParams.get('is_active')).toBe('true');
+        expect(url.searchParams.get('per_page')).toBe('1');
+        // iNat recommended-practices doc requires a meaningful UA.
+        expect(request.headers.get('User-Agent')).toMatch(/bird-maps\.com/);
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              matched_term: 'Setophaga coronata',
+              wikipedia_url:
+                'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+            },
+          ],
+        });
+      })
+    );
+
+    const taxon = await fetchInatTaxon('Setophaga coronata');
+
+    expect(taxon).not.toBeNull();
+    expect(taxon).toEqual({
+      inatTaxonId: 9083,
+      wikipediaUrl: 'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+    });
+  });
+
+  it('resolves a trinomial (subspecies) to the canonical species via matched_term', async () => {
+    // iNat's `rank=species` filter forces results to species-level; the
+    // matched_term echoes "Setophaga coronata coronata" but `id` and `name`
+    // belong to the species, not the subspecies. This is what makes the single
+    // /v1/taxa call sufficient for both subspecies and synonym lookups.
+    server.use(
+      http.get(INAT_TAXA_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('q')).toBe('Setophaga coronata coronata');
+        expect(url.searchParams.get('rank')).toBe('species');
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              matched_term: 'Setophaga coronata coronata',
+              wikipedia_url:
+                'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+            },
+          ],
+        });
+      })
+    );
+
+    const taxon = await fetchInatTaxon('Setophaga coronata coronata');
+
+    // The species-level inatTaxonId is what gets persisted in
+    // `species_meta.inat_taxon_id` (child #371) — never the subspecies-level
+    // id, which would silently break per-id Wikipedia lookups in #374.
+    expect(taxon?.inatTaxonId).toBe(9083);
+    expect(taxon?.wikipediaUrl).toBe(
+      'https://en.wikipedia.org/wiki/Yellow-rumped_warbler'
+    );
+  });
+
+  it('resolves a cross-genus synonym (Dendroica → Setophaga) via matched_term', async () => {
+    // Dendroica coronata is the obsolete genus name for Setophaga coronata
+    // (split formalised by AOU 50th supplement, 2009). iNat's synonym table
+    // resolves the obsolete binomial to the current species in a single call.
+    server.use(
+      http.get(INAT_TAXA_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('q')).toBe('Dendroica coronata');
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              matched_term: 'Dendroica coronata',
+              wikipedia_url:
+                'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+            },
+          ],
+        });
+      })
+    );
+
+    const taxon = await fetchInatTaxon('Dendroica coronata');
+
+    expect(taxon?.inatTaxonId).toBe(9083);
+    expect(taxon?.wikipediaUrl).toBe(
+      'https://en.wikipedia.org/wiki/Yellow-rumped_warbler'
+    );
+  });
+
+  it('returns null on zero results', async () => {
+    server.use(
+      http.get(INAT_TAXA_URL, () =>
+        HttpResponse.json({
+          total_results: 0,
+          page: 1,
+          per_page: 1,
+          results: [],
+        })
+      )
+    );
+
+    const taxon = await fetchInatTaxon('Imaginarius nonexistens');
+    expect(taxon).toBeNull();
+  });
+
+  it('surfaces wikipedia_url: null in the response as wikipediaUrl: null', async () => {
+    // Some species have an iNat taxon record but no Wikipedia cross-reference
+    // (rare splits, regional lumps). The helper must not coerce null to "" or
+    // a string "null" — child #374's per-id fetch needs to detect the absence
+    // and fall back to the iNat-summary path.
+    server.use(
+      http.get(INAT_TAXA_URL, () =>
+        HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 12345,
+              name: 'Some Species',
+              rank: 'species',
+              matched_term: 'Some Species',
+              wikipedia_url: null,
+            },
+          ],
+        })
+      )
+    );
+
+    const taxon = await fetchInatTaxon('Some Species');
+
+    expect(taxon).toEqual({ inatTaxonId: 12345, wikipediaUrl: null });
+  });
+
+  it('retries once on 429 and succeeds on the second attempt', async () => {
+    let calls = 0;
+    server.use(
+      http.get(INAT_TAXA_URL, () => {
+        calls++;
+        if (calls === 1) {
+          return new HttpResponse('rate limited', { status: 429 });
+        }
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              matched_term: 'Setophaga coronata',
+              wikipedia_url:
+                'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+            },
+          ],
+        });
+      })
+    );
+
+    const taxon = await fetchInatTaxon('Setophaga coronata', {
+      retryBaseMs: 1,
+    });
+
+    expect(calls).toBe(2);
+    expect(taxon?.inatTaxonId).toBe(9083);
+  });
+
+  it('throws InatClientError on 4xx (non-429) without retry', async () => {
+    let calls = 0;
+    server.use(
+      http.get(INAT_TAXA_URL, () => {
+        calls++;
+        return new HttpResponse('bad request', { status: 400 });
+      })
+    );
+
+    await expect(fetchInatTaxon('Bad Query')).rejects.toBeInstanceOf(
+      InatClientError
+    );
+    // 400 is a programming error — retrying would obscure the bug. Confirm we
+    // didn't retry.
+    expect(calls).toBe(1);
+  });
+});

--- a/services/ingestor/src/inat/taxon-client.ts
+++ b/services/ingestor/src/inat/taxon-client.ts
@@ -1,0 +1,85 @@
+import { getJsonWithRetry } from './client.js';
+import type { InatTaxon } from './types.js';
+
+const INAT_BASE_URL = 'https://api.inaturalist.org/v1';
+
+// Internal projection of the iNat /v1/taxa response we care about. The real
+// payload includes ~30 fields per result (ancestors, default_photo, conservation
+// status, observations_count, etc.) — we only need id and wikipedia_url to
+// satisfy the consumer contract in `InatTaxon`. matched_term is captured to
+// document the resolution path (subspecies / synonym) but not surfaced.
+interface InatTaxaResult {
+  id: number;
+  name: string;
+  rank: string;
+  matched_term?: string;
+  wikipedia_url: string | null;
+}
+
+interface InatTaxaResponse {
+  total_results: number;
+  page: number;
+  per_page: number;
+  results: InatTaxaResult[];
+}
+
+export interface FetchInatTaxonOptions {
+  baseUrl?: string;
+  /** Total attempts on transient failures (429 / 5xx). Default 1 retry => 2 total attempts. */
+  maxRetries?: number;
+  retryBaseMs?: number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Resolves a binomial scientific name to an iNaturalist taxon record via the
+ * `/v1/taxa` search endpoint.
+ *
+ * iNat's `rank=species` + `matched_term` resolves both trinomials (e.g.
+ * *Setophaga coronata coronata*) and cross-genus synonyms (e.g. *Dendroica
+ * coronata* → *Setophaga coronata*) in a single call — verified live against
+ * `https://api.inaturalist.org/v1/taxa?q=...&rank=species&is_active=true`.
+ * No client-side synonym retry loop is needed.
+ *
+ * Returns `null` when iNat reports zero hits — callers (child #371's
+ * `run-descriptions.ts`) will treat null as "no iNat record; skip the
+ * Wikipedia fallback path for this species".
+ *
+ * Retries once on transient failures (429, 5xx, network/timeout) via the
+ * shared `getJsonWithRetry` helper. 4xx other than 429 throws immediately
+ * (programmer error — retrying would only obscure the bug).
+ *
+ * Note: `wikipedia_summary` is intentionally NOT in this return shape — the
+ * search endpoint does not populate it. Child #374 owns the per-id
+ * (`/v1/taxa/{id}`) fetch path that surfaces the summary text.
+ */
+export async function fetchInatTaxon(
+  sciName: string,
+  opts: FetchInatTaxonOptions = {}
+): Promise<InatTaxon | null> {
+  const baseUrl = opts.baseUrl ?? INAT_BASE_URL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+
+  const url = new URL(`${baseUrl}/taxa`);
+  url.searchParams.set('q', sciName);
+  url.searchParams.set('rank', 'species');
+  url.searchParams.set('is_active', 'true');
+  url.searchParams.set('per_page', '1');
+
+  const body = await getJsonWithRetry<InatTaxaResponse>(
+    url,
+    maxRetries,
+    retryBaseMs,
+    requestTimeoutMs
+  );
+
+  const first = body.results[0];
+  if (!first) return null;
+
+  return {
+    inatTaxonId: first.id,
+    wikipediaUrl: first.wikipedia_url,
+  };
+}

--- a/services/ingestor/src/inat/types.ts
+++ b/services/ingestor/src/inat/types.ts
@@ -27,3 +27,13 @@ export interface InatObservationsResponse {
   per_page: number;
   results: InatObservation[];
 }
+
+// Public type contract for the iNaturalist /v1/taxa client. Consumers depend
+// only on this shape — the raw iNat taxon payload (much larger, with
+// matched_term, ancestors, default_photo, conservation_status, etc.) is
+// projected down to just the two fields child #371/#374 will consume from
+// `species_meta` (`inat_taxon_id`) and the descriptions cache (`wikipediaUrl`).
+export interface InatTaxon {
+  inatTaxonId: number;
+  wikipediaUrl: string | null; // null when iNat has no Wikipedia article cross-reference
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant CLI as cli.ts (probe-taxon)
    participant Helper as fetchInatTaxon
    participant Retry as getJsonWithRetry
    participant iNat as api.inaturalist.org

    CLI->>Helper: fetchInatTaxon("Setophaga coronata")
    Helper->>Retry: GET /v1/taxa?q=...&rank=species&is_active=true&per_page=1
    Retry->>iNat: fetch (UA: bird-maps.com/1.0)
    iNat-->>Retry: 429 rate limited
    Note over Retry: full-jitter exp backoff<br/>(retryBaseMs * 2^attempt)
    Retry->>iNat: fetch (retry attempt)
    iNat-->>Retry: 200 { results: [{ id, wikipedia_url, matched_term }] }
    Retry-->>Helper: parsed JSON
    Helper-->>CLI: { inatTaxonId, wikipediaUrl } | null
```

## Summary

- New `fetchInatTaxon(sciName, opts?)` helper resolves a binomial to `{ inatTaxonId, wikipediaUrl }` via iNat's `/v1/taxa` endpoint. `rank=species` + `matched_term` resolves trinomials AND cross-genus synonyms in a single call (verified live against iNat API), so no client-side synonym retry loop is needed.
- New `probe-taxon <sciName>` CLI debug kind for operator triage. Early-returns ahead of the `EBIRD_API_KEY`/`DATABASE_URL` env guards because it does not touch the DB and does not need eBird credentials — operators can debug name resolution locally without setting secrets in their shell.
- `getJsonWithRetry` and the `INAT_USER_AGENT` constant are now exported from `inat/client.ts` so the new helper reuses identical retry/UA/timeout semantics. Avoids a divergent retry policy that would silently double our 429 surface against iNat's per-UA throttle bucketing.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — 65 tests green (12 files, including the new 7-case `taxon-client.test.ts` and 2 new `cli.test.ts` cases for `probe-taxon`)
- [x] New unit tests added: exact-match, trinomial → canonical species, cross-genus synonym, zero results returns null, `wikipedia_url: null` surfaces as `wikipediaUrl: null`, 429 retries once and succeeds, 4xx (non-429) throws `InatClientError` without retry. Plus 2 CLI cases: `probe-taxon` runs without `EBIRD_API_KEY`/`DATABASE_URL` set, and throws when the binomial argument is missing.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, ingestor-only change
- [x] `npm run build` — clean across all workspaces (shared-types, db-client, ingestor, read-api, frontend)
- [x] `npm test` (full monorepo) — 576 tests across 4 workspaces, all green
- [x] `npm run lint` — clean
- [x] `npx knip` — exit 0, no new orphans (the `probe-taxon` CLI dispatch keeps `fetchInatTaxon` reachable from a static-traceable site)
- [x] Live acceptance: `npx tsx services/ingestor/src/cli.ts probe-taxon "Setophaga coronata"` (with `EBIRD_API_KEY` and `DATABASE_URL` unset) printed `{ "inatTaxonId": 145245, "wikipediaUrl": "http://en.wikipedia.org/wiki/Yellow-rumped_warbler" }` — confirms the env-guard bypass works against the real iNat API. Cross-genus synonym `"Dendroica coronata"` resolved to the same canonical species, confirming the issue's matched_term premise.

## Plan reference

Out of plan — epic #368 / closes #369

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)