### PR TITLE
chore(skill): add plan-literal manifest convention to writing-plans (closes #464)

### DIFF
--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -46,6 +46,60 @@ grep -n "className" <plan-file>.md | grep -v "grep\|CSS rules\|Step N:"
 If the grep returns any lines without a corresponding CSS sub-task in the same
 task block, the plan is incomplete — add the missing CSS step(s) before saving.
 
+## Quantified plan literals
+
+Every plan that contains numeric or universal quantifiers in its task acceptance criteria MUST include a `## Quantified plan literals (implementer checklist)` section. This section appears **before the first task block** (after the file structure table if one exists, before Task 1).
+
+**What qualifies as a manifest entry:**
+
+- **Numeric quantifiers**: any count or measurement that appears in a task's acceptance criteria or success steps. Examples: "ship 14 dark-mode token overrides", "render 9 region polygons", "support 4 freshness states", "migrate 35 font-size literals", "344 rows of representative data".
+- **Universal quantifiers**: "all", "every", "each", "no" applied to a set named in the plan's task ACs. Examples: "all surface tabs", "every viewport size", "each phase plan", "zero console errors".
+
+If a plan contains no numeric or universal quantifiers in its task ACs, the section is omitted and a brief note (`_No quantified literals in this plan._`) is added in its place so reviewers know the author checked.
+
+**Ownership — explicit:**
+
+- **Plan author** writes the manifest section before authoring any task block. The author is responsible for keeping it current if the plan is amended. Omitting a qualifying literal is an author-side gap that silences the reviewer-side gate (see Composition with R13 T7 below).
+- **Implementer** must check off each manifest item before opening the impl PR, or cite a deferral document with a lexically-matching subject (per R13 T7, issue #461). "Lexically matching" means the deferral document's subject line contains the same noun phrase as the manifest item (e.g., manifest says "14 dark-mode tokens"; a valid deferral says "Defer 14 dark-mode token overrides to Phase 2 — [reason]"; an invalid deferral says "Defer basemap loading" — subject mismatch, T7 fires).
+- **Reviewer** (bot or human): verifies that each manifest item is either checked or has a valid lexically-matching deferral citation. An unchecked item with no deferral is a T7 finding (SUGGESTION tier).
+
+**Composition with R13 T7 (issue #461) — manifest coverage is a T7 precondition:**
+
+R13 T7 is a *reviewer* gate that fires when the bot reviews an impl PR: it checks whether each quantified literal in the plan's manifest appears as either a checked box or a cited deferral. If the plan author omits a quantified literal from the manifest, T7 has no corpus to lexically match against and silently skips — the gap passes undetected. The author-side manifest is therefore a **necessary precondition** for the reviewer-side gate to fire. Both gates must be in place to close the gap at both ends.
+
+**Worked example (the T7 lexical-match failure case):**
+
+Plan manifest entry:
+```
+- [ ] Ship 14 dark-mode token overrides in `[data-theme="dark"]` block
+```
+
+Implementer opens PR without checking this box, instead adding a deferral doc titled: _"Defer basemap loading to Phase 2"_.
+
+T7 fires: the deferral subject ("basemap loading") does not lexically match the manifest item ("14 dark-mode token overrides"). The reviewer catches the gap. Correct fix: either check the box (ship the tokens) or write a deferral doc whose subject reads _"Defer 14 dark-mode token overrides to Phase 2 — [reason]"_.
+
+**Manifest format:**
+
+```markdown
+## Quantified plan literals (implementer checklist)
+
+Before opening a PR for this plan, check off each item or cite a deferral doc
+with a lexically-matching subject (per R13 T7, issue #461):
+
+- [ ] Ship 14 dark-mode token overrides in `[data-theme="dark"]` block
+- [ ] Render 9 region polygons on map load
+- [ ] Expose `MAX(inserted_at)` as `meta.freshestObservationAt` in API envelope
+- [ ] All surface tabs respond to keyboard navigation
+- [ ] Every viewport: zero console errors
+```
+
+**Retroactive backfill scope for Sky Atlas plans:**
+
+- Sky Atlas has 7 phase plans (Phases 0–6). Do not assume 9.
+- **High-value backfill: Phase 1 only** (the documented walkback case — makes the worked example concrete with real literals from the token-foundation plan).
+- Phases 0, 2–6: optional follow-up; must not block Phase 1 backfill or any impl PR.
+- Merged plans beyond Phase 1: do not backfill (the manifest cannot retroactively gate closed PRs).
+
 ## Multi-viewport design-review gate
 
 For any plan that adds or modifies visible UI under `frontend/**`, the plan

--- a/docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md
+++ b/docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md
@@ -17,7 +17,7 @@
 Before opening a PR for this plan, check off each item or cite a deferral doc
 with a lexically-matching subject (per R13 T7, issue #461):
 
-- [ ] Ship 14 dark-mode token overrides in `[data-theme="dark"]` block (`tokens.css` Layer 2 dark section)
+- [ ] Ship 18 dark-mode token overrides in `[data-theme="dark"]` block (`tokens.css` Layer 2 dark section)
 - [ ] Establish 3-tier token contract: primitive → semantic → component (all three tiers present in `tokens.css`)
 - [ ] Migrate 35 hardcoded `font-size` literals in `styles.css` to type ramp tokens (`grep -c 'font-size: [0-9]' frontend/src/styles.css` returns `0`)
 - [ ] 6-step type ramp declared: `--type-xs`, `--type-sm`, `--type-base`, `--type-md`, `--type-lg`, `--type-hero` (all 6 present in `tokens.css`)

--- a/docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md
+++ b/docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md
@@ -12,6 +12,23 @@
 
 ---
 
+## Quantified plan literals (implementer checklist)
+
+Before opening a PR for this plan, check off each item or cite a deferral doc
+with a lexically-matching subject (per R13 T7, issue #461):
+
+- [ ] Ship 14 dark-mode token overrides in `[data-theme="dark"]` block (`tokens.css` Layer 2 dark section)
+- [ ] Establish 3-tier token contract: primitive → semantic → component (all three tiers present in `tokens.css`)
+- [ ] Migrate 35 hardcoded `font-size` literals in `styles.css` to type ramp tokens (`grep -c 'font-size: [0-9]' frontend/src/styles.css` returns `0`)
+- [ ] 6-step type ramp declared: `--type-xs`, `--type-sm`, `--type-base`, `--type-md`, `--type-lg`, `--type-hero` (all 6 present in `tokens.css`)
+- [ ] 8 ThemeToggle unit tests pass (toggle state, localStorage persistence, aria-label, aria-label update after toggle)
+- [ ] 2 MapCanvas MutationObserver tests pass (setStyle called with correct URL on data-theme mutation to dark and to light)
+- [ ] FOUC script: `grep -c 'data-theme' frontend/dist/index.html` returns ≥ 1
+- [ ] Forbidden-token lint guard covers all named v3/v4 mock token names (accent, notable, bg-page, bg-surface, bg-tint, text-strong, text-body, text-muted, text-subtle, border)
+- [ ] Zero remaining pixel `font-size` literals in `styles.css` after migration
+
+---
+
 ## Spec reference
 
 - Token system (three tiers, namespace migration table, type ramp, light/dark mechanic): `docs/design/01-spec/tokens.md`


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["Plan author writes plan"] --> B["Adds '## Quantified plan literals' section\nbefore Task 1"]
    B --> C["Implementer works tasks"]
    C --> D{Each manifest\nitem checked?}
    D -- "Yes" --> E["Opens impl PR"]
    D -- "No" --> F["Cites lexically-matching\ndeferral doc (R13 T7 / #461)"]
    F --> E
    E --> G["Reviewer / bot verifies\nall items checked or deferred"]
    G -- "Gap found" --> H["T7 fires → SUGGESTION finding"]
    G -- "All covered" --> I["PR approved"]
```

## Summary

- Adds a **"Quantified plan literals"** convention section to `.claude/skills/writing-plans/SKILL.md`. Every plan containing numeric or universal quantifiers in its task ACs must enumerate them in a `## Quantified plan literals (implementer checklist)` section placed before Task 1. Ownership is explicit: plan author writes, implementer checks off (or cites a lexically-matching deferral per R13 T7 / #461), reviewer verifies.
- Retroactive Phase 1 manifest added to `docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md` with 9 literal entries (14 dark-mode tokens, 3-tier contract, 35 font-size migrations, 6-step type ramp, 8 ThemeToggle tests, 2 MapCanvas observer tests, FOUC grep, forbidden-token guard, zero-literal postcondition) — the documented walkback case.
- Skill text includes the T7 lexical-match worked example and retroactive backfill scope (Phase 1 only; 7 total phases, not 9).

## Screenshots

N/A — not UI. Skill markdown and plan doc edits only; no frontend code changes.

## Test plan

- [x] Skill markdown lints (no broken code fences, no missing section headers)
- [x] Phase 1 plan manifest section renders correctly with 9 checkbox entries
- [x] `npm run build --workspace @bird-watch/frontend` confirms zero build impact (pre-existing TypeScript error on `main` is unrelated to this change)
- [x] No new TS files, no new CSS, no new test files — CI impact is zero

## Plan reference

Part of Plan P4 (Sky Atlas v2 fidelity plan), closes #464. See `docs/plans/2026-05-09-sky-atlas-phase-1-token-foundation.md` (Phase 1 retroactive manifest) and `.claude/skills/writing-plans/SKILL.md` (convention addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
