### PR TITLE
infra(ingestor): bump Cloud Run job timeout 300s→900s

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -287,9 +287,8 @@ resource "google_cloud_scheduler_job" "ingest_taxonomy" {
 #
 # Separate Cloud Run Job because the photos kind originally needed a 600s
 # timeout to walk ~344 species × (iNat fetch + R2 PUT) — kept distinct from
-# the shared `bird-ingestor` job so its needs evolve independently. The
-# shared job's timeout is now 900s (post-#506) and still under the photos
-# ceiling. Mirrors the .ingestor job's shape (image, env,
+# the shared `bird-ingestor` job so its needs evolve independently.
+# Mirrors the .ingestor job's shape (image, env,
 # lifecycle.ignore_changes) so deploy-ingestor.yml's image-tag rollout
 # reaches both jobs from a single Artifact Registry push.
 resource "google_cloud_run_v2_job" "ingestor_photos" {

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -98,8 +98,8 @@ resource "google_cloud_run_v2_job" "ingestor" {
       # container is killed. 15 minutes is still well below Cloud Run Jobs'
       # 168h max and short enough that a genuinely-stuck job surfaces
       # within a single cron interval (30 min for `recent`).
-      timeout         = "900s"
-      max_retries     = 1
+      timeout     = "900s"
+      max_retries = 1
 
       containers {
         image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/ingestor:latest"

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -88,7 +88,17 @@ resource "google_cloud_run_v2_job" "ingestor" {
   template {
     template {
       service_account = google_service_account.ingestor.email
-      timeout         = "300s"
+      # Bumped 300s → 900s in PR following #505/#506. The 300s ceiling was
+      # exposed as too tight when the nightly backfill stamp-UPDATE ran for
+      # 5 days against a growing observations table and got SIGKILLed
+      # mid-batch. #506 fixed the underlying O(N²) stamp scope, so backfill
+      # now finishes in seconds — but the 300s fuse was also serving as a
+      # defensive ceiling, and we want more headroom for transient Neon
+      # latency / eBird slow responses / future scope creep before the
+      # container is killed. 15 minutes is still well below Cloud Run Jobs'
+      # 168h max and short enough that a genuinely-stuck job surfaces
+      # within a single cron interval (30 min for `recent`).
+      timeout         = "900s"
       max_retries     = 1
 
       containers {
@@ -275,13 +285,13 @@ resource "google_cloud_scheduler_job" "ingest_taxonomy" {
 
 # ── Photos ingest job (issue #327) ───────────────────────────────────────
 #
-# Separate Cloud Run Job because the photos kind needs a 600s timeout to
-# walk ~344 species × (iNat fetch + R2 PUT). The other kinds (recent,
-# backfill, hotspots, taxonomy) finish well within 300s and are tuned for
-# that ceiling — bumping the shared job's timeout would mask runtime
-# regressions in the eBird-driven kinds. Mirrors the .ingestor job's shape
-# (image, env, lifecycle.ignore_changes) so deploy-ingestor.yml's image-tag
-# rollout reaches both jobs from a single Artifact Registry push.
+# Separate Cloud Run Job because the photos kind originally needed a 600s
+# timeout to walk ~344 species × (iNat fetch + R2 PUT) — kept distinct from
+# the shared `bird-ingestor` job so its needs evolve independently. The
+# shared job's timeout is now 900s (post-#506) and still under the photos
+# ceiling. Mirrors the .ingestor job's shape (image, env,
+# lifecycle.ignore_changes) so deploy-ingestor.yml's image-tag rollout
+# reaches both jobs from a single Artifact Registry push.
 resource "google_cloud_run_v2_job" "ingestor_photos" {
   name     = "bird-ingestor-photos"
   location = var.gcp_region


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph "before"
        S1[Cloud Scheduler<br/>bird-ingest-backfill] -->|runWithOverrides| J1[bird-ingestor<br/>timeout=300s<br/>SIGKILL @ 5min]
    end
    subgraph "after #506 + this PR"
        S2[Cloud Scheduler<br/>bird-ingest-backfill] -->|runWithOverrides| J2[bird-ingestor<br/>timeout=900s<br/>15-min defensive fuse]
        J2 -->|finishes in seconds<br/>per #506 algorithmic fix| OK[clean exit]
    end
```

## Summary

- Raises `timeout` on the `bird-ingestor` Cloud Run Job from 300s to 900s. The 300s ceiling was the binding constraint behind the 5-day backfill hang documented in #505. #506 fixed the root cause (`packages/db-client/src/observations.ts` stamp UPDATE was scanning the whole `observations` table on every batch), so backfill now finishes in seconds — this PR adds defensive headroom on top of the algorithmic fix.
- 900s is well below Cloud Run Jobs' 168h max and still short enough that a genuinely-stuck execution surfaces within a single `recent` cron interval (every 30 min). It gives the shared job room for transient Neon latency, eBird slow responses, and future scope creep without changing the operating point of the healthy crons.
- Sibling jobs `bird-ingestor-photos` (600s) and `bird-ingestor-descriptions` (1800s) are intentionally untouched — already tuned for their per-workload needs. Refreshes a now-stale comment on the photos job that justified itself against the old 300s shared ceiling.

## Screenshots

N/A — infra only.

## Test plan

- [x] `terraform init && terraform plan` — clean. Single in-place update, only the `timeout` attribute on `google_cloud_run_v2_job.ingestor`:

```
  # google_cloud_run_v2_job.ingestor will be updated in-place
  ~ resource "google_cloud_run_v2_job" "ingestor" {
        id                       = "projects/bird-maps-prod/locations/us-west1/jobs/bird-ingestor"
        name                     = "bird-ingestor"
      ~ template {
          ~ template {
              ~ timeout                       = "300s" -> "900s"
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

- [x] No drift in unrelated resources — verified the plan output names only `google_cloud_run_v2_job.ingestor` with `~ update in-place`, every other resource is `Refreshing state...` only.
- [x] `terraform apply` deliberately NOT run from this branch — apply happens post-merge via the project's deploy pipeline.
- [N/A] `npm run typecheck && npm run test` — no application code changed.
- [N/A] New unit / integration tests — infra-only timeout bump, no behavior to assert in test code.
- [N/A] New Playwright e2e spec — not UI.
- [N/A] `npm run build` — no app code changed.
- [N/A] Playwright MCP smoke — not UI.

## Plan reference

Out of plan — followup to #505 (issue) / #506 (root-cause fix that just merged). The algorithmic fix lands in code; this PR follows up on the infra side to widen the defensive fuse now that the binding constraint has shifted away from raw wall-time.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)