### PR TITLE
fix(chrome): AppHeader CSS — design-faithful chrome (closes #438)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -143,6 +143,140 @@ body {
   margin-left: var(--space-xs);
 }
 
+/* ── AppHeader chrome bar (#437) ────────────────────────────────────────────
+   Phase 3 renamed SurfaceNav → AppHeader and introduced these class names.
+   The CSS rules were never written (only the .brand-region span landed in
+   Phase 6). Rules below restore the visual contract that .surface-nav /
+   .surface-nav-tab carried, mapped onto the new selector surface.
+
+   Token contract: all tokens resolve identically in light and dark modes
+   for these semantic roles — see tokens.css dark-mode comment at line ~115.
+   Do not add per-theme overrides here without revisiting that constraint. */
+
+/* Top-level chrome bar — stretches full width, pins to top of the
+   flex-column .app layout. Sticky so it stays in view when #main-surface
+   overflows. gap + padding mirror the surface-nav spacing contract. */
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border-ui);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+/* Brand link — suppress UA link chrome; inherit body typography.
+   font-weight-bold distinguishes the wordmark from body text.
+   The .brand-region span inside carries its own Phase 6 rule above. */
+.app-header-wordmark {
+  text-decoration: none;
+  color: var(--color-text-strong);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+.app-header-wordmark:hover {
+  opacity: 0.8;
+}
+.app-header-wordmark:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Tablist container — sits between wordmark and action buttons. flex: 1
+   pushes the right cluster to the far edge on wide viewports. */
+.app-header-nav {
+  display: flex;
+  gap: var(--space-xs);
+  flex: 1;
+}
+
+/* Tab buttons — full UA reset, then design-token styling.
+   Visual contract mirrors the former .surface-nav-tab exactly:
+   same padding, border-radius, font-size, hover / focus / active states. */
+.app-header-tab {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: var(--type-sm);
+  color: var(--color-text-strong);
+  cursor: pointer;
+  line-height: 1.2;
+}
+.app-header-tab:hover {
+  background: var(--color-bg-tint);
+}
+.app-header-tab:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.app-header-tab.is-active {
+  background: var(--color-text-strong);
+  color: var(--color-text-white);
+  border-color: var(--color-text-strong);
+}
+
+/* Right-side action cluster — Attribution, Filters, ThemeToggle. */
+.app-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+/* Attribution + Filters buttons — same UA reset + visual contract as tabs.
+   Slightly subdued: color-text-body rather than color-text-strong keeps
+   them secondary to the navigation tabs without becoming invisible. */
+.app-header-attribution,
+.app-header-filters {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 6px 14px;
+  font: inherit;
+  font-size: var(--type-sm);
+  color: var(--color-text-body);
+  cursor: pointer;
+  line-height: 1.2;
+  position: relative;
+}
+.app-header-attribution:hover,
+.app-header-filters:hover {
+  background: var(--color-bg-tint);
+}
+.app-header-attribution:focus-visible,
+.app-header-filters:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+
+/* Numeric badge on the Filters button when filters are active.
+   Inline-block pill positioned after the label text; does not affect
+   button height because it shares the button's line-height. */
+.app-header-filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: var(--space-xs);
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: var(--color-text-strong);
+  color: var(--color-text-white);
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  line-height: 1;
+}
+
 /* Feed lede paragraph (#439). The .feed-lede class is applied to the
    introductory <p> above the feed list. --lede-size (26px) is made available
    via the extended selector in tokens.css (.lede, .feed-lede). Approach A
@@ -431,40 +565,6 @@ body {
 }
 .filters-bar label { display: flex; gap: 6px; align-items: center; font-size: var(--type-sm); }
 .filters-bar select, .filters-bar input { padding: 4px 8px; }
-
-/* Surface-toggle tablist (#111). Sits between FiltersBar and the map / main
-   surface. The three tabs drive ?view= in UrlState; see SurfaceNav.tsx for
-   the WAI-ARIA tablist keyboard contract. Styling is intentionally minimal —
-   tokenised palette/typography land with the first real surface in #116. */
-.surface-nav {
-  display: flex;
-  gap: var(--space-xs);
-  padding: var(--space-sm) var(--space-lg);
-  background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-ui);
-}
-.surface-nav-tab {
-  appearance: none;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 6px 14px;
-  font: inherit;
-  font-size: var(--type-sm);
-  color: var(--color-text-strong);
-  cursor: pointer;
-  line-height: 1.2;
-}
-.surface-nav-tab:hover { background: var(--color-bg-tint); }
-.surface-nav-tab:focus-visible {
-  outline: 2px solid var(--color-text-strong);
-  outline-offset: 2px;
-}
-.surface-nav-tab.is-active {
-  background: var(--color-text-strong);
-  color: var(--color-text-white);
-  border-color: var(--color-text-strong);
-}
 
 /* Species detail surface (#151). In-flow surface inside <main>, replaces the
    old position:fixed SpeciesPanel sidebar/drawer. Styled consistently with


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before ["Before (Phase 3 gap)"]
        A[".surface-nav* rules\n(orphaned, dead code)"] -->|no match| B["AppHeader JSX\n.app-header* classes"]
        B -->|UA defaults| C["Browser renders:\nblue link, button borders"]
    end

    subgraph After ["After (this PR)"]
        D[".app-header* rules\n(8 new rules)"] -->|matches| E["AppHeader JSX\n.app-header* classes"]
        E -->|design tokens| F["Renders: dark wordmark,\ntoken-styled tabs + actions"]
    end
```

## Summary

- Phase 3 (PR #427) renamed `SurfaceNav` → `AppHeader` and introduced `.app-header*` class names in JSX, but the matching CSS rules were never written — leaving wordmark as default browser blue link, tabs as UA buttons, and action cluster with unpainted chrome. This is a production regression on every surface.
- Writes all 8 `.app-header*` CSS rules using Phase 1 tokens, replicating the visual contract the orphaned `.surface-nav*` block carried before the rename.
- Deletes the orphan `.surface-nav*` block (lines 378–405 pre-edit) that became dead code when Phase 3 landed. `SurfaceNav.tsx` source and its `knip.ts` ignore rule are intentionally left alone (separate cleanup per issue scope).

## Screenshots

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="390" alt="390x844-light" src="https://github.com/user-attachments/assets/47004049-1bd4-4ac2-b3b5-b47e0b90408d" /> | <img width="390" alt="390x844-dark" src="https://github.com/user-attachments/assets/887ce454-aa43-44d7-93b8-2cf1490dca31" /> |
| 768×1024 (tablet) | <img width="390" alt="768x1024-light" src="https://github.com/user-attachments/assets/437caf1d-9b0e-49df-9aa7-533000738a9b" /> | <img width="390" alt="768x1024-dark" src="https://github.com/user-attachments/assets/7ddf323e-a77c-491a-bcca-e173b975f9e0" /> |
| 1024×768 (landscape) | <img width="390" alt="1024x768-light" src="https://github.com/user-attachments/assets/ba57ad8d-e03f-4ddb-86b8-7134c2b8d844" /> | <img width="390" alt="1024x768-dark" src="https://github.com/user-attachments/assets/108fb0dd-24c1-4549-8ad1-2e7232e09145" /> |
| 1440×900 (desktop) | <img width="390" alt="1440x900-light" src="https://github.com/user-attachments/assets/eb2267fa-8965-4d5a-954c-59aaefcd34b0" /> | <img width="390" alt="1440x900-dark" src="https://github.com/user-attachments/assets/5ab70b94-9193-4d80-9616-a360a65ac385" /> |
| 1920×1080 (full HD) | <img width="390" alt="1920x1080-light" src="https://github.com/user-attachments/assets/bf9027bd-4da1-4a97-9206-5919cb3ec1cc" /> | <img width="390" alt="1920x1080-dark" src="https://github.com/user-attachments/assets/30532e2f-5cc4-4cda-961e-8834065d05b2" /> |

## Test plan

- [x] `grep -cE '^.app-header' frontend/src/styles.css` returns 18 (≥7 required)
- [x] `grep -cE '^.surface-nav' frontend/src/styles.css` returns 0
- [x] DevTools: `.app-header-wordmark` color is `rgb(26, 26, 26)` (not `rgb(0, 0, 238)`)
- [x] DevTools: `.app-header-wordmark` text-decoration is `none`
- [x] Playwright MCP: AppHeader visually distinct from UA defaults at all 5 viewports × 2 themes
- [x] Console errors: pre-existing API 502s only (backend not running locally); zero CSS-related errors/warnings
- [x] `npm run test --workspace @bird-watch/frontend` — 629/629 passing; 2 pre-existing failures in `viewport-filter.test.ts` and `MapCanvas.test.tsx` due to maplibre-gl missing from node_modules in worktree (pre-existing, unrelated to CSS)
- [x] `npm run build --workspace @bird-watch/frontend` — pre-existing TS errors for maplibre-gl types (same root cause, pre-existing on main)

## Plan reference

Out of plan — emergency fix for production regression at bird-maps.com introduced by Phase 3 rename without matching CSS. Closes #438.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)