### PR TITLE
fix(silhouettes): bind family shape from DB to legend + feed + detail (NEW-3 follow-up)

### DIFF
--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -184,6 +184,7 @@ export function FamilyLegend({
                     layout="thumb"
                     shape={shape}
                     color={entry.silhouette.color}
+                    {...(entry.silhouette.svgData != null ? { pathD: entry.silhouette.svgData } : {})}
                   />
                   <span className="family-legend-entry-label">{entry.label}</span>
                   <span

--- a/frontend/src/components/FeedCard.tsx
+++ b/frontend/src/components/FeedCard.tsx
@@ -17,6 +17,12 @@ export interface FeedCardProps {
    * the palette channel fill in <FamilySilhouette>. Absent = palette/grey fallback.
    */
   color?: string;
+  /**
+   * Raw SVG path string from the DB silhouettes payload. When provided, overrides
+   * the abstract FAMILY_PATHS lookup in <FamilySilhouette>.
+   * Absent = abstract palette path fallback.
+   */
+  pathD?: string | null;
 }
 
 /**
@@ -54,7 +60,7 @@ export interface FeedCardProps {
  *   </li>
  */
 export function FeedCard(props: FeedCardProps) {
-  const { observation, now, onSelectSpecies, color } = props;
+  const { observation, now, onSelectSpecies, color, pathD } = props;
 
   const countSlot =
     observation.howMany === null
@@ -90,6 +96,7 @@ export function FeedCard(props: FeedCardProps) {
           family={observation.familyCode}
           layout="inline"
           {...(color !== undefined ? { color } : {})}
+          {...(pathD != null ? { pathD } : {})}
         />
         <div className="feed-card-body">
           <span className="feed-card-meta" aria-hidden="true">NOTABLE</span>

--- a/frontend/src/components/FeedRow.tsx
+++ b/frontend/src/components/FeedRow.tsx
@@ -14,6 +14,13 @@ export interface FeedRowProps {
    * falls back to the null-family grey (graceful degradation).
    */
   color?: string;
+  /**
+   * Raw SVG path string from the DB silhouettes payload resolved by the
+   * parent (FeedSurface) via buildFamilyPathResolver. When provided,
+   * overrides the abstract FAMILY_PATHS lookup in <FamilySilhouette>.
+   * When absent, falls back to the abstract palette path (graceful degradation).
+   */
+  pathD?: string | null;
 }
 
 /**
@@ -52,7 +59,7 @@ export interface FeedRowProps {
  * identity-stable onSelectSpecies (useCallback in parent).
  */
 function FeedRowImpl(props: FeedRowProps) {
-  const { observation, now, onSelectSpecies, color } = props;
+  const { observation, now, onSelectSpecies, color, pathD } = props;
 
   function activate() {
     onSelectSpecies(observation.speciesCode);
@@ -94,6 +101,7 @@ function FeedRowImpl(props: FeedRowProps) {
           family={observation.familyCode}
           layout="thumb"
           {...(color !== undefined ? { color } : {})}
+          {...(pathD != null ? { pathD } : {})}
         />
         <span className="feed-row-name" aria-hidden="true">{observation.comName}</span>
         {countContent.chip !== null && (

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -7,7 +7,7 @@ import { FeedRow } from './FeedRow.js';
 import { FilterSentence } from './ds/FilterSentence.js';
 import { SortLabel } from './ds/SortLabel.js';
 import type { Freshness } from './MapLede.js';
-import { buildFamilyColorResolver } from '../data/family-color.js';
+import { buildFamilyColorResolver, buildFamilyPathResolver } from '../data/family-color.js';
 
 export interface FeedSurfaceFilters {
   notable: boolean;
@@ -117,6 +117,14 @@ export function FeedSurface(props: FeedSurfaceProps) {
   // haven't yet threaded silhouettes down.
   const resolveColor = useMemo(
     () => buildFamilyColorResolver(silhouettes ?? []),
+    [silhouettes],
+  );
+
+  // Build the familyCode → svgData (path) resolver once per silhouettes identity
+  // change. Mirrors the color resolver — returns null when no DB path is available
+  // so FamilySilhouette falls back to the abstract palette (graceful degradation).
+  const resolvePath = useMemo(
+    () => buildFamilyPathResolver(silhouettes ?? []),
     [silhouettes],
   );
 
@@ -265,6 +273,7 @@ export function FeedSurface(props: FeedSurfaceProps) {
       <ol className="feed" aria-label="Observations">
         {topNotable && (() => {
           const notableColor = topNotable.familyCode ? resolveColor(topNotable.familyCode) : undefined;
+          const notablePath = topNotable.familyCode ? resolvePath(topNotable.familyCode) : null;
           return (
             <FeedCard
               key={`card:${topNotable.subId}:${topNotable.speciesCode}`}
@@ -272,11 +281,13 @@ export function FeedSurface(props: FeedSurfaceProps) {
               now={now}
               onSelectSpecies={onSelectSpecies}
               {...(notableColor !== undefined ? { color: notableColor } : {})}
+              {...(notablePath != null ? { pathD: notablePath } : {})}
             />
           );
         })()}
         {flatObservations.map(o => {
           const familyColor = o.familyCode ? resolveColor(o.familyCode) : undefined;
+          const familyPath = o.familyCode ? resolvePath(o.familyCode) : null;
           return (
             <FeedRow
               key={`${o.subId}:${o.speciesCode}`}
@@ -284,6 +295,7 @@ export function FeedSurface(props: FeedSurfaceProps) {
               now={now}
               onSelectSpecies={onSelectSpecies}
               {...(familyColor !== undefined ? { color: familyColor } : {})}
+              {...(familyPath != null ? { pathD: familyPath } : {})}
             />
           );
         })}

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
 import { useSilhouettes } from '../data/use-silhouettes.js';
-import { buildFamilyColorResolver } from '../data/family-color.js';
+import { buildFamilyColorResolver, buildFamilyPathResolver } from '../data/family-color.js';
 import { analytics } from '../analytics.js';
 import { PhenologyChart } from './PhenologyChart.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
@@ -51,6 +51,14 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   // family's DB color when photoUrl is null (bot finding on #480).
   const resolveColor = useMemo(
     () => buildFamilyColorResolver(silhouettes),
+    [silhouettes],
+  );
+
+  // Build the familyCode → svgData (path) resolver once per silhouettes identity
+  // change. Mirrors the color resolver — ensures the masthead fallback silhouette
+  // renders the real DB shape (not the generic apple glyph).
+  const resolvePath = useMemo(
+    () => buildFamilyPathResolver(silhouettes),
     [silhouettes],
   );
 
@@ -129,6 +137,7 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
         alt={`${data.comName} photo`}
         family={data.familyCode as FamilyCode | null}
         color={resolveColor(data.familyCode)}
+        pathD={resolvePath(data.familyCode)}
         priority={true}
         layout="masthead"
       />

--- a/frontend/src/components/ds/FamilySilhouette.test.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.test.tsx
@@ -130,6 +130,51 @@ describe('<FamilySilhouette>', () => {
     expect(el).toHaveStyle({ '--family-fill': '#5a6472' });
   });
 
+  // --- pathD prop (DB-sourced SVG path override, issue #NEW-3 follow-up) ---
+
+  const DB_PATH = 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z';
+
+  it('renders the provided pathD string as the <path d> attribute when pathD is given', () => {
+    render(<FamilySilhouette family="tyrannidae" pathD={DB_PATH} color="#C77A2E" />);
+    const path = document.querySelector('path');
+    expect(path).not.toBeNull();
+    expect(path).toHaveAttribute('d', DB_PATH);
+  });
+
+  it('uses a 24×24 viewBox when pathD is provided (DB coordinate space)', () => {
+    render(<FamilySilhouette family="tyrannidae" pathD={DB_PATH} color="#C77A2E" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('uses a 100×100 viewBox when pathD is absent (abstract palette coordinate space)', () => {
+    render(<FamilySilhouette family="raptor" />);
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 100 100');
+  });
+
+  it('falls back to the abstract FAMILY_PATHS palette path when pathD is null', () => {
+    // pathD=null (Phylopic-less family) must fall through to the abstract
+    // palette — NOT render an empty <path d="">.
+    render(<FamilySilhouette family="tyrannidae" pathD={null} />);
+    const path = document.querySelector('path');
+    expect(path).not.toBeNull();
+    // Must have some path data (the null-family fallback from FAMILY_PATHS)
+    expect(path?.getAttribute('d')?.length).toBeGreaterThan(0);
+    // viewBox should be the abstract palette's 100×100 space
+    const svg = document.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 100 100');
+  });
+
+  it('pathD does not affect color — color prop and pathD are independent', () => {
+    render(<FamilySilhouette family="tyrannidae" pathD={DB_PATH} color="#FF0808" />);
+    const el = document.querySelector('[data-testid="family-silhouette"]');
+    expect(el).toHaveStyle({ '--family-fill': '#FF0808' });
+    // And the path is still the DB path
+    const path = document.querySelector('path');
+    expect(path).toHaveAttribute('d', DB_PATH);
+  });
+
   // --- Accessibility ---
 
   it('is hidden from the SR tree (presentational) when inside <Photo>', () => {

--- a/frontend/src/components/ds/FamilySilhouette.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.tsx
@@ -43,6 +43,22 @@ export interface FamilySilhouetteProps {
    * consumers that haven't yet threaded the silhouettes color down.
    */
   color?: string;
+  /**
+   * Raw SVG `<path d="...">` string from the DB silhouettes payload.
+   * When provided, overrides the abstract FAMILY_PATHS palette lookup so
+   * the real per-family silhouette shape is rendered instead of the 7-key
+   * abstract placeholder. Mirrors the `color` prop's override pattern.
+   *
+   * Fallback semantics: when absent (pre-resolve, unknown family, or the DB
+   * row has svgData=null), the component falls back to FAMILY_PATHS[pathKey]
+   * exactly as before — graceful degradation is preserved.
+   *
+   * The DB viewBox is 24×24 (all seed migrations use a 24-unit coordinate
+   * space); the SVG element's viewBox remains "0 0 100 100" (set by the
+   * abstract palette) when pathD is absent, and switches to "0 0 24 24"
+   * when pathD is present to match the DB path coordinate space.
+   */
+  pathD?: string | null;
   /** aria-label for standalone use. Omit when inside <Photo> (aria-hidden). */
   ariaLabel?: string;
 }
@@ -81,6 +97,7 @@ export function FamilySilhouette({
   layout = 'inline',
   shape: shapeProp,
   color,
+  pathD,
   ariaLabel,
 }: FamilySilhouetteProps): ReactNode {
   // Narrow to a known FamilyCode if recognized; treat unknowns as null.
@@ -96,7 +113,14 @@ export function FamilySilhouette({
   // Use knownFamily (narrowed FamilyCode | null) rather than the raw `family`
   // prop (string) so TypeScript can verify the index against the Record type.
   const pathKey = knownFamily ?? '__null__';
-  const path = FAMILY_PATHS[pathKey];
+
+  // `pathD` prop (DB-sourced SVG path string) takes precedence over the abstract
+  // FAMILY_PATHS palette. When absent or null, fall back to the palette path so
+  // graceful degradation (pre-resolve, Phylopic-less families, tests) still works.
+  // DB paths use a 24×24 coordinate space; palette paths use 100×100.
+  const resolvedPathD = pathD ?? FAMILY_PATHS[pathKey];
+  const viewBox = pathD ? '0 0 24 24' : '0 0 100 100';
+
   // `color` prop (DB-sourced hex) takes precedence over the palette channel
   // fill. The palette's fill becomes shape-encoding-only when color is set.
   // This makes the DB silhouettes table the single source of truth for color.
@@ -119,13 +143,13 @@ export function FamilySilhouette({
       style={{ '--family-fill': fill } as React.CSSProperties}
     >
       <svg
-        viewBox="0 0 100 100"
+        viewBox={viewBox}
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden={ariaLabel ? undefined : 'true'}
         aria-label={ariaLabel}
         role={ariaLabel ? 'img' : undefined}
       >
-        <path d={path} />
+        <path d={resolvedPathD} />
       </svg>
     </span>
   );

--- a/frontend/src/components/ds/Photo.tsx
+++ b/frontend/src/components/ds/Photo.tsx
@@ -46,6 +46,12 @@ export interface PhotoProps {
    * the palette channel fill in <FamilySilhouette>. Absent = palette/grey fallback.
    */
   color?: string;
+  /**
+   * Raw SVG path string from the DB silhouettes payload. When provided, overrides
+   * the abstract FAMILY_PATHS lookup in <FamilySilhouette> so the detail masthead
+   * fallback renders the real family shape. Absent = abstract palette path fallback.
+   */
+  pathD?: string | null;
 }
 
 type PhotoInternalState = 'null' | 'loading' | 'loaded' | 'errored';
@@ -58,6 +64,7 @@ export function Photo({
   attribution,
   layout = 'inline',
   color,
+  pathD,
 }: PhotoProps): ReactNode {
   const [imgState, setImgState] = useState<PhotoInternalState>(
     src === null ? 'null' : 'loading'
@@ -98,6 +105,7 @@ export function Photo({
           family={family}
           layout={layout}
           {...(color !== undefined ? { color } : {})}
+          {...(pathD != null ? { pathD } : {})}
         />
       </span>
     );

--- a/frontend/src/data/family-color.test.ts
+++ b/frontend/src/data/family-color.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { buildFamilyColorResolver, FAMILY_COLOR_FALLBACK } from './family-color.js';
+import { buildFamilyColorResolver, buildFamilyPathResolver, FAMILY_COLOR_FALLBACK } from './family-color.js';
 import type { FamilySilhouette } from '@bird-watch/shared-types';
 
+const TYRANNIDAE_PATH = 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z';
+const TROCHILIDAE_PATH = 'M3 13 L8 11 L13 12 L18 9 L22 11 L18 13 L13 14 L8 14 L3 15 Z';
+
 const sampleSilhouettes: FamilySilhouette[] = [
-  { familyCode: 'tyrannidae',   color: '#C77A2E', svgData: null, source: null, license: null, commonName: null, creator: null },
-  { familyCode: 'trochilidae',  color: '#7B2D8E', svgData: null, source: null, license: null, commonName: null, creator: null },
+  { familyCode: 'tyrannidae',   color: '#C77A2E', svgData: TYRANNIDAE_PATH, source: 'placeholder', license: 'CC0', commonName: null, creator: null },
+  { familyCode: 'trochilidae',  color: '#7B2D8E', svgData: TROCHILIDAE_PATH, source: 'placeholder', license: 'CC0', commonName: null, creator: null },
   { familyCode: 'picidae',      color: '#FF0808', svgData: null, source: null, license: null, commonName: null, creator: null },
 ];
 
@@ -45,5 +48,49 @@ describe('buildFamilyColorResolver', () => {
     const out = color('nope');
     expect(out.length).toBeGreaterThan(0);
     expect(out).not.toBe('transparent');
+  });
+});
+
+describe('buildFamilyPathResolver', () => {
+  it('returns the DB svgData path string for a family with a non-null svgData', () => {
+    const path = buildFamilyPathResolver(sampleSilhouettes);
+    expect(path('tyrannidae')).toBe(TYRANNIDAE_PATH);
+    expect(path('trochilidae')).toBe(TROCHILIDAE_PATH);
+  });
+
+  it('matches family codes case-insensitively', () => {
+    const path = buildFamilyPathResolver(sampleSilhouettes);
+    expect(path('TYRANNIDAE')).toBe(TYRANNIDAE_PATH);
+    expect(path('Trochilidae')).toBe(TROCHILIDAE_PATH);
+  });
+
+  it('returns null for a family whose svgData is null (Phylopic-less policy)', () => {
+    // picidae row has svgData: null — resolver must return null so caller
+    // falls back to the abstract FAMILY_PATHS palette, not an empty string.
+    const path = buildFamilyPathResolver(sampleSilhouettes);
+    expect(path('picidae')).toBeNull();
+  });
+
+  it('returns null for an unknown family code (not in silhouettes)', () => {
+    const path = buildFamilyPathResolver(sampleSilhouettes);
+    expect(path('not-a-family')).toBeNull();
+  });
+
+  it('returns null when familyCode is null or undefined', () => {
+    const path = buildFamilyPathResolver(sampleSilhouettes);
+    expect(path(null)).toBeNull();
+    expect(path(undefined)).toBeNull();
+  });
+
+  it('returns null for every lookup when the silhouettes array is empty (pre-resolve state)', () => {
+    const path = buildFamilyPathResolver([]);
+    expect(path('tyrannidae')).toBeNull();
+    expect(path(null)).toBeNull();
+  });
+
+  it('never throws — callers rely on null as the stable fallback signal', () => {
+    const path = buildFamilyPathResolver([]);
+    expect(() => path('anything')).not.toThrow();
+    expect(() => path(null)).not.toThrow();
   });
 });

--- a/frontend/src/data/family-color.ts
+++ b/frontend/src/data/family-color.ts
@@ -10,7 +10,42 @@ import type { FamilySilhouette } from '@bird-watch/shared-types';
  */
 export const FAMILY_COLOR_FALLBACK = '#555';
 
+export type FamilyPathResolver = (familyCode: string | null | undefined) => string | null;
+
 export type FamilyColorResolver = (familyCode: string | null | undefined) => string;
+
+/**
+ * Build a `familyCode → svgData` resolver from the `/api/silhouettes` response.
+ *
+ * Mirrors `buildFamilyColorResolver` — the DB stores per-family SVG path data
+ * keyed by real eBird family code (e.g. "tyrannidae", "accipitridae"). This
+ * resolver is the single source of truth for shape; it replaces the
+ * frontend-only abstract FAMILY_PATHS palette for all DB-backed families.
+ *
+ * Fallback semantics:
+ *   - null / undefined familyCode → null (caller falls back to FAMILY_PATHS)
+ *   - familyCode not in silhouettes → null
+ *   - svgData is null for that family → null (Phylopic-less policy)
+ *   - silhouettes === [] (pre-resolve) → null for every code
+ *
+ * Returns null (not a sentinel string) so callers can detect "no DB shape
+ * available" and fall back to the abstract FAMILY_PATHS palette gracefully.
+ * This preserves the graceful degradation contract for test environments and
+ * the cold-load state before useSilhouettes resolves.
+ */
+export function buildFamilyPathResolver(
+  silhouettes: readonly FamilySilhouette[],
+): FamilyPathResolver {
+  const byFamily = new Map<string, string | null>();
+  for (const s of silhouettes) byFamily.set(s.familyCode.toLowerCase(), s.svgData);
+
+  return (familyCode: string | null | undefined): string | null => {
+    if (!familyCode) return null;
+    const key = familyCode.toLowerCase();
+    if (!byFamily.has(key)) return null;
+    return byFamily.get(key) ?? null;
+  };
+}
 
 /**
  * Build a `familyCode → color` resolver from the `/api/silhouettes` response.


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant FeedSurface
    participant buildFamilyPathResolver
    participant FeedRow/FeedCard
    participant FamilySilhouette

    FeedSurface->>buildFamilyPathResolver: silhouettes[] from useSilhouettes
    buildFamilyPathResolver-->>FeedSurface: resolvePath(familyCode) → svgData | null
    FeedSurface->>FeedRow/FeedCard: pathD={svgData}
    FeedRow/FeedCard->>FamilySilhouette: pathD={svgData}
    Note over FamilySilhouette: pathD overrides FAMILY_PATHS lookup, viewBox 100×100 → 24×24
```

## Summary

- **Root cause:** `FamilySilhouette` resolved shape via lookup in a 7-key abstract `FAMILY_PATHS` map (`raptor | waterfowl | …`). Real eBird family codes (`tyrannidae | corvidae | anatidae | …`) never matched, falling through to the `__null__` generic glyph — same shape for every bird.
- **Fix (Option B):** DB `family_silhouettes.svg_data` already stores the correct per-family SVG path keyed by real eBird family code. Added `buildFamilyPathResolver` (mirrors `buildFamilyColorResolver` from #480) and a `pathD` prop on `<FamilySilhouette>` that overrides `FAMILY_PATHS` when a DB path is available. Threaded through FeedSurface → FeedCard/FeedRow, FamilyLegend, and SpeciesDetailSurface → Photo.
- **Graceful degradation preserved:** `pathD=null` falls back to `FAMILY_PATHS[pathKey]` exactly as before; no behavior change in test environments or before `useSilhouettes` resolves.

## Screenshots

**Before** — every silhouette is the same generic circle glyph (production, `main` branch):

| Feed (mobile 390×844) | Legend (mobile 390×844) |
|---|---|
| ![Feed before — all circles](https://github.com/user-attachments/assets/def04692-7ded-47f0-b0ad-f5bf6735b8d2) | ![Legend before — all circles](https://github.com/user-attachments/assets/7c7a2b05-f84c-4588-9924-418cd91b5405) |

**After** — each family has its own distinct shape (local dev with mocked DB data):

| Feed (mobile 390×844) | Legend (mobile 390×844) |
|---|---|
| ![Feed after — varied shapes](https://github.com/user-attachments/assets/3583c5be-b3e7-416a-87d1-e805b2fd29d0) | ![Legend after — varied shapes](https://github.com/user-attachments/assets/f53b6fc8-e146-4d12-b094-d1e4769e98b2) |

| Feed (desktop 1440×900) | Legend (desktop 1440×900) |
|---|---|
| ![Feed after desktop](https://github.com/user-attachments/assets/698ddf64-a5be-4667-a33e-b002672ec0e0) | ![Legend after desktop](https://github.com/user-attachments/assets/5cbd47b6-631b-4c76-b4b7-1f44fa87306a) |

Notable visible differences: Roadrunner (cuculidae) = elongated runner · Cardinal (cardinalidae) = upright crest bird · Crow (corvidae) = wide-wing soarer · Duck (anatidae) = flat-bodied duck · Woodpecker (picidae) = upright climber · Hummingbird (trochilidae) = needle-bill hoverer · Hawk (accipitridae) = broad-wing raptor.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no new class names
- [x] Multi-viewport design QA: screenshots at 390×844 (mobile) + 1440×900 (desktop) captured above

## Test plan

- [x] `npm run build --workspace @bird-watch/shared-types` — clean
- [x] `npm run build --workspace @bird-watch/frontend` — clean (tsc + vite)
- [x] `npm test --workspace @bird-watch/frontend` — 760 passed (was 748; +12 new tests covering `buildFamilyPathResolver` and `pathD` prop branches)
- [x] New unit tests added: `buildFamilyPathResolver` (7 cases in `family-color.test.ts`) + `pathD` prop (5 cases in `FamilySilhouette.test.tsx`)
- [x] No new Playwright e2e spec — shape binding covered by unit tests; visual regression captured in screenshots
- [x] Playwright MCP smoke at 390×844 + 1440×900 — varied shapes per family, console 0 errors/warnings

## Plan reference

Out of plan — follow-up to #480 (NEW-3 color binding). Same root cause, shape dimension.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)