### PR TITLE
feat(frontend): Phase 5 — Feed + species surfaces

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -310,6 +310,54 @@ describe('Phase 5: FeedSurface lede wiring (App → FeedSurface)', () => {
   });
 });
 
+describe('Phase 5: FeedSurface cross-surface FilterSentence drift regression', () => {
+  // Regression for PR #429 finding: FeedSurface activeFilters memo hard-coded
+  // speciesCode/familyCode as null, causing the lede to name the species but
+  // the sibling FilterSentence to omit it. Both must reflect the same URL state.
+  const SPECIES_OBS = {
+    subId: 'S1',
+    speciesCode: 'vermfly',
+    comName: 'Vermilion Flycatcher',
+    lat: 32.2,
+    lng: -110.9,
+    obsDt: new Date().toISOString(),
+    locId: 'L1',
+    locName: 'Sabino Canyon',
+    howMany: 1,
+    isNotable: false,
+    regionId: null,
+    silhouetteId: null,
+    familyCode: 'songbird',
+  };
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetSilhouettes.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('with species filter active on feed view, both lede AND FilterSentence mention the species', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: 'vermfly', familyCode: null, view: 'feed',
+    };
+    mockGetObservations.mockResolvedValue([SPECIES_OBS]);
+    const { container } = render(<App />);
+    // Lede must resolve the species name from the speciesIndex and include it.
+    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona in the last 14 days\./i);
+    // FilterSentence visible sentence must also reflect speciesCode — it renders
+    // the raw code as a filter-bullet when no resolved name is available. Either
+    // the code "vermfly" or the resolved name should appear; the key invariant
+    // is that the element is rendered (non-null) and contains the species token.
+    const filterSentenceVisible = container.querySelector('.filter-sentence__visible');
+    expect(filterSentenceVisible).not.toBeNull();
+    expect(filterSentenceVisible?.textContent).toMatch(/vermfly/i);
+  });
+});
+
 describe('Phase 5: SpeciesSearchSurface activeFilters wiring (App → SpeciesSearchSurface)', () => {
   beforeEach(() => {
     __resetSilhouettesCache();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -248,3 +248,102 @@ describe('Phase 3: AppHeader + Filters panel', () => {
     expect(trigger).toBeInTheDocument();
   });
 });
+
+describe('Phase 5: FeedSurface lede wiring (App → FeedSurface)', () => {
+  const SPECIES_OBS = {
+    subId: 'S1',
+    speciesCode: 'vermfly',
+    comName: 'Vermilion Flycatcher',
+    lat: 32.2,
+    lng: -110.9,
+    obsDt: new Date().toISOString(),
+    locId: 'L1',
+    locName: 'Sabino Canyon',
+    howMany: 1,
+    isNotable: false,
+    regionId: null,
+    silhouetteId: null,
+    familyCode: 'songbird',
+  };
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetSilhouettes.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Priority 1 default lede fires when no species/family filter is set', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+    };
+    mockGetObservations.mockResolvedValue([SPECIES_OBS]);
+    render(<App />);
+    await screen.findByText(/species seen across Arizona/i);
+    expect(screen.queryByText(/sightings of/i)).toBeNull();
+    expect(screen.queryByText(/species of Songbird/i)).toBeNull();
+  });
+
+  it('Priority 2 lede fires (species name in lede) when speciesCode filter is active', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: 'vermfly', familyCode: null, view: 'feed',
+    };
+    mockGetObservations.mockResolvedValue([SPECIES_OBS]);
+    render(<App />);
+    // Priority 2: "{N} sightings of {name} in Arizona…"
+    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona/i);
+  });
+
+  it('Priority 3 lede fires (family name in lede) when familyCode filter is active (no speciesCode)', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: 'songbird', view: 'feed',
+    };
+    mockGetObservations.mockResolvedValue([SPECIES_OBS]);
+    render(<App />);
+    // Priority 3: "{N} species of {family} seen across Arizona…"
+    await screen.findByText(/species of Songbird seen across Arizona/i);
+  });
+});
+
+describe('Phase 5: SpeciesSearchSurface activeFilters wiring (App → SpeciesSearchSurface)', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue([]);
+    mockGetSilhouettes.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders FilterSentence live region on the species surface', async () => {
+    // FilterSentence always mounts an aria-live="polite" region regardless
+    // of filter state — verify it is present when view=species.
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'species',
+    };
+    const { container } = render(<App />);
+    await screen.findByRole('banner');
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).not.toBeNull();
+  });
+
+  it('FilterSentence visible sentence surfaces active filters on the species surface', async () => {
+    // With notable=true, FilterSentence renders a visible .filter-sentence__visible
+    // paragraph (synchronous — no debounce on the visible element, only the live
+    // region). This confirms activeFilters is actually wired through from App.
+    mockUrlState.state = {
+      since: '14d', notable: true, speciesCode: null, familyCode: null, view: 'species',
+    };
+    render(<App />);
+    await screen.findByRole('banner');
+    // The visible paragraph is synchronously rendered when filters are active.
+    const visible = document.querySelector('.filter-sentence__visible');
+    expect(visible).not.toBeNull();
+    expect(visible?.textContent?.toLowerCase()).toMatch(/notable/);
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -293,8 +293,10 @@ describe('Phase 5: FeedSurface lede wiring (App → FeedSurface)', () => {
     };
     mockGetObservations.mockResolvedValue([SPECIES_OBS]);
     render(<App />);
-    // Priority 2: "{N} sightings of {name} in Arizona…"
-    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona/i);
+    // Priority 2: "{N} sightings of {name} in Arizona in the last {period}."
+    // Regex anchors the period token ("14 days") to catch PERIOD_LABELS
+    // regressions that produce "in the last Last 14 days." or similar.
+    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona in the last 14 days\./i);
   });
 
   it('Priority 3 lede fires (family name in lede) when familyCode filter is active (no speciesCode)', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
 import { ApiClient, ApiError } from './api/client.js';
 import { useUrlState } from './state/url-state.js';
+import type { Since } from './state/url-state.js';
 import { useBirdData } from './data/use-bird-data.js';
 import { useSilhouettes } from './data/use-silhouettes.js';
 import { useSpeciesDetail } from './data/use-species-detail.js';
@@ -20,6 +21,7 @@ import { useIsMobile } from './lib/use-is-mobile.js';
 import { AttributionModal } from './components/AttributionModal.js';
 import { deriveFamilies, deriveSpeciesIndex } from './derived.js';
 import { filterObservationsByBounds } from './lib/viewport-filter.js';
+import { REGION_LABEL } from './config/region.js';
 
 const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? '' });
 
@@ -47,6 +49,30 @@ export function App() {
 
   const families = useMemo(() => deriveFamilies(observations), [observations]);
   const speciesIndex = useMemo(() => deriveSpeciesIndex(observations), [observations]);
+
+  // Map the Since discriminant to the canonical human label used in lede templates.
+  // These labels match the voice-and-content spec; keep in sync with FeedSurface defaults.
+  const PERIOD_LABELS: Record<Since, string> = {
+    '1d': 'Today',
+    '7d': 'Last 7 days',
+    '14d': 'Last 14 days',
+    '30d': 'Last 30 days',
+  };
+  const period = PERIOD_LABELS[state.since];
+
+  // Resolve human-readable species name when a speciesCode filter is active.
+  // Derived from speciesIndex — same source the FiltersBar autocomplete uses.
+  const speciesName = useMemo(
+    () => (state.speciesCode ? speciesIndex.find(s => s.code === state.speciesCode)?.comName : undefined),
+    [speciesIndex, state.speciesCode],
+  );
+
+  // Resolve human-readable family name when a familyCode filter is active.
+  // Derived from families (prettyFamily-capitalised code from deriveFamilies).
+  const familyName = useMemo(
+    () => (state.familyCode ? families.find(f => f.code === state.familyCode)?.name : undefined),
+    [families, state.familyCode],
+  );
 
   // Issue #351: viewport-aware FamilyLegend counts. MapCanvas reports
   // the current bounds on each `idle` (camera-change settle) via
@@ -236,6 +262,11 @@ export function App() {
             filters={{ notable: state.notable, since: state.since }}
             onSelectSpecies={onSelectSpecies}
             speciesIndex={speciesIndex}
+            observationCount={observations.length}
+            regionLabel={REGION_LABEL}
+            period={period}
+            {...(speciesName !== undefined ? { speciesName } : {})}
+            {...(familyName !== undefined ? { familyName } : {})}
           />
         )}
         {state.view === 'map' && (
@@ -262,6 +293,12 @@ export function App() {
             speciesIndex={speciesIndex}
             now={now}
             onSelectSpecies={onSelectSpecies}
+            activeFilters={{
+              notable: state.notable,
+              since: state.since,
+              speciesCode: state.speciesCode,
+              familyCode: state.familyCode,
+            }}
           />
         )}
         {/*

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,13 +50,16 @@ export function App() {
   const families = useMemo(() => deriveFamilies(observations), [observations]);
   const speciesIndex = useMemo(() => deriveSpeciesIndex(observations), [observations]);
 
-  // Map the Since discriminant to the canonical human label used in lede templates.
-  // These labels match the voice-and-content spec; keep in sync with FeedSurface defaults.
+  // Map the Since discriminant to bare-duration tokens used in lede templates.
+  // These must be bare duration strings (e.g. "14 days") NOT noun phrases —
+  // the lede template at FeedSurface reads "in the last {period}." which
+  // would produce "in the last Last 14 days." with full noun phrases.
+  // Spec: docs/design/01-spec/voice-and-content.md §Lede contract.
   const PERIOD_LABELS: Record<Since, string> = {
-    '1d': 'Today',
-    '7d': 'Last 7 days',
-    '14d': 'Last 14 days',
-    '30d': 'Last 30 days',
+    '1d': '1 day',
+    '7d': '7 days',
+    '14d': '14 days',
+    '30d': '30 days',
   };
   const period = PERIOD_LABELS[state.since];
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -262,7 +262,7 @@ export function App() {
             loading={loading}
             observations={observations}
             now={now}
-            filters={{ notable: state.notable, since: state.since }}
+            filters={{ notable: state.notable, since: state.since, speciesCode: state.speciesCode, familyCode: state.familyCode }}
             onSelectSpecies={onSelectSpecies}
             speciesIndex={speciesIndex}
             observationCount={observations.length}

--- a/frontend/src/components/FeedCard.test.tsx
+++ b/frontend/src/components/FeedCard.test.tsx
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { Observation } from '@bird-watch/shared-types';
+import type { NotableObservation } from '@bird-watch/shared-types';
 import { FeedCard } from './FeedCard.js';
 
 const NOW = new Date(2026, 3, 15, 15, 0, 0, 0);
 
-const NOTABLE_OBS: Observation = {
+// Typed as NotableObservation (Observation & { isNotable: true }) — this is the
+// narrowed type FeedCard accepts. The type annotation documents the contract
+// enforced at the prop boundary: callers must narrow before passing.
+const NOTABLE_OBS: NotableObservation = {
   subId: 'S001',
   speciesCode: 'vermfly',
   comName: 'Vermilion Flycatcher',
@@ -114,5 +117,16 @@ describe('FeedCard', () => {
       />
     );
     expect(screen.getByTestId('family-silhouette')).toHaveAttribute('data-family', 'null');
+  });
+
+  it('type narrowing: observation prop is NotableObservation (isNotable: true) at the call site', () => {
+    // This test documents the narrowed-type contract rather than a runtime behaviour.
+    // At compile time, passing an Observation with isNotable: false to FeedCard is a
+    // type error — the prop is NotableObservation (Observation & { isNotable: true }).
+    // Here we assert the fixture itself satisfies the narrowed type and renders correctly,
+    // confirming no runtime regression from the type tightening.
+    const narrowed: NotableObservation = { ...NOTABLE_OBS, isNotable: true };
+    render(<FeedCard observation={narrowed} now={NOW} onSelectSpecies={() => {}} />);
+    expect(screen.getByText('NOTABLE')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/FeedCard.test.tsx
+++ b/frontend/src/components/FeedCard.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Observation } from '@bird-watch/shared-types';
+import { FeedCard } from './FeedCard.js';
+
+const NOW = new Date(2026, 3, 15, 15, 0, 0, 0);
+
+const NOTABLE_OBS: Observation = {
+  subId: 'S001',
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  lat: 32.2,
+  lng: -110.9,
+  obsDt: new Date(NOW.getTime() - 10 * 60_000).toISOString(),
+  locId: 'L001',
+  locName: 'Sabino Canyon',
+  howMany: 3,
+  isNotable: true,
+  regionId: null,
+  silhouetteId: null,
+  familyCode: 'tyrannidae',
+};
+
+describe('FeedCard', () => {
+  it('renders the NOTABLE meta-label', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    // Text label "NOTABLE" must be present — notable token is amplification,
+    // not sole signal per docs/design/01-spec/accessibility.md §color-independent.
+    expect(screen.getByText('NOTABLE')).toBeInTheDocument();
+  });
+
+  it('applies the feed-card-meta class to the NOTABLE label (not decision-point)', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    const label = screen.getByText('NOTABLE');
+    // Must use .feed-card-meta which maps to --color-accent-notable-fg,
+    // never --color-decision-point. Verified structurally here; visual
+    // token separation is enforced by the stylelint guard in package.json.
+    expect(label).toHaveClass('feed-card-meta');
+  });
+
+  it('renders a <FamilySilhouette layout="inline"> at elevated scale', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    const silhouette = screen.getByTestId('family-silhouette');
+    // Card uses inline layout (larger than thumb) for the elevated treatment.
+    expect(silhouette).toHaveAttribute('data-layout', 'inline');
+    expect(silhouette).toHaveAttribute('data-family', 'tyrannidae');
+  });
+
+  it('renders comName as the card heading', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    expect(screen.getByRole('heading', { name: /Vermilion Flycatcher/i })).toBeInTheDocument();
+  });
+
+  it('renders location and relative time in the card meta line', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    expect(screen.getByText(/Sabino Canyon/)).toBeInTheDocument();
+    expect(screen.getByText('10 min ago')).toBeInTheDocument();
+  });
+
+  it('renders count chip when howMany > 1', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    // NOTABLE_OBS has howMany: 3
+    expect(screen.getByText('×3')).toBeInTheDocument();
+  });
+
+  it('carries a comprehensive accessible name on the interactive region', () => {
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    // Card is a button for keyboard navigation; accessible name mirrors
+    // the FeedRow five-slot contract so SR experience is consistent.
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Notable sighting, Vermilion Flycatcher, 3 birds, at Sabino Canyon, 10 min ago',
+    );
+  });
+
+  it('fires onSelectSpecies with the species code on click', async () => {
+    const onSelectSpecies = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={onSelectSpecies} />
+    );
+    await user.click(screen.getByRole('button'));
+    expect(onSelectSpecies).toHaveBeenCalledWith('vermfly');
+  });
+
+  it('renders inside an <li> with class feed-card-item', () => {
+    const { container } = render(
+      <FeedCard observation={NOTABLE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    expect(container.firstChild?.nodeName).toBe('LI');
+    expect(container.firstChild).toHaveClass('feed-card-item');
+  });
+
+  it('handles null familyCode with the neutral silhouette path', () => {
+    render(
+      <FeedCard
+        observation={{ ...NOTABLE_OBS, familyCode: null }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByTestId('family-silhouette')).toHaveAttribute('data-family', 'null');
+  });
+});

--- a/frontend/src/components/FeedCard.tsx
+++ b/frontend/src/components/FeedCard.tsx
@@ -1,0 +1,99 @@
+import type { Observation } from '@bird-watch/shared-types';
+import { formatRelativeTime } from '../utils/format-time.js';
+import { FamilySilhouette } from './ds/FamilySilhouette.js';
+
+export interface FeedCardProps {
+  observation: Observation;
+  now: Date;
+  onSelectSpecies: (speciesCode: string) => void;
+}
+
+/**
+ * Elevated card treatment for the top-notable observation in the feed.
+ *
+ * Used by FeedSurface for the single most-recent notable observation. The
+ * card renders at higher visual weight than <FeedRow>:
+ *   - <FamilySilhouette layout="inline"> (larger than "thumb")
+ *   - Species name as a heading element
+ *   - NOTABLE meta-label using .feed-card-meta → --color-accent-notable-fg
+ *   - Location + time on a second line
+ *
+ * Accent discipline: the NOTABLE label MUST reference .feed-card-meta which
+ * maps to --color-accent-notable-fg. Never use --color-decision-point here.
+ * The stylelint guard in package.json enforces this at CI time:
+ *   grep -rE 'var\(--color-decision-point\).*notable' frontend/src/
+ *
+ * ARIA contract: single button wraps the entire card for keyboard nav.
+ * The button's aria-label mirrors the FeedRow five-slot contract so SR
+ * experience is consistent across card and row treatments:
+ *   "Notable sighting, {comName}, [{N} birds,] [at {locName},] {relative time}"
+ * The internal heading + meta text are aria-hidden (subsumed by aria-label).
+ *
+ * DOM:
+ *   <li .feed-card-item>
+ *     <button .feed-card [aria-label]>
+ *       <FamilySilhouette layout="inline" />
+ *       <div .feed-card-body>
+ *         <span .feed-card-meta>NOTABLE</span>
+ *         [<span .feed-card-count>×N</span>]
+ *         <h2 .feed-card-name aria-hidden>comName</h2>
+ *         <p .feed-card-detail aria-hidden>locName · relative time</p>
+ *       </div>
+ *     </button>
+ *   </li>
+ */
+export function FeedCard(props: FeedCardProps) {
+  const { observation, now, onSelectSpecies } = props;
+
+  const countSlot =
+    observation.howMany === null
+      ? 'count unknown'
+      : observation.howMany > 1
+      ? `${observation.howMany} birds`
+      : null;
+
+  const ariaLabel = [
+    'Notable sighting',
+    observation.comName,
+    countSlot,
+    observation.locName ? `at ${observation.locName}` : null,
+    formatRelativeTime(observation.obsDt, now),
+  ]
+    .filter((s): s is string => s !== null)
+    .join(', ');
+
+  const countChip =
+    observation.howMany !== null && observation.howMany > 1
+      ? `×${observation.howMany}`
+      : null;
+
+  return (
+    <li className="feed-card-item">
+      <button
+        type="button"
+        className="feed-card"
+        aria-label={ariaLabel}
+        onClick={() => onSelectSpecies(observation.speciesCode)}
+      >
+        <FamilySilhouette
+          family={observation.familyCode}
+          layout="inline"
+        />
+        <div className="feed-card-body">
+          <span className="feed-card-meta" aria-hidden="true">NOTABLE</span>
+          {countChip !== null && (
+            <span className="feed-card-count" aria-hidden="true">{countChip}</span>
+          )}
+          {/* h2 is NOT aria-hidden — screen readers can navigate by heading
+              level. The button's aria-label is the comprehensive accessible
+              name; the heading is a redundant but valid structural landmark. */}
+          <h2 className="feed-card-name">{observation.comName}</h2>
+          <p className="feed-card-detail" aria-hidden="true">
+            {observation.locName && <span>{observation.locName}</span>}
+            <span>{formatRelativeTime(observation.obsDt, now)}</span>
+          </p>
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/frontend/src/components/FeedCard.tsx
+++ b/frontend/src/components/FeedCard.tsx
@@ -1,9 +1,15 @@
-import type { Observation } from '@bird-watch/shared-types';
+import type { NotableObservation } from '@bird-watch/shared-types';
 import { formatRelativeTime } from '../utils/format-time.js';
 import { FamilySilhouette } from './ds/FamilySilhouette.js';
 
 export interface FeedCardProps {
-  observation: Observation;
+  /**
+   * Narrowed to NotableObservation — callers must guard with `o.isNotable`
+   * before passing. FeedSurface already does this in the topNotable branch.
+   * The type system enforces the notable contract at compile time rather than
+   * relying on structural trust at runtime.
+   */
+  observation: NotableObservation;
   now: Date;
   onSelectSpecies: (speciesCode: string) => void;
 }

--- a/frontend/src/components/FeedRow.test.tsx
+++ b/frontend/src/components/FeedRow.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Observation } from '@bird-watch/shared-types';
+import { FeedRow } from './FeedRow.js';
+
+const NOW = new Date(2026, 3, 15, 15, 0, 0, 0);
+
+const BASE_OBS: Observation = {
+  subId: 'S001',
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  lat: 32.2,
+  lng: -110.9,
+  obsDt: new Date(NOW.getTime() - 15 * 60_000).toISOString(),
+  locId: 'L001',
+  locName: 'Sabino Canyon',
+  howMany: 1,
+  isNotable: false,
+  regionId: null,
+  silhouetteId: null,
+  familyCode: 'tyrannidae',
+};
+
+describe('FeedRow', () => {
+  it('renders a <FamilySilhouette> thumb in the leading slot', () => {
+    render(
+      <FeedRow
+        observation={BASE_OBS}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    // Phase 2's <FamilySilhouette layout="thumb"> renders with
+    // data-testid="family-silhouette" and data-family="tyrannidae"
+    const thumb = screen.getByTestId('family-silhouette');
+    expect(thumb).toBeInTheDocument();
+    expect(thumb).toHaveAttribute('data-family', 'tyrannidae');
+    expect(thumb).toHaveAttribute('data-layout', 'thumb');
+  });
+
+  it('renders the null-family neutral path when familyCode is null', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, familyCode: null }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    const thumb = screen.getByTestId('family-silhouette');
+    expect(thumb).toHaveAttribute('data-family', 'null');
+  });
+
+  it('renders comName, locName, and relative time', () => {
+    render(
+      <FeedRow observation={BASE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    expect(screen.getByText('Vermilion Flycatcher')).toBeInTheDocument();
+    expect(screen.getByText('Sabino Canyon')).toBeInTheDocument();
+    expect(screen.getByText('15 min ago')).toBeInTheDocument();
+  });
+
+  it('renders a count chip "×N" when howMany > 1', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, howMany: 5 }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByText('×5')).toBeInTheDocument();
+  });
+
+  it('renders "—" when howMany is null', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, howMany: null }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('omits count chip when howMany is 1 (solo sighting)', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, howMany: 1 }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.queryByText(/×\d/)).toBeNull();
+  });
+
+  it('applies feed-row-notable class modifier when isNotable is true', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, isNotable: true }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    // Flat row notable is a class modifier only — no separate glyph badge.
+    // The ARIA label still carries the Notable signal in the accessible name.
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('feed-row-notable');
+  });
+
+  it('preserves the five-slot ARIA accessible name contract', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, isNotable: true, howMany: 7 }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Notable sighting, Vermilion Flycatcher, 7 birds, at Sabino Canyon, 15 min ago',
+    );
+  });
+
+  it('omits notable prefix, count, and location when absent', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, isNotable: false, howMany: 1, locName: null }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Vermilion Flycatcher, 15 min ago',
+    );
+  });
+
+  it('announces "count unknown" when howMany is null', () => {
+    render(
+      <FeedRow
+        observation={{ ...BASE_OBS, howMany: null, locName: null }}
+        now={NOW}
+        onSelectSpecies={() => {}}
+      />
+    );
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      'Vermilion Flycatcher, count unknown, 15 min ago',
+    );
+  });
+
+  it('fires onSelectSpecies with the species code on click', async () => {
+    const onSelectSpecies = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FeedRow
+        observation={BASE_OBS}
+        now={NOW}
+        onSelectSpecies={onSelectSpecies}
+      />
+    );
+    await user.click(screen.getByRole('button'));
+    expect(onSelectSpecies).toHaveBeenCalledWith('vermfly');
+  });
+
+  it('fires onSelectSpecies on Enter keypress', async () => {
+    const onSelectSpecies = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FeedRow observation={BASE_OBS} now={NOW} onSelectSpecies={onSelectSpecies} />
+    );
+    screen.getByRole('button').focus();
+    await user.keyboard('{Enter}');
+    expect(onSelectSpecies).toHaveBeenCalledWith('vermfly');
+  });
+
+  it('is a React.memo component', () => {
+    const MemoSymbol = Symbol.for('react.memo');
+    expect(
+      (FeedRow as unknown as { $$typeof: symbol }).$$typeof
+    ).toBe(MemoSymbol);
+  });
+
+  it('renders inside an <li> so it composes correctly inside <ol>', () => {
+    const { container } = render(
+      <FeedRow observation={BASE_OBS} now={NOW} onSelectSpecies={() => {}} />
+    );
+    expect(container.firstChild?.nodeName).toBe('LI');
+  });
+});

--- a/frontend/src/components/FeedRow.tsx
+++ b/frontend/src/components/FeedRow.tsx
@@ -1,0 +1,110 @@
+import { memo } from 'react';
+import type { Observation } from '@bird-watch/shared-types';
+import { formatRelativeTime } from '../utils/format-time.js';
+import { FamilySilhouette } from './ds/FamilySilhouette.js';
+
+export interface FeedRowProps {
+  observation: Observation;
+  now: Date;
+  onSelectSpecies: (speciesCode: string) => void;
+}
+
+/**
+ * Flat feed list row. Replaces the emoji/glyph approach of the v3 mock with
+ * a `<FamilySilhouette layout="thumb">` in the leading slot. The silhouette
+ * is always present: null familyCode renders the neutral grey generic-bird
+ * path (see docs/design/01-spec/components.md §<FamilySilhouette>).
+ *
+ * DOM structure:
+ *   <li .feed-row-item>
+ *     <button .feed-row [.feed-row-notable]>
+ *       <FamilySilhouette layout="thumb" />   ← leading silhouette thumb
+ *       <span .feed-row-name>comName</span>
+ *       [<span .feed-row-count>×N</span>]     ← omitted when howMany === 1
+ *       [<span .feed-row-count-unknown>—</span>]  ← when howMany === null
+ *       [<span .feed-row-loc>locName</span>]
+ *       <span .feed-row-time>relative time</span>
+ *     </button>
+ *   </li>
+ *
+ * ARIA contract (preserved from ObservationFeedRow, issue #117):
+ *   Single aria-label on the button combines all five slots in fixed order:
+ *   notable flag → comName → count → locName → relative time.
+ *   All child spans are aria-hidden. The button receives focus; Enter/Space
+ *   activate natively. The <li> keeps the list structure intact per WCAG
+ *   (aria-required-children on <ol> expects listitem, not button directly).
+ *
+ * Notable on flat rows: class modifier `.feed-row-notable` only.
+ *   No separate "!" glyph badge (that lives on <FeedCard> for the elevated
+ *   card treatment). Color alone is not the signal — the class adds a left
+ *   border accent per the accent-discipline rules (colour + structural
+ *   discriminator). The ARIA label prefix "Notable sighting" is preserved.
+ *
+ * Memoised for the same reason as ObservationFeedRow: a 300+ row feed must
+ * not re-render every row on filter toggle or tab focus. Requires
+ * identity-stable onSelectSpecies (useCallback in parent).
+ */
+function FeedRowImpl(props: FeedRowProps) {
+  const { observation, now, onSelectSpecies } = props;
+
+  function activate() {
+    onSelectSpecies(observation.speciesCode);
+  }
+
+  const countContent: { chip: string | null; dash: boolean } =
+    observation.howMany === null
+      ? { chip: null, dash: true }
+      : observation.howMany > 1
+      ? { chip: `×${observation.howMany}`, dash: false }
+      : { chip: null, dash: false };
+
+  const countSlot =
+    observation.howMany === null
+      ? 'count unknown'
+      : observation.howMany > 1
+      ? `${observation.howMany} birds`
+      : null;
+
+  const ariaLabel = [
+    observation.isNotable ? 'Notable sighting' : null,
+    observation.comName,
+    countSlot,
+    observation.locName ? `at ${observation.locName}` : null,
+    formatRelativeTime(observation.obsDt, now),
+  ]
+    .filter((s): s is string => s !== null)
+    .join(', ');
+
+  return (
+    <li className="feed-row-item">
+      <button
+        type="button"
+        className={`feed-row${observation.isNotable ? ' feed-row-notable' : ''}`}
+        aria-label={ariaLabel}
+        onClick={activate}
+      >
+        <FamilySilhouette
+          family={observation.familyCode}
+          layout="thumb"
+        />
+        <span className="feed-row-name" aria-hidden="true">{observation.comName}</span>
+        {countContent.chip !== null && (
+          <span className="feed-row-count" aria-hidden="true">
+            {countContent.chip}
+          </span>
+        )}
+        {countContent.dash && (
+          <span className="feed-row-count feed-row-count-unknown" aria-hidden="true">—</span>
+        )}
+        {observation.locName !== null && (
+          <span className="feed-row-loc" aria-hidden="true">{observation.locName}</span>
+        )}
+        <span className="feed-row-time" aria-hidden="true">
+          {formatRelativeTime(observation.obsDt, now)}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export const FeedRow = memo(FeedRowImpl);

--- a/frontend/src/components/FeedSurface.test.tsx
+++ b/frontend/src/components/FeedSurface.test.tsx
@@ -314,4 +314,270 @@ describe('FeedSurface', () => {
       expect(rows).toHaveLength(3);
     });
   });
+
+  // --- Phase 5: lede, SortLabel, FilterSentence, FeedCard ---
+
+  describe('lede state machine (4 templates)', () => {
+    it('renders Priority 4 lede (default, no filters) with observation count', () => {
+      const items = [
+        obs({ subId: 'S1', speciesCode: 'vermfly' }),
+        obs({ subId: 'S2', speciesCode: 'cacwre', comName: 'Cactus Wren' }),
+      ];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={2}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // Template: "{N} species seen across {REGION_LABEL} in the last {period}."
+      // Count is unique species, not observation rows.
+      expect(screen.getByText(/species seen across Arizona/i)).toBeInTheDocument();
+    });
+
+    it('renders Priority 1 lede when observationCount is 0', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[]}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={0}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      expect(screen.getByText(/No sightings match your current filters/i)).toBeInTheDocument();
+    });
+
+    it('renders Priority 2 lede when speciesCode filter is set', () => {
+      const items = [obs({ subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher' })];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+          speciesName="Vermilion Flycatcher"
+        />
+      );
+      // Template: "{N} sightings of {commonName} in {REGION_LABEL} in the last {period}."
+      expect(screen.getByText(/sightings of Vermilion Flycatcher in Arizona/i)).toBeInTheDocument();
+    });
+
+    it('renders Priority 3 lede when familyCode filter is set', () => {
+      const items = [obs({ subId: 'S1', speciesCode: 'vermfly', familyCode: 'tyrannidae' })];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+          familyName="Tyrant Flycatchers"
+        />
+      );
+      // Template: "{N} species of {familyName} seen across {REGION_LABEL} in the last {period}."
+      expect(screen.getByText(/species of Tyrant Flycatchers seen across Arizona/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('<SortLabel> sibling', () => {
+    it('renders <SortLabel> showing "Sorted by recency" when sortMode is recent', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1' })]}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // SortLabel renders its text; not coupled to FilterSentence.
+      expect(screen.getByText(/Sorted by recency/i)).toBeInTheDocument();
+    });
+
+    it('SortLabel is a separate sibling from FilterSentence — not inside it', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1' })]}
+          now={NOW}
+          filters={{ notable: true, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      const sortLabel = screen.getByText(/Sorted by recency/i);
+      const filterSentence = screen.getByText(/notable sightings/i);
+      // Neither element contains the other.
+      expect(sortLabel.contains(filterSentence)).toBe(false);
+      expect(filterSentence.contains(sortLabel)).toBe(false);
+    });
+  });
+
+  describe('<FilterSentence> mount', () => {
+    it('mounts the always-on live region even when zero filters are active', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1' })]}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // The hidden live region is always mounted per the FilterSentence spec;
+      // it carries role="status" aria-live="polite".
+      const liveRegion = document.querySelector('.filter-sentence-live');
+      expect(liveRegion).toBeInTheDocument();
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('renders the visible FilterSentence when notable filter is active', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1', isNotable: true })]}
+          now={NOW}
+          filters={{ notable: true, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // FilterSentence visible template: "Showing {filter-terms} from the last {period}."
+      expect(screen.getByText(/notable sightings/i)).toBeInTheDocument();
+    });
+
+    it('FilterSentence collapses to null visually when zero filters are active', () => {
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1' })]}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // At zero filters, the visible sentence element is absent from the DOM.
+      // The hidden live region remains.
+      expect(document.querySelector('.filter-sentence-visible')).toBeNull();
+    });
+  });
+
+  describe('<FeedCard> top-notable mount', () => {
+    it('renders the top-notable observation as an elevated FeedCard', () => {
+      const items = [
+        obs({ subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher', isNotable: true }),
+        obs({ subId: 'S2', speciesCode: 'cacwre', comName: 'Cactus Wren', isNotable: false }),
+      ];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={2}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      // The NOTABLE label is the FeedCard discriminator.
+      expect(screen.getByText('NOTABLE')).toBeInTheDocument();
+    });
+
+    it('does not render a FeedCard when no observations are notable', () => {
+      const items = [
+        obs({ subId: 'S1', isNotable: false }),
+        obs({ subId: 'S2', speciesCode: 'cacwre', comName: 'Cactus Wren', isNotable: false }),
+      ];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={2}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      expect(screen.queryByText('NOTABLE')).toBeNull();
+    });
+
+    it('renders the top-notable card as the first item in the list', () => {
+      const items = [
+        obs({ subId: 'S1', speciesCode: 'cacwre', comName: 'Cactus Wren', isNotable: false }),
+        obs({ subId: 'S2', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher', isNotable: true }),
+        obs({ subId: 'S3', speciesCode: 'annhum', comName: "Anna's Hummingbird", isNotable: false }),
+      ];
+      render(
+        <FeedSurface
+          loading={false}
+          observations={items}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={() => {}}
+          observationCount={3}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      const buttons = screen.getAllByRole('button');
+      // First button is the FeedCard for the notable observation (after the radio buttons).
+      // The radio group has 2 radio buttons — the first list-item button follows.
+      // Find the button with 'Notable sighting' in its accessible name.
+      const cardButton = buttons.find(b => b.getAttribute('aria-label')?.includes('Notable sighting'));
+      expect(cardButton).toBeTruthy();
+      expect(cardButton).toHaveAccessibleName(expect.stringContaining('Notable sighting'));
+      expect(cardButton).toHaveAccessibleName(expect.stringContaining('Vermilion Flycatcher'));
+    });
+
+    it('clicking the FeedCard fires onSelectSpecies', async () => {
+      const onSelectSpecies = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <FeedSurface
+          loading={false}
+          observations={[obs({ subId: 'S1', speciesCode: 'vermfly', isNotable: true })]}
+          now={NOW}
+          filters={{ notable: false, since: '14d' }}
+          onSelectSpecies={onSelectSpecies}
+          observationCount={1}
+          regionLabel="Arizona"
+          period="14 days"
+        />
+      );
+      await user.click(screen.getByRole('button', { name: /Notable sighting/i }));
+      expect(onSelectSpecies).toHaveBeenCalledWith('vermfly');
+    });
+  });
 });

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -10,6 +10,8 @@ import { SortLabel } from './ds/SortLabel.js';
 export interface FeedSurfaceFilters {
   notable: boolean;
   since: Since;
+  speciesCode: string | null;
+  familyCode: string | null;
 }
 
 export type FeedSortMode = 'recent' | 'taxonomic';
@@ -128,12 +130,15 @@ export function FeedSurface(props: FeedSurfaceProps) {
   }, [effectiveCount, speciesName, familyName, regionLabel, period]);
 
   // Build the ActiveFilters shape expected by <FilterSentence>.
-  // Phase 5 maps the existing FeedSurfaceFilters onto it.
+  // Forward all four filter dimensions so FilterSentence renders the same
+  // active-filter sentence as the species surface. Omitting speciesCode/
+  // familyCode caused cross-surface drift: feed lede named the species but
+  // the sibling FilterSentence omitted it (fix for PR #429 review finding).
   const activeFilters = useMemo(() => ({
     notable: filters.notable,
     since: filters.since,
-    speciesCode: null as string | null,
-    familyCode: null as string | null,
+    speciesCode: filters.speciesCode,
+    familyCode: filters.familyCode,
   }), [filters]);
 
   if (loading) {

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -165,9 +165,8 @@ export function FeedSurface(props: FeedSurfaceProps) {
 
   // Find the first notable observation for the elevated card treatment.
   // "First" respects the current sort order.
-  const topNotableIndex = visibleObservations.findIndex(o => o.isNotable);
   const topNotable: Observation | null =
-    topNotableIndex >= 0 ? visibleObservations[topNotableIndex] : null;
+    visibleObservations.find(o => o.isNotable) ?? null;
 
   // All other observations (non-card rows): if a notable is elevated,
   // exclude it from the flat list so it doesn't appear twice.

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { Observation } from '@bird-watch/shared-types';
+import type { Observation, NotableObservation } from '@bird-watch/shared-types';
 import type { Since } from '../state/url-state.js';
 import type { SpeciesOption } from './FiltersBar.js';
 import { FeedCard } from './FeedCard.js';
@@ -164,9 +164,10 @@ export function FeedSurface(props: FeedSurfaceProps) {
   }
 
   // Find the first notable observation for the elevated card treatment.
-  // "First" respects the current sort order.
-  const topNotable: Observation | null =
-    visibleObservations.find(o => o.isNotable) ?? null;
+  // "First" respects the current sort order. Narrowed to NotableObservation
+  // (Observation & { isNotable: true }) to satisfy FeedCard's type contract.
+  const topNotable: NotableObservation | null =
+    visibleObservations.find((o): o is NotableObservation => o.isNotable) ?? null;
 
   // All other observations (non-card rows): if a notable is elevated,
   // exclude it from the flat list so it doesn't appear twice.

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -2,7 +2,10 @@ import { useMemo, useState } from 'react';
 import type { Observation } from '@bird-watch/shared-types';
 import type { Since } from '../state/url-state.js';
 import type { SpeciesOption } from './FiltersBar.js';
-import { ObservationFeedRow } from './ObservationFeedRow.js';
+import { FeedCard } from './FeedCard.js';
+import { FeedRow } from './FeedRow.js';
+import { FilterSentence } from './ds/FilterSentence.js';
+import { SortLabel } from './ds/SortLabel.js';
 
 export interface FeedSurfaceFilters {
   notable: boolean;
@@ -24,48 +27,68 @@ export interface FeedSurfaceProps {
    * as the all-null-taxonOrder cold-load case).
    */
   speciesIndex?: SpeciesOption[];
+  /**
+   * Total unique-species count for the lede template (Priority 4).
+   * When absent, FeedSurface derives it from observations.length as a
+   * rough fallback (may overcount if multiple obs share a species code).
+   */
+  observationCount?: number;
+  /** Human-readable region label for the lede ("Arizona"). */
+  regionLabel?: string;
+  /** Human-readable period for the lede ("14 days"). */
+  period?: string;
+  /**
+   * Common name of the selected species — present when speciesCode filter
+   * is active. Triggers the Priority 2 lede template.
+   */
+  speciesName?: string;
+  /**
+   * Common name of the selected family — present when familyCode filter is
+   * active. Triggers the Priority 3 lede template.
+   */
+  familyName?: string;
 }
 
 /**
- * Default view for the bird-maps site: reverse-chronological observation
- * rows. The parent (App.tsx) supplies already-filtered observations — this
- * component does NOT re-filter by `notable` or `since`. The `filters` prop
- * is consumed only to generate filter-aware empty-state copy.
+ * Feed surface — Sky Atlas Phase 5.
  *
- * Sort contract (Plan 6 Task 10 / issue #119):
- *   - "Recent" (default): the server order is preserved. No client
- *     re-sort; the Read API already returns observations by `obs_dt DESC`.
- *   - "Taxonomic": sort by `speciesIndex[code].taxonOrder ASC`, with
- *     null values placed AFTER all non-null values. Within the null
- *     group, sort alphabetically by `comName` so the output is
- *     deterministic regardless of the input order. Rationale: on a
- *     cold load, no cached `SpeciesMeta` means every `taxonOrder` is
- *     null and taxonomic sort degrades to alphabetical — the same
- *     contract documented on the issue body.
+ * Lede templates (evaluated in priority order, from
+ * docs/design/01-spec/voice-and-content.md §Lede contract):
+ *   1. Zero results → "No sightings match your current filters."
+ *   2. speciesName set → "{N} sightings of {name} in {region} in the last {period}."
+ *   3. familyName set → "{N} species of {family} seen across {region} in the last {period}."
+ *   4. Default → "{N} species seen across {region} in the last {period}."
  *
- * The sort mode is COMPONENT-LOCAL state (not URL-persisted) per the
- * "Out of scope" note on issue #119. A future URL-persistent iteration
- * would lift this into useUrlState.
+ * <SortLabel> is a separate sibling ABOVE <FilterSentence> in the context
+ * strip. These are independent components that must NOT be composed together
+ * (docs/design/01-spec/components.md §<FilterSentence>: "Sort prefix is NOT
+ * this component").
  *
- * Empty-state branches (spec):
- *   - loading       → "Loading observations…"
- *   - notable=true  → "No notable sightings in this window."
- *   - since=1d      → "No observations reported today."
- *   - otherwise     → "No observations to show."
+ * The top-notable observation (first isNotable=true in the observations array)
+ * renders as an elevated <FeedCard>. Remaining observations render as flat
+ * <FeedRow> items. Both are children of the same <ol> to preserve list semantics.
  *
- * NOTE on error states: a broken API surfaces as the full-screen
- * `.error-screen` in App.tsx (it returns early). By the time a FeedSurface
- * renders, we know the request succeeded — an empty array means zero
- * matches, not a backend outage. That's why no empty branch mentions
- * "something broke" or "try again".
+ * Sort contract (unchanged from existing implementation):
+ *   - "Recent" (default): server order preserved. No client re-sort.
+ *   - "Taxonomic": taxonOrder ASC, nulls last, ties by comName.
  */
 export function FeedSurface(props: FeedSurfaceProps) {
-  const { loading, observations, now, filters, onSelectSpecies, speciesIndex } = props;
+  const {
+    loading,
+    observations,
+    now,
+    filters,
+    onSelectSpecies,
+    speciesIndex,
+    observationCount,
+    regionLabel = 'Arizona',
+    period = '14 days',
+    speciesName,
+    familyName,
+  } = props;
+
   const [sortMode, setSortMode] = useState<FeedSortMode>('recent');
 
-  // Derive a code→taxonOrder lookup from speciesIndex once per render.
-  // Missing speciesIndex or species without a taxonOrder bucket as null
-  // (sorted last per the documented contract above).
   const taxonMap = useMemo(() => {
     const map = new Map<string, number | null>();
     if (speciesIndex) {
@@ -76,19 +99,42 @@ export function FeedSurface(props: FeedSurfaceProps) {
 
   const visibleObservations = useMemo(() => {
     if (sortMode === 'recent') return observations;
-    // Taxonomic: nulls last, ascending by taxonOrder, ties broken by comName.
-    // The slice() preserves the parent's array reference identity so
-    // server-order memoisation higher up isn't defeated.
     return observations.slice().sort((a, b) => {
       const ta = taxonMap.get(a.speciesCode) ?? null;
       const tb = taxonMap.get(b.speciesCode) ?? null;
       if (ta === null && tb === null) return a.comName.localeCompare(b.comName);
-      if (ta === null) return 1; // a after b
-      if (tb === null) return -1; // a before b
+      if (ta === null) return 1;
+      if (tb === null) return -1;
       if (ta === tb) return a.comName.localeCompare(b.comName);
       return ta - tb;
     });
   }, [observations, sortMode, taxonMap]);
+
+  // Derive the lede string using the 4-template priority state machine.
+  // Templates are explicit branches — no string-template engine.
+  // (docs/design/01-spec/voice-and-content.md §Templates are explicit)
+  const effectiveCount = observationCount ?? observations.length;
+  const lede: string = useMemo(() => {
+    if (effectiveCount === 0) {
+      return 'No sightings match your current filters.';
+    }
+    if (speciesName) {
+      return `${effectiveCount} sightings of ${speciesName} in ${regionLabel} in the last ${period}.`;
+    }
+    if (familyName) {
+      return `${effectiveCount} species of ${familyName} seen across ${regionLabel} in the last ${period}.`;
+    }
+    return `${effectiveCount} species seen across ${regionLabel} in the last ${period}.`;
+  }, [effectiveCount, speciesName, familyName, regionLabel, period]);
+
+  // Build the ActiveFilters shape expected by <FilterSentence>.
+  // Phase 5 maps the existing FeedSurfaceFilters onto it.
+  const activeFilters = useMemo(() => ({
+    notable: filters.notable,
+    since: filters.since,
+    speciesCode: null as string | null,
+    familyCode: null as string | null,
+  }), [filters]);
 
   if (loading) {
     return (
@@ -108,17 +154,38 @@ export function FeedSurface(props: FeedSurfaceProps) {
       hint = 'No observations to show.';
     }
     return (
-      <div className="feed-empty" role="status">
-        {hint}
+      <div className="feed-surface">
+        <p className="feed-lede">{lede}</p>
+        <div className="feed-empty" role="status">
+          {hint}
+        </div>
       </div>
     );
   }
 
+  // Find the first notable observation for the elevated card treatment.
+  // "First" respects the current sort order.
+  const topNotableIndex = visibleObservations.findIndex(o => o.isNotable);
+  const topNotable: Observation | null =
+    topNotableIndex >= 0 ? visibleObservations[topNotableIndex] : null;
+
+  // All other observations (non-card rows): if a notable is elevated,
+  // exclude it from the flat list so it doesn't appear twice.
+  const flatObservations: Observation[] = topNotable
+    ? visibleObservations.filter(o => o !== topNotable)
+    : visibleObservations;
+
   return (
-    <>
-      {/* Radio group for native keyboard arrow-key traversal. role=radiogroup
-          with a visible label satisfies axe without an explicit aria-labelledby
-          on every radio. */}
+    <div className="feed-surface">
+      {/* Lede — runtime truth claim, Priority 1–4 state machine */}
+      <p className="feed-lede">{lede}</p>
+
+      {/* Context strip: SortLabel sibling ABOVE FilterSentence.
+          These are independent; do not compose or merge them. */}
+      <SortLabel mode={sortMode} />
+      <FilterSentence filters={activeFilters} />
+
+      {/* Sort toggle — radio group for native keyboard arrow-key traversal */}
       <div
         className="feed-sort"
         role="radiogroup"
@@ -145,9 +212,19 @@ export function FeedSurface(props: FeedSurfaceProps) {
           <span>Taxonomic</span>
         </label>
       </div>
+
+      {/* Unified observation list: top-notable card-row first, then flat rows */}
       <ol className="feed" aria-label="Observations">
-        {visibleObservations.map(o => (
-          <ObservationFeedRow
+        {topNotable && (
+          <FeedCard
+            key={`card:${topNotable.subId}:${topNotable.speciesCode}`}
+            observation={topNotable}
+            now={now}
+            onSelectSpecies={onSelectSpecies}
+          />
+        )}
+        {flatObservations.map(o => (
+          <FeedRow
             key={`${o.subId}:${o.speciesCode}`}
             observation={o}
             now={now}
@@ -155,6 +232,6 @@ export function FeedSurface(props: FeedSurfaceProps) {
           />
         ))}
       </ol>
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/ObservationFeedRow.test.tsx
+++ b/frontend/src/components/ObservationFeedRow.test.tsx
@@ -75,9 +75,10 @@ describe('ObservationFeedRow', () => {
     expect(
       screen.getByRole('button', { name: /^Notable sighting, Vermilion Flycatcher/ }),
     ).toBeInTheDocument();
-    // And the visible "!" glyph is aria-hidden so screen readers don't
-    // announce it twice.
-    expect(screen.getByTitle('Notable sighting')).toHaveAttribute('aria-hidden', 'true');
+    // FeedRow encodes notable in the button aria-label; no separate glyph span.
+    expect(screen.getByRole('button')).toHaveAccessibleName(
+      expect.stringContaining('Notable sighting'),
+    );
   });
 
   it('pins the comprehensive accessible name with all five slots', () => {

--- a/frontend/src/components/ObservationFeedRow.tsx
+++ b/frontend/src/components/ObservationFeedRow.tsx
@@ -1,104 +1,13 @@
-import { memo } from 'react';
-import type { Observation } from '@bird-watch/shared-types';
-import { formatRelativeTime } from '../utils/format-time.js';
-
-export interface ObservationFeedRowProps {
-  observation: Observation;
-  now: Date;
-  onSelectSpecies: (speciesCode: string) => void;
-}
-
 /**
- * Single feed row. DOM column order:
- *   notable badge → comName → count chip → locName → relative time
+ * Compatibility re-export shim — Sky Atlas Phase 5.
  *
- * The visual row is a `<button>` nested inside an `<li>` — WCAG requires
- * `<ol>` children to be `listitem`s, so we cannot put `role="button"`
- * directly on the `<li>` (axe's `aria-required-children` rule fires,
- * tripping the WCAG 2.1 AA gate in `e2e/axe.spec.ts`). The button carries
- * the accessible name, focus, and keyboard semantics; the `<li>` keeps the
- * list structure intact. Enter/Space get native-button behaviour for free.
+ * ObservationFeedRow has been refactored into FeedRow (which adds the
+ * <FamilySilhouette> thumb) and FeedCard (elevated notable treatment).
+ * This shim preserves the existing named export so callers that haven't
+ * migrated continue to compile and render correctly.
  *
- * Row-level `isNotable` is INDEPENDENT of the global `?notable=true` filter.
- * A user toggling "Notable only" narrows the FEED (parent filters the list)
- * but the badge still renders on every remaining row whose observation.
- * isNotable is true — see ObservationFeedRow.test.tsx for the contract.
- *
- * Memoised so a 2000-row feed does not re-render every row on unrelated
- * state changes (filter toggles, SurfaceNav tab focus). Identity-stable
- * props from the parent (`onSelectSpecies` via useCallback, `now` via a
- * top-level ref) are required for the memo to actually fire.
+ * Callers should migrate to importing from FeedRow.tsx directly. This
+ * shim will be removed in Phase 6 cleanup.
  */
-function ObservationFeedRowImpl(props: ObservationFeedRowProps) {
-  const { observation, now, onSelectSpecies } = props;
-
-  function activate() {
-    onSelectSpecies(observation.speciesCode);
-  }
-
-  // howMany display rules (per spec):
-  //   null → "—" (em dash)
-  //   1    → chip omitted (solo sighting is the default; no noise)
-  //   >1   → "×N" chip
-  const countContent: { chip: string | null; dash: boolean } =
-    observation.howMany === null
-      ? { chip: null, dash: true }
-      : observation.howMany > 1
-      ? { chip: `×${observation.howMany}`, dash: false }
-      : { chip: null, dash: false };
-
-  // Build ONE comprehensive accessible name on the button. Children's
-  // aria-label/aria-labelledby are silenced when the parent carries an
-  // aria-label, so the button must carry every signal we want announced.
-  // Order matches the plan's spec (#116 + Plan 6 Task 7): notable flag →
-  // comName → count → locName → relative time.
-  const countSlot =
-    observation.howMany === null
-      ? 'count unknown'
-      : observation.howMany > 1
-      ? `${observation.howMany} birds`
-      : null;
-  const ariaLabel = [
-    observation.isNotable ? 'Notable sighting' : null,
-    observation.comName,
-    countSlot,
-    observation.locName ? `at ${observation.locName}` : null,
-    formatRelativeTime(observation.obsDt, now),
-  ]
-    .filter((s): s is string => s !== null)
-    .join(', ');
-
-  return (
-    <li className="feed-row-item">
-      <button
-        type="button"
-        className={`feed-row${observation.isNotable ? ' feed-row-notable' : ''}`}
-        aria-label={ariaLabel}
-        onClick={activate}
-      >
-        {observation.isNotable && (
-          <span className="feed-row-badge" aria-hidden="true" title="Notable sighting">
-            !
-          </span>
-        )}
-        <span className="feed-row-name" aria-hidden="true">{observation.comName}</span>
-        {countContent.chip !== null && (
-          <span className="feed-row-count" aria-hidden="true">
-            {countContent.chip}
-          </span>
-        )}
-        {countContent.dash && (
-          <span className="feed-row-count feed-row-count-unknown" aria-hidden="true">—</span>
-        )}
-        {observation.locName !== null && (
-          <span className="feed-row-loc" aria-hidden="true">{observation.locName}</span>
-        )}
-        <span className="feed-row-time" aria-hidden="true">
-          {formatRelativeTime(observation.obsDt, now)}
-        </span>
-      </button>
-    </li>
-  );
-}
-
-export const ObservationFeedRow = memo(ObservationFeedRowImpl);
+export { FeedRow as ObservationFeedRow } from './FeedRow.js';
+export type { FeedRowProps as ObservationFeedRowProps } from './FeedRow.js';

--- a/frontend/src/components/SpeciesSearchSurface.test.tsx
+++ b/frontend/src/components/SpeciesSearchSurface.test.tsx
@@ -191,4 +191,97 @@ describe('SpeciesSearchSurface', () => {
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
     expect(screen.queryByRole('list', { name: /recent sightings/i })).toBeNull();
   });
+
+  // --- Phase 5: hero autocomplete visual contrast + FilterSentence ---
+
+  describe('visual contrast — hero autocomplete vs header filter', () => {
+    it('autocomplete wrapper carries species-search-hero class', () => {
+      const { container } = render(
+        <SpeciesSearchSurface
+          loading={false}
+          speciesCode={null}
+          observations={[]}
+          speciesIndex={SPECIES_INDEX}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          onClearSpecies={() => {}}
+        />
+      );
+      // The hero class distinguishes the surface autocomplete (navigates)
+      // from the chip-shaped FiltersBar input (narrows). CSS maps this
+      // class to larger input height, search icon, and full-width layout.
+      expect(container.querySelector('.species-search-hero')).toBeInTheDocument();
+    });
+
+    it('search icon element is present inside the hero wrapper', () => {
+      const { container } = render(
+        <SpeciesSearchSurface
+          loading={false}
+          speciesCode={null}
+          observations={[]}
+          speciesIndex={SPECIES_INDEX}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          onClearSpecies={() => {}}
+        />
+      );
+      // Icon is aria-hidden; its presence is tested structurally.
+      const icon = container.querySelector('.species-search-hero-icon');
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('autocomplete combobox input is still accessible by role after hero wrapper added', () => {
+      render(
+        <SpeciesSearchSurface
+          loading={false}
+          speciesCode={null}
+          observations={[]}
+          speciesIndex={SPECIES_INDEX}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          onClearSpecies={() => {}}
+        />
+      );
+      // SpeciesAutocomplete's ARIA contract must survive the wrapper change.
+      const input = screen.getByRole('combobox', { name: /search species/i });
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    });
+  });
+
+  describe('<FilterSentence> on SpeciesSearchSurface', () => {
+    it('mounts the always-on live region', () => {
+      render(
+        <SpeciesSearchSurface
+          loading={false}
+          speciesCode={null}
+          observations={[]}
+          speciesIndex={SPECIES_INDEX}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          onClearSpecies={() => {}}
+        />
+      );
+      const liveRegion = document.querySelector('.filter-sentence-live');
+      expect(liveRegion).toBeInTheDocument();
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('renders visible FilterSentence when filters prop is active', () => {
+      render(
+        <SpeciesSearchSurface
+          loading={false}
+          speciesCode={null}
+          observations={[]}
+          speciesIndex={SPECIES_INDEX}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          onClearSpecies={() => {}}
+          activeFilters={{ notable: true, since: '14d', speciesCode: null, familyCode: null }}
+        />
+      );
+      expect(screen.getByText(/notable sightings/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/SpeciesSearchSurface.tsx
+++ b/frontend/src/components/SpeciesSearchSurface.tsx
@@ -1,4 +1,5 @@
 import type { Observation } from '@bird-watch/shared-types';
+import type { Since } from '../state/url-state.js';
 import { FeedRow } from './FeedRow.js';
 import { SpeciesAutocomplete } from './SpeciesAutocomplete.js';
 import { FilterSentence } from './ds/FilterSentence.js';
@@ -6,7 +7,7 @@ import type { SpeciesOption } from './FiltersBar.js';
 
 export interface ActiveFilters {
   notable: boolean;
-  since: string;
+  since: Since;
   speciesCode: string | null;
   familyCode: string | null;
 }

--- a/frontend/src/components/SpeciesSearchSurface.tsx
+++ b/frontend/src/components/SpeciesSearchSurface.tsx
@@ -1,7 +1,15 @@
 import type { Observation } from '@bird-watch/shared-types';
-import { ObservationFeedRow } from './ObservationFeedRow.js';
+import { FeedRow } from './FeedRow.js';
 import { SpeciesAutocomplete } from './SpeciesAutocomplete.js';
+import { FilterSentence } from './ds/FilterSentence.js';
 import type { SpeciesOption } from './FiltersBar.js';
+
+export interface ActiveFilters {
+  notable: boolean;
+  since: string;
+  speciesCode: string | null;
+  familyCode: string | null;
+}
 
 export interface SpeciesSearchSurfaceProps {
   loading: boolean;
@@ -10,33 +18,58 @@ export interface SpeciesSearchSurfaceProps {
   speciesIndex: SpeciesOption[];
   now: Date;
   onSelectSpecies: (speciesCode: string) => void;
+  onClearSpecies?: () => void;
+  /**
+   * Active filter state for the <FilterSentence> context strip.
+   * Optional: when absent, FilterSentence receives zero-filter state
+   * (live region still mounts; visible sentence is null).
+   */
+  activeFilters?: ActiveFilters;
 }
 
-/** Stable module-level no-op. */
+/** Stable module-level no-op for the recent-sightings row list. */
 const ROW_NOOP: (speciesCode: string) => void = () => {};
 
+const DEFAULT_FILTERS: ActiveFilters = {
+  notable: false,
+  since: '14d',
+  speciesCode: null,
+  familyCode: null,
+};
+
 /**
- * Species-first surface (`?view=species`). Dedicated navigation
- * autocomplete at the top; below it, when `?species=` is set, a
- * "Recent sightings for this species" list — filtered client-side
- * from the parent's observation set, rendered via the shared
- * `<ObservationFeedRow>`.
+ * Species-first surface — Sky Atlas Phase 5.
  *
- * Navigation vs filter (critical distinction):
- *   - `FiltersBar`'s species input NARROWS the observation set in place.
- *     The feed reacts, the URL sets `?species=`, but the user stays on
- *     the feed surface.
- *   - `SpeciesAutocomplete` here is NAVIGATION. Committing a species sets
- *     `?detail=` + `?view=detail` which opens the SpeciesDetailSurface.
+ * Visual distinction between the two species inputs:
+ *   - <FiltersBar> species input (in the header): chip-shaped, narrow,
+ *     class="filters-bar-species-input". It NARROWS the observation set.
+ *   - <SpeciesAutocomplete> here: hero-sized, full-width, search icon,
+ *     wrapped in .species-search-hero. It NAVIGATES to the detail surface.
  *
- * Clicking a row in the recent-sightings list intentionally does NOT
- * re-open the panel (panel is already open for the same species). The
- * row's `onSelectSpecies` receives a no-op handler so the row renders
- * with the same accessible contract as in `FeedSurface`, but a user
- * click does nothing observable — the panel does not flash.
+ * The hero wrapper and icon are purely visual. <SpeciesAutocomplete>'s
+ * ARIA contract (role="combobox", aria-autocomplete="list", aria-expanded,
+ * aria-controls, aria-activedescendant, flat-sentinel group headers,
+ * ArrowDown/Up/Enter/Escape) is preserved verbatim — do NOT pass additional
+ * ARIA attributes via the wrapper.
+ *
+ * <FilterSentence> mounts in the context strip below the hero autocomplete.
+ * The live region is always present (even at zero filters); the visible
+ * sentence renders only when filters are active.
+ *
+ * Recent-sightings row list uses <FeedRow> (not <ObservationFeedRow>).
+ * Rows receive ROW_NOOP for onSelectSpecies — clicking a row when the panel
+ * is already open for the same species is a no-op by design.
  */
 export function SpeciesSearchSurface(props: SpeciesSearchSurfaceProps) {
-  const { loading, speciesCode, observations, speciesIndex, now, onSelectSpecies } = props;
+  const {
+    loading,
+    speciesCode,
+    observations,
+    speciesIndex,
+    now,
+    onSelectSpecies,
+    activeFilters = DEFAULT_FILTERS,
+  } = props;
 
   const filtered = speciesCode
     ? observations.filter(o => o.speciesCode === speciesCode)
@@ -44,10 +77,27 @@ export function SpeciesSearchSurface(props: SpeciesSearchSurfaceProps) {
 
   return (
     <div className="species-search-surface">
-      <SpeciesAutocomplete
-        speciesIndex={speciesIndex}
-        onSelectSpecies={onSelectSpecies}
-      />
+      {/* Hero autocomplete — navigates to detail surface.
+          The wrapper class establishes visual distinction from the header filter chip. */}
+      <div className="species-search-hero">
+        <span className="species-search-hero-icon" aria-hidden="true">
+          {/* SVG search icon — rendered as inline SVG so it inherits currentColor
+              and is not a separate network request. The icon slot is purely decorative;
+              aria-hidden prevents SR double-announcement (combobox label already conveys
+              the search affordance). */}
+          <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="8.5" cy="8.5" r="5.75" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M13.25 13.25L17 17" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </span>
+        <SpeciesAutocomplete
+          speciesIndex={speciesIndex}
+          onSelectSpecies={onSelectSpecies}
+        />
+      </div>
+
+      {/* Context strip: FilterSentence (always-mounted live region) */}
+      <FilterSentence filters={activeFilters} />
 
       {speciesCode === null && (
         <p className="species-search-prompt" role="status">
@@ -70,7 +120,7 @@ export function SpeciesSearchSurface(props: SpeciesSearchSurfaceProps) {
       {speciesCode !== null && !loading && filtered.length > 0 && (
         <ol className="feed" aria-label="Recent sightings">
           {filtered.map(o => (
-            <ObservationFeedRow
+            <FeedRow
               key={`${o.subId}:${o.speciesCode}`}
               observation={o}
               now={now}

--- a/frontend/src/components/ds/FamilySilhouette.test.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.test.tsx
@@ -77,6 +77,28 @@ describe('<FamilySilhouette>', () => {
     expect(document.querySelector('.family-silhouette--circle')).toBeInTheDocument();
   });
 
+  // --- Unknown / raw eBird codes ---
+
+  it('renders the null-family neutral path (not a crash) for an unknown raw eBird family code', () => {
+    // "tyrannidae" is a raw eBird family code that is NOT in the FamilyCode
+    // union — it arrives as `string` from the Observation type. The component
+    // must fall back to the neutral null-family path rather than throwing or
+    // rendering an unknown path key.
+    render(<FamilySilhouette family="tyrannidae" />);
+    // SVG must be present — no crash
+    expect(document.querySelector('svg')).toBeInTheDocument();
+    // The silhouette wrapper must be in the document (component rendered)
+    const el = document.querySelector('[data-testid="family-silhouette"]');
+    expect(el).toBeInTheDocument();
+    // Unknown code still carries the raw family value on the data attribute
+    // (same as the known-code path) — the fallback is internal (path data),
+    // not a CSS-class difference.
+    expect(el).toHaveAttribute('data-family', 'tyrannidae');
+    // The neutral null-family fill is applied via the style custom property
+    // (getFamilyChannel returns the NULL_FAMILY_CHANNEL for unrecognised codes).
+    expect(el).toHaveStyle({ '--family-fill': '#5a6472' });
+  });
+
   // --- Accessibility ---
 
   it('is hidden from the SR tree (presentational) when inside <Photo>', () => {

--- a/frontend/src/components/ds/FamilySilhouette.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.tsx
@@ -83,7 +83,9 @@ export function FamilySilhouette({
   // pathKey covers the 7 known FamilyCodes and the explicit null sentinel
   // '__null__'. Unknown codes (e.g. raw eBird family codes that haven't
   // been mapped) fall back to '__null__' so no undefined path is rendered.
-  const pathKey = (family !== null && family in FAMILY_PATHS) ? family : '__null__';
+  // Use knownFamily (narrowed FamilyCode | null) rather than the raw `family`
+  // prop (string) so TypeScript can verify the index against the Record type.
+  const pathKey = knownFamily ?? '__null__';
   const path = FAMILY_PATHS[pathKey];
 
   const classes = [

--- a/frontend/src/components/ds/FamilySilhouette.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.tsx
@@ -29,7 +29,8 @@ import type { FamilyCode, ShapeVariant } from '../../config/family-palette.js';
 export type SilhouetteLayout = 'inline' | 'masthead' | 'thumb';
 
 export interface FamilySilhouetteProps {
-  family: FamilyCode | null;
+  /** FamilyCode string or null. Unknown codes fall back to the null-family neutral path. */
+  family: FamilyCode | string | null;
   layout?: SilhouetteLayout;
   /** Overrides the palette's default shape if provided. */
   shape?: ShapeVariant;
@@ -72,7 +73,12 @@ export function FamilySilhouette({
   shape: shapeProp,
   ariaLabel,
 }: FamilySilhouetteProps): ReactNode {
-  const channel = getFamilyChannel(family);
+  // Narrow to a known FamilyCode if recognized; treat unknowns as null.
+  const knownFamily: FamilyCode | null =
+    family !== null && family in FAMILY_PATHS
+      ? (family as FamilyCode)
+      : null;
+  const channel = getFamilyChannel(knownFamily);
   const resolvedShape: ShapeVariant = shapeProp ?? channel.shape;
   // pathKey covers the 7 known FamilyCodes and the explicit null sentinel
   // '__null__'. Unknown codes (e.g. raw eBird family codes that haven't
@@ -88,7 +94,14 @@ export function FamilySilhouette({
   ].join(' ');
 
   return (
-    <span className={classes} data-shape={resolvedShape} style={{ '--family-fill': channel.fill } as React.CSSProperties}>
+    <span
+      className={classes}
+      data-shape={resolvedShape}
+      data-testid="family-silhouette"
+      data-family={String(family)}
+      data-layout={layout}
+      style={{ '--family-fill': channel.fill } as React.CSSProperties}
+    >
       <svg
         viewBox="0 0 100 100"
         xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/ds/SortLabel.tsx
+++ b/frontend/src/components/ds/SortLabel.tsx
@@ -5,17 +5,30 @@
  * the feed surface ("Sorted by recency"). Separate component per the
  * design spec: <FilterSentence> does not gain a view prop for sort.
  *
+ * Accepts either:
+ *   - `label` prop (string): rendered as-is.
+ *   - `mode` prop ('recent' | 'taxonomic'): mapped to a human-readable label.
+ *
  * Returns null when label is empty or undefined.
  *
  * Spec: docs/design/01-spec/components.md (<SortLabel> sibling note)
  */
 import type { ReactNode } from 'react';
 
+export type SortMode = 'recent' | 'taxonomic';
+
+const MODE_LABELS: Record<SortMode, string> = {
+  recent: 'Sorted by recency',
+  taxonomic: 'Sorted taxonomically',
+};
+
 export interface SortLabelProps {
   label?: string;
+  mode?: SortMode;
 }
 
-export function SortLabel({ label }: SortLabelProps): ReactNode {
-  if (!label) return null;
-  return <p className="sort-label">{label}</p>;
+export function SortLabel({ label, mode }: SortLabelProps): ReactNode {
+  const resolved = label ?? (mode ? MODE_LABELS[mode] : undefined);
+  if (!resolved) return null;
+  return <p className="sort-label">{resolved}</p>;
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -99,6 +99,17 @@ export interface FamilySilhouette {
   creator: string | null;
 }
 
+/**
+ * Type-narrowed variant of Observation for sightings confirmed as notable.
+ * FeedCard (and any elevated-card consumer) accepts only NotableObservation —
+ * the type system enforces that callers narrow before passing, eliminating the
+ * structural trust the old Observation prop required.
+ *
+ * The caller (FeedSurface) already guards with `o.isNotable` before passing
+ * to FeedCard; this type makes that guard a compile-time contract.
+ */
+export type NotableObservation = Observation & { isNotable: true };
+
 export interface IngestRun {
   id: number;
   kind: 'recent' | 'notable' | 'backfill' | 'hotspots' | 'taxonomy' | 'photos';


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph FeedSurface["FeedSurface (Phase 5)"]
        Lede["feed-lede\n4-template state machine"]
        SortLabel["SortLabel\nSorted by recency"]
        FilterSentence["FilterSentence\nAlways-mounted live region"]
        FeedCard["FeedCard\nTop-notable elevated"]
        FeedList["FeedRow list\nFamilySilhouette thumbs"]
    end

    subgraph SpeciesSearchSurface["SpeciesSearchSurface (Phase 5)"]
        HeroWrapper[".species-search-hero\nSearch icon + full-width input"]
        Autocomplete["SpeciesAutocomplete\nWAI-ARIA 1.2 combobox (untouched)"]
        SpeciesFilterSentence["FilterSentence\nContext strip"]
        RecentRows["FeedRow list\nRecent sightings"]
    end

    subgraph Shim["Backward Compat"]
        ObsFeedRow["ObservationFeedRow.tsx\nRe-export shim → FeedRow"]
    end

    Lede --> SortLabel --> FilterSentence --> FeedCard --> FeedList
    HeroWrapper --> Autocomplete
    HeroWrapper --> SpeciesFilterSentence
    SpeciesFilterSentence --> RecentRows
    ObsFeedRow -.-> FeedRow["FeedRow.tsx"]
```

## Summary

- Add `<FeedRow>` (refactored from `ObservationFeedRow`) with `<FamilySilhouette layout="thumb">` in the leading slot, replacing the v3 emoji/glyph approach. `<ObservationFeedRow>` becomes a compatibility shim.
- Add `<FeedCard>` for the elevated top-notable observation: inline-layout silhouette, NOTABLE meta-label via `.feed-card-meta` → `--color-accent-notable-fg`, species name as `<h2>`.
- Rewrite `<FeedSurface>` with the 4-template lede state machine, `<SortLabel>` sibling above `<FilterSentence>`, and unified `<ol>` containing the card-row + flat rows.
- `<SpeciesSearchSurface>` hero autocomplete visual sharpening: `.species-search-hero` wrapper + search icon distinguish the navigation input from the chip-shaped `<FiltersBar>` header control. `<FilterSentence>` mounts in the context strip.

## Screenshots

Screenshots pending user paste — the worktree environment is missing `maplibre-gl` in node_modules, preventing `npm run dev` from starting in this CI context. The Playwright MCP smoke validation and screenshot capture will be completed by the reviewer via `gh pr checkout 428 && npm run dev --workspace @bird-watch/frontend` against the PR head SHA per CLAUDE.md §UI verification.

Visual changes implemented:
- `<FeedRow>`: leading `<FamilySilhouette layout="thumb">` slot; notable as class modifier (`.feed-row-notable`), no glyph badge
- `<FeedCard>`: inline-layout silhouette; `<h2>` species name; `.feed-card-meta` NOTABLE label; elevated card treatment
- `<SpeciesSearchSurface>`: `.species-search-hero` full-width wrapper + SVG search icon; `<FilterSentence>` context strip below

## Test plan

- [x] `<FeedRow>` unit tests (13): silhouette thumb, null-family neutral path, all five ARIA slots, notable class modifier, memo contract, `<li>` wrapper.
- [x] `<FeedCard>` unit tests (10): NOTABLE label, `.feed-card-meta` class (not decision-point), inline-layout silhouette, card heading, five-slot accessible name, `<li class="feed-card-item">`.
- [x] `<FeedSurface>` unit tests (28 total, 9 new): 4-template lede state machine, SortLabel sibling, FilterSentence always-on live region, FeedCard elevation for first notable, all existing sort-toggle tests preserved.
- [x] `<SpeciesSearchSurface>` unit tests (13 total, 4 new): `.species-search-hero` wrapper, icon element aria-hidden, combobox ARIA contract preserved, FilterSentence live region.
- [x] `npm run test --workspace @bird-watch/frontend` — 636 tests, 57 test files, all pass.
- [x] `npm run build --workspace @bird-watch/frontend` — tsc emits only pre-existing maplibre-gl errors (package not installed in this worktree); zero new TypeScript errors from Phase 5 code.
- [x] `grep -rE 'var\(--color-decision-point\).*notable' frontend/src/` — 0 matches (accent discipline preserved).
- [x] `grep -rE 'ObservationFeedRow' frontend/src/` — only comments and the shim file reference it; no live imports outside the alias.
- [ ] Playwright MCP smoke — BLOCKED: `npm run dev` fails in this worktree (maplibre-gl not in node_modules). Reviewer must run `gh pr checkout <N> && npm run dev --workspace @bird-watch/frontend` per CLAUDE.md §UI verification. Screenshots pending user paste (pr-screenshots-via-user-attachments skill).
- [ ] Manual VoiceOver pass (Task 6) — requires macOS VoiceOver + Safari; deferred to reviewer or follow-up. FilterSentence debounce wiring is unit-tested; timing behavior (500ms debounce, 1500ms clear-hold) was established in Phase 2's FilterSentence tests.
- [ ] `npm run test:e2e --workspace @bird-watch/frontend` — also blocked by same maplibre-gl constraint; CI will run these on merge.

## Plan reference

Part of Plan docs/plans/2026-05-09-sky-atlas-phase-5-feed-species.md, Tasks 1–7. Implements issue #405.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)