### PR TITLE
fix(feed): feed-lede typography rule (closes #439)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -143,6 +143,18 @@ body {
   margin-left: var(--space-xs);
 }
 
+/* Feed lede paragraph (#439). The .feed-lede class is applied to the
+   introductory <p> above the feed list. --lede-size (26px) is made available
+   via the extended selector in tokens.css (.lede, .feed-lede). Approach A
+   chosen: design-faithful 26px rather than the 22px --type-lg fallback. */
+.feed-lede {
+  font-size: var(--lede-size);
+  font-weight: 600;
+  line-height: 1.25;
+  margin-bottom: var(--space-lg);
+  color: var(--color-text-strong);
+}
+
 /* Feed surface (#116). Reverse-chronological observation rows. Row min-
    height is 44px — iOS HIG tap-target minimum, also referenced in
    risk-viability.md Part 2. Interior spacing uses design-token custom

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -163,6 +163,7 @@
  * exception inside the ladder weakens the contract. Moved out of Layer 1
  * intentionally — see commit "refactor(styles): relocate --lede-size".
  */
-.lede {
+.lede,
+.feed-lede {
   --lede-size: 26px;
 }


### PR DESCRIPTION
## Diagrams

N/A — CSS-only change, no data flow or component tree change.

## Summary

- `--lede-size` (26 px) is declared inside `.lede { ... }` at Layer-3 scope in `tokens.css`, so a bare `.feed-lede { font-size: var(--lede-size) }` rule would silently fall back to the browser default. Approach A extends the existing selector to `.lede, .feed-lede { --lede-size: 26px }`, making the token available without adding new root-level tokens or accepting a size compromise.
- Approach A chosen over Approach B: 26 px (design-faithful) vs 22 px (`--type-lg`). The lede is the first thing a user reads on the Feed surface; matching the spec's intended size between `--type-lg` and `--type-hero` preserves the intended visual weight.
- `getComputedStyle(document.querySelector('.feed-lede'))` on the running dev server confirmed: `fontSize: "26px"`, `fontWeight: "600"`, `lineHeight: "32.5px"` (= 26 × 1.25), `marginBottom: "16px"` (= `--space-lg`), `color: "rgb(26, 26, 26)"` (= `--color-text-strong`).

## Screenshots

**Light mode**

| 390×844 | 768×1024 | 1024×768 | 1440×900 | 1920×1080 |
|---|---|---|---|---|
| ![390x844 light](https://github.com/user-attachments/assets/b487e01c-333a-4112-b50c-4b89a28b811b) | ![768x1024 light](https://github.com/user-attachments/assets/c5277fb6-6e0d-4c06-b68c-a3dfd96731ff) | ![1024x768 light](https://github.com/user-attachments/assets/bbbd276d-8ef1-4ea2-92ce-ba1d48a6d0d3) | ![1440x900 light](https://github.com/user-attachments/assets/a4ea91f7-4fd0-415c-ad75-a19b6cb88e47) | ![1920x1080 light](https://github.com/user-attachments/assets/b97130db-9aeb-467d-9d0c-45288fa93a8c) |

**Dark mode**

| 390×844 | 768×1024 | 1024×768 | 1440×900 | 1920×1080 |
|---|---|---|---|---|
| ![390x844 dark](https://github.com/user-attachments/assets/cf9cb911-339b-451a-bb14-b003d1ca8c88) | ![768x1024 dark](https://github.com/user-attachments/assets/42864964-e8ac-4179-874d-901916ca2abe) | ![1024x768 dark](https://github.com/user-attachments/assets/d96bb9ac-db67-43b2-a9cd-d1f92caaafb7) | ![1440x900 dark](https://github.com/user-attachments/assets/223f9581-dccc-4ed2-9b7f-b2a6f147367c) | ![1920x1080 dark](https://github.com/user-attachments/assets/4f4cd84c-766c-489f-8cec-446c9e9eb4fa) |

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — 629 tests pass; 2 pre-existing failures (maplibre-gl resolution in test env, unrelated to this change)
- [x] Acceptance criteria greps: `grep -nE '^\.feed-lede' frontend/src/styles.css` returns line 150; `grep -nE '\.lede|\.feed-lede' frontend/src/styles/tokens.css` returns lines 166-167
- [x] DevTools verification on running dev server: `fontSize: "26px"` (Approach A, not the 22px fallback), `fontWeight: "600"`, `lineHeight: "32.5px"`, `marginBottom: "16px"`, `color: "rgb(26, 26, 26)"`
- [x] (UI only) Playwright MCP drive at 5 viewports × 2 themes — feed surface shows lede hierarchy, zero console errors on feed surface at each clean viewport

## Plan reference

Out of plan — targeted bugfix for issue #439 (missing `.feed-lede` CSS rule).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)