### PR TITLE
fix(db-client): scope post-INSERT stamp UPDATE to current batch

### DIFF
--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -87,6 +87,56 @@ describe('upsertObservations', () => {
     const verm = all.find(o => o.subId === 'S100')!;
     expect(verm.isNotable).toBe(true);
   });
+
+  it('scopes the stamp UPDATE to the current batch — pre-existing NULL-stamp residue is not touched (#505)', async () => {
+    // Insert N₁ pre-existing rows directly (bypassing upsertObservations) with
+    // region_id NULL — these simulate the NULL-stamp residue that turned the
+    // per-iteration stamp UPDATE into an O(table) scan on every backfill day.
+    const residueRows: string[] = [];
+    const residueValues: unknown[] = [];
+    for (let i = 0; i < 100; i++) {
+      const off = i * 9;
+      residueRows.push(
+        `($${off + 1}, $${off + 2}, $${off + 3}, $${off + 4}, $${off + 5}, ` +
+        `$${off + 6}, $${off + 7}, $${off + 8}, $${off + 9})`
+      );
+      residueValues.push(
+        `R-${i}`, 'vermfly', 31.72, -110.88, '2026-04-01T08:00:00Z',
+        `L-residue-${i}`, 'Madera', 1, false,
+      );
+    }
+    await db.pool.query(
+      `INSERT INTO observations
+        (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       VALUES ${residueRows.join(',')}`,
+      residueValues
+    );
+    // Force NULL stamps on the residue rows.
+    await db.pool.query("UPDATE observations SET region_id = NULL, silhouette_id = NULL");
+
+    // Now call upsertObservations with a small batch of M new rows.
+    const count = await upsertObservations(db.pool, sample);
+    expect(count).toBe(2);
+
+    // Assert: the M new rows are stamped...
+    const all = await getObservations(db.pool, {});
+    const newVerm = all.find(o => o.subId === 'S100')!;
+    expect(newVerm.regionId).toBe('sky-islands-santa-ritas');
+    expect(newVerm.silhouetteId).toBe('tyrannidae');
+    const newAnna = all.find(o => o.subId === 'S101')!;
+    expect(newAnna.regionId).toBe('sonoran-tucson');
+
+    // ...AND the N₁ pre-existing NULL residue rows are STILL NULL — proving
+    // the stamp UPDATE was scoped to the batch, not the table.
+    const residueAfter = await db.pool.query<{ region_id: string | null; silhouette_id: string | null }>(
+      "SELECT region_id, silhouette_id FROM observations WHERE sub_id LIKE 'R-%'"
+    );
+    expect(residueAfter.rows).toHaveLength(100);
+    for (const r of residueAfter.rows) {
+      expect(r.region_id).toBeNull();
+      expect(r.silhouette_id).toBeNull();
+    }
+  });
 });
 
 describe('getObservations filters', () => {

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -50,6 +50,19 @@ export async function upsertObservations(
       ingested_at = now()
   `;
 
+  // Build a (sub_id, species_code) VALUES set that scopes the stamp UPDATE to
+  // just the rows in this batch. Without this scoping the WHERE clause goes
+  // O(table) — every batch re-scans every NULL-stamp residue row in
+  // observations, which is what made the daily backfill loop time out (#505).
+  // runReconcileStamping() remains the once-per-run sweeper for NULL residue.
+  const stampValues: unknown[] = [];
+  const stampPlaceholders: string[] = [];
+  inputs.forEach((o, i) => {
+    const off = i * 2;
+    stampPlaceholders.push(`($${off + 1}, $${off + 2})`);
+    stampValues.push(o.subId, o.speciesCode);
+  });
+
   const stampSql = `
     UPDATE observations o
     SET
@@ -66,11 +79,14 @@ export async function upsertObservations(
         WHERE sm.species_code = o.species_code
         LIMIT 1
       )
-    WHERE o.region_id IS NULL OR o.silhouette_id IS NULL
+    FROM (VALUES ${stampPlaceholders.join(',')}) AS batch(sub_id, species_code)
+    WHERE o.sub_id = batch.sub_id
+      AND o.species_code = batch.species_code
+      AND (o.region_id IS NULL OR o.silhouette_id IS NULL)
   `;
 
   await pool.query(insertSql, values);
-  await pool.query(stampSql);
+  await pool.query(stampSql, stampValues);
   return inputs.length;
 }
 
@@ -78,11 +94,11 @@ export async function upsertObservations(
  * Re-runs the region/silhouette stamping UPDATE across ALL observations whose
  * region_id or silhouette_id is still NULL. Idempotent.
  *
- * upsertObservations only stamps rows it just touched (via its WHERE filter,
- * which in practice catches the current batch). When species_meta is empty
- * at ingest time (as on prod pre-#83), the silhouette JOIN finds no row and
- * silhouette_id stays NULL — even after the batch is stamped. Running this
- * after a taxonomy job is loaded backfills every orphaned row.
+ * upsertObservations stamps only the rows in its own batch (the UPDATE is
+ * scoped to the batch's (sub_id, species_code) pairs). Anything that was NULL
+ * at the time of its batch — e.g. a silhouette JOIN that missed because
+ * species_meta was empty at the time, as on prod pre-#83 — stays NULL until
+ * this function sweeps it. Run once at the end of a taxonomy or backfill run.
  *
  * Returns the number of rows updated.
  */

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -111,7 +111,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (kind === 'backfill') {
-      summary = await deps.runBackfill({ pool, apiKey, regionCode: 'US-AZ', days: 30 });
+      summary = await deps.runBackfill({ pool, apiKey, regionCode: 'US-AZ', days: 19 });
     } else if (kind === 'backfill-extended') {
       // 'backfill-extended': one-shot 365-day backfill at 1 rps; this is NOT
       // scheduled — it's an operator-triggered one-shot to populate historical

--- a/services/ingestor/src/handler.test.ts
+++ b/services/ingestor/src/handler.test.ts
@@ -95,7 +95,7 @@ describe('handleScheduled', () => {
   });
 
   it("dispatches to runBackfill when kind is 'backfill'", async () => {
-    const summary = { status: 'success', daysProcessed: 30 };
+    const summary = { status: 'success', daysProcessed: 19 };
     runBackfillMock.mockResolvedValue(summary);
 
     const result = await handleScheduled('backfill', ENV);
@@ -104,7 +104,7 @@ describe('handleScheduled', () => {
       pool: POOL_SENTINEL,
       apiKey: 'test-key',
       regionCode: 'US-AZ',
-      days: 30,
+      days: 19,
     });
     expect(result).toBe(summary);
     expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);

--- a/services/ingestor/src/handler.ts
+++ b/services/ingestor/src/handler.ts
@@ -44,7 +44,7 @@ export async function handleScheduled(
         return await runHotspotIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ' });
       case 'backfill':
         return await runBackfill({
-          pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ', days: 30,
+          pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ', days: 19,
         });
       case 'taxonomy':
         return await runTaxonomy({ pool, apiKey: env.EBIRD_API_KEY });


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Loop as Backfill loop (19 iters)
    participant Ingestor
    participant Postgres

    loop per day
        Ingestor->>Postgres: INSERT batch of N observations
        Note over Ingestor,Postgres: BEFORE: stamp UPDATE WHERE (region_id IS NULL OR silhouette_id IS NULL)<br/>O(table) — re-scans NULL residue every iteration
        Note over Ingestor,Postgres: AFTER: stamp UPDATE FROM VALUES(batch sub_id,species_code)<br/>O(batch) — only touches just-INSERTed rows
        Ingestor->>Postgres: scoped stamp UPDATE
    end
    Ingestor->>Postgres: runReconcileStamping() (once at end, sweeps residue)
```

## Summary

- The daily `bird-ingest-backfill` Cloud Run job has timed out at 300s every night since 2026-05-09 because `upsertObservations` ran a table-wide stamp UPDATE after every per-day INSERT inside the backfill loop. NULL-stamp residue seeded by recent epics (#495, #500, #501) made the WHERE clause O(table) per iteration — `ST_Contains` polygon checks + `species_meta` -> `family_silhouettes` join per residue row, 30 times per run. Closes #505.
- Fix scopes the stamp UPDATE to the batch via `FROM (VALUES ...) AS batch(sub_id, species_code)`, so runtime now scales with batch size. `runReconcileStamping` is untouched — still the once-per-run sweeper for NULL residue from species_meta-empty-at-ingest-time rows.
- Bundles the orthogonal `days: 30 -> 19` cut in `services/ingestor/src/{handler,cli}.ts` (and the matching `handler.test.ts` assertion) — drops daily backfill API calls from 31 to 20.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/db-client -- --run observations.test.ts` — 11/11 pass
- [x] New regression test (`scopes the stamp UPDATE to the current batch — pre-existing NULL-stamp residue is not touched (#505)`) FAILS against `main` and PASSES against this branch, verified by stashing the `observations.ts` change and re-running the suite
- [x] `npm run test --workspace @bird-watch/ingestor -- --run handler.test.ts` — 7/7 pass (covers the `days: 19` change)
- [x] `npm run build --workspace @bird-watch/db-client` — clean
- [x] `npm run lint` — clean

### Pre-existing failures observed

- `services/ingestor/src/run-backfill.test.ts:80` (`preserves is_notable=true after backfill re-processes a day runIngest already stamped`) fails on both `main` (`6705fe3`) and this branch with `expected undefined to be true`. Not introduced by this PR; out of scope.

## Plan reference

Out of plan — fix landed via drift-detection investigation; root cause documented in #505.

---

Generated with [Claude Code](https://claude.com/claude-code)