### PR TITLE
fix(silhouettes): bind DB color to FeedSurface + FamilyLegend silhouettes (NEW-3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -335,6 +335,7 @@ export function App() {
             period={period}
             freshness={freshnessState}
             freshnessLabel={freshnessLabel}
+            silhouettes={silhouettes}
             {...(speciesName !== undefined ? { speciesName } : {})}
             {...(familyName !== undefined ? { familyName } : {})}
           />

--- a/frontend/src/components/FamilyLegend.test.tsx
+++ b/frontend/src/components/FamilyLegend.test.tsx
@@ -393,3 +393,44 @@ describe('Phase 3: shape-paired swatches', () => {
     }
   });
 });
+
+describe('DB color binding (NEW-3 fix)', () => {
+  it('legend silhouette chips use the DB color from silhouettes[].color, not the grey fallback', () => {
+    // The tyrannidae silhouette has color '#C77A2E' in baseSilhouettes.
+    // Before the fix, every entry rendered grey (#5a6472 / null-family fallback)
+    // because the legend passed paletteCode=null for all unknown family codes.
+    // After the fix, the silhouette.color from the DB payload must reach
+    // <FamilySilhouette color="..."> and override channel.fill.
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    // Find the tyrannidae entry's FamilySilhouette span
+    const tyrEntry = screen.getByRole('button', { name: /Tyrant Flycatchers/ });
+    const silhouette = tyrEntry.querySelector('[data-testid="family-silhouette"]') as HTMLElement;
+    expect(silhouette).not.toBeNull();
+    // Must use DB color #C77A2E, NOT the grey null-family fallback #5a6472
+    expect(silhouette.style.getPropertyValue('--family-fill')).toBe('#C77A2E');
+  });
+
+  it('trochilidae legend chip uses its DB color', () => {
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    const trochEntry = screen.getByRole('button', { name: /Hummingbirds/ });
+    const silhouette = trochEntry.querySelector('[data-testid="family-silhouette"]') as HTMLElement;
+    expect(silhouette).not.toBeNull();
+    expect(silhouette.style.getPropertyValue('--family-fill')).toBe('#7B2D8E');
+  });
+});

--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -160,11 +160,11 @@ export function FamilyLegend({
         >
           {entries.map(entry => {
             const active = entry.familyCode === familyCode;
-            // Resolve the palette channel for shape encoding. Codes not
-            // in FAMILY_PALETTE (e.g. novel families not yet in the type
-            // union) fall back to the null channel via getFamilyChannel(null),
-            // which returns a neutral grey circle — shape still satisfies
-            // WCAG 1.4.1 (circle is the null-family sentinel).
+            // Shape is still sourced from the palette channel (WCAG 1.4.1 —
+            // color is not the sole discriminator). Codes not in FAMILY_PALETTE
+            // fall back to the null-channel shape (circle). The fill color,
+            // however, now comes from the DB silhouettes payload via the `color`
+            // prop — the palette fill is shape-encoding-only after this fix.
             const paletteCode = (entry.familyCode in FAMILY_PALETTE)
               ? (entry.familyCode as FamilyCode)
               : null;
@@ -180,9 +180,10 @@ export function FamilyLegend({
                   onClick={() => onFamilyToggle(entry.familyCode)}
                 >
                   <FamilySilhouette
-                    family={paletteCode}
+                    family={entry.familyCode}
                     layout="thumb"
                     shape={shape}
+                    color={entry.silhouette.color}
                   />
                   <span className="family-legend-entry-label">{entry.label}</span>
                   <span

--- a/frontend/src/components/FeedCard.tsx
+++ b/frontend/src/components/FeedCard.tsx
@@ -12,6 +12,11 @@ export interface FeedCardProps {
   observation: NotableObservation;
   now: Date;
   onSelectSpecies: (speciesCode: string) => void;
+  /**
+   * Concrete hex color from the DB silhouettes payload. When provided, overrides
+   * the palette channel fill in <FamilySilhouette>. Absent = palette/grey fallback.
+   */
+  color?: string;
 }
 
 /**
@@ -49,7 +54,7 @@ export interface FeedCardProps {
  *   </li>
  */
 export function FeedCard(props: FeedCardProps) {
-  const { observation, now, onSelectSpecies } = props;
+  const { observation, now, onSelectSpecies, color } = props;
 
   const countSlot =
     observation.howMany === null
@@ -84,6 +89,7 @@ export function FeedCard(props: FeedCardProps) {
         <FamilySilhouette
           family={observation.familyCode}
           layout="inline"
+          {...(color !== undefined ? { color } : {})}
         />
         <div className="feed-card-body">
           <span className="feed-card-meta" aria-hidden="true">NOTABLE</span>

--- a/frontend/src/components/FeedRow.test.tsx
+++ b/frontend/src/components/FeedRow.test.tsx
@@ -184,4 +184,29 @@ describe('FeedRow', () => {
     );
     expect(container.firstChild?.nodeName).toBe('LI');
   });
+
+  describe('DB color binding (NEW-3 fix)', () => {
+    it('renders grey fallback when no color prop is provided', () => {
+      // Without the color prop, the silhouette falls back to the null-family
+      // grey (#5a6472) because tyrannidae is not in the 7-item FamilyCode union.
+      render(<FeedRow observation={BASE_OBS} now={NOW} onSelectSpecies={() => {}} />);
+      const silhouette = screen.getByTestId('family-silhouette') as HTMLElement;
+      // Without color prop: grey fallback from NULL_FAMILY_CHANNEL
+      expect(silhouette.style.getPropertyValue('--family-fill')).toBe('#5a6472');
+    });
+
+    it('uses the color prop to tint the FamilySilhouette with DB color', () => {
+      // When the parent threads the DB color down, it must reach the silhouette.
+      render(
+        <FeedRow
+          observation={BASE_OBS}
+          now={NOW}
+          onSelectSpecies={() => {}}
+          color="#C77A2E"
+        />
+      );
+      const silhouette = screen.getByTestId('family-silhouette') as HTMLElement;
+      expect(silhouette.style.getPropertyValue('--family-fill')).toBe('#C77A2E');
+    });
+  });
 });

--- a/frontend/src/components/FeedRow.tsx
+++ b/frontend/src/components/FeedRow.tsx
@@ -7,6 +7,13 @@ export interface FeedRowProps {
   observation: Observation;
   now: Date;
   onSelectSpecies: (speciesCode: string) => void;
+  /**
+   * Concrete hex color from the DB silhouettes payload resolved by the
+   * parent (FeedSurface) via buildFamilyColorResolver. When provided,
+   * overrides the palette channel fill in <FamilySilhouette>. When absent,
+   * falls back to the null-family grey (graceful degradation).
+   */
+  color?: string;
 }
 
 /**
@@ -45,7 +52,7 @@ export interface FeedRowProps {
  * identity-stable onSelectSpecies (useCallback in parent).
  */
 function FeedRowImpl(props: FeedRowProps) {
-  const { observation, now, onSelectSpecies } = props;
+  const { observation, now, onSelectSpecies, color } = props;
 
   function activate() {
     onSelectSpecies(observation.speciesCode);
@@ -86,6 +93,7 @@ function FeedRowImpl(props: FeedRowProps) {
         <FamilySilhouette
           family={observation.familyCode}
           layout="thumb"
+          {...(color !== undefined ? { color } : {})}
         />
         <span className="feed-row-name" aria-hidden="true">{observation.comName}</span>
         {countContent.chip !== null && (

--- a/frontend/src/components/FeedSurface.test.tsx
+++ b/frontend/src/components/FeedSurface.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import type { Observation, FamilySilhouette } from '@bird-watch/shared-types';
 import type { SpeciesOption } from './FiltersBar.js';
 import { FeedSurface } from './FeedSurface.js';
+import { FAMILY_COLOR_FALLBACK } from '../data/family-color.js';
 
 const NOW = new Date(2026, 3, 15, 15, 0, 0, 0);
 
@@ -644,11 +645,10 @@ describe('FeedSurface — DB color threading (NEW-3 fix)', () => {
     );
     const silhouetteEl = container.querySelector('[data-testid="family-silhouette"]') as HTMLElement;
     expect(silhouetteEl).not.toBeNull();
-    // Without silhouettes, resolveColor('tyrannidae') returns FAMILY_COLOR_FALLBACK
-    // (#555). That gets passed as color prop. To preserve the true grey-fallback
-    // behavior, we verify the silhouette is NOT the DB orange — the actual value
-    // is the FAMILY_COLOR_FALLBACK from buildFamilyColorResolver.
-    expect(silhouetteEl.style.getPropertyValue('--family-fill')).not.toBe('#C77A2E');
+    // Without silhouettes, resolveColor('tyrannidae') returns FAMILY_COLOR_FALLBACK.
+    // Assert the exact fallback value rather than negating the DB orange — safer
+    // because a future palette change wouldn't silently pass a wrong value.
+    expect(silhouetteEl.style.getPropertyValue('--family-fill')).toBe(FAMILY_COLOR_FALLBACK);
   });
 });
 

--- a/frontend/src/components/FeedSurface.test.tsx
+++ b/frontend/src/components/FeedSurface.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { Observation } from '@bird-watch/shared-types';
+import type { Observation, FamilySilhouette } from '@bird-watch/shared-types';
 import type { SpeciesOption } from './FiltersBar.js';
 import { FeedSurface } from './FeedSurface.js';
 
@@ -579,6 +579,76 @@ describe('FeedSurface', () => {
       await user.click(screen.getByRole('button', { name: /Notable sighting/i }));
       expect(onSelectSpecies).toHaveBeenCalledWith('vermfly');
     });
+  });
+});
+
+describe('FeedSurface — DB color threading (NEW-3 fix)', () => {
+  const silhouettes: FamilySilhouette[] = [
+    {
+      familyCode: 'tyrannidae',
+      color: '#C77A2E',
+      svgData: null,
+      source: null,
+      license: null,
+      commonName: 'Tyrant Flycatchers',
+      creator: null,
+    },
+  ];
+
+  // Construct an observation with a real familyCode. The obs() helper always
+  // sets familyCode: null; build inline to exercise the color-resolution path.
+  const obsWithFamily: Observation = {
+    subId: 'S-color',
+    speciesCode: 'vermfly',
+    comName: 'Vermilion Flycatcher',
+    lat: 32.2,
+    lng: -110.9,
+    obsDt: new Date(NOW.getTime() - 60 * 60_000).toISOString(),
+    locId: 'L001',
+    locName: 'Sabino Canyon',
+    howMany: 1,
+    isNotable: false,
+    regionId: null,
+    silhouetteId: null,
+    familyCode: 'tyrannidae',
+  };
+
+  it('threads DB color to feed row silhouettes when silhouettes prop is provided', () => {
+    const { container } = render(
+      <FeedSurface
+        loading={false}
+        observations={[obsWithFamily]}
+        now={NOW}
+        filters={{ notable: false, since: '14d' }}
+        onSelectSpecies={() => {}}
+        silhouettes={silhouettes}
+      />
+    );
+    // The FeedRow FamilySilhouette must carry the DB color, not the grey fallback.
+    const silhouetteEl = container.querySelector('[data-testid="family-silhouette"]') as HTMLElement;
+    expect(silhouetteEl).not.toBeNull();
+    expect(silhouetteEl.style.getPropertyValue('--family-fill')).toBe('#C77A2E');
+  });
+
+  it('falls back to grey when silhouettes prop is absent (backward compat)', () => {
+    // FeedSurface callers that haven't passed silhouettes yet must still work.
+    // Unknown family code → null-family grey fallback.
+    const { container } = render(
+      <FeedSurface
+        loading={false}
+        observations={[obsWithFamily]}
+        now={NOW}
+        filters={{ notable: false, since: '14d' }}
+        onSelectSpecies={() => {}}
+      />
+    );
+    const silhouetteEl = container.querySelector('[data-testid="family-silhouette"]') as HTMLElement;
+    expect(silhouetteEl).not.toBeNull();
+    // Without silhouettes, resolveColor('tyrannidae') returns FAMILY_COLOR_FALLBACK
+    // (#555). That gets passed as color prop. To preserve the true grey-fallback
+    // behavior, we verify the silhouette is NOT the DB orange — the actual value
+    // is the FAMILY_COLOR_FALLBACK from buildFamilyColorResolver.
+    expect(silhouetteEl.style.getPropertyValue('--family-fill')).not.toBe('#C77A2E');
   });
 });
 

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { Observation, NotableObservation } from '@bird-watch/shared-types';
+import type { Observation, NotableObservation, FamilySilhouette } from '@bird-watch/shared-types';
 import type { Since } from '../state/url-state.js';
 import type { SpeciesOption } from './FiltersBar.js';
 import { FeedCard } from './FeedCard.js';
@@ -7,6 +7,7 @@ import { FeedRow } from './FeedRow.js';
 import { FilterSentence } from './ds/FilterSentence.js';
 import { SortLabel } from './ds/SortLabel.js';
 import type { Freshness } from './MapLede.js';
+import { buildFamilyColorResolver } from '../data/family-color.js';
 
 export interface FeedSurfaceFilters {
   notable: boolean;
@@ -61,6 +62,12 @@ export interface FeedSurfaceProps {
    * Displayed below the lede on the feed surface.
    */
   freshnessLabel?: string;
+  /**
+   * Family silhouettes from the DB (via /api/silhouettes). Used to resolve
+   * per-family colors for each FeedRow's <FamilySilhouette>. Optional for
+   * backward-compat — when absent, rows fall back to the null-family grey.
+   */
+  silhouettes?: FamilySilhouette[];
 }
 
 /**
@@ -101,7 +108,17 @@ export function FeedSurface(props: FeedSurfaceProps) {
     familyName,
     freshness = 'fresh',
     freshnessLabel,
+    silhouettes,
   } = props;
+
+  // Build the familyCode → color resolver once per silhouettes identity change.
+  // When silhouettes is absent or empty, the resolver always returns the grey
+  // fallback (FAMILY_COLOR_FALLBACK) — backward-compat with callers that
+  // haven't yet threaded silhouettes down.
+  const resolveColor = useMemo(
+    () => buildFamilyColorResolver(silhouettes ?? []),
+    [silhouettes],
+  );
 
   const [sortMode, setSortMode] = useState<FeedSortMode>('recent');
 
@@ -254,14 +271,18 @@ export function FeedSurface(props: FeedSurfaceProps) {
             onSelectSpecies={onSelectSpecies}
           />
         )}
-        {flatObservations.map(o => (
-          <FeedRow
-            key={`${o.subId}:${o.speciesCode}`}
-            observation={o}
-            now={now}
-            onSelectSpecies={onSelectSpecies}
-          />
-        ))}
+        {flatObservations.map(o => {
+          const familyColor = o.familyCode ? resolveColor(o.familyCode) : undefined;
+          return (
+            <FeedRow
+              key={`${o.subId}:${o.speciesCode}`}
+              observation={o}
+              now={now}
+              onSelectSpecies={onSelectSpecies}
+              {...(familyColor !== undefined ? { color: familyColor } : {})}
+            />
+          );
+        })}
       </ol>
     </div>
   );

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -263,14 +263,18 @@ export function FeedSurface(props: FeedSurfaceProps) {
 
       {/* Unified observation list: top-notable card-row first, then flat rows */}
       <ol className="feed" aria-label="Observations">
-        {topNotable && (
-          <FeedCard
-            key={`card:${topNotable.subId}:${topNotable.speciesCode}`}
-            observation={topNotable}
-            now={now}
-            onSelectSpecies={onSelectSpecies}
-          />
-        )}
+        {topNotable && (() => {
+          const notableColor = topNotable.familyCode ? resolveColor(topNotable.familyCode) : undefined;
+          return (
+            <FeedCard
+              key={`card:${topNotable.subId}:${topNotable.speciesCode}`}
+              observation={topNotable}
+              now={now}
+              onSelectSpecies={onSelectSpecies}
+              {...(notableColor !== undefined ? { color: notableColor } : {})}
+            />
+          );
+        })()}
         {flatObservations.map(o => {
           const familyColor = o.familyCode ? resolveColor(o.familyCode) : undefined;
           return (

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -6,6 +6,7 @@ import type { SpeciesMeta, FamilySilhouette } from '@bird-watch/shared-types';
 import { __resetSilhouettesCache } from '../data/use-silhouettes.js';
 import { __resetSpeciesDetailCache } from '../data/use-species-detail.js';
 import { analytics } from '../analytics.js';
+import { FAMILY_COLOR_FALLBACK } from '../data/family-color.js';
 
 // Mock posthog-js so no network call escapes the test environment, even
 // if a future contributor sets `VITE_POSTHOG_KEY` in their local .env.
@@ -347,6 +348,27 @@ describe('SpeciesDetailSurface', () => {
     await waitFor(() =>
       expect(container.querySelector('.family-silhouette')).not.toBeNull()
     );
+  });
+
+  it('masthead silhouette carries family DB color (not grey) when photoUrl is null and silhouettes resolve', async () => {
+    // Bot finding on #480: Photo.color was added but SpeciesDetailSurface never
+    // resolved or forwarded it. When data.photoUrl is null the silhouette must
+    // render in the family's DB color, not the FAMILY_COLOR_FALLBACK grey.
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    // Wait for the silhouette to render (data and silhouettes must both resolve).
+    const silhouetteEl = await waitFor(() => {
+      const el = container.querySelector('.family-silhouette') as HTMLElement | null;
+      if (!el) throw new Error('.family-silhouette not yet rendered');
+      return el;
+    });
+    // The DB color (#C77A2E) from TYRANNIDAE_SILHOUETTE must be wired through
+    // buildFamilyColorResolver → Photo.color → FamilySilhouette → --family-fill.
+    expect(silhouetteEl.style.getPropertyValue('--family-fill')).toBe('#C77A2E');
+    expect(silhouetteEl.style.getPropertyValue('--family-fill')).not.toBe(FAMILY_COLOR_FALLBACK);
   });
 
   // ─── Analytics instrumentation (issue #357 tasks 3, 4) ─────────────────

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
 import { useSilhouettes } from '../data/use-silhouettes.js';
+import { buildFamilyColorResolver } from '../data/family-color.js';
 import { analytics } from '../analytics.js';
 import { PhenologyChart } from './PhenologyChart.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
@@ -40,10 +41,18 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   const { speciesCode, apiClient } = props;
   const detail = useSpeciesDetail(apiClient, speciesCode);
   const { loading, error, data } = detail;
-  // useSilhouettes is still mounted here so the <Photo> component's
-  // internal FamilySilhouette fallback can find the family payload. The
-  // data is cached at module level so there is no second network call.
-  void useSilhouettes(apiClient);
+  // useSilhouettes provides the family-color payload. The data is cached at
+  // module level so there is no second network call when other consumers
+  // (App.tsx, AttributionModal) have already called the hook.
+  const { silhouettes } = useSilhouettes(apiClient);
+
+  // Build the familyCode → color resolver once per silhouettes identity change.
+  // Mirrors the FeedSurface pattern so the masthead silhouette renders in the
+  // family's DB color when photoUrl is null (bot finding on #480).
+  const resolveColor = useMemo(
+    () => buildFamilyColorResolver(silhouettes),
+    [silhouettes],
+  );
 
   // Analytics: panel_opened / panel_dwell_ms (preserved from pre-Phase-4).
   useEffect(() => {
@@ -119,6 +128,7 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
         src={data.photoUrl ?? null}
         alt={`${data.comName} photo`}
         family={data.familyCode as FamilyCode | null}
+        color={resolveColor(data.familyCode)}
         priority={true}
         layout="masthead"
       />

--- a/frontend/src/components/ds/FamilySilhouette.test.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.test.tsx
@@ -77,6 +77,37 @@ describe('<FamilySilhouette>', () => {
     expect(document.querySelector('.family-silhouette--circle')).toBeInTheDocument();
   });
 
+  // --- color prop (DB-sourced hex override) ---
+
+  it('uses the color prop as --family-fill when provided, overriding the palette fill', () => {
+    // The DB silhouettes payload ships real hex per familyCode. When passed as
+    // `color`, it must win over the palette channel's fill regardless of whether
+    // `family` is a known FamilyCode or a raw eBird code.
+    render(<FamilySilhouette family="tyrannidae" color="#C77A2E" />);
+    const el = document.querySelector('[data-testid="family-silhouette"]');
+    expect(el).toBeInTheDocument();
+    // color prop must override the null-family fallback (#5a6472)
+    expect(el).toHaveStyle({ '--family-fill': '#C77A2E' });
+  });
+
+  it('uses the color prop as --family-fill for a known FamilyCode too', () => {
+    // Even for known family codes, the DB color (passed as prop) wins over the
+    // palette — the palette's fill becomes shape-encoding-only.
+    render(<FamilySilhouette family="raptor" color="#FF0000" />);
+    const el = document.querySelector('[data-testid="family-silhouette"]');
+    expect(el).toHaveStyle({ '--family-fill': '#FF0000' });
+  });
+
+  it('falls back to palette fill when color prop is absent', () => {
+    // When color is not provided, the existing palette-channel fill applies.
+    // This preserves the graceful degradation path (null silhouettes / missing
+    // color) so components that don't yet thread color remain grey.
+    render(<FamilySilhouette family="raptor" />);
+    const el = document.querySelector('[data-testid="family-silhouette"]');
+    // raptor palette fill is #8b5e3c (FAMILY_PALETTE)
+    expect(el).toHaveStyle({ '--family-fill': '#8b5e3c' });
+  });
+
   // --- Unknown / raw eBird codes ---
 
   it('renders the null-family neutral path (not a crash) for an unknown raw eBird family code', () => {

--- a/frontend/src/components/ds/FamilySilhouette.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.tsx
@@ -34,6 +34,15 @@ export interface FamilySilhouetteProps {
   layout?: SilhouetteLayout;
   /** Overrides the palette's default shape if provided. */
   shape?: ShapeVariant;
+  /**
+   * Concrete hex color from the DB silhouettes payload (e.g. "#C77A2E").
+   * When provided, overrides the palette channel's fill in the inline style.
+   * The FAMILY_PALETTE fill becomes shape-encoding-only when this is set.
+   * If absent, falls back to the palette channel fill (or neutral grey for
+   * unknown/null families). This preserves graceful degradation for
+   * consumers that haven't yet threaded the silhouettes color down.
+   */
+  color?: string;
   /** aria-label for standalone use. Omit when inside <Photo> (aria-hidden). */
   ariaLabel?: string;
 }
@@ -71,6 +80,7 @@ export function FamilySilhouette({
   family,
   layout = 'inline',
   shape: shapeProp,
+  color,
   ariaLabel,
 }: FamilySilhouetteProps): ReactNode {
   // Narrow to a known FamilyCode if recognized; treat unknowns as null.
@@ -87,6 +97,10 @@ export function FamilySilhouette({
   // prop (string) so TypeScript can verify the index against the Record type.
   const pathKey = knownFamily ?? '__null__';
   const path = FAMILY_PATHS[pathKey];
+  // `color` prop (DB-sourced hex) takes precedence over the palette channel
+  // fill. The palette's fill becomes shape-encoding-only when color is set.
+  // This makes the DB silhouettes table the single source of truth for color.
+  const fill = color ?? channel.fill;
 
   const classes = [
     'family-silhouette',
@@ -102,7 +116,7 @@ export function FamilySilhouette({
       data-testid="family-silhouette"
       data-family={String(family)}
       data-layout={layout}
-      style={{ '--family-fill': channel.fill } as React.CSSProperties}
+      style={{ '--family-fill': fill } as React.CSSProperties}
     >
       <svg
         viewBox="0 0 100 100"

--- a/frontend/src/components/ds/Photo.tsx
+++ b/frontend/src/components/ds/Photo.tsx
@@ -41,6 +41,11 @@ export interface PhotoProps {
   priority?: boolean;
   attribution?: { text: string; href: string };
   layout?: PhotoLayout;
+  /**
+   * Concrete hex color from the DB silhouettes payload. When provided, overrides
+   * the palette channel fill in <FamilySilhouette>. Absent = palette/grey fallback.
+   */
+  color?: string;
 }
 
 type PhotoInternalState = 'null' | 'loading' | 'loaded' | 'errored';
@@ -52,6 +57,7 @@ export function Photo({
   priority = false,
   attribution,
   layout = 'inline',
+  color,
 }: PhotoProps): ReactNode {
   const [imgState, setImgState] = useState<PhotoInternalState>(
     src === null ? 'null' : 'loading'
@@ -88,7 +94,11 @@ export function Photo({
   if (showSilhouette) {
     return (
       <span className={classes}>
-        <FamilySilhouette family={family} layout={layout} />
+        <FamilySilhouette
+          family={family}
+          layout={layout}
+          {...(color !== undefined ? { color } : {})}
+        />
       </span>
     );
   }


### PR DESCRIPTION
## Diagrams

\`\`\`mermaid
graph LR
    DB["/api/silhouettes\nfamilyCode, color"] -->|buildFamilyColorResolver| Resolver
    Resolver -->|resolveColor| FeedSurface
    FeedSurface -->|color prop| FeedRow
    FeedSurface -->|color prop| FeedCard
    FeedRow -->|color prop| FSil["FamilySilhouette"]
    FeedCard -->|color prop| FSil
    FSil -->|"--family-fill: color ?? channel.fill"| SVG

    FamilyLegend -->|entry.silhouette.color| FSil2["FamilySilhouette"]
    FSil2 -->|"--family-fill: color ?? channel.fill"| SVG2["SVG"]
\`\`\`

## Summary

- Every \`<FamilySilhouette>\` on the Feed and Legend surfaces was rendering flat grey (\`#5a6472\` light / \`#8a98ad\` dark) because \`FamilyCode\` is a 7-item abstract union while the API ships real eBird taxonomy codes (\`tyrannidae\`, \`accipitridae\`, etc.) — the codes never matched \`FAMILY_PATHS\` so \`knownFamily\` collapsed to null.
- Added a \`color?: string\` prop to \`FamilySilhouette\` (and \`Photo\` as its silhouette-fallback consumer) so callers can inject the DB-sourced hex directly, bypassing the palette lookup for fill while shape remains palette-controlled (WCAG 1.4.1).
- Wired \`buildFamilyColorResolver\` (previously built but unused in production) into \`FeedSurface\` via \`useMemo\`, threads resolved colors down to \`FeedRow\` and \`FeedCard\`; \`FamilyLegend\` picks up \`entry.silhouette.color\` directly from its already-threaded prop.

## Screenshots

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

Before and after screenshots captured from `bird-maps.com` at 5 canonical viewports. "After" screenshots used JS color injection to simulate the fix (prod deploy needed for real after). Before = flat grey silhouettes (BUG). After = DB-sourced family colors (FIX).

### 390×844 (iPhone 14 Pro / mobile)

| Before (BEFORE — grey) | After (AFTER — colors) | After dark |
|---|---|---|
| ![before-mobile-390x844-light](https://github.com/user-attachments/assets/b037af19-8eaf-4504-a1b7-368be064bed6) | ![after-mobile-390x844-light](https://github.com/user-attachments/assets/1c5a2a25-a0c7-4ea0-9f27-3e5b479b5b84) | ![after-mobile-390x844-dark](https://github.com/user-attachments/assets/c5d8ce9a-b9a4-4859-a799-170aaa7cd18a) |

### 768×1024 (iPad portrait / tablet)

| Before | After light | After dark |
|---|---|---|
| ![before-tablet-768x1024-light](https://github.com/user-attachments/assets/159c7179-4acf-4942-8282-653cbd26d738) | ![after-tablet-768x1024-light](https://github.com/user-attachments/assets/19a6b4ea-e853-42ea-b42d-cc0f812fcd6c) | ![after-tablet-768x1024-dark](https://github.com/user-attachments/assets/e84dc5a3-9adc-40e1-9d9a-7b0020e1cc11) |

### 1024×768 (iPad landscape / small laptop)

| Before | After light | After dark |
|---|---|---|
| ![before-laptop-1024x768-light](https://github.com/user-attachments/assets/13d0ef2b-6ba7-4a4d-a056-a054f6fbfac5) | ![after-laptop-1024x768-light](https://github.com/user-attachments/assets/caec0203-dfee-44a1-a91d-745c464bdbd6) | ![after-laptop-1024x768-dark](https://github.com/user-attachments/assets/9bba4c2f-9bf5-42ed-88af-d5803c0f2e32) |

### 1440×900 (desktop standard)

| Before | After light | After dark |
|---|---|---|
| ![before-desktop-1440x900-light](https://github.com/user-attachments/assets/944f3e40-2b8a-46cc-849e-abcddc2bce06) | ![after-desktop-1440x900-light](https://github.com/user-attachments/assets/32b5fe6a-b6ab-4502-b763-1592bcb9db76) | ![after-desktop-1440x900-dark](https://github.com/user-attachments/assets/44c35c32-2112-4744-9763-bc27de84d384) |

### 1920×1080 (wide desktop)

| Before | After light | After dark |
|---|---|---|
| ![before-wide-1920x1080-light](https://github.com/user-attachments/assets/be9ccac1-3b63-4ea2-9231-f0cbadfdfada) | ![after-wide-1920x1080-light](https://github.com/user-attachments/assets/cf6cbefc-b02e-4654-82e0-50f5476cdc6e) | ![after-wide-1920x1080-dark](https://github.com/user-attachments/assets/1edb649a-3eb2-4469-9ba2-7d8d8586cbd4) |

## Test plan

- [x] \`npm run typecheck && npm run test\` — green (694 tests, 9 new, same 2 pre-existing MapCanvas CSS failures)
- [x] New unit / integration tests added: \`FamilySilhouette.test.tsx\` (+3), \`FamilyLegend.test.tsx\` (+2), \`FeedRow.test.tsx\` (+2), \`FeedSurface.test.tsx\` (+2)
- [x] New Playwright e2e spec added — N/A; color binding is unit-tested via DOM assertion on \`--family-fill\`
- [x] \`npm run build\` — clean production build
- [x] (UI only) Playwright MCP smoke — captured at 5 canonical viewports × 2 themes from prod \`bird-maps.com\` with JS color injection simulating the fix; \`browser_console_messages\` returned 0 errors, 0 warnings at all viewports

## Plan reference

Out of plan — resolves NEW-3 BLOCKER from 2026-04-27 codebase drift audit (\`docs/analyses/2026-04-27-codebase-drift-audit/report.md\`): every \`<FamilySilhouette>\` standalone instance renders grey regardless of family.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)