### PR TITLE
feat(frontend): Phase 1 — Token foundation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,14 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      - name: Forbidden raw token names (Sky Atlas Phase 1 lint guard)
+        run: |
+          # Fail if any source file uses the v3/v4 mock token names directly.
+          # These names collide silently with production --color-* tokens.
+          # Use production names instead: see docs/design/01-spec/tokens.md §Namespace migration.
+          if grep -rE \
+            'var\(--(accent|notable|bg-page|bg-surface|bg-tint|text-strong|text-body|text-muted|text-subtle|border)([^-]|$)' \
+            frontend/src/ ; then
+            echo "ERROR: Forbidden raw token name found. Use --color-* production names."
+            exit 1
+          fi

--- a/docs/specs/2026-05-09-v3-token-mapping.md
+++ b/docs/specs/2026-05-09-v3-token-mapping.md
@@ -24,6 +24,12 @@ Records the translation from v3/v4 Figma mock token names to the production `--c
 | `--density-sand` | `--color-density-mid` | **New in tokens.css** | Cluster mid-density tier |
 | `--density-ember` | `--color-density-high` | **New in tokens.css** | Cluster high-density tier |
 
+## Phase 1 color-value preservation
+
+The `[data-theme="light"]` block in `frontend/src/styles/tokens.css` preserves the **existing** production color values from `frontend/src/styles.css` `:root` for tokens that already exist (text grays, borders, accents, errors). The redesign palette from the spec (lighter grays, warm cream surfaces) is coupled to surface redesign and lands in Phase 3+, not Phase 1.
+
+This preserves AA contrast invariants verified by the e2e axe spec (e.g. `.feed-row-time` at 11px on `#fff` with `--color-text-subtle = #5c5c5c` = 6.86:1, passing 4.5:1). New tokens with no existing equivalent (`--color-bg-skeleton`, `--color-decision-point`, `--color-density-*`) take the spec values directly.
+
 ## Lint guard
 
 The CI step `Forbidden raw token names` in `.github/workflows/lint.yml` fails on any

--- a/docs/specs/2026-05-09-v3-token-mapping.md
+++ b/docs/specs/2026-05-09-v3-token-mapping.md
@@ -1,0 +1,34 @@
+# v3 Token Mapping — Mock → Production Names
+
+Companion artifact for Sky Atlas Phase 1 (`docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md`).
+
+Records the translation from v3/v4 Figma mock token names to the production `--color-*` namespace. The production names coexist with the existing flat `:root` tokens in `frontend/src/styles.css:1–63` without collision.
+
+## Translation table
+
+| Mock name (v3/v4) | Production name | Status | Notes |
+|---|---|---|---|
+| `--bg-page` | `--color-bg-page` | Exists in styles.css | Semantic token on `[data-theme]` overrides the `:root` declaration |
+| `--bg-surface` | `--color-bg-surface` | Exists in styles.css | Same override mechanism |
+| `--bg-tint` | `--color-bg-tint` | Exists in styles.css | Same |
+| `--bg-skeleton` | `--color-bg-skeleton` | **New in tokens.css** | Aliases `--color-bg-tint` initially; Phase 2 may diverge |
+| `--text-strong` | `--color-text-strong` | Exists in styles.css | — |
+| `--text-body` | `--color-text-body` | Exists in styles.css | — |
+| `--text-muted` | `--color-text-muted` | Exists in styles.css | — |
+| `--text-subtle` | `--color-text-subtle` | Exists in styles.css | — |
+| `--border` | `--color-border-ui` | Exists in styles.css | Live codebase already uses `--color-border-ui` |
+| `--accent` | `--color-decision-point` | **New in tokens.css** | DO NOT use `--color-accent-notable-fg` — different semantic |
+| `--notable` | `--color-accent-notable-fg` | Exists in styles.css | Preserved as-is; DO NOT rename |
+| `--font` | (dropped) | — | `body { font-family: var(--font-stack) }` replaces it |
+| `--density-sky` | `--color-density-low` | **New in tokens.css** | Cluster low-density tier |
+| `--density-sand` | `--color-density-mid` | **New in tokens.css** | Cluster mid-density tier |
+| `--density-ember` | `--color-density-high` | **New in tokens.css** | Cluster high-density tier |
+
+## Lint guard
+
+The CI step `Forbidden raw token names` in `.github/workflows/lint.yml` fails on any
+`var(--<mock-name>)` usage outside a legacy scope. See `docs/design/01-spec/tokens.md §Lint guard`.
+
+## Source
+
+Canonical spec: `docs/design/01-spec/tokens.md §Namespace migration`

--- a/docs/specs/2026-05-09-v3-token-mapping.md
+++ b/docs/specs/2026-05-09-v3-token-mapping.md
@@ -30,6 +30,25 @@ The `[data-theme="light"]` block in `frontend/src/styles/tokens.css` preserves t
 
 This preserves AA contrast invariants verified by the e2e axe spec (e.g. `.feed-row-time` at 11px on `#fff` with `--color-text-subtle = #5c5c5c` = 6.86:1, passing 4.5:1). New tokens with no existing equivalent (`--color-bg-skeleton`, `--color-decision-point`, `--color-density-*`) take the spec values directly.
 
+## Phase 1 dark-mode contract
+
+The `[data-theme="dark"]` block in `tokens.css` intentionally overrides ONLY new tokens (no existing equivalent in styles.css `:root`). Existing tokens stay at their light-mode values in dark mode for now.
+
+Why: existing CSS patterns like `.surface-nav-tab.is-active { background: var(--color-text-strong); }` reuse text tokens as backgrounds. Flipping `--color-text-strong` to a near-white in dark mode would put white text on near-white background (1.07:1 contrast). The full dark-mode palette landing requires component rewrites that are out of Phase 1 scope.
+
+What this means visually: when a user toggles to dark mode in Phase 1, the page mostly looks like light mode (because no existing token has a dark-mode value). Only NEW tokens (cluster density triad, decision-point) take their dark-mode pairing. This is the deliberate "mechanism-ready, palette-deferred" Phase 1 contract. Phases 3-5 add full dark-mode palette pairings as each surface is rewritten on Phase 2 primitives.
+
+Tokens overridden in `[data-theme="dark"]` (Phase 1):
+- `--color-bg-skeleton` (NEW)
+- `--color-decision-point` (NEW)
+- `--color-density-low|mid|high` (NEW)
+- `--color-density-text` (NEW)
+
+Tokens NOT overridden in `[data-theme="dark"]` (Phase 1):
+- All existing tokens carried from `styles.css :root` (`--color-text-*`, `--color-bg-page|surface|tint|*`, `--color-border-ui`, `--color-accent-notable-*`, `--color-error-*`).
+
+The MutationObserver mechanism in `MapCanvas.tsx` is still active and verified to fire on `[data-theme]` change; it calls `map.setStyle(basemapStyleDark)` even though OpenFreeMap's dark style aliases visually similar tiles for now (G8 is also deferred — see `docs/design/01-spec/open-questions.md`).
+
 ## Lint guard
 
 The CI step `Forbidden raw token names` in `.github/workflows/lint.yml` fails on any

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,15 +10,34 @@
       prefers-color-scheme on first visit. User's explicit toggle takes
       precedence over the OS preference after first load.
 
+      Both localStorage and matchMedia are wrapped in try/catch:
+      Safari Private Browsing and sandboxed iframes throw SecurityError
+      on storage access. Without the wrap the script would abort and
+      [data-theme] would never be set, producing a FOUC.
+
+      The resolution rules are mirrored in src/utils/boot-theme.ts and
+      unit-tested there; any change to the rules MUST be applied in both
+      places.
+
       Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
     -->
     <script>
       (function () {
-        var t = localStorage.getItem('theme');
-        if (!t) {
-          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light';
+        var t = null;
+        try {
+          t = localStorage.getItem('theme');
+        } catch (e) {
+          // SecurityError (Safari Private Browsing, sandboxed iframe)
+          // — fall through to the prefers-color-scheme branch.
+        }
+        if (t !== 'light' && t !== 'dark') {
+          try {
+            t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light';
+          } catch (e) {
+            t = 'light';
+          }
         }
         document.documentElement.setAttribute('data-theme', t);
       })();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>bird-watch — Arizona</title>
+    <!--
+      Inline blocking script: sets [data-theme] on <html> before first paint
+      to prevent FOUC. Reads localStorage['theme']; falls back to
+      prefers-color-scheme on first visit. User's explicit toggle takes
+      precedence over the OS preference after first load.
+
+      Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+    -->
+    <script>
+      (function () {
+        var t = localStorage.getItem('theme');
+        if (!t) {
+          t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', t);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/ThemeToggle.test.tsx
+++ b/frontend/src/components/ThemeToggle.test.tsx
@@ -80,4 +80,24 @@ describe('ThemeToggle', () => {
       'Switch to light mode',
     );
   });
+
+  // Safari Private Browsing and sandboxed iframes throw SecurityError on
+  // localStorage writes. The toggle MUST swallow the error and still
+  // update [data-theme] (the in-session source of truth) — only the
+  // cross-reload persistence is forfeit.
+  it('does not crash and still updates [data-theme] when localStorage.setItem throws SecurityError', async () => {
+    setTheme('light');
+    document.documentElement.setAttribute('data-theme', 'light');
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage access denied', 'SecurityError');
+    });
+
+    render(<ThemeToggle />);
+
+    await expect(
+      userEvent.click(screen.getByRole('button')),
+    ).resolves.not.toThrow();
+
+    expect(getTheme()).toBe('dark');
+  });
 });

--- a/frontend/src/components/ThemeToggle.test.tsx
+++ b/frontend/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeToggle } from './ThemeToggle.js';
+
+function setTheme(theme: 'light' | 'dark') {
+  document.documentElement.setAttribute('data-theme', theme);
+  localStorage.setItem('theme', theme);
+}
+
+function getTheme(): string | null {
+  return document.documentElement.getAttribute('data-theme');
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    setTheme('light');
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a button', () => {
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('displays sun icon (☀) when theme is light', () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button')).toHaveTextContent('☀');
+  });
+
+  it('displays moon icon (☾) when theme is dark', () => {
+    setTheme('dark');
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button')).toHaveTextContent('☾');
+  });
+
+  it('toggles from light to dark on click', async () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(getTheme()).toBe('dark');
+  });
+
+  it('toggles from dark to light on click', async () => {
+    setTheme('dark');
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(getTheme()).toBe('light');
+  });
+
+  it('persists the new theme to localStorage on click', async () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('has an accessible aria-label that names the current mode', () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Switch to dark mode',
+    );
+  });
+
+  it('aria-label updates after toggle', async () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Switch to light mode',
+    );
+  });
+});

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react';
+
+type Theme = 'light' | 'dark';
+
+function readCurrentTheme(): Theme {
+  const attr = document.documentElement.getAttribute('data-theme');
+  return attr === 'dark' ? 'dark' : 'light';
+}
+
+/**
+ * ThemeToggle — header button that flips [data-theme] on <html>.
+ *
+ * Writes both localStorage['theme'] (for persistence across page loads,
+ * read by the inline blocking script in index.html) and the attribute on
+ * document.documentElement (so CSS responds immediately without a reload).
+ *
+ * The MutationObserver in MapCanvas.tsx observes data-theme changes and
+ * swaps the basemap style accordingly — no prop-drilling needed.
+ *
+ * Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+ * Spec: docs/design/01-spec/architecture.md §Persistent chrome
+ */
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(readCurrentTheme);
+
+  const toggle = useCallback(() => {
+    const next: Theme = theme === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    setTheme(next);
+  }, [theme]);
+
+  const icon  = theme === 'light' ? '☀' : '☾';
+  const label = theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode';
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={label}
+      aria-live="polite"
+    >
+      {icon}
+    </button>
+  );
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -26,7 +26,13 @@ export function ThemeToggle() {
   const toggle = useCallback(() => {
     const next: Theme = theme === 'light' ? 'dark' : 'light';
     document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('theme', next);
+    try {
+      localStorage.setItem('theme', next);
+    } catch {
+      // Storage failures (Safari Private Browsing, sandboxed iframe,
+      // quota exceeded) are non-fatal — [data-theme] is the in-session
+      // source of truth, the only loss is persistence across reloads.
+    }
     setTheme(next);
   }, [theme]);
 

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -134,6 +134,9 @@ function makeFakeMap() {
     }),
     hasImage: vi.fn((id: string) => sprites.has(id)),
     removeImage: vi.fn((id: string) => sprites.delete(id)),
+    // Phase 1: MutationObserver in MapCanvas calls setStyle when
+    // [data-theme] flips. Default no-op spy; tests assert call args.
+    setStyle: vi.fn(),
   };
 }
 
@@ -1881,5 +1884,64 @@ describe('MapCanvas', () => {
     expect(onViewportChange).toHaveBeenCalledTimes(2);
     expect(onViewportChange).toHaveBeenNthCalledWith(1, firstBounds);
     expect(onViewportChange).toHaveBeenNthCalledWith(2, secondBounds);
+  });
+
+  // --- Phase 1: [data-theme] MutationObserver for basemap swap ---
+  //
+  // The observer is registered on document.documentElement after
+  // mapReady. When [data-theme] flips, observer reads the new value and
+  // calls map.setStyle() with the matching basemap URL. Cleanup on
+  // unmount is verified by the observer.disconnect() call (no leak).
+
+  describe('[data-theme] MutationObserver swaps basemap', () => {
+    it('calls map.setStyle with dark URL when data-theme changes to dark', async () => {
+      // Start in light mode; the observer must register before the flip.
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      render(<MapCanvas observations={[]} silhouettes={SILHOUETTES} />);
+
+      // MockMap fires onLoad in useEffect → handleLoad → mapReady=true.
+      // Wait for the observer effect to register.
+      await waitFor(() => {
+        expect(fakeMap).not.toBeNull();
+      });
+
+      // Mutate the attribute — MutationObserver should pick it up and
+      // call setStyle with the dark URL.
+      act(() => {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      });
+
+      await waitFor(() => {
+        expect(fakeMap.setStyle).toHaveBeenCalledWith(
+          'https://tiles.openfreemap.org/styles/dark',
+        );
+      });
+
+      // Cleanup
+      document.documentElement.setAttribute('data-theme', 'light');
+    });
+
+    it('calls map.setStyle with light URL when data-theme changes to light', async () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+
+      render(<MapCanvas observations={[]} silhouettes={SILHOUETTES} />);
+
+      await waitFor(() => {
+        expect(fakeMap).not.toBeNull();
+      });
+
+      act(() => {
+        document.documentElement.setAttribute('data-theme', 'light');
+      });
+
+      await waitFor(() => {
+        expect(fakeMap.setStyle).toHaveBeenCalledWith(
+          'https://tiles.openfreemap.org/styles/positron',
+        );
+      });
+
+      document.documentElement.removeAttribute('data-theme');
+    });
   });
 });

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1955,5 +1955,34 @@ describe('MapCanvas', () => {
 
       document.documentElement.removeAttribute('data-theme');
     });
+
+    // Same-value guard: setAttribute('data-theme', x) when the attribute
+    // already equals x still fires a MutationRecord. Without the
+    // prevThemeRef short-circuit, this would trigger a redundant setStyle
+    // and tile re-fetch on every no-op write.
+    it('does NOT call map.setStyle when data-theme is set to its current value', async () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+
+      render(<MapCanvas observations={[]} silhouettes={SILHOUETTES} />);
+
+      await waitFor(() => {
+        expect(fakeMap).not.toBeNull();
+      });
+
+      (fakeMap.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+      // Write the SAME value the attribute already has. The MutationRecord
+      // fires; the observer must short-circuit before invoking setStyle.
+      act(() => {
+        document.documentElement.setAttribute('data-theme', 'light');
+      });
+
+      // Wait one microtask so any setStyle queued by the observer would
+      // have flushed by now. Then assert it never fired.
+      await Promise.resolve();
+      expect(fakeMap.setStyle).not.toHaveBeenCalled();
+
+      document.documentElement.removeAttribute('data-theme');
+    });
   });
 });

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1890,39 +1890,46 @@ describe('MapCanvas', () => {
   //
   // The observer is registered on document.documentElement after
   // mapReady. When [data-theme] flips, observer reads the new value and
-  // calls map.setStyle() with the matching basemap URL. Cleanup on
-  // unmount is verified by the observer.disconnect() call (no leak).
+  // calls map.setStyle() with the resolved URL for that theme. Cleanup
+  // on unmount is verified by the observer.disconnect() call (no leak).
+  //
+  // G8 gate: basemapStyleDark currently aliases basemapStyleLight (see
+  // basemap-style.ts module comment), so both URL inputs resolve to the
+  // same positron URL. The mechanism is what's under test — that
+  // setStyle fires with the right URL for the current theme — not the
+  // URL distinctness. When G8 closes, basemapStyleDark stops aliasing
+  // and these assertions naturally diverge.
 
   describe('[data-theme] MutationObserver swaps basemap', () => {
-    it('calls map.setStyle with dark URL when data-theme changes to dark', async () => {
-      // Start in light mode; the observer must register before the flip.
+    it('calls map.setStyle when data-theme changes to dark', async () => {
       document.documentElement.setAttribute('data-theme', 'light');
 
       render(<MapCanvas observations={[]} silhouettes={SILHOUETTES} />);
 
-      // MockMap fires onLoad in useEffect → handleLoad → mapReady=true.
-      // Wait for the observer effect to register.
       await waitFor(() => {
         expect(fakeMap).not.toBeNull();
       });
 
-      // Mutate the attribute — MutationObserver should pick it up and
-      // call setStyle with the dark URL.
+      // Reset prior calls so the assertion isolates the flip.
+      (fakeMap.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
       act(() => {
         document.documentElement.setAttribute('data-theme', 'dark');
       });
 
       await waitFor(() => {
-        expect(fakeMap.setStyle).toHaveBeenCalledWith(
-          'https://tiles.openfreemap.org/styles/dark',
-        );
+        expect(fakeMap.setStyle).toHaveBeenCalledTimes(1);
       });
 
-      // Cleanup
+      // The URL passed must be a string (the dark-resolved basemap URL).
+      const arg = (fakeMap.setStyle as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(typeof arg).toBe('string');
+      expect(arg).toMatch(/openfreemap\.org\/styles\//);
+
       document.documentElement.setAttribute('data-theme', 'light');
     });
 
-    it('calls map.setStyle with light URL when data-theme changes to light', async () => {
+    it('calls map.setStyle when data-theme changes to light', async () => {
       document.documentElement.setAttribute('data-theme', 'dark');
 
       render(<MapCanvas observations={[]} silhouettes={SILHOUETTES} />);
@@ -1931,15 +1938,20 @@ describe('MapCanvas', () => {
         expect(fakeMap).not.toBeNull();
       });
 
+      (fakeMap.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
       act(() => {
         document.documentElement.setAttribute('data-theme', 'light');
       });
 
       await waitFor(() => {
-        expect(fakeMap.setStyle).toHaveBeenCalledWith(
-          'https://tiles.openfreemap.org/styles/positron',
-        );
+        expect(fakeMap.setStyle).toHaveBeenCalledTimes(1);
       });
+
+      const arg = (fakeMap.setStyle as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(typeof arg).toBe('string');
+      // Light theme always resolves to the positron URL (no aliasing).
+      expect(arg).toBe('https://tiles.openfreemap.org/styles/positron');
 
       document.documentElement.removeAttribute('data-theme');
     });

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -717,10 +717,24 @@ export function MapCanvas({
   // Dark URL aliasing (G8): basemapStyleDark may resolve to the same
   // visual tiles as light during the rollout window; the swap mechanism
   // is correct regardless. See docs/design/01-spec/open-questions.md.
+  //
+  // Same-value guard: MutationRecord fires on every attribute write,
+  // including writes that set the SAME value the attribute already had
+  // (e.g. setAttribute('data-theme', 'light') when it's already 'light').
+  // Without the prevTheme ref, a no-op write would trigger setStyle and
+  // a redundant tile re-fetch.
+  const prevThemeRef = useRef<'light' | 'dark' | null>(null);
   useEffect(() => {
     if (!mapReady) return;
     const map = mapRef.current?.getMap();
     if (!map) return;
+
+    // Seed the prev ref with the current attribute value so the first
+    // observed mutation only fires setStyle when the value genuinely flips.
+    prevThemeRef.current =
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'dark'
+        : 'light';
 
     const observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
@@ -728,8 +742,13 @@ export function MapCanvas({
           mutation.type === 'attributes' &&
           mutation.attributeName === 'data-theme'
         ) {
-          const theme = document.documentElement.getAttribute('data-theme');
-          const style = theme === 'dark' ? basemapStyleDark : basemapStyleLight;
+          const next: 'light' | 'dark' =
+            document.documentElement.getAttribute('data-theme') === 'dark'
+              ? 'dark'
+              : 'light';
+          if (next === prevThemeRef.current) return;
+          prevThemeRef.current = next;
+          const style = next === 'dark' ? basemapStyleDark : basemapStyleLight;
           map.setStyle(style);
         }
       }

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -13,7 +13,7 @@ import {
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { FamilySilhouette, Observation } from '@bird-watch/shared-types';
-import { basemapStyle } from './basemap-style.js';
+import { basemapStyleLight, basemapStyleDark } from './basemap-style.js';
 import {
   observationsToGeoJson,
   buildClusterLayerSpec,
@@ -710,6 +710,39 @@ export function MapCanvas({
     // updates don't need a re-registration.
   }, [silhouettes.length, mapReady]);
 
+  // Phase 1: [data-theme] observer — swap basemap when user toggles theme.
+  // Registered after mapReady so the map instance is guaranteed to exist.
+  // Cleaned up on unmount to prevent leaks. The observer is the single
+  // source of truth for basemap-vs-theme coupling — no prop drilling.
+  // Dark URL aliasing (G8): basemapStyleDark may resolve to the same
+  // visual tiles as light during the rollout window; the swap mechanism
+  // is correct regardless. See docs/design/01-spec/open-questions.md.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-theme'
+        ) {
+          const theme = document.documentElement.getAttribute('data-theme');
+          const style = theme === 'dark' ? basemapStyleDark : basemapStyleLight;
+          map.setStyle(style);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, [mapReady]);
+
   /**
    * Mosaic-marker click handler:
    *   currentZoom < CLUSTER_MAX_ZOOM → easeTo (zoom in to break up the cluster).
@@ -808,7 +841,12 @@ export function MapCanvas({
         ref={mapRef}
         initialViewState={INITIAL_VIEW}
         style={{ width: '100%', height: '100%' }}
-        mapStyle={basemapStyle}
+        mapStyle={
+          typeof document !== 'undefined' &&
+          document.documentElement.getAttribute('data-theme') === 'dark'
+            ? basemapStyleDark
+            : basemapStyleLight
+        }
         onLoad={handleLoad}
         attributionControl={false}
       >

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -1,14 +1,20 @@
 /**
- * Basemap for the map surface.
+ * Basemap URLs for the map surface.
  *
- * Points at OpenFreeMap's hosted `positron` style — free, MapLibre-compatible,
- * includes glyphs + sources + rendering layers. Prototype finding 2
- * (docs/plans/2026-04-22-map-v1-prototype/learnings.md) notes the style emits
- * MapLibre warnings at zoom >7, but those are cosmetic upstream issues, not
- * crashes. Acceptable for production.
+ * Light: OpenFreeMap positron — free, MapLibre-compatible.
+ * Dark:  OpenFreeMap dark — gated on G7/G8 contrast gate; see
+ *        docs/design/01-spec/open-questions.md. If the gate fails,
+ *        MapCanvas falls back to the light basemap for both modes.
  *
- * No self-hosted tile pipeline is planned; the unapplied map-v1 PMTiles
- * Terraform was removed in #385 once it was confirmed the live map at
- * https://bird-maps.com fetches all tiles from `tiles.openfreemap.org`.
+ * `basemapStyle` is kept as a light alias so existing callers compile
+ * without changes until Phase 3 wires the theme-aware prop.
+ *
+ * Prototype finding 2 (docs/plans/2026-04-22-map-v1-prototype/learnings.md):
+ * positron emits MapLibre warnings at zoom >7 — cosmetic, not crashes.
  */
-export const basemapStyle = 'https://tiles.openfreemap.org/styles/positron';
+export const basemapStyleLight = 'https://tiles.openfreemap.org/styles/positron';
+export const basemapStyleDark  = 'https://tiles.openfreemap.org/styles/dark';
+
+/** Backward-compatible alias — Phase 3 will replace callsites with the
+ *  theme-aware selection. */
+export const basemapStyle = basemapStyleLight;

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -2,18 +2,32 @@
  * Basemap URLs for the map surface.
  *
  * Light: OpenFreeMap positron — free, MapLibre-compatible.
- * Dark:  OpenFreeMap dark — gated on G7/G8 contrast gate; see
- *        docs/design/01-spec/open-questions.md. If the gate fails,
- *        MapCanvas falls back to the light basemap for both modes.
+ * Dark:  G7/G8 gate (family-palette × dark-tile contrast) is open. Until
+ *        the gate closes, the dark URL deliberately aliases the light
+ *        positron URL: the MutationObserver in MapCanvas still fires
+ *        map.setStyle on theme flip, but setStyle to the same URL is a
+ *        cheap no-op (and avoids OpenFreeMap dark-style sprite-load
+ *        warnings — circle-11 etc. — that fire when sprites referenced
+ *        by the dark style are not present in the positron sprite sheet
+ *        the map originally loaded).
+ *
+ *        When G8 closes, switch basemapStyleDark to point at
+ *        'https://tiles.openfreemap.org/styles/dark' (or a self-hosted
+ *        equivalent) and the swap mechanism light up automatically.
  *
  * `basemapStyle` is kept as a light alias so existing callers compile
  * without changes until Phase 3 wires the theme-aware prop.
  *
  * Prototype finding 2 (docs/plans/2026-04-22-map-v1-prototype/learnings.md):
  * positron emits MapLibre warnings at zoom >7 — cosmetic, not crashes.
+ *
+ * Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+ * Spec: docs/design/01-spec/open-questions.md (G7/G8)
  */
 export const basemapStyleLight = 'https://tiles.openfreemap.org/styles/positron';
-export const basemapStyleDark  = 'https://tiles.openfreemap.org/styles/dark';
+
+/** Aliased to the light URL until G8 closes — see the module comment. */
+export const basemapStyleDark  = basemapStyleLight;
 
 /** Backward-compatible alias — Phase 3 will replace callsites with the
  *  theme-aware selection. */

--- a/frontend/src/components/map/basemap-style.ts
+++ b/frontend/src/components/map/basemap-style.ts
@@ -15,9 +15,6 @@
  *        'https://tiles.openfreemap.org/styles/dark' (or a self-hosted
  *        equivalent) and the swap mechanism light up automatically.
  *
- * `basemapStyle` is kept as a light alias so existing callers compile
- * without changes until Phase 3 wires the theme-aware prop.
- *
  * Prototype finding 2 (docs/plans/2026-04-22-map-v1-prototype/learnings.md):
  * positron emits MapLibre warnings at zoom >7 — cosmetic, not crashes.
  *
@@ -28,7 +25,3 @@ export const basemapStyleLight = 'https://tiles.openfreemap.org/styles/positron'
 
 /** Aliased to the light URL until G8 closes — see the module comment. */
 export const basemapStyleDark  = basemapStyleLight;
-
-/** Backward-compatible alias — Phase 3 will replace callsites with the
- *  theme-aware selection. */
-export const basemapStyle = basemapStyleLight;

--- a/frontend/src/config/region.test.ts
+++ b/frontend/src/config/region.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { REGION_LABEL } from './region.js';
+
+describe('REGION_LABEL', () => {
+  it('is the string "Arizona"', () => {
+    expect(REGION_LABEL).toBe('Arizona');
+  });
+
+  it('is a non-empty string', () => {
+    expect(typeof REGION_LABEL).toBe('string');
+    expect(REGION_LABEL.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/config/region.ts
+++ b/frontend/src/config/region.ts
@@ -1,0 +1,11 @@
+/**
+ * Region configuration.
+ *
+ * REGION_LABEL is the source of truth for the region name used in the
+ * wordmark ("Bird Maps · Arizona"), the lede, and any region claim in
+ * the UI. Change this string to relocate the application to a different
+ * region — downstream consumers read it from here.
+ *
+ * Spec: docs/design/01-spec/architecture.md §Cross-cutting structures
+ */
+export const REGION_LABEL = 'Arizona' as const;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { App } from './App.js';
 // key is empty, the import is a strict no-op — posthog.init is never
 // called and no console warnings are emitted (issue #357 task 2).
 import './analytics.js';
+import './styles/tokens.css';
 import './styles.css';
 import './styles/motion.css';
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -260,8 +260,8 @@ body {
 .feed-row-time {
   flex-shrink: 0;
   font-size: var(--type-xs);
-  /* #5c5c5c on #fff = 6.86:1 — passes AA for 12px normal weight. #777
-     (the first draft) failed at 4.47:1. Do NOT lighten this back. */
+  /* #5c5c5c on #fff = 6.86:1 — passes AA at 11px. tokens.css preserves
+     this color in light mode (see tokens.css [data-theme="light"]). */
   color: var(--color-text-subtle);
   font-variant-numeric: tabular-nums;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -153,7 +153,7 @@ body {
   display: flex;
   gap: var(--space-lg);
   padding: var(--space-sm) var(--space-md);
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
 }
 .feed-sort-option {
@@ -216,7 +216,7 @@ body {
   border-radius: 50%;
   background: var(--color-accent-notable-fg);
   color: var(--color-text-white);
-  font-size: 12px;
+  font-size: var(--type-xs);
   font-weight: 700;
   line-height: 1;
 }
@@ -224,7 +224,7 @@ body {
   flex: 1;
   min-width: 0;
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -233,7 +233,7 @@ body {
 .feed-row-count {
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-body);
   background: var(--color-bg-tint);
   padding: 2px 6px;
@@ -250,7 +250,7 @@ body {
 .feed-row-loc {
   flex-shrink: 1;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--type-sm);
   /* #555 on #fff = 7.46:1 — well clear of 4.5:1. */
   color: var(--color-text-muted);
   overflow: hidden;
@@ -259,7 +259,7 @@ body {
 }
 .feed-row-time {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: var(--type-xs);
   /* #5c5c5c on #fff = 6.86:1 — passes AA for 12px normal weight. #777
      (the first draft) failed at 4.47:1. Do NOT lighten this back. */
   color: var(--color-text-subtle);
@@ -269,7 +269,7 @@ body {
   padding: var(--space-xl);
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 14px;
+  font-size: var(--type-sm);
   max-width: 480px;
   margin-inline: auto;
 }
@@ -290,7 +290,7 @@ body {
   width: 100%;
   box-sizing: border-box;
   padding: 10px 14px;
-  font-size: 15px;
+  font-size: var(--type-base);
   border: 1px solid var(--color-border-ui);
   border-radius: 6px;
   background: var(--color-bg-surface);
@@ -329,7 +329,7 @@ body {
 }
 .species-autocomplete-option {
   padding: 8px 14px;
-  font-size: 14px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   cursor: pointer;
   line-height: 1.3;
@@ -348,14 +348,14 @@ body {
   border: 1px solid var(--color-border-ui);
   border-radius: 6px;
   color: var(--color-text-muted);
-  font-size: 13px;
+  font-size: var(--type-sm);
 }
 .species-search-prompt,
 .species-search-empty {
   padding: var(--space-xl) var(--space-lg);
   text-align: center;
   color: var(--color-text-muted);
-  font-size: 14px;
+  font-size: var(--type-sm);
   margin: 0;
 }
 
@@ -368,7 +368,7 @@ body {
   align-items: center;
   flex-wrap: wrap;
 }
-.filters-bar label { display: flex; gap: 6px; align-items: center; font-size: 13px; }
+.filters-bar label { display: flex; gap: 6px; align-items: center; font-size: var(--type-sm); }
 .filters-bar select, .filters-bar input { padding: 4px 8px; }
 
 /* Surface-toggle tablist (#111). Sits between FiltersBar and the map / main
@@ -389,7 +389,7 @@ body {
   border-radius: 4px;
   padding: 6px 14px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   cursor: pointer;
   line-height: 1.2;
@@ -441,20 +441,20 @@ body {
 }
 .species-detail-common-name {
   margin: 0 0 4px 0;
-  font-size: 20px;
+  font-size: var(--type-lg);
   font-weight: 700;
 }
 .species-detail-sci-name {
   margin: 0 0 12px 0;
-  font-size: 14px;
+  font-size: var(--type-sm);
   color: var(--color-text-muted);
 }
 .species-detail-family {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-body);
 }
-.species-detail-loading { color: var(--color-text-muted); font-size: 13px; margin: 8px 0 0 0; }
+.species-detail-loading { color: var(--color-text-muted); font-size: var(--type-sm); margin: 8px 0 0 0; }
 /* Phenology chart (#356, #363, #365). 12 monthly observation-count bars
    rendered as inline SVG inside the species detail body. Sits below
    .species-detail-family. The SVG uses width:100% with a max-width cap so
@@ -513,7 +513,7 @@ body {
 }
 .phenology-chart-loading {
   color: var(--color-text-muted);
-  font-size: 13px;
+  font-size: var(--type-sm);
   margin: 12px 0 0 0;
 }
 .species-detail-error {
@@ -523,7 +523,7 @@ body {
   border: 1px solid var(--color-error-border);
   border-radius: 4px;
   color: var(--color-error-text);
-  font-size: 13px;
+  font-size: var(--type-sm);
 }
 
 /* Map surface (#165, #158, #249). The MapLibre canvas fills #main-surface
@@ -568,7 +568,7 @@ body {
   padding: var(--space-sm) var(--space-lg);
   background: var(--color-bg-surface);
   border-top: 1px solid var(--color-border-ui);
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-muted);
 }
 
@@ -584,7 +584,7 @@ body {
   padding: var(--space-xs) var(--space-sm);
   color: var(--color-text-muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-xs);
   text-decoration: underline;
   cursor: pointer;
   border-radius: 4px;
@@ -646,7 +646,7 @@ body {
 }
 .attribution-modal-header h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--type-md);
   font-weight: 700;
   color: var(--color-text-strong);
 }
@@ -657,7 +657,7 @@ body {
   border-radius: 4px;
   padding: 4px 12px;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   cursor: pointer;
   min-height: 32px;
@@ -674,13 +674,13 @@ body {
 }
 .attribution-modal-section h3 {
   margin: 0 0 var(--space-xs) 0;
-  font-size: 14px;
+  font-size: var(--type-sm);
   font-weight: 700;
   color: var(--color-text-strong);
 }
 .attribution-modal-section p {
   margin: 0 0 var(--space-xs) 0;
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-body);
   line-height: 1.4;
 }
@@ -711,7 +711,7 @@ body {
   gap: var(--space-xs);
 }
 .attribution-modal-phylopic-row {
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-body);
   line-height: 1.4;
   padding: 2px 0;
@@ -752,7 +752,7 @@ body {
   border: 1px solid var(--color-border-ui);
   border-radius: 6px;
   box-shadow: var(--shadow-listbox);
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   max-width: 240px;
 }
@@ -783,7 +783,7 @@ body {
   font-weight: 600;
 }
 .family-legend-chevron {
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-muted);
 }
 .family-legend-entries {
@@ -812,7 +812,7 @@ body {
   border-radius: 4px;
   padding: 4px 6px;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-strong);
   cursor: pointer;
   text-align: left;
@@ -839,7 +839,7 @@ body {
 .family-legend-entry-count {
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
-  font-size: 11px;
+  font-size: var(--type-xs);
   color: var(--color-text-body);
   background: var(--color-bg-tint);
   padding: 1px 5px;
@@ -878,7 +878,7 @@ body {
   border-radius: 6px;
   box-shadow: var(--shadow-listbox);
   padding: var(--space-sm) var(--space-md);
-  font-size: 13px;
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   max-width: 280px;
 }
@@ -901,7 +901,7 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 11px;
+  font-size: var(--type-xs);
   font-weight: 700;
 }
 .observation-popover-close {
@@ -909,7 +909,7 @@ body {
   background: transparent;
   border: none;
   font: inherit;
-  font-size: 18px;
+  font-size: var(--type-md);
   line-height: 1;
   color: var(--color-text-muted);
   cursor: pointer;
@@ -921,7 +921,7 @@ body {
 .observation-popover-location,
 .observation-popover-time,
 .observation-popover-count {
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-body);
   margin-top: 2px;
 }
@@ -932,7 +932,7 @@ body {
   padding: var(--space-xs) 0 0 0;
   margin-top: var(--space-xs);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-xs);
   color: var(--color-text-strong);
   cursor: pointer;
   text-decoration: underline;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -45,7 +45,6 @@
   --type-md:   17px;  /* species name in row, modal headings */
   --type-lg:   22px;  /* surface section titles */
   --type-hero: 34px;  /* lede, detail-surface species name */
-  --lede-size: 26px;  /* documented exception between lg and hero */
 
   --font-stack:
     -apple-system, BlinkMacSystemFont, "Segoe UI Variable",
@@ -153,4 +152,15 @@
 .feed-row {
   --feed-row-bg:       var(--color-bg-surface);
   --feed-row-bg-hover: var(--color-bg-tint);
+}
+
+/*
+ * Lede — a one-off display size that sits between --type-lg (22px) and
+ * --type-hero (34px). Scoped here (Layer 3) rather than inside the type
+ * ramp because a type ramp's value is in being a discrete ladder; an
+ * exception inside the ladder weakens the contract. Moved out of Layer 1
+ * intentionally — see commit "refactor(styles): relocate --lede-size".
+ */
+.lede {
+  --lede-size: 26px;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -59,32 +59,47 @@
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */
+/*
+ * Phase 1 contract: the [data-theme="light"] block preserves the existing
+ * production color values from styles.css :root for tokens that already
+ * exist (text grays, borders, accents, errors). The redesign palette
+ * (spec docs/design/01-spec/tokens.md §Light/dark mechanic — lighter
+ * grays, warm cream surfaces) is a Phase 3+ concern coupled to surface
+ * redesign; landing the lighter palette here would regress AA contrast
+ * (e.g. .feed-row-time @ 12px on #fff with #8a8a8a fails 4.5:1).
+ *
+ * NEW additions in this block (no existing equivalent in styles.css):
+ *   --color-bg-skeleton, --color-decision-point, --color-density-{low,mid,high},
+ *   --color-density-text. These can use the spec values directly.
+ */
 :root[data-theme="light"] {
-  --color-bg-page:    var(--c-warm-50);
-  --color-bg-surface: #ffffff;
-  --color-bg-tint:    var(--c-warm-100);
-  --color-bg-skeleton: var(--c-warm-100); /* alias of bg-tint initially */
+  --color-bg-page:    #f4f1ea;  /* preserve existing — warm cream page bg */
+  --color-bg-surface: #ffffff;  /* preserve existing */
+  --color-bg-tint:    #f0ebe0;  /* preserve existing */
+  --color-bg-skeleton: #f0ebe0; /* alias of bg-tint initially (NEW) */
 
-  --color-text-strong: #1a1a1a;
-  --color-text-body:   #2a2a2a;
-  --color-text-muted:  #5a5a5a;
-  --color-text-subtle: #8a8a8a;
+  --color-text-strong: #1a1a1a; /* preserve existing */
+  --color-text-body:   #444;    /* preserve existing — AA-tuned */
+  --color-text-muted:  #555;    /* preserve existing — AA-tuned */
+  --color-text-subtle: #5c5c5c; /* preserve existing — AA at 12px */
 
-  --color-border-ui: var(--c-warm-200);
+  --color-border-ui: #d8d3c3;   /* preserve existing */
 
-  /* RENAMED from mock --accent; DO NOT collide with --color-accent-notable-fg */
+  /* RENAMED from mock --accent; DO NOT collide with --color-accent-notable-fg.
+     Decision-point is a NEW token; spec value lands. */
   --color-decision-point: var(--c-orange-500);
 
+  /* NEW cluster-density triad (no existing equivalent) */
   --color-density-low:  var(--c-sky-500);
   --color-density-mid:  var(--c-sand-500);
   --color-density-high: var(--c-ember-500);
   --color-density-text: #1a1a1a;
 
-  /* PRESERVED from existing codebase — do not rename */
-  --color-accent-notable-fg: var(--c-deep-ember);
-  --color-error-bg:     #fcebe4;
-  --color-error-border: #e8a890;
-  --color-error-text:   #8a3a1a;
+  /* PRESERVED from existing codebase — do not rename, do not change values */
+  --color-accent-notable-fg: #b8860b; /* dark amber stripe / badge */
+  --color-error-bg:     #fdecec;
+  --color-error-border: #d48e8e;
+  --color-error-text:   #8a1f1f;
 }
 
 /* ── Layer 2: Semantic — dark mode ──────────────────────────────────── */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -104,23 +104,37 @@
 
 /* ── Layer 2: Semantic — dark mode ──────────────────────────────────── */
 /*
- * Dark basemap is gated on G7/G8 (family palette contrast against dark
- * tiles). If G8 fails, dark mode ships with the same positron basemap as
- * light; the basemap swap in MapCanvas is a no-op until G8 passes.
- * See docs/design/01-spec/open-questions.md.
+ * Phase 1 dark-mode contract:
+ *
+ * The dark-mode block intentionally LIMITS overrides to NEW tokens that
+ * have no existing equivalent in styles.css :root. Existing tokens
+ * (--color-text-{strong,body,muted,subtle}, --color-bg-{page,surface,tint},
+ * --color-border-ui, --color-accent-notable-*, --color-error-*) keep
+ * their light-mode values in dark mode for now. Overriding them in
+ * dark mode breaks existing CSS patterns like
+ * `.surface-nav-tab.is-active { background: var(--color-text-strong) }`
+ * (a near-black bg in light mode becomes near-white in dark mode,
+ * trashing contrast against `var(--color-text-white) = #fff` text).
+ *
+ * Surface-redesign palette (lighter grays, proper dark-mode pairings)
+ * lands together with the surface redesigns in Phase 3-5, where each
+ * component is rewritten to consume Phase 2 primitives that are
+ * dark-mode-aware by design.
+ *
+ * The mechanism (MutationObserver basemap swap, [data-theme] attribute
+ * flow, token override site) is fully wired; only the visual palette
+ * is held back. Dark basemap is also gated on G7/G8 — see
+ * docs/design/01-spec/open-questions.md.
+ *
+ * Tokens overridden in this block are limited to:
+ *   - NEW Phase-1 cluster-density triad (--color-density-*) so the
+ *     three tiers retain their relative-weight semantic in either mode.
+ *   - --color-decision-point because it is a NEW token; the cyan-500
+ *     value is the dark-mode pairing the spec specifies.
+ *   - --color-bg-skeleton because it is NEW.
  */
 :root[data-theme="dark"] {
-  --color-bg-page:    var(--c-navy-900);
-  --color-bg-surface: #131c30;
-  --color-bg-tint:    #1c2640;
   --color-bg-skeleton: #1c2640;
-
-  --color-text-strong: #f5f7fb;
-  --color-text-body:   #d8dee8;
-  --color-text-muted:  #8a98ad;
-  --color-text-subtle: #5a6478;
-
-  --color-border-ui: #283354;
 
   --color-decision-point: var(--c-cyan-500);
 
@@ -128,11 +142,6 @@
   --color-density-mid:  #c49850;
   --color-density-high: #c46038;
   --color-density-text: #f5f7fb;
-
-  --color-accent-notable-fg: var(--c-orange-500);
-  --color-error-bg:     #3a1a1a;
-  --color-error-border: #6a3030;
-  --color-error-text:   #f5b8a8;
 }
 
 /* ── Layer 3: Component aliases ─────────────────────────────────────── */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,132 @@
+/*
+ * Three-tier token contract for the Sky Atlas redesign.
+ *
+ * Layer 1 — Primitives: raw scale values, no semantic meaning.
+ *   Declared on :root. Never consumed in component CSS directly.
+ *
+ * Layer 2 — Semantic: role-named, mode-paired via [data-theme].
+ *   Declared on :root[data-theme="light"] and :root[data-theme="dark"].
+ *   All component CSS uses these.
+ *
+ * Layer 3 — Component: scoped aliases that make light/dark a 1-line
+ *   override. Declared as CSS custom properties on the component selector.
+ *
+ * Type ramp and font-stack are also declared here (Layer 1 scale).
+ *
+ * Spec: docs/design/01-spec/tokens.md
+ * Phase: docs/design/02-phases/phase-1-token-foundation.md
+ */
+
+/* ── Layer 1: Primitives ────────────────────────────────────────────── */
+:root {
+  /* Warm cream scale (light surfaces) */
+  --c-warm-50:  #fafaf6;
+  --c-warm-100: #f0ece4;
+  --c-warm-200: #e6e0d4;
+
+  /* Sky / Sand / Ember — cluster density triad (measured contrast) */
+  --c-sky-500:   #6ec5d9;   /* 8.2:1 against #1a1a1a */
+  --c-sand-500:  #e8c060;   /* 10.4:1 against #1a1a1a */
+  --c-ember-500: #e87a4a;   /* 5.1:1 against #1a1a1a */
+
+  /* Accent hues (mode-paired) */
+  --c-orange-500: #f5853b;  /* sunrise — light accent */
+  --c-cyan-500:   #6db8d4;  /* moon — dark accent */
+  --c-deep-ember: #c43a1a;  /* notable — distinct from accent */
+
+  /* Navy / dark scale */
+  --c-navy-50:  #f5f7fb;
+  --c-navy-900: #0d1424;
+
+  /* ── Type ramp (Apple HIG-derived, no webfont) ────────────────────── */
+  --type-xs:   11px;  /* meta labels, captions */
+  --type-sm:   13px;  /* body small, secondary */
+  --type-base: 15px;  /* body */
+  --type-md:   17px;  /* species name in row, modal headings */
+  --type-lg:   22px;  /* surface section titles */
+  --type-hero: 34px;  /* lede, detail-surface species name */
+  --lede-size: 26px;  /* documented exception between lg and hero */
+
+  --font-stack:
+    -apple-system, BlinkMacSystemFont, "Segoe UI Variable",
+    "Helvetica Neue", "Inter", sans-serif;
+
+  --font-weight-regular:  400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+  --font-weight-heavy:    800;
+}
+
+/* ── Layer 2: Semantic — light mode ─────────────────────────────────── */
+:root[data-theme="light"] {
+  --color-bg-page:    var(--c-warm-50);
+  --color-bg-surface: #ffffff;
+  --color-bg-tint:    var(--c-warm-100);
+  --color-bg-skeleton: var(--c-warm-100); /* alias of bg-tint initially */
+
+  --color-text-strong: #1a1a1a;
+  --color-text-body:   #2a2a2a;
+  --color-text-muted:  #5a5a5a;
+  --color-text-subtle: #8a8a8a;
+
+  --color-border-ui: var(--c-warm-200);
+
+  /* RENAMED from mock --accent; DO NOT collide with --color-accent-notable-fg */
+  --color-decision-point: var(--c-orange-500);
+
+  --color-density-low:  var(--c-sky-500);
+  --color-density-mid:  var(--c-sand-500);
+  --color-density-high: var(--c-ember-500);
+  --color-density-text: #1a1a1a;
+
+  /* PRESERVED from existing codebase — do not rename */
+  --color-accent-notable-fg: var(--c-deep-ember);
+  --color-error-bg:     #fcebe4;
+  --color-error-border: #e8a890;
+  --color-error-text:   #8a3a1a;
+}
+
+/* ── Layer 2: Semantic — dark mode ──────────────────────────────────── */
+/*
+ * Dark basemap is gated on G7/G8 (family palette contrast against dark
+ * tiles). If G8 fails, dark mode ships with the same positron basemap as
+ * light; the basemap swap in MapCanvas is a no-op until G8 passes.
+ * See docs/design/01-spec/open-questions.md.
+ */
+:root[data-theme="dark"] {
+  --color-bg-page:    var(--c-navy-900);
+  --color-bg-surface: #131c30;
+  --color-bg-tint:    #1c2640;
+  --color-bg-skeleton: #1c2640;
+
+  --color-text-strong: #f5f7fb;
+  --color-text-body:   #d8dee8;
+  --color-text-muted:  #8a98ad;
+  --color-text-subtle: #5a6478;
+
+  --color-border-ui: #283354;
+
+  --color-decision-point: var(--c-cyan-500);
+
+  --color-density-low:  #4a8aa8;
+  --color-density-mid:  #c49850;
+  --color-density-high: #c46038;
+  --color-density-text: #f5f7fb;
+
+  --color-accent-notable-fg: var(--c-orange-500);
+  --color-error-bg:     #3a1a1a;
+  --color-error-border: #6a3030;
+  --color-error-text:   #f5b8a8;
+}
+
+/* ── Layer 3: Component aliases ─────────────────────────────────────── */
+/*
+ * Component tokens scope to their selector so light/dark is a 1-line
+ * override on the component scope rather than per-property.
+ * Expand this block as Phase 2 primitives land.
+ */
+.feed-row {
+  --feed-row-bg:       var(--color-bg-surface);
+  --feed-row-bg-hover: var(--color-bg-tint);
+}

--- a/frontend/src/utils/boot-theme.test.ts
+++ b/frontend/src/utils/boot-theme.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resolveInitialTheme, applyInitialTheme } from './boot-theme.js';
+import { setMatchMedia, resetMatchMedia } from '../test-setup.js';
+
+/**
+ * Tests for the theme-boot resolution logic. Mirrors what the inline
+ * blocking script in index.html does — any change to the rules must be
+ * applied in both places.
+ *
+ * The SecurityError tests guard the Safari Private Browsing / sandboxed-
+ * iframe failure mode where localStorage.getItem throws synchronously.
+ * Without try/catch the inline script would abort, leaving [data-theme]
+ * unset and producing a FOUC flash.
+ */
+
+describe('resolveInitialTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    resetMatchMedia();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the stored value when localStorage has "light"', () => {
+    localStorage.setItem('theme', 'light');
+    expect(resolveInitialTheme()).toBe('light');
+  });
+
+  it('returns the stored value when localStorage has "dark"', () => {
+    localStorage.setItem('theme', 'dark');
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  it('falls back to prefers-color-scheme when localStorage is empty', () => {
+    setMatchMedia((q) => q === '(prefers-color-scheme: dark)');
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  it('returns "light" when localStorage is empty and OS prefers light', () => {
+    setMatchMedia(() => false);
+    expect(resolveInitialTheme()).toBe('light');
+  });
+
+  it('does not crash and falls through to OS preference when localStorage.getItem throws SecurityError', () => {
+    // Simulate Safari Private Browsing / sandboxed-iframe failure mode.
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage access denied', 'SecurityError');
+    });
+    setMatchMedia((q) => q === '(prefers-color-scheme: dark)');
+
+    expect(() => resolveInitialTheme()).not.toThrow();
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  it('returns "light" as last resort when both localStorage and matchMedia throw', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage access denied', 'SecurityError');
+    });
+    // Install a matchMedia that throws synchronously on every call.
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => {
+        throw new Error('matchMedia unavailable');
+      },
+    });
+
+    expect(() => resolveInitialTheme()).not.toThrow();
+    expect(resolveInitialTheme()).toBe('light');
+  });
+});
+
+describe('applyInitialTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+  });
+
+  it('sets [data-theme] on documentElement to the resolved value', () => {
+    localStorage.setItem('theme', 'dark');
+    applyInitialTheme();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('still sets [data-theme] when localStorage throws — no FOUC', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage access denied', 'SecurityError');
+    });
+
+    expect(() => applyInitialTheme()).not.toThrow();
+    // The attribute MUST be set so first-paint CSS resolves correctly,
+    // even when persistence is unavailable.
+    const attr = document.documentElement.getAttribute('data-theme');
+    expect(attr === 'light' || attr === 'dark').toBe(true);
+  });
+});

--- a/frontend/src/utils/boot-theme.ts
+++ b/frontend/src/utils/boot-theme.ts
@@ -1,0 +1,61 @@
+/**
+ * Theme boot logic — resolves the initial [data-theme] value before first
+ * paint to prevent FOUC.
+ *
+ * Mirrors the inline blocking script in index.html. The inline script is
+ * load-bearing (must execute before first paint, can't be a deferred
+ * module), so it duplicates this logic verbatim. This module exists so
+ * the resolution rules are unit-testable; any change to the rules MUST
+ * be applied in both places.
+ *
+ * Resolution order:
+ *   1. localStorage['theme']  → 'light' | 'dark' (explicit user preference)
+ *   2. prefers-color-scheme   → OS-level preference fallback
+ *   3. 'light'                → safe default when both sources fail
+ *
+ * Both localStorage access and matchMedia access can throw:
+ *   - localStorage throws SecurityError in Safari Private Browsing and
+ *     in sandboxed iframes that disallow storage.
+ *   - matchMedia is undefined in older test environments.
+ *
+ * Storage failures are non-fatal — the theme falls through to the OS
+ * preference (or 'light' as last resort), and the in-session [data-theme]
+ * attribute remains the source of truth until the next page load.
+ *
+ * Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+ */
+
+export type Theme = 'light' | 'dark';
+
+export function resolveInitialTheme(): Theme {
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem('theme');
+  } catch {
+    // SecurityError (Safari Private Browsing, sandboxed iframe) — fall
+    // through to the prefers-color-scheme branch.
+  }
+
+  if (stored === 'dark' || stored === 'light') {
+    return stored;
+  }
+
+  try {
+    if (
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    ) {
+      return 'dark';
+    }
+  } catch {
+    // matchMedia rarely throws but is defensively wrapped — fall through.
+  }
+
+  return 'light';
+}
+
+export function applyInitialTheme(): Theme {
+  const theme = resolveInitialTheme();
+  document.documentElement.setAttribute('data-theme', theme);
+  return theme;
+}

--- a/knip.ts
+++ b/knip.ts
@@ -85,7 +85,23 @@ const config: KnipConfig = {
       //             aliases are flagged.
       //             Re-audit 2026-07-27: remove if those types gain import
       //             sites knip can trace, or drop the types if still unused.
-      ignore: ['src/tokens.ts'],
+      //
+      // 2026-05-10: basemap-style.ts — basemapStyleLight and basemapStyleDark
+      //             both alias the same OpenFreeMap positron URL string. Knip
+      //             correctly detects the duplicate value and reports it as a
+      //             "Duplicate exports" finding. The aliasing is INTENTIONAL
+      //             and gated on G7/G8 (family-palette × dark-tile contrast):
+      //             dark resolves to the light URL until the gate closes, at
+      //             which point basemapStyleDark switches to the real dark URL
+      //             and the duplicate goes away. Until then, both names are
+      //             part of the public mechanism contract — the MapCanvas
+      //             MutationObserver imports both names by their semantic role,
+      //             so collapsing them would force a rename when G8 closes.
+      //             Risk: masks a genuine duplicate export added later under
+      //             this file. Re-audit 2026-07-27 by confirming both names
+      //             are still consumed by MapCanvas.tsx OR the dark URL has
+      //             diverged from the light one.
+      ignore: ['src/tokens.ts', 'src/components/map/basemap-style.ts'],
     },
 
     'services/read-api': {},


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
  subgraph "Phase 1 token contract — three tiers"
    P["Primitives<br/>--c-warm-50..navy-900<br/>--type-xs..hero<br/>--font-stack"] --> S
    S["Semantic<br/>:root&#91;data-theme=light&#93;<br/>:root&#91;data-theme=dark&#93;<br/>--color-bg-page<br/>--color-text-*"] --> C
    C[".feed-row { --feed-row-bg ... }"]
  end

  subgraph "Theme flow"
    HTML["index.html<br/>inline blocking script"] -->|reads localStorage<br/>or prefers-color-scheme| ATTR["data-theme on html"]
    Toggle["ThemeToggle.tsx"] -->|writes| ATTR
    ATTR -->|MutationObserver in MapCanvas| MapStyle["map.setStyle"]
    ATTR -->|CSS selector| S
  end

  subgraph "Type ramp migration"
    Old["35 font-size literals<br/>11/12/13/14/15/18/20px"] --> Tokens["var(--type-xs..lg)"]
  end

  subgraph "Lint guard"
    LintCI[".github/workflows/lint.yml"] -->|grep -rE| Forbidden["var(--accent), var(--notable)<br/>var(--bg-page) etc."]
    Forbidden -.->|fail CI| LintCI
  end
```

```mermaid
sequenceDiagram
    participant User
    participant ThemeToggle
    participant DocEl as document.documentElement
    participant MO as MutationObserver
    participant Map as MapCanvas
    participant LS as localStorage

    User->>ThemeToggle: click
    ThemeToggle->>DocEl: setAttribute('data-theme', next)
    ThemeToggle->>LS: setItem('theme', next)
    DocEl-->>MO: attribute mutation
    MO->>Map: setStyle(basemapStyle{Light|Dark})
    Note over Map: G8 deferred — dark URL aliases light<br/>until family-palette × dark-tile gate closes
```

## Summary

- Establishes the three-tier CSS token contract (primitive → semantic → component) so each subsequent phase can rewrite surfaces against tokens that already pair to light/dark via `[data-theme]`. Without this scaffolding, every Phase 2+ component would invent its own theme indirection.
- Wires the FOUC-free path end-to-end (inline blocking script → `localStorage['theme']` → `data-theme` attribute → MapLibre basemap swap via MutationObserver) so the redesign's theme-toggle demo in Phase 3 can land without a re-architecture pass.
- Migrates 35 hardcoded `font-size` literals in `styles.css` to `var(--type-*)` references — indirection only, computed values unchanged. Adds a CI grep guard preventing the v3/v4 mock token names from silently colliding with production tokens.

## Screenshots

Playwright MCP drive at desktop 1440×900 and mobile 390×844, both light and dark themes, against canned fixtures. Phase 1 is a token-mechanism phase: light-mode visuals are pixel-identical to main (computed values preserved); dark-mode visuals are also identical to light because the dark-mode block intentionally overrides only NEW tokens (existing tokens stay at light values to avoid breaking CSS patterns like `.surface-nav-tab.is-active { background: var(--color-text-strong); }` — see `docs/specs/2026-05-09-v3-token-mapping.md`). The mechanism (MutationObserver, FOUC blocking, basemap setStyle dispatch, attribute persistence) is fully wired and verified.

### Desktop 1440×900

| Surface | Light | Dark |
| --- | --- | --- |
| Map | <img src="https://github.com/user-attachments/assets/70fdd186-7ac0-48b7-ab37-b0eeded5d409" width="380"> | <img src="https://github.com/user-attachments/assets/ce4cb5ba-2de9-450d-9b92-c9a4f3832ff9" width="380"> |
| Species | <img src="https://github.com/user-attachments/assets/ae2727c6-63ad-44cd-b2b3-56d45e9a09c5" width="380"> | <img src="https://github.com/user-attachments/assets/b6b3670c-482e-40bb-9536-220225dbc852" width="380"> |
| Feed | <img src="https://github.com/user-attachments/assets/c89071ce-2988-42c5-a642-5ea1707a6d09" width="380"> | <img src="https://github.com/user-attachments/assets/4fde7ee2-94af-4752-b294-390b09ea1ed7" width="380"> |
| Detail | <img src="https://github.com/user-attachments/assets/ee8f3a07-c83a-4d22-9ecb-5e12d577bea0" width="380"> | <img src="https://github.com/user-attachments/assets/4314ed4e-e22a-4ac5-a49c-8b6d49714eb7" width="380"> |

### Mobile 390×844

| Surface | Light | Dark |
| --- | --- | --- |
| Map | <img src="https://github.com/user-attachments/assets/71297c22-2cab-4a5e-bddb-59a2e42194cd" width="200"> | <img src="https://github.com/user-attachments/assets/6d9d3603-9a7d-4f81-ba33-279d42364d1f" width="200"> |
| Species | <img src="https://github.com/user-attachments/assets/1c8fd077-e6ca-4c1b-8d62-bdda3378b1bb" width="200"> | <img src="https://github.com/user-attachments/assets/b4d44866-af48-440f-a9f1-2dda6c7f364f" width="200"> |
| Feed | <img src="https://github.com/user-attachments/assets/487a0b6f-51e9-49e6-a4e7-74c6331392cf" width="200"> | <img src="https://github.com/user-attachments/assets/f6b7a024-1937-442b-a72c-7314ee5f042f" width="200"> |
| Detail | <img src="https://github.com/user-attachments/assets/a613ce6f-4f2c-4064-bbe6-0dcfc696791a" width="200"> | <img src="https://github.com/user-attachments/assets/96224ea9-f0cb-4af9-b9d5-ba57306ec753" width="200"> |

## Test plan

- [x] `npm test` — 689 unit tests pass across all workspaces (frontend 455 / read-api 36 / db-client 117 / shared-types 81)
- [x] New unit tests added: `region.test.ts` (2), `ThemeToggle.test.tsx` (8), `MapCanvas.test.tsx` MutationObserver describe (2)
- [x] No new Playwright e2e spec — Phase 1 introduces no new user-visible behavior (the `<ThemeToggle>` is built but not yet wired into the app shell; that lands in Phase 3 alongside persistent-chrome redesign). Existing 107 e2e specs pass.
- [x] `npm run build --workspace @bird-watch/frontend` clean. Bundle inspection: `[data-theme="light"]` and `[data-theme="dark"]` selectors present; `--type-xs..hero` tokens resolved; zero pixel `font-size` literals remain in source.
- [x] `npm run lint` clean. Forbidden-token grep in `lint.yml` returns zero matches on `frontend/src/`. Synthetic violation (`var(--accent)`) trips the regex (verified locally).
- [x] Playwright MCP drive: 4 surfaces × 2 viewports × 2 themes (16 combinations). Console: 0 errors / 0 warnings on every surface and theme except map (1 pre-existing `_FALLBACK` sprite warning that exists on main and is not introduced by Phase 1). Axe-core scan: 0 violations on all surfaces and themes except map (1 pre-existing `nested-interactive` on `.maplibregl-marker` — verified to exist on main baseline at the same SHA `60ecea3`).
- [x] Theme persistence: 5 hard reloads in light + 5 in dark; `data-theme` attribute is set pre-paint on every reload (FOUC-free verified by reading the attribute at `domcontentloaded`).
- [x] MutationObserver mechanism: live network log shows `setStyle` re-fetches the basemap URL on `[data-theme]` flip (mechanism active even though dark URL aliases light visually for now per G8 deferral).

## Plan reference

Part of Plan 1, Tasks 1–10. See `docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md`. Closes #401.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
