### PR TITLE
chore(docs): update Sky Atlas phases index — all plans linked, Phase 0 shipped

### DIFF
--- a/docs/design/02-phases/README.md
+++ b/docs/design/02-phases/README.md
@@ -47,13 +47,13 @@ Phases 3, 4, 5 can ship in any order or in parallel after Phase 2 lands.
 
 | # | Title | Goal | Plan | Status |
 |---|---|---|---|---|
-| 0 | [Pre-redesign engineering](./phase-0-pre-redesign.md) | `pushState` + `DEFAULTS.view='map'` + `motion.css` + MapLibre guard | [`../../plans/2026-05-09-sky-atlas-phase-0-pre-redesign.md`](../../plans/2026-05-09-sky-atlas-phase-0-pre-redesign.md) | Plan written |
-| 1 | [Token foundation](./phase-1-token-foundation.md) | Three-tier tokens, `[data-theme]` mechanic, type ramp, lint guard | not yet written | — |
-| 2 | [Design-system primitives](./phase-2-primitives.md) | `<StatusBlock>`, `<Photo>`, `<FamilySilhouette>`, `<ClusterPill>`, `<FilterSentence>` | not yet written | — |
-| 3 | [Map surface redesign](./phase-3-map-surface.md) | Cluster pills + lede + FamilyLegend revision | not yet written | — |
-| 4 | [Detail surface redesign](./phase-4-detail-surface.md) | Modal desktop + bottom-sheet mobile, photo masthead, h1 + focus | not yet written | — |
-| 5 | [Feed + species surfaces](./phase-5-feed-species.md) | Top-notable card, search visual contrast, FilterSentence live region | not yet written | — |
-| 6 | [Metadata + brand voice](./phase-6-metadata-voice.md) | 19 metadata gaps, voice strings, structured data | not yet written | — |
+| 0 | [Pre-redesign engineering](./phase-0-pre-redesign.md) | `pushState` + `DEFAULTS.view='map'` + `motion.css` + MapLibre guard | [`../../plans/2026-05-09-sky-atlas-phase-0-pre-redesign.md`](../../plans/2026-05-09-sky-atlas-phase-0-pre-redesign.md) | Shipped (#409) |
+| 1 | [Token foundation](./phase-1-token-foundation.md) | Three-tier tokens, `[data-theme]` mechanic, type ramp, lint guard | [`../../plans/2026-05-09-sky-atlas-phase-1-token-foundation.md`](../../plans/2026-05-09-sky-atlas-phase-1-token-foundation.md) | Plan written |
+| 2 | [Design-system primitives](./phase-2-primitives.md) | `<StatusBlock>`, `<Photo>`, `<FamilySilhouette>`, `<ClusterPill>`, `<FilterSentence>` | [`../../plans/2026-05-09-sky-atlas-phase-2-primitives.md`](../../plans/2026-05-09-sky-atlas-phase-2-primitives.md) | Plan written |
+| 3 | [Map surface redesign](./phase-3-map-surface.md) | Cluster pills + lede + FamilyLegend revision | [`../../plans/2026-05-09-sky-atlas-phase-3-map-surface.md`](../../plans/2026-05-09-sky-atlas-phase-3-map-surface.md) | Plan written |
+| 4 | [Detail surface redesign](./phase-4-detail-surface.md) | Modal desktop + bottom-sheet mobile, photo masthead, h1 + focus | [`../../plans/2026-05-09-sky-atlas-phase-4-detail-surface.md`](../../plans/2026-05-09-sky-atlas-phase-4-detail-surface.md) | Plan written |
+| 5 | [Feed + species surfaces](./phase-5-feed-species.md) | Top-notable card, search visual contrast, FilterSentence live region | [`../../plans/2026-05-09-sky-atlas-phase-5-feed-species.md`](../../plans/2026-05-09-sky-atlas-phase-5-feed-species.md) | Plan written |
+| 6 | [Metadata + brand voice](./phase-6-metadata-voice.md) | 19 metadata gaps, voice strings, structured data | [`../../plans/2026-05-09-sky-atlas-phase-6-metadata-voice.md`](../../plans/2026-05-09-sky-atlas-phase-6-metadata-voice.md) | Plan written |
 
 ## Sequencing rationale
 


### PR DESCRIPTION
## Diagrams

N/A — docs-only.

## Summary

Doc-drift fix on the Sky Atlas phase index: Phase 0's status moves from "Plan written" to "Shipped (#409)" now that the pre-redesign engineering work merged on 2026-05-10, and Phases 1–6 each get the relative link to their already-on-disk plan file in column 4 plus "Plan written" in column 5 (mirroring Phase 0's pre-ship format). The plan files for 1–6 were committed in #400 but the index was never updated to reference them, so column 4 still read "not yet written" — this PR closes that gap. Refs: epic #397, Phase 0 PR #409.

## Screenshots

N/A — not UI.

## Test plan

N/A — markdown-only; verified via `git diff --stat main..HEAD` that only `docs/design/02-phases/README.md` changed (1 file, +7/-7).

## Plan reference

Part of the Sky Atlas redesign orchestration plan: `/Users/j/.claude/plans/execute-the-sky-atlas-reflective-rabin.md`. Doc-drift cleanup slot identified between Phase 0 merge (#409) and Phase 1 dispatch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)