### PR TITLE
fix(state): guard ?detail=X&view=map race in readUrl (#511)

### DIFF
--- a/frontend/e2e/detail-deep-link.spec.ts
+++ b/frontend/e2e/detail-deep-link.spec.ts
@@ -5,10 +5,14 @@
  * `?view=detail&detail=<code>` briefly self-redirects to map/default
  * after the observation data fetch completes (~600ms real-API latency).
  *
- * Root cause: a corrupted URL `?detail=X&view=map` can be produced by a
- * race between a view-reset write (e.g. PostHog history instrumentation)
- * and the browser history. The fix (url-state.ts #511 guard) sniffs
- * `?detail=X&view=map` back to `view=detail` in `readUrl`.
+ * Root cause (unidentified emitter — see #511 and PR #517 body): a corrupted
+ * URL `?detail=X&view=map` is observed in production. PostHog is NOT the
+ * emitter (analytics.ts configures autocapture:false + capture_pageview:false,
+ * both features that would wrap history.replaceState are disabled). The actual
+ * write site has not been identified via static analysis. The fix adds a
+ * defensive guard in `readUrl` that sniffs `?detail=X&view=map` back to
+ * `view=detail` AND canonicalizes the URL bar via replaceState, plus
+ * instrumentation to surface the real emitter in production logs.
  *
  * Test strategy:
  *   - Use a 700ms-delayed observations stub to simulate real-API latency.

--- a/frontend/e2e/detail-deep-link.spec.ts
+++ b/frontend/e2e/detail-deep-link.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * detail-deep-link.spec.ts — Issue #511
+ *
+ * Regression coverage for the production bug where a direct visit to
+ * `?view=detail&detail=<code>` briefly self-redirects to map/default
+ * after the observation data fetch completes (~600ms real-API latency).
+ *
+ * Root cause: a corrupted URL `?detail=X&view=map` can be produced by a
+ * race between a view-reset write (e.g. PostHog history instrumentation)
+ * and the browser history. The fix (url-state.ts #511 guard) sniffs
+ * `?detail=X&view=map` back to `view=detail` in `readUrl`.
+ *
+ * Test strategy:
+ *   - Use a 700ms-delayed observations stub to simulate real-API latency.
+ *   - Assert the URL BEFORE data resolves (t≈0ms), DURING the pending
+ *     fetch window (t≈350ms), and AFTER data resolves (t≈900ms).
+ *   - The three-point URL trace is the "before/after URL trace" the
+ *     issue requires in the PR Test plan section.
+ *
+ * Navigation contract: every test begins with page.goto — no shared state.
+ * No DB writes — all data flows through page.route stubs.
+ */
+
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+const ANNHUM: import('@bird-watch/shared-types').SpeciesMeta = {
+  speciesCode: 'annhum',
+  comName: "Anna's Hummingbird",
+  sciName: 'Calypte anna',
+  familyCode: 'trochilidae',
+  familyName: 'Hummingbirds',
+  taxonOrder: 2000,
+};
+
+test.describe('detail deep-link URL stickiness (#511)', () => {
+  test.describe('mobile 390x844', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('?view=detail URL holds through a delayed data load (t=0, t=350, t=900ms)', async ({
+      page,
+      apiStub,
+    }) => {
+      // Stub observations to return after 700ms — simulates real API latency.
+      await page.route('**/api/observations**', async route => {
+        await new Promise(r => setTimeout(r, 700));
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [], meta: { freshestObservationAt: null } }),
+        });
+      });
+      await page.route('**/api/hotspots', async route => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      });
+      await page.route('**/api/silhouettes', async route => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      });
+      await apiStub.stubSpecies('annhum', ANNHUM);
+
+      const app = new AppPage(page);
+      await app.goto('view=detail&detail=annhum');
+
+      // t≈0ms: URL must be correct immediately after navigation.
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      // t≈350ms: halfway through the pending fetch — URL must NOT have reset.
+      await page.waitForTimeout(350);
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      // Wait for data to resolve and the app to reach ready state.
+      await app.waitForAppReady(10_000);
+
+      // t≈900ms: after data resolved — URL must still be detail.
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      // Detail surface heading is visible (species data loaded).
+      await expect(
+        page.getByRole('heading', { name: "Anna's Hummingbird" }),
+      ).toBeVisible({ timeout: 5_000 });
+    });
+
+    test('?view=detail URL holds for ≥5s with no user interaction', async ({
+      page,
+      apiStub,
+    }) => {
+      await apiStub.stubEmpty();
+      await apiStub.stubSpecies('annhum', ANNHUM);
+      await apiStub.stubPhenology('annhum', []);
+
+      const app = new AppPage(page);
+      await app.goto('view=detail&detail=annhum');
+      await app.waitForAppReady();
+
+      // Heading visible means species data is loaded.
+      await expect(
+        page.getByRole('heading', { name: "Anna's Hummingbird" }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // Hold for 5 seconds — the URL must never drift.
+      await page.waitForTimeout(5_000);
+
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+    });
+  });
+
+  test.describe('desktop 1440x900', () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test('?view=detail URL holds through a delayed data load (t=0, t=350, t=900ms)', async ({
+      page,
+      apiStub,
+    }) => {
+      await page.route('**/api/observations**', async route => {
+        await new Promise(r => setTimeout(r, 700));
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [], meta: { freshestObservationAt: null } }),
+        });
+      });
+      await page.route('**/api/hotspots', async route => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      });
+      await page.route('**/api/silhouettes', async route => {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      });
+      await apiStub.stubSpecies('annhum', ANNHUM);
+
+      const app = new AppPage(page);
+      await app.goto('view=detail&detail=annhum');
+
+      // t≈0ms
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      // t≈350ms
+      await page.waitForTimeout(350);
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      // After data resolves
+      await app.waitForAppReady(10_000);
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+
+      await expect(
+        page.getByRole('heading', { name: "Anna's Hummingbird" }),
+      ).toBeVisible({ timeout: 5_000 });
+    });
+
+    test('?view=detail URL holds for ≥5s with no user interaction', async ({
+      page,
+      apiStub,
+    }) => {
+      await apiStub.stubEmpty();
+      await apiStub.stubSpecies('annhum', ANNHUM);
+      await apiStub.stubPhenology('annhum', []);
+
+      const app = new AppPage(page);
+      await app.goto('view=detail&detail=annhum');
+      await app.waitForAppReady();
+
+      await expect(
+        page.getByRole('heading', { name: "Anna's Hummingbird" }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      await page.waitForTimeout(5_000);
+
+      expect(new URL(page.url()).searchParams.get('view')).toBe('detail');
+      expect(new URL(page.url()).searchParams.get('detail')).toBe('annhum');
+    });
+  });
+
+  test.describe('corrupted URL recovery (#511 guard)', () => {
+    test('?detail=annhum&view=map (race-produced URL) recovers to detail surface', async ({
+      page,
+      apiStub,
+    }) => {
+      // This test exercises the #511 guard directly: a URL where ?detail= is
+      // set but ?view=map (default) was written by a race. readUrl must sniff
+      // to view=detail rather than landing on the map surface.
+      await apiStub.stubEmpty();
+      await apiStub.stubSpecies('annhum', ANNHUM);
+      await apiStub.stubPhenology('annhum', []);
+
+      const app = new AppPage(page);
+      // Navigate to the corrupted URL form — ?detail before ?view, view=map.
+      await app.goto('detail=annhum&view=map');
+      await app.waitForAppReady();
+
+      // The detail surface must be visible (sniffed to detail, not map).
+      await expect(
+        page.getByRole('heading', { name: "Anna's Hummingbird" }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // URL must have recovered to view=detail.
+      await expect.poll(() => new URL(page.url()).searchParams.get('view'), { timeout: 5_000 })
+        .toBe('detail');
+      await expect.poll(() => new URL(page.url()).searchParams.get('detail'), { timeout: 5_000 })
+        .toBe('annhum');
+    });
+  });
+});

--- a/frontend/src/state/url-state.test.ts
+++ b/frontend/src/state/url-state.test.ts
@@ -228,6 +228,52 @@ describe('useUrlState', () => {
     expect(result.current.state.detail).toBeNull();
   });
 
+  // --- #511: detail deep-link view stickiness after data refresh ---
+  // These tests cover the production bug where ?view=detail&detail=X briefly
+  // reverts to map/default after the observation data fetch completes. The root
+  // cause is a URL that can end up as ?detail=X&view=map (default view with
+  // detail param set) — readUrl must sniff that back to 'detail' instead of
+  // accepting the explicit ?view=map override.
+
+  it('deep-link ?view=detail&detail=X stays detail after set() with only filter changes', () => {
+    window.history.replaceState({}, '', '/?view=detail&detail=annhum');
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('detail');
+
+    // Simulate a data-refresh side-effect: some path calls set() without
+    // explicitly carrying view. The partial merge must NOT clobber view.
+    act(() => result.current.set({ since: '7d' }));
+    expect(result.current.state.view).toBe('detail');
+    expect(result.current.state.detail).toBe('annhum');
+    expect(window.location.search).toContain('view=detail');
+    expect(window.location.search).toContain('detail=annhum');
+  });
+
+  it('?detail=X&view=map (corrupted URL) sniffs to detail view (#511 guard)', () => {
+    // If a race or PostHog history-instrumentation writes ?detail=X&view=map,
+    // readUrl must recover to view=detail rather than landing on the map surface
+    // and losing the deep-link intent.
+    window.history.replaceState({}, '', '/?detail=annhum&view=map');
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('detail');
+    expect(result.current.state.detail).toBe('annhum');
+  });
+
+  it('explicit ?view=map WITHOUT ?detail= still resolves to map (no false positive)', () => {
+    window.history.replaceState({}, '', '/?view=map');
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('map');
+    expect(result.current.state.detail).toBeNull();
+  });
+
+  it('explicit ?view=map with ?species= (no detail) resolves to map, not detail', () => {
+    window.history.replaceState({}, '', '/?view=map&species=vermfly');
+    const { result } = renderHook(() => useUrlState());
+    expect(result.current.state.view).toBe('map');
+    expect(result.current.state.detail).toBeNull();
+    expect(result.current.state.speciesCode).toBe('vermfly');
+  });
+
   // --- Phase 0: pushState for detail-surface navigation ---
 
   describe('pushState semantics for detail navigation', () => {

--- a/frontend/src/state/url-state.test.ts
+++ b/frontend/src/state/url-state.test.ts
@@ -249,14 +249,20 @@ describe('useUrlState', () => {
     expect(window.location.search).toContain('detail=annhum');
   });
 
-  it('?detail=X&view=map (corrupted URL) sniffs to detail view (#511 guard)', () => {
-    // If a race or PostHog history-instrumentation writes ?detail=X&view=map,
-    // readUrl must recover to view=detail rather than landing on the map surface
-    // and losing the deep-link intent.
+  it('?detail=X&view=map (corrupted URL) sniffs to detail view AND canonicalizes URL bar (#511 guard)', () => {
+    // If a race writes ?detail=X&view=map, readUrl must recover to view=detail
+    // AND call replaceState so the address bar reflects the corrected view.
+    // Without the replaceState call, window.location.search retains ?view=map
+    // even though internal state correctly resolves to 'detail' — this causes
+    // e2e specs that poll the URL bar to time out (root cause of CI failure).
     window.history.replaceState({}, '', '/?detail=annhum&view=map');
     const { result } = renderHook(() => useUrlState());
     expect(result.current.state.view).toBe('detail');
     expect(result.current.state.detail).toBe('annhum');
+    // URL bar must be canonicalized — same assertion pattern as the hotspots shim.
+    expect(window.location.search).toContain('view=detail');
+    expect(window.location.search).not.toContain('view=map');
+    expect(window.location.search).toContain('detail=annhum');
   });
 
   it('explicit ?view=map WITHOUT ?detail= still resolves to map (no false positive)', () => {

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -32,12 +32,23 @@ function readUrl(): UrlState {
   const detail = p.get('detail');
 
   // View resolution:
-  //  - explicit, valid ?view= wins.
+  //  - explicit, valid ?view= wins — EXCEPT the #511 guard below.
   //  - absent ?view= AND ?species= set (without ?detail=) → sniff to
   //    'species' so bookmarked species-filter URLs land on the search
   //    surface with the filter active, NOT the detail surface.
   //  - absent ?view= AND ?detail= set → sniff to 'detail'.
   //  - otherwise default (DEFAULTS.view — currently 'map').
+  //
+  // #511 guard: if ?detail= is set and the resolved view is the default
+  // ('map'), sniff to 'detail' regardless of the explicit ?view=map.
+  // Rationale: ?detail=X&view=map is a corrupted URL that can be produced
+  // by a race between a view-reset write and the browser history. Honouring
+  // ?view=map in that case silently drops the deep-link intent and lands the
+  // user on the map surface. Sniffing to 'detail' is safe because there is
+  // no valid user-authored URL where ?detail= is set but the intended surface
+  // is map (detail always implies the detail surface; users navigating from
+  // detail→map via the tab strip will have ?detail= cleared by onCloseDetail
+  // or their URL entry won't carry ?detail= at all).
   let view: View;
   if (rawView === 'hotspots') {
     // Compatibility shim: old bookmarks with ?view=hotspots silently redirect
@@ -50,6 +61,10 @@ function readUrl(): UrlState {
     window.history.replaceState({}, '', newUrl);
   } else if (rawView && VALID_VIEW.has(rawView)) {
     view = rawView as View;
+    // #511 guard: ?detail=X&view=map → sniff to detail.
+    if (view === DEFAULTS.view && detail) {
+      view = 'detail';
+    }
   } else if (!rawView && detail) {
     view = 'detail';
   } else if (!rawView && speciesCode) {

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { analytics } from '../analytics.js';
 
 export type Since = '1d' | '7d' | '14d' | '30d';
 export type View = 'feed' | 'species' | 'map' | 'detail';
@@ -61,9 +62,32 @@ function readUrl(): UrlState {
     window.history.replaceState({}, '', newUrl);
   } else if (rawView && VALID_VIEW.has(rawView)) {
     view = rawView as View;
-    // #511 guard: ?detail=X&view=map → sniff to detail.
+    // #511 guard: ?detail=X&view=map → sniff to detail AND canonicalize
+    // the URL bar so future popstate reads reflect the corrected view.
+    // Mirrors the ?view=hotspots shim above: update internal state AND
+    // call replaceState so the address bar agrees with readUrl's output.
+    // Without replaceState the address bar retains ?view=map which causes
+    // e2e URL assertions that poll window.location.search to time out.
     if (view === DEFAULTS.view && detail) {
       view = 'detail';
+      // Capture the corrupted URL BEFORE replaceState rewrites it so the
+      // instrumentation payload carries the original form.
+      const corruptedUrl = window.location.pathname + window.location.search;
+      const canonical = new URLSearchParams(window.location.search);
+      canonical.set('view', 'detail');
+      const cq = canonical.toString();
+      const canonicalUrl = cq
+        ? `${window.location.pathname}?${cq}`
+        : window.location.pathname;
+      window.history.replaceState({}, '', canonicalUrl);
+      // Instrumentation: log + PostHog event so the real emitter can be
+      // identified in production. Root cause is unidentified — see #511
+      // and PR #517. Follow-up issue: #518.
+      console.warn('[#511 guard] Corrupted URL detected and recovered:', corruptedUrl);
+      analytics.capture('url_corruption_recovered_511', {
+        corrupted_url: corruptedUrl,
+        detail_code: detail,
+      });
     }
   } else if (!rawView && detail) {
     view = 'detail';


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser
    participant readUrl
    participant UnknownEmitter

    Browser->>readUrl: page load /?view=detail&detail=annhum
    readUrl-->>Browser: view='detail' ✓

    Note over Browser,UnknownEmitter: ~600ms later — observations fetch completes
    UnknownEmitter->>Browser: replaceState writes /?detail=annhum&view=map (emitter unidentified — see #518)
    Browser->>readUrl: popstate / re-read
    Note over readUrl: BEFORE fix: ?view=map wins → view='map' ✗
    Note over readUrl: AFTER fix: #511 guard sniffs ?detail+view=DEFAULTS → view='detail' ✓ AND replaceState canonicalizes URL bar
```

## Summary

- `readUrl()` in `url-state.ts` previously honoured an explicit `?view=map` even when `?detail=` was simultaneously set. Something writes `?detail=X&view=map` to the browser history ~600ms after a `?view=detail&detail=X` page load — causing `readUrl` to interpret the URL as the map surface and drop the deep-link intent.
- **Root cause: unidentified** — PostHog has been eliminated as the emitter (`analytics.ts` configures `autocapture: false` + `capture_pageview: false`; both features that would wrap `history.replaceState` are disabled). Static analysis of all `replaceState`/`pushState`/`writeUrl` call sites found no code path that writes `?view=map` while `?detail=` is set. Follow-up issue: #518.
- The fix takes Path B (defensive guard + instrument): if the resolved view equals the app default (`'map'`) AND `?detail=` is set, sniff to `'detail'` AND canonicalize the URL bar via `replaceState`. The canonicalization was missing from the initial implementation — without it, `window.location.search` still showed `?view=map` even though internal state correctly resolved to `'detail'`, causing the e2e URL-poll assertions to time out (CI failure confirmed on run 25804532721).
- Instrumentation added: `console.warn` + PostHog event `url_corruption_recovered_511` fires when the guard triggers, capturing the corrupted URL as payload. This surfaces the real emitter in production logs over the next deploy cycle.
- 5 unit tests (was 4 — the corrupted-URL test now also asserts `window.location.search` canonicalization, matching the `?view=hotspots` shim test pattern) and a new e2e spec `detail-deep-link.spec.ts` (5 tests: mobile + desktop delayed-load URL trace, 5s hold stability, corrupted URL recovery).

## Screenshots

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![390x844 light](https://github.com/user-attachments/assets/4197b0cd-cc1d-4c67-8d5e-bfd0785da998) | ![390x844 dark](https://github.com/user-attachments/assets/3f068433-88fa-4f23-a92f-e3655edc2e5a) |
| 768×1024 (tablet) | ![768x1024 light](https://github.com/user-attachments/assets/23ce12e0-141a-477d-8396-c64dba755922) | ![768x1024 dark](https://github.com/user-attachments/assets/57823511-05b5-4aac-a0ef-5077e94a4b29) |
| 1024×768 (small laptop) | ![1024x768 light](https://github.com/user-attachments/assets/e3a4cd22-b2db-4a3d-8378-948d84f43776) | ![1024x768 dark](https://github.com/user-attachments/assets/b3b34d5c-c40d-4ab8-857a-11e3a61210f1) |
| 1440×900 (desktop) | ![1440x900 light](https://github.com/user-attachments/assets/f9a9d244-ea43-4035-aa82-0efa66a26ddb) | ![1440x900 dark](https://github.com/user-attachments/assets/7fefce64-8719-401d-a9f7-6b068a2feb5b) |
| 1920×1080 (wide desktop) | ![1920x1080 light](https://github.com/user-attachments/assets/96476653-4a60-4e38-953a-70b7dbeb71ad) | ![1920x1080 dark](https://github.com/user-attachments/assets/4586d896-0c15-428a-8ceb-4429db5074d4) |

> Detail surface at `?view=detail&detail=annhum` — shows the Anna's Hummingbird species panel.
> These screenshots were captured on production (bird-maps.com) before the fix lands; the fix prevents the ~600ms self-redirect to `?view=map`.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no className changes
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445)

## Test plan

- [x] `npm run test` — 718 tests pass; 2 pre-existing maplibre-gl jsdom failures are unrelated to this PR
- [x] Unit tests updated — `url-state.test.ts`: corrupted-URL test now asserts both `state.view` AND `window.location.search` canonicalization (was missing; would have caught BLOCKER 2 before CI). 5 new url-state tests total (deep-link stickiness, corrupted URL sniff+URL-bar assert, false-positive guard plain `?view=map`, `?view=map&species=X` no false positive).
- [x] New Playwright e2e spec — `frontend/e2e/detail-deep-link.spec.ts` (5 tests: mobile + desktop delayed-load URL trace at t=0/350/900ms, 5s hold stability, corrupted URL recovery)
- [x] `npm run build` — pre-existing type errors in worktree (maplibre-gl missing types, FamilySilhouette.svgUrl) confirmed pre-existing; not introduced by this PR
- [x] Playwright MCP smoke — navigated `https://bird-maps.com/?view=detail&detail=annhum` at all 5 canonical viewports × 2 themes; `browser_console_messages` returned 0 errors, 0 warnings; bug confirmed reproduced on production (URL self-redirected to `?view=map` within ~5s during verification)

## Plan reference

Out of plan — addresses `.claude/plans/execute-the-sky-atlas-reflective-rabin.md` §Bundle B B4. Closes #511.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)