### PR TITLE
fix(ebird-client): fetch all 7 taxonomy categories, not just species

### DIFF
--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -70,7 +70,12 @@ describe('EbirdClient.fetchTaxonomy', () => {
     server.use(
       http.get('https://api.ebird.org/v2/ref/taxonomy/ebird', ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get('cat')).toBe('species');
+        // `cat` IS server-side (see client.ts comment + issue #527): we must
+        // pass the full 7-category union explicitly. `cat=species` alone
+        // returns ~11.2k rows; the full list returns ~17.8k.
+        expect(url.searchParams.get('cat')).toBe(
+          'species,issf,hybrid,spuh,slash,domestic,form'
+        );
         expect(url.searchParams.get('fmt')).toBe('json');
         expect(url.searchParams.get('locale')).toBe('en');
         // eBird's /ref/taxonomy/ebird requires a NUMERIC version (e.g. 2024) OR

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -66,10 +66,13 @@ export class EbirdClient {
   }
 
   /**
-   * Fetches the full eBird taxonomy (~17k rows including issf/spuh/slash/form/
-   * hybrid sub-categories). The `cat=species` parameter is an eBird server-side
-   * hint but does not actually restrict the response — callers MUST still filter
-   * to `category === 'species'` before writing to species_meta.
+   * Fetches eBird taxonomy across all 7 categories (species, issf, hybrid,
+   * spuh, slash, domestic, form) — ~17.8k rows. `cat` IS server-side: probes
+   * confirmed `cat=species` returns 11,167 rows vs 17,891 with no `cat` param
+   * and 17,849 with the full 7-value list (see issue #527). We pass the list
+   * explicitly to match our typed `EbirdTaxon['category']` union — if eBird
+   * ever invents an 8th category it falls through `run-taxonomy.ts`'s
+   * `KEPT_CATEGORIES` allowlist rather than being silently upserted.
    *
    * NOTE: no `version` param. `/ref/taxonomy/ebird` wants a NUMERIC version
    * (e.g. 2024) — sending `version=latest` triggers `400 typeMismatch`
@@ -79,7 +82,7 @@ export class EbirdClient {
    */
   async fetchTaxonomy(): Promise<EbirdTaxon[]> {
     const url = new URL(`${this.baseUrl}/ref/taxonomy/ebird`);
-    url.searchParams.set('cat', 'species');
+    url.searchParams.set('cat', 'species,issf,hybrid,spuh,slash,domestic,form');
     url.searchParams.set('fmt', 'json');
     url.searchParams.set('locale', 'en');
     return this.getJson<EbirdTaxon[]>(url);


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Cron as Taxonomy Cron
    participant Client as EbirdClient.fetchTaxonomy
    participant eBird as eBird /ref/taxonomy/ebird
    participant Filter as run-taxonomy.ts<br/>KEPT_CATEGORIES
    participant DB as species_meta

    Note over Client,eBird: BEFORE (PR #530 only)
    Client->>eBird: cat=species (server-side filter)
    eBird-->>Client: 11,167 rows (species only)
    Client->>Filter: 11,167 rows
    Filter->>DB: 11,167 upserted<br/>(client-side widening was a no-op)

    Note over Client,eBird: AFTER (this PR)
    Client->>eBird: cat=species,issf,hybrid,spuh,slash,domestic,form
    eBird-->>Client: 17,849 rows (all 7 categories)
    Client->>Filter: 17,849 rows
    Filter->>DB: 17,849 upserted<br/>(hybrids like x00013 now land)
```

## Summary

Follow-up to #530, completes PR-2 of #527. PR #530 widened
`run-taxonomy.ts`'s client-side `KEPT_CATEGORIES` allowlist to admit
hybrid/spuh/slash/domestic/form/issf rows, but `EbirdClient.fetchTaxonomy()`
itself was still sending `cat=species` — which IS server-side, not just a
hint. Non-species rows never reached the client filter, so the widening
was a no-op in production.

- Send `cat=species,issf,hybrid,spuh,slash,domestic,form` explicitly so
  eBird returns the full ~17.8k-row taxonomy instead of the ~11.2k-row
  species subset.
- Keep `cat=` rather than dropping it: passing the typed 7-value union
  matches `EbirdTaxon['category']`; if eBird invents an 8th category it
  falls through `KEPT_CATEGORIES` rather than being silently upserted.
- Rewrite the misleading docstring that claimed `cat=species` "does not
  actually restrict the response".

**Direct probes against `/ref/taxonomy/ebird` (proof the bug is real):**

| `cat` param | Rows returned |
| --- | --- |
| `cat=species` (old behavior) | 11,167 |
| (no `cat` param) | 17,891 |
| `cat=species,issf,hybrid,spuh,slash,domestic,form` (this PR) | 17,849 |

## Screenshots

N/A — backend only.

## Test plan

- [x] `npm run test --workspace services/ingestor` — green (139/139,
      including 10 tests in `ebird/client.test.ts` covering the updated
      URL-param assertion + the `version=latest` regression guards)
- [x] `npm run build --workspace services/ingestor` — clean tsc, no diagnostics
- [x] New assertion in `ebird/client.test.ts` verifies the request URL
      carries `cat=species,issf,hybrid,spuh,slash,domestic,form` (would
      fail loudly if anyone re-narrows it)
- [ ] Post-merge: orchestrator re-runs the taxonomy Cloud Run Job and
      confirms `totalFetched ≈ 17.8k` (vs the ~11.2k that #530 was still
      seeing because of this bug)

## Plan reference

Out of plan — incident follow-up. PR-2 of issue #527 (the species_meta
hybrid-coverage epic); the orchestrator's post-merge verification of #530
uncovered the server-side `cat` filtering, so this PR completes what #530
intended to ship.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)