### PR TITLE
chore(styles): v2.2 visual polish + dead-CSS cleanup (B5/B6/B7)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -37,7 +37,11 @@
   /* Notable / amber accent */
   --color-accent-notable-bg:       #fff8e1; /* soft amber notable row bg   */
   --color-accent-notable-bg-hover: #fff3c4; /* hover on notable row        */
-  --color-accent-notable-fg:       #b8860b; /* dark amber stripe / badge   */
+  /* --color-accent-notable-fg removed — tokens.css [data-theme] block is
+     the sole authority: light → #c43a1a (--c-deep-ember), dark → #f5853b
+     (--c-orange-500). The former bare-:root value #b8860b (olive amber)
+     was only reachable if no data-theme attribute was set, and served as
+     an unintended fallback that misrepresented the redesign palette.    */
 
   /* Borders */
   --color-border-subtle:   #e6e1d2; /* row dividers                        */
@@ -190,11 +194,15 @@ body {
 }
 
 /* Tablist container — sits between wordmark and action buttons. flex: 1
-   pushes the right cluster to the far edge on wide viewports. */
+   pushes the right cluster to the far edge on wide viewports.
+   justify-content: center aligns the tab cluster to the horizontal
+   midpoint of the available space between the wordmark and right cluster,
+   matching the v4 mock's centred navigation treatment. */
 .app-header-nav {
   display: flex;
   gap: var(--space-xs);
   flex: 1;
+  justify-content: center;
 }
 
 /* Tab buttons — full UA reset, then design-token styling.


### PR DESCRIPTION
## Diagrams

N/A — CSS property additions and token cleanup; no data flow or component tree change.

## Summary

- **B5:** `.app-header-nav` lacked `justify-content: center`, leaving the tab cluster left-aligned vs the v4 mock's centred treatment. One property addition at `styles.css:205`.
- **B6:** `--color-accent-notable-fg: #b8860b` (old olive amber) sat in the bare `:root {}` block as a low-specificity fallback reachable only when neither `data-theme` attribute was set. `tokens.css` already owns both values (`#c43a1a` light, `#f5853b` dark). The bare-`:root` declaration was removed and replaced with a clarifying comment.
- **B7 (no-op):** Pre-dispatch fact-check confirmed all `.family-silhouette--*` selectors in `ds-primitives.css` are live (layout: `--masthead`/`--inline`/`--thumb` for both SVG and img paths; `--null-family`). No dead color-modifier selectors exist post-#480/#481. `orphan-classname-check: PASS`. No CSS changes for B7.

## Screenshots

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `justify-content: center` is a property addition on an existing selector, not a new class.
- [x] Multi-viewport design QA: ≥10 `user-attachments` URLs below (5 viewports × 2 themes).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (iPhone 14 Pro) | ![390×844 light](https://github.com/user-attachments/assets/55d1b2ed-5c34-422f-bfb7-b9787f457560) | ![390×844 dark](https://github.com/user-attachments/assets/369efbec-b70f-4ded-ae60-8fd41929026e) |
| 768×1024 (iPad portrait) | ![768×1024 light](https://github.com/user-attachments/assets/91b6cb71-0bd2-448e-b910-d4bedbe9da29) | ![768×1024 dark](https://github.com/user-attachments/assets/9ac5eacc-2528-42a2-8126-699a64a3effe) |
| 1024×768 (iPad landscape) | ![1024×768 light](https://github.com/user-attachments/assets/ab581e15-c33f-4f36-9932-75ac2013282e) | ![1024×768 dark](https://github.com/user-attachments/assets/97052d63-1be9-4983-988a-88135f24e4e0) |
| 1440×900 (Desktop) | ![1440×900 light](https://github.com/user-attachments/assets/946f0a38-b93f-4f9d-b87c-ad1ee3e49718) | ![1440×900 dark](https://github.com/user-attachments/assets/bf145066-0165-4d62-b0ca-3bf34773cbfd) |
| 1920×1080 (Wide desktop) | ![1920×1080 light](https://github.com/user-attachments/assets/96f7e0bd-e6d0-4fbc-b5ca-3489c10a5cef) | ![1920×1080 dark](https://github.com/user-attachments/assets/9aaf8a9d-b9be-4820-8f1f-fb9cf0415c2f) |

## Test plan

- [x] `npm run typecheck && npm run test` — pre-existing TS errors in worktree (`svgUrl` property on FamilySilhouette shared-type, unrelated to this PR's CSS-only changes). CSS-specific: Vite build clean (`npx vite build` from `frontend/` — 108 modules transformed, 0 CSS errors).
- [x] No new unit tests needed — CSS property change, no behavior change.
- [x] No new Playwright e2e spec needed — visual-only change verified via Playwright MCP below.
- [x] `npx vite build` — clean (108 modules, 225ms). Full `npm run build` blocked by pre-existing TS type error in shared-types (`svgUrl` on `FamilySilhouette`, unrelated to this PR).
- [x] Playwright MCP smoke (all 5 viewports × 2 themes):
  - B5 before: `.app-header-nav` computed `justify-content: normal` at 1440×900 on live `bird-maps.com`
  - B5 after: `.app-header-nav` computed `justify-content: center` at 1440×900 on local dev
  - B6 before: `rootRuleValue: "#b8860b"` found in bare `:root` stylesheet rule on live site
  - B6 after: `rootRuleValue: "not found"`, `foundB8860b: false` — confirmed removed from `:root`
  - B7: `orphan-classname-check: PASS` both before and after changes. Actual modifier selector count: 7 (all live). No CSS removed.
  - Console: 0 errors, 0 warnings at all 5 viewports (both themes)
  - Screenshot pairs: 10 distinct MD5 hashes (no byte-identical light/dark pairs)

## Plan reference

Closes #512. Out of plan — addresses `/Users/j/.claude/plans/execute-the-sky-atlas-reflective-rabin.md` §Bundle C.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)