### PR TITLE
fix(a11y): aria-pressed + cluster-pill target size + nested-interactive markers (#459 W4-C)

### DIFF
--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -79,7 +79,8 @@ describe('<AppHeader>', () => {
 
   it('mounts the <ThemeToggle> in the right cluster', () => {
     render(<AppHeader {...baseProps} />);
-    // ThemeToggle from Phase 1 renders a button with aria-label like "Switch to dark theme"
-    expect(screen.getByRole('button', { name: /Switch to (light|dark) theme/i })).toBeInTheDocument();
+    // Fix #459 W4-C: ThemeToggle now uses a static aria-label + aria-pressed.
+    // The label no longer changes with theme state.
+    expect(screen.getByRole('button', { name: /Toggle color theme/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ThemeToggle.test.tsx
+++ b/frontend/src/components/ThemeToggle.test.tsx
@@ -62,23 +62,49 @@ describe('ThemeToggle', () => {
     expect(localStorage.getItem('theme')).toBe('dark');
   });
 
-  it('has an accessible aria-label that names the target theme', () => {
+  // Fix #459 W4-C: static aria-label + aria-pressed is the WAI-ARIA-compliant
+  // pattern for a toggle button. Changing aria-label to describe the *target*
+  // state (antipattern) causes AT to announce "Switch to dark theme, toggle
+  // button, pressed" after the toggle — incoherent. Static label + aria-pressed
+  // lets AT announce "Toggle color theme, toggle button, pressed/not pressed".
+  it('has a static aria-label that does not change on toggle', async () => {
     setTheme('light');
     render(<ThemeToggle />);
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-label',
-      'Switch to dark theme',
-    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-label', 'Toggle color theme');
+    await userEvent.click(btn);
+    // After toggle, the aria-label must remain the same static value
+    expect(btn).toHaveAttribute('aria-label', 'Toggle color theme');
   });
 
-  it('aria-label updates after toggle', async () => {
+  it('aria-pressed is false when theme is light', () => {
     setTheme('light');
     render(<ThemeToggle />);
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-label',
-      'Switch to light theme',
-    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('aria-pressed is true when theme is dark', () => {
+    setTheme('dark');
+    render(<ThemeToggle />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('aria-pressed toggles from false to true on click (light → dark)', async () => {
+    setTheme('light');
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+    await userEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('aria-pressed toggles from true to false on click (dark → light)', async () => {
+    setTheme('dark');
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    await userEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('button has no aria-live attribute (fix #416 — live region is a sibling)', () => {

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -49,15 +49,15 @@ export function ThemeToggle() {
     setTheme(next);
   }, [theme]);
 
-  const icon  = theme === 'light' ? '☀' : '☾';
-  const label = theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme';
+  const icon = theme === 'light' ? '☀' : '☾';
 
   return (
     <>
       <button
         type="button"
         onClick={toggle}
-        aria-label={label}
+        aria-label="Toggle color theme"
+        aria-pressed={theme === 'dark'}
       >
         {icon}
       </button>

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -371,6 +371,10 @@
   font-weight: var(--font-weight-semibold);
   white-space: nowrap;
   transition: transform var(--dur-fast), box-shadow var(--dur-fast);
+  /* WCAG 2.5.8 Target Size (Minimum) — 24×24px floor. Audit measured
+     sky-tier pills at ~21px tall on desktop; this ensures the touch target
+     meets the 24px minimum without altering the visual padding. */
+  min-height: 24px;
 }
 
 .cluster-pill:hover {

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -43,6 +43,54 @@ import {
 import { StackedSilhouetteMarker } from './StackedSilhouetteMarker.js';
 import { useAutoSpider } from './use-auto-spider.js';
 
+/**
+ * PresentationMarker — a <Marker> wrapper that removes `role="button"` from
+ * the maplibre-gl marker container div after mount.
+ *
+ * Why this is needed (WCAG 4.1.2 / #459 W4-C):
+ *   maplibre-gl's Marker.addTo() calls `setAttribute('role', 'button')` on
+ *   its container element unless a role is already present. When the Marker
+ *   children are themselves interactive elements (<button>: MosaicMarker,
+ *   StackedSilhouetteMarker, ClusterPill), the result is a `<div role="button">`
+ *   wrapping a `<button>` — a nested-interactive WCAG 4.1.2 violation that
+ *   axe-core flags on every visible marker (47 violations in the 2026-05-11
+ *   audit).
+ *
+ * Fix: react-map-gl's Marker component exposes the MapLibre MarkerInstance
+ * via forwardRef. After mount we set role="presentation" on the wrapper
+ * element. This overrides maplibre's role="button" and removes the
+ * interactive semantics from the container; the child <button> remains the
+ * canonical interactive element with full keyboard + AT support.
+ *
+ * We do NOT use aria-hidden="true" — that propagates to children and hides
+ * the inner <button> from assistive technologies (silent AT regression).
+ */
+interface PresentationMarkerProps {
+  longitude: number;
+  latitude: number;
+  anchor?: 'center' | 'top' | 'bottom' | 'left' | 'right' |
+    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  children: React.ReactNode;
+}
+
+function PresentationMarker({ longitude, latitude, anchor, children }: PresentationMarkerProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const markerRef = useRef<any>(null);
+
+  useEffect(() => {
+    const mk = markerRef.current;
+    if (mk && typeof mk.getElement === 'function') {
+      mk.getElement().setAttribute('role', 'presentation');
+    }
+  }, []);
+
+  return (
+    <Marker ref={markerRef} longitude={longitude} latitude={latitude} anchor={anchor}>
+      {children}
+    </Marker>
+  );
+}
+
 export interface MapCanvasProps {
   observations: Observation[];
   /**
@@ -1004,7 +1052,7 @@ export function MapCanvas({
         */}
         {Array.from(mosaics.values())
           .map((entry) => (
-            <Marker
+            <PresentationMarker
               key={entry.clusterId}
               longitude={entry.longitude}
               latitude={entry.latitude}
@@ -1014,7 +1062,7 @@ export function MapCanvas({
                 totalCount={entry.totalCount}
                 onClick={handleMosaicClick(entry)}
               />
-            </Marker>
+            </PresentationMarker>
           ))}
         {/*
           Issue #277 (Spider v2 Task 3): one <Marker>+<StackedSilhouetteMarker>
@@ -1024,7 +1072,7 @@ export function MapCanvas({
         */}
         {autoSpiderStacks.flatMap((stack) =>
           stack.leaves.map((leaf) => (
-            <Marker
+            <PresentationMarker
               key={leaf.subId}
               longitude={leaf.lngLat[0]}
               latitude={leaf.lngLat[1]}
@@ -1047,16 +1095,16 @@ export function MapCanvas({
                   if (obs) setSelectedObs(obs);
                 }}
               />
-            </Marker>
+            </PresentationMarker>
           )),
         )}
         {/* Phase 3: <ClusterPill> overlays — one per large cluster (point_count > 8).
             The mosaics reconciler handles point_count <= 8; pills cover the rest.
             Keyed by cluster_id so panning/zooming reconciles cleanly. */}
         {clusterFeatures.map((c) => (
-          <Marker key={c.cluster_id} longitude={c.lng} latitude={c.lat} anchor="center">
+          <PresentationMarker key={c.cluster_id} longitude={c.lng} latitude={c.lat} anchor="center">
             <ClusterPill count={c.point_count} onClick={() => handleClusterPillClick(c)} />
-          </Marker>
+          </PresentationMarker>
         ))}
       </MapView>
       {/* Issue #247 (original hit-layer) / #277 (Spider v2 narrowed to auto-spider stacks +


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    state "ThemeToggle button" as TT
    state "aria-pressed=false\naria-label='Toggle color theme'" as L
    state "aria-pressed=true\naria-label='Toggle color theme'" as D
    [*] --> L : light theme
    L --> D : click
    D --> L : click
    note right of L : Fix 1 — WCAG 4.1.2\nStatic label + aria-pressed\nreplaces dynamic label swap
```

```mermaid
graph LR
    A[".cluster-pill"] -->|"before: height ~21px"| B["WCAG 2.5.8 ❌"]
    A -->|"after: min-height 24px"| C["WCAG 2.5.8 ✅"]

    D["div (maplibre Marker)"] -->|"before: role=button wrapping button"| E["WCAG 4.1.2 nested-interactive ❌"]
    D -->|"after: role=presentation via PresentationMarker"| F["WCAG 4.1.2 ✅"]
```

## Summary

- **Why:** Three independent WCAG AA violations surfaced by the 2026-05-11 fidelity audit (W4-C): ThemeToggle lacked `aria-pressed` (4.1.2), cluster-pills were 21px tall below the 24px SC 2.5.8 minimum, and maplibre-gl's Marker class injected `role="button"` onto container divs wrapping child `<button>` elements — 47 nested-interactive violations at audit time.
- **Fix 1 (4.1.2):** Static `aria-label="Toggle color theme"` + `aria-pressed={theme === 'dark'}` — the WAI-ARIA toggle-button pattern. The prior dynamic-label swap plus `aria-pressed` is an antipattern; AT announces the label coherently only when it is state-invariant.
- **Fix 3 (4.1.2):** `PresentationMarker` wrapper calls `setAttribute('role', 'presentation')` on the maplibre Marker container after mount — overrides maplibre-gl's unconditional `role="button"` injection without using `aria-hidden` (which would propagate into child buttons and silently remove them from the AT tree).

## Screenshots

- [x] Every new/renamed `className` in this PR has a matching CSS rule (no new classNames added — only `min-height` added to existing `.cluster-pill`)
- [x] Multi-viewport design QA: 12 user-attachments URLs (6 surfaces × 2 themes)

**Map surface (ThemeToggle Fix 1 + Fix 3 visible in header + map container)**

| | Light (aria-pressed=false) | Dark (aria-pressed=true) |
|---|---|---|
| Mobile 390×844 | ![mobile-map-light](https://github.com/user-attachments/assets/8c4c7825-89f8-49b1-b911-ddae9df6956f) | ![mobile-map-dark](https://github.com/user-attachments/assets/a5222ab4-ebb8-4866-901b-9c85b3899948) |
| Desktop 1440×900 | ![desktop-map-light](https://github.com/user-attachments/assets/6ac6799d-82cc-4e17-ab64-80861fd9cbae) | ![desktop-map-dark](https://github.com/user-attachments/assets/085ad22a-0049-4bb8-9e7e-96481e5969dd) |

**Feed surface (ThemeToggle Fix 1 visible in header)**

| | Light | Dark |
|---|---|---|
| Mobile 390×844 | ![mobile-feed-light](https://github.com/user-attachments/assets/275d80b7-729c-44c9-9129-75005880c4cd) | ![mobile-feed-dark](https://github.com/user-attachments/assets/b324c4aa-4401-4963-a802-5c7d9a41ae5b) |
| Desktop 1440×900 | ![desktop-feed-light](https://github.com/user-attachments/assets/cd99c819-4a3f-40c4-b92a-ded511867240) | ![desktop-feed-dark](https://github.com/user-attachments/assets/7074d830-f4b3-4565-b528-138f4696d2dd) |

**ThemeToggle close-up (Fix 1 — aria-pressed state per viewport)**

| | Light (aria-pressed=false) | Dark (aria-pressed=true) |
|---|---|---|
| Mobile 390×844 | ![mobile-light-theme](https://github.com/user-attachments/assets/6c1829bb-3643-438c-9dd0-a6ffa8e02605) | ![mobile-dark-theme](https://github.com/user-attachments/assets/ced41b8a-23e7-411a-99c8-4bfaa7e23a26) |
| Desktop 1440×900 | ![desktop-light-theme](https://github.com/user-attachments/assets/37ee5830-18f1-4939-8618-66f12732e1ce) | ![desktop-dark-theme](https://github.com/user-attachments/assets/197a511a-47d4-4751-b85d-a449ceb4c92b) |

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 734/734 passing (63 test files)
- [x] New unit tests added: `ThemeToggle.test.tsx` — 8 new aria-pressed/static-label assertions (regression coverage for Fix 1)
- [x] `AppHeader.test.tsx` updated to match static label
- [x] No new Playwright e2e spec needed — fixes are semantic (ARIA attribute changes), not behavioral; existing axe.spec.ts covers SC 4.1.2
- [x] `npm run build --workspace @bird-watch/frontend` — clean build (✓ built in 348ms)
- [x] Playwright MCP smoke at 390×844 (mobile) and 1440×900 (desktop), both `[data-theme]` states — zero console errors, zero warnings
- [x] axe-core injected at both viewports × both themes — 0 violations for `button-name`, `aria-required-attr`, `aria-valid-attr`, `aria-valid-attr-value`, `nested-interactive`, `target-size` rules
- [x] Fix 1 verified: `aria-label="Toggle color theme"` (static), `aria-pressed="true"` in dark mode, `aria-pressed="false"` in light mode — confirmed in browser DOM
- [x] Fix 2 verified: `.cluster-pill` CSS rule has `min-height: 24px`; computed style on dynamically created sky-tier pill = 24px
- [x] Fix 3 verified: zero `div[role="button"]` elements in the live DOM — maplibre marker containers correctly carry `role="presentation"`

## Plan reference

Closes #459. Out of plan — accessibility remediation from the 2026-05-11 Sky Atlas fidelity audit (W4-C row in `docs/analyses/2026-05-11-brainstorm-vs-prod-fidelity/phase-4/analysis-report.md`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)