### PR TITLE
fix(a11y): keep family legend controls target mounted

### DIFF
--- a/frontend/src/components/FamilyLegend.test.tsx
+++ b/frontend/src/components/FamilyLegend.test.tsx
@@ -214,8 +214,10 @@ describe('FamilyLegend', () => {
     );
     expect(screen.getAllByTestId('family-legend-entry')).toHaveLength(3);
     await user.click(screen.getByRole('button', { name: /bird families in view/i }));
-    // Once collapsed, no entries are rendered (or at least none visible).
-    expect(screen.queryAllByTestId('family-legend-entry')).toHaveLength(0);
+    const list = screen.getByRole('list', { hidden: true });
+    expect(list).toHaveAttribute('id', 'family-legend-entries');
+    expect(list).toHaveAttribute('hidden');
+    expect(screen.queryByRole('button', { name: /Tyrant Flycatchers/ })).toBeNull();
     // And the toggle button reports collapsed state via aria-expanded=false.
     expect(screen.getByRole('button', { name: /bird families in view/i })).toHaveAttribute('aria-expanded', 'false');
   });
@@ -230,8 +232,12 @@ describe('FamilyLegend', () => {
         defaultExpanded={false}
       />
     );
-    expect(screen.queryAllByTestId('family-legend-entry')).toHaveLength(0);
-    expect(screen.getByRole('button', { name: /bird families in view/i })).toHaveAttribute('aria-expanded', 'false');
+    const toggle = screen.getByRole('button', { name: /bird families in view/i });
+    const list = screen.getByRole('list', { hidden: true });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'family-legend-entries');
+    expect(list).toHaveAttribute('id', 'family-legend-entries');
+    expect(list).toHaveAttribute('hidden');
   });
 
   it('persists collapse state to localStorage (.v2 key)', async () => {

--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -152,54 +152,53 @@ export function FamilyLegend({
           {expanded ? '▾' : '▸'}
         </span>
       </button>
-      {expanded && entries.length > 0 && (
-        <ul
-          id="family-legend-entries"
-          className="family-legend-entries"
-          role="list"
-        >
-          {entries.map(entry => {
-            const active = entry.familyCode === familyCode;
-            // Shape is still sourced from the palette channel (WCAG 1.4.1 —
-            // color is not the sole discriminator). Codes not in FAMILY_PALETTE
-            // fall back to the null-channel shape (circle). The fill color,
-            // however, now comes from the DB silhouettes payload via the `color`
-            // prop — the palette fill is shape-encoding-only after this fix.
-            const paletteCode = (entry.familyCode in FAMILY_PALETTE)
-              ? (entry.familyCode as FamilyCode)
-              : null;
-            const channel = getFamilyChannel(paletteCode);
-            const shape: ShapeVariant = channel.shape;
-            return (
-              <li key={entry.familyCode} className="family-legend-entry-item">
-                <button
-                  type="button"
-                  data-testid="family-legend-entry"
-                  className={'family-legend-entry' + (active ? ' is-active' : '')}
-                  aria-pressed={active}
-                  onClick={() => onFamilyToggle(entry.familyCode)}
+      <ul
+        id="family-legend-entries"
+        className="family-legend-entries"
+        role="list"
+        hidden={!expanded || entries.length === 0}
+      >
+        {entries.map(entry => {
+          const active = entry.familyCode === familyCode;
+          // Shape is still sourced from the palette channel (WCAG 1.4.1 —
+          // color is not the sole discriminator). Codes not in FAMILY_PALETTE
+          // fall back to the null-channel shape (circle). The fill color,
+          // however, now comes from the DB silhouettes payload via the `color`
+          // prop — the palette fill is shape-encoding-only after this fix.
+          const paletteCode = (entry.familyCode in FAMILY_PALETTE)
+            ? (entry.familyCode as FamilyCode)
+            : null;
+          const channel = getFamilyChannel(paletteCode);
+          const shape: ShapeVariant = channel.shape;
+          return (
+            <li key={entry.familyCode} className="family-legend-entry-item">
+              <button
+                type="button"
+                data-testid="family-legend-entry"
+                className={'family-legend-entry' + (active ? ' is-active' : '')}
+                aria-pressed={active}
+                onClick={() => onFamilyToggle(entry.familyCode)}
+              >
+                <FamilySilhouette
+                  family={entry.familyCode}
+                  layout="thumb"
+                  shape={shape}
+                  color={entry.silhouette.color}
+                  {...(entry.silhouette.svgUrl != null ? { imgUrl: entry.silhouette.svgUrl } : {})}
+                  {...(entry.silhouette.svgData != null ? { pathD: entry.silhouette.svgData } : {})}
+                />
+                <span className="family-legend-entry-label">{entry.label}</span>
+                <span
+                  className="family-legend-entry-count"
+                  aria-label={`${entry.count} observations in view`}
                 >
-                  <FamilySilhouette
-                    family={entry.familyCode}
-                    layout="thumb"
-                    shape={shape}
-                    color={entry.silhouette.color}
-                    {...(entry.silhouette.svgUrl != null ? { imgUrl: entry.silhouette.svgUrl } : {})}
-                    {...(entry.silhouette.svgData != null ? { pathD: entry.silhouette.svgData } : {})}
-                  />
-                  <span className="family-legend-entry-label">{entry.label}</span>
-                  <span
-                    className="family-legend-entry-count"
-                    aria-label={`${entry.count} observations in view`}
-                  >
-                    {entry.count}
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                  {entry.count}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- keep the `#family-legend-entries` list mounted whenever the family legend renders
- hide the list with `hidden` when collapsed or empty so `aria-controls` always points at an existing target
- update FamilyLegend tests to assert the collapsed controlled target remains present but hidden

Closes #525

## Validation
- `npm ci`
- `npm test -- FamilyLegend.test.tsx`
- `npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/frontend`
- `npm test -w @bird-watch/frontend`
- `git diff --check`

Note: `npm run build -w @bird-watch/frontend` by itself fails from a clean checkout until `@bird-watch/shared-types` is built, so the validation above builds the workspace dependency first.