### PR TITLE
fix(ingestor): keep all 7 eBird taxonomy categories, not just 'species'

### DIFF
--- a/services/ingestor/src/run-taxonomy.test.ts
+++ b/services/ingestor/src/run-taxonomy.test.ts
@@ -11,8 +11,10 @@ import { runTaxonomy } from './run-taxonomy.js';
 const server = setupServer();
 let db: TestDb;
 
-// A realistic mix: 5 species rows + 2 non-species (issf + spuh) that must be
-// dropped. familyComName → familyName is the only rename.
+// A realistic mix: 5 species rows + 2 non-species (issf + spuh). After #527
+// PR-2 the filter keeps all 7 known eBird categories — issf/spuh/hybrid/
+// slash/domestic/form upsert alongside species. The "unknown future eBird
+// category" case has its own test below.
 const TAXONOMY_FIXTURE = [
   {
     sciName: 'Pyrocephalus rubinus', comName: 'Vermilion Flycatcher',
@@ -44,7 +46,7 @@ const TAXONOMY_FIXTURE = [
     familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
     familySciName: 'Tyrannidae',
   },
-  // issf — subspecies form, must be dropped
+  // issf — subspecies form, kept post-#527
   {
     sciName: 'Junco hyemalis hyemalis/carolinensis',
     comName: 'Dark-eyed Junco (Slate-colored)',
@@ -52,12 +54,72 @@ const TAXONOMY_FIXTURE = [
     familyCode: 'passer1', familyComName: 'Old World Sparrows',
     familySciName: 'Passeridae',
   },
-  // spuh — genus-level, must be dropped
+  // spuh — genus-level, kept post-#527
   {
     sciName: 'Empidonax sp.', comName: 'Empidonax flycatcher sp.',
     speciesCode: 'y00005', category: 'spuh', taxonOrder: 30400,
     familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
     familySciName: 'Tyrannidae',
+  },
+];
+
+// All 7 known eBird categories — used by the post-#527 test that exercises
+// the full allowlist plus a forward-compat unknown-category row that must
+// still be filtered out.
+const ALL_CATEGORIES_FIXTURE = [
+  {
+    sciName: 'Pyrocephalus rubinus', comName: 'Vermilion Flycatcher',
+    speciesCode: 'verfly', category: 'species', taxonOrder: 30501,
+    familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
+    familySciName: 'Tyrannidae',
+  },
+  {
+    sciName: 'Junco hyemalis hyemalis', comName: 'Dark-eyed Junco (Slate-colored)',
+    speciesCode: 'daejun1', category: 'issf', taxonOrder: 31000,
+    familyCode: 'passer1', familyComName: 'Old World Sparrows',
+    familySciName: 'Passeridae',
+  },
+  {
+    sciName: 'Icterus bullockii x galbula', comName: "Bullock's x Baltimore Oriole (hybrid)",
+    speciesCode: 'x00013', category: 'hybrid', taxonOrder: 32500,
+    familyCode: 'icteri1', familyComName: 'Troupials and Allies',
+    familySciName: 'Icteridae',
+  },
+  {
+    sciName: 'Empidonax sp.', comName: 'Empidonax flycatcher sp.',
+    speciesCode: 'y00005', category: 'spuh', taxonOrder: 30400,
+    familyCode: 'tyrann1', familyComName: 'Tyrant Flycatchers',
+    familySciName: 'Tyrannidae',
+  },
+  {
+    sciName: 'Buteo jamaicensis/swainsoni',
+    comName: 'Red-tailed/Swainson’s Hawk',
+    speciesCode: 'y00050', category: 'slash', taxonOrder: 5100,
+    familyCode: 'accipi1', familyComName: 'Hawks, Eagles, and Kites',
+    familySciName: 'Accipitridae',
+  },
+  {
+    sciName: 'Anas platyrhynchos (Domestic type)',
+    comName: 'Mallard (Domestic type)',
+    speciesCode: 'maldom', category: 'domestic', taxonOrder: 250,
+    familyCode: 'anatid1', familyComName: 'Ducks, Geese, and Waterfowl',
+    familySciName: 'Anatidae',
+  },
+  {
+    sciName: 'Columba livia (Feral Pigeon)', comName: 'Rock Pigeon (Feral Pigeon)',
+    speciesCode: 'rocpig1', category: 'form', taxonOrder: 14000,
+    familyCode: 'columb1', familyComName: 'Pigeons and Doves',
+    familySciName: 'Columbidae',
+  },
+  // Forward-compat: an eBird-invented 8th category. Must be filtered out so
+  // a future schema change can't silently land rows with unknown semantics.
+  // The Set<EbirdTaxon['category']> typing in run-taxonomy.ts ensures we
+  // can't accidentally widen the allowlist without a type-system signal.
+  {
+    sciName: 'Future Sp.', comName: 'Future Category Bird',
+    speciesCode: 'z99999', category: 'newcategory', taxonOrder: 99999,
+    familyCode: 'futur1', familyComName: 'Future Family',
+    familySciName: 'Futuridae',
   },
 ];
 
@@ -79,7 +141,7 @@ afterAll(async () => {
 });
 
 describe('runTaxonomy', () => {
-  it('fetches taxonomy, filters to species, upserts species_meta, records success run', async () => {
+  it('fetches taxonomy, keeps all 7 known categories, upserts species_meta, records success run', async () => {
     server.use(
       http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', () =>
         HttpResponse.json(TAXONOMY_FIXTURE)
@@ -92,8 +154,10 @@ describe('runTaxonomy', () => {
 
     expect(summary.status).toBe('success');
     expect(summary.totalFetched).toBe(7);
-    expect(summary.nonSpeciesFiltered).toBe(2);
-    expect(summary.speciesInserted).toBe(5);
+    // Post-#527 PR-2: issf + spuh are kept alongside species. Nothing is
+    // filtered because all 7 fixture rows match a known category.
+    expect(summary.nonSpeciesFiltered).toBe(0);
+    expect(summary.speciesInserted).toBe(7);
 
     // Verify a real row landed. `family_code` is derived from `familySciName`
     // (lowercased) — not eBird's `familyCode` — because family_silhouettes is
@@ -109,16 +173,50 @@ describe('runTaxonomy', () => {
       taxonOrder: 30501,
     });
 
-    // Non-species rows are not written.
-    expect(await getSpeciesMeta(db.pool, 'daejun1')).toBeNull();
-    expect(await getSpeciesMeta(db.pool, 'y00005')).toBeNull();
+    // The hybrid/spuh/issf rows that #484 used to drop now land. This is the
+    // structural fix for the x00013 incident (#527).
+    expect(await getSpeciesMeta(db.pool, 'daejun1')).not.toBeNull();
+    expect(await getSpeciesMeta(db.pool, 'y00005')).not.toBeNull();
 
     // Ingest run is recorded with kind='taxonomy' and status='success'.
     const runs = await getRecentIngestRuns(db.pool, 5);
     expect(runs[0]?.kind).toBe('taxonomy');
     expect(runs[0]?.status).toBe('success');
     expect(runs[0]?.obsFetched).toBe(7);
-    expect(runs[0]?.obsUpserted).toBe(5);
+    expect(runs[0]?.obsUpserted).toBe(7);
+  });
+
+  it('keeps all 7 eBird categories and filters out unknown future categories (#527 forward-compat)', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', () =>
+        HttpResponse.json(ALL_CATEGORIES_FIXTURE)
+      )
+    );
+
+    const summary = await runTaxonomy({
+      pool: db.pool, apiKey: 'test-key',
+    });
+
+    expect(summary.status).toBe('success');
+    expect(summary.totalFetched).toBe(8);
+    // 7 known categories kept + 1 unknown ('newcategory') filtered.
+    expect(summary.nonSpeciesFiltered).toBe(1);
+    expect(summary.speciesInserted).toBe(7);
+
+    // Each of the 7 known categories produced a species_meta row.
+    expect(await getSpeciesMeta(db.pool, 'verfly')).not.toBeNull();  // species
+    expect(await getSpeciesMeta(db.pool, 'daejun1')).not.toBeNull(); // issf
+    expect(await getSpeciesMeta(db.pool, 'x00013')).not.toBeNull();  // hybrid
+    expect(await getSpeciesMeta(db.pool, 'y00005')).not.toBeNull();  // spuh
+    expect(await getSpeciesMeta(db.pool, 'y00050')).not.toBeNull();  // slash
+    expect(await getSpeciesMeta(db.pool, 'maldom')).not.toBeNull();  // domestic
+    expect(await getSpeciesMeta(db.pool, 'rocpig1')).not.toBeNull(); // form
+
+    // The forward-compat row with an unknown category is NOT upserted. If
+    // eBird ever invents an 8th category, the relaxed missing-code invariant
+    // in run-ingest.ts (PR-3, gated on #528) is what surfaces it — not a
+    // silent insert here with unknown semantics.
+    expect(await getSpeciesMeta(db.pool, 'z99999')).toBeNull();
   });
 
   it('reconcile-stamps existing observations — post-run they carry silhouette_id and region_id', async () => {

--- a/services/ingestor/src/run-taxonomy.ts
+++ b/services/ingestor/src/run-taxonomy.ts
@@ -43,7 +43,20 @@ export async function runTaxonomy(opts: RunTaxonomyOptions): Promise<RunTaxonomy
   const runId = await startIngestRun(opts.pool, 'taxonomy');
   try {
     const taxonomy = await client.fetchTaxonomy();
-    const speciesOnly = taxonomy.filter(t => t.category === 'species');
+    // eBird's category enum is a closed union of 7 values (see
+    // `ebird/types.ts:42`). We keep all of them here so the monthly taxonomy
+    // cron populates species_meta for hybrid/spuh/slash/domestic/form/issf
+    // rows (not just true species). PR #484's species-only invariant
+    // previously stalled production for 42h on a missing hybrid (`x00013`,
+    // Bullock's x Baltimore Oriole); see issue #527 for the incident. The
+    // allowlist shape is deliberate: if eBird invents an 8th category, it
+    // falls through and is logged by the relaxed invariant in
+    // `run-ingest.ts` (#527 PR-3, gated on #528) rather than silently
+    // upserted with unknown semantics.
+    const KEPT_CATEGORIES = new Set<EbirdTaxon['category']>([
+      'species', 'issf', 'hybrid', 'spuh', 'slash', 'domestic', 'form',
+    ]);
+    const speciesOnly = taxonomy.filter(t => KEPT_CATEGORIES.has(t.category));
     const nonSpeciesFiltered = taxonomy.length - speciesOnly.length;
 
     const inputs = speciesOnly.map(toSpeciesMeta);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    eBird[eBird /ref/taxonomy/ebird] -->|7-value category union| Filter

    subgraph Before["Before #527 PR-2"]
        FilterOld["filter t.category === 'species'"] --> SpeciesMetaOld[(species_meta<br/>species only)]
    end

    subgraph After["After #527 PR-2"]
        Filter["filter KEPT_CATEGORIES.has(t.category)<br/>Set { species, issf, hybrid, spuh,<br/>slash, domestic, form }"] --> SpeciesMetaNew[(species_meta<br/>all 7 categories)]
        Filter -. unknown future cat .-> Dropped[/Dropped, surfaced by<br/>relaxed invariant PR-3/]
    end

    SpeciesMetaNew --> Ingest[run-ingest.ts]
    Ingest -.->|no longer throws on<br/>hybrid/spuh/slash/etc.| Healthy[Ingest stays green]
```

## Summary

- Part of #527 (PR-2 of 3). Structural fix for the 2026-05-12 incident where a single missing hybrid (`x00013`) stalled production ingest for 42h.
- Replaces `taxonomy.filter(t => t.category === 'species')` with an allowlist `Set` covering all 7 values in eBird's closed `category` union (`services/ingestor/src/ebird/types.ts:42`). Typed `Set<EbirdTaxon['category']>` so the type system catches accidental widening.
- Forward-compat: an unknown 8th eBird category is filtered out here and surfaced by PR-3's relaxed invariant (gated on #528), not silently upserted with unknown semantics.

## Screenshots

N/A — backend only.

## Test plan

- [x] `npm test --workspace @bird-watch/ingestor` — green (16 files, 139 tests)
- [x] `npm run build --workspace @bird-watch/ingestor` — tsc clean
- [x] Updated existing happy-path test: now asserts all 7 fixture rows land (was 5 species + 2 dropped non-species)
- [x] New regression test: 7 known categories upsert, an unknown `newcategory` row is filtered out
- [x] N/A — not UI (no Playwright drive required)

## Plan reference

Part of #527 (PR-2 of 3). PR-1 (#529) shipped the `x00013` hotfix; PR-3 will relax the throw-on-missing invariant in `run-ingest.ts`, gated on #528 (alarming for ingest cron failures).

## Post-merge runbook (for the merger)

This PR is code-only. After merge and the Cloud Run image redeploys, manually invoke the taxonomy job in prod to backfill the hybrid/spuh/slash/domestic/form/issf rows that were never upserted historically:

```sh
gcloud run jobs execute bird-ingestor --args=taxonomy --region=us-west1 --project=bird-maps-prod --wait
```

Expected: exit 0, `species_meta` row count increases by the count of non-species eBird taxa (≈hundreds — eBird's global taxonomy has thousands of issf/hybrid/spuh/etc. rows but `species_meta` only needs the ones referenced by `observations`, which is much smaller; the reconcile pass at the end of the job will stamp `silhouette_id` / `region_id` on any previously-NULL rows).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)