### PR TITLE
infra(cf): cloudflare provider v4→v5 migration

### DIFF
--- a/infra/CLOUDFLARE_V5_APPLY_CHECKLIST.md
+++ b/infra/CLOUDFLARE_V5_APPLY_CHECKLIST.md
@@ -1,0 +1,153 @@
+# Cloudflare provider v4 → v5 — operator apply checklist
+
+This is the operator-side bridge for `feat/cloudflare-v5-migration`. The
+HCL was authored on the branch (commits C1–C3) but **no `terraform apply`
+was run by the implementer** — production at bird-maps.com is live.
+Julian runs the steps below by hand, in order, between bot review and
+queue-merge.
+
+Plan reference:
+`docs/plans/2026-05-03-cloudflare-provider-v5-migration.md` (§3 commit
+gates, §5 forward-recovery).
+
+## Pre-flight
+
+### P5 — back up state and record the serial number
+
+Plan §2 P5. Run from `infra/terraform/`:
+
+```bash
+terraform state pull > /tmp/tfstate-pre-cf-v5-$(date -u +%Y%m%dT%H%M%SZ).backup
+ls -lh /tmp/tfstate-pre-cf-v5-*.backup     # confirm non-empty
+jq '.serial' /tmp/tfstate-pre-cf-v5-*.backup
+```
+
+**Record the serial number** (paste it into your operator notes).
+It is the only signal that decides whether catastrophic rollback
+(plan §5) is safe versus requires escalation.
+
+### P1 — confirm clean v4 surface
+
+```bash
+terraform state list | grep cloudflare_
+```
+
+Expected: exactly 8 resources (`cloudflare_pages_project.frontend`,
+`cloudflare_pages_domain.root`, `cloudflare_record.{root, api, photos}`,
+`cloudflare_r2_bucket.photos`, `cloudflare_workers_script.photo_server`,
+`cloudflare_workers_route.photos`). No `map-v1` artifacts. If extras
+appear, escalate before applying.
+
+## Per-commit apply
+
+### After C1 (provider bumped to `~> 4.52, >= 4.52.5`)
+
+```bash
+cd infra/terraform
+terraform init -upgrade
+terraform plan
+terraform apply
+```
+
+**Gate G1** (plan §3): plan shows zero infra diffs (computed-attribute
+refreshes only). Apply succeeds. If a real diff appears at this stage,
+STOP — investigate before proceeding to C2.
+
+### C2 lands as-authored on the branch (no apply needed)
+
+C2 only rewrites HCL + adds `moved` blocks. Nothing is applied between
+C2 and C3 — the v4 provider does not understand the v5 attribute names,
+so any plan attempt here will error. Move on to C3.
+
+### After C3 (provider pinned to `~> 5.19`)
+
+```bash
+cd infra/terraform
+terraform init -upgrade
+terraform plan -out=plan.bin
+terraform show plan.bin > plan.txt
+```
+
+**Gate G3** (HARD, plan §3): plan shows zero `-/+ replace` on any
+resource. State upgraders fire automatically; `moved` blocks re-key
+the renamed resources in state without forcing recreation.
+
+When pasting the plan summary into the PR or operator notes, paste only
+**redacted (address, action) tuples** — never the full plan output, which
+echoes account/zone/bucket identifiers.
+
+If `tf-migrate verify-drift` is installed locally, run:
+
+```bash
+tf-migrate verify-drift --file plan.txt
+```
+
+(Exit code 0 expected. If `tf-migrate` is not installed, the manual gate
+above is sufficient.)
+
+### Apply
+
+```bash
+terraform apply plan.bin
+terraform plan      # re-plan; expect empty or perpetual-only deltas
+```
+
+**Gate G4** (plan §3):
+
+```bash
+terraform state show cloudflare_r2_bucket.photos | grep prevent_destroy
+# Expected: prevent_destroy = true
+```
+
+## Live smoke tests
+
+**Gate G5** (plan §3 — run after the apply):
+
+```bash
+# Photos worker still serves objects from R2
+curl -I https://photos.bird-maps.com/<known-key>           # → 200
+
+# Cloud Run API still resolves through the unproxied CNAME
+curl -I https://api.bird-maps.com/api/regions              # → 200
+
+# DNS chain intact for api.*
+dig +short api.bird-maps.com                               # → ghs.googlehosted.com
+
+# Cloud Run's Let's Encrypt cert serves directly (proxied=false survived)
+openssl s_client -connect api.bird-maps.com:443 \
+  -servername api.bird-maps.com </dev/null 2>/dev/null \
+  | openssl x509 -noout -issuer
+# → issuer= /C=US/O=Let's Encrypt/CN=...
+
+# Pages frontend still serves the React app at the apex
+curl -sI https://bird-maps.com/ | head -5                  # → 200
+```
+
+If any of the five fail, see plan §5 (forward-recovery / catastrophic
+path).
+
+## Forward-recovery references
+
+There is no real "rollback" once C3's apply runs — state is v5-shaped.
+Per-resource recovery (`state rm` + `import`) is documented in plan §5
+table. The catastrophic path (C3 apply errors past the first resource)
+is the strict 7-step procedure in plan §5 — read it before invoking,
+and **do not force-push** if the state serial diverged from the P5
+backup.
+
+## Mergify queue
+
+Once Gates G1, G3, G4, G5 are all green, the PR is ready for the bot
+review (`pr-workflow` skill → `julianken-bot` subagent). After bot
+approval, queue with `@Mergifyio queue` (per `pr-workflow` SKILL.md).
+
+## Post-merge follow-up
+
+**Do NOT delete `moved.tf` blocks (or the inline `moved {}` blocks added
+in C2) in this PR.** Wait ≥48h post-merge for one clean nightly
+`terraform-plan-drift-check.yml` run against post-v5 main. Premature
+deletion risks the nightly proposing destructive replaces if any
+external operator inits a fresh `.terraform/` against pre-merge state.
+
+After one clean nightly, file a follow-up PR (`infra(cf): remove moved
+blocks after one clean nightly`) per plan §3 / §6 step 8.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,5 +1,19 @@
 # Infrastructure
 
+> **APPLY FREEZE — 2026-05-03 → merge of `feat/cloudflare-v5-migration`**
+>
+> Do not `terraform apply` from `main` between 2026-05-03 and the merge of
+> the `feat/cloudflare-v5-migration` PR. Reason: provider-version skew
+> window during the Cloudflare provider v4 → v5 migration. While the
+> migration branch pins the transitional `~> 4.52, >= 4.52.5` constraint,
+> any parallel `apply` from `main` (still on the prior `~> 4.20` constraint
+> if not yet rebased) can rewrite state schema backward and break the
+> in-flight migration. Coordinate any urgent infra changes through the
+> migration branch instead.
+>
+> Tracker: PR (TBD — to be filled when `feat/cloudflare-v5-migration`
+> opens). Plan: `docs/plans/2026-05-03-cloudflare-provider-v5-migration.md`.
+
 Terraform configuration for the bird-watch system, managing GCP (Cloud Run,
 Artifact Registry, Secret Manager, Cloud Scheduler), Neon (Postgres), and
 Cloudflare (Pages, DNS).

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,8 +11,8 @@
 > in-flight migration. Coordinate any urgent infra changes through the
 > migration branch instead.
 >
-> Tracker: PR (TBD — to be filled when `feat/cloudflare-v5-migration`
-> opens). Plan: `docs/plans/2026-05-03-cloudflare-provider-v5-migration.md`.
+> Tracker: PR #393. Plan:
+> `docs/plans/2026-05-03-cloudflare-provider-v5-migration.md`.
 
 Terraform configuration for the bird-watch system, managing GCP (Cloud Run,
 Artifact Registry, Secret Manager, Cloud Scheduler), Neon (Postgres), and

--- a/infra/terraform/frontend.tf
+++ b/infra/terraform/frontend.tf
@@ -4,10 +4,21 @@ resource "cloudflare_pages_project" "frontend" {
   production_branch = "main"
 }
 
+# v5 attribute rename: cloudflare_pages_domain.domain → name (same resource
+# type, no `moved` block needed). Verified against context7 v5 schema.
 resource "cloudflare_pages_domain" "root" {
   account_id   = var.cloudflare_account_id
   project_name = cloudflare_pages_project.frontend.name
-  domain       = var.domain
+  name         = var.domain
+}
+
+# v5 resource rename: cloudflare_record → cloudflare_dns_record. The
+# attribute set (zone_id, name, type, content, proxied, ttl) is preserved
+# unchanged. The `moved` block re-keys existing state without forcing a
+# `-/+ replace`.
+moved {
+  from = cloudflare_record.root
+  to   = cloudflare_dns_record.root
 }
 
 # Apex "@" → CNAME to the Pages project's auto-assigned pages.dev subdomain.
@@ -17,7 +28,7 @@ resource "cloudflare_pages_domain" "root" {
 # hardcoding "birdwatch-1xe.pages.dev" — if the project is ever recreated,
 # Cloudflare may assign a different pages.dev suffix. proxied=true lets CF
 # auto-flatten the apex CNAME.
-resource "cloudflare_record" "root" {
+resource "cloudflare_dns_record" "root" {
   zone_id = var.cloudflare_zone_id
   name    = "@"
   type    = "CNAME"
@@ -26,13 +37,18 @@ resource "cloudflare_record" "root" {
   ttl     = 1
 }
 
+moved {
+  from = cloudflare_record.api
+  to   = cloudflare_dns_record.api
+}
+
 # Subdomain "api" → CNAME to Cloud Run's documented CNAME target.
 # Cloud Run rejects requests whose Host header is not a registered domain
 # mapping, so pointing straight at the run.app URL returns 404. The canonical
 # path is a CNAME to ghs.googlehosted.com plus a google_cloud_run_domain_mapping
 # below; proxied MUST be false so Cloud Run's own Let's Encrypt cert serves
 # (proxying through Cloudflare breaks the SSL handshake).
-resource "cloudflare_record" "api" {
+resource "cloudflare_dns_record" "api" {
   zone_id = var.cloudflare_zone_id
   name    = "api"
   type    = "CNAME"

--- a/infra/terraform/photos.tf
+++ b/infra/terraform/photos.tf
@@ -24,29 +24,49 @@ resource "cloudflare_r2_bucket" "photos" {
 # The bucket has no public ACL; this Worker is the only public ingress.
 # Worker source lives in infra/workers/photo-server.js (kept as a real .js
 # file, not an inline heredoc, so it can be unit-tested with `node --test`).
-
+#
+# v5 attribute changes (cloudflare_workers_script):
+#   - `name` → `script_name`
+#   - `module = true` → `main_module = "photo-server.js"`
+#   - typed binding blocks (e.g. r2_bucket_binding {...}) collapse into a
+#     single `bindings = [{ type = "r2_bucket", ... }]` list. The legacy
+#     `r2_bucket_binding` attribute name is removed entirely in v5.
+#   - `compatibility_date` is now required for module workers.
+# Same resource type, no `moved` block needed.
 resource "cloudflare_workers_script" "photo_server" {
-  account_id = var.cloudflare_account_id
-  name       = "birdwatch-photo-server"
-  module     = true
+  account_id         = var.cloudflare_account_id
+  script_name        = "birdwatch-photo-server"
+  main_module        = "photo-server.js"
+  compatibility_date = "2024-09-23"
 
   content = file("${path.module}/../workers/photo-server.js")
 
-  r2_bucket_binding {
-    name        = "PHOTOS"
-    bucket_name = cloudflare_r2_bucket.photos.name
-  }
+  bindings = [
+    {
+      name        = "PHOTOS"
+      type        = "r2_bucket"
+      bucket_name = cloudflare_r2_bucket.photos.name
+    },
+  ]
 }
 
+# v5 attribute rename: cloudflare_workers_route.script_name → script. The
+# rhs is the script's `script_name` (not `.id`, not `.name`) — verified
+# against context7 v5 schema (plan §1).
 resource "cloudflare_workers_route" "photos" {
-  zone_id     = var.cloudflare_zone_id
-  pattern     = "photos.${var.domain}/*"
-  script_name = cloudflare_workers_script.photo_server.name
+  zone_id = var.cloudflare_zone_id
+  pattern = "photos.${var.domain}/*"
+  script  = cloudflare_workers_script.photo_server.script_name
+}
+
+moved {
+  from = cloudflare_record.photos
+  to   = cloudflare_dns_record.photos
 }
 
 # photos.bird-maps.com CNAME — Worker-routed hostname needs Cloudflare proxy
 # (proxied = true) so the Worker route fires. Same pattern as tiles.
-resource "cloudflare_record" "photos" {
+resource "cloudflare_dns_record" "photos" {
   zone_id = var.cloudflare_zone_id
   name    = "photos"
   type    = "CNAME"

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.52, >= 4.52.5"
+      version = "~> 5.19"
     }
   }
 }

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.20"
+      version = "~> 4.52, >= 4.52.5"
     }
   }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph "C1: transitional pin"
        V1["versions.tf<br/>cloudflare ~> 4.20<br/>→ ~> 4.52, >= 4.52.5"]
        R1["infra/README.md<br/>APPLY FREEZE banner"]
    end
    subgraph "C2: HCL rewrite + moved blocks"
        F2["frontend.tf<br/>cloudflare_record.{root,api}<br/>→ cloudflare_dns_record.*<br/>+ moved blocks<br/><br/>cloudflare_pages_domain.root<br/>attr: domain → name"]
        P2["photos.tf<br/>cloudflare_record.photos<br/>→ cloudflare_dns_record.photos<br/>+ moved block<br/><br/>cloudflare_workers_script.photo_server<br/>name → script_name<br/>module → main_module<br/>r2_bucket_binding{} → bindings=[{type=r2_bucket}]<br/>+ compatibility_date<br/><br/>cloudflare_workers_route.photos<br/>script_name → script<br/>rhs → .script_name<br/><br/>(prevent_destroy on r2 bucket: preserved)"]
    end
    subgraph "C3: v5 pin"
        V3["versions.tf<br/>cloudflare ~> 4.52,>=4.52.5<br/>→ ~> 5.19"]
    end
    subgraph "C4: operator bridge"
        D4["infra/CLOUDFLARE_V5_APPLY_CHECKLIST.md<br/>P5 backup → G1 → G3 → G4 → G5"]
    end

    V1 --> R1 --> F2 --> P2 --> V3 --> D4
```

## Summary

- Migrates the `cloudflare/cloudflare` Terraform provider from `~> 4.20` to `~> 5.19` across the 8 Cloudflare resources at `infra/terraform/{frontend,photos,versions}.tf`. Per plan §3, sequenced as transitional 4.52.5 pin → HCL rewrite + `moved` blocks → v5 pin → operator-side apply checklist.
- HCL was authored manually (tf-migrate not installed in implementer env) per the v5 attribute corrections in plan §1, cross-referenced against context7-fetched v5 schema. The two load-bearing renames easy to get wrong: unified `bindings = [{ type = "r2_bucket", ... }]` shape on `cloudflare_workers_script` (legacy `r2_bucket_binding {}` block fully removed in v5), and `cloudflare_pages_domain.domain → name` (same resource type — no `moved` block).
- **No `terraform apply` was run by the implementer.** Production at bird-maps.com is live. The plan structure assumes Julian runs the per-commit applies + smoke tests by hand; commands and gates are documented in `infra/CLOUDFLARE_V5_APPLY_CHECKLIST.md` (added in C4).

## Screenshots

N/A — not UI (infra-only PR; no files under `frontend/**` touched).

## Test plan

- [x] Per-commit C2 grep gates (plan §3 G2) — all 8 PASS, output captured in C2 commit body
- [ ] **Operator (Julian)** runs the per-commit apply sequence per `infra/CLOUDFLARE_V5_APPLY_CHECKLIST.md`:
  - [ ] P5: `terraform state pull` backup with serial recorded
  - [ ] G1: after C1 — `terraform apply` shows zero infra diffs
  - [ ] G3: after C3 — `terraform plan` shows zero `-/+ replace` on any resource (state upgraders + `moved` blocks re-key the v4-named resources)
  - [ ] G4: post-apply — `terraform state show cloudflare_r2_bucket.photos` shows `prevent_destroy = true`
  - [ ] G5: live smoke — `curl -I https://photos.bird-maps.com/<key>` 200, `curl -I https://api.bird-maps.com/api/regions` 200, `dig +short api.bird-maps.com` → ghs.googlehosted.com, `openssl s_client` shows Let's Encrypt issuer (proxied=false survived), `https://bird-maps.com/` serves React app
- [ ] Bot review (`pr-workflow` skill → `julianken-bot` subagent) after operator confirms G1/G3/G4/G5 green
- [x] CI gates (test, lint, build, e2e) — trivially green; no app code changed
- N/A — `npm run typecheck`, unit tests, Playwright MCP (no app code under `frontend/**` or `services/**` touched)

## Plan reference

Implements `docs/plans/2026-05-03-cloudflare-provider-v5-migration.md` end-to-end (commits C1–C4). Forward-recovery (per-resource `state rm` + `import`, plus the catastrophic-path 7-step procedure) is in plan §5 — referenced from the apply checklist rather than duplicated. Sequencing and post-merge follow-up (≥48h-after `moved`-block removal PR) per plan §6.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)