### PR TITLE
docs(skills): add curating-fallback-silhouettes operator skill

### DIFF
--- a/.claude/skills/curating-fallback-silhouettes/SKILL.md
+++ b/.claude/skills/curating-fallback-silhouettes/SKILL.md
@@ -26,7 +26,7 @@ The Phylopic curation pipeline (`scripts/curate-phylopic.mjs`) sweeps every AZ f
 ## Preconditions
 
 - `bird-admin-api` Cloud Run service deployed (issue #502 landed it; see `docs/runbooks/silhouette-override.md` for the deploy bootstrap).
-- `npm run silhouette` alias present in root `package.json` (it forwards to `scripts/silhouette-cli.mjs`).
+- `npm run silhouette` alias present in root `package.json` (it forwards to `scripts/silhouette.mjs`).
 - Env loaded:
   ```bash
   export ADMIN_API_URL="$(gcloud run services describe bird-admin-api \
@@ -91,16 +91,22 @@ Ordering rule (best tracing-fit first, so the eye lands on the most likely winne
 4. CC-BY-SA-* (share-alike propagation — flag with a badge)
 5. CC-BY-NC-*, CC-BY-ND-*, PD-mark (reference only — include with a "cannot ship" warning so the user knows why a tempting result is excluded)
 
-A quick substitution:
+A quick substitution (multi-line `sed` form — portable across macOS BSD
+`sed` and GNU `sed`; the single-line `{r file; d}` shape that GNU `sed`
+accepts fails on BSD `sed` with `extra characters at the end of d
+command`):
 
 ```bash
 FAMILY=cuculidae
 DIR="/tmp/silhouette-picker/$FAMILY"
 mkdir -p "$DIR"
-# Build CANDIDATES_HTML in your head or via a small helper; then:
+# Build /tmp/candidates.html (one <article class="card">…</article> per
+# candidate; see the picker template header for the card shape), then:
 sed -e "s/{{FAMILY}}/$FAMILY/g" \
-    -e "/{{CANDIDATES}}/{r /tmp/candidates.html
-                         d}" \
+    -e "/{{CANDIDATES}}/{
+          r /tmp/candidates.html
+          d
+        }" \
     .claude/skills/curating-fallback-silhouettes/templates/picker.html.template \
   > "$DIR/index.html"
 cd "$DIR" && python3 -m http.server 8765 &
@@ -118,7 +124,15 @@ Admin-api validator requires:
 - Body ≤ 64 KB
 - path-d charset: digits, the SVG command letters, space, dash, dot, comma
 - No `<g>`, `<defs>`, `<use>`, `<style>`, `<script>`, event handlers, or `xlink:*`
-- ≥20 path commands (gate from `extractPathD` in `scripts/curate-phylopic.mjs`)
+
+Operator hint (not enforced by the validator): paths under ~20 commands
+tend to render as unrecognizable blobs at 24–28px legend scale. The
+automated Phylopic sourcing pipeline (`extractPathD` in
+`scripts/curate-phylopic.mjs`) applies a ≥20-command floor at curation
+time as a quality heuristic, but the admin-api validator
+(`services/admin-api/src/validate.ts`) does not — a hand-curated
+silhouette below 20 commands will upload fine but may not read at small
+sizes. Squint-test before shipping.
 
 If the chosen file violates any rule, reduce it. The algorithm to apply:
 
@@ -227,7 +241,7 @@ Apply this on every candidate before adding it to the picker.
 - **"Unknown" creator on Wikimedia.** Plates labeled "Unknown, <year>" by Wikimedia editors are usually well-known publications (Audubon, Bird-Lore, Birds and Nature). Substitute the publication name + year as the creator string before upload — anonymous credit is rejected by the audit downstream.
 - **CSS `mask-image` requires CORS on the silhouette URL.** The Worker that serves R2 silhouette URLs sets `access-control-allow-origin: *`. If the Worker is ever modified, preserve that header — without it the `mask-image` pipeline degrades to inline-SVG fallback and the SDF clustering breaks.
 - **One iconic species per family.** Squint-test at 24–28px before committing. A "technically correct but unrecognizable at small sizes" silhouette is worse than the `_FALLBACK` shape because the user assumes it's information.
-- **Validator's ≥20-command floor was tightened in #500.** Pre-#500 silhouettes can have fewer (median 16, see comment block in `extractPathD`). Going forward, anything below 20 is rejected — if a hand-curated silhouette is otherwise good but trips the floor, add a few smoothing curves rather than dropping the candidate.
+- **Phylopic curation pipeline's ≥20-command floor (issue #500) is a sourcing filter, not a validator rule.** It fires inside `extractPathD` in `scripts/curate-phylopic.mjs` and gates which Phylopic results the automated pipeline accepts. The admin-api validator (`services/admin-api/src/validate.ts`) does NOT enforce a path-command floor, so a hand-curated silhouette below 20 commands will upload successfully. Pre-#500 silhouettes ship at a median of 16 commands. Treat ~20 as a squint-test rule of thumb for legibility at 24–28px; if a hand-curated silhouette is otherwise good but reads as a blob, add a few smoothing curves before retrying — but don't drop the candidate just because it trips the heuristic.
 
 ## Rollback
 

--- a/.claude/skills/curating-fallback-silhouettes/SKILL.md
+++ b/.claude/skills/curating-fallback-silhouettes/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: curating-fallback-silhouettes
+description: Use when a family on bird-maps.com renders the `_FALLBACK` shape because Phylopic has no usable CC-licensed art, when the `/api/silhouettes` audit returns families with `svgData == null AND svgUrl == null`, or when the user asks to "hand-curate", "hand-pick", or "source" a silhouette for a specific bird family. Also triggers on "process the remaining null silhouettes", "find a roadrunner silhouette", "fix the cuckoos", or similar requests to add non-Phylopic silhouettes via the silhouette admin-api.
+---
+
+# Curating fallback silhouettes (human-in-the-loop)
+
+## What this is
+
+The Phylopic curation pipeline (`scripts/curate-phylopic.mjs`) sweeps every AZ family and picks the best CC-licensed Phylopic silhouette it can find — but a residual cohort of families have no usable Phylopic art (anonymous-creator-only, NC/ND-only, or no node at all). This skill closes that gap: source a silhouette from outside Phylopic (Wikimedia Commons, SVG Repo, OpenClipArt, iNaturalist, etc.), normalize it to the admin-api validator's shape, and upload it via `npm run silhouette set`. The two workflows complement each other — Phylopic for the families it has art for, this skill for the residual cohort.
+
+## When to use
+
+- A family chip in `FamilyLegend` renders the `_FALLBACK` outline (generic bird shape) and the user wants a real silhouette.
+- `curl $READ_API_URL/api/silhouettes` returns one or more entries with `svgData == null AND svgUrl == null`.
+- The user names a specific family ("fix the cuckoos", "find a roadrunner silhouette") that the Phylopic curator already exhausted.
+- Batch request: "process the remaining nulls" or "fill the rest of the family silhouettes".
+
+## When NOT to use
+
+- Species-level silhouette overrides — the `family_silhouettes` schema is keyed by `family_code` only. Species overrides require a schema change first.
+- Photo-based markers — the map renders SDF-traced silhouettes, not photos. A photo system would be a separate feature.
+- A family that Phylopic *does* have art for but the auto-pick chose poorly — re-run `node scripts/curate-phylopic.mjs --family <code>` with the existing pipeline first; this skill is the fallback when that pipeline has nothing to pick from.
+- Reverting a silhouette — use `npm run silhouette unset <family>` (see Rollback).
+
+## Preconditions
+
+- `bird-admin-api` Cloud Run service deployed (issue #502 landed it; see `docs/runbooks/silhouette-override.md` for the deploy bootstrap).
+- `npm run silhouette` alias present in root `package.json` (it forwards to `scripts/silhouette-cli.mjs`).
+- Env loaded:
+  ```bash
+  export ADMIN_API_URL="$(gcloud run services describe bird-admin-api \
+    --region=us-west1 --project=bird-maps-prod --format='value(status.url)')"
+  export ADMIN_API_TOKEN="$(gcloud secrets versions access latest \
+    --secret=bird-watch-admin-api-token --project=bird-maps-prod)"
+  ```
+- `gcloud auth login` on `bird-maps-prod` (the secret read above will 403 otherwise).
+- Read API base URL for the audit step: `export READ_API_URL="https://api.bird-maps.com"`.
+
+## Workflow
+
+### 1. Detect gaps
+
+```bash
+curl -s "$READ_API_URL/api/silhouettes" \
+  | jq -r '.silhouettes[] | select(.svgData == null and .svgUrl == null) | .familyCode'
+```
+
+Each line is a family that currently renders the `_FALLBACK` outline. If the list is empty, there's nothing to do. Keep the list — step 2 picks from it.
+
+### 2. Pick a target family
+
+Either the user names one explicitly, or pop the next family from step 1's list. For each family, identify the iconic AZ species — the one a regional birder pictures when they hear the family name. Squint test at 24-28px decides whether a silhouette is recognizable; pick the most distinctive species.
+
+| Family code | Iconic AZ species | Why |
+|---|---|---|
+| `cuculidae` | Greater Roadrunner | Unmistakable terrestrial silhouette; Arizona icon |
+| `gaviidae` | Common Loon | Heavy body, dagger bill, low waterline pose |
+| `icteriidae` | Yellow-breasted Chat | Only species in the family; thrush-like profile |
+| `tytonidae` | Barn Owl | Heart-shaped face — diagnostic at small sizes |
+| `numididae` | Helmeted Guineafowl | Rare in AZ but the only family member — helmet-and-wattle shape |
+| `peucedramidae` | Olive Warbler | Monotypic; warbler profile with longer tail |
+| `phasianidae` | Gambel's Quail | Topknot makes the AZ species pickable at any size |
+
+When in doubt: pick the species the family is colloquially named after, or the most-reported species in AZ eBird data for that family.
+
+### 3. Auto-source candidates
+
+For the chosen species, sweep 4–6 CC-licensed sources. Construct queries from the binomial (e.g. `Geococcyx californianus`) and the common name. Always check the license string on each result before adding to the picker — see the License gate below.
+
+| Source | Query URL pattern | Notes |
+|---|---|---|
+| Wikimedia Commons | `https://commons.wikimedia.org/wiki/Category:<Scientific_name>` | Best yield. Especially `Audubon's Birds of America` plates (PD-old), `Bird-Lore` and `Birds and Nature` lithographs (PD-old). Look for line drawings, not color photos. |
+| SVG Repo | `https://www.svgrepo.com/search/?q=<species>` | Filter by license = CC0 in the sidebar. Many results are stylized but trace cleanly. |
+| OpenClipArt | `https://openclipart.org/search/?query=<species>` | All CC0 by site policy. Coverage is patchy. |
+| Phylopic (relaxed) | `https://api.phylopic.org/images?build=537&filter_name=<scientific-name>&page=0` | `filter_name` is **case-sensitive on the URL** — always lowercase the slug. Useful at genus/species level when the family-level call already failed. |
+| iNaturalist CC0 photos | `https://www.inaturalist.org/observations?taxon_name=<species>&license=cc0` | Last resort: trace a photo via `potrace` (`brew install potrace`). Profile shots with high contrast work; busy backgrounds don't. |
+| The Noun Project | `https://thenounproject.com/search/icons/?q=<species>` | CC-BY icons. Attribution required. Often the cleanest geometry but stylized. |
+
+Capture for each candidate: download URL of the asset, license id, creator name (or "Unknown, <year>" for PD-old plates), source-page URL.
+
+### 4. Build the picker
+
+Render `templates/picker.html.template` (in this skill folder) into `/tmp/silhouette-picker/<family>/index.html`, substituting `{{FAMILY}}` and `{{CANDIDATES}}`. The template is self-contained (inline CSS, no JS frameworks) and shows each candidate as a numbered card with the original asset thumbnail, license badge, creator, and source link.
+
+Ordering rule (best tracing-fit first, so the eye lands on the most likely winner):
+
+1. CC0-1.0 SVGs (no attribution friction, vector source)
+2. PD-old illustrations (line drawings trace cleanly)
+3. CC-BY-* SVGs (attribution propagates but ships fine)
+4. CC-BY-SA-* (share-alike propagation — flag with a badge)
+5. CC-BY-NC-*, CC-BY-ND-*, PD-mark (reference only — include with a "cannot ship" warning so the user knows why a tempting result is excluded)
+
+A quick substitution:
+
+```bash
+FAMILY=cuculidae
+DIR="/tmp/silhouette-picker/$FAMILY"
+mkdir -p "$DIR"
+# Build CANDIDATES_HTML in your head or via a small helper; then:
+sed -e "s/{{FAMILY}}/$FAMILY/g" \
+    -e "/{{CANDIDATES}}/{r /tmp/candidates.html
+                         d}" \
+    .claude/skills/curating-fallback-silhouettes/templates/picker.html.template \
+  > "$DIR/index.html"
+cd "$DIR" && python3 -m http.server 8765 &
+open "http://localhost:8765/"
+```
+
+Wait for the user to name the winning number. If none of the candidates work, return to step 3 with broadened queries (genus level, related species, alternate common names).
+
+### 5. Normalize the chosen SVG
+
+Admin-api validator requires:
+
+- Single `<svg>` root with exactly one `<path>` child
+- `viewBox="0 0 24 24"` (or absent)
+- Body ≤ 64 KB
+- path-d charset: digits, the SVG command letters, space, dash, dot, comma
+- No `<g>`, `<defs>`, `<use>`, `<style>`, `<script>`, event handlers, or `xlink:*`
+- ≥20 path commands (gate from `extractPathD` in `scripts/curate-phylopic.mjs`)
+
+If the chosen file violates any rule, reduce it. The algorithm to apply:
+
+1. Parse the SVG, locate the first `<path d="...">`.
+2. If a `<g transform="translate(...) scale(...)">` wraps it, flatten the transform into the path coordinates (potrace's translate-then-scale shape is what `parseGTransform` / `transformPathD` in `scripts/curate-phylopic.mjs` handle).
+3. Multi-path SVGs: concatenate `d` attributes (`M ... Z M ... Z`) — the validator accepts a single `<path>` whose `d` contains multiple sub-paths.
+4. Normalize coordinates so the bounding box maps to 0..24. The `normalizePath` helper in `scripts/curate-phylopic.mjs` does this in two passes (read bounds, scale uniformly).
+5. Re-emit as `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="..."/></svg>` with no other attributes.
+
+The cleanest path is to call the existing helpers directly. A minimal wrapper:
+
+```js
+// scripts/normalize-foreign-svg.mjs (write ad-hoc; don't commit unless useful)
+import { readFileSync } from 'node:fs';
+// `extractPathD` is not exported by curate-phylopic.mjs today — either
+// re-export it for this use, or hand-port the ~60 lines (parseGTransform +
+// transformPathD + normalizePath + extractPathD) into the wrapper.
+const svg = readFileSync(process.argv[2], 'utf8');
+const result = extractPathD(svg);
+if (!result.ok) { console.error(result.reason); process.exit(1); }
+process.stdout.write(
+  `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="${result.d}"/></svg>\n`
+);
+```
+
+If flattening fails (gradients, masks, non-reducible transforms, multi-style fills), the file is not tractable — either hand-edit in Inkscape (Path → Object to Path, then Path → Combine) and re-run, or fall back to a different candidate from step 3.
+
+### 6. Upload and verify
+
+```bash
+npm run silhouette set <family> ./cleaned.svg
+```
+
+Expected: HTTP 200, JSON `{ familyCode, svgUrl, etag, ... }`. A 400 names the failing validator rule — fix and retry.
+
+Then confirm end-to-end:
+
+```bash
+# 1. Cache freshens within ~30s. Read API echoes the new payload.
+curl -s "$READ_API_URL/api/silhouettes" \
+  | jq ".silhouettes[] | select(.familyCode == \"<family>\")"
+# Expect both svgData (inline path-d) and svgUrl (R2 URL) populated.
+
+# 2. R2 URL serves the SVG directly.
+curl -sI "$(curl -s "$READ_API_URL/api/silhouettes" \
+  | jq -r ".silhouettes[] | select(.familyCode == \"<family>\") | .svgUrl")"
+# Expect HTTP/2 200, content-type: image/svg+xml.
+
+# 3. Hard-refresh https://bird-maps.com — the FamilyLegend chip for <family>
+#    renders the new silhouette and the map cluster mosaic picks it up on
+#    next render (SDF re-bake is automatic).
+```
+
+### 7. Cleanup
+
+```bash
+rm -rf "/tmp/silhouette-picker/<family>"
+# Kill the http.server background job:
+kill %1 2>/dev/null || true
+```
+
+## Batch mode
+
+For "process the remaining nulls", loop steps 2–7 per family. Suggested driver shape:
+
+```bash
+NULLS=$(curl -s "$READ_API_URL/api/silhouettes" \
+  | jq -r '.silhouettes[] | select(.svgData == null and .svgUrl == null) | .familyCode')
+for family in $NULLS; do
+  echo "=== $family ==="
+  # steps 2-7, with the user confirming each pick before upload
+done
+```
+
+Don't auto-pick across the loop — the human is the discriminator. The loop just saves typing.
+
+## Sourcing playbook by family type
+
+| Family shape | Primary sources | Secondary | Notes |
+|---|---|---|---|
+| Cuckoos / roadrunners | Wikimedia (Audubon plates) | SVG Repo CC0 | Long-tailed terrestrial profile traces well |
+| Loons | Wikimedia (Bird-Lore plates) | Phylopic genus-level | Heavy body + dagger bill — needs profile pose |
+| Game birds (quail, guineafowl) | Phylopic species-level | Wikimedia | Body shape is family-diagnostic; pick the AZ species |
+| Small passerines (chats, warblers) | Wikimedia | iNaturalist CC0 traced | Family shapes blur at 24px — pick a pose with tail extended |
+| Owls | Phylopic species-level | NPS / USFWS public-domain SVGs | Heart-face for Tyto, round-face for Strix |
+| Hummingbirds | SVG Repo CC0 | Wikimedia | Hover pose with extended bill reads at small sizes |
+
+## License gate
+
+Apply this on every candidate before adding it to the picker.
+
+| License | Ship? | Notes |
+|---|---|---|
+| CC0-1.0 | YES | No attribution required. First choice. |
+| CC-BY-3.0 / 4.0 | YES | Attribution required — add to `AttributionModal` via the curation migration or follow-up |
+| CC-BY-SA-3.0 / 4.0 | CAUTION | Share-alike propagates. The site's silhouette pipeline arguably qualifies as a derivative work; flag with a badge in the picker and confirm with Julian before shipping |
+| PD-old (pre-1928 publications) | YES | No attribution but include the "Publication, year" in commit message for traceability |
+| PD-USGov (NPS, USFWS, USGS) | YES | Federal-government works are public domain by 17 U.S.C. § 105 |
+| PD-mark | NO | Indicates "no known restrictions" but isn't a license — too ambiguous to ship |
+| CC-BY-NC-* | NO | Non-commercial restriction; bird-maps.com isn't strictly commercial but the line is fuzzy enough to skip |
+| CC-BY-ND-* | NO | No-derivatives forbids the SDF trace and the viewBox renormalization, both of which are derivative acts |
+
+## Common gotchas
+
+- **Phylopic `filter_name` is case-sensitive on the URL.** Always `.toLowerCase()` the slug or the API returns an empty list. The `nodeBySlug` helper in `scripts/curate-phylopic.mjs` learned this the hard way.
+- **"Unknown" creator on Wikimedia.** Plates labeled "Unknown, <year>" by Wikimedia editors are usually well-known publications (Audubon, Bird-Lore, Birds and Nature). Substitute the publication name + year as the creator string before upload — anonymous credit is rejected by the audit downstream.
+- **CSS `mask-image` requires CORS on the silhouette URL.** The Worker that serves R2 silhouette URLs sets `access-control-allow-origin: *`. If the Worker is ever modified, preserve that header — without it the `mask-image` pipeline degrades to inline-SVG fallback and the SDF clustering breaks.
+- **One iconic species per family.** Squint-test at 24–28px before committing. A "technically correct but unrecognizable at small sizes" silhouette is worse than the `_FALLBACK` shape because the user assumes it's information.
+- **Validator's ≥20-command floor was tightened in #500.** Pre-#500 silhouettes can have fewer (median 16, see comment block in `extractPathD`). Going forward, anything below 20 is rejected — if a hand-curated silhouette is otherwise good but trips the floor, add a few smoothing curves rather than dropping the candidate.
+
+## Rollback
+
+```bash
+npm run silhouette unset <family>
+```
+
+Reverts that row's `svg_data` + `svg_url` to NULL. The frontend renders the `_FALLBACK` shape again within ~30s of cache refresh. There is no soft-delete; if a curated silhouette ever ships and is later unset, the upload step has to repeat from step 4 onward to restore it.

--- a/.claude/skills/curating-fallback-silhouettes/templates/picker.html.template
+++ b/.claude/skills/curating-fallback-silhouettes/templates/picker.html.template
@@ -1,0 +1,231 @@
+<!--
+  Silhouette candidate picker — template
+  ======================================
+
+  Used by the `curating-fallback-silhouettes` skill (SKILL.md, step 4).
+
+  Substitution variables:
+    {{FAMILY}}      - the family_code (e.g. "cuculidae"). Appears in <title> and <h1>.
+    {{CANDIDATES}}  - the candidate cards block: one <article class="card">…</article>
+                      per source. The skill produces this block from the auto-sourcing
+                      step (step 3).
+
+  Substitution example (bash):
+
+    FAMILY=cuculidae
+    CANDIDATES_HTML=$(cat /tmp/candidates-cuculidae.html)
+    DEST=/tmp/silhouette-picker/$FAMILY/index.html
+    mkdir -p "$(dirname "$DEST")"
+    sed -e "s/{{FAMILY}}/$FAMILY/g" \
+        -e "/{{CANDIDATES}}/{
+              r /tmp/candidates-cuculidae.html
+              d
+            }" \
+        .claude/skills/curating-fallback-silhouettes/templates/picker.html.template \
+      > "$DEST"
+    (cd /tmp/silhouette-picker/$FAMILY && python3 -m http.server 8765 &)
+    open http://localhost:8765/
+
+  Candidate card shape (paste N of these in place of {{CANDIDATES}}, numbered
+  starting at 1):
+
+    <article class="card tier-cc0">
+      <header>
+        <span class="num">1</span>
+        <span class="badge badge-cc0">CC0-1.0</span>
+      </header>
+      <img src="ORIGINAL_ASSET_URL" alt="">
+      <footer>
+        <div class="creator">CREATOR_OR_PUBLICATION_YEAR</div>
+        <a href="SOURCE_PAGE_URL" target="_blank" rel="noopener">source</a>
+      </footer>
+    </article>
+
+  Tier classes: tier-cc0, tier-pd, tier-ccby, tier-ccbysa, tier-noship.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Silhouette picker — {{FAMILY}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #fafaf7;
+      --fg: #1a1a1a;
+      --muted: #666;
+      --card-bg: #fff;
+      --card-border: #ddd;
+      --thumb-bg: #f5f5f5;
+      --warn-bg: #fff8e1;
+      --warn-border: #f0c040;
+      --tier-cc0: #2e7d32;
+      --tier-pd: #1565c0;
+      --tier-ccby: #6a1b9a;
+      --tier-ccbysa: #b26a00;
+      --tier-noship: #c62828;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #161616;
+        --fg: #f0f0f0;
+        --muted: #aaa;
+        --card-bg: #1f1f1f;
+        --card-border: #2d2d2d;
+        --thumb-bg: #0c0c0c;
+        --warn-bg: #3a2e10;
+        --warn-border: #806020;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 24px;
+      background: var(--bg);
+      color: var(--fg);
+      font: 15px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 28px;
+      font-weight: 600;
+    }
+    .lede {
+      max-width: 56em;
+      color: var(--muted);
+      margin: 0 0 16px;
+    }
+    .constraints {
+      max-width: 56em;
+      background: var(--warn-bg);
+      border: 1px solid var(--warn-border);
+      border-radius: 6px;
+      padding: 12px 16px;
+      margin: 0 0 24px;
+      font-size: 14px;
+    }
+    .constraints code {
+      background: rgba(127,127,127,0.15);
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 13px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 16px;
+    }
+    .card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 8px;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .card header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .num {
+      font-size: 20px;
+      font-weight: 700;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: rgba(127,127,127,0.15);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .badge {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 3px 8px;
+      border-radius: 3px;
+      color: #fff;
+    }
+    .badge-cc0     { background: var(--tier-cc0); }
+    .badge-pd      { background: var(--tier-pd); }
+    .badge-ccby    { background: var(--tier-ccby); }
+    .badge-ccbysa  { background: var(--tier-ccbysa); }
+    .badge-noship  { background: var(--tier-noship); }
+    .card img {
+      max-width: 100%;
+      max-height: 240px;
+      object-fit: contain;
+      background: var(--thumb-bg);
+      border-radius: 4px;
+      display: block;
+      margin: 0 auto;
+    }
+    .card footer {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+      font-size: 13px;
+    }
+    .creator {
+      color: var(--muted);
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .card a {
+      color: inherit;
+    }
+    .tier-noship {
+      opacity: 0.55;
+      filter: grayscale(0.4);
+    }
+    .tier-noship::after {
+      content: "cannot ship — reference only";
+      display: block;
+      font-size: 12px;
+      color: var(--tier-noship);
+      font-weight: 600;
+      text-align: center;
+    }
+    .tier-ccbysa::after {
+      content: "share-alike propagates — confirm before ship";
+      display: block;
+      font-size: 12px;
+      color: var(--tier-ccbysa);
+      font-weight: 600;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>Silhouette picker — {{FAMILY}}</h1>
+  <p class="lede">
+    Pick the numbered candidate that best represents <strong>{{FAMILY}}</strong>
+    at 24–28px render size. Tell the operator the number; they will normalize
+    and upload it via <code>npm run silhouette set {{FAMILY}}</code>.
+  </p>
+
+  <div class="constraints">
+    <strong>Validator constraints</strong> (admin-api will reject otherwise):
+    single <code>&lt;path&gt;</code> child of <code>&lt;svg&gt;</code>;
+    <code>viewBox="0 0 24 24"</code> (or absent);
+    path-d uses only the <code>M / L / H / V / C / S / Q / T / A / Z</code>
+    command set; no <code>&lt;g&gt;</code> /
+    <code>&lt;defs&gt;</code> / <code>&lt;style&gt;</code> /
+    <code>&lt;script&gt;</code> / event handlers / <code>xlink:*</code>;
+    body ≤ 64 KB; <strong>≥ 20 path commands</strong>
+    (typical real silhouettes land at 22–33 commands).
+  </div>
+
+  <div class="grid">
+{{CANDIDATES}}
+  </div>
+</body>
+</html>

--- a/.claude/skills/curating-fallback-silhouettes/templates/picker.html.template
+++ b/.claude/skills/curating-fallback-silhouettes/templates/picker.html.template
@@ -220,8 +220,14 @@
     command set; no <code>&lt;g&gt;</code> /
     <code>&lt;defs&gt;</code> / <code>&lt;style&gt;</code> /
     <code>&lt;script&gt;</code> / event handlers / <code>xlink:*</code>;
-    body ≤ 64 KB; <strong>≥ 20 path commands</strong>
-    (typical real silhouettes land at 22–33 commands).
+    body ≤ 64 KB.
+    <br><br>
+    <em>Operator hint (not a validator gate):</em> paths under ~20
+    commands tend to render as unrecognizable blobs at 24–28px legend
+    scale. The automated Phylopic sourcing pipeline applies a ≥20-command
+    floor at curation time for this reason; the admin-api validator does
+    not enforce a floor, so a hand-curated silhouette below 20 will upload
+    fine but may not read at small sizes.
   </div>
 
   <div class="grid">

--- a/README.md
+++ b/README.md
@@ -121,3 +121,8 @@ The compute is plain Docker. To migrate to AWS / Azure / Fly:
 | **GCP → Azure** | Push Dockerfiles to ACR; deploy to Azure Container Apps; replace Cloud Scheduler with Azure Logic Apps or Functions Timer; replace Secret Manager with Key Vault | Application code, Neon DB, frontend |
 | **GCP → Fly.io** | Push Dockerfiles to Fly registry; `fly deploy` for the API service; use Fly's Cron Manager (JSON schedules) for arbitrary crons — `fly machines run --schedule` only accepts `hourly`/`daily`/`weekly`/`monthly` literals, which covers the backfill + hotspots jobs but not the 30-minute recent cron | Application code, frontend (could move to Fly too) |
 | **Neon → another Postgres** | `pg_dump` from Neon → restore to RDS / Cloud SQL / Azure DB / self-hosted; update `DATABASE_URL` secret | Compute layer, all application code |
+
+## Operator runbooks
+
+- Silhouette upload (technical reference) — [`docs/runbooks/silhouette-override.md`](docs/runbooks/silhouette-override.md)
+- Curating fallback silhouettes (human-in-the-loop workflow) — [`.claude/skills/curating-fallback-silhouettes/SKILL.md`](.claude/skills/curating-fallback-silhouettes/SKILL.md)


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A["/api/silhouettes audit<br/>(svgData == null AND svgUrl == null)"] --> B[Pick target family]
    B --> C[Auto-source candidates<br/>Wikimedia · SVG Repo · OpenClipArt<br/>· Phylopic relaxed · iNat CC0 · Noun]
    C --> D["Render picker.html.template<br/>at /tmp/silhouette-picker/&lt;family&gt;/"]
    D --> E[User picks N]
    E --> F["Normalize via<br/>extractPathD pipeline<br/>(single path, 0..24 viewBox, ≥20 cmds)"]
    F --> G["npm run silhouette set &lt;family&gt;<br/>→ admin-api → R2 + DB"]
    G --> H["bird-maps.com FamilyLegend +<br/>map cluster mosaic render new silhouette"]
```

## Summary

- Formalizes the human-in-the-loop curation workflow we just used for `cuculidae` (Greater Roadrunner) into a reusable project-level skill at `.claude/skills/curating-fallback-silhouettes/`. The skill complements the automated Phylopic pipeline (`scripts/curate-phylopic.mjs`) — Phylopic covers families it has art for, this skill covers the residual cohort with no usable Phylopic node.
- Skill body is triggering-condition-only in the frontmatter description (per `superpowers:writing-skills` style); workflow steps, sourcing playbook, license gate, and gotchas live in the markdown body. Templates folder ships a self-contained `picker.html.template` with light/dark CSS, license-tier badges, and validator-constraint banner — operator substitutes `{{FAMILY}}` and `{{CANDIDATES}}` and serves via `python3 -m http.server`.
- Adds two-bullet "Operator runbooks" section to top-level README pointing future operators at this skill plus the existing technical reference at `docs/runbooks/silhouette-override.md`.

## Screenshots

N/A — docs-only

## Test plan

- [x] Skill frontmatter parses (`name`, `description` present; description is triggering conditions only, no workflow summary)
- [x] SKILL.md under 500 lines (238 lines, 2179 words)
- [x] Template substitution variables documented in template header with worked `sed` example
- [x] README link targets verified to exist (`docs/runbooks/silhouette-override.md`, `.claude/skills/curating-fallback-silhouettes/SKILL.md`)
- [x] Workflow steps 1–7 each have a concrete command or URL — no placeholder prose
- [x] License gate covers CC0, CC-BY, CC-BY-SA, PD-old, PD-USGov, PD-mark, CC-BY-NC, CC-BY-ND
- [x] References to `extractPathD`, `parseGTransform`, `transformPathD`, `normalizePath` in `scripts/curate-phylopic.mjs` are accurate (verified against the file)
- [x] No code under `frontend/**` touched — Playwright MCP / multi-viewport screenshot protocol does not apply

## Plan reference

Out of plan — operator tooling for the post-#502 residual silhouette cohort. Captures the workflow used during the cuculidae hand-curation session so future operators (human or agent) can repeat it without rediscovery.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)