### PR TITLE
ci(infra): auto-roll :latest tag on every main push

### DIFF
--- a/.github/workflows/deploy-ingestor.yml
+++ b/.github/workflows/deploy-ingestor.yml
@@ -52,6 +52,27 @@ jobs:
           docker push "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
+      - name: Promote SHA-tagged image to :latest
+        # Cloud Run Jobs (bird-ingestor, bird-ingestor-photos,
+        # bird-ingestor-descriptions) and the read-api Service all reference
+        # `<image>:latest` in infra/terraform/. Without this step, :latest
+        # stays pinned to whatever SHA last had it manually re-tagged — which
+        # caused the 2026-05-03 production miss documented in #383 (the
+        # descriptions Cloud Run Job pulled a 2026-04-19 image that pre-dated
+        # the `descriptions` kind). Re-tagging on every successful push to
+        # main keeps :latest honest. Auth context is reused from the
+        # google-github-actions/auth step above. The `if:` guard is defense in
+        # depth — `on.push.branches` already restricts triggers to main, but
+        # workflow_dispatch can fire from any branch, and we only want to
+        # promote when the SHA we just pushed is on main.
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          gcloud artifacts docker tags add \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:${GITHUB_SHA}" \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:latest" \
+            --project="${GCP_PROJECT}"
+
       - name: Deploy to Cloud Run Jobs
         run: |
           # Two jobs share this image: bird-ingestor (the original — recent /

--- a/.github/workflows/deploy-read-api.yml
+++ b/.github/workflows/deploy-read-api.yml
@@ -52,6 +52,24 @@ jobs:
           docker push "$IMAGE"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
 
+      - name: Promote SHA-tagged image to :latest
+        # Cloud Run Service (bird-read-api) references `read-api:latest` in
+        # infra/terraform/read-api.tf:40. Without this step, :latest stays
+        # pinned to whatever SHA last had it manually re-tagged — see #383
+        # for the production miss this caused on the ingestor side. Re-tagging
+        # on every successful push to main keeps :latest honest. Auth context
+        # is reused from the google-github-actions/auth step above. The `if:`
+        # guard is defense in depth — `on.push.branches` already restricts
+        # triggers to main, but workflow_dispatch can fire from any branch,
+        # and we only want to promote when the SHA we just pushed is on main.
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          gcloud artifacts docker tags add \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:${GITHUB_SHA}" \
+            "${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/${IMAGE_NAME}:latest" \
+            --project="${GCP_PROJECT}"
+
       - name: Deploy to Cloud Run
         run: |
           gcloud run services update "$SERVICE_NAME" \


### PR DESCRIPTION
## Diagrams

### Before — manual retag pattern, drift accumulated until production miss on 2026-05-03

```mermaid
sequenceDiagram
    participant Dev as Dev (merge to main)
    participant CI as deploy-ingestor.yml
    participant AR as Artifact Registry
    participant Job as Cloud Run Job<br/>(bird-ingestor-descriptions)
    participant Sched as Cloud Scheduler

    Dev->>CI: push to main
    CI->>AR: docker push ingestor:<sha>
    Note over AR: ingestor:<sha> exists<br/>ingestor:latest UNCHANGED<br/>(stale, 2026-04-19 build)
    CI->>Job: gcloud run jobs update --image=ingestor:<sha>
    Note right of Job: bird-ingestor + photos updated<br/>descriptions job NOT updated by this workflow
    Sched->>Job: trigger descriptions job
    Job->>AR: pull ingestor:latest (stale!)
    Job--xJob: Unknown kind: descriptions
```

### After — :latest auto-rolls on every successful push to main

```mermaid
sequenceDiagram
    participant Dev as Dev (merge to main)
    participant CI as deploy-ingestor.yml<br/>deploy-read-api.yml
    participant AR as Artifact Registry
    participant Job as Cloud Run Jobs<br/>+ Service

    Dev->>CI: push to main
    CI->>AR: docker push ingestor:<sha>
    CI->>AR: gcloud artifacts docker tags add<br/>ingestor:<sha> -> ingestor:latest
    Note over AR: ingestor:<sha> AND ingestor:latest<br/>now point to same digest
    CI->>Job: gcloud run jobs/services update --image=ingestor:<sha>
    Note right of Job: Future Cloud Run Jobs/Services<br/>that reference :latest pull a fresh image
```

## Summary

- Add a `Promote SHA-tagged image to :latest` step to both `deploy-ingestor.yml` and `deploy-read-api.yml`. The step runs after the SHA-tagged image is pushed and re-tags the same digest as `:latest` via `gcloud artifacts docker tags add`. Guarded by `if: github.ref == 'refs/heads/main'` (defense-in-depth — the `on.push.branches` filter already covers the push path; the guard covers `workflow_dispatch` from feature branches).
- Per-workflow inline retag rather than a separate cross-image loop: each deploy workflow only ever pushes one image, so the SHA tag is guaranteed to exist at the moment we promote it. No image-existence pre-check needed; no risk of skipping an image that was just rebuilt.
- No Cloud Run TF or `:latest` reference change. Terraform still pins `:latest`; the automation maintains its honesty.

## Screenshots

N/A — not UI

## Test plan

- [x] `actionlint .github/workflows/deploy-ingestor.yml .github/workflows/deploy-read-api.yml` — clean for both new steps (only pre-existing SC2086 info-level finding on the `Configure docker` line, unrelated to this PR)
- [ ] CI run on this PR (feature branch): the retag step should be **skipped** (its `if:` evaluates false on `refs/heads/ci(infra)/auto-roll-latest-tag`). Verify by inspecting the workflow run after CI fires.
- [ ] After merge to `main`: a tiny no-op change touching `services/ingestor/` should trigger `deploy-ingestor`. Verify post-merge:
  ```
  gcloud artifacts docker images list \
    us-west1-docker.pkg.dev/bird-maps-prod/birdwatch/ingestor \
    --filter='tags:latest' \
    --project=bird-maps-prod
  ```
  CREATE_TIME on the `:latest` row should be within minutes of the merge SHA's CREATE_TIME.
- [ ] Same verification for `read-api` after the next read-api change merges.

## Plan reference

Out of plan — fast-follow on #383 (operational debt: the manual `:latest` retag pattern caused the 2026-05-03 descriptions Cloud Run Job miss).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)