### PR TITLE
fix(infra): grant artifactregistry tag-delete to gh-deploy SA for admin-api (#502 follow-up)

### DIFF
--- a/infra/terraform/registry.tf
+++ b/infra/terraform/registry.tf
@@ -7,6 +7,32 @@ resource "google_artifact_registry_repository" "birdwatch" {
   depends_on = [google_project_service.artifactregistry]
 }
 
+# ── gh-deploy SA: repo-scoped repoAdmin ─────────────────────────────────
+#
+# The gh-deploy@<project>.iam.gserviceaccount.com service account is used
+# by every deploy-*.yml workflow via Workload Identity Federation. It needs
+# `artifactregistry.tags.delete` to overwrite the `:latest` tag on each
+# push to main (the "Promote SHA-tagged image to :latest" step).
+#
+# The project-level `roles/artifactregistry.writer` binding (managed
+# manually outside Terraform) grants tags.create/update/get/list but NOT
+# tags.delete — and `gcloud artifacts docker tags add` on an existing tag
+# performs a delete+create. As a result every deploy-{read-api,ingestor,
+# admin-api,migrations}.yml run has failed at the Promote step since
+# 2026-05-03 (first re-tag attempt after first ship). repoAdmin scoped to
+# the birdwatch repo is the minimum role that includes tags.delete +
+# versions.delete; we deliberately do NOT widen the project-level writer
+# role, and we keep the binding repo-scoped (not project-wide) so a
+# compromised deploy SA cannot touch other Artifact Registry repos that
+# might be added later.
+resource "google_artifact_registry_repository_iam_member" "gh_deploy_repo_admin" {
+  project    = google_artifact_registry_repository.birdwatch.project
+  location   = google_artifact_registry_repository.birdwatch.location
+  repository = google_artifact_registry_repository.birdwatch.name
+  role       = "roles/artifactregistry.repoAdmin"
+  member     = "serviceAccount:gh-deploy@${var.gcp_project_id}.iam.gserviceaccount.com"
+}
+
 output "artifact_registry_url" {
   value = "${var.gcp_region}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}"
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph GitHub_Actions["GitHub Actions"]
      DA["deploy-admin-api.yml"]
      DR["deploy-read-api.yml"]
      DI["deploy-ingestor.yml"]
      DM["deploy-migrations.yml"]
    end

    DA -->|"WIF auth"| SA["gh-deploy@bird-maps-prod"]
    DR -->|"WIF auth"| SA
    DI -->|"WIF auth"| SA
    DM -->|"WIF auth"| SA

    SA -.->|"writer (project)<br/>NO tags.delete"| AR_OLD["Artifact Registry: birdwatch"]
    SA -->|"repoAdmin (repo)<br/>tags.delete OK"| AR_NEW["Artifact Registry: birdwatch"]

    AR_NEW --> ADD["gcloud artifacts docker tags add<br/>&lt;sha&gt; → :latest<br/>(delete + create)"]

    style AR_OLD stroke-dasharray: 4 4
    style ADD fill:#dfd
```

## Summary

- Root cause: `gh-deploy@bird-maps-prod.iam.gserviceaccount.com` has project-level `roles/artifactregistry.writer`, which lacks `artifactregistry.tags.delete`. `gcloud artifacts docker tags add` on an existing tag performs delete-then-create, so the "Promote SHA-tagged image to :latest" step has failed `PERMISSION_DENIED` on every deploy workflow run since 2026-05-03 22:40 UTC (first re-tag attempt after #383 automated the rolling `:latest` step). admin-api is the most-recent symptom but read-api/ingestor are equally blocked.
- Fix: add `google_artifact_registry_repository_iam_member` binding `roles/artifactregistry.repoAdmin` scoped to the `birdwatch` Artifact Registry repository (narrower than widening the project-level writer role; codified instead of left as a manual binding). This is the smallest predefined role that includes `tags.delete` + `versions.delete`.
- Scope: terraform-only; no application code, no workflow YAML changes. After apply, re-running each deploy-*.yml on `main` should green the Promote step.

## Screenshots

N/A — infra-only.

## Test plan

- [x] `terraform fmt registry.tf` — clean
- [x] `terraform validate` — Success
- [ ] `terraform plan` shows only the new `google_artifact_registry_repository_iam_member.gh_deploy_repo_admin` resource being created (verified post-apply during the apply step)
- [ ] After merge + apply: re-run `deploy-admin-api.yml` on `main`; "Promote SHA-tagged image to :latest" step succeeds; same expected for `deploy-read-api.yml` and `deploy-ingestor.yml`

## Plan reference

Out of plan — fix for the deploy gap surfaced post-merge of #504 (silhouette admin-api). admin-api is the most-recent symptom of a project-wide deploy outage that has blocked all four deploy workflows since 2026-05-03; this PR is the load-bearing follow-up.

---

Generated with [Claude Code](https://claude.com/claude-code)