### PR TITLE
fix(migrations): backfill species_meta x00013 to unblock recent ingest cron (PR-1 of #527)

### DIFF
--- a/migrations/1700000038000_backfill_species_meta_x00013.sql
+++ b/migrations/1700000038000_backfill_species_meta_x00013.sql
@@ -1,0 +1,50 @@
+-- Up Migration
+--
+-- Issue #527 (PR-1 of 3). Backfills the species_meta row for eBird hybrid
+-- code `x00013` ("Bullock's x Baltimore Oriole"), which has been observed in
+-- US-AZ since ~2026-05-12 with no matching species_meta parent — tripping
+-- the ingest invariant added in #484 (services/ingestor/src/run-ingest.ts:54-63)
+-- and exiting the `recent` ingest cron non-zero every 30 minutes for ~40
+-- hours before this hotfix lands.
+--
+-- Root cause is identical to #484: `runTaxonomy` filters eBird's taxonomy
+-- stream to `category === 'species'` (services/ingestor/src/run-taxonomy.ts:46),
+-- which drops every `hybrid` row. Recent observation ingest
+-- (`/data/obs/US-AZ/recent`) is NOT filtered the same way, so hybrid codes
+-- flow into `observations` without a matching `species_meta` parent. The
+-- invariant correctly refuses the insert; this row unblocks the cron.
+--
+-- PR-2 and PR-3 of this epic widen `runTaxonomy` to keep hybrid/spuh/slash/
+-- form/domestic rows and add alarming so future occurrences surface in
+-- minutes instead of hours. Until those land, this single-row backfill is
+-- the minimal hotfix.
+--
+-- Source: eBird taxonomy v2 API,
+-- /v2/ref/taxonomy/ebird?species=x00013&fmt=json, queried 2026-05-14.
+-- The row carries (speciesCode, comName, sciName, familyCode, familyName,
+-- taxonOrder) verbatim from eBird, with familyCode lowercased per the
+-- ingestor's existing convention in services/ingestor/src/run-taxonomy.ts:
+-- `(t.familySciName ?? t.familyCode ?? '').toLowerCase()` — i.e. 'icteridae'
+-- (lowercased `familySciName`), not eBird's raw `familyCode` 'icteri1'.
+--
+-- Family JOIN: `family_code = 'icteridae'` already exists in
+-- `family_silhouettes` per migration 1700000033000, so `silhouette_id` will
+-- be non-NULL and the hybrid renders with the icteridae icon and #F4B400
+-- color used by Western Meadowlark, the orioles, and the grackles.
+--
+-- ON CONFLICT DO NOTHING preserves any row a future `runTaxonomy` run might
+-- legitimately produce (e.g. if eBird reclassifies the code or PR-2's
+-- widened filter lands first).
+INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+VALUES
+  -- Bullock's x Baltimore Oriole hybrid. Both parents (Icterus bullockii,
+  -- I. galbula) are Icteridae. Observed live in AZ from 2026-05-12.
+  ('x00013', 'Bullock''s x Baltimore Oriole (hybrid)', 'Icterus bullockii x galbula', 'icteridae', 'Troupials and Allies', 33771)
+ON CONFLICT (species_code) DO NOTHING;
+
+-- Down Migration
+--
+-- Removes only the single row this migration inserted. Defensive: filters by
+-- the exact species_code so a future migration that legitimately adds OTHER
+-- icteridae or hybrid rows won't be reverted here.
+DELETE FROM species_meta WHERE species_code = 'x00013';

--- a/packages/db-client/src/species-meta-x00013-migration.test.ts
+++ b/packages/db-client/src/species-meta-x00013-migration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration test for migration 1700000038000 —
+ * backfill species_meta row for eBird hybrid code `x00013`
+ * ("Bullock's x Baltimore Oriole").
+ *
+ * Issue #527 (PR-1 of 3). The `recent` ingest cron has been exiting non-zero
+ * every 30 min for ~40 hours because the #484 invariant
+ * (services/ingestor/src/run-ingest.ts:54-63) correctly refuses to insert
+ * observations for a species_code with no species_meta parent. This
+ * migration ships the single missing row.
+ *
+ * Schema invariants exercised here:
+ *   - The Up migration inserts exactly one row with the documented values.
+ *   - `family_code = 'icteridae'` JOINs cleanly to `family_silhouettes`
+ *     (the silhouette exists from migration 1700000033000), so the read-api
+ *     `silhouette_id` resolution works for x00013 observations.
+ *   - The Down migration removes only the x00013 row, leaving other
+ *     species_meta rows (including those inserted by migration 1700000032000)
+ *     intact.
+ *
+ * No DB mocks — runs against a real PostGIS testcontainer per the
+ * project-wide rule (CLAUDE.md "No DB mocks in tests").
+ *
+ * Test pattern mirrors species-photos-migration.test.ts: a one-off container
+ * with all migrations applied in beforeAll, no TRUNCATE in beforeEach (so the
+ * seeded row survives for the assertions).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers before any query.
+import './pool.js';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+const MIGRATION_FILE = '1700000038000_backfill_species_meta_x00013.sql';
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const sql = readFileSync(filePath, 'utf-8');
+  const [rawUpPart = '', rawDownPart = ''] = sql.split(/-- Down Migration/i);
+  return {
+    up: rawUpPart.replace(/-- Up Migration/i, '').trim(),
+    down: rawDownPart.trim(),
+  };
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  // Apply all Up migrations in numeric order. Same logic as startTestDb.
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  for (const f of files) {
+    const { up } = parseMigration(join(migrationsDir, f));
+    if (up) {
+      await pool.query(up);
+    }
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('migration 1700000038000_backfill_species_meta_x00013 — Up', () => {
+  it('inserts the x00013 row with the documented values', async () => {
+    const { rows } = await pool.query<{
+      species_code: string;
+      com_name: string;
+      sci_name: string;
+      family_code: string;
+      family_name: string;
+      taxon_order: number | null;
+    }>(
+      `SELECT species_code, com_name, sci_name, family_code, family_name, taxon_order
+         FROM species_meta WHERE species_code = 'x00013'`
+    );
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.com_name).toBe("Bullock's x Baltimore Oriole (hybrid)");
+    expect(row.sci_name).toBe('Icterus bullockii x galbula');
+    expect(row.family_code).toBe('icteridae');
+    expect(row.family_name).toBe('Troupials and Allies');
+    // pool.ts registers the NUMERIC → number parser, so taxon_order is a
+    // number not a string (same contract as species.test.ts line 44).
+    expect(typeof row.taxon_order).toBe('number');
+    expect(row.taxon_order).toBe(33771);
+  });
+
+  it('JOINs cleanly to family_silhouettes via family_code', async () => {
+    // The whole point of choosing family_code='icteridae' is that
+    // migration 1700000033000 already seeded that row in family_silhouettes,
+    // so the read-api silhouette resolution returns a real icon (not
+    // _FALLBACK) for x00013 observations.
+    const { rows } = await pool.query<{
+      species_code: string;
+      family_code: string;
+      silhouette_id: string;
+      color: string;
+    }>(
+      `SELECT sm.species_code, sm.family_code, fs.id AS silhouette_id, fs.color
+         FROM species_meta sm
+         JOIN family_silhouettes fs ON fs.family_code = sm.family_code
+        WHERE sm.species_code = 'x00013'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.silhouette_id).toBe('icteridae');
+    // #F4B400 is the icteridae color set by migration 1700000033000.
+    expect(rows[0]?.color).toBe('#F4B400');
+  });
+
+  it('is idempotent — re-running Up does not duplicate the row', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    // Re-apply Up; the ON CONFLICT (species_code) DO NOTHING clause should
+    // make this a no-op rather than a unique-violation throw.
+    await pool.query(up);
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_meta WHERE species_code = 'x00013'`
+    );
+    expect(Number(rows[0]?.count)).toBe(1);
+  });
+});
+
+describe('migration 1700000038000_backfill_species_meta_x00013 — Down', () => {
+  it('removes only the x00013 row, leaving migration-32000 rows intact', async () => {
+    // Snapshot one row that migration 1700000032000 inserted, so we can prove
+    // Down(38000) doesn't fall back to a sci_name LIKE '% x %' delete.
+    const before = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_meta WHERE species_code = 'ixlbun'`
+    );
+    expect(Number(before.rows[0]?.count)).toBe(1);
+
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { down } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    expect(down).toBeTruthy();
+    await pool.query(down);
+
+    const x00013 = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_meta WHERE species_code = 'x00013'`
+    );
+    expect(Number(x00013.rows[0]?.count)).toBe(0);
+
+    const ixlbun = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_meta WHERE species_code = 'ixlbun'`
+    );
+    expect(Number(ixlbun.rows[0]?.count)).toBe(1);
+
+    // Re-apply Up so the file's test order doesn't leave a partial state if
+    // other test files in the same vitest run share the container (they
+    // don't — each *-migration.test.ts spins its own — but defensive).
+    const { up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    await pool.query(up);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Cron as recent-ingest cron (every 30 min)
    participant Ingestor
    participant eBird
    participant DB as Postgres (species_meta + observations)

    Note over Cron,DB: BEFORE — broken state, ~40 hours of non-zero exits
    Cron->>Ingestor: kick run
    Ingestor->>eBird: GET /data/obs/US-AZ/recent
    eBird-->>Ingestor: rows include species_code=x00013
    Ingestor->>DB: findMissingSpeciesMeta(['x00013', ...])
    DB-->>Ingestor: ['x00013']
    Ingestor->>Ingestor: throw invariant — refuse insert
    Ingestor-->>Cron: exit 1

    Note over Cron,DB: AFTER — this PR seeds the row
    Cron->>Ingestor: kick run
    Ingestor->>eBird: GET /data/obs/US-AZ/recent
    eBird-->>Ingestor: rows include species_code=x00013
    Ingestor->>DB: findMissingSpeciesMeta(['x00013', ...])
    DB-->>Ingestor: []
    Ingestor->>DB: INSERT observations (with region stamp)
    Ingestor-->>Cron: exit 0
```

## Summary

- Part of #527 (PR-1 of 3). Stops the bleeding: ships the one missing `species_meta` row that the #484 invariant has been blocking on for ~40 hours.
- The eBird code is `x00013` ("Bullock's x Baltimore Oriole", a hybrid). `runTaxonomy` filters to `category === 'species'`, so hybrids never land in `species_meta` until someone backfills them by hand. Same root cause as #484; PR-2 widens the taxonomy filter and PR-3 adds alarming so the next hybrid surfaces in minutes, not 40 hours.
- Migration mirrors `1700000032000_backfill_species_meta_spuh_hybrid.sql` verbatim: `ON CONFLICT (species_code) DO NOTHING`, lowercased `familySciName` as `family_code` (`icteridae`), eBird's `familyComName` verbatim as `family_name`, `taxon_order=33771` from the live eBird taxonomy API. `family_code='icteridae'` already exists in `family_silhouettes` (migration `1700000033000`), so x00013 observations render with the icteridae silhouette and `#F4B400` — not `_FALLBACK`.

### Preflight (gcloud, corrected regex from orchestrator comment)

```sh
gcloud logging read 'resource.type="cloud_run_job" AND resource.labels.job_name="bird-ingestor" AND textPayload=~"Missing codes"' \
  --freshness=7d --limit=50 --format="value(textPayload)"
```

Returned 50/50 lines, every one identical:

```
"error": "ingest invariant violation: 1 observation species_code(s) have no species_meta row — refusing to insert observations the read-api cannot resolve. Missing codes: x00013. Fix: add species_meta rows for these codes (see issue #484 for the pattern)."
```

The orchestrator's recommended `grep -oE 'x[0-9]+|[a-z]{4,10}[0-9]*' | sort -u` post-filter outputs 20 tokens, but 19 of them are English words from the log prose (`cannot`, `code`, `codes`, `error`, `have`, `ingest`, `insert`, `invariant`, `issing`, `issue`, `meta`, `observatio`, `pattern`, `read`, `refusing`, `resolve`, `rows`, `species`, `these`, `violation`) — the regex is overbroad against the JSON payload's surrounding words. The only species-code-shaped token is `x00013`, and it is the same code referenced in the live `Missing codes:` field in every record. **Branching decision: single-code path. PR-1 covers exactly this one row.**

### Live eBird taxonomy lookup

```sh
curl -s -H "X-eBirdApiToken: $KEY" 'https://api.ebird.org/v2/ref/taxonomy/ebird?fmt=json&species=x00013' | jq '.[0]'
```

```json
{
  "sciName": "Icterus bullockii x galbula",
  "comName": "Bullock's x Baltimore Oriole (hybrid)",
  "speciesCode": "x00013",
  "category": "hybrid",
  "taxonOrder": 33771.0,
  "familyCode": "icteri1",
  "familyComName": "Troupials and Allies",
  "familySciName": "Icteridae"
}
```

`family_code` stored as `icteridae` (lowercased `familySciName`, matching the ingestor convention in `run-taxonomy.ts` and migration 32000) — NOT eBird's raw `familyCode` (`icteri1`).

## Screenshots

N/A — backend only (single SQL migration row + integration test).

## Test plan

- [x] `npm test --workspace @bird-watch/db-client -- --run species-meta-x00013-migration` — **4 passed** (Up: row inserted with documented values, JOIN to `family_silhouettes` returns `silhouette_id=icteridae`/`color=#F4B400`, re-running Up is idempotent; Down: removes only `x00013`, leaves `ixlbun` from migration 32000 intact)
- [x] `npm test --workspace @bird-watch/db-client` — **91 passed** across 13 files (no regressions in `species.test.ts`, `migrations-down-chain.test.ts`, etc.)
- [x] `npm test --workspace @bird-watch/ingestor` — **138 passed** across 16 files (the invariant-related tests in `run-ingest.test.ts` still pass; this PR doesn't touch ingestor code, only the missing data row it was correctly refusing to ignore)
- [x] `npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api` — clean
- [ ] `npm run build -w @bird-watch/frontend` — **fails on `main` too**, pre-existing `MapCanvas.tsx` TS errors unrelated to this PR. This PR adds two files only (`migrations/1700000038000_backfill_species_meta_x00013.sql` + `packages/db-client/src/species-meta-x00013-migration.test.ts`); `git diff main --stat` shows zero frontend changes.
- [x] `npm run lint` — root-level no-op (no workspace declares a `lint` script). Matches CI behavior.

### Not run

- Production migration. Local Postgres only via `@testcontainers/postgresql` (per CLAUDE.md "No DB mocks").
- Manual ingest cron trigger. The orchestrator owns the deploy + post-merge verification step (`exit code 0 AND freshestObservationAt > 2026-05-14T13:00Z`) per the epic's PR-1 AC.

## Plan reference

Part of issue #527 (PR-1 of 3 — single-row hotfix). PR-2 widens the taxonomy filter so future hybrids self-heal; PR-3 wires alarming (gated on #528). See the epic body's "PR-1" section and the orchestrator's follow-up comment for the concession-folded spec.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)