### PR TITLE
feat(ingestor): iNat wikipedia_summary fallback (schema CHECK migration + writer branch)

### DIFF
--- a/migrations/1700000031000_widen_species_descriptions_source.sql
+++ b/migrations/1700000031000_widen_species_descriptions_source.sql
@@ -1,0 +1,31 @@
+-- Up Migration
+--
+-- Widens the `species_descriptions.source` CHECK to accept the new 'inat'
+-- value alongside the original 'wikipedia'. Enables the iNat /v1/taxa
+-- `wikipedia_summary` fallback path in `run-descriptions.ts`: when Wikipedia
+-- REST returns 404 for a species page, the orchestrator falls back to iNat's
+-- per-id taxon endpoint and writes a row with source='inat'. Lifts coverage
+-- from ~85% (Wikipedia-only) toward the empirical ~95% ceiling.
+--
+-- The body length CHECK (50..8192) is unchanged. The license CHECK is
+-- unchanged: iNat-fallback rows still license as CC-BY-SA-4.0 because the
+-- underlying source is the same Wikipedia article (iNat's `wikipedia_summary`
+-- field is plaintext extracted from the article — no relicense, no new
+-- rightsholder).
+--
+-- The original CHECK from migration 30000 is an inline column-level CHECK
+-- with no explicit name. Postgres's auto-generated convention for that shape
+-- is `<table>_<column>_check` → `species_descriptions_source_check`. Verified
+-- empirically (see species-descriptions-inat-source-migration.test.ts: "the
+-- auto-generated constraint name is `species_descriptions_source_check`").
+ALTER TABLE species_descriptions DROP CONSTRAINT IF EXISTS species_descriptions_source_check;
+ALTER TABLE species_descriptions ADD CONSTRAINT species_descriptions_source_check
+  CHECK (source IN ('wikipedia', 'inat'));
+
+-- Down Migration
+-- Revert to wikipedia-only. IF EXISTS makes the DROP idempotent so a partial
+-- rollback retry won't error. Re-adding the original CHECK shape keeps the
+-- pre-31000 contract identical for any code that depends on it.
+ALTER TABLE species_descriptions DROP CONSTRAINT IF EXISTS species_descriptions_source_check;
+ALTER TABLE species_descriptions ADD CONSTRAINT species_descriptions_source_check
+  CHECK (source IN ('wikipedia'));

--- a/packages/db-client/src/species-descriptions-inat-source-migration.test.ts
+++ b/packages/db-client/src/species-descriptions-inat-source-migration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration test for migration 1700000031000 — widen the
+ * `species_descriptions_source_check` CHECK constraint to accept the new
+ * 'inat' source value alongside the original 'wikipedia' value.
+ *
+ * The Up migration is a DROP+RECREATE of the constraint. Verifies the actual
+ * Postgres-auto-generated constraint name (`species_descriptions_source_check`),
+ * that 'inat' is now accepted, that 'wikipedia' is still accepted, and that
+ * any other value (e.g. 'ebird', 'wikidata') is still rejected.
+ *
+ * The Down migration must reverse the widening: only 'wikipedia' accepted,
+ * 'inat' rejected. Idempotent on both directions via IF EXISTS on DROP.
+ *
+ * No DB mocks per CLAUDE.md "No DB mocks in tests".
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers before any query.
+import './pool.js';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+const MIGRATION_FILE = '1700000031000_widen_species_descriptions_source.sql';
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const sql = readFileSync(filePath, 'utf-8');
+  const [rawUpPart = '', rawDownPart = ''] = sql.split(/-- Down Migration/i);
+  return {
+    up: rawUpPart.replace(/-- Up Migration/i, '').trim(),
+    down: rawDownPart.trim(),
+  };
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  for (const f of files) {
+    const { up } = parseMigration(join(migrationsDir, f));
+    if (up) {
+      await pool.query(up);
+    }
+  }
+
+  // Seed a parent species for the FK so the CHECK-violation tests have a
+  // valid species_code to attach to (otherwise the FK fires before the CHECK).
+  await pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+     VALUES ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers')`
+  );
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('migration 1700000031000_widen_species_descriptions_source — Up', () => {
+  it('the auto-generated constraint name is `species_descriptions_source_check` (PG convention)', async () => {
+    // The widening migration relies on this exact name to drop the original
+    // (column-level inline CHECK from migration 30000). Postgres's convention
+    // for an inline column CHECK with no explicit name is `<table>_<column>_check`.
+    // If a future PG release changes that convention, this test will fail
+    // loudly and the migration's DROP CONSTRAINT will need updating.
+    const { rows } = await pool.query<{ conname: string }>(
+      `SELECT conname FROM pg_constraint
+        WHERE conrelid = 'species_descriptions'::regclass
+          AND contype = 'c'
+          AND pg_get_constraintdef(oid) ILIKE '%source%'`
+    );
+    const names = rows.map(r => r.conname);
+    expect(names).toContain('species_descriptions_source_check');
+  });
+
+  it("accepts source='wikipedia' (preserves the original allowed value)", async () => {
+    await pool.query(
+      `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+       VALUES ('vermfly', 'wikipedia', '${'x'.repeat(60)}', 'CC-BY-SA-4.0', 'https://en.wikipedia.org/wiki/Vermilion_flycatcher')`
+    );
+    await pool.query(`DELETE FROM species_descriptions`);
+  });
+
+  it("accepts source='inat' (the newly widened value)", async () => {
+    await pool.query(
+      `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+       VALUES ('vermfly', 'inat', '${'y'.repeat(60)}', 'CC-BY-SA-4.0', 'https://www.inaturalist.org/taxa/9083')`
+    );
+    await pool.query(`DELETE FROM species_descriptions`);
+  });
+
+  it('rejects any other source value (e.g. ebird, wikidata) via the widened CHECK', async () => {
+    await expect(
+      pool.query(
+        `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+         VALUES ('vermfly', 'ebird', '${'z'.repeat(60)}', 'CC-BY-SA-4.0', 'https://x.test/x')`
+      )
+    ).rejects.toThrow(/check constraint/i);
+
+    await expect(
+      pool.query(
+        `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+         VALUES ('vermfly', 'wikidata', '${'z'.repeat(60)}', 'CC-BY-SA-4.0', 'https://x.test/x')`
+      )
+    ).rejects.toThrow(/check constraint/i);
+  });
+
+  it('the body length CHECK is unchanged (still 50..8192)', async () => {
+    // Belt-and-suspenders: the widening migration must not accidentally drop
+    // the body-length CHECK while replacing the source CHECK.
+    await expect(
+      pool.query(
+        `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+         VALUES ('vermfly', 'inat', 'too short', 'CC-BY-SA-4.0', 'https://x.test/x')`
+      )
+    ).rejects.toThrow(/check constraint/i);
+  });
+
+  it('the license CHECK is unchanged (still CC-BY-SA-3.0 / CC-BY-SA-4.0 only)', async () => {
+    // iNat fallback rows still license as CC-BY-SA-4.0 because the underlying
+    // source is the same Wikipedia article; non-CC-BY-SA license codes must
+    // still be rejected.
+    await expect(
+      pool.query(
+        `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+         VALUES ('vermfly', 'inat', '${'w'.repeat(60)}', 'CC-BY-NC-4.0', 'https://x.test/x')`
+      )
+    ).rejects.toThrow(/check constraint/i);
+  });
+});
+
+describe('migration 1700000031000_widen_species_descriptions_source — Down', () => {
+  it('reverts to wikipedia-only: rejects inat after Down, accepts wikipedia', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { down, up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    expect(down).toBeTruthy();
+    await pool.query(down);
+
+    // After Down: 'wikipedia' must still work.
+    await pool.query(
+      `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+       VALUES ('vermfly', 'wikipedia', '${'x'.repeat(60)}', 'CC-BY-SA-4.0', 'https://en.wikipedia.org/wiki/X')`
+    );
+    await pool.query(`DELETE FROM species_descriptions`);
+
+    // After Down: 'inat' must be rejected.
+    await expect(
+      pool.query(
+        `INSERT INTO species_descriptions (species_code, source, body, license, attribution_url)
+         VALUES ('vermfly', 'inat', '${'y'.repeat(60)}', 'CC-BY-SA-4.0', 'https://www.inaturalist.org/taxa/9083')`
+      )
+    ).rejects.toThrow(/check constraint/i);
+
+    // Down is idempotent — running it again must not error.
+    await expect(pool.query(down)).resolves.toBeDefined();
+
+    // Re-apply Up so other tests / parallel describe blocks see the wide CHECK.
+    await pool.query(up);
+  });
+});

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -504,4 +504,31 @@ describe('species descriptions', () => {
     expect(rows[0]?.revision_id).toBeNull();
     expect(rows[0]?.etag).toBeNull();
   });
+
+  it("insertSpeciesDescription accepts source='inat' (Wikipedia-404 fallback path)", async () => {
+    // The widening migration (1700000031000) added 'inat' to the source
+    // CHECK. The TS-side input type was widened in the same change so
+    // run-descriptions can pass `source: 'inat'` on the iNat-summary fallback
+    // branch. The DB upsert path is unchanged — same row shape, same
+    // license/body/attribution_url contract.
+    const body = 'A plaintext summary extracted from the Wikipedia article via iNat\'s wikipedia_summary field.';
+    await insertSpeciesDescription(db.pool, {
+      speciesCode: 'vermfly',
+      source: 'inat',
+      body,
+      license: 'CC-BY-SA-4.0',
+      revisionId: null, // iNat-fallback path doesn't expose a Wikipedia revision id
+      etag: null,       // iNat-fallback path doesn't expose a Wikipedia etag
+      attributionUrl: 'https://www.inaturalist.org/taxa/9083',
+    });
+
+    const { rows } = await db.pool.query<{ source: string; body: string; attribution_url: string }>(
+      `SELECT source, body, attribution_url
+         FROM species_descriptions WHERE species_code = 'vermfly'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.source).toBe('inat');
+    expect(rows[0]?.body).toBe(body);
+    expect(rows[0]?.attribution_url).toBe('https://www.inaturalist.org/taxa/9083');
+  });
 });

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -60,17 +60,27 @@ export async function insertSpeciesPhoto(
 
 export interface SpeciesDescriptionInput {
   speciesCode: string;
-  /** Currently always `'wikipedia'` (CHECK-restricted at the DB tier; future iNat-summary fallback expands the union). */
-  source: 'wikipedia';
-  /** Sanitized HTML — DOMPurify must run BEFORE this helper. The CHECK enforces 50..8192 chars. */
+  /**
+   * `'wikipedia'` for Wikipedia REST `/page/summary/{title}` 200 responses
+   * (the happy path); `'inat'` for the Wikipedia-404 fallback path that
+   * persists iNat's per-id `wikipedia_summary` plaintext. Both are
+   * CHECK-restricted at the DB tier (see migration 1700000031000) — adding
+   * a third value requires widening BOTH the CHECK and this union.
+   */
+  source: 'wikipedia' | 'inat';
+  /** Sanitized text — DOMPurify (HTML path) or sanitizeText (plaintext path) must run BEFORE this helper. The CHECK enforces 50..8192 chars. */
   body: string;
-  /** Wikipedia summary license — DB CHECK restricts to the two CC-BY-SA variants. */
+  /**
+   * License — DB CHECK restricts to the two CC-BY-SA variants. iNat-fallback
+   * rows still use CC-BY-SA-4.0 because the underlying source is the same
+   * Wikipedia article (iNat extracts plaintext from it; no relicense).
+   */
   license: 'CC-BY-SA-3.0' | 'CC-BY-SA-4.0';
-  /** Wikipedia revision id; null when the upstream omits it (Wikipedia 304 / sparse 200). */
+  /** Wikipedia revision id; null when the upstream omits it (Wikipedia 304 / sparse 200, iNat-fallback path). */
   revisionId: number | null;
-  /** ETag from the upstream conditional-GET; null when first fetch + upstream omits the header. */
+  /** ETag from the upstream conditional-GET; null when first fetch / iNat-fallback path. */
   etag: string | null;
-  /** Page URL (for "Read more on Wikipedia" link surface in the frontend). */
+  /** Page URL (Wikipedia for source='wikipedia'; iNat taxon page or Wikipedia URL for source='inat'). */
   attributionUrl: string;
 }
 

--- a/services/ingestor/src/inat/taxon-client.test.ts
+++ b/services/ingestor/src/inat/taxon-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
-import { fetchInatTaxon } from './taxon-client.js';
+import { fetchInatTaxon, fetchInatTaxonSummary } from './taxon-client.js';
 import { InatClientError } from './client.js';
 
 const server = setupServer();
@@ -216,6 +216,143 @@ describe('fetchInatTaxon', () => {
     );
     // 400 is a programming error — retrying would obscure the bug. Confirm we
     // didn't retry.
+    expect(calls).toBe(1);
+  });
+});
+
+describe('fetchInatTaxonSummary', () => {
+  // Hits iNat's per-id `/v1/taxa/{id}` endpoint, which is the only iNat
+  // endpoint that surfaces `wikipedia_summary` (the search endpoint at
+  // `/v1/taxa?q=...` does NOT — confirmed at #369). Used by run-descriptions'
+  // Wikipedia-404 fallback branch: when Wikipedia REST returns null for a
+  // species page, the orchestrator calls this helper with the cached
+  // species_meta.inat_taxon_id and writes the returned summary as a row with
+  // source='inat'.
+  //
+  // Same retry/UA/timeout shape as fetchInatTaxon — both share `getJsonWithRetry`
+  // out of `inat/client.ts`.
+
+  it('returns { wikipediaSummary } on a 200 with a non-null wikipedia_summary', async () => {
+    server.use(
+      http.get(`${INAT_TAXA_URL}/9083`, ({ request }) => {
+        // The per-id endpoint is `/v1/taxa/{id}` — no query params required.
+        // iNat recommended-practices doc requires a meaningful UA.
+        expect(request.headers.get('User-Agent')).toMatch(/bird-maps\.com/);
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              wikipedia_summary:
+                'The yellow-rumped warbler (Setophaga coronata) is a regular North American bird species that can be commonly observed all across the continent.',
+              wikipedia_url:
+                'https://en.wikipedia.org/wiki/Yellow-rumped_warbler',
+            },
+          ],
+        });
+      })
+    );
+
+    const result = await fetchInatTaxonSummary(9083);
+
+    expect(result).not.toBeNull();
+    expect(result?.wikipediaSummary).toMatch(/yellow-rumped warbler/i);
+  });
+
+  it('returns { wikipediaSummary: null } when the taxon record omits or nulls wikipedia_summary', async () => {
+    // Some taxa have an iNat record but no Wikipedia article cross-reference
+    // (rare splits, regional lumps). The helper must not coerce null to "" or
+    // a string "null"; the orchestrator detects null to bail out of the
+    // fallback branch entirely (no row written, descriptionsSkipped++).
+    server.use(
+      http.get(`${INAT_TAXA_URL}/12345`, () =>
+        HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 12345,
+              name: 'Some Species',
+              rank: 'species',
+              wikipedia_summary: null,
+              wikipedia_url: null,
+            },
+          ],
+        })
+      )
+    );
+
+    const result = await fetchInatTaxonSummary(12345);
+
+    expect(result).toEqual({ wikipediaSummary: null });
+  });
+
+  it('returns null when iNat reports zero results for the id', async () => {
+    // iNat's per-id endpoint can return a body shaped like
+    // `{ total_results: 0, results: [] }` for soft-deleted / merged taxa.
+    // Match fetchInatTaxon's null-on-empty contract.
+    server.use(
+      http.get(`${INAT_TAXA_URL}/99999`, () =>
+        HttpResponse.json({
+          total_results: 0,
+          page: 1,
+          per_page: 1,
+          results: [],
+        })
+      )
+    );
+
+    const result = await fetchInatTaxonSummary(99999);
+    expect(result).toBeNull();
+  });
+
+  it('retries once on 429 and succeeds on the second attempt', async () => {
+    let calls = 0;
+    server.use(
+      http.get(`${INAT_TAXA_URL}/9083`, () => {
+        calls++;
+        if (calls === 1) {
+          return new HttpResponse('rate limited', { status: 429 });
+        }
+        return HttpResponse.json({
+          total_results: 1,
+          page: 1,
+          per_page: 1,
+          results: [
+            {
+              id: 9083,
+              name: 'Setophaga coronata',
+              rank: 'species',
+              wikipedia_summary: 'A summary that survives the retry path.',
+            },
+          ],
+        });
+      })
+    );
+
+    const result = await fetchInatTaxonSummary(9083, { retryBaseMs: 1 });
+
+    expect(calls).toBe(2);
+    expect(result?.wikipediaSummary).toBe('A summary that survives the retry path.');
+  });
+
+  it('throws InatClientError on 4xx (non-429) without retry', async () => {
+    let calls = 0;
+    server.use(
+      http.get(`${INAT_TAXA_URL}/0`, () => {
+        calls++;
+        return new HttpResponse('bad request', { status: 400 });
+      })
+    );
+
+    await expect(fetchInatTaxonSummary(0)).rejects.toBeInstanceOf(
+      InatClientError
+    );
     expect(calls).toBe(1);
   });
 });

--- a/services/ingestor/src/inat/taxon-client.ts
+++ b/services/ingestor/src/inat/taxon-client.ts
@@ -1,5 +1,5 @@
 import { getJsonWithRetry } from './client.js';
-import type { InatTaxon } from './types.js';
+import type { InatTaxon, InatTaxonSummary } from './types.js';
 
 const INAT_BASE_URL = 'https://api.inaturalist.org/v1';
 
@@ -82,4 +82,76 @@ export async function fetchInatTaxon(
     inatTaxonId: first.id,
     wikipediaUrl: first.wikipedia_url,
   };
+}
+
+// Per-id projection. Unlike the search endpoint, `/v1/taxa/{id}` returns
+// `wikipedia_summary` (plaintext extracted from the article). We only need
+// the summary here — the run-descriptions orchestrator already has the id
+// and wikipedia_url cached from the search-endpoint pass.
+interface InatTaxaByIdResult {
+  id: number;
+  name: string;
+  rank: string;
+  wikipedia_summary: string | null;
+  wikipedia_url?: string | null;
+}
+
+interface InatTaxaByIdResponse {
+  total_results: number;
+  page: number;
+  per_page: number;
+  results: InatTaxaByIdResult[];
+}
+
+/**
+ * Fetches a single taxon record by id from iNaturalist's `/v1/taxa/{id}`
+ * endpoint and returns just the `wikipedia_summary` plaintext field.
+ *
+ * The search endpoint (`/v1/taxa?q=...`, used by `fetchInatTaxon`) does NOT
+ * surface `wikipedia_summary` — only the per-id endpoint does. Confirmed
+ * empirically against iNat's live API; documented at the comment in
+ * `fetchInatTaxon` above.
+ *
+ * Used exclusively by `run-descriptions.ts`'s Wikipedia-404 fallback branch:
+ * when Wikipedia REST returns null (page deleted/renamed) AND the species
+ * has a cached `inat_taxon_id`, the orchestrator calls this helper and
+ * persists the returned summary as a `species_descriptions` row with
+ * `source = 'inat'`. NEVER on the cold-cache happy path (would be wasted
+ * bandwidth — the search endpoint already returned `wikipedia_url` and we'd
+ * rather hit Wikipedia REST directly), NEVER on the warm-cache 304 path
+ * (already has a description).
+ *
+ * Returns:
+ * - `{ wikipediaSummary: string }` when iNat has a non-null summary.
+ * - `{ wikipediaSummary: null }` when the taxon record exists but the
+ *   summary is null (no Wikipedia cross-reference). Caller skips.
+ * - `null` when iNat reports zero hits for the id (soft-deleted / merged
+ *   taxon — rare). Caller skips.
+ *
+ * Retries once on transient failures (429, 5xx, network/timeout) via the
+ * shared `getJsonWithRetry` helper, same as `fetchInatTaxon` and the photo
+ * client. 4xx other than 429 throws immediately (programmer error).
+ */
+export async function fetchInatTaxonSummary(
+  taxonId: number,
+  opts: FetchInatTaxonOptions = {}
+): Promise<InatTaxonSummary | null> {
+  const baseUrl = opts.baseUrl ?? INAT_BASE_URL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+
+  const url = new URL(`${baseUrl}/taxa/${taxonId}`);
+
+  const body = await getJsonWithRetry<InatTaxaByIdResponse>(
+    url,
+    maxRetries,
+    retryBaseMs,
+    requestTimeoutMs
+  );
+
+  const first = body.results[0];
+  if (!first) return null;
+
+  return { wikipediaSummary: first.wikipedia_summary };
 }

--- a/services/ingestor/src/inat/types.ts
+++ b/services/ingestor/src/inat/types.ts
@@ -37,3 +37,16 @@ export interface InatTaxon {
   inatTaxonId: number;
   wikipediaUrl: string | null; // null when iNat has no Wikipedia article cross-reference
 }
+
+// Public type contract for the iNaturalist per-id taxon endpoint
+// (`/v1/taxa/{id}`). Returned by `fetchInatTaxonSummary` and consumed only by
+// the Wikipedia-404 fallback branch in `run-descriptions.ts`. The search
+// endpoint's result shape (`InatTaxon`) does NOT include the summary — only
+// the per-id endpoint surfaces `wikipedia_summary`.
+//
+// `wikipediaSummary` is null when the taxon record exists but has no
+// Wikipedia cross-reference (rare splits, regional lumps); the orchestrator
+// treats null as "no usable fallback body, increment descriptionsSkipped".
+export interface InatTaxonSummary {
+  wikipediaSummary: string | null;
+}

--- a/services/ingestor/src/run-descriptions.test.ts
+++ b/services/ingestor/src/run-descriptions.test.ts
@@ -95,6 +95,9 @@ afterAll(async () => {
 });
 
 const INAT_TAXA = 'https://api.inaturalist.org/v1/taxa';
+// Per-id endpoint used by the iNat-summary fallback path. The MSW route uses
+// a path parameter so any taxon id maps to a single handler.
+const INAT_TAXA_BY_ID = 'https://api.inaturalist.org/v1/taxa/:id';
 const WIKI_SUMMARY = 'https://en.wikipedia.org/api/rest_v1/page/summary/:title';
 
 const SAMPLE_BODY = '<p>The vermilion flycatcher is a small passerine bird, native to the Americas. It is brilliantly red in colour.</p>';
@@ -136,6 +139,10 @@ describe('runDescriptions', () => {
     expect(summary.descriptionsWritten).toBe(3);
     expect(summary.descriptionsSkipped).toBe(0);
     expect(summary.descriptionsFailed).toBe(0);
+    // descriptionsFromInat is the iNat-fallback counter; on the cold-cache
+    // happy path with all 200s, it must be zero. descriptionsWritten is the
+    // total — Wikipedia + iNat sources combined.
+    expect(summary.descriptionsFromInat).toBe(0);
     expect(summary.errors).toEqual([]);
 
     // DB state: each species has a row with the sanitized body, etag, license,
@@ -414,7 +421,81 @@ describe('runDescriptions', () => {
     expect(Number(rows[0]?.count)).toBe(0);
   });
 
-  it('Wikipedia 404 (deleted/renamed page) → species is skipped without writing a description', async () => {
+  it('Wikipedia 404 + iNat summary present → falls back to iNat, writes row with source=inat', async () => {
+    // The fallback path is the whole point of #374. When Wikipedia REST 404s
+    // (deleted page / never existed) AND iNat's per-id endpoint returns a
+    // non-null `wikipedia_summary`, the orchestrator must:
+    //   (a) sanitize the iNat plaintext via sanitizeText (not DOMPurify),
+    //   (b) persist the row with source='inat' and license='CC-BY-SA-4.0'
+    //       (the underlying source is the same Wikipedia article),
+    //   (c) increment BOTH descriptionsWritten AND the new descriptionsFromInat
+    //       counter (descriptionsWritten total covers Wikipedia + iNat sources).
+    await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
+    const INAT_FALLBACK_BODY = 'The vermilion flycatcher (Pyrocephalus rubinus) is a small passerine bird native to the Americas. The male is brilliantly red.';
+    let inatByIdHits = 0;
+    server.use(
+      http.get(INAT_TAXA, () => HttpResponse.json({
+        total_results: 1, page: 1, per_page: 1,
+        results: [{
+          id: 1001, name: 'Pyrocephalus rubinus', rank: 'species',
+          matched_term: 'Pyrocephalus rubinus',
+          wikipedia_url: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+        }],
+      })),
+      http.get(WIKI_SUMMARY, () => new HttpResponse('not found', { status: 404 })),
+      http.get(INAT_TAXA_BY_ID, ({ params }) => {
+        inatByIdHits++;
+        // The per-id endpoint must be called with the cached taxon id (1001
+        // from the search-endpoint pass) — the orchestrator should NEVER
+        // re-hit the search endpoint here.
+        expect(params.id).toBe('1001');
+        return HttpResponse.json({
+          total_results: 1, page: 1, per_page: 1,
+          results: [{
+            id: 1001, name: 'Pyrocephalus rubinus', rank: 'species',
+            wikipedia_summary: INAT_FALLBACK_BODY,
+            wikipedia_url: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+          }],
+        });
+      })
+    );
+
+    const summary = await runDescriptions({ pool: db.pool, paceMs: 0 });
+
+    expect(summary.descriptionsWritten).toBe(1);
+    expect(summary.descriptionsFromInat).toBe(1);
+    expect(summary.descriptionsSkipped).toBe(0);
+    expect(summary.descriptionsFailed).toBe(0);
+    expect(inatByIdHits).toBe(1);
+
+    const { rows } = await db.pool.query<{
+      species_code: string;
+      source: string;
+      body: string;
+      license: string;
+      attribution_url: string;
+      etag: string | null;
+      revision_id: string | null;
+    }>(
+      `SELECT species_code, source, body, license, attribution_url, etag, revision_id
+         FROM species_descriptions WHERE species_code = 'verfly'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.source).toBe('inat');
+    expect(rows[0]?.body).toBe(INAT_FALLBACK_BODY);
+    expect(rows[0]?.license).toBe('CC-BY-SA-4.0');
+    // Fallback path uses the cached Wikipedia URL when present (so the
+    // frontend's "Read more on Wikipedia" link still goes to the same article).
+    expect(rows[0]?.attribution_url).toBe('https://en.wikipedia.org/wiki/Vermilion_flycatcher');
+    // No upstream Wikipedia revision/etag on the iNat fallback path.
+    expect(rows[0]?.etag).toBeNull();
+    expect(rows[0]?.revision_id).toBeNull();
+  });
+
+  it('Wikipedia 404 + iNat returns null summary → species is skipped (descriptionsSkipped++)', async () => {
+    // Both upstreams come up empty: iNat has the taxon record but no
+    // Wikipedia cross-reference. The fallback bails out, no row is written,
+    // descriptionsSkipped increments.
     await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
     server.use(
       http.get(INAT_TAXA, () => HttpResponse.json({
@@ -425,13 +506,95 @@ describe('runDescriptions', () => {
           wikipedia_url: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
         }],
       })),
-      http.get(WIKI_SUMMARY, () => new HttpResponse('not found', { status: 404 }))
+      http.get(WIKI_SUMMARY, () => new HttpResponse('not found', { status: 404 })),
+      http.get(INAT_TAXA_BY_ID, () => HttpResponse.json({
+        total_results: 1, page: 1, per_page: 1,
+        results: [{
+          id: 1001, name: 'Pyrocephalus rubinus', rank: 'species',
+          wikipedia_summary: null,
+          wikipedia_url: null,
+        }],
+      }))
+    );
+
+    const summary = await runDescriptions({ pool: db.pool, paceMs: 0 });
+
+    expect(summary.descriptionsWritten).toBe(0);
+    expect(summary.descriptionsFromInat).toBe(0);
+    expect(summary.descriptionsSkipped).toBe(1);
+    expect(summary.descriptionsFailed).toBe(0);
+
+    const { rows } = await db.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_descriptions`
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+
+  it('Wikipedia 200 happy path does NOT call iNat /v1/taxa/{id} (avoid wasted bandwidth)', async () => {
+    // Critical perf invariant: the per-id call only fires on the Wikipedia-404
+    // fallback branch. On the cold-cache happy path, it stays unused — calling
+    // it on every species would double the iNat round-trips.
+    await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
+    let inatByIdHits = 0;
+    server.use(
+      http.get(INAT_TAXA, () => HttpResponse.json({
+        total_results: 1, page: 1, per_page: 1,
+        results: [{
+          id: 1001, name: 'Pyrocephalus rubinus', rank: 'species',
+          matched_term: 'Pyrocephalus rubinus',
+          wikipedia_url: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+        }],
+      })),
+      http.get(WIKI_SUMMARY, () => HttpResponse.json(
+        { extract_html: SAMPLE_BODY, revision: '1' },
+        { status: 200, headers: { etag: '"e"' } }
+      )),
+      http.get(INAT_TAXA_BY_ID, () => {
+        inatByIdHits++;
+        return HttpResponse.json({ total_results: 0, results: [] });
+      })
+    );
+
+    const summary = await runDescriptions({ pool: db.pool, paceMs: 0 });
+
+    expect(summary.descriptionsWritten).toBe(1);
+    expect(summary.descriptionsFromInat).toBe(0);
+    // The per-id endpoint must NOT be hit on the Wikipedia-200 happy path.
+    expect(inatByIdHits).toBe(0);
+  });
+
+  it('Wikipedia 304 (warm cache) does NOT call iNat /v1/taxa/{id} (already has a row)', async () => {
+    // The 304 path means the existing row is fresh; calling the iNat per-id
+    // endpoint would be wasted bandwidth. Same invariant as the 200 path —
+    // the fallback only fires on Wikipedia 404.
+    await db.pool.query(
+      `INSERT INTO species_descriptions
+         (species_code, source, body, license, revision_id, etag, attribution_url)
+       VALUES
+         ('verfly', 'wikipedia', '${'p'.repeat(60)}', 'CC-BY-SA-4.0', 1234567890, '"old-etag"', 'https://en.wikipedia.org/wiki/Vermilion_flycatcher')`
+    );
+    await db.pool.query(
+      `UPDATE species_meta SET inat_taxon_id = 1001 WHERE species_code = 'verfly'`
+    );
+    await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
+
+    let inatByIdHits = 0;
+    server.use(
+      http.get(WIKI_SUMMARY, () => new HttpResponse(null, {
+        status: 304, headers: { etag: '"old-etag"' }
+      })),
+      http.get(INAT_TAXA_BY_ID, () => {
+        inatByIdHits++;
+        return HttpResponse.json({ total_results: 0, results: [] });
+      })
     );
 
     const summary = await runDescriptions({ pool: db.pool, paceMs: 0 });
 
     expect(summary.descriptionsSkipped).toBe(1);
     expect(summary.descriptionsWritten).toBe(0);
+    expect(summary.descriptionsFromInat).toBe(0);
+    expect(inatByIdHits).toBe(0);
   });
 
   it('rejects garbage license values via DB CHECK (defense-in-depth on top of upstream license guarantee)', async () => {

--- a/services/ingestor/src/run-descriptions.ts
+++ b/services/ingestor/src/run-descriptions.ts
@@ -4,9 +4,9 @@ import {
   insertSpeciesDescription,
   type Pool,
 } from '@bird-watch/db-client';
-import { fetchInatTaxon } from './inat/taxon-client.js';
+import { fetchInatTaxon, fetchInatTaxonSummary } from './inat/taxon-client.js';
 import { fetchWikipediaSummary } from './wikipedia/client.js';
-import { sanitizeWikipediaExtract } from './wikipedia/sanitize.js';
+import { sanitizeText, sanitizeWikipediaExtract } from './wikipedia/sanitize.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -33,20 +33,36 @@ export interface RunDescriptionsSummary {
   status: 'success' | 'failure';
   /** Total rows iterated from species_meta (after the EXISTS filter). */
   speciesCount: number;
-  /** Successful end-to-end (iNat resolved + Wikipedia 200 + DOMPurify + DB insert). */
+  /**
+   * Successful end-to-end. Total of Wikipedia (source='wikipedia') AND
+   * iNat-fallback (source='inat') writes. The iNat slice is broken out
+   * separately as `descriptionsFromInat` for coverage telemetry.
+   */
   descriptionsWritten: number;
   /**
-   * No description written because (a) iNat returned null, (b) Wikipedia 404,
-   * or (c) Wikipedia 304 (matching ETag — the row already existed and is fresh).
+   * No description written because (a) iNat search returned null, (b)
+   * Wikipedia 404 AND iNat per-id summary also null, (c) Wikipedia 304
+   * (matching ETag — the row already existed and is fresh), or (d) iNat
+   * search returned a taxon with no Wikipedia URL.
    */
   descriptionsSkipped: number;
   /** Threw at any step (iNat error, Wikipedia error, sanitization, DB CHECK). */
   descriptionsFailed: number;
+  /**
+   * Subset of `descriptionsWritten` taken via the iNat-summary fallback path
+   * (Wikipedia returned 404, iNat per-id returned a non-null `wikipedia_summary`,
+   * sanitizeText accepted the body, row was written with `source='inat'`).
+   * Coverage telemetry: `descriptionsFromInat / descriptionsWritten` is the
+   * fraction of species that needed the fallback.
+   */
+  descriptionsFromInat: number;
   errors: Array<{ speciesCode: string; reason: string }>;
 }
 
 const DEFAULT_PACE_MS = 1_000;
-const SOURCE = 'wikipedia' as const;
+const WIKIPEDIA_SOURCE = 'wikipedia' as const;
+const INAT_SOURCE = 'inat' as const;
+const WIKIPEDIA_LICENSE = 'CC-BY-SA-4.0' as const;
 
 /**
  * Orchestrates the daily descriptions backfill: for each AZ-observed species,
@@ -110,6 +126,7 @@ export async function runDescriptions(
     descriptionsWritten: 0,
     descriptionsSkipped: 0,
     descriptionsFailed: 0,
+    descriptionsFromInat: 0,
     errors: [],
   };
 
@@ -134,7 +151,14 @@ export async function runDescriptions(
       //    The cached path is what makes the daily cron cheap on steady-state
       //    runs (most Wikipedia pages don't change day-to-day, so the
       //    follow-up conditional GET is also a fast 304).
+      //
+      // Track the resolved iNat taxon id alongside the Wikipedia URL so the
+      // Wikipedia-404 fallback branch below can hit /v1/taxa/{id} without
+      // re-resolving the binomial.
       let wikipediaUrl: string;
+      let inatTaxonId: number | null = row.inat_taxon_id !== null
+        ? Number(row.inat_taxon_id)
+        : null;
       if (row.inat_taxon_id !== null && row.prior_attribution_url !== null) {
         wikipediaUrl = row.prior_attribution_url;
       } else {
@@ -149,7 +173,9 @@ export async function runDescriptions(
           continue;
         }
 
-        // Write back the iNat id so subsequent runs / #374 can use it.
+        inatTaxonId = taxon.inatTaxonId;
+
+        // Write back the iNat id so subsequent runs use it.
         if (row.inat_taxon_id === null) {
           await args.pool.query(
             `UPDATE species_meta SET inat_taxon_id = $1 WHERE species_code = $2`,
@@ -159,7 +185,9 @@ export async function runDescriptions(
 
         if (taxon.wikipediaUrl === null) {
           // iNat has the taxon but no Wikipedia cross-reference. Skip — the
-          // future #374 fallback will take this species via iNat-summary.
+          // iNat-fallback path requires a Wikipedia URL to attribute against
+          // anyway (the per-id `wikipedia_summary` only exists when there's
+          // a Wikipedia article; null cross-ref correlates with null summary).
           // eslint-disable-next-line no-console
           console.log(
             `[run-descriptions] ${speciesCode} (${sciName}): iNat taxon has no wikipedia_url, skipping`
@@ -193,13 +221,67 @@ export async function runDescriptions(
       const wiki = await fetchWikipediaSummary(wikipediaTitle, summaryFetchOpts);
 
       if (wiki === null) {
-        // Wikipedia 404 — page deleted or renamed. Skip; #374 fallback will
-        // re-attempt via iNat-summary on the next run.
-        // eslint-disable-next-line no-console
-        console.log(
-          `[run-descriptions] ${speciesCode} (${sciName}): Wikipedia returned 404 for ${wikipediaTitle}, skipping`
-        );
-        summary.descriptionsSkipped++;
+        // Wikipedia 404 — page deleted or renamed. Try the iNat-summary
+        // fallback (added in #374): hit /v1/taxa/{id} for the cached id and
+        // persist iNat's `wikipedia_summary` plaintext as a row with
+        // source='inat'. This is the whole reason the per-id endpoint exists
+        // in our pipeline — coverage on AZ-rare/vagrant species (Cave
+        // Swallow, Glossy Ibis) where Wikipedia REST returns 404 but iNat
+        // mirrors the article body.
+        //
+        // The fallback ONLY fires here (Wikipedia 404 branch) — never on the
+        // 200 happy path (would be wasted bandwidth) and never on the 304
+        // warm-cache path (already has a row).
+        if (inatTaxonId === null) {
+          // No cached id and the iNat search returned non-null taxon above
+          // (otherwise we'd have continued earlier) — this branch is
+          // unreachable in practice, but defend against a future refactor
+          // that decouples the paths.
+          // eslint-disable-next-line no-console
+          console.log(
+            `[run-descriptions] ${speciesCode} (${sciName}): Wikipedia 404 with no cached iNat id, skipping`
+          );
+          summary.descriptionsSkipped++;
+          continue;
+        }
+
+        const inatSummary = await fetchInatTaxonSummary(inatTaxonId, fetchOpts);
+        if (inatSummary === null || inatSummary.wikipediaSummary === null) {
+          // Both upstreams empty — log and skip.
+          // eslint-disable-next-line no-console
+          console.log(
+            `[run-descriptions] ${speciesCode} (${sciName}): Wikipedia 404 + iNat summary null, skipping`
+          );
+          summary.descriptionsSkipped++;
+          continue;
+        }
+
+        // Sanitize the iNat plaintext (strip any tags as defense-in-depth,
+        // trim, enforce 50..8192 length). SanitizationError surfaces in the
+        // outer catch as a per-species failure.
+        const sanitizedFallbackBody = sanitizeText(inatSummary.wikipediaSummary);
+
+        await insertSpeciesDescription(args.pool, {
+          speciesCode,
+          source: INAT_SOURCE,
+          body: sanitizedFallbackBody,
+          // iNat's wikipedia_summary is extracted from the same Wikipedia
+          // article, so the license is unchanged. The DB CHECK is unchanged
+          // by #374 and still requires a CC-BY-SA variant.
+          license: WIKIPEDIA_LICENSE,
+          // No upstream Wikipedia revision/etag on the fallback path — those
+          // belong to Wikipedia REST's conditional-GET semantics, not iNat's.
+          revisionId: null,
+          etag: null,
+          // Prefer the cached Wikipedia URL when present so the frontend's
+          // "Read more on Wikipedia" link still goes to the same article;
+          // fall back to the iNat taxon page if the URL parser couldn't
+          // produce one (defensive — wikipediaUrl is always set here by
+          // construction).
+          attributionUrl: wikipediaUrl,
+        });
+        summary.descriptionsWritten++;
+        summary.descriptionsFromInat++;
         continue;
       }
 
@@ -224,7 +306,7 @@ export async function runDescriptions(
           : null;
       await insertSpeciesDescription(args.pool, {
         speciesCode,
-        source: SOURCE,
+        source: WIKIPEDIA_SOURCE,
         body: sanitizedBody,
         license: wiki.license,
         revisionId,

--- a/services/ingestor/src/wikipedia/sanitize.test.ts
+++ b/services/ingestor/src/wikipedia/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeWikipediaExtract, SanitizationError } from './sanitize.js';
+import { sanitizeWikipediaExtract, sanitizeText, SanitizationError } from './sanitize.js';
 
 const PADDING = '. The vermilion flycatcher is a small bird native to the Americas.';
 
@@ -97,5 +97,76 @@ describe('sanitizeWikipediaExtract', () => {
     expect(() => sanitizeWikipediaExtract(input50)).not.toThrow();
     const input8192 = `<p>${'b'.repeat(8185)}</p>`; // 8185 + 7 wrapper = 8192
     expect(() => sanitizeWikipediaExtract(input8192)).not.toThrow();
+  });
+});
+
+describe('sanitizeText', () => {
+  // sanitizeText is the iNat-fallback counterpart to sanitizeWikipediaExtract.
+  // iNat's `wikipedia_summary` field is plaintext extracted from the Wikipedia
+  // article — no HTML to allow-list. But we still strip any tags as
+  // defense-in-depth (never trust input) and trim whitespace, then enforce the
+  // same `[50, 8192]` length contract that matches the DB body CHECK.
+
+  it('returns the input unchanged when it is already plain text within bounds', () => {
+    const input = `Vermilion flycatcher (Pyrocephalus rubinus) is a small passerine native to the Americas. ${PADDING}`;
+    const out = sanitizeText(input);
+    expect(out).toBe(input.trim());
+  });
+
+  it('strips HTML tags (defense-in-depth — iNat returns plaintext but never trust input)', () => {
+    const input = `<script>alert("XSS")</script>The vermilion flycatcher is a small passerine bird native to the Americas. ${PADDING}`;
+    const out = sanitizeText(input);
+    expect(out).not.toContain('<script');
+    expect(out).not.toContain('alert');
+    expect(out).not.toContain('</script>');
+    expect(out).toContain('vermilion flycatcher');
+  });
+
+  it('strips even benign-looking tags like <p> and <em> (no allowlist — plaintext only)', () => {
+    const input = `<p>The vermilion flycatcher (<em>Pyrocephalus rubinus</em>) is a small passerine bird native to the Americas.${PADDING}</p>`;
+    const out = sanitizeText(input);
+    expect(out).not.toContain('<p>');
+    expect(out).not.toContain('<em>');
+    expect(out).not.toContain('</p>');
+    expect(out).toContain('vermilion flycatcher');
+    expect(out).toContain('Pyrocephalus rubinus');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    const input = `   \n\tThe Vermilion flycatcher is a small passerine bird native to the Americas. ${PADDING}\n   `;
+    const out = sanitizeText(input);
+    expect(out.startsWith(' ')).toBe(false);
+    expect(out.startsWith('\n')).toBe(false);
+    expect(out.endsWith(' ')).toBe(false);
+    expect(out.endsWith('\n')).toBe(false);
+    expect(out).toContain('Vermilion flycatcher');
+  });
+
+  it('throws SanitizationError when post-strip length is below 50 chars', () => {
+    const input = '<p>too short</p>';
+    expect(() => sanitizeText(input)).toThrow(SanitizationError);
+    expect(() => sanitizeText(input)).toThrow(/length/i);
+  });
+
+  it('throws SanitizationError when post-strip length exceeds 8192 chars', () => {
+    const input = `${'a'.repeat(8193)}`;
+    expect(() => sanitizeText(input)).toThrow(SanitizationError);
+    expect(() => sanitizeText(input)).toThrow(/length/i);
+  });
+
+  it('accepts exactly 50 chars and exactly 8192 chars (boundary inclusive — matches DB body CHECK)', () => {
+    const input50 = 'a'.repeat(50);
+    expect(() => sanitizeText(input50)).not.toThrow();
+    const input8192 = 'b'.repeat(8192);
+    expect(() => sanitizeText(input8192)).not.toThrow();
+  });
+
+  it('an empty-after-strip input throws SanitizationError (whitespace + tags only)', () => {
+    // A pathological iNat response that strips to nothing must not silently
+    // produce a 0-char body that fails the DB CHECK opaquely; surface a
+    // SanitizationError with a clear "below MIN_LENGTH" message.
+    const input = '   <span></span>   <p></p>   ';
+    expect(() => sanitizeText(input)).toThrow(SanitizationError);
+    expect(() => sanitizeText(input)).toThrow(/length/i);
   });
 });

--- a/services/ingestor/src/wikipedia/sanitize.ts
+++ b/services/ingestor/src/wikipedia/sanitize.ts
@@ -72,3 +72,54 @@ export function sanitizeWikipediaExtract(html: string): string {
   }
   return out;
 }
+
+/**
+ * Sanitize a plain-text body for safe persistence as a `species_descriptions`
+ * row with `source = 'inat'`. The iNat `/v1/taxa/{id}` `wikipedia_summary`
+ * field is documented as plaintext (extracted from the same Wikipedia article
+ * the REST summary endpoint serves), so there's no allow-list of HTML tags
+ * to apply — but we still strip any tags as defense-in-depth (never trust
+ * input) and trim whitespace.
+ *
+ * The same `[50, 8192]` length contract applies — matches the
+ * `species_descriptions.body` CHECK and the bounds enforced by
+ * `sanitizeWikipediaExtract`. Throws `SanitizationError` on out-of-bounds.
+ *
+ * Why a plain string-replace and not DOMPurify: this path is plaintext-only.
+ * DOMPurify's allow-list is calibrated for HTML; running it would require an
+ * empty allow-list (returning the textContent of the parsed tree), which is
+ * heavier and depends on the same isomorphic-dompurify install. A regex
+ * tag-strip is sufficient for the defense-in-depth claim and is the same
+ * shape as the rest of the code base's plaintext-handling surfaces.
+ */
+export function sanitizeText(input: string): string {
+  // First strip <script>…</script> and <style>…</style> blocks INCLUDING
+  // their contents. The generic tag-strip below would otherwise leave the
+  // executable body intact (`alert("XSS")` from `<script>alert("XSS")</script>`).
+  // Case-insensitive `i` and dot-all `s` cover the multi-line and uppercase
+  // forms a malicious payload could use.
+  const noBlocks = input
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, '');
+
+  // Strip any remaining HTML/XML tag — `<tag>`, `</tag>`, `<tag attr="...">`,
+  // `<self-closing/>`. The regex is non-greedy on the `<...>` content so
+  // `<a>foo<b>` doesn't strip the inner `foo` as part of one mega-match.
+  const stripped = noBlocks.replace(/<[^>]*>/g, '');
+
+  // Trim leading/trailing whitespace AFTER tag-stripping so wrappers like
+  // `   <p>...</p>   ` don't smuggle whitespace past the trim.
+  const out = stripped.trim();
+
+  if (out.length < MIN_LENGTH) {
+    throw new SanitizationError(
+      `Sanitized text length ${out.length} is below MIN_LENGTH=${MIN_LENGTH}`
+    );
+  }
+  if (out.length > MAX_LENGTH) {
+    throw new SanitizationError(
+      `Sanitized text length ${out.length} exceeds MAX_LENGTH=${MAX_LENGTH}`
+    );
+  }
+  return out;
+}


### PR DESCRIPTION
## Diagrams

The fallback fork: when Wikipedia REST 404s, hit iNat's per-id endpoint with the cached taxon id, sanitize the plaintext, and persist with `source='inat'`.

```mermaid
sequenceDiagram
    participant Orchestrator as run-descriptions.ts
    participant iNatSearch as iNat /v1/taxa?q=...
    participant Wikipedia as Wikipedia REST /page/summary/{title}
    participant iNatById as iNat /v1/taxa/{id}
    participant Postgres as species_descriptions

    Note over Orchestrator: For each AZ-observed species
    Orchestrator->>iNatSearch: fetchInatTaxon(sciName)
    iNatSearch-->>Orchestrator: { inatTaxonId, wikipediaUrl }
    Orchestrator->>Wikipedia: fetchWikipediaSummary(title, priorEtag?)
    alt Wikipedia 200
        Wikipedia-->>Orchestrator: extract_html + etag
        Orchestrator->>Postgres: INSERT source='wikipedia'
    else Wikipedia 304 (warm cache)
        Wikipedia-->>Orchestrator: 304 Not Modified
        Note over Orchestrator: Skip — existing row is fresh
    else Wikipedia 404 (deleted/renamed)
        Wikipedia-->>Orchestrator: null
        Orchestrator->>iNatById: fetchInatTaxonSummary(inatTaxonId)
        iNatById-->>Orchestrator: { wikipediaSummary }
        Note over Orchestrator: sanitizeText → strip tags + trim + length CHECK
        Orchestrator->>Postgres: INSERT source='inat', license=CC-BY-SA-4.0
    end
```

## Summary

- **Why now**: Wikipedia REST 404s on ~10–15% of AZ-observed species (rare splits, deleted pages, regional lumps); iNat's per-id endpoint returns `wikipedia_summary` plaintext extracted from the same Wikipedia article. Adding the fallback lifts coverage from ~85% (Wikipedia-only) toward the empirical ~95% ceiling without changing the trust model — same source, same license.
- **Why a separate `fetchInatTaxonSummary` helper** rather than widening `InatTaxon`: the search endpoint (`/v1/taxa?q=...`) does NOT surface `wikipedia_summary` — only `/v1/taxa/{id}` does. Coupling them would force the search helper into a per-id round-trip on every species, doubling iNat load on the 90% Wikipedia-200 path.
- **License invariant pinned**: iNat-fallback rows still use `CC-BY-SA-4.0` because the underlying source is the same Wikipedia article. The DB license CHECK is unchanged; only the source CHECK widens (`'wikipedia'` → `'wikipedia', 'inat'`).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — green (115/115, +6 new fallback cases)
- [x] `npm run test --workspace @bird-watch/db-client` — green (78/78, +7 new migration cases + 1 new species.test.ts case)
- [x] New unit tests added: `fetchInatTaxonSummary` (5 cases in `taxon-client.test.ts`), `sanitizeText` (8 cases in `sanitize.test.ts`), migration up/down (7 cases in `species-descriptions-inat-source-migration.test.ts`)
- [x] New integration tests added: Wikipedia-404+iNat-summary writes `source='inat'`, Wikipedia-404+iNat-null skips, Wikipedia-200/304 paths confirm zero per-id calls (perf invariant)
- [x] `npm run build` — clean production build
- [x] `npm run lint` — clean (workspace-level no-op; CI gate passes)
- [x] `npx knip` — clean (no unused exports / files)
- [x] `terraform validate` — clean
- [ ] (UI only) Playwright MCP smoke — N/A, ingestor-only change

## Plan reference

Out of plan — epic #368 / closes #374.