### PR TITLE
chore(perf): preconnect to api.bird-maps.com + tiles.openfreemap.org (#458 W4-B)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,10 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
 
+    <!-- Preconnect: establish TCP+TLS to critical-path cross-origin hosts during parse -->
+    <link rel="preconnect" href="https://api.bird-maps.com" crossorigin>
+    <link rel="preconnect" href="https://tiles.openfreemap.org" crossorigin>
+
     <!-- [data-theme] inline blocking script — added in Phase 1; verify present above this comment -->
 
     <!-- Structured data -->


### PR DESCRIPTION
## Diagrams

N/A — HTML head hint, no data flow change.

## Summary

- Without `<link rel="preconnect">`, the browser performs DNS + TCP + TLS for `api.bird-maps.com` and `tiles.openfreemap.org` at first fetch time rather than during document parse, costing 300–600ms LCP on slow networks (perf.md Finding 4).
- Both tags carry `crossorigin` because `client.ts:60` calls `fetch()` in CORS mode (anonymous); without `crossorigin` the browser only resolves DNS and skips the TLS handshake, recovering only ~50–100ms instead of 200–400ms.
- Tags are placed before the inline `[data-theme]` boot script so the connection opens during the earliest possible parse phase.

## Screenshots

DOM verification via Playwright MCP at 1440×900 after `npm run dev`:

```
document.querySelectorAll('link[rel="preconnect"]') →
[
  { href: "https://api.bird-maps.com/", crossorigin: "" },
  { href: "https://tiles.openfreemap.org/", crossorigin: "" }
]
```

Both origins resolved successfully in Network panel (tiles.openfreemap.org: 200 on style, planet tiles, sprites, fonts; api.bird-maps.com: reachable). Console: 0 errors (3 pre-existing sprite warnings unrelated to this change).

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css` (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
  N/A — no className changes
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445). Verify: `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'` returns ≥ 10 (or marked `N/A — not UI`)
  N/A — HTML `<head>` only, no visible UI change

## Test plan

- [x] `npm run build --workspace @bird-watch/shared-types` — green (workaround for pre-existing TS issue)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build; both preconnect tags present in `dist/index.html` at lines 34–35
- [x] New unit / integration tests added — N/A (HTML head change, no runtime branch)
- [x] New Playwright e2e spec added — N/A (not user-visible behavior)
- [x] Playwright MCP smoke at 1440×900: `browser_navigate` to dev server, `browser_evaluate` confirmed both `link[rel="preconnect"]` elements in DOM with `crossorigin=""`, `browser_console_messages` returned 0 errors
- [x] Verified both cross-origin hosts appear in Network requests (tiles.openfreemap.org 200s on style/tiles/sprites/fonts)

## Plan reference

Out of plan — W4-B from Sky Atlas v2 fidelity plan (brainstorm-vs-prod-fidelity audit). Closes #458.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)