### PR TITLE
infra(terraform): add secret_manager_secret_version for cloudflare_zone_id + api_token

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -438,12 +438,22 @@ resource "google_secret_manager_secret" "cloudflare_zone_id" {
   depends_on = [google_project_service.secretmanager]
 }
 
+resource "google_secret_manager_secret_version" "cloudflare_zone_id" {
+  secret      = google_secret_manager_secret.cloudflare_zone_id.id
+  secret_data = var.cloudflare_zone_id
+}
+
 resource "google_secret_manager_secret" "cloudflare_api_token" {
   secret_id = "bird-watch-cloudflare-api-token"
   replication {
     auto {}
   }
   depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "cloudflare_api_token" {
+  secret      = google_secret_manager_secret.cloudflare_api_token.id
+  secret_data = var.cloudflare_api_token
 }
 
 resource "google_secret_manager_secret_iam_member" "ingestor_cloudflare_zone_id" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -33,6 +33,7 @@ variable "cloudflare_api_token" {
 
 variable "cloudflare_zone_id" {
   type        = string
+  sensitive   = true
   description = "Cloudflare zone ID for `domain`."
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    tfvars["terraform.tfvars<br/>(gitignored)"]
    var_zone["var.cloudflare_zone_id<br/>(sensitive)"]
    var_token["var.cloudflare_api_token<br/>(sensitive)"]

    sec_zone["google_secret_manager_secret<br/>cloudflare_zone_id"]
    sec_token["google_secret_manager_secret<br/>cloudflare_api_token"]

    ver_zone["google_secret_manager_secret_version<br/>cloudflare_zone_id<br/>**(NEW)**"]
    ver_token["google_secret_manager_secret_version<br/>cloudflare_api_token<br/>**(NEW)**"]

    job["google_cloud_run_v2_job<br/>bird-ingestor-descriptions"]
    env_zone["env CLOUDFLARE_ZONE_ID<br/>secret_key_ref version=latest"]
    env_token["env CLOUDFLARE_API_TOKEN<br/>secret_key_ref version=latest"]

    runtime["run-descriptions.ts<br/>cache-purge fork"]

    tfvars --> var_zone
    tfvars --> var_token
    var_zone -->|secret_data| ver_zone
    var_token -->|secret_data| ver_token
    sec_zone --> ver_zone
    sec_token --> ver_token
    ver_zone -.resolved by.-> env_zone
    ver_token -.resolved by.-> env_token
    sec_zone --> env_zone
    sec_token --> env_token
    env_zone --> job
    env_token --> job
    job --> runtime
```

## Summary

- PR #377 declared `google_secret_manager_secret.cloudflare_zone_id` and `cloudflare_api_token` but no `_version` resources, so initial `terraform apply` 404'd on `versions/latest` for the new `bird-ingestor-descriptions` Cloud Run Job. Versions 1 of both secrets were patched in manually on 2026-05-03 via `gcloud secrets versions add` from `terraform.tfvars` — this PR brings them back under TF management, mirroring the `google_secret_manager_secret_version.ebird_key` precedent in shape exactly.
- Also marks `var.cloudflare_zone_id` as `sensitive = true` for parity with `cloudflare_api_token` (both are now consumed as secret payloads — the zone-id isn't classically a secret but it's stored in Secret Manager alongside the token, and marking sensitive prevents accidental log leaks).
- The manual `gcloud secrets versions add` from 2026-05-03 will become TF-managed on the next `terraform apply`. Idempotent on identical content (TF reuses the existing version when `secret_data` matches); creates a new version if the value differs (rotation case).

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean (no diff)
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform plan` against the live `bird-maps-tfstate` GCS backend — confirms the two new resources will be created, no destroys, no other unintended changes from this PR. Full plan summary:

  ```
  Terraform will perform the following actions:
    # cloudflare_r2_bucket.pmtiles will be created
    # cloudflare_record.api will be updated in-place
    # cloudflare_record.photos will be updated in-place
    # cloudflare_record.root will be updated in-place
    # cloudflare_record.tiles will be created
    # cloudflare_workers_route.map_tiles will be created
    # cloudflare_workers_route.photos will be updated in-place
    # cloudflare_workers_script.map_server will be created
    # google_cloud_run_v2_job.ingestor will be updated in-place
    # google_cloud_run_v2_job.ingestor_photos will be updated in-place
    # google_cloud_run_v2_service.read_api will be updated in-place
    # google_secret_manager_secret_version.cloudflare_api_token will be created
    # google_secret_manager_secret_version.cloudflare_zone_id will be created
  Plan: 6 to add, 7 to change, 0 to destroy.
  ```

  The two `_version.*` lines are this PR's contribution. The other 11 actions are pre-existing drift on `main` unrelated to this change (map-server worker, R2 bucket, Cloudflare DNS records, the `client`/`client_version` attribute scrub from prior `gcloud run jobs update` ops, and `FRONTEND_ORIGINS` env on `read_api`) — out of scope for this PR.
- [x] No code changes to `services/ingestor/` or `packages/` — TF-only.
- [x] Did NOT add `lifecycle { ignore_changes = [secret_data] }` (issue #384 explicitly excludes this — rotation should flow through TF).
- [x] Did NOT modify existing secret declarations or their IAM bindings.
- [ ] `terraform apply` post-merge — orchestrator-level operation, not run from this worktree.

## Plan reference

Out of plan — fast-follow on #384 (operational follow-up to PR #377 / epic #368).

---

Closes #384

Generated with [Claude Code](https://claude.com/claude-code)