### PR TITLE
chore(process): plan-template + R14 + multi-viewport design-review gate (closes #445)

### DIFF
--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: writing-plans
+description: Project-level extension of the superpowers:writing-plans skill for julianken/bird-sight-system. Adds mandatory CSS sub-task gate for frontend component plans (closes #445). Triggers on all the same conditions as superpowers:writing-plans — "write a plan", "create an implementation plan", any planning work in this repo.
+---
+
+# Writing Plans (bird-sight-system extension)
+
+This skill extends `superpowers:writing-plans` with project-specific gates.
+Load and apply all rules from `superpowers:writing-plans` first, then apply the
+additional rules below.
+
+## Frontend component plans — mandatory CSS sub-task (closes #445)
+
+When the plan touches any file under `frontend/src/components/**`, every task
+that introduces or modifies a component MUST include an explicit sub-task for
+surface-level CSS. This is non-optional — omitting it produced the class of
+miss captured in #445 (Phase 3–5 plans said "build FooBar.tsx" without
+saying "write CSS for `.foo-bar`").
+
+**Required sub-task template (insert after the TSX implementation step):**
+
+```markdown
+- [ ] **Step N: Write CSS rules for [ComponentName]**
+
+  In `frontend/src/styles.css` and/or `frontend/src/components/ds/ds-primitives.css`,
+  add rules for every className introduced in this component. Exhaustive class list:
+  `.class-a`, `.class-b`, `.class-c`  ← fill from the TSX you just wrote.
+
+  Verify each class has at least one rule:
+
+  grep -cE '^\.(class-a|class-b|class-c)' \
+    frontend/src/styles.css \
+    frontend/src/components/ds/ds-primitives.css
+
+  Expected: non-zero count for every class. If any returns 0, add the missing
+  rule before committing.
+```
+
+**Self-review gate (applies to plan author, not plan executor):** After
+writing the plan, run the following search on the draft plan text itself:
+
+```bash
+grep -n "className" <plan-file>.md | grep -v "grep\|CSS rules\|Step N:"
+```
+
+If the grep returns any lines without a corresponding CSS sub-task in the same
+task block, the plan is incomplete — add the missing CSS step(s) before saving.
+
+## Multi-viewport design-review gate
+
+For any plan that adds or modifies visible UI under `frontend/**`, the plan
+MUST include a task that dispatches a design-review subagent at all 5 canonical
+viewports. Reference this issue's process: #445.
+
+**Canonical viewport set** (non-negotiable for design-related PRs):
+
+| # | Viewport | Device class |
+|---|---|---|
+| 1 | 390×844 | iPhone 14 Pro (mobile) |
+| 2 | 768×1024 | iPad portrait (tablet) |
+| 3 | 1024×768 | iPad landscape / small laptop |
+| 4 | 1440×900 | Desktop standard |
+| 5 | 1920×1080 | Wide desktop |
+
+Capture at both light and dark theme (10 screenshots minimum per touched
+surface). Dark-mode trigger: `document.documentElement.setAttribute('data-theme', 'dark')`
+via Playwright MCP `browser_evaluate` — NOT `prefers-color-scheme` emulation
+(the repo overrides via attribute, not media query).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,14 @@ Upload screenshots via the user-attachments paste flow (skill:
 and survive branch deletion. Do NOT commit PNGs to the repo and do NOT use
 `raw.githubusercontent.com` URLs. -->
 
+- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
+      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
+      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
+- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
+      (5 viewports × 2 themes per #445). Verify:
+      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
+      returns ≥ 10 (or marked `N/A — not UI`)
+
 ## Test plan
 
 <!-- Checklist of the verifications you ran. Reviewers expect all boxes checked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,16 +86,60 @@ Protocol:
    per-PR preview URLs are configured on this repo yet (Pages deploys only on
    merge to `main`).
 2. `mcp__plugin_playwright_playwright__browser_navigate` to each touched
-   surface; `browser_resize` to at least one mobile (390×844) and one desktop
-   (1440×900) viewport — the two viewports the release-1 exit criteria name.
+   surface; `browser_resize` to all 5 canonical viewports (see below).
 3. Interact with the feature the way a user would (clicks, form fills, URL
    round-trips). `browser_console_messages` must return zero errors and zero
    warnings. A dirty console is a Tier-1 finding at review time.
-4. `browser_take_screenshot` per viewport per touched surface; those feed the
-   PR's Screenshots section (implementer only — reviewers don't re-capture).
-   Screenshots: use the `pr-screenshots-via-user-attachments` skill
-   (paste-flow → `user-attachments/assets/<uuid>` URLs); never commit PNGs to
-   the repo.
+4. `browser_take_screenshot` per viewport per touched surface × 2 themes (light
+   + dark); those feed the PR's Screenshots section (implementer only —
+   reviewers don't re-capture). Screenshots: use the
+   `pr-screenshots-via-user-attachments` skill (paste-flow →
+   `user-attachments/assets/<uuid>` URLs); never commit PNGs to the repo.
+5. Dark-mode capture: set `document.documentElement.setAttribute('data-theme', 'dark')`
+   via Playwright MCP `browser_evaluate` before taking the dark screenshot.
+   Do NOT use `prefers-color-scheme` emulation — the repo's `[data-theme]`
+   attribute convention overrides the media query and emulation won't trigger it.
+
+**Canonical viewport set** (non-negotiable for any design-related PR):
+
+| # | Viewport | Device class |
+|---|---|---|
+| 1 | 390×844 | iPhone 14 Pro (mobile) |
+| 2 | 768×1024 | iPad portrait (tablet) |
+| 3 | 1024×768 | iPad landscape / small laptop |
+| 4 | 1440×900 | Desktop standard |
+| 5 | 1920×1080 | Wide desktop |
+
+This yields 10 captures minimum per touched surface (5 viewports × 2 themes).
+The PR body must contain ≥10 `user-attachments` URLs before bot review.
+Verify: `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
+
+**Design-review subagent invocation contract** (for design-related PRs, #445):
+
+After capturing screenshots, the orchestrator dispatches a design-review
+subagent via the Task tool using these arguments:
+
+```
+subagent_type: "ui-design:ui-designer"
+model: "opus"   # explicit override required — the agent's frontmatter declares
+                # model: inherit, so without this override the subagent inherits
+                # the orchestrator's model (Sonnet). The explicit "opus" provides
+                # cross-tier discipline (NYU, January 2026) even when the
+                # implementer also ran on Sonnet.
+prompt: |
+  <brief naming PR URL, design-intent reference (mock path / spec path /
+   v4 HTML path), all screenshot user-attachments URLs, AC reference from
+   the plan, expected verdict format: PASS / FAIL with file:line-equivalent
+   evidence, capped at 3 findings per viewport per R3>
+```
+
+**NOT via `/design-review`** — that slash command is interactive and serves
+a different purpose (live design ideation sessions). The Task-tool dispatch is
+the correct invocation for automated pre-merge design review.
+
+One dispatch per PR covers all viewports, OR one dispatch per viewport for
+narrower context per pass — orchestrator's choice. All 5 viewports must PASS
+before bot review, critic review, and queue.
 
 `.playwright-mcp/` is already gitignored so per-call snapshot YAMLs never land
 in git. Do not remove it from `.gitignore`.


### PR DESCRIPTION
## Diagrams

N/A — process/docs PR, no data flows or component trees to diagram.

## Summary

- **Root cause fix for #438–#444**: plan templates didn't require surface-level CSS as explicit sub-tasks, and the reviewer rubric had no CSS contract check. This PR adds both.
- **Four artifacts**: project-level plan-writing skill extension, R14 bot rubric rule (SHADOW MODE), two new PR template checkboxes, and CLAUDE.md UI-verification section update naming the 5-viewport canonical set with design-review subagent invocation contract.
- **Why now**: closes the methodology gap identified in #445 before more Sky Atlas phases ship under the same gap.

## Screenshots

N/A — process/docs PR, no visible UI changes.

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

## Test plan

- [ ] `npm run typecheck && npm run test` — green
- [ ] New unit / integration tests added (if behavior changed)
- [ ] New Playwright e2e spec added (if user-visible behavior changed)
- [ ] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Out of plan — methodology fix closes #445 (process gap, not implementation plan task).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)