### PR TITLE
feat(frontend): SpeciesDescription + AttributionModal 6th section + axe modal-open + has_description PostHog tag

### DIFF
--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -296,4 +296,57 @@ test.describe('axe-core WCAG scans', () => {
     }
     expect(results.violations).toEqual([]);
   });
+
+  // Issue #373 task 5 — axe scan with the AttributionModal OPEN. The
+  // existing detail-surface scans cover the modal-CLOSED state, but the
+  // modal contributes a non-trivial focus-trap, dialog landmark, and a
+  // long list of external-link anchors that only exist in the DOM once
+  // showModal() has run. WCAG 2.1.3 (Info & Relationships), 2.1.1
+  // (Keyboard) and 4.1.2 (Name/Role/Value) are all sensitive to the
+  // dialog's open state. Mirrors the existing paired-viewport pattern
+  // (desktop + mobile via the inner describe at line ~137 below).
+  //
+  // Implementation note: assert the `[open]` attribute on the dialog,
+  // NOT bare visibility. The codebase already documents this lesson at
+  // AttributionModal.tsx:206-214 — headless-Chromium can race between
+  // visibility and the dialog's open-attribute commit. Mirror that
+  // pattern here.
+  test('attribution modal open has no WCAG 2/2.1 A/AA violations (desktop)', async ({ page }) => {
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+    await page.getByRole('button', { name: /credits/i }).click();
+    // Wait on the [open] attribute commit — observable contract that
+    // showModal() has run, focus-delegation is settled, and the dialog
+    // is in the top layer.
+    await expect(page.locator('dialog.attribution-modal[open]')).toBeVisible();
+    const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+    if (results.violations.length) {
+      await test.info().attach('axe-violations', {
+        body: JSON.stringify(results.violations, null, 2),
+        contentType: 'application/json',
+      });
+    }
+    expect(results.violations).toEqual([]);
+  });
+
+  test.describe('attribution modal open at 390×844 mobile viewport', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('attribution modal open has no WCAG 2/2.1 A/AA violations (mobile)', async ({ page }) => {
+      const app = new AppPage(page);
+      await app.goto('view=feed');
+      await app.waitForAppReady();
+      await page.getByRole('button', { name: /credits/i }).click();
+      await expect(page.locator('dialog.attribution-modal[open]')).toBeVisible();
+      const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+      if (results.violations.length) {
+        await test.info().attach('axe-violations', {
+          body: JSON.stringify(results.violations, null, 2),
+          contentType: 'application/json',
+        });
+      }
+      expect(results.violations).toEqual([]);
+    });
+  });
 });

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -102,16 +102,85 @@ describe('AttributionModal', () => {
     expect(screen.getByRole('heading', { level: 2, name: /credits/i })).toBeInTheDocument();
   });
 
-  it('renders four sections, each with an <h3> heading', async () => {
+  it('renders five sections (without optional Photos), each with an <h3> heading', async () => {
     const user = userEvent.setup();
     render(<AttributionModal silhouettes={SILHOUETTES} />);
     await user.click(screen.getByRole('button', { name: /credits/i }));
-    // eBird, Family Silhouettes (Phylopic), Map Tiles (OSM/OpenFreeMap),
-    // Privacy (PostHog disclosure — issue #357 task 7).
+    // eBird, Family Silhouettes (Phylopic), Species descriptions
+    // (Wikipedia — #373), Map Tiles (OSM/OpenFreeMap), Privacy
+    // (PostHog disclosure — issue #357 task 7). Photos is optional and
+    // not rendered without photoAttribution + photoLicense.
     expect(screen.getByRole('heading', { level: 3, name: /bird sightings data/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /family silhouettes/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: /species descriptions/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /map tiles/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /privacy/i })).toBeInTheDocument();
+  });
+
+  // Issue #373 task 4: catch-all "Species descriptions" section sits
+  // between Photos (optional) and Map Tiles. Renders unconditionally —
+  // descriptions exist for >85% of species and the inline per-article
+  // credit on SpeciesDetailSurface satisfies the per-work attribution
+  // requirement, so the modal-level credit is the catch-all.
+  it('renders a Species descriptions section disclosing Wikipedia + CC BY-SA', async () => {
+    const user = userEvent.setup();
+    render(<AttributionModal silhouettes={SILHOUETTES} />);
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const heading = screen.getByRole('heading', { level: 3, name: /species descriptions/i });
+    expect(heading).toBeInTheDocument();
+    const section = heading.closest('section');
+    expect(section).not.toBeNull();
+    // Disclosure copy must surface (a) Wikipedia as the source and
+    // (b) CC BY-SA as the license + (c) the per-species panel link
+    // pointer (the inline "From Wikipedia, CC BY-SA" credit on
+    // SpeciesDescription is the per-article attribution).
+    expect(section!.textContent).toMatch(/Wikipedia/i);
+    expect(section!.textContent).toMatch(/CC BY-SA/i);
+    expect(section!.textContent).toMatch(/per-article|species panel/i);
+  });
+
+  it('renders the Species descriptions section between Photos and Map Tiles in DOM order', async () => {
+    const user = userEvent.setup();
+    render(
+      <AttributionModal
+        silhouettes={SILHOUETTES}
+        photoAttribution="Jane Photographer"
+        photoLicense="cc-by"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const headings = screen
+      .getAllByRole('heading', { level: 3 })
+      .map(h => h.textContent?.toLowerCase() ?? '');
+    const photosIdx = headings.findIndex(h => h.includes('photos'));
+    const descriptionsIdx = headings.findIndex(h => h.includes('species descriptions'));
+    const mapIdx = headings.findIndex(h => h.includes('map tiles'));
+    expect(photosIdx).toBeGreaterThan(-1);
+    expect(descriptionsIdx).toBeGreaterThan(-1);
+    expect(mapIdx).toBeGreaterThan(-1);
+    // Photos < Species descriptions < Map Tiles in DOM order.
+    expect(photosIdx).toBeLessThan(descriptionsIdx);
+    expect(descriptionsIdx).toBeLessThan(mapIdx);
+  });
+
+  it('renders the Species descriptions section even with Photos absent (sits between Family Silhouettes and Map Tiles)', async () => {
+    const user = userEvent.setup();
+    render(<AttributionModal silhouettes={SILHOUETTES} />);
+    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const headings = screen
+      .getAllByRole('heading', { level: 3 })
+      .map(h => h.textContent?.toLowerCase() ?? '');
+    const familyIdx = headings.findIndex(h => h.includes('family silhouettes'));
+    const descriptionsIdx = headings.findIndex(h => h.includes('species descriptions'));
+    const mapIdx = headings.findIndex(h => h.includes('map tiles'));
+    expect(familyIdx).toBeGreaterThan(-1);
+    expect(descriptionsIdx).toBeGreaterThan(-1);
+    expect(mapIdx).toBeGreaterThan(-1);
+    // No Photos heading in this branch.
+    expect(headings.findIndex(h => h.includes('photos'))).toBe(-1);
+    // Family Silhouettes < Species descriptions < Map Tiles.
+    expect(familyIdx).toBeLessThan(descriptionsIdx);
+    expect(descriptionsIdx).toBeLessThan(mapIdx);
   });
 
   it('renders a Privacy section disclosing PostHog analytics + DNT respect', async () => {

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -462,6 +462,43 @@ export function AttributionModal({
               </section>
             );
           })()}
+          {/*
+            Species descriptions credit (issue #373 / epic #368). The
+            section renders unconditionally — descriptions exist for >85%
+            of species per the ingestor's Wikipedia coverage probe, and
+            the catch-all credit covers the small minority that don't.
+            Per-article attribution lives inline on SpeciesDetailSurface
+            (the SpeciesDescription component renders "From Wikipedia,
+            CC BY-SA" with a link to the source article); this modal
+            section satisfies the prominence-of-attribution requirement
+            without forcing a per-species credit row in the modal itself
+            (which would scale to 344+ rows).
+          */}
+          <section
+            className="attribution-modal-section"
+            data-testid="attribution-descriptions-section"
+          >
+            <h3>Species descriptions</h3>
+            <p>
+              Species descriptions adapted from{' '}
+              <a
+                href="https://www.wikipedia.org"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Wikipedia
+              </a>
+              {' '}under{' '}
+              <a
+                href="https://creativecommons.org/licenses/by-sa/3.0/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CC BY-SA
+              </a>
+              . See each species panel for a per-article link.
+            </p>
+          </section>
           <section className="attribution-modal-section">
             <h3>Map Tiles</h3>
             <p>

--- a/frontend/src/components/SpeciesDescription.test.tsx
+++ b/frontend/src/components/SpeciesDescription.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SpeciesDescription } from './SpeciesDescription.js';
+
+/**
+ * SpeciesDescription tests (#373 / epic #368).
+ *
+ * The component is the only place in the codebase that uses React's
+ * HTML-injection escape hatch. Sanitization happens at INGEST time
+ * (`services/ingestor/src/wikipedia/sanitize.ts` via DOMPurify with a
+ * narrow tag allowlist + DB CHECK constraints); the writer-side allowlist
+ * is the trust boundary. Tests pin three behaviors:
+ *
+ *   1. Renders sanitized HTML via the escape hatch when `descriptionBody`
+ *      is present (no encoding of the inner markup).
+ *   2. Returns `null` (renders nothing) when `descriptionBody` is absent —
+ *      matches the CDN-stale contract on the wire (optional field) and
+ *      avoids an empty `<section>` shell.
+ *   3. The inline credit anchor carries `target="_blank"` +
+ *      `rel="noopener noreferrer"` and the per-article `href`.
+ */
+
+describe('SpeciesDescription', () => {
+  it('renders the descriptionBody HTML via the React injection escape hatch', () => {
+    const body =
+      '<p>The <em>Vermilion Flycatcher</em> is a small passerine bird.</p>';
+    render(
+      <SpeciesDescription
+        descriptionBody={body}
+        descriptionAttributionUrl="https://en.wikipedia.org/wiki/Vermilion_flycatcher"
+      />,
+    );
+    // Verify the inner <p> + <em> render as actual DOM nodes (i.e. the
+    // string was injected as HTML, not encoded as a text node). Querying
+    // by role catches the case where the HTML is rendered as escaped
+    // text — `screen.getByText('<p>The...')` would match the escaped
+    // rendering, but `<em>` selection only succeeds when the HTML
+    // parsed as markup.
+    const em = screen.getByText(/Vermilion Flycatcher/i);
+    expect(em.tagName).toBe('EM');
+    expect(em.textContent).toBe('Vermilion Flycatcher');
+  });
+
+  it('renders nothing when descriptionBody is undefined', () => {
+    const { container } = render(
+      <SpeciesDescription
+        descriptionAttributionUrl="https://en.wikipedia.org/wiki/Vermilion_flycatcher"
+      />,
+    );
+    // A bare `null` return — no shell `<section>`, no credit anchor.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when descriptionBody is an empty string', () => {
+    // Empty string is falsy in the `!descriptionBody` guard. Rendering an
+    // empty `<section>` would be worse than nothing (it would create a
+    // visual gap in the surface that SR users would land on).
+    const { container } = render(
+      <SpeciesDescription
+        descriptionBody=""
+        descriptionAttributionUrl="https://en.wikipedia.org/wiki/Vermilion_flycatcher"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('surfaces the inline credit only when descriptionBody is present', () => {
+    render(
+      <SpeciesDescription
+        descriptionBody="<p>Body.</p>"
+        descriptionAttributionUrl="https://en.wikipedia.org/wiki/Vermilion_flycatcher"
+      />,
+    );
+    expect(screen.getByText(/From/)).toBeInTheDocument();
+    expect(screen.getByText(/CC BY-SA/)).toBeInTheDocument();
+  });
+
+  it('the credit anchor carries target="_blank" + rel="noopener noreferrer" + href={descriptionAttributionUrl}', () => {
+    const url = 'https://en.wikipedia.org/wiki/Vermilion_flycatcher';
+    render(
+      <SpeciesDescription
+        descriptionBody="<p>Body.</p>"
+        descriptionAttributionUrl={url}
+      />,
+    );
+    const link = screen.getByRole('link', { name: /wikipedia/i });
+    expect(link).toHaveAttribute('href', url);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders the credit text even when descriptionAttributionUrl is undefined (no crash)', () => {
+    // Defensive: the writer-side contract is that body + URL co-vary
+    // (both present or both absent on the wire), but a CDN-stale
+    // response carrying body without URL must not crash. The credit
+    // copy still appears; the `<a>` carries no `href` attribute and
+    // therefore has no implicit `link` role per ARIA — that is OK,
+    // the visual fallback is just unstyled "Wikipedia" text.
+    const { container } = render(<SpeciesDescription descriptionBody="<p>Body.</p>" />);
+    expect(screen.getByText(/From/)).toBeInTheDocument();
+    expect(screen.getByText('Wikipedia')).toBeInTheDocument();
+    // Anchor element exists in the DOM but with no href attribute.
+    const anchor = container.querySelector('.species-detail-description-credit a');
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute('href')).toBeNull();
+  });
+
+  it('wraps the rendered HTML in a section.species-detail-description', () => {
+    const { container } = render(
+      <SpeciesDescription
+        descriptionBody="<p>Body.</p>"
+        descriptionAttributionUrl="https://en.wikipedia.org/wiki/X"
+      />,
+    );
+    const section = container.querySelector('section.species-detail-description');
+    expect(section).not.toBeNull();
+  });
+});

--- a/frontend/src/components/SpeciesDescription.tsx
+++ b/frontend/src/components/SpeciesDescription.tsx
@@ -1,0 +1,78 @@
+/**
+ * SpeciesDescription — renders the per-species Wikipedia summary HTML
+ * surfaced by `/api/species/:code` and credits Wikipedia inline.
+ *
+ * SECURITY INVARIANT
+ * ──────────────────
+ * - Sanitization is performed at INGEST time
+ *   (`services/ingestor/src/wikipedia/sanitize.ts` via DOMPurify with a
+ *   narrow tag/attr allowlist) and pinned at the database layer via
+ *   CHECK constraints on `species_descriptions.body`. The writer-side
+ *   allowlist + DB constraints constitute the trust boundary. Never
+ *   render description body without going through the writer-side
+ *   sanitizer.
+ * - This is the FIRST USE of React's HTML-injection escape hatch in
+ *   the codebase. Defense-in-depth runtime DOMPurify is intentionally
+ *   deferred to v2 (the trust boundary above is sufficient for v1).
+ *   See epic #368 for the audit trail.
+ *
+ * Render contract
+ * ───────────────
+ * - `descriptionBody` absent / empty → returns `null` (no shell, no
+ *   credit anchor, no visual gap on CDN-stale responses predating the
+ *   field).
+ * - `descriptionBody` present → injects the HTML via the escape hatch
+ *   and surfaces the inline "From Wikipedia, CC BY-SA" credit. The
+ *   credit's anchor uses `target="_blank"` + `rel="noopener noreferrer"`
+ *   matching the convention shared with AttributionModal's external
+ *   links (the modal hosts the catch-all "Species descriptions" credit
+ *   section; this inline credit covers the per-article requirement).
+ */
+
+export interface SpeciesDescriptionProps {
+  /**
+   * Sanitized HTML body sourced from `species_descriptions.body`. Optional
+   * on the wire — older / cache-stale `/api/species/:code` responses omit
+   * the field, in which case the component renders nothing. Empty string
+   * is treated identically to undefined so a writer race can never produce
+   * an empty `<section>` shell on the surface.
+   */
+  descriptionBody?: string;
+  /**
+   * Absolute URL to the source Wikipedia article. When the body is
+   * present this URL backs the inline credit anchor's `href`. Defensive:
+   * a CDN-stale response carrying body without URL renders the credit
+   * text without an href rather than crashing.
+   */
+  descriptionAttributionUrl?: string;
+}
+
+export function SpeciesDescription({
+  descriptionBody,
+  descriptionAttributionUrl,
+}: SpeciesDescriptionProps) {
+  if (!descriptionBody) return null;
+  return (
+    <section className="species-detail-description">
+      {/*
+        SECURITY INVARIANT (see file-header doc): description body is
+        DOMPurify-sanitized at ingest (services/ingestor/src/wikipedia/
+        sanitize.ts). Never render description body without going
+        through the writer-side sanitizer. First use of this escape
+        hatch in the codebase — see epic #368 for the audit trail.
+      */}
+      <div dangerouslySetInnerHTML={{ __html: descriptionBody }} />
+      <p className="species-detail-description-credit">
+        From{' '}
+        <a
+          href={descriptionAttributionUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Wikipedia
+        </a>
+        , CC BY-SA
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/SpeciesDescription.tsx
+++ b/frontend/src/components/SpeciesDescription.tsx
@@ -36,15 +36,21 @@ export interface SpeciesDescriptionProps {
    * the field, in which case the component renders nothing. Empty string
    * is treated identically to undefined so a writer race can never produce
    * an empty `<section>` shell on the surface.
+   *
+   * The explicit `| undefined` is required under
+   * `exactOptionalPropertyTypes: true` so call sites can pass
+   * `data.descriptionBody` (which TypeScript widens to `string | undefined`
+   * because the source field is optional on `SpeciesMeta`) directly.
+   * Mirrors the photoUrl convention on `SpeciesDetailVisual`.
    */
-  descriptionBody?: string;
+  descriptionBody?: string | undefined;
   /**
    * Absolute URL to the source Wikipedia article. When the body is
    * present this URL backs the inline credit anchor's `href`. Defensive:
    * a CDN-stale response carrying body without URL renders the credit
    * text without an href rather than crashing.
    */
-  descriptionAttributionUrl?: string;
+  descriptionAttributionUrl?: string | undefined;
 }
 
 export function SpeciesDescription({

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -200,6 +200,84 @@ describe('SpeciesDetailSurface', () => {
     });
   });
 
+  // ─── Species description mount (issue #373 / epic #368) ──────────────
+  //
+  // SpeciesDescription renders the per-species Wikipedia summary HTML when
+  // SpeciesMeta carries a non-null `descriptionBody`. The component
+  // returns `null` when the field is absent so the surface gracefully
+  // degrades on CDN-stale responses predating the field.
+  //
+  // The mount sits BETWEEN PhenologyChart and the bottom-sentinel — the
+  // sentinel must remain the LAST child of `.species-detail-body` for the
+  // IntersectionObserver to fire only after the user scrolls past every
+  // descendant content node.
+
+  it('mounts SpeciesDescription when descriptionBody is present and the credit links to the article', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue({
+        ...VERMFLY,
+        descriptionBody: '<p>The <em>Vermilion Flycatcher</em> is small and red.</p>',
+        descriptionLicense: 'CC-BY-SA-3.0',
+        descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+      }),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
+    const section = await waitFor(() => {
+      const node = container.querySelector('section.species-detail-description');
+      if (!node) throw new Error('species-detail-description not yet rendered');
+      return node;
+    });
+    expect(section).toBeInTheDocument();
+    // The injected HTML rendered as DOM (not encoded as text).
+    const em = section.querySelector('em');
+    expect(em?.textContent).toBe('Vermilion Flycatcher');
+    // Inline credit anchor: href + target + rel.
+    const link = section.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe(
+      'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+    );
+    expect(link!.getAttribute('target')).toBe('_blank');
+    expect(link!.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('does not mount SpeciesDescription when descriptionBody is absent', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument(),
+    );
+    expect(container.querySelector('section.species-detail-description')).toBeNull();
+  });
+
+  it('keeps the bottom sentinel as the LAST child of .species-detail-body when description renders', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue({
+        ...VERMFLY,
+        descriptionBody: '<p>Body.</p>',
+        descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/X',
+      }),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    const sentinel = await screen.findByTestId('phenology-bottom-sentinel');
+    const body = sentinel.closest('.species-detail-body');
+    expect(body).not.toBeNull();
+    // The IntersectionObserver fires on FIRST intersection then disconnects.
+    // For that to mean "scrolled past everything" the sentinel must remain
+    // the final child of the body container regardless of which optional
+    // sub-components mount above it.
+    expect(body!.lastElementChild).toBe(sentinel);
+  });
+
   it('does not mount PhenologyChart while species is still loading', () => {
     const getPhenology = vi.fn();
     const client = makeClient({
@@ -230,7 +308,7 @@ describe('SpeciesDetailSurface', () => {
   // directly to verify the events fire with the right payload.
 
   describe('analytics instrumentation', () => {
-    it('fires panel_opened on mount with species_code', async () => {
+    it('fires panel_opened on mount with species_code and has_description=false when no description', async () => {
       const captureSpy = vi.spyOn(analytics, 'capture');
       const client = makeClient({
         getSpecies: vi.fn().mockResolvedValue(VERMFLY),
@@ -240,7 +318,42 @@ describe('SpeciesDetailSurface', () => {
       await waitFor(() =>
         expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
       );
-      expect(captureSpy).toHaveBeenCalledWith('panel_opened', { species_code: 'vermfly' });
+      expect(captureSpy).toHaveBeenCalledWith('panel_opened', {
+        species_code: 'vermfly',
+        has_description: false,
+      });
+      captureSpy.mockRestore();
+    });
+
+    // Issue #373 task 6: stratify the panel-thinness analysis post-hoc by
+    // tagging `panel_opened` with `has_description: !!data.descriptionBody`.
+    // The dwell event shape stays unchanged (PostHog's UI lets the analyst
+    // group on the open-event property at query time).
+    it('fires panel_opened with has_description=true when descriptionBody is present', async () => {
+      const captureSpy = vi.spyOn(analytics, 'capture');
+      const client = makeClient({
+        getSpecies: vi.fn().mockResolvedValue({
+          ...VERMFLY,
+          descriptionBody: '<p>Body.</p>',
+          descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+        }),
+        getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+      } as unknown as Partial<ApiClient>);
+      render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
+      );
+      expect(captureSpy).toHaveBeenCalledWith('panel_opened', {
+        species_code: 'vermfly',
+        has_description: true,
+      });
+      // Defensive: dwell event shape is unchanged — no `has_description` on
+      // the dwell payload (the analyst groups on the open-event property at
+      // query time).
+      const dwellCalls = captureSpy.mock.calls.filter(([name]) => name === 'panel_dwell_ms');
+      for (const [, payload] of dwellCalls) {
+        expect(payload as Record<string, unknown>).not.toHaveProperty('has_description');
+      }
       captureSpy.mockRestore();
     });
 

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -2,32 +2,10 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
 import { useSilhouettes } from '../data/use-silhouettes.js';
-import type { FamilySilhouette, SpeciesMeta } from '@bird-watch/shared-types';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
 import { analytics } from '../analytics.js';
 import { PhenologyChart } from './PhenologyChart.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
-
-/**
- * Local widening of `SpeciesMeta` to surface the optional description
- * projection fields that ship with #372 (the db-client + shared-types PR
- * landing in parallel with this one). Once #372 lands and the fields
- * become first-class on `SpeciesMeta`, this alias becomes redundant — the
- * narrowing-via-truthy-check pattern is identical either way. Keeping the
- * alias here avoids a hard ordering coupling between the two PRs in the
- * Mergify queue: this PR builds clean against either type shape.
- *
- * Ordering: the wire payload from `/api/species/:code` carries these
- * fields when the read-api projection is updated (also in #372). When
- * the projection is absent, the fields deserialize as `undefined` and
- * the SpeciesDescription mount silently no-ops. A CDN-stale response
- * predating the projection has the same shape — the same render path
- * handles both.
- */
-type SpeciesMetaWithDescription = SpeciesMeta & {
-  descriptionBody?: string;
-  descriptionLicense?: string;
-  descriptionAttributionUrl?: string;
-};
 
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
@@ -149,11 +127,7 @@ function SpeciesDetailVisual({
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   const { speciesCode, apiClient } = props;
   const detail = useSpeciesDetail(apiClient, speciesCode);
-  const { loading, error } = detail;
-  // Widen the resolved meta to the description-aware variant (see file-level
-  // type alias). Read access is via the local `data` binding everywhere
-  // below, so the cast is contained to one site.
-  const data = detail.data as SpeciesMetaWithDescription | null;
+  const { loading, error, data } = detail;
   const { silhouettes } = useSilhouettes(apiClient);
 
   // Analytics instrumentation (issue #357 task 3): fire `panel_opened`

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -2,10 +2,32 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
 import { useSilhouettes } from '../data/use-silhouettes.js';
-import type { FamilySilhouette } from '@bird-watch/shared-types';
+import type { FamilySilhouette, SpeciesMeta } from '@bird-watch/shared-types';
 import { analytics } from '../analytics.js';
 import { PhenologyChart } from './PhenologyChart.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
+
+/**
+ * Local widening of `SpeciesMeta` to surface the optional description
+ * projection fields that ship with #372 (the db-client + shared-types PR
+ * landing in parallel with this one). Once #372 lands and the fields
+ * become first-class on `SpeciesMeta`, this alias becomes redundant — the
+ * narrowing-via-truthy-check pattern is identical either way. Keeping the
+ * alias here avoids a hard ordering coupling between the two PRs in the
+ * Mergify queue: this PR builds clean against either type shape.
+ *
+ * Ordering: the wire payload from `/api/species/:code` carries these
+ * fields when the read-api projection is updated (also in #372). When
+ * the projection is absent, the fields deserialize as `undefined` and
+ * the SpeciesDescription mount silently no-ops. A CDN-stale response
+ * predating the projection has the same shape — the same render path
+ * handles both.
+ */
+type SpeciesMetaWithDescription = SpeciesMeta & {
+  descriptionBody?: string;
+  descriptionLicense?: string;
+  descriptionAttributionUrl?: string;
+};
 
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
@@ -126,7 +148,12 @@ function SpeciesDetailVisual({
  */
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   const { speciesCode, apiClient } = props;
-  const { loading, error, data } = useSpeciesDetail(apiClient, speciesCode);
+  const detail = useSpeciesDetail(apiClient, speciesCode);
+  const { loading, error } = detail;
+  // Widen the resolved meta to the description-aware variant (see file-level
+  // type alias). Read access is via the local `data` binding everywhere
+  // below, so the cast is contained to one site.
+  const data = detail.data as SpeciesMetaWithDescription | null;
   const { silhouettes } = useSilhouettes(apiClient);
 
   // Analytics instrumentation (issue #357 task 3): fire `panel_opened`

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -183,7 +183,7 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
         dwell_ms: Date.now() - t0,
       });
     };
-  }, [data?.speciesCode, data?.descriptionBody]);
+  }, [data?.speciesCode]);
 
   // Bottom-sentinel ref + IntersectionObserver effect (task 4).  Binary-
   // only signal: fire `panel_scrolled_to_bottom` once on first intersection

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -5,6 +5,7 @@ import { useSilhouettes } from '../data/use-silhouettes.js';
 import type { FamilySilhouette } from '@bird-watch/shared-types';
 import { analytics } from '../analytics.js';
 import { PhenologyChart } from './PhenologyChart.js';
+import { SpeciesDescription } from './SpeciesDescription.js';
 
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
@@ -140,14 +141,22 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
     if (!data?.speciesCode) return;
     const t0 = Date.now();
     const code = data.speciesCode;
-    analytics.capture('panel_opened', { species_code: code });
+    // Issue #373 task 6: tag `panel_opened` with `has_description` so the
+    // panel-thinness dwell analysis can stratify post-hoc by whether a
+    // species had a Wikipedia summary at the time of view. The dwell event
+    // shape is intentionally unchanged — the analyst groups on the
+    // `has_description` property of the open event at PostHog query time.
+    analytics.capture('panel_opened', {
+      species_code: code,
+      has_description: !!data.descriptionBody,
+    });
     return () => {
       analytics.capture('panel_dwell_ms', {
         species_code: code,
         dwell_ms: Date.now() - t0,
       });
     };
-  }, [data?.speciesCode]);
+  }, [data?.speciesCode, data?.descriptionBody]);
 
   // Bottom-sentinel ref + IntersectionObserver effect (task 4).  Binary-
   // only signal: fire `panel_scrolled_to_bottom` once on first intersection
@@ -211,13 +220,26 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
           <p className="species-detail-family">{data.familyName}</p>
           <PhenologyChart speciesCode={speciesCode} apiClient={apiClient} />
           {/*
+            SpeciesDescription mount (issue #373 / epic #368). Renders
+            sanitized Wikipedia summary HTML when SpeciesMeta carries a
+            non-null `descriptionBody`; returns `null` (silent no-op)
+            when absent so CDN-stale responses degrade gracefully.
+            Sits between PhenologyChart and the bottom sentinel — the
+            sentinel must remain the LAST child of `.species-detail-body`
+            (see comment below).
+          */}
+          <SpeciesDescription
+            descriptionBody={data.descriptionBody}
+            descriptionAttributionUrl={data.descriptionAttributionUrl}
+          />
+          {/*
             Bottom sentinel for the IntersectionObserver-driven
             `panel_scrolled_to_bottom` event (issue #357 task 4).
             `aria-hidden` because there is no semantic content here —
             it exists only to anchor the observer.  Must remain the LAST
             child of `.species-detail-body` so it only intersects after
-            the user has scrolled past PhenologyChart and the rest of
-            the panel content.
+            the user has scrolled past PhenologyChart, SpeciesDescription
+            (when present), and the rest of the panel content.
           */}
           <div
             ref={sentinelRef}


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
  A[SpeciesDetailSurface] --> B[SpeciesDetailVisual]
  A --> C[h2/p taxonomy]
  A --> D[PhenologyChart]
  A --> E[SpeciesDescription]
  A --> F[bottom sentinel]
  E --> G["div with dangerouslySetInnerHTML"]
  E --> H[p.species-detail-description-credit]
  H --> I["a target=_blank rel=noopener noreferrer<br/>href=descriptionAttributionUrl"]

  classDef sec fill:#fde68a,stroke:#92400e,color:#1f2937
  class G sec
  class E sec
```

```mermaid
sequenceDiagram
    participant T as e2e test (axe.spec.ts)
    participant P as Playwright page
    participant A as App.tsx
    participant M as AttributionModal
    participant X as axe-core

    T->>P: page.goto('?view=feed')
    T->>P: app.waitForAppReady()
    T->>P: getByRole('button', {name: 'Credits'}).click()
    P->>A: click event
    A->>M: AttributionModal.onOpen()
    M->>P: dialog.showModal() + queueMicrotask focus
    Note over M,P: open attribute commits
    T->>P: expect(dialog.attribution-modal[open]).toBeVisible()
    T->>X: AxeBuilder.analyze() with WCAG_TAGS
    X-->>T: violations: []
    T->>T: expect(violations).toEqual([])
```

## Summary

- Adds `SpeciesDescription` (FIRST USE of React's HTML-injection escape hatch in this codebase) — sanitization is the writer-side responsibility (DOMPurify + DB CHECK constraints in the ingestor; defense-in-depth runtime DOMPurify is intentionally deferred to v2 per epic #368). The component documents the security invariant inline at the call site, names the trust boundary file (`services/ingestor/src/wikipedia/sanitize.ts`), flags itself as the first use of the escape hatch, and links to epic #368 for the audit trail.
- Inserts the catch-all "Species descriptions" credit section into `AttributionModal` between Photos (optional) and Map Tiles. Per-article attribution lives inline on `SpeciesDescription`; this modal section satisfies prominence-of-attribution without scaling to a per-species credit row (which would balloon to 344+ rows).
- Adds a paired axe scan with the modal OPEN at desktop + mobile. Asserts on `dialog.attribution-modal[open]` (not bare visibility) per the lesson documented at `frontend/src/components/AttributionModal.tsx:206-214` — headless Chromium can race between visibility and the dialog's `open`-attribute commit. Mirrors that pattern.
- Tags `panel_opened` PostHog event with `has_description: !!data.descriptionBody` so the post-hoc panel-thinness dwell analysis can stratify by whether the species had a Wikipedia summary at view time. Dwell event shape unchanged.

## Screenshots

| Desktop (1440×900) | Mobile (390×844) |
|---|---|
| Detail surface — Wikipedia summary HTML rendered below the phenology chart with inline "From Wikipedia, CC BY-SA" credit:<br><br><img width="600" alt="desktop detail surface with description" src="https://github.com/user-attachments/assets/b333c0e6-f5ad-4343-8725-8ea38eedb86b" /> | Mobile detail surface scrolled to inline credit:<br><br><img width="300" alt="mobile detail surface with credit visible" src="https://github.com/user-attachments/assets/c698e112-7a82-40a7-a863-6f982025b72a" /> |
| AttributionModal scrolled to the new "Species descriptions" section (between Family Silhouettes and Map Tiles):<br><br><img width="600" alt="desktop attribution modal species descriptions section" src="https://github.com/user-attachments/assets/95a24b99-1810-46d7-a499-2411122a19fd" /> | Mobile AttributionModal scrolled to "Species descriptions":<br><br><img width="300" alt="mobile attribution modal species descriptions section" src="https://github.com/user-attachments/assets/c66f1c6e-ba41-4248-a004-3ae33bed6293" /> |

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 433 tests, all green
- [x] New unit tests added (`SpeciesDescription.test.tsx`, 7 cases; extensions to `SpeciesDetailSurface.test.tsx` + `AttributionModal.test.tsx`)
- [x] New Playwright e2e specs added (axe modal-open at both viewports — 2 cases)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx knip` — zero findings
- [x] (UI only) Playwright MCP smoke — drove `?detail=vermfly&view=detail` at 1440×900 + 390×844, opened the AttributionModal at both viewports, `browser_console_messages` returned 0 errors and 0 warnings (the only error across the entire session was a `favicon.ico` 404, a pre-existing local-dev condition unrelated to this PR — there is no `frontend/public/` directory in the repo). Screenshots captured above.

## Plan reference

Out of plan — epic #368 / closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)