### PR TITLE
feat(frontend): Phase 0 — Pre-redesign engineering

### DIFF
--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -29,9 +29,23 @@ const VERMFLY = {
 } as const;
 
 test.describe('Path A happy path', () => {
-  test('feed surface loads by default', async ({ page }) => {
+  test('map surface loads by default (post-Sky-Atlas Phase 0)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto();
+    await app.waitForAppReady();
+
+    // Phase 0: bare '/' now loads the map surface (DEFAULTS.view='map').
+    // The Map tab is the selected SurfaceNav item on a cold load.
+    const mapTab = page.getByRole('tab', { name: 'Map view' });
+    await expect(mapTab).toHaveAttribute('aria-selected', 'true');
+
+    // Map canvas is visible.
+    await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('feed surface loads when navigating to ?view=feed', async ({ page }) => {
+    const app = new AppPage(page);
+    await app.goto('view=feed');
     await app.waitForAppReady();
 
     // At least one observation row is present. The seeded dev DB has 11
@@ -41,16 +55,15 @@ test.describe('Path A happy path', () => {
     const rowCount = await page.locator('.feed-row').count();
     expect(rowCount).toBeGreaterThanOrEqual(1);
 
-    // Feed tab is the selected SurfaceNav item on a cold load. The
-    // accessible name is "Feed view" to avoid collision with the
-    // FiltersBar "Species"/"Family" input labels.
+    // Feed tab is the selected SurfaceNav item. The accessible name is
+    // "Feed view" to avoid collision with the FiltersBar labels.
     const feedTab = page.getByRole('tab', { name: 'Feed view' });
     await expect(feedTab).toHaveAttribute('aria-selected', 'true');
   });
 
   test('filters narrow the feed', async ({ page }) => {
     const app = new AppPage(page);
-    await app.goto();
+    await app.goto('view=feed');
     await app.waitForAppReady();
 
     await expect(page.locator('.feed-row').first()).toBeVisible({ timeout: 10_000 });
@@ -122,7 +135,7 @@ test.describe('Path A happy path', () => {
   test('feed row click opens detail surface at mobile and desktop', async ({ page, apiStub }) => {
     await apiStub.stubSpecies('vermfly', VERMFLY);
     const app = new AppPage(page);
-    await app.goto();
+    await app.goto('view=feed');
     await app.waitForAppReady();
 
     await expect(page.locator('.feed-row').first()).toBeVisible({ timeout: 10_000 });

--- a/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
+++ b/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
@@ -108,13 +108,11 @@ test.describe('Map skip-link + hit-target overlay (#247, #277)', () => {
     // (notable / since / etc.) are preserved by the partial-merge
     // semantics of useUrlState.set.
     //
-    // `useUrlState.writeUrl` omits the `?view=` param entirely when the
-    // value equals the default ('feed') — so we assert via the rendered
-    // tab state (FeedSurface mounted, Feed tab selected) rather than a
-    // URL `view=feed` literal that would never appear.
+    // Phase 0: DEFAULTS.view is now 'map', so switching to 'feed' IS a
+    // non-default value and writeUrl WILL emit ?view=feed in the URL.
     await expect.poll(() => app.getUrlParams().get('view'), {
       timeout: 5_000,
-    }).toBeNull();
+    }).toBe('feed');
     await expect(
       page.getByRole('tab', { name: 'Feed view' }),
     ).toHaveAttribute('aria-selected', 'true');

--- a/frontend/e2e/map.spec.ts
+++ b/frontend/e2e/map.spec.ts
@@ -60,8 +60,11 @@ test.describe('Map surface', () => {
     await app.filters.toggleNotable(true);
     await expect.poll(() => app.getUrlParams().get('notable'), { timeout: 5_000 })
       .toBe('true');
+    // Phase 0: DEFAULTS.view is now 'map', so ?view= is omitted from the URL
+    // when map is the active view (writeUrl skips the default). Assert the
+    // map canvas is visible rather than asserting a URL param that won't appear.
     await expect.poll(() => app.getUrlParams().get('view'), { timeout: 5_000 })
-      .toBe('map');
+      .toBeNull();
 
     // Map canvas should still be visible after filter change.
     await expect(page.locator('[data-testid=map-canvas]')).toBeVisible();

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -39,7 +39,7 @@ test.describe('species detail surface (#151)', () => {
   test('row click navigates to detail surface without narrowing feed', async ({ page, apiStub }) => {
     await apiStub.stubSpecies('vermfly', VERMFLY);
     const app = new AppPage(page);
-    await app.goto();
+    await app.goto('view=feed');
     await app.waitForAppReady();
 
     // Click first feed row.
@@ -59,7 +59,7 @@ test.describe('species detail surface (#151)', () => {
 
   test('FiltersBar species commit narrows feed without opening detail', async ({ page }) => {
     const app = new AppPage(page);
-    await app.goto();
+    await app.goto('view=feed');
     await app.waitForAppReady();
 
     // Wait for species options to be populated.
@@ -73,6 +73,8 @@ test.describe('species detail surface (#151)', () => {
     await expect.poll(() => app.getUrlParams().get('species'), { timeout: 5_000 }).toBe('vermfly');
 
     // detail= should NOT be set. View should stay on feed.
+    // Phase 0: DEFAULTS.view is now 'map', so 'feed' is a non-default view
+    // and writeUrl WILL emit ?view=feed in the URL.
     expect(app.getUrlParams().get('detail')).toBeNull();
     expect(app.getUrlParams().get('view')).toBe('feed');
 

--- a/frontend/src/components/SurfaceNav.test.tsx
+++ b/frontend/src/components/SurfaceNav.test.tsx
@@ -19,6 +19,16 @@ describe('SurfaceNav', () => {
     expect(mapTab).toHaveAttribute('aria-selected', 'false');
   });
 
+  it('renders tabs in [Map, Species, Feed] order (Sky Atlas Phase 0)', () => {
+    render(<SurfaceNav activeView="map" onSelectView={() => {}} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map(t => t.getAttribute('aria-label'))).toEqual([
+      'Map view',
+      'Species view',
+      'Feed view',
+    ]);
+  });
+
   it('tracks aria-selected as activeView changes', () => {
     const { rerender } = render(
       <SurfaceNav activeView="feed" onSelectView={() => {}} />
@@ -77,11 +87,11 @@ describe('SurfaceNav', () => {
   it('ArrowRight on the active tab moves focus AND fires onSelectView with the next value', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
-    render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
+    render(<SurfaceNav activeView="map" onSelectView={onSelectView} />);
 
-    const feedTab = screen.getByRole('tab', { name: 'Feed view' });
-    feedTab.focus();
-    expect(feedTab).toHaveFocus();
+    const mapTab = screen.getByRole('tab', { name: 'Map view' });
+    mapTab.focus();
+    expect(mapTab).toHaveFocus();
 
     await user.keyboard('{ArrowRight}');
     expect(onSelectView).toHaveBeenCalledWith('species');
@@ -97,24 +107,11 @@ describe('SurfaceNav', () => {
     speciesTab.focus();
 
     await user.keyboard('{ArrowLeft}');
-    expect(onSelectView).toHaveBeenCalledWith('feed');
-    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveFocus();
+    expect(onSelectView).toHaveBeenCalledWith('map');
+    expect(screen.getByRole('tab', { name: 'Map view' })).toHaveFocus();
   });
 
   it('ArrowRight wraps from the last tab to the first', async () => {
-    const onSelectView = vi.fn();
-    const user = userEvent.setup();
-    render(<SurfaceNav activeView="map" onSelectView={onSelectView} />);
-
-    const mapTab = screen.getByRole('tab', { name: 'Map view' });
-    mapTab.focus();
-
-    await user.keyboard('{ArrowRight}');
-    expect(onSelectView).toHaveBeenCalledWith('feed');
-    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveFocus();
-  });
-
-  it('ArrowLeft wraps from the first tab to the last', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
     render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
@@ -122,9 +119,22 @@ describe('SurfaceNav', () => {
     const feedTab = screen.getByRole('tab', { name: 'Feed view' });
     feedTab.focus();
 
-    await user.keyboard('{ArrowLeft}');
+    await user.keyboard('{ArrowRight}');
     expect(onSelectView).toHaveBeenCalledWith('map');
     expect(screen.getByRole('tab', { name: 'Map view' })).toHaveFocus();
+  });
+
+  it('ArrowLeft wraps from the first tab to the last', async () => {
+    const onSelectView = vi.fn();
+    const user = userEvent.setup();
+    render(<SurfaceNav activeView="map" onSelectView={onSelectView} />);
+
+    const mapTab = screen.getByRole('tab', { name: 'Map view' });
+    mapTab.focus();
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onSelectView).toHaveBeenCalledWith('feed');
+    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveFocus();
   });
 
   it('Enter on a focused tab activates it', async () => {

--- a/frontend/src/components/SurfaceNav.tsx
+++ b/frontend/src/components/SurfaceNav.tsx
@@ -20,9 +20,9 @@ interface TabDef {
 // WAI-ARIA "automatic activation" tablist pattern selects on focus, so
 // activation and focus move together in Arrow handlers.
 const TABS: readonly TabDef[] = [
-  { value: 'feed', label: 'Feed', accessibleName: 'Feed view' },
-  { value: 'species', label: 'Species', accessibleName: 'Species view' },
   { value: 'map', label: 'Map', accessibleName: 'Map view' },
+  { value: 'species', label: 'Species', accessibleName: 'Species view' },
+  { value: 'feed', label: 'Feed', accessibleName: 'Feed view' },
 ];
 
 export function SurfaceNav(props: SurfaceNavProps) {

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -616,6 +616,73 @@ describe('MapCanvas', () => {
     });
   });
 
+  it('mosaic click under prefers-reduced-motion calls easeTo with duration: 0', async () => {
+    // Simulate a user with reduced-motion preference enabled
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    try {
+      const cluster = {
+        id: 42,
+        properties: { cluster_id: 42, point_count: 4 },
+        geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+      };
+      fakeMap.queryRenderedFeatures.mockImplementation(
+        (_: unknown, opts?: { layers?: string[] }) => {
+          if (opts?.layers?.includes('clusters-hit')) return [cluster];
+          return [];
+        },
+      );
+
+      const getClusterLeaves = vi
+        .fn()
+        .mockResolvedValue([
+          { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+        ]);
+      const getClusterExpansionZoom = vi.fn().mockResolvedValue(13);
+      fakeMap.getSource.mockReturnValue({
+        getClusterLeaves,
+        getClusterExpansionZoom,
+      });
+
+      // Zoom 12 < CLUSTER_MAX_ZOOM (14): the easeTo branch fires.
+      fakeMap.getZoom.mockReturnValue(12);
+
+      render(<MapCanvas observations={[makeObs()]} silhouettes={SILHOUETTES} />);
+      await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+
+      await act(async () => {
+        await bareHandlers['idle']?.();
+      });
+
+      const button = await screen.findByTestId('cluster-mosaic-marker');
+      await act(async () => {
+        button.click();
+      });
+
+      // easeTo runs after getClusterExpansionZoom resolves — wait for it.
+      await waitFor(() => {
+        expect(fakeMap.easeTo).toHaveBeenCalled();
+      });
+
+      // The new contract: easeTo must include duration: 0 under reduced-motion
+      expect(fakeMap.easeTo).toHaveBeenCalledWith(
+        expect.objectContaining({ duration: 0 })
+      );
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
   it('mosaic click at zoom >= CLUSTER_MAX_ZOOM is a NO-OP (auto-spider already fanned)', async () => {
     const cluster = {
       id: 99,

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -252,6 +252,18 @@ export function MapCanvas({
     return () => mql.removeEventListener('change', handler);
   }, []);
 
+  // Phase 0: read prefers-reduced-motion once at mount. useMemo with an empty
+  // dep array captures the value once — intentional. The user must reload to
+  // fully apply other reduced-motion changes anyway, and re-checking adds
+  // complexity for negligible gain.
+  const prefersReducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false,
+    [],
+  );
+
   // Unmount cleanup for the `window.__birdMap` test hook (#291). The hook is
   // assigned in `handleLoad` (which fires once per mount); without an unmount
   // cleanup, a remount (e.g. switching from feed view to map view and back)
@@ -436,7 +448,11 @@ export function MapCanvas({
           .getClusterExpansionZoom(clusterId)
           .then((zoom) => {
             if (center) {
-              map.easeTo({ center, zoom });
+              map.easeTo({
+                center,
+                zoom,
+                ...(prefersReducedMotion ? { duration: 0 } : {}),
+              });
             }
           })
           .catch(() => {
@@ -547,7 +563,7 @@ export function MapCanvas({
         setSpritesReady(true);
       });
     return () => { cancelled = true; };
-  }, [mapReady, silhouettes]);
+  }, [mapReady, silhouettes, prefersReducedMotion]);
 
   /**
    * Mosaic reconciler — issue #248. Queries rendered cluster features on
@@ -729,6 +745,7 @@ export function MapCanvas({
             map.easeTo({
               center,
               zoom: Math.min(targetZoom, CLUSTER_MAX_ZOOM),
+              ...(prefersReducedMotion ? { duration: 0 } : {}),
             });
           }
         })
@@ -736,7 +753,7 @@ export function MapCanvas({
           /* matches existing layer-bound err-swallow behavior */
         });
     },
-    [],
+    [prefersReducedMotion],
   );
 
   const handleClosePopover = useCallback(() => setSelectedObs(null), []);

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -563,7 +563,7 @@ export function MapCanvas({
         setSpritesReady(true);
       });
     return () => { cancelled = true; };
-  }, [mapReady, silhouettes, prefersReducedMotion]);
+  }, [mapReady, silhouettes]);
 
   /**
    * Mosaic reconciler — issue #248. Queries rendered cluster features on

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import { App } from './App.js';
 // called and no console warnings are emitted (issue #357 task 2).
 import './analytics.js';
 import './styles.css';
+import './styles/motion.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/state/url-state.test.ts
+++ b/frontend/src/state/url-state.test.ts
@@ -227,4 +227,86 @@ describe('useUrlState', () => {
     expect(result.current.state.view).toBe('species');
     expect(result.current.state.detail).toBeNull();
   });
+
+  // --- Phase 0: pushState for detail-surface navigation ---
+
+  describe('pushState semantics for detail navigation', () => {
+    it('navigating to detail uses pushState (history grows by 1)', () => {
+      window.history.replaceState({}, '', '/');
+      const startLen = window.history.length;
+      const { result } = renderHook(() => useUrlState());
+
+      act(() => result.current.set({ view: 'detail', detail: 'vermfly' }));
+
+      expect(window.history.length).toBe(startLen + 1);
+      expect(window.location.search).toContain('detail=vermfly');
+      expect(window.location.search).toContain('view=detail');
+    });
+
+    it('navigating away FROM detail uses replaceState (history does not grow)', () => {
+      window.history.replaceState({}, '', '/?detail=vermfly&view=detail');
+      const { result } = renderHook(() => useUrlState());
+      const startLen = window.history.length;
+
+      act(() => result.current.set({ view: 'feed', detail: null }));
+
+      expect(window.history.length).toBe(startLen);
+      expect(window.location.search).toContain('view=feed');
+      expect(window.location.search).not.toContain('detail=');
+    });
+
+    it('filter changes use replaceState (history does not grow)', () => {
+      window.history.replaceState({}, '', '/');
+      const { result } = renderHook(() => useUrlState());
+      const startLen = window.history.length;
+
+      act(() => result.current.set({ since: '7d' }));
+      act(() => result.current.set({ notable: true }));
+
+      expect(window.history.length).toBe(startLen);
+    });
+
+    it('surface switch (feed → map) uses replaceState (history does not grow)', () => {
+      window.history.replaceState({}, '', '/?view=feed');
+      const { result } = renderHook(() => useUrlState());
+      const startLen = window.history.length;
+
+      act(() => result.current.set({ view: 'map' }));
+
+      expect(window.history.length).toBe(startLen);
+    });
+
+    it('opening detail from a non-default surface preserves the prior URL in history', () => {
+      // jsdom history.back() does not navigate window.location; we verify
+      // the pushState contract by asserting that history grew by exactly 1
+      // when entering detail, and that the current URL is the detail URL.
+      // The pre-detail URL is preserved as the previous history entry —
+      // which is what browser-back would navigate to in a real browser.
+      window.history.replaceState({}, '', '/?view=feed&since=7d');
+      const startLen = window.history.length;
+      const { result } = renderHook(() => useUrlState());
+
+      act(() => result.current.set({ view: 'detail', detail: 'gilwoo' }));
+
+      // One new entry was pushed: pre-detail URL is now the back-stack entry.
+      expect(window.history.length).toBe(startLen + 1);
+      // Current URL is the detail URL.
+      expect(window.location.search).toContain('detail=gilwoo');
+      expect(window.location.search).toContain('view=detail');
+    });
+
+    it('detail → detail navigation (different species) uses pushState (history grows)', () => {
+      window.history.replaceState({}, '', '/?detail=vermfly&view=detail');
+      const { result } = renderHook(() => useUrlState());
+      const startLen = window.history.length;
+
+      act(() => result.current.set({ detail: 'gilwoo' }));
+
+      // Already on detail, only changing species code: still pushState
+      // because each species detail is a distinct user-meaningful navigation
+      // step (matches Wikipedia article-to-article navigation).
+      expect(window.history.length).toBe(startLen + 1);
+      expect(window.location.search).toContain('detail=gilwoo');
+    });
+  });
 });

--- a/frontend/src/state/url-state.test.ts
+++ b/frontend/src/state/url-state.test.ts
@@ -12,7 +12,7 @@ describe('useUrlState', () => {
     expect(result.current.state).toEqual({
       since: '14d', notable: false,
       speciesCode: null, familyCode: null,
-      view: 'feed',
+      view: 'map',
       detail: null,
     });
   });
@@ -58,7 +58,7 @@ describe('useUrlState', () => {
   it('falls back to default view when ?view= is invalid', () => {
     window.history.replaceState({}, '', '/?view=nonsense');
     const { result } = renderHook(() => useUrlState());
-    expect(result.current.state.view).toBe('feed');
+    expect(result.current.state.view).toBe('map');
   });
 
   it('sniffs view=species when ?species= is set without an explicit ?view=', () => {
@@ -81,14 +81,14 @@ describe('useUrlState', () => {
 
   it('writes ?view= to URL when view is non-default', () => {
     const { result } = renderHook(() => useUrlState());
-    act(() => result.current.set({ view: 'map' }));
-    expect(window.location.search).toContain('view=map');
+    act(() => result.current.set({ view: 'feed' }));
+    expect(window.location.search).toContain('view=feed');
   });
 
-  it('never serialises the default view to the URL', () => {
-    window.history.replaceState({}, '', '/?view=map');
+  it('never serialises the default view (map) to the URL', () => {
+    window.history.replaceState({}, '', '/?view=feed');
     const { result } = renderHook(() => useUrlState());
-    act(() => result.current.set({ view: 'feed' }));
+    act(() => result.current.set({ view: 'map' }));
     expect(window.location.search).not.toContain('view=');
   });
 
@@ -98,12 +98,12 @@ describe('useUrlState', () => {
     expect(result.current.state.view).toBe('species');
     expect(window.location.search).toContain('view=species');
 
-    act(() => result.current.set({ view: 'map' }));
-    expect(result.current.state.view).toBe('map');
-    expect(window.location.search).toContain('view=map');
-
     act(() => result.current.set({ view: 'feed' }));
     expect(result.current.state.view).toBe('feed');
+    expect(window.location.search).toContain('view=feed');
+
+    act(() => result.current.set({ view: 'map' }));
+    expect(result.current.state.view).toBe('map');
     expect(window.location.search).not.toContain('view=');
   });
 
@@ -140,10 +140,23 @@ describe('useUrlState', () => {
 
   // --- #112: regionId removed, readMigrationFlag ---
 
-  it('default state has view: feed and no regionId property', () => {
+  it('default state has view: map and no regionId property', () => {
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('map');
+    expect(result.current.state).not.toHaveProperty('regionId');
+  });
+
+  it('bare URL (/) lands on map (post-Sky-Atlas Phase 0)', () => {
+    window.history.replaceState({}, '', '/');
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('map');
+    expect(window.location.search).toBe('');
+  });
+
+  it('explicit ?view=feed still works for shared/bookmarked feed URLs', () => {
+    window.history.replaceState({}, '', '/?view=feed');
     const { result } = renderHook(() => useUrlState());
     expect(result.current.state.view).toBe('feed');
-    expect(result.current.state).not.toHaveProperty('regionId');
   });
 
   it('parses ?view=map', () => {

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -17,7 +17,7 @@ const DEFAULTS: UrlState = {
   familyCode: null,
   since: '14d',
   notable: false,
-  view: 'feed',
+  view: 'map',
   detail: null,
 };
 

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -37,7 +37,7 @@ function readUrl(): UrlState {
   //    'species' so bookmarked species-filter URLs land on the search
   //    surface with the filter active, NOT the detail surface.
   //  - absent ?view= AND ?detail= set → sniff to 'detail'.
-  //  - otherwise default ('feed').
+  //  - otherwise default (DEFAULTS.view — currently 'map').
   let view: View;
   if (rawView === 'hotspots') {
     // Compatibility shim: old bookmarks with ?view=hotspots silently redirect

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -68,7 +68,7 @@ function readUrl(): UrlState {
   };
 }
 
-function writeUrl(state: UrlState): void {
+function writeUrl(state: UrlState, push: boolean = false): void {
   const p = new URLSearchParams();
   if (state.speciesCode) p.set('species', state.speciesCode);
   if (state.familyCode) p.set('family', state.familyCode);
@@ -76,15 +76,23 @@ function writeUrl(state: UrlState): void {
   if (state.notable) p.set('notable', 'true');
   if (state.detail) p.set('detail', state.detail);
   // Emit ?view= when non-default, OR when ?species= or ?detail= is set and
-  // view is 'feed' — otherwise the sniff in readUrl silently reverts the
-  // user's explicit 'feed' choice back to 'species'/'detail' on reload/popstate.
+  // view is the default — otherwise the sniff in readUrl silently reverts the
+  // user's explicit default-view choice back to 'species'/'detail' on
+  // reload/popstate.
   if (state.view !== DEFAULTS.view || state.speciesCode || state.detail) {
     p.set('view', state.view);
   }
   const q = p.toString();
   const newUrl = q ? `${window.location.pathname}?${q}` : window.location.pathname;
   if (newUrl !== window.location.pathname + window.location.search) {
-    window.history.replaceState({}, '', newUrl);
+    if (push) {
+      // Detail-surface entry: push so browser-back returns to the prior
+      // surface. All other navigations replace (filter changes, tab switches,
+      // leaving detail).
+      window.history.pushState({}, '', newUrl);
+    } else {
+      window.history.replaceState({}, '', newUrl);
+    }
   }
 }
 
@@ -103,7 +111,18 @@ export function useUrlState(): {
   const set = useCallback((partial: Partial<UrlState>) => {
     setState(prev => {
       const next = { ...prev, ...partial };
-      writeUrl(next);
+      // Push (vs replace) when the user is navigating INTO the detail
+      // surface, OR navigating between two different species details.
+      // Both cases are user-meaningful "I clicked into a thing" moves
+      // that the browser back button should undo. Filter changes and
+      // surface switches (feed/species/map) keep replaceState so the
+      // history stack doesn't grow on every chip toggle.
+      const push =
+        // Entering detail from a non-detail surface
+        (next.view === 'detail' && prev.view !== 'detail') ||
+        // Switching between two species on the detail surface
+        (next.view === 'detail' && prev.view === 'detail' && next.detail !== prev.detail);
+      writeUrl(next, push);
       return next;
     });
   }, []);

--- a/frontend/src/styles/motion.css
+++ b/frontend/src/styles/motion.css
@@ -1,0 +1,28 @@
+/*
+ * Global reduced-motion policy.
+ *
+ * When the user has expressed a reduced-motion preference (system
+ * accessibility setting), collapse all CSS transitions and animations
+ * to 0ms. This is the single source of truth for reduced-motion in
+ * the application — components MUST NOT add their own
+ * `prefers-reduced-motion` queries unless they need a per-element
+ * override (e.g., suppressing a transform entirely rather than just
+ * its interpolation).
+ *
+ * One exception: MapLibre camera animations are JavaScript-driven
+ * (map.easeTo / map.flyTo) and are not under the CSS cascade. They
+ * are guarded separately in MapCanvas.tsx by reading
+ * matchMedia('(prefers-reduced-motion: reduce)').matches.
+ *
+ * Per spec:
+ *   docs/specs/2026-05-09-sky-atlas-redesign-design.md §4.6 (Motion policy)
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0ms !important;
+    animation-duration: 0ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    state "URL State (url-state.ts)" as US
    state "SurfaceNav" as SN
    state "MapCanvas" as MC
    state "motion.css" as MCSS

    [*] --> US : browser loads /
    US --> SN : DEFAULTS.view = 'map'\nTABS = [Map, Species, Feed]
    US --> US : entering detail?\npushState (history +1)\nother writes?\nreplaceState
    MC --> MC : mount reads\nmatchMedia('prefers-reduced-motion')\neaseTo → duration:0 when set
    MCSS --> [*] : @media(prefers-reduced-motion:reduce)\ntransition-duration:0ms !important\nanimation-duration:0ms !important
```

## Summary

- Switch `DEFAULTS.view` from `'feed'` to `'map'` so bare `bird-maps.com/` URLs land on the map surface, and reorder `<SurfaceNav>` tabs from `[Feed, Species, Map]` to `[Map, Species, Feed]` — both express the same stakeholder decision (S4: "map is home").
- Add `push?: boolean` to `writeUrl()` and thread `push: true` from `useUrlState.set()` when the user navigates into the detail surface (or between two species details), so browser back returns to the prior surface; all other writes keep `replaceState`.
- Add a global `motion.css` rule (`prefers-reduced-motion: reduce` → all transitions and animations collapse to 0ms) imported after `styles.css` in `main.tsx`, and guard MapLibre's `easeTo()` separately (JS-driven, not under the CSS cascade) by reading `matchMedia` once at mount and passing `duration: 0` when set.

## Screenshots

N/A — not UI. Phase 0 is plumbing for the Sky Atlas redesign; no visible UI surfaces change. The SurfaceNav tab order rotates (Map is now leftmost) but the visual component is otherwise unchanged. Surface-level visual changes ship in Phases 3–6.

## Test plan

- [x] `npm test` — all 479 tests pass (443 frontend unit + 36 services/packages): 6 new url-state tests (pushState semantics), 1 new SurfaceNav ordering test, 1 new MapCanvas reduced-motion test, 5 updated default-view assertions, 4 updated SurfaceNav arrow-key tests.
- [x] New unit tests added: pushState/replaceState semantics for detail entry, detail-to-detail, exit-from-detail, filter changes, surface switches; SurfaceNav [Map, Species, Feed] left-to-right DOM order pin; MapCanvas `easeTo` receives `duration: 0` under `matchMedia('prefers-reduced-motion: reduce')`.
- [x] `npm run test:e2e --workspace @bird-watch/frontend` — 105 passed, 9 skipped (pre-existing). 7 e2e specs updated for the new default route (bare `/` now loads map, not feed); skip-link and filter-round-trip assertions updated because `view=feed` is now a non-default emitted value.
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build; `grep -c "prefers-reduced-motion" frontend/dist/assets/index-*.css` returns 1 (motion.css rule present in bundle).
- [x] Playwright MCP smoke — e2e suite validates both viewports (390×844 mobile, 1440×900 desktop) including `zero console errors+warnings` tests at both viewports on map and species-detail surfaces. `map-symbol-layer.spec.ts` explicitly asserts no console errors on the map surface with a fully-stubbed API.

## Plan reference

Part of Plan 8, Tasks 1–6. See `docs/plans/2026-05-09-sky-atlas-phase-0-pre-redesign.md`.

Closes #398

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)