### PR TITLE
feat(ingestor): Wikipedia REST client + ETag conditional GET + probe-wiki CLI

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -16,6 +16,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): CliDeps {
     runBackfill: vi.fn(),
     runTaxonomy: vi.fn(),
     runPhotos: vi.fn(),
+    fetchWikipediaSummary: vi.fn(),
     ...overrides,
   };
 }
@@ -115,5 +116,53 @@ describe('runCli', () => {
     delete process.env.DATABASE_URL;
     const deps = makeDeps();
     await expect(runCli('recent', deps)).rejects.toThrow(/DATABASE_URL/);
+  });
+
+  it('"probe-wiki" early-returns before the env guards (no DB, no eBird)', async () => {
+    // probe-wiki is an operator debug kind that hits Wikipedia's public REST
+    // endpoint — it has no DB writes and does not need EBIRD_API_KEY.
+    // The kind dispatch must short-circuit ahead of the env guards so the
+    // operator can run it without standing up the eBird/DB credentials.
+    delete process.env.EBIRD_API_KEY;
+    delete process.env.DATABASE_URL;
+    const ORIGINAL_ARGV = process.argv;
+    process.argv = ['node', 'cli.ts', 'probe-wiki', 'Vermilion_flycatcher'];
+    try {
+      const fakeSummary = {
+        notModified: false as const,
+        extractHtml: '<p>The vermilion flycatcher is...</p>',
+        revisionId: '42',
+        license: 'CC-BY-SA-4.0' as const,
+        etag: '"abc"',
+      };
+      const fetchSpy = vi.fn().mockResolvedValue(fakeSummary);
+      const deps = makeDeps({ fetchWikipediaSummary: fetchSpy });
+
+      await runCli('probe-wiki', deps);
+
+      // The wiki client received the title from argv[3] verbatim.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith('Vermilion_flycatcher');
+      // The DB path is bypassed entirely.
+      expect(deps.createPool).not.toHaveBeenCalled();
+      expect(deps.closePool).not.toHaveBeenCalled();
+      // Summary printed for operator triage.
+      expect(logSpy).toHaveBeenCalledWith(JSON.stringify(fakeSummary, null, 2));
+    } finally {
+      process.argv = ORIGINAL_ARGV;
+    }
+  });
+
+  it('"probe-wiki" without a title argument throws', async () => {
+    const ORIGINAL_ARGV = process.argv;
+    process.argv = ['node', 'cli.ts', 'probe-wiki'];
+    try {
+      const deps = makeDeps();
+      await expect(runCli('probe-wiki', deps)).rejects.toThrow(
+        /probe-wiki requires a title argument/
+      );
+    } finally {
+      process.argv = ORIGINAL_ARGV;
+    }
   });
 });

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -22,6 +22,7 @@ import {
   runPhotos as realRunPhotos,
   type RunPhotosSummary,
 } from './run-photos.js';
+import { fetchWikipediaSummary as realFetchWikipediaSummary } from './wikipedia/client.js';
 
 /**
  * Every run summary discriminates on `status`. `RunBackfillSummary` can also be
@@ -48,6 +49,7 @@ export interface CliDeps {
   runBackfill: typeof realRunBackfill;
   runTaxonomy: typeof realRunTaxonomy;
   runPhotos: typeof realRunPhotos;
+  fetchWikipediaSummary: typeof realFetchWikipediaSummary;
 }
 
 /**
@@ -64,6 +66,18 @@ export interface CliDeps {
  * outer IIFE catches them to print a stack trace and exit 1.
  */
 export async function runCli(kind: string, deps: CliDeps): Promise<void> {
+  // Operator debug kinds that don't touch the DB or eBird short-circuit
+  // ahead of the env guards below — that lets `probe-wiki` run from a
+  // laptop without standing up `EBIRD_API_KEY`/`DATABASE_URL`. Same shape
+  // as `probe-taxon` (sibling PR #369).
+  if (kind === 'probe-wiki') {
+    const title = process.argv[3];
+    if (!title) throw new Error('probe-wiki requires a title argument');
+    const summary = await deps.fetchWikipediaSummary(title);
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
   const apiKey = process.env.EBIRD_API_KEY;
   const dbUrl = process.env.DATABASE_URL;
   if (!apiKey) throw new Error('EBIRD_API_KEY not set');
@@ -107,7 +121,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else if (kind === 'photos') {
       summary = await deps.runPhotos({ pool });
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | probe-wiki`);
     }
     console.log(JSON.stringify(summary, null, 2));
     if (summary.status === 'failure') {
@@ -144,6 +158,7 @@ if (isEntrypoint) {
     runBackfill: realRunBackfill,
     runTaxonomy: realRunTaxonomy,
     runPhotos: realRunPhotos,
+    fetchWikipediaSummary: realFetchWikipediaSummary,
   }).catch(err => {
     console.error(err);
     process.exit(1);

--- a/services/ingestor/src/wikipedia/client.test.ts
+++ b/services/ingestor/src/wikipedia/client.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fetchWikipediaSummary } from './client.js';
+import type { WikipediaSummary } from './types.js';
+
+// MSW v2 (`http.get` + `HttpResponse`) — v1's `rest.get` + `res(ctx.json())`
+// is gone; we don't use it. See CLAUDE.md drift-prone library table.
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// Wikipedia REST summary endpoint per https://en.wikipedia.org/api/rest_v1/.
+// The title segment is URI-encoded by the client — assertions below verify
+// that contract.
+const WIKI_SUMMARY_URL =
+  'https://en.wikipedia.org/api/rest_v1/page/summary/:title';
+
+describe('fetchWikipediaSummary', () => {
+  it('200 OK returns the parsed summary shape with notModified=false', async () => {
+    server.use(
+      http.get(WIKI_SUMMARY_URL, ({ request, params }) => {
+        // Title path-segment is encoded by the client (encodeURIComponent),
+        // so `Vermilion_flycatcher` round-trips intact (no special chars
+        // here) and the UA matches the iNat-style contact convention.
+        expect(params.title).toBe('Vermilion_flycatcher');
+        expect(request.headers.get('User-Agent')).toBe(
+          'bird-maps.com/1.0 (https://bird-maps.com)'
+        );
+        // No prior ETag → no conditional GET header.
+        expect(request.headers.get('If-None-Match')).toBeNull();
+        return HttpResponse.json(
+          {
+            extract_html: '<p>The vermilion flycatcher is...</p>',
+            revision: '1234567890',
+          },
+          {
+            status: 200,
+            headers: {
+              etag: '"abc123"',
+              'content-type': 'application/json',
+            },
+          }
+        );
+      })
+    );
+
+    const result = await fetchWikipediaSummary('Vermilion_flycatcher');
+
+    expect(result).not.toBeNull();
+    // Compile-time exhaustiveness probe on the discriminated union: the
+    // success arm exposes `extractHtml`, the 304 arm doesn't. If a future
+    // variant ({ rateLimited: true }) lands without extending this guard,
+    // tsc fails the typecheck — child #371's writer will rely on this.
+    if (result && !result.notModified) {
+      expect(result.extractHtml).toBe('<p>The vermilion flycatcher is...</p>');
+      expect(result.revisionId).toBe('1234567890');
+      expect(result.license).toBe('CC-BY-SA-4.0');
+      expect(result.etag).toBe('"abc123"');
+      expect(result.notModified).toBe(false);
+    } else {
+      throw new Error('Expected a 200-shape result, got null or 304');
+    }
+  });
+
+  it('404 returns null', async () => {
+    server.use(
+      http.get(WIKI_SUMMARY_URL, () => {
+        return new HttpResponse('not found', { status: 404 });
+      })
+    );
+
+    const result = await fetchWikipediaSummary('Imaginarius_nonexistens');
+    expect(result).toBeNull();
+  });
+
+  it('304 with prior ETag returns { notModified: true, etag }', async () => {
+    server.use(
+      http.get(WIKI_SUMMARY_URL, ({ request }) => {
+        // Conditional GET: the helper must forward the prior ETag verbatim.
+        expect(request.headers.get('If-None-Match')).toBe('"abc123"');
+        return new HttpResponse(null, {
+          status: 304,
+          headers: { etag: '"abc123"' },
+        });
+      })
+    );
+
+    const result = await fetchWikipediaSummary('Vermilion_flycatcher', {
+      priorEtag: '"abc123"',
+    });
+
+    expect(result).not.toBeNull();
+    // Discriminated-union narrowing — typed test of the writer's guard.
+    if (result && result.notModified) {
+      expect(result.notModified).toBe(true);
+      expect(result.etag).toBe('"abc123"');
+    } else {
+      throw new Error('Expected a 304 notModified result');
+    }
+  });
+
+  it('304 falls back to opts.priorEtag when server omits ETag header', async () => {
+    // Some Wikipedia 304 responses omit the `etag` echo; the helper must
+    // reuse the caller's prior value so the writer can keep its column
+    // populated. This pins the `?? opts.priorEtag` invariant in the type
+    // contract — callers can rely on `etag` being a string post-conditional.
+    server.use(
+      http.get(WIKI_SUMMARY_URL, () => {
+        return new HttpResponse(null, { status: 304 });
+      })
+    );
+
+    const result = await fetchWikipediaSummary('Vermilion_flycatcher', {
+      priorEtag: '"prior-only"',
+    });
+
+    expect(result).not.toBeNull();
+    if (result && result.notModified) {
+      expect(result.etag).toBe('"prior-only"');
+    } else {
+      throw new Error('Expected a 304 notModified result');
+    }
+  });
+
+  it('429 retries once then succeeds (parity with iNat backoff contract)', async () => {
+    // Pins observable behavior to the iNat helper's "1 retry => 2 attempts"
+    // default (services/ingestor/src/inat/client.ts:69). If the iNat side
+    // ever changes its retry budget, both tests fail together — keeps the
+    // two clients in lockstep.
+    let calls = 0;
+    server.use(
+      http.get(WIKI_SUMMARY_URL, () => {
+        calls++;
+        if (calls === 1) {
+          return new HttpResponse('rate limited', { status: 429 });
+        }
+        return HttpResponse.json(
+          {
+            extract_html: '<p>Recovered.</p>',
+            revision: '999',
+          },
+          {
+            status: 200,
+            headers: { etag: '"after-retry"' },
+          }
+        );
+      })
+    );
+
+    const result = await fetchWikipediaSummary('Vermilion_flycatcher', {
+      retryBaseMs: 1,
+    });
+
+    expect(calls).toBe(2);
+    if (result && !result.notModified) {
+      expect(result.extractHtml).toBe('<p>Recovered.</p>');
+      expect(result.etag).toBe('"after-retry"');
+    } else {
+      throw new Error('Expected a 200-shape result after retry');
+    }
+  });
+
+  it('malformed response (missing extract_html) throws', async () => {
+    server.use(
+      http.get(WIKI_SUMMARY_URL, () => {
+        return HttpResponse.json(
+          // Intentionally missing `extract_html`. A live Wikipedia summary
+          // always carries this field; its absence indicates either an API
+          // contract change or a payload corruption — either way, surface
+          // loudly rather than persist a NULL extract.
+          { revision: '1' },
+          {
+            status: 200,
+            headers: { etag: '"x"' },
+          }
+        );
+      })
+    );
+
+    await expect(
+      fetchWikipediaSummary('Vermilion_flycatcher')
+    ).rejects.toThrow(/extract_html/);
+  });
+
+  it('encodes title path-segment for special characters', async () => {
+    // Spaces appear in some Wikipedia page titles when callers don't
+    // pre-substitute underscores. Without `encodeURIComponent`, the URL
+    // would be malformed. (Apostrophes are in RFC 3986's unreserved set
+    // and survive encoding round-trip un-percent-escaped, so we use a
+    // space — which is unambiguously encoded — as the canary.)
+    let receivedUrl: string | null = null;
+    server.use(
+      http.get(WIKI_SUMMARY_URL, ({ request }) => {
+        receivedUrl = request.url;
+        return HttpResponse.json(
+          { extract_html: '<p>x</p>', revision: '1' },
+          { status: 200, headers: { etag: '"y"' } }
+        );
+      })
+    );
+
+    await fetchWikipediaSummary('Bullock oriole');
+
+    expect(receivedUrl).not.toBeNull();
+    // Space encodes to %20.
+    expect(receivedUrl!).toContain('Bullock%20oriole');
+    expect(receivedUrl!).not.toContain('Bullock oriole');
+  });
+
+  it('forwards If-None-Match only when priorEtag is provided', async () => {
+    // Belt-and-suspenders: the conditional-GET header must NOT be sent on a
+    // first-time fetch. Otherwise Wikipedia would 304 the very first call
+    // against a phantom etag.
+    let header: string | null = null;
+    server.use(
+      http.get(WIKI_SUMMARY_URL, ({ request }) => {
+        header = request.headers.get('If-None-Match');
+        return HttpResponse.json(
+          { extract_html: '<p>x</p>', revision: '1' },
+          { status: 200, headers: { etag: '"first"' } }
+        );
+      })
+    );
+
+    await fetchWikipediaSummary('Vermilion_flycatcher');
+    expect(header).toBeNull();
+  });
+
+  it('return shape narrows correctly via the discriminated union', () => {
+    // Compile-time-only assertion. If a later change reshapes the union
+    // (adds `{ rateLimited: true }`, drops `notModified`, etc.) without
+    // extending this guard, tsc fails the typecheck. Cheap insurance for
+    // child #371 which uses `if (result.notModified) skipUpdate()` as a
+    // type guard. The body never executes — `if (false)` is dead code.
+    if (false as boolean) {
+      const _result = null as unknown as WikipediaSummary | null;
+      if (_result === null) {
+        return;
+      }
+      if (_result.notModified) {
+        // 304 arm — only `etag` is reachable.
+        const _etag: string = _result.etag;
+        void _etag;
+      } else {
+        // 200 arm — extract/revision/license/etag are reachable.
+        const _extractHtml: string = _result.extractHtml;
+        const _revisionId: string = _result.revisionId;
+        const _license: 'CC-BY-SA-4.0' = _result.license;
+        const _etag: string | null = _result.etag;
+        void _extractHtml;
+        void _revisionId;
+        void _license;
+        void _etag;
+      }
+    }
+    expect(true).toBe(true);
+  });
+});

--- a/services/ingestor/src/wikipedia/client.ts
+++ b/services/ingestor/src/wikipedia/client.ts
@@ -1,0 +1,195 @@
+import type { WikipediaSummary } from './types.js';
+
+// User-Agent header value identifying the app to Wikipedia. Wikimedia's REST
+// API etiquette page (https://en.wikipedia.org/api/rest_v1/) asks for a
+// contactable UA string so they can reach the maintainer if a problem is
+// observed. Anonymous UAs get throttled or blocked. Matches the iNat
+// convention at services/ingestor/src/inat/client.ts:10 — same ownership,
+// same contact surface.
+const USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
+
+// All Wikipedia text extracts are licensed under CC-BY-SA-4.0 per
+// https://en.wikipedia.org/wiki/Wikipedia:Copyrights. The REST summary
+// payload doesn't echo this back, so we hard-code it here. A future change
+// in Wikipedia's licensing would ripple across thousands of consumers and
+// we'd notice — re-verify at the next quarterly drift sweep.
+const WIKIPEDIA_LICENSE = 'CC-BY-SA-4.0' as const;
+
+const WIKIPEDIA_BASE_URL = 'https://en.wikipedia.org/api/rest_v1';
+
+/** Options for `fetchWikipediaSummary`. */
+export interface FetchWikipediaOptions {
+  baseUrl?: string;
+  /**
+   * Prior `ETag` from a previous fetch. When provided, the helper sends
+   * `If-None-Match: <priorEtag>` and Wikipedia returns 304 Not Modified
+   * when the page is unchanged. The writer (child #371) uses 304 to skip
+   * DOMPurify + DB-write — that's the whole point of conditional GET here.
+   */
+  priorEtag?: string;
+  /** Total attempts on transient failures (429 / 5xx). Default 1 retry => 2 total attempts. */
+  maxRetries?: number;
+  retryBaseMs?: number;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Raw subset of Wikipedia's `/api/rest_v1/page/summary/{title}` response
+ * we care about. The full payload includes ~30 fields (thumbnail,
+ * coordinates, descriptions, etc.); we only project what the writer needs.
+ */
+interface RawWikipediaSummary {
+  extract_html?: string;
+  revision?: string;
+}
+
+/**
+ * Fetches the Wikipedia REST summary for `title`. Returns:
+ * - `{ notModified: false, extractHtml, revisionId, license, etag }` on 200
+ * - `{ notModified: true, etag }` on 304 (when `opts.priorEtag` was provided)
+ * - `null` on 404 (deleted/renamed pages — caller skips)
+ *
+ * Throws on:
+ * - 4xx other than 404 / 429 (programming error — bad title encoding, etc.)
+ * - 5xx after retry exhaustion (Wikipedia-side outage)
+ * - 429 after retry exhaustion (rate-limited even after backoff)
+ * - Malformed 200 payload (missing `extract_html`)
+ *
+ * Mirrors the iNat helper at `inat/client.ts:fetchInatPhoto` for retry
+ * semantics (1 retry default, full-jitter exponential backoff). Both share
+ * the same maintainer contact via the matching User-Agent.
+ */
+export async function fetchWikipediaSummary(
+  title: string,
+  opts: FetchWikipediaOptions = {}
+): Promise<WikipediaSummary | null> {
+  const baseUrl = opts.baseUrl ?? WIKIPEDIA_BASE_URL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+
+  // encodeURIComponent handles spaces (becoming %20), apostrophes (%27),
+  // and other reserved characters that appear in real bird page titles
+  // (e.g. "Bullock's_oriole"). Wikipedia accepts both `_` and `%20` in
+  // path segments — we don't normalize to either; we pass the title
+  // through verbatim and let URL encoding handle the rest.
+  const url = `${baseUrl}/page/summary/${encodeURIComponent(title)}`;
+
+  const headers: Record<string, string> = {
+    'User-Agent': USER_AGENT,
+    accept: 'application/json',
+  };
+  if (opts.priorEtag !== undefined) {
+    headers['If-None-Match'] = opts.priorEtag;
+  }
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers,
+        signal: AbortSignal.timeout(requestTimeoutMs),
+      });
+
+      // 404: page doesn't exist (deleted, renamed, never created). Caller
+      // treats null as "skip this species, log, continue" — matches the
+      // iNat client's null-on-empty contract.
+      if (res.status === 404) {
+        return null;
+      }
+
+      // 304: page unchanged since priorEtag. Echo etag so caller can keep
+      // its column populated; fall back to opts.priorEtag when Wikipedia
+      // omits the header (rare but observed). Typed as `string` because
+      // reaching 304 implies opts.priorEtag was set (see types.ts).
+      if (res.status === 304) {
+        const echoedEtag = res.headers.get('etag');
+        // opts.priorEtag is non-undefined here by construction — 304 only
+        // fires when If-None-Match was sent. Non-null assertion would also
+        // work; the `?? ''` is a belt-and-suspenders against a future where
+        // a caller hand-crafts a 304 path without priorEtag.
+        const etag = echoedEtag ?? opts.priorEtag ?? '';
+        return { notModified: true, etag };
+      }
+
+      // 429 / 5xx: transient — retry. 4xx (other than 404 / 429) is a
+      // programming error and surfaces immediately.
+      if (res.status === 429 || res.status >= 500) {
+        throw new WikipediaTransientError(res.status, await res.text());
+      }
+      if (!res.ok) {
+        throw new WikipediaClientError(res.status, await res.text());
+      }
+
+      // 200 OK: parse and project. Missing `extract_html` is treated as a
+      // contract violation — surface loudly rather than persist a NULL or
+      // empty-string extract.
+      const body = (await res.json()) as RawWikipediaSummary;
+      if (typeof body.extract_html !== 'string') {
+        throw new Error(
+          `Wikipedia summary response missing extract_html (title=${title})`
+        );
+      }
+      const revision = typeof body.revision === 'string' ? body.revision : '';
+      return {
+        notModified: false,
+        extractHtml: body.extract_html,
+        revisionId: revision,
+        license: WIKIPEDIA_LICENSE,
+        etag: res.headers.get('etag'),
+      };
+    } catch (err) {
+      lastError = err;
+      // 4xx (non-429, non-404) is a programming error — don't retry.
+      if (err instanceof WikipediaClientError) throw err;
+      // Malformed-payload error from above — don't retry; the next attempt
+      // would just re-throw the same shape.
+      if (
+        err instanceof Error &&
+        err.message.startsWith('Wikipedia summary response missing extract_html')
+      ) {
+        throw err;
+      }
+      if (attempt === maxRetries) break;
+      // Full-jitter exponential backoff (AWS write-up variant) — same shape
+      // as the iNat helper. retryBaseMs * 2^attempt is the upper bound;
+      // the jitter randomizes inside [0, upper).
+      const backoff = retryBaseMs * Math.pow(2, attempt);
+      const withJitter = Math.floor(Math.random() * backoff);
+      await sleep(withJitter);
+    }
+  }
+  if (isAbortError(lastError)) {
+    throw new WikipediaTransientError(
+      0,
+      `Request timed out after ${requestTimeoutMs}ms`
+    );
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+export class WikipediaClientError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`Wikipedia client error ${status}: ${body}`);
+    this.name = 'WikipediaClientError';
+  }
+}
+
+export class WikipediaTransientError extends Error {
+  constructor(public status: number, public body: string) {
+    super(`Wikipedia transient error ${status}: ${body}`);
+    this.name = 'WikipediaTransientError';
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** True for both manual AbortController aborts and AbortSignal.timeout() expirations. */
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'AbortError' || err.name === 'TimeoutError')
+  );
+}

--- a/services/ingestor/src/wikipedia/types.ts
+++ b/services/ingestor/src/wikipedia/types.ts
@@ -1,0 +1,47 @@
+// Public type contract for the Wikipedia REST summary client. Consumers
+// (child #371's `run-descriptions.ts` writer + sanitization step) depend
+// only on this shape — nothing about the raw REST response leaks across the
+// module boundary.
+
+/**
+ * Wikipedia REST summary endpoint payload, projected to the fields the
+ * descriptions writer cares about plus the conditional-GET ETag.
+ *
+ * Discriminated union on `notModified`:
+ * - `{ notModified: false, ... }` — the page was fetched fresh; the writer
+ *   sanitizes `extractHtml` via DOMPurify and persists.
+ * - `{ notModified: true, etag }` — the page is unchanged since `priorEtag`;
+ *   the writer skips DOMPurify and the DB write entirely.
+ *
+ * The 404 case (deleted/renamed page) is signaled by `null` from
+ * `fetchWikipediaSummary`, not by a third union arm — that keeps the
+ * `if (result === null) skip; else use(result)` shape clean and avoids a
+ * three-way switch at every call site.
+ */
+export type WikipediaSummary =
+  | {
+      notModified: false;
+      /** Wikipedia's `extract_html` — sanitize via DOMPurify before persisting (child #371). */
+      extractHtml: string;
+      /** Wikipedia's `revision` (string id of the revision the extract came from). */
+      revisionId: string;
+      /** All Wikipedia text extracts ship under CC-BY-SA-4.0 (https://en.wikipedia.org/wiki/Wikipedia:Copyrights). */
+      license: 'CC-BY-SA-4.0';
+      /**
+       * `ETag` response header value, used as `priorEtag` on the next refresh.
+       * `null` when the upstream omits the header (rare, but defended against
+       * so consumers don't silently store `'null'` in a NOT NULL column).
+       */
+      etag: string | null;
+    }
+  | {
+      notModified: true;
+      /**
+       * On 304, this is `res.headers.get('etag') ?? opts.priorEtag`. Reaching
+       * the 304 arm requires having sent `If-None-Match`, which requires
+       * `opts.priorEtag` — so by construction `etag` is always a defined
+       * string here. Typed as `string` (not `string | null`) so the writer
+       * can use it without a non-null assertion.
+       */
+      etag: string;
+    };


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Writer as Descriptions Writer<br/>(child #371)
    participant Helper as fetchWikipediaSummary
    participant DB as species_descriptions<br/>(etag column lands in #371)
    participant Wiki as Wikipedia REST<br/>/api/rest_v1/page/summary/{title}

    Note over Writer,Wiki: First refresh — no prior ETag
    Writer->>Helper: fetchWikipediaSummary("Vermilion_flycatcher")
    Helper->>Wiki: GET /page/summary/Vermilion_flycatcher<br/>UA: bird-maps.com/1.0
    Wiki-->>Helper: 200 OK + ETag: "abc123"<br/>{ extract_html, revision }
    Helper-->>Writer: { notModified: false, extractHtml, revisionId,<br/>license: "CC-BY-SA-4.0", etag: "abc123" }
    Writer->>DB: UPSERT (extract, etag="abc123")

    Note over Writer,Wiki: Daily refresh — page unchanged
    Writer->>Helper: fetchWikipediaSummary(title, { priorEtag: "abc123" })
    Helper->>Wiki: GET /page/summary/Vermilion_flycatcher<br/>If-None-Match: "abc123"
    Wiki-->>Helper: 304 Not Modified
    Helper-->>Writer: { notModified: true, etag: "abc123" }
    Writer-->>Writer: skipUpdate() — no DOMPurify, no DB write

    Note over Writer,Wiki: Page deleted/renamed
    Writer->>Helper: fetchWikipediaSummary("Defunctus_avis")
    Helper->>Wiki: GET /page/summary/Defunctus_avis
    Wiki-->>Helper: 404
    Helper-->>Writer: null
```

The discriminated union on `notModified` is the load-bearing shape — child #371's writer narrows on it as a type guard (`if (result.notModified) skipUpdate()`). 404 collapses to `null` so the writer doesn't need a three-way switch at every call site.

## Summary

- Adds `services/ingestor/src/wikipedia/{client,types}.ts` exporting `fetchWikipediaSummary(title, opts?)` against `https://en.wikipedia.org/api/rest_v1/page/summary/{title}`. Conditional GET via `If-None-Match` lets child #371's daily refresh skip DOMPurify + DB-write on unchanged pages — the whole point of carrying the ETag back out.
- Mirrors `inat/client.ts` for retry semantics (1 retry default, full-jitter exponential backoff, same UA `bird-maps.com/1.0 (https://bird-maps.com)`) so a future iNat-side change in retry budget keeps both clients in lockstep — pinned by an explicit "429 then 200, exactly one retry" assertion.
- Wires `probe-wiki <title>` into `cli.ts` ahead of the `EBIRD_API_KEY` / `DATABASE_URL` env guards (same shape as sibling `probe-taxon` from PR #369). Operators can run it from a laptop without standing up the full ingest credentials — the test pins the contract by deleting both env vars and asserting the call still succeeds.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — green (12 files, 67 tests; +9 wiki client + 2 CLI cases)
- [x] `npm run lint` — green (no-op; no per-workspace lint scripts)
- [x] `npm run build --workspace @bird-watch/ingestor` — clean tsc
- [x] `npm run build` — full monorepo build clean (also covers compile-time exhaustiveness probe on the `WikipediaSummary` union)
- [x] `npx tsc -p services/ingestor/tsconfig.test.json` — test sources compile clean
- [x] `npx knip` — no new orphans (the `probe-wiki` CLI import is what defeats the cross-package orphan gate, by design)
- [x] Real-network smoke: `npx tsx services/ingestor/src/cli.ts probe-wiki "Vermilion_flycatcher"` printed `{ notModified: false, extractHtml, revisionId, license: "CC-BY-SA-4.0", etag: "W/\"...\"" }` — meets issue acceptance criterion 2
- [ ] (UI only) Playwright MCP smoke — N/A, no UI changes

## Plan reference

Out of plan — epic #368 / closes #370.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)