### PR TITLE
feat(read-api): project species_descriptions onto /api/species/:code via LEFT JOIN

### DIFF
--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -254,6 +254,80 @@ describe('species photos', () => {
   });
 });
 
+describe('species meta — description projection', () => {
+  beforeEach(async () => {
+    // Descriptions FK to species_meta; seed a parent so inserts succeed.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+  });
+
+  it('getSpeciesMeta surfaces descriptionBody/descriptionLicense/descriptionAttributionUrl when a description row exists', async () => {
+    const body = 'The vermilion flycatcher is a small, brilliantly colored passerine bird. '.repeat(2);
+    await insertSpeciesDescription(db.pool, {
+      speciesCode: 'vermfly',
+      source: 'wikipedia',
+      body,
+      license: 'CC-BY-SA-4.0',
+      revisionId: 1234567890,
+      etag: '"abc123"',
+      attributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+    });
+
+    const meta = await getSpeciesMeta(db.pool, 'vermfly');
+    expect(meta).not.toBeNull();
+    expect(meta!.descriptionBody).toBe(body);
+    expect(meta!.descriptionLicense).toBe('CC-BY-SA-4.0');
+    expect(meta!.descriptionAttributionUrl).toBe('https://en.wikipedia.org/wiki/Vermilion_flycatcher');
+    // Taxonomy fields still populated.
+    expect(meta!.comName).toBe('Vermilion Flycatcher');
+    expect(meta!.familyCode).toBe('tyrannidae');
+  });
+
+  it('getSpeciesMeta returns undefined for the three description fields when no description row exists', async () => {
+    const meta = await getSpeciesMeta(db.pool, 'vermfly');
+    expect(meta).not.toBeNull();
+    // Three description fields are undefined (not present, not null, not empty)
+    // — same contract as photoUrl when species_photos has no row. The
+    // exactOptionalPropertyTypes contract requires absent properties when the
+    // JOIN produces NULLs, not properties with `undefined` values.
+    expect(meta!.descriptionBody).toBeUndefined();
+    expect(meta!.descriptionLicense).toBeUndefined();
+    expect(meta!.descriptionAttributionUrl).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(meta, 'descriptionBody')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(meta, 'descriptionLicense')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(meta, 'descriptionAttributionUrl')).toBe(false);
+  });
+
+  it('getSpeciesMeta surfaces description fields even when revision_id is NULL (304-path / sparse-200 case)', async () => {
+    // The 304 conditional-GET path may produce a row where Wikipedia omits
+    // revision_id. The description body/license/attribution_url MUST still
+    // surface — the description-fields projection is independent of
+    // revision_id, which is a cache-invalidation knob the writer uses, not a
+    // wire-facing field. A regression where the projection accidentally
+    // gates on revision_id IS NOT NULL would silently hide descriptions for
+    // species refreshed via 304 paths.
+    const body = 'The vermilion flycatcher is a small bright red passerine bird. '.repeat(2);
+    await insertSpeciesDescription(db.pool, {
+      speciesCode: 'vermfly',
+      source: 'wikipedia',
+      body,
+      license: 'CC-BY-SA-3.0',
+      revisionId: null,
+      etag: null,
+      attributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+    });
+
+    const meta = await getSpeciesMeta(db.pool, 'vermfly');
+    expect(meta).not.toBeNull();
+    expect(meta!.descriptionBody).toBe(body);
+    expect(meta!.descriptionLicense).toBe('CC-BY-SA-3.0');
+    expect(meta!.descriptionAttributionUrl).toBe('https://en.wikipedia.org/wiki/Vermilion_flycatcher');
+  });
+});
+
 describe('species phenology', () => {
   beforeEach(async () => {
     // Phenology rows pivot off observations, but the species_meta row exists

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -166,31 +166,47 @@ export async function getSpeciesMeta(
     photo_url: string | null;
     photo_attribution: string | null;
     photo_license: string | null;
+    description_body: string | null;
+    description_license: string | null;
+    description_attribution_url: string | null;
   }>(
     // LEFT JOIN species_photos so the species row is returned regardless of
     // whether a detail-panel photo exists. The (species_code, purpose) UNIQUE
     // guarantees at most one matching row, so no LIMIT/aggregation needed.
+    //
+    // Second LEFT JOIN to species_descriptions (issue #372) projects the
+    // description body/license/attribution_url onto the same payload the
+    // photo fields ride. The (species_code) UNIQUE on species_descriptions
+    // guarantees at most one matching row per species. revision_id and etag
+    // are deliberately NOT projected — they are cache-invalidation knobs
+    // the writer uses, not wire-facing fields.
     `SELECT sm.species_code, sm.com_name, sm.sci_name, sm.family_code,
             sm.family_name, sm.taxon_order,
             sp.url         AS photo_url,
             sp.attribution AS photo_attribution,
-            sp.license     AS photo_license
+            sp.license     AS photo_license,
+            sd.body            AS description_body,
+            sd.license         AS description_license,
+            sd.attribution_url AS description_attribution_url
        FROM species_meta sm
        LEFT JOIN species_photos sp
          ON sp.species_code = sm.species_code
         AND sp.purpose = 'detail-panel'
+       LEFT JOIN species_descriptions sd
+         ON sd.species_code = sm.species_code
       WHERE sm.species_code = $1`,
     [speciesCode]
   );
   const r = rows[0];
   if (!r) return null;
   // Build the result with the taxonomy fields always populated and the
-  // optional photo fields ONLY set when present. Under
+  // optional photo + description fields ONLY set when present. Under
   // exactOptionalPropertyTypes, assigning `undefined` to an optional
   // string-typed property is a type error — so omit the keys outright when
   // the JOIN produced NULLs. Consumers see `meta.photoUrl === undefined`
-  // because the property is missing, which is the contract spec'd in
-  // species.test.ts ("not present, not null, not empty").
+  // (and `meta.descriptionBody === undefined`) because the property is
+  // missing, which is the contract spec'd in species.test.ts ("not
+  // present, not null, not empty").
   const meta: SpeciesMeta = {
     speciesCode: r.species_code,
     comName: r.com_name,
@@ -202,6 +218,11 @@ export async function getSpeciesMeta(
   if (r.photo_url !== null) meta.photoUrl = r.photo_url;
   if (r.photo_attribution !== null) meta.photoAttribution = r.photo_attribution;
   if (r.photo_license !== null) meta.photoLicense = r.photo_license;
+  if (r.description_body !== null) meta.descriptionBody = r.description_body;
+  if (r.description_license !== null) meta.descriptionLicense = r.description_license;
+  if (r.description_attribution_url !== null) {
+    meta.descriptionAttributionUrl = r.description_attribution_url;
+  }
   return meta;
 }
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -55,6 +55,19 @@ export interface SpeciesMeta {
   photoUrl?: string;
   photoAttribution?: string;
   photoLicense?: string;
+  // Optional description projection fields. Mirrors the photo-projection
+  // shape (issue #372): derived at read time from a LEFT JOIN to
+  // species_descriptions and NEVER stored on species_meta itself. The Read
+  // API populates them on /api/species/:code when a row exists in
+  // species_descriptions for the species; absent otherwise.
+  // exactOptionalPropertyTypes contract: properties are absent (not
+  // `undefined`) when the JOIN produces NULLs — same as the photo fields
+  // above. Cache caveat: stale CDN responses predating these fields
+  // deserialize with all three === undefined, which the frontend treats as
+  // "no description" (silent no-op) — no Cache-Control bump is required.
+  descriptionBody?: string;
+  descriptionLicense?: string;
+  descriptionAttributionUrl?: string;
 }
 
 export interface FamilySilhouette {

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -5,6 +5,7 @@ import {
   upsertSpeciesMeta,
   upsertObservations,
   insertSpeciesPhoto,
+  insertSpeciesDescription,
 } from '@bird-watch/db-client';
 import { createApp } from './app.js';
 
@@ -222,6 +223,62 @@ describe('GET /api/species/:code', () => {
     expect(body.photoUrl).toBe('https://photos.example/vermfly.jpg');
     expect(body.photoAttribution).toBe('Photographer Name / iNaturalist');
     expect(body.photoLicense).toBe('CC-BY-NC');
+  });
+
+  it('populates descriptionBody/descriptionLicense/descriptionAttributionUrl when species_descriptions has a row', async () => {
+    // Seed a description row for vermfly. The route handler at app.ts:102
+    // delegates to getSpeciesMeta which LEFT JOINs species_descriptions
+    // (issue #372); the three optional fields round-trip through the Hono
+    // JSON response when the JOIN matches.
+    const descBody = 'The vermilion flycatcher is a small, brilliantly colored passerine bird. '.repeat(2);
+    await insertSpeciesDescription(db.pool, {
+      speciesCode: 'vermfly',
+      source: 'wikipedia',
+      body: descBody,
+      license: 'CC-BY-SA-4.0',
+      revisionId: 1234567890,
+      etag: '"abc123"',
+      attributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+    });
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/vermfly');
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      speciesCode: string;
+      descriptionBody?: string;
+      descriptionLicense?: string;
+      descriptionAttributionUrl?: string;
+    };
+    expect(body.speciesCode).toBe('vermfly');
+    expect(body.descriptionBody).toBe(descBody);
+    expect(body.descriptionLicense).toBe('CC-BY-SA-4.0');
+    expect(body.descriptionAttributionUrl)
+      .toBe('https://en.wikipedia.org/wiki/Vermilion_flycatcher');
+  });
+
+  it('omits the three description fields when species_descriptions has no row', async () => {
+    // Seed a fresh species with neither a photo nor a description, so we can
+    // assert that both projection blocks return *absent* fields (the
+    // exactOptionalPropertyTypes contract from species.ts:200-205 carries
+    // through to the wire — JSON serialization of an object missing the
+    // key produces a body where the key is absent, deserializing as
+    // `=== undefined` for consumers).
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'nodescspc', comName: 'No-Description Species',
+        sciName: 'Empty descriptionicus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 99003 },
+    ]);
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/nodescspc');
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['speciesCode']).toBe('nodescspc');
+    // The three description fields are absent from the JSON body — `in`
+    // catches even an explicit `undefined` value, which would be a type
+    // contract violation under exactOptionalPropertyTypes.
+    expect('descriptionBody' in body).toBe(false);
+    expect('descriptionLicense' in body).toBe(false);
+    expect('descriptionAttributionUrl' in body).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Client
    participant Hono as Hono route<br/>(app.ts:102)
    participant DB as getSpeciesMeta<br/>(species.ts)
    participant PG as Postgres

    Client->>Hono: GET /api/species/:code
    Hono->>DB: getSpeciesMeta(pool, code)
    DB->>PG: SELECT sm.*, sp.url/.../, sd.body/.../<br/>FROM species_meta sm<br/>LEFT JOIN species_photos sp ON ...<br/>LEFT JOIN species_descriptions sd ON sd.species_code = sm.species_code
    PG-->>DB: row | null
    alt row exists & sd.body IS NOT NULL
        DB-->>Hono: { ..., descriptionBody, descriptionLicense, descriptionAttributionUrl }
    else row exists & sd row absent
        DB-->>Hono: { ... }  (description keys absent — exactOptionalPropertyTypes)
    else no row
        DB-->>Hono: null
    end
    Hono-->>Client: 200 JSON | 404
```

The route handler at `app.ts:102-110` is unchanged; only the db-client query + projection extends. When no `species_descriptions` row exists, the three new keys are absent from the JSON body (not present, not `null`, not `undefined`) — same exactOptionalPropertyTypes contract the photo fields already enforce.

## Summary

- Mirrors the photo-projection pattern (#327) at `packages/db-client/src/species.ts:99-150`. A second `LEFT JOIN` to `species_descriptions` surfaces `descriptionBody`/`descriptionLicense`/`descriptionAttributionUrl` on the same payload `getSpeciesMeta` already returns. `revision_id` and `etag` are deliberately NOT projected — they are cache-invalidation knobs the writer uses, not wire-facing fields.
- No new route, no `Cache-Control` change. Stale CDN responses pre-feature deserialize with all three description fields `=== undefined`, which the frontend (child #5 of epic #368) treats as "no description" (silent no-op) — same caching contract the photo fields already use.
- `getSpeciesMeta` has a SECOND consumer at `services/read-api/src/app.ts:116` (the phenology route's existence-check, which throws away the result and just uses it as a 404-or-not signal). Adding 3 columns to the projection is safe — the existence-check doesn't care about the new fields — but flagging it explicitly so it doesn't read as oversight.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/db-client` — 73/73 green (3 new cases on `getSpeciesMeta`: description present, description absent, NULL `revision_id`)
- [x] `npm run test --workspace @bird-watch/read-api` — 36/36 green (2 new cases on `/api/species/:code`: description fields surface, description fields absent — `'descriptionBody' in body === false`)
- [x] `npm test` (full monorepo) — 627 tests green; no consumer of `SpeciesMeta` breaks on the optional-field extension
- [x] `npm run build` — clean across all workspaces
- [x] `npm run lint` — clean
- [x] `npx knip` — clean (exit 0)

## Plan reference

Out of plan — epic #368 / closes #372

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)