### PR TITLE
fix(ingestor): clear stale attribution_url on Wikipedia 404 in warm cache

### DIFF
--- a/services/ingestor/src/run-descriptions.test.ts
+++ b/services/ingestor/src/run-descriptions.test.ts
@@ -635,4 +635,146 @@ describe('runDescriptions', () => {
     expect(summary.errors[0]?.speciesCode).toBe('verfly');
     expect(summary.errors[0]?.reason).toMatch(/length/i);
   });
+
+  it('warm cache + Wikipedia 404 (renamed article) → deletes stale row and increments staleUrls', async () => {
+    // Hazard: the cached short-circuit at the top of the loop trusts both
+    // species_meta.inat_taxon_id and species_descriptions.attribution_url.
+    // When Wikipedia silently renames the underlying article, the cached URL
+    // produces an indefinite stream of 404s — and #374's iNat-summary fallback
+    // sits in the cold-cache `else` branch, so it never fires for a row whose
+    // attribution_url is already populated. Without this fix the species
+    // permanently loses coverage.
+    //
+    // Fix: on the warm-cache path, when fetchWikipediaSummary returns null
+    // (404), DELETE the row so the next cron run takes the cold path —
+    // re-resolving via /v1/taxa, picking up the renamed wikipedia_url, and
+    // either writing a fresh description or falling through to the
+    // iNat-summary fallback per #374.
+    await db.pool.query(
+      `INSERT INTO species_descriptions
+         (species_code, source, body, license, revision_id, etag, attribution_url)
+       VALUES
+         ('verfly', 'wikipedia', '${'p'.repeat(60)}', 'CC-BY-SA-4.0', 1234567890, '"old-etag"', 'https://en.wikipedia.org/wiki/Stale_old_title')`
+    );
+    await db.pool.query(
+      `UPDATE species_meta SET inat_taxon_id = 1001 WHERE species_code = 'verfly'`
+    );
+    await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
+
+    let inatHits = 0;
+    let inatByIdHits = 0;
+    server.use(
+      // The warm-cache path skips iNat /v1/taxa — confirm it stays unhit.
+      http.get(INAT_TAXA, () => {
+        inatHits++;
+        return HttpResponse.json({ total_results: 0, results: [] });
+      }),
+      // Cached Wikipedia title resolves to 404 — the article was renamed.
+      http.get(WIKI_SUMMARY, () => new HttpResponse('not found', { status: 404 })),
+      // The fallback /v1/taxa/{id} must NOT be called on the warm-cache path:
+      // the orchestrator's job here is to clear the stale cache so the NEXT
+      // run takes the cold path; firing the fallback now would persist a row
+      // against a stale URL.
+      http.get(INAT_TAXA_BY_ID, () => {
+        inatByIdHits++;
+        return HttpResponse.json({ total_results: 0, results: [] });
+      })
+    );
+
+    const summary = await runDescriptions({ pool: db.pool, paceMs: 0 });
+
+    expect(summary.descriptionsWritten).toBe(0);
+    expect(summary.descriptionsFromInat).toBe(0);
+    expect(summary.descriptionsFailed).toBe(0);
+    expect(summary.staleUrls).toBe(1);
+    expect(inatHits).toBe(0);
+    expect(inatByIdHits).toBe(0);
+
+    // Row was deleted — the next cron run will take the cold-cache path.
+    const { rows } = await db.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_descriptions WHERE species_code = 'verfly'`
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+    // species_meta.inat_taxon_id is preserved — only the description-side
+    // cache is invalidated, not the iNat taxon mapping.
+    const { rows: metaRows } = await db.pool.query<{ inat_taxon_id: string | null }>(
+      `SELECT inat_taxon_id FROM species_meta WHERE species_code = 'verfly'`
+    );
+    expect(metaRows[0]?.inat_taxon_id).toBe('1001');
+  });
+
+  it('after stale-URL clear, next run takes cold path and repopulates with renamed Wikipedia URL', async () => {
+    // Two-run integration: first run clears the stale row (Wikipedia 404 on
+    // cached URL); second run re-resolves via iNat (returning the renamed
+    // wikipedia_url) and persists a fresh description with the new URL.
+    await db.pool.query(
+      `INSERT INTO species_descriptions
+         (species_code, source, body, license, revision_id, etag, attribution_url)
+       VALUES
+         ('verfly', 'wikipedia', '${'p'.repeat(60)}', 'CC-BY-SA-4.0', 1234567890, '"old-etag"', 'https://en.wikipedia.org/wiki/Stale_old_title')`
+    );
+    await db.pool.query(
+      `UPDATE species_meta SET inat_taxon_id = 1001 WHERE species_code = 'verfly'`
+    );
+    await db.pool.query(`DELETE FROM observations WHERE species_code != 'verfly'`);
+
+    // Run 1: cached URL 404s on Wikipedia, stale row deleted.
+    server.use(
+      http.get(WIKI_SUMMARY, () => new HttpResponse('not found', { status: 404 }))
+    );
+    const summary1 = await runDescriptions({ pool: db.pool, paceMs: 0 });
+    expect(summary1.staleUrls).toBe(1);
+    expect(summary1.descriptionsWritten).toBe(0);
+
+    // Confirm the row is gone (cold-cache state).
+    const { rows: between } = await db.pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_descriptions WHERE species_code = 'verfly'`
+    );
+    expect(Number(between[0]?.count)).toBe(0);
+
+    // Run 2: cold cache → iNat returns the RENAMED wikipedia_url, Wikipedia
+    // returns 200 for the new title, row repopulates.
+    server.resetHandlers();
+    server.use(
+      http.get(INAT_TAXA, ({ request }) => {
+        const sciName = new URL(request.url).searchParams.get('q');
+        if (sciName !== 'Pyrocephalus rubinus') {
+          return HttpResponse.json({ total_results: 0, results: [] });
+        }
+        return HttpResponse.json({
+          total_results: 1, page: 1, per_page: 1,
+          results: [{
+            id: 1001, name: sciName, rank: 'species', matched_term: sciName,
+            // The new (renamed) Wikipedia URL.
+            wikipedia_url: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher_(renamed)',
+          }],
+        });
+      }),
+      http.get(WIKI_SUMMARY, () => HttpResponse.json(
+        { extract_html: SAMPLE_BODY, revision: '9999' },
+        { status: 200, headers: { etag: '"new-etag"' } }
+      ))
+    );
+
+    const summary2 = await runDescriptions({ pool: db.pool, paceMs: 0 });
+    expect(summary2.descriptionsWritten).toBe(1);
+    expect(summary2.staleUrls).toBe(0);
+    expect(summary2.descriptionsFailed).toBe(0);
+
+    const { rows: after } = await db.pool.query<{
+      species_code: string;
+      source: string;
+      attribution_url: string;
+      etag: string | null;
+    }>(
+      `SELECT species_code, source, attribution_url, etag
+         FROM species_descriptions WHERE species_code = 'verfly'`
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0]?.attribution_url).toBe(
+      'https://en.wikipedia.org/wiki/Vermilion_flycatcher_(renamed)'
+    );
+    expect(after[0]?.source).toBe('wikipedia');
+    expect(after[0]?.etag).toBe('"new-etag"');
+  });
 });

--- a/services/ingestor/src/run-descriptions.ts
+++ b/services/ingestor/src/run-descriptions.ts
@@ -56,6 +56,17 @@ export interface RunDescriptionsSummary {
    * fraction of species that needed the fallback.
    */
   descriptionsFromInat: number;
+  /**
+   * Warm-cache rows whose cached `attribution_url` resolved to a Wikipedia 404
+   * — typically the article was renamed since the prior run. The orchestrator
+   * deletes the stale row so the next cron tick takes the cold-cache path:
+   * re-resolves via iNat /v1/taxa, picks up the renamed `wikipedia_url`, and
+   * either writes a fresh description or falls through to #374's iNat-summary
+   * fallback. Without this counter the daily cron log silently masks the
+   * stream of 404s a renamed article would otherwise produce indefinitely.
+   * Tracks issue #378 fast-follow on the warm-cache short-circuit added in #377.
+   */
+  staleUrls: number;
   errors: Array<{ speciesCode: string; reason: string }>;
 }
 
@@ -127,6 +138,7 @@ export async function runDescriptions(
     descriptionsSkipped: 0,
     descriptionsFailed: 0,
     descriptionsFromInat: 0,
+    staleUrls: 0,
     errors: [],
   };
 
@@ -159,8 +171,15 @@ export async function runDescriptions(
       let inatTaxonId: number | null = row.inat_taxon_id !== null
         ? Number(row.inat_taxon_id)
         : null;
-      if (row.inat_taxon_id !== null && row.prior_attribution_url !== null) {
-        wikipediaUrl = row.prior_attribution_url;
+      // Track warm-cache vs cold-cache so the Wikipedia-404 branch below can
+      // choose the right recovery: warm-cache 404 means the cached title is
+      // stale (article renamed) — delete the row so the next run re-resolves
+      // via iNat. Cold-cache 404 falls through to the #374 iNat-summary
+      // fallback (the row doesn't exist yet, so deletion isn't applicable).
+      const usedWarmCache =
+        row.inat_taxon_id !== null && row.prior_attribution_url !== null;
+      if (usedWarmCache) {
+        wikipediaUrl = row.prior_attribution_url!;
       } else {
         const taxon = await fetchInatTaxon(sciName, fetchOpts);
         if (taxon === null) {
@@ -221,17 +240,45 @@ export async function runDescriptions(
       const wiki = await fetchWikipediaSummary(wikipediaTitle, summaryFetchOpts);
 
       if (wiki === null) {
-        // Wikipedia 404 — page deleted or renamed. Try the iNat-summary
-        // fallback (added in #374): hit /v1/taxa/{id} for the cached id and
-        // persist iNat's `wikipedia_summary` plaintext as a row with
-        // source='inat'. This is the whole reason the per-id endpoint exists
-        // in our pipeline — coverage on AZ-rare/vagrant species (Cave
-        // Swallow, Glossy Ibis) where Wikipedia REST returns 404 but iNat
-        // mirrors the article body.
+        // Wikipedia 404 — page deleted or renamed. Two recovery paths,
+        // depending on whether we got here via the warm-cache short-circuit
+        // or the cold-cache iNat resolution:
         //
-        // The fallback ONLY fires here (Wikipedia 404 branch) — never on the
-        // 200 happy path (would be wasted bandwidth) and never on the 304
-        // warm-cache path (already has a row).
+        //   warm-cache → cached title is stale (article was renamed since
+        //   the previous run). DELETE the species_descriptions row so the
+        //   next cron tick takes the cold path: re-resolves via iNat
+        //   /v1/taxa, picks up the renamed wikipedia_url, and either writes
+        //   a fresh description or falls through to the iNat-summary
+        //   fallback below. Without this fork the cached URL produces an
+        //   indefinite stream of 404s and the species silently loses
+        //   coverage. (#378 fast-follow on the warm-cache short-circuit
+        //   added in #377.)
+        //
+        //   cold-cache → iNat just told us the wikipedia_url, and Wikipedia
+        //   denies it. Fall through to #374's iNat-summary fallback: hit
+        //   /v1/taxa/{id} for the cached id and persist iNat's
+        //   `wikipedia_summary` plaintext as a row with source='inat'.
+        //   Coverage path for AZ-rare/vagrant species (Cave Swallow, Glossy
+        //   Ibis) where Wikipedia REST 404s but iNat mirrors the body.
+        //
+        // The fallback ONLY fires on the cold-cache 404 branch — never on
+        // the 200 happy path (would be wasted bandwidth), never on the 304
+        // warm-cache path (already has a row), and never on the warm-cache
+        // 404 path (defer to next run's cold path so iNat resolves the
+        // renamed URL first; firing the fallback now would persist a row
+        // against a stale attribution URL).
+        if (usedWarmCache) {
+          await args.pool.query(
+            `DELETE FROM species_descriptions WHERE species_code = $1`,
+            [speciesCode]
+          );
+          summary.staleUrls++;
+          // eslint-disable-next-line no-console
+          console.log(
+            `[run-descriptions] ${speciesCode} (${sciName}): cached Wikipedia URL 404, cleared row for cold re-resolution next run`
+          );
+          continue;
+        }
         if (inatTaxonId === null) {
           // No cached id and the iNat search returned non-null taxon above
           // (otherwise we'd have continued earlier) — this branch is


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Start(["per species in run-descriptions loop"]) --> CacheCheck{"inat_taxon_id<br/>AND<br/>prior_attribution_url<br/>both set?"}

    CacheCheck -- "yes (warm)" --> WarmReuse["reuse cached<br/>wikipediaUrl"]
    CacheCheck -- "no (cold)" --> ColdResolve["fetchInatTaxon<br/>resolve binomial"]

    ColdResolve --> ColdHit{"hit?"}
    ColdHit -- no --> SkipCold["descriptionsSkipped++<br/>continue"]
    ColdHit -- yes --> WriteBack["UPDATE species_meta<br/>SET inat_taxon_id"]
    WriteBack --> ColdUrl["wikipediaUrl =<br/>taxon.wikipediaUrl"]

    WarmReuse --> WikiFetch["fetchWikipediaSummary<br/>w/ priorEtag"]
    ColdUrl --> WikiFetch

    WikiFetch --> WikiResp{"response"}
    WikiResp -- 200 --> SanitizeWrite["sanitize +<br/>insertSpeciesDescription<br/>source='wikipedia'"]
    WikiResp -- 304 --> Skip304["descriptionsSkipped++<br/>continue"]
    WikiResp -- 404 --> WarmCheck{"usedWarmCache?"}

    WarmCheck -- yes --> WarmFork["<b>NEW (this PR)</b><br/>DELETE row<br/>staleUrls++<br/>continue"]
    WarmCheck -- no --> ColdFallback["fetchInatTaxonSummary<br/>per-id endpoint"]
    ColdFallback --> InatSummary{"wikipedia_summary<br/>non-null?"}
    InatSummary -- no --> SkipFallback["descriptionsSkipped++<br/>continue"]
    InatSummary -- yes --> WriteFallback["sanitizeText +<br/>insertSpeciesDescription<br/>source='inat'"]

    WarmFork --> NextRun(["next cron tick<br/>row absent<br/>cold path runs"])
    NextRun --> ColdResolve

    classDef newcls fill:#dff,stroke:#0aa,stroke-width:2px;
    class WarmFork,NextRun newcls
```

## Summary

- Fork the Wikipedia-404 branch in `run-descriptions.ts` on warm-cache vs cold-cache: warm 404 means the cached title was renamed since the previous run, so DELETE the stale row and let the next cron tick re-resolve via iNat. Cold 404 keeps the existing #374 iNat-summary fallback semantics.
- Without this fork, a renamed Wikipedia article produced an indefinite stream of 404s and the species silently lost coverage forever — the #374 iNat-summary fallback sits in the cold-cache `else` branch and never fires for a row whose `attribution_url` is already populated.
- New `staleUrls` counter on `RunDescriptionsSummary` so the daily cron log surfaces when this fires (Cloud Run's stdout JSON includes the field automatically via `cli.ts`'s `JSON.stringify(summary)`).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build && npm run test` — green (117 ingestor + 36 read-api + 433 frontend tests pass; full repo build clean)
- [x] New unit / integration tests added (two testcontainer cases against MSW v2 — warm-cache 404 deletes row + increments `staleUrls`; second run with renamed `wikipedia_url` repopulates the row)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, ingestor-only change
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` changes

## Plan reference

Out of plan — fast-follow on #378.

---

Generated with [Claude Code](https://claude.com/claude-code)