### PR TITLE
fix(ingestor): backfill species_meta for ebird spuh/sub-species codes + add ingest invariant

### DIFF
--- a/migrations/1700000032000_backfill_species_meta_spuh_hybrid.sql
+++ b/migrations/1700000032000_backfill_species_meta_spuh_hybrid.sql
@@ -1,0 +1,72 @@
+-- Up Migration
+--
+-- Issue #484. Backfills 10 species_meta rows for eBird hybrid/spuh codes that
+-- have been observed in US-AZ but lack a species_meta row, causing
+-- /api/species/:code to 404 even though the codes appear in /api/observations.
+--
+-- Root cause: `runTaxonomy` filters eBird's taxonomy stream to
+-- `category === 'species'` (services/ingestor/src/run-taxonomy.ts:46), which
+-- drops every `hybrid`, `spuh`, `slash`, `domestic`, and `form` row. Recent
+-- observation ingest (`/data/obs/US-AZ/recent`) is NOT filtered the same way,
+-- so hybrid codes flow into `observations` without a matching `species_meta`
+-- parent. The read-api 404 path is services/read-api/src/app.ts:119.
+--
+-- The companion fix in this PR adds an ingest-time invariant
+-- (services/ingestor/src/run-ingest.ts) that fails the ingest loudly when an
+-- observation references a missing `species_meta` row — so any FUTURE eBird
+-- hybrid/spuh code that surfaces in the AZ feed will trip the invariant
+-- before silently creating another 404, instead of waiting for a user report.
+--
+-- Family-bucket strategy: every hybrid maps to the lowercased scientific
+-- family of its parent species' family (eBird's `familySciName` lowercased).
+-- All 5 referenced families (anatidae, cardinalidae, odontophoridae,
+-- parulidae, trochilidae) already exist in `family_silhouettes`, so this
+-- migration ships zero new silhouettes — observations of these hybrids
+-- render with the parent family's existing icon and color.
+--
+-- Source: eBird taxonomy v2 API,
+-- /v2/ref/taxonomy/ebird?species=<codes>&fmt=json, queried 2026-05-12.
+-- Each row carries (speciesCode, comName, sciName, familyCode, familyName,
+-- taxonOrder) verbatim from eBird, with familyCode lowercased per the
+-- ingestor's existing convention in services/ingestor/src/run-taxonomy.ts:
+-- `(t.familySciName ?? t.familyCode ?? '').toLowerCase()`.
+--
+-- ON CONFLICT DO NOTHING preserves any row a future `runTaxonomy` run might
+-- legitimately produce (e.g. if eBird reclassifies a code from hybrid → species).
+INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+VALUES
+  -- Lazuli x Indigo Bunting hybrid. Both parents (Passerina amoena, P. cyanea)
+  -- are Cardinalidae. AZ birders care about this hybrid — keeping it visible.
+  ('ixlbun', 'Lazuli x Indigo Bunting (hybrid)', 'Passerina amoena x cyanea', 'cardinalidae', 'Cardinals and Allies', 34609),
+  -- Mallard x Mexican Duck hybrid. eBird taxonomy lists this code under
+  -- `category=hybrid`, not the domestic-Mallard form (`mallar3`). Both parents
+  -- are Anatidae.
+  ('mallar4', 'Mallard x Mexican Duck (hybrid)', 'Anas platyrhynchos x diazi', 'anatidae', 'Ducks, Geese, and Waterfowl', 569),
+  -- Townsend's x Hermit Warbler hybrid. Both parents are Parulidae.
+  ('x00059', 'Townsend''s x Hermit Warbler (hybrid)', 'Setophaga townsendi x occidentalis', 'parulidae', 'New World Warblers', 34213),
+  -- Anna's x Costa's Hummingbird hybrid. Both parents are Trochilidae.
+  ('x00618', 'Anna''s x Costa''s Hummingbird (hybrid)', 'Calypte anna x costae', 'trochilidae', 'Hummingbirds', 4821),
+  -- Scaled x Gambel's Quail hybrid. Both parents are Odontophoridae.
+  ('x00689', 'Scaled x Gambel''s Quail (hybrid)', 'Callipepla squamata x gambelii', 'odontophoridae', 'New World Quail', 1111),
+  -- Graylag x Canada Goose hybrid. Both parents are Anatidae.
+  ('x00758', 'Graylag x Canada Goose (hybrid)', 'Anser anser x Branta canadensis', 'anatidae', 'Ducks, Geese, and Waterfowl', 358),
+  -- Graylag x Swan Goose hybrid. Both parents are Anatidae.
+  ('x00776', 'Graylag x Swan Goose (hybrid)', 'Anser anser x cygnoides', 'anatidae', 'Ducks, Geese, and Waterfowl', 286),
+  -- Broad-billed x White-eared Hummingbird hybrid. Both parents are Trochilidae.
+  ('x01129', 'Broad-billed x White-eared Hummingbird (hybrid)', 'Cynanthus latirostris x Basilinna leucotis', 'trochilidae', 'Hummingbirds', 4924),
+  -- Broad-billed x Berylline Hummingbird hybrid. Both parents are Trochilidae.
+  ('x01172', 'Broad-billed x Berylline Hummingbird (hybrid)', 'Cynanthus latirostris x Saucerottia beryllina', 'trochilidae', 'Hummingbirds', 5065),
+  -- Broad-tailed x White-eared Hummingbird hybrid. Both parents are Trochilidae.
+  ('x01228', 'Broad-tailed x White-eared Hummingbird (hybrid)', 'Selasphorus platycercus x Basilinna leucotis', 'trochilidae', 'Hummingbirds', 4923)
+ON CONFLICT (species_code) DO NOTHING;
+
+-- Down Migration
+--
+-- Removes only the 10 rows this migration inserted. Defensive: filters by the
+-- exact species_code list rather than by sci_name LIKE '% x %', so a future
+-- migration that legitimately adds OTHER hybrid rows won't be reverted here.
+DELETE FROM species_meta WHERE species_code IN (
+  'ixlbun', 'mallar4',
+  'x00059', 'x00618', 'x00689', 'x00758', 'x00776',
+  'x01129', 'x01172', 'x01228'
+);

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   getSpeciesMeta,
   upsertSpeciesMeta,
+  findMissingSpeciesMeta,
   insertSpeciesPhoto,
   getSpeciesPhotos,
   getSpeciesPhenology,

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -3,6 +3,7 @@ import { startTestDb, type TestDb } from './test-helpers.js';
 import {
   getSpeciesMeta,
   upsertSpeciesMeta,
+  findMissingSpeciesMeta,
   insertSpeciesPhoto,
   getSpeciesPhotos,
   getSpeciesPhenology,
@@ -42,6 +43,44 @@ describe('species meta', () => {
     expect(meta).toBeDefined();
     expect(typeof meta!.taxonOrder).toBe('number');
     expect(meta!.taxonOrder).toBe(30501);
+  });
+});
+
+describe('findMissingSpeciesMeta (#484 ingest invariant helper)', () => {
+  beforeEach(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+    ]);
+  });
+
+  it('returns [] when every code has a species_meta row', async () => {
+    const missing = await findMissingSpeciesMeta(db.pool, ['vermfly', 'annhum']);
+    expect(missing).toEqual([]);
+  });
+
+  it('returns [] for an empty input (no DB round-trip needed)', async () => {
+    const missing = await findMissingSpeciesMeta(db.pool, []);
+    expect(missing).toEqual([]);
+  });
+
+  it('returns the subset of codes that have no species_meta row', async () => {
+    const missing = await findMissingSpeciesMeta(db.pool, [
+      'vermfly', 'xMISS1', 'annhum', 'xMISS2',
+    ]);
+    // Sorted lexicographically for stable error messages.
+    expect(missing).toEqual(['xMISS1', 'xMISS2']);
+  });
+
+  it('de-duplicates repeated missing codes in the input', async () => {
+    const missing = await findMissingSpeciesMeta(db.pool, [
+      'xMISS', 'xMISS', 'xMISS',
+    ]);
+    expect(missing).toEqual(['xMISS']);
   });
 });
 

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -270,6 +270,41 @@ export async function getSpeciesPhenology(
   return rows.map(r => ({ month: r.month, count: r.count }));
 }
 
+/**
+ * Returns the subset of `speciesCodes` that have NO matching `species_meta`
+ * row. Result is sorted lexicographically so error messages are stable across
+ * runs (easier to grep ingest-run logs).
+ *
+ * Loadbearing for the ingest-time invariant in
+ * `services/ingestor/src/run-ingest.ts` (issue #484): before upserting a batch
+ * of eBird observations, we ask the DB which `species_code`s in the batch
+ * have no `species_meta` parent. Any missing code aborts the ingest with a
+ * loud error rather than silently inserting an observation the read-api will
+ * 404 on. Future eBird hybrid/spuh additions to the AZ feed therefore become
+ * a CI/cron failure a maintainer sees, not a user-reported prod 404.
+ *
+ * Empty input → empty output (no DB round-trip). Duplicate codes in the input
+ * are de-duplicated by the SQL UNNEST + EXCEPT shape, so the caller does not
+ * need to pre-dedupe.
+ */
+export async function findMissingSpeciesMeta(
+  pool: Pool,
+  speciesCodes: readonly string[]
+): Promise<string[]> {
+  if (speciesCodes.length === 0) return [];
+  const { rows } = await pool.query<{ species_code: string }>(
+    `SELECT code AS species_code
+       FROM UNNEST($1::text[]) AS u(code)
+      WHERE NOT EXISTS (
+        SELECT 1 FROM species_meta sm WHERE sm.species_code = u.code
+      )
+      GROUP BY code
+      ORDER BY code`,
+    [speciesCodes]
+  );
+  return rows.map(r => r.species_code);
+}
+
 export async function upsertSpeciesMeta(
   pool: Pool,
   inputs: SpeciesMeta[]

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -107,4 +107,67 @@ describe('runIngest', () => {
     expect(runs[0]?.status).toBe('failure');
     expect(runs[0]?.errorMessage).toContain('502');
   });
+
+  // Invariant from issue #484: if eBird returns an observation whose
+  // species_code has no matching species_meta row, the ingest must fail
+  // LOUDLY rather than silently inserting an observation that the read-api
+  // cannot resolve to a /api/species/:code response. Future eBird hybrid/spuh
+  // codes that appear in the AZ feed therefore become a CI/cron failure that
+  // a maintainer sees, not a silent prod 404 a user reports.
+  it('fails the ingest when an observation references a missing species_meta row (#484 invariant)', async () => {
+    const RECENT_WITH_LEAK = [
+      ...RECENT,
+      // `xUNKNOWN1` is a synthetic eBird-style spuh code with no
+      // species_meta row — simulates the bug class from #484
+      // (`ixlbun`, `x00059`, etc. before the backfill).
+      { speciesCode: 'xUNKNOWN1', comName: 'Unknown Hybrid',
+        sciName: 'Genus species x other', locId: 'L3', locName: 'Test',
+        obsDt: '2026-04-15 10:00', howMany: 1, lat: 32.30, lng: -110.99,
+        obsValid: true, obsReviewed: false, locationPrivate: false,
+        subId: 'S102' },
+    ];
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent',
+        () => HttpResponse.json(RECENT_WITH_LEAK)),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
+        () => HttpResponse.json([])),
+    );
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
+    });
+
+    expect(summary.status).toBe('failure');
+    expect(summary.error).toBeDefined();
+    // Error message must name the offending code(s) so a triage agent can
+    // jump straight to a `species_meta` backfill PR without re-deriving
+    // which code triggered the failure.
+    expect(summary.error).toContain('xUNKNOWN1');
+    // No observations may have been inserted — the invariant runs BEFORE
+    // upsert, so a leak fails the whole batch rather than corrupting the
+    // read path.
+    const obs = await getObservations(db.pool, {});
+    expect(obs).toHaveLength(0);
+    // Failure must be recorded in ingest_runs for the freshness monitor.
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.status).toBe('failure');
+    expect(runs[0]?.errorMessage).toContain('xUNKNOWN1');
+  });
+
+  it('succeeds (no false-positive invariant trip) when every observation has a species_meta row', async () => {
+    // Regression guard: the invariant must NOT block legitimate ingests
+    // — only the ones that genuinely reference missing species_meta rows.
+    // RECENT's two codes (vermfly, annhum) are both seeded in beforeAll.
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent',
+        () => HttpResponse.json(RECENT)),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
+        () => HttpResponse.json([])),
+    );
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
+    });
+    expect(summary.status).toBe('success');
+    expect(summary.upserted).toBe(2);
+  });
 });

--- a/services/ingestor/src/run-ingest.ts
+++ b/services/ingestor/src/run-ingest.ts
@@ -1,5 +1,6 @@
 import {
-  upsertObservations, startIngestRun, finishIngestRun, type Pool,
+  upsertObservations, findMissingSpeciesMeta,
+  startIngestRun, finishIngestRun, type Pool,
 } from '@bird-watch/db-client';
 import { EbirdClient } from './ebird/client.js';
 import { toObservationInput, notableKeyset } from './transform.js';
@@ -39,6 +40,28 @@ export async function runIngest(opts: RunIngestOptions): Promise<RunSummary> {
     ]);
     const notableKeys = notableKeyset(notable);
     const inputs = recent.map(o => toObservationInput(o, notableKeys));
+
+    // Invariant (issue #484): every observation we insert must have a
+    // matching `species_meta` row, otherwise the read-api 404s on
+    // /api/species/:code for a code the same API also returns from
+    // /api/observations. The check runs BEFORE upsert so a leak aborts the
+    // whole batch — converting future eBird hybrid/spuh additions to the AZ
+    // feed into a loud CI/cron failure instead of a silent prod 404. The
+    // error names every offending code so a triage agent can jump straight
+    // to a `species_meta` backfill PR (see migration
+    // 1700000032000_backfill_species_meta_spuh_hybrid.sql for the 10 codes
+    // this fix unblocked).
+    const speciesCodes = inputs.map(o => o.speciesCode);
+    const missing = await findMissingSpeciesMeta(opts.pool, speciesCodes);
+    if (missing.length > 0) {
+      throw new Error(
+        `ingest invariant violation: ${missing.length} observation species_code(s) ` +
+        `have no species_meta row — refusing to insert observations the read-api ` +
+        `cannot resolve. Missing codes: ${missing.join(', ')}. ` +
+        `Fix: add species_meta rows for these codes (see issue #484 for the pattern).`
+      );
+    }
+
     const upserted = await upsertObservations(opts.pool, inputs);
 
     await finishIngestRun(opts.pool, runId, {

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -146,6 +146,74 @@ describe('GET /api/observations', () => {
   });
 });
 
+describe('species_meta backfill for eBird hybrid/spuh codes (#484)', () => {
+  // The 10 codes from issue #484 — eBird hybrid codes that have been observed
+  // in US-AZ but historically had no species_meta row, causing /api/species/:code
+  // to 404 even though /api/observations returns them. Migration
+  // 1700000032000_backfill_species_meta_spuh_hybrid.sql inserts these rows;
+  // the ingest-time invariant in services/ingestor/src/run-ingest.ts catches
+  // any future leak before it reaches the read path.
+  const LEAKING_CODES = [
+    'ixlbun', 'mallar4',
+    'x00059', 'x00618', 'x00689', 'x00758', 'x00776',
+    'x01129', 'x01172', 'x01228',
+  ];
+
+  it('every backfilled code resolves with HTTP 200 from /api/species/:code', async () => {
+    const app = createApp({ pool: db.pool });
+    for (const code of LEAKING_CODES) {
+      const res = await app.request(`/api/species/${code}`);
+      expect(res.status, `species_code ${code} should resolve 200`).toBe(200);
+      const body = await res.json() as {
+        speciesCode: string; comName: string; sciName: string;
+        familyCode: string; familyName: string;
+      };
+      expect(body.speciesCode).toBe(code);
+      // family_code must be lowercased scientific family name (the join key
+      // used by family_silhouettes), per the convention in run-taxonomy.ts.
+      expect(body.familyCode).toMatch(/^[a-z]+$/);
+      // family_name carries the human-readable English label.
+      expect(body.familyName.length).toBeGreaterThan(0);
+      // Hybrid display name should round-trip — the comName must include
+      // either ' x ' (eBird hybrid convention) or the literal word 'hybrid'.
+      expect(body.comName.toLowerCase()).toMatch(/hybrid| x /);
+    }
+  });
+
+  it('the acceptance invariant — every speciesCode in /api/observations resolves 200 from /api/species/:code', async () => {
+    // Seed observations with each leaking code, then walk /api/observations
+    // and verify every species_code there is renderable via /api/species/:code.
+    // This is the acceptance assertion from #484: "Every speciesCode in
+    // /api/observations resolves with HTTP 200 from /api/species/:code".
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, LEAKING_CODES.map((code, i) => ({
+      subId: `S-leak-${i}`,
+      speciesCode: code,
+      comName: code,
+      lat: 32.30,
+      lng: -110.99,
+      obsDt: new Date(Date.now() - i * 86400_000).toISOString(),
+      locId: 'L-leak',
+      locName: 'Test',
+      howMany: 1,
+      isNotable: false,
+    })));
+
+    const app = createApp({ pool: db.pool });
+    const obsRes = await app.request('/api/observations?since=30d');
+    expect(obsRes.status).toBe(200);
+    const obsBody = await obsRes.json() as {
+      data: Array<{ speciesCode: string }>;
+    };
+    const codes = Array.from(new Set(obsBody.data.map(o => o.speciesCode)));
+    expect(codes.length).toBeGreaterThan(0);
+    for (const code of codes) {
+      const res = await app.request(`/api/species/${code}`);
+      expect(res.status, `species_code ${code} must resolve 200`).toBe(200);
+    }
+  });
+});
+
 describe('error handling', () => {
   it('returns 503 when DB query throws a connection error', async () => {
     const pg = await import('pg');


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ingestor
    participant eBird
    participant Postgres
    participant ReadAPI

    Note over Ingestor,Postgres: BEFORE (issue #484)
    Ingestor->>eBird: GET /data/obs/US-AZ/recent (+ /notable)
    eBird-->>Ingestor: observations incl. hybrid codes (ixlbun, mallar4, x000.., x011..)
    Ingestor->>Postgres: INSERT observations (silently — no species_meta row)
    ReadAPI->>Postgres: SELECT * FROM species_meta WHERE species_code = 'ixlbun'
    Postgres-->>ReadAPI: 0 rows
    Note right of ReadAPI: 404 on /api/species/:code (user sees error screen)

    Note over Ingestor,Postgres: AFTER (this PR)
    Ingestor->>eBird: GET /data/obs/US-AZ/recent (+ /notable)
    eBird-->>Ingestor: observations incl. hybrid codes
    Ingestor->>Postgres: findMissingSpeciesMeta(speciesCodes)
    alt any species_code missing
        Postgres-->>Ingestor: ['xNEWLEAK']
        Note right of Ingestor: throw — ingest_runs records failure, NO rows inserted
    else all codes present
        Postgres-->>Ingestor: []
        Ingestor->>Postgres: INSERT observations + stamp region/silhouette
        ReadAPI->>Postgres: SELECT * FROM species_meta WHERE species_code = 'ixlbun'
        Postgres-->>ReadAPI: 1 row (backfilled by migration 32000)
        Note right of ReadAPI: 200 — detail surface renders the hybrid
    end
```

```mermaid
flowchart LR
    M[migrations/1700000032000_<br/>backfill_species_meta_spuh_hybrid.sql] -->|INSERT 10 rows| SM[species_meta]
    SM -->|FK target| OBS[observations]
    SM -->|JOIN at read time| RA[GET /api/species/:code]
    RI[services/ingestor/src/run-ingest.ts] -->|findMissingSpeciesMeta<br/>before upsert| SM
    RI -->|throw on miss| IR[ingest_runs status=failure]
```

## Summary

- Backfills 10 species_meta rows for eBird hybrid/spuh codes (ixlbun, mallar4, x00059, x00618, x00689, x00758, x00776, x01129, x01172, x01228) using authoritative metadata from eBird's /v2/ref/taxonomy/ebird endpoint — so the read-api stops 404ing on codes that are simultaneously emitted by /api/observations.
- Adds a load-bearing ingest-time invariant in services/ingestor/src/run-ingest.ts: every batch is now pre-checked with findMissingSpeciesMeta before upsert, and any missing species_code aborts the ingest with a loud error naming the offenders — converting future eBird hybrid/spuh additions to the AZ feed into a CI/cron failure a maintainer sees, not a silent prod 404 a user reports.
- Family-bucket strategy: every hybrid maps to its parent species' lowercased scientific family name (anatidae, cardinalidae, odontophoridae, parulidae, trochilidae) — all 5 already exist in family_silhouettes, so no new silhouettes ship and observations of these hybrids render with the parent family's existing icon.

## Screenshots

N/A — ingestor + read-api change. No files under \`frontend/**\` are modified.

## Test plan

- [x] \`packages/db-client\` — \`findMissingSpeciesMeta\` unit tests (empty input, all-present, partial miss, dedupe) green via @testcontainers/postgresql
- [x] \`services/ingestor\` — full suite green (15 files, 119 tests); two new tests cover the invariant (loud-failure path naming the offender + no-false-positive guard)
- [x] \`services/read-api\` — full suite green (3 files, 40 tests); new \`species_meta backfill for eBird hybrid/spuh codes (#484)\` describe block asserts every backfilled code returns HTTP 200 from /api/species/:code AND that the issue's acceptance invariant holds — every speciesCode in /api/observations resolves 200 from /api/species/:code
- [x] \`npm run build\` clean across @bird-watch/shared-types, db-client, ingestor, read-api
- [x] \`npx knip\` shows no new findings (only pre-existing frontend config hints)
- [x] No DB mocks — every test runs against a real Postgres + PostGIS via @testcontainers/postgresql per CLAUDE.md
- [x] Migration uses \`-- Up Migration\` / \`-- Down Migration\` markers; the Down step filters by exact species_code list so a future migration adding other hybrid rows won't be reverted here

## Plan reference

Out of plan — bug fix closing #484 (10 eBird hybrid/spuh codes 404 from /api/species/:code). The companion ingest-time invariant converts this drift class from a silent prod 404 into a CI/cron failure for any future code that leaks the same way.

Closes #484.