### PR TITLE
fix(infra/workers): add CORS headers to silhouette-server so legend mask-image renders cross-origin

### DIFF
--- a/infra/workers/silhouette-server.js
+++ b/infra/workers/silhouette-server.js
@@ -46,11 +46,19 @@ export default {
 
     const object = await env.SILHOUETTES.get(key);
 
+    // Silhouettes are public, read-only, license-clean (CC0/CC-BY) assets and
+    // are consumed by the frontend legend via CSS `mask-image: url(...)`. The
+    // browser treats the SVG as cross-origin tainted and silently fails the
+    // mask render unless the response carries an `Access-Control-Allow-Origin`
+    // header. Wildcard origin is appropriate for this asset class. Applied to
+    // both hit and miss so a family that later lands starts rendering in the
+    // legend without a cache bust.
     if (object === null) {
       return new Response(null, {
         status: 404,
         headers: {
           'Cache-Control': 'public, max-age=60',
+          'Access-Control-Allow-Origin': '*',
         },
       });
     }
@@ -59,6 +67,7 @@ export default {
       headers: {
         'Content-Type': contentTypeFor(key),
         'Cache-Control': 'public, max-age=31536000, immutable',
+        'Access-Control-Allow-Origin': '*',
       },
     });
   },

--- a/infra/workers/silhouette-server.test.js
+++ b/infra/workers/silhouette-server.test.js
@@ -13,7 +13,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { contentTypeFor } from './silhouette-server.js';
+import worker, { contentTypeFor } from './silhouette-server.js';
 
 describe('contentTypeFor (silhouette-server)', () => {
   it('returns image/svg+xml for .svg', () => {
@@ -32,5 +32,45 @@ describe('contentTypeFor (silhouette-server)', () => {
     // get the right Content-Type if it ever lands.
     assert.equal(contentTypeFor('family/cuculidae.SVG'), 'image/svg+xml');
     assert.equal(contentTypeFor('family/cuculidae.Svg'), 'image/svg+xml');
+  });
+});
+
+// CORS: the frontend legend uses CSS `mask-image: url(...)` against the
+// silhouette URL. Browsers silently treat the SVG as cross-origin tainted and
+// the mask fails to render unless the response carries an
+// `Access-Control-Allow-Origin` header. Silhouettes are public, read-only,
+// CC0/CC-BY assets, so a wildcard origin is appropriate. Both hit (200) and
+// miss (404) responses must include the header — a missed family that later
+// lands must not require a cache bust to start working in the legend.
+describe('silhouette-server fetch (CORS)', () => {
+  /** @returns {{ SILHOUETTES: { get: (key: string) => Promise<{ body: string } | null> } }} */
+  function envWith(map) {
+    return {
+      SILHOUETTES: {
+        async get(key) {
+          return key in map ? { body: map[key] } : null;
+        },
+      },
+    };
+  }
+
+  it('returns Access-Control-Allow-Origin: * on a hit', async () => {
+    const env = envWith({ 'family/cuculidae.deadbeef.svg': '<svg/>' });
+    const res = await worker.fetch(
+      new Request('https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg'),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+  });
+
+  it('returns Access-Control-Allow-Origin: * on a miss', async () => {
+    const env = envWith({});
+    const res = await worker.fetch(
+      new Request('https://silhouettes.bird-maps.com/family/missing.svg'),
+      env,
+    );
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser
    participant Legend as Legend (CSS mask-image)
    participant Worker as silhouettes.bird-maps.com<br/>(silhouette-server)
    participant R2 as R2: bird-maps-silhouettes

    Note over Browser,R2: BEFORE — mask-image silently fails
    Legend->>Worker: GET /family/cuculidae.<sha>.svg
    Worker->>R2: env.SILHOUETTES.get(key)
    R2-->>Worker: object
    Worker-->>Legend: 200 image/svg+xml<br/>(no ACAO header)
    Browser--xLegend: cross-origin taint → mask renders empty

    Note over Browser,R2: AFTER — header present, mask renders
    Legend->>Worker: GET /family/cuculidae.<sha>.svg
    Worker->>R2: env.SILHOUETTES.get(key)
    R2-->>Worker: object
    Worker-->>Legend: 200 image/svg+xml<br/>Access-Control-Allow-Origin: *
    Legend->>Browser: silhouette renders in legend slot
```

## Summary

- The legend uses CSS `mask-image: url(https://silhouettes.bird-maps.com/...)`; without `Access-Control-Allow-Origin` on the response, browsers silently fail the mask render and the legend slot is empty for any family resolved via `svg_url` (e.g. cuculidae). The map itself is unaffected because it consumes inline `svg_data` and never fetches the asset.
- Silhouettes are public, read-only, license-clean (CC0/CC-BY) assets; wildcard `*` is the appropriate origin policy. Header is added to both the 200 hit and the 404 miss so a family that later lands starts rendering in the legend without a cache bust.

## Screenshots

N/A — Worker-only (no `frontend/**` files changed).

## Test plan

- [x] `node --test infra/workers/silhouette-server.test.js` — 5/5 green (3 prior + 2 new CORS cases asserting `Access-Control-Allow-Origin: *` on hit and miss)
- [x] `node --test infra/workers/photo-server.test.js` — 6/6 green (no regression in sibling worker)
- [x] New unit tests added (RED → GREEN: confirmed failure with `null !== '*'` before adding header, passing after)
- [ ] **Post-merge deploy required.** The Worker is deployed via Terraform (`cloudflare_workers_script.silhouette_server` in `infra/terraform/silhouettes.tf` reads the `.js` file). After merge, a maintainer must run `terraform apply` against the prod workspace — there is no `deploy-workers.yml` GitHub Actions workflow on this repo, and `terraform-plan-drift-check.yml` only plans, never applies. Until apply lands, the live response from `https://silhouettes.bird-maps.com/...` will still lack the header. Verify post-deploy with: `curl -sI https://silhouettes.bird-maps.com/family/cuculidae.<sha>.svg | grep -i access-control-allow-origin`.

## Plan reference

Out of plan — production legend-rendering regression observed after the silhouette-server worker shipped (#502). Silhouette `svg_url` path renders empty in the legend; the map is unaffected because it uses inline `svg_data`. CORS is the minimal correct fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)