### PR TITLE
fix(mobile): Bundle E — header collapse, iOS auto-zoom, 44pt targets, sheet polish (#514)

### DIFF
--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Mobile Bundle E (issue #514) — six mobile residuals from the v2.2 Tier-5 audit.
+ *
+ * MOB-1  (BLOCKER)  — AppHeader overflows 390px; body.scrollWidth must be ≤ 390px.
+ * MOB-3  (IMPORTANT)— iOS auto-zoom: .species-autocomplete-input font-size must be ≥ 16px.
+ * MOB-4  (IMPORTANT)— Header buttons sub-44pt touch target.
+ * MOB-5  (IMPORTANT)— Sheet safe-area-top: env(safe-area-inset-top) must appear in CSS.
+ * MOB-6  (IMPORTANT)— Drag slop: DISMISS_THRESHOLD_PX tuned for thumb reach.
+ * MOB-7  (IMPORTANT)— Sheet handle 24→44pt drag target.
+ * MOB-N1 (IMPORTANT)— .filters-panel-close 24×22 unstyled; must be ≥ 44×44pt.
+ *
+ * All touch-target tests run at 390×844 (iPhone 14 Pro) — the canonical mobile
+ * viewport from the release-1 exit criteria.
+ */
+import { test, expect, VERMFLY_WITH_PHOTO } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+// ── MOB-1: No horizontal overflow at 390px ─────────────────────────────────
+
+test.describe('MOB-1 — AppHeader no horizontal overflow at 390px', () => {
+  test('body.scrollWidth must be ≤ 390 on feed view', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+    expect(scrollWidth, 'body.scrollWidth must be ≤ 390px on mobile').toBeLessThanOrEqual(390);
+  });
+
+  test('app-header width must be ≤ 390 on feed view', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const headerBox = await app.appHeader.boundingBox();
+    expect(headerBox, 'app-header bounding box must exist').not.toBeNull();
+    expect(headerBox!.width, 'app-header width must be ≤ 390px').toBeLessThanOrEqual(390);
+  });
+});
+
+// ── MOB-3: iOS auto-zoom guard — font-size ≥ 16px ──────────────────────────
+
+test.describe('MOB-3 — species-autocomplete-input font-size ≥ 16px', () => {
+  test('autocomplete input font-size ≥ 16px on species view (prevents iOS auto-zoom)', async ({
+    page,
+    apiStub,
+  }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=species');
+    await app.waitForAppReady();
+
+    const fontSize = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('.species-autocomplete-input');
+      if (!el) return 0;
+      return parseFloat(window.getComputedStyle(el).fontSize);
+    });
+    expect(fontSize, 'autocomplete input font-size must be ≥ 16px to prevent iOS auto-zoom').toBeGreaterThanOrEqual(16);
+  });
+});
+
+// ── MOB-4: Header button touch targets ≥ 44×44pt ───────────────────────────
+
+test.describe('MOB-4 — AppHeader buttons ≥ 44×44pt', () => {
+  test('Filters button is ≥ 44px tall', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const box = await app.filtersTrigger.boundingBox();
+    expect(box, 'Filters button bounding box must exist').not.toBeNull();
+    expect(box!.height, 'Filters button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(box!.width, 'Filters button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+  });
+
+  test('Attribution button is ≥ 44px tall', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const box = await app.attributionTrigger.boundingBox();
+    expect(box, 'Attribution button bounding box must exist').not.toBeNull();
+    expect(box!.height, 'Attribution button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(box!.width, 'Attribution button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+  });
+
+  test('Feed tab button is ≥ 44px tall', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const tab = page.getByRole('tab', { name: 'Feed view' });
+    const box = await tab.boundingBox();
+    expect(box, 'Feed tab bounding box must exist').not.toBeNull();
+    expect(box!.height, 'Feed tab height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+  });
+});
+
+// ── MOB-7: Sheet handle ≥ 44pt drag target ─────────────────────────────────
+
+test.describe('MOB-7 — sheet handle ≥ 44pt drag target', () => {
+  test('sheet-handle button height ≥ 44px', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+    await apiStub.stubPhotoImage();
+    const app = new AppPage(page);
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    const handle = page.locator('[data-testid=species-detail-sheet-handle]');
+    const box = await handle.boundingBox();
+    expect(box, 'sheet handle bounding box must exist').not.toBeNull();
+    expect(box!.height, 'sheet handle height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(box!.width, 'sheet handle width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+  });
+});
+
+// ── MOB-N1: .filters-panel-close ≥ 44×44pt ─────────────────────────────────
+
+test.describe('MOB-N1 — .filters-panel-close touch target ≥ 44×44pt', () => {
+  test('filters-panel-close button is ≥ 44×44px', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    await app.openFilters();
+
+    const closeBtn = page.locator('.filters-panel-close');
+    const box = await closeBtn.boundingBox();
+    expect(box, 'filters-panel-close bounding box must exist').not.toBeNull();
+    expect(box!.height, 'filters-panel-close height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(box!.width, 'filters-panel-close width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+  });
+});

--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -147,6 +147,38 @@ test.describe('MOB-4 — AppHeader buttons ≥ 44×44pt', () => {
     expect(box, 'Feed tab bounding box must exist').not.toBeNull();
     expect(box!.height, 'Feed tab height must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
+
+  // Regression guard: round-1 fix used font-size:0 which produced empty
+  // 44×44 squares with no visual affordance. Strategy A (SVG icons) must
+  // render a visible <svg> inside each button at mobile viewport.
+  test('Filters button has a visible SVG icon at 390px (no empty-square regression)', async ({
+    page,
+    apiStub,
+  }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const icon = app.filtersTrigger.locator('svg.app-header-btn-icon');
+    await expect(icon, 'Filters button must contain a visible SVG icon at mobile').toBeVisible();
+  });
+
+  test('Attribution button has a visible SVG icon at 390px (no empty-square regression)', async ({
+    page,
+    apiStub,
+  }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    const icon = app.attributionTrigger.locator('svg.app-header-btn-icon');
+    await expect(
+      icon,
+      'Attribution button must contain a visible SVG icon at mobile',
+    ).toBeVisible();
+  });
 });
 
 // ── MOB-7: Sheet handle ≥ 44pt drag target ─────────────────────────────────

--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -30,6 +30,29 @@ test.describe('MOB-1 — AppHeader no horizontal overflow at 390px', () => {
     expect(scrollWidth, 'body.scrollWidth must be ≤ 390px on mobile').toBeLessThanOrEqual(390);
   });
 
+  test('wordmark renders full "Bird Maps" text without truncation at 390px', async ({
+    page,
+    apiStub,
+  }) => {
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=feed');
+    await app.waitForAppReady();
+
+    // Visible text must include full product name — not "Bird ..." or "B.."
+    await expect(page.locator('.app-header-wordmark')).toContainText('Bird Maps');
+
+    // scrollWidth ≤ clientWidth confirms no ellipsis is applied
+    const wm = await page.locator('.app-header-wordmark').evaluate(el => ({
+      scroll: (el as HTMLElement).scrollWidth,
+      client: (el as HTMLElement).clientWidth,
+    }));
+    expect(
+      wm.scroll,
+      `wordmark scrollWidth (${wm.scroll}px) must be ≤ clientWidth (${wm.client}px) — ellipsis applied`,
+    ).toBeLessThanOrEqual(wm.client);
+  });
+
   test('app-header width must be ≤ 390 on feed view', async ({ page, apiStub }) => {
     await apiStub.stubEmpty();
     const app = new AppPage(page);
@@ -43,9 +66,11 @@ test.describe('MOB-1 — AppHeader no horizontal overflow at 390px', () => {
 });
 
 // ── MOB-3: iOS auto-zoom guard — font-size ≥ 16px ──────────────────────────
+// Covers iPhone 14 Pro (390px), iPhone 14 Pro Max (428px), iPhone 15 Pro Max
+// (430px) — all are affected by iOS Safari's auto-zoom on inputs < 16px.
 
 test.describe('MOB-3 — species-autocomplete-input font-size ≥ 16px', () => {
-  test('autocomplete input font-size ≥ 16px on species view (prevents iOS auto-zoom)', async ({
+  test('autocomplete input font-size ≥ 16px on species view at 390px (prevents iOS auto-zoom)', async ({
     page,
     apiStub,
   }) => {
@@ -60,6 +85,27 @@ test.describe('MOB-3 — species-autocomplete-input font-size ≥ 16px', () => {
       return parseFloat(window.getComputedStyle(el).fontSize);
     });
     expect(fontSize, 'autocomplete input font-size must be ≥ 16px to prevent iOS auto-zoom').toBeGreaterThanOrEqual(16);
+  });
+
+  test('autocomplete input font-size ≥ 16px on species view at 428px (iPhone Pro Max — prevents iOS auto-zoom)', async ({
+    page,
+    apiStub,
+  }) => {
+    // iPhone Pro Max viewports (428/430px) are wider than the old 414px guard
+    // and were previously excluded from the 16px override. The rule is now
+    // unconditional so this viewport inherits it automatically.
+    await page.setViewportSize({ width: 428, height: 926 });
+    await apiStub.stubEmpty();
+    const app = new AppPage(page);
+    await app.goto('view=species');
+    await app.waitForAppReady();
+
+    const fontSize = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('.species-autocomplete-input');
+      if (!el) return 0;
+      return parseFloat(window.getComputedStyle(el).fontSize);
+    });
+    expect(fontSize, 'autocomplete input font-size must be ≥ 16px at 428px (iPhone Pro Max)').toBeGreaterThanOrEqual(16);
   });
 });
 

--- a/frontend/e2e/sheet-snap.spec.ts
+++ b/frontend/e2e/sheet-snap.spec.ts
@@ -48,10 +48,10 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     if (!handleBox) throw new Error('handle bounding box unavailable');
 
     // Synthesize a touch drag-down from the handle well past DISMISS_THRESHOLD_PX
-    // (160px). We compute the target from the handle's own position so the test
+    // (80px). We compute the target from the handle's own position so the test
     // is stable regardless of where the peek sheet sits vertically — at 390×844
-    // the 96px peek sheet has its handle near y≈748, so a fixed y=800 target
-    // only gives ~48px of travel. Using handleBox.y + 200 guarantees ≥200px.
+    // the 120px peek sheet has its handle near y≈724, so a fixed y=800 target
+    // only gives ~68px of travel. Using handleBox.y + 200 guarantees ≥200px.
     const startX = handleBox.x + handleBox.width / 2;
     const startY = handleBox.y + handleBox.height / 2;
     await page.mouse.move(startX, startY);

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -121,7 +121,24 @@ export function AppHeader({
           onClick={onOpenAttribution}
           aria-label="Credits & attribution"
         >
-          Attribution
+          {/* Info-circle icon — visible at mobile (≤480px), hidden at desktop via CSS */}
+          <svg
+            className="app-header-btn-icon"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 16v-4M12 8h.01" />
+          </svg>
+          {/* Text label — visible at desktop (>480px), sr-only at mobile */}
+          <span className="app-header-btn-label">Attribution</span>
         </button>
         <button
           type="button"
@@ -129,7 +146,23 @@ export function AppHeader({
           onClick={onOpenFilters}
           aria-label={filterTriggerLabel}
         >
-          Filters
+          {/* Funnel/filter icon — visible at mobile (≤480px), hidden at desktop via CSS */}
+          <svg
+            className="app-header-btn-icon"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+          </svg>
+          {/* Text label — visible at desktop (>480px), sr-only at mobile */}
+          <span className="app-header-btn-label">Filters</span>
           {filterCount > 0 && (
             <span className="app-header-filter-badge" aria-hidden="true">
               {filterCount}

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -13,15 +13,20 @@ import { useSpeciesDetail } from '../data/use-species-detail.js';
 
 type SnapState = 'peek' | 'half' | 'full';
 
-const PEEK_PX = 96;
+// MOB-6: PEEK_PX raised from 96 → 120 so the peek strip is comfortably
+// reachable by a thumb at the bottom of a 390×844 screen (96px was tight
+// against the safe-area-inset-bottom on notched devices). DISMISS_THRESHOLD_PX
+// lowered from 160 → 80 so a short downward flick dismisses the sheet — the
+// old 160px required a deliberate two-thirds swipe that felt sluggish.
+const PEEK_PX = 120;
 // half + full are computed at runtime against window.innerHeight so they
 // honor the actual viewport (post safe-area, post URL-bar collapse on
 // mobile Safari). Constants here are the FRACTIONS:
 const HALF_FRACTION = 0.6;
 const FULL_INSET_PX = 8;
 // Drag dismissal: dragging the handle down past peek by this many pixels
-// dismisses the sheet (calls onClose).
-const DISMISS_THRESHOLD_PX = 160;
+// dismisses the sheet (calls onClose). 80px ≈ one thumb's travel.
+const DISMISS_THRESHOLD_PX = 80;
 // Drag transition thresholds — half travel between adjacent snaps flips.
 const SNAP_TRANSITION_RATIO = 0.5;
 

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -40,7 +40,7 @@ export interface SpeciesDetailSheetProps {
 
 /**
  * Mobile bottom-sheet detail surface (Sky Atlas Phase 4). Apple Maps
- * "Look Up" idiom: three snap points (peek 96px / half 60vh / full
+ * "Look Up" idiom: three snap points (peek 120px / half 60vh / full
  * 100vh−8px). The sheet is NOT a <dialog> at peek/half — peek/half
  * leave the map underneath interactive, which a modal <dialog> by
  * definition cannot. The role flips with snap state per

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -208,7 +208,8 @@ body {
 /* Tab buttons — full UA reset, then design-token styling.
    Visual contract mirrors the former .surface-nav-tab exactly:
    same padding, border-radius, font-size, hover / focus / active states.
-   min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target on mobile. */
+   min-height is applied inside the ≤480px media query (MOB-4) to keep the
+   desktop header height unchanged. */
 .app-header-tab {
   appearance: none;
   background: transparent;
@@ -221,7 +222,6 @@ body {
   color: var(--color-text-strong);
   cursor: pointer;
   line-height: 1.2;
-  min-height: 44px;
 }
 .app-header-tab:hover {
   background: var(--color-bg-tint);
@@ -246,8 +246,9 @@ body {
 
 /* Right-side action cluster — Attribution, Filters, ThemeToggle.
    ThemeToggle renders a plain <button> with no class; target all
-   buttons in this cluster with the descendant rule below so the
-   44pt touch target applies uniformly (MOB-4). */
+   buttons in this cluster with the descendant rule below.
+   min-height/min-width 44pt touch targets are applied inside the
+   ≤480px media query (MOB-4) to keep the desktop header unchanged. */
 .app-header-right {
   display: flex;
   align-items: center;
@@ -255,14 +256,13 @@ body {
   flex-shrink: 0;
 }
 .app-header-right button {
-  min-height: 44px;
-  min-width: 44px;
+  /* touch targets set in @media (max-width: 480px) block — see MOB-4 */
 }
 
 /* Attribution + Filters buttons — same UA reset + visual contract as tabs.
    Slightly subdued: color-text-body rather than color-text-strong keeps
    them secondary to the navigation tabs without becoming invisible.
-   min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target on mobile. */
+   min-height applied inside ≤480px media query (MOB-4) — desktop unchanged. */
 .app-header-attribution,
 .app-header-filters {
   appearance: none;
@@ -276,7 +276,6 @@ body {
   cursor: pointer;
   line-height: 1.2;
   position: relative;
-  min-height: 44px;
 }
 .app-header-attribution:hover,
 .app-header-filters:hover {
@@ -1748,7 +1747,7 @@ dialog.species-detail-modal .species-detail-modal-close {
    Breakpoint ≤ 414px targets iPhone 14 Pro (390×844) and all narrower phones.
    ========================================================================== */
 
-/* ── MOB-1: AppHeader collapse at ≤ 414px ──────────────────────────────────
+/* ── MOB-1/MOB-4: AppHeader collapse + touch targets at ≤ 480px ─────────────
    The unconstrained header overflows at 390px (body.scrollWidth≈578px).
    Strategy: hide the brand region label, compress nav padding, reduce the
    outer header gap so the three segments (wordmark · tabs · actions) fit
@@ -1758,10 +1757,22 @@ dialog.species-detail-modal .species-detail-modal-close {
    should remain visible. The " · Arizona" region badge is redundant at mobile
    (single-region product) and is the largest single contributor to overflow.
 
-   Each tab button and action button already has min-height: 44px globally
-   (MOB-4). The padding reduction here preserves that height while shrinking
-   horizontal footprint. */
-@media (max-width: 414px) {
+   Space budget at 390px:
+     16px (padding) + 8px (2×4px gaps) = 24px overhead.
+     Available: 366px.
+     Wordmark:       80px (flex-shrink: 0 — guaranteed, no flex contention)
+     Right cluster: 140px (3 × 44px icon-only buttons + 2 × 4px gaps)
+     Nav:           146px remaining for 3 tabs
+
+   The right-cluster Attribution + Filters buttons hide their text labels
+   at this breakpoint (font-size: 0; icon-sized footprint). Their aria-label
+   attributes remain intact — accessibility is preserved via the accessible
+   name, not the visible text. This frees ~120px vs. the previous text-label
+   layout, giving the wordmark guaranteed render space.
+
+   min-height: 44px touch targets (MOB-4) are scoped here rather than
+   globally so the desktop header height is unchanged. */
+@media (max-width: 480px) {
   .app-header {
     padding: 0 var(--space-sm);
     gap: var(--space-xs);
@@ -1772,32 +1783,51 @@ dialog.species-detail-modal .species-detail-modal-close {
     overflow: hidden;
   }
 
-  /* Hide the region label (" · Arizona"). "Bird Maps" remains visible. */
+  /* Hide the region label (" · Arizona"). "Bird Maps" remains fully visible. */
   .app-header-wordmark .brand-region {
     display: none;
   }
 
-  /* Compress the wordmark so it doesn't crowd the tabs. */
+  /* Guarantee the wordmark renders untruncated.
+     flex-shrink: 0 prevents the nav's flex:1 from squeezing the wordmark
+     below its natural width (~65px for "Bird Maps" at --type-sm / 13px).
+     max-width: 80px gives comfortable headroom above the 65px scrollWidth.
+     Without flex-shrink: 0 here, the flex algorithm allocates space to the
+     nav first (flex-grow: 1) and the wordmark falls below 72px (measured
+     46px at 390px — see design review BLOCKING finding). */
   .app-header-wordmark {
     font-size: var(--type-sm);
-    flex-shrink: 1;
+    flex-shrink: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 72px;
+    max-width: 80px;
   }
 
-  /* Compress tab padding while keeping the 44pt min-height from the global rule. */
+  /* Compress tab padding while keeping the 44pt min-height touch target. */
   .app-header-tab {
     padding: 0 8px;
     font-size: var(--type-xs);
+    min-height: 44px;
   }
 
-  /* Compress right-cluster buttons. */
+  /* Right-cluster text buttons: collapse to 44px icon-only touch targets.
+     font-size: 0 hides the visible text ("Attribution", "Filters") without
+     removing it from the DOM — aria-label on each button preserves the
+     accessible name (the filterCount is baked into aria-label when > 0).
+     min-height + min-width enforce the 44pt touch target. */
   .app-header-attribution,
   .app-header-filters {
-    padding: 0 8px;
-    font-size: var(--type-xs);
+    font-size: 0;
+    padding: 0;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Hide the filter count badge at mobile — the accessible name on the
+     Filters button already announces "Filters (N active)" via aria-label. */
+  .app-header-filter-badge {
+    display: none;
   }
 
   /* ThemeToggle uses a plain <button> with no className.
@@ -1811,14 +1841,13 @@ dialog.species-detail-modal .species-detail-modal-close {
 
 /* ── MOB-3: iOS auto-zoom guard ─────────────────────────────────────────────
    iOS Safari auto-zooms the page when a focused input has font-size < 16px.
-   .species-autocomplete-input uses --type-base (15px) globally. Override to
-   16px on mobile only — desktop typography is unchanged.
-   The override uses min-width: 0 to avoid affecting the selector specificity
-   of the global rule; it simply wins by source order within the media query. */
-@media (max-width: 414px) {
-  .species-autocomplete-input {
-    font-size: 16px;
-  }
+   This affects ALL iPhone models regardless of viewport width — including
+   iPhone 12/14/15 Pro Max (428/430px) which were missed by the original
+   max-width: 414px scope. The rule is pulled out of the media query entirely:
+   16px on an autocomplete input is visually neutral at desktop and eliminates
+   the maintenance liability of tracking new iPhone widths. */
+.species-autocomplete-input {
+  font-size: 16px;
 }
 
 /* ── MOB-N1: .filters-panel-close touch target ─────────────────────────────

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -207,7 +207,8 @@ body {
 
 /* Tab buttons — full UA reset, then design-token styling.
    Visual contract mirrors the former .surface-nav-tab exactly:
-   same padding, border-radius, font-size, hover / focus / active states. */
+   same padding, border-radius, font-size, hover / focus / active states.
+   min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target on mobile. */
 .app-header-tab {
   appearance: none;
   background: transparent;
@@ -220,6 +221,7 @@ body {
   color: var(--color-text-strong);
   cursor: pointer;
   line-height: 1.2;
+  min-height: 44px;
 }
 .app-header-tab:hover {
   background: var(--color-bg-tint);
@@ -242,17 +244,25 @@ body {
   border-bottom-width: 2px;
 }
 
-/* Right-side action cluster — Attribution, Filters, ThemeToggle. */
+/* Right-side action cluster — Attribution, Filters, ThemeToggle.
+   ThemeToggle renders a plain <button> with no class; target all
+   buttons in this cluster with the descendant rule below so the
+   44pt touch target applies uniformly (MOB-4). */
 .app-header-right {
   display: flex;
   align-items: center;
   gap: var(--space-xs);
   flex-shrink: 0;
 }
+.app-header-right button {
+  min-height: 44px;
+  min-width: 44px;
+}
 
 /* Attribution + Filters buttons — same UA reset + visual contract as tabs.
    Slightly subdued: color-text-body rather than color-text-strong keeps
-   them secondary to the navigation tabs without becoming invisible. */
+   them secondary to the navigation tabs without becoming invisible.
+   min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target on mobile. */
 .app-header-attribution,
 .app-header-filters {
   appearance: none;
@@ -266,6 +276,7 @@ body {
   cursor: pointer;
   line-height: 1.2;
   position: relative;
+  min-height: 44px;
 }
 .app-header-attribution:hover,
 .app-header-filters:hover {
@@ -1298,6 +1309,11 @@ dialog.species-detail-modal .species-detail-modal-close {
   z-index: 10;
   display: flex;
   flex-direction: column;
+  /* MOB-5: notched devices need env(safe-area-inset-top) so the sheet
+     handle clears the Dynamic Island / status bar when fully expanded.
+     max() keeps the sheet from losing its rounded-corner top edge if
+     the safe-area inset is larger than the default padding. */
+  padding-top: max(var(--space-xs, 4px), env(safe-area-inset-top, 0px));
   padding-bottom: env(safe-area-inset-bottom, 0);
   transition: height 200ms ease, transform 200ms ease;
   will-change: height, transform;
@@ -1310,12 +1326,18 @@ dialog.species-detail-modal .species-detail-modal-close {
 }
 
 .sheet-handle {
-  /* Drag-region: own the gesture entirely; do not pan-scroll the page. */
+  /* Drag-region: own the gesture entirely; do not pan-scroll the page.
+     min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target (MOB-7).
+     The visual grip pill (.sheet-handle-grip) stays 4px tall; padding
+     above/below expands the actual touch target without changing appearance. */
   touch-action: none;
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 24px;
+  width: 100%;
+  min-height: 44px;
+  padding-top: 10px;
+  padding-bottom: 10px;
   background: transparent;
   border: none;
   cursor: grab;
@@ -1719,4 +1741,123 @@ dialog.species-detail-modal .species-detail-modal-close {
     background: ButtonFace;
     color: ButtonText;
   }
+}
+
+/* ==========================================================================
+   Mobile polish — Bundle E (issue #514)
+   Breakpoint ≤ 414px targets iPhone 14 Pro (390×844) and all narrower phones.
+   ========================================================================== */
+
+/* ── MOB-1: AppHeader collapse at ≤ 414px ──────────────────────────────────
+   The unconstrained header overflows at 390px (body.scrollWidth≈578px).
+   Strategy: hide the brand region label, compress nav padding, reduce the
+   outer header gap so the three segments (wordmark · tabs · actions) fit
+   inside 390px without wrapping.
+
+   We do NOT hide the wordmark entirely — "Bird Maps" is the product name and
+   should remain visible. The " · Arizona" region badge is redundant at mobile
+   (single-region product) and is the largest single contributor to overflow.
+
+   Each tab button and action button already has min-height: 44px globally
+   (MOB-4). The padding reduction here preserves that height while shrinking
+   horizontal footprint. */
+@media (max-width: 414px) {
+  .app-header {
+    padding: 0 var(--space-sm);
+    gap: var(--space-xs);
+    /* overflow: hidden prevents the header itself from being wider than the
+       viewport while the body catches up to the new layout. Without this,
+       the header's flex children can still force the layout wider than 390px
+       if any child has a min-width that exceeds available space. */
+    overflow: hidden;
+  }
+
+  /* Hide the region label (" · Arizona"). "Bird Maps" remains visible. */
+  .app-header-wordmark .brand-region {
+    display: none;
+  }
+
+  /* Compress the wordmark so it doesn't crowd the tabs. */
+  .app-header-wordmark {
+    font-size: var(--type-sm);
+    flex-shrink: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 72px;
+  }
+
+  /* Compress tab padding while keeping the 44pt min-height from the global rule. */
+  .app-header-tab {
+    padding: 0 8px;
+    font-size: var(--type-xs);
+  }
+
+  /* Compress right-cluster buttons. */
+  .app-header-attribution,
+  .app-header-filters {
+    padding: 0 8px;
+    font-size: var(--type-xs);
+  }
+
+  /* ThemeToggle uses a plain <button> with no className.
+     Target it via the right-cluster wrapper. */
+  .app-header-right button {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0 6px;
+  }
+}
+
+/* ── MOB-3: iOS auto-zoom guard ─────────────────────────────────────────────
+   iOS Safari auto-zooms the page when a focused input has font-size < 16px.
+   .species-autocomplete-input uses --type-base (15px) globally. Override to
+   16px on mobile only — desktop typography is unchanged.
+   The override uses min-width: 0 to avoid affecting the selector specificity
+   of the global rule; it simply wins by source order within the media query. */
+@media (max-width: 414px) {
+  .species-autocomplete-input {
+    font-size: 16px;
+  }
+}
+
+/* ── MOB-N1: .filters-panel-close touch target ─────────────────────────────
+   The close button for the FiltersPanel was unstyled (24×22px per audit).
+   Full UA reset + 44×44pt minimum touch area. Visual: text × as the icon,
+   positioned at the top-right of the panel. The panel itself needs position:
+   relative so the absolute positioning of the close button resolves correctly. */
+.filters-panel {
+  position: relative;
+}
+
+.filters-panel-close {
+  /* UA reset */
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  /* 44×44pt touch target (Apple HIG, WCAG 2.5.5) */
+  min-width: 44px;
+  min-height: 44px;
+  /* Visual: pull to top-right corner of the panel */
+  position: absolute;
+  top: var(--space-xs, 4px);
+  right: var(--space-xs, 4px);
+  /* Content centering */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: var(--type-md, 17px);
+  color: var(--color-text-body);
+  line-height: 1;
+  z-index: 1;
+}
+.filters-panel-close:hover {
+  background: var(--color-bg-tint);
+}
+.filters-panel-close:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -262,7 +262,10 @@ body {
 /* Attribution + Filters buttons — same UA reset + visual contract as tabs.
    Slightly subdued: color-text-body rather than color-text-strong keeps
    them secondary to the navigation tabs without becoming invisible.
-   min-height applied inside ≤480px media query (MOB-4) — desktop unchanged. */
+   min-height applied inside ≤480px media query (MOB-4) — desktop unchanged.
+   Icon/label visibility:
+   - .app-header-btn-icon hidden at desktop (>480px); shown at mobile (≤480px).
+   - .app-header-btn-label shown at desktop (>480px); sr-only at mobile (≤480px). */
 .app-header-attribution,
 .app-header-filters {
   appearance: none;
@@ -276,6 +279,19 @@ body {
   cursor: pointer;
   line-height: 1.2;
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Desktop default: icon hidden, text label visible */
+.app-header-btn-icon {
+  display: none;
+}
+
+/* Desktop default: text label visible (override sr-only at desktop) */
+.app-header-btn-label {
+  /* visible by default at desktop */
 }
 .app-header-attribution:hover,
 .app-header-filters:hover {
@@ -1811,17 +1827,41 @@ dialog.species-detail-modal .species-detail-modal-close {
     min-height: 44px;
   }
 
-  /* Right-cluster text buttons: collapse to 44px icon-only touch targets.
-     font-size: 0 hides the visible text ("Attribution", "Filters") without
-     removing it from the DOM — aria-label on each button preserves the
-     accessible name (the filterCount is baked into aria-label when > 0).
-     min-height + min-width enforce the 44pt touch target. */
+  /* Right-cluster buttons: collapse to 44pt icon-only touch targets at mobile.
+     The text label (.app-header-btn-label) becomes sr-only so screen readers
+     still announce the button's purpose. The SVG icon (.app-header-btn-icon)
+     is shown as the visual affordance. aria-label on each button provides the
+     accessible name (the filterCount is baked in when > 0).
+     padding: 0 + justify-content: center + min-width/height enforce the 44pt
+     touch target (Apple HIG). */
   .app-header-attribution,
   .app-header-filters {
-    font-size: 0;
     padding: 0;
     min-width: 44px;
     min-height: 44px;
+    justify-content: center;
+  }
+
+  /* Mobile: show the SVG icon */
+  .app-header-btn-icon {
+    display: inline-block;
+    flex-shrink: 0;
+  }
+
+  /* Mobile: visually hide the text label but keep it in the accessibility tree.
+     Uses the same clip pattern as .sr-only (defined globally). The inline-flex
+     container on the button means we can't use position:absolute without layout
+     side effects, so we apply sr-only via a scoped class override. */
+  .app-header-btn-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   /* Hide the filter count badge at mobile — the accessible name on the


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    state "BEFORE (390px viewport)" as BEFORE {
        state "AppHeader" as H1
        H1: wordmark 'Bird Maps · Arizona'\nbrandRegion: inline\nbody.scrollWidth: 578px\nbutton height: ~30px
    }

    state "AFTER (390px viewport)" as AFTER {
        state "AppHeader" as H2
        H2: wordmark 'Bird Maps' (region hidden, untruncated)\nbrandRegion: none\nbody.scrollWidth: 390px\nbutton height: 44px\nicon buttons visible at mobile
    }

    BEFORE --> AFTER : @media max-width:480px\nCSS collapse + 44pt targets + wordmark flex-shrink fix\nRound 2: SVG icons replace font-size:0
```

## Summary

- **MOB-1 (BLOCKER — design review fix):** Wordmark was truncating to "Bird ..." at 390×844. Root cause: `.app-header-wordmark` had `flex-shrink: 1` at mobile, letting the nav's `flex: 1` squeeze the wordmark below its 65px natural width (measured 46px). Fix: `flex-shrink: 0` on the wordmark + right-cluster Attribution/Filters buttons collapsed to icon-only touch targets at mobile to free space. Wordmark measured 65px scrollWidth = clientWidth at both 390 and 428 viewports.
- **Round 2 regression fix — Strategy A (SVG icons):** Round-1 used `font-size: 0` to collapse Attribution/Filters buttons at mobile. This left two empty 44×44 squares — no visual affordance. Fix: inline SVG icons (`.app-header-btn-icon`) added to each button. Desktop (>480px): icons hidden, text labels shown (unchanged from pre-PR prod). Mobile (≤480px): SVG icon visible, text becomes sr-only via clip pattern. `aria-label` unchanged — accessible name intact. Regression guard tests added to `mobile-bundle-e.spec.ts`.
- **MOB-1 original:** `body.scrollWidth` was 578px at 390px viewport. Fixed via `@media (max-width: 480px)` block: hides `.brand-region` label, compresses tab/button padding, sets `overflow: hidden` on the header.
- **MOB-3 (IMPORTANT — design review fix):** iOS auto-zoom guard now **unconditional** (pulled out of `@media (max-width: 414px)`), covering all iPhone widths including Pro Max 428/430px.
- **Tier-3 (design review):** `min-height: 44px` touch-target rules moved from global scope into `@media (max-width: 480px)` — desktop header height is unchanged.
- **MOB-4/7/N1 (IMPORTANT):** All header buttons and sheet handle ≥ 44pt minimum touch target; `.filters-panel-close` styled at 44×44pt; sheet carries `env(safe-area-inset-top)` for notched devices.
- **MOB-6 (IMPORTANT):** `PEEK_PX` raised 96→120px and `DISMISS_THRESHOLD_PX` lowered 160→80px.

## Screenshots

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (iPhone 14 Pro — icons visible) | ![390×844 light](https://github.com/user-attachments/assets/5b00766d-f162-446f-ba1d-dfa0823853fe) | ![390×844 dark](https://github.com/user-attachments/assets/bada8aec-e02a-4b11-98b0-6b3b2c661386) |
| 428×926 (iPhone Pro Max — icons visible) | ![428×926 light](https://github.com/user-attachments/assets/de1a8e1d-a9de-4f61-bf6f-0d4c3ec5ec27) | ![428×926 dark](https://github.com/user-attachments/assets/f9ddac0b-7011-4c14-9fa7-96882a1ee4c0) |
| 768×1024 (tablet) | ![768×1024 light](https://github.com/user-attachments/assets/aa0651a1-dcaa-4a0f-9ff3-62c8e7df1cc0) | ![768×1024 dark](https://github.com/user-attachments/assets/1317a2bd-c81e-4dac-a8e2-2fb77295ca7b) |
| 1024×768 (laptop) | ![1024×768 light](https://github.com/user-attachments/assets/eb75f8eb-b0f2-46e7-b47f-633203515022) | ![1024×768 dark](https://github.com/user-attachments/assets/4b2c8ee4-c05f-4a25-8fe3-5b6dba230b3e) |
| 1440×900 (desktop — text labels, no icons) | ![1440×900 light](https://github.com/user-attachments/assets/3b0b8f70-3904-44be-8537-fdb002665903) | ![1440×900 dark](https://github.com/user-attachments/assets/60a47361-f654-490d-9731-04b9842f8f32) |
| 1920×1080 (wide — text labels, no icons) | ![1920×1080 light](https://github.com/user-attachments/assets/37efff4a-4635-4124-8a42-b807e758de90) | ![1920×1080 dark](https://github.com/user-attachments/assets/4f0b1da9-0369-43dc-8696-b08a3361a247) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule (`.app-header-btn-icon`, `.app-header-btn-label`)
- [x] Multi-viewport design QA: 6 viewports × 2 themes = 12 screenshots above via user-attachments paste flow
- [x] Round-2 regression: Attribution and Filters buttons show visible SVG icons at 390+428 (no empty squares)

### BEFORE (390×844, overflow + wordmark truncation)

`body.scrollWidth = 578px` — overflows 390px viewport by 188px. Button heights sub-44pt. Wordmark: measured 46.35px clientWidth with 65px scrollWidth — truncated to "Bird ...".

### AFTER measurements (Playwright MCP + CSS injection)

| Metric | Before | After 390 | After 428 | Pass |
|---|---|---|---|---|
| `body.scrollWidth` | 578px | **390px** | **428px** | ✓ |
| wordmark clientWidth | 46px (squeezed) | **65px** | **65px** | ✓ |
| wordmark scrollWidth | 65px | **65px** | **65px** | ✓ |
| wordmark truncated | yes ("Bird ...") | **no** | **no** | ✓ |
| Filters button height | 29.6px | **44px** | **44px** | ✓ |
| Attribution button height | 29.6px | **44px** | **44px** | ✓ |
| Feed tab height | 30.6px | **44px** | **44px** | ✓ |
| `.brand-region` display | inline | **none** | **none** | ✓ |
| Autocomplete font-size | 15px | **16px** | **16px** | ✓ |
| Desktop header height | baseline | **unchanged** | n/a | ✓ |
| Attribution icon visible at 390 | n/a | **true (44×44px SVG)** | **true** | ✓ |
| Filters icon visible at 390 | n/a | **true (44×44px SVG)** | **true** | ✓ |

## Test plan

- [x] `npm run test` — 722 tests pass (2 pre-existing test file failures from missing `maplibre-gl`/`react-window` — unrelated to this PR, exist on `main`)
- [x] New Playwright e2e spec: `frontend/e2e/mobile-bundle-e.spec.ts` — 12 tests covering MOB-1 (including wordmark non-truncation), MOB-3 (390px + 428px), MOB-4 (including SVG icon regression guards), MOB-7, MOB-N1
- [x] Orphan-className check — exit 0, no new orphans (`.app-header-btn-icon` and `.app-header-btn-label` have matching CSS rules)
- [x] Playwright MCP verification: wordmark scrollWidth=65 ≤ clientWidth=65, truncated=false at 390 and 428
- [x] SVG icons: Attribution (info-circle) and Filters (funnel) visible at 390 + 428; confirmed via `window.getComputedStyle` + `getBoundingClientRect`
- [x] Functionality: Attribution click opens Credits dialog; Filters click opens FiltersPanel — both confirmed via Playwright MCP at 390px
- [x] Console: zero errors, zero warnings at all 5 canonical viewports
- [x] 12 screenshots (6 viewports × 2 themes) via user-attachments paste flow
- [ ] `npm run build` — blocked by pre-existing `tsc -b` errors (present on `main`)

### Doc drift fixes

- `SpeciesDetailSheet.tsx:43`: comment "peek 96px" → "peek 120px" (matches `PEEK_PX = 120`)
- `frontend/e2e/sheet-snap.spec.ts:50–54`: "160px" DISMISS_THRESHOLD → "80px", "96px peek" → "120px peek"

## Plan reference

Out of plan — addresses §Bundle E mobile fixes. Closes #514.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)