### PR TITLE
refactor(db-client): stop writing observations.region_id and hotspots.region_id (#532 PR-1 of 4)

### DIFF
--- a/packages/db-client/src/hotspots.ts
+++ b/packages/db-client/src/hotspots.ts
@@ -55,23 +55,11 @@ export async function upsertHotspots(pool: Pool, inputs: HotspotInput[]): Promis
       latest_obs_dt       = EXCLUDED.latest_obs_dt
   `;
 
-  const updateSql = `
-    UPDATE hotspots h
-    SET region_id = (
-      SELECT r.id FROM regions r
-      WHERE ST_Contains(r.geom, h.geom)
-      ORDER BY ST_Area(r.geom) ASC
-      LIMIT 1
-    )
-    WHERE region_id IS NULL OR region_id <> (
-      SELECT r.id FROM regions r
-      WHERE ST_Contains(r.geom, h.geom)
-      ORDER BY ST_Area(r.geom) ASC
-      LIMIT 1
-    )
-  `;
-
+  // region_id stamping was removed in #532 (PR-1 of 4). The per-state
+  // ecoregion concept is being retired from the data layer; the column
+  // itself is dropped in PR-3. This is the incidental retirement of #527's
+  // Recommendation 0C (docs/analyses/2026-05-14-process-scale-options/
+  // phase-4/analysis-report.md).
   await pool.query(insertSql, values);
-  await pool.query(updateSql);
   return inputs.length;
 }

--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -37,21 +37,32 @@ describe('upsertObservations', () => {
     },
   ];
 
-  it('inserts new observations and stamps region_id + silhouette_id', async () => {
+  it('inserts new observations and stamps silhouette_id (region_id no longer written; #532)', async () => {
     const count = await upsertObservations(db.pool, sample);
     expect(count).toBe(2);
 
     const all = await getObservations(db.pool, {});
     expect(all).toHaveLength(2);
     const verm = all.find(o => o.subId === 'S100')!;
-    expect(verm.regionId).toBe('sky-islands-santa-ritas');
+    expect(verm.regionId).toBeNull();
     expect(verm.silhouetteId).toBe('tyrannidae');
     expect(verm.familyCode).toBe('tyrannidae');
     const anna = all.find(o => o.subId === 'S101')!;
-    expect(anna.regionId).toBe('sonoran-tucson');
+    expect(anna.regionId).toBeNull();
     expect(anna.silhouetteId).toBe('trochilidae');
     expect(anna.familyCode).toBe('trochilidae');
     expect(anna.isNotable).toBe(true);
+  });
+
+  it('does not write observations.region_id for new rows (#532 PR-1 regression)', async () => {
+    await upsertObservations(db.pool, sample);
+    const { rows } = await db.pool.query<{ region_id: string | null }>(
+      'SELECT region_id FROM observations'
+    );
+    expect(rows).toHaveLength(2);
+    for (const r of rows) {
+      expect(r.region_id).toBeNull();
+    }
   });
 
   it('returns familyCode = null when the species is absent from species_meta (#57)', async () => {
@@ -90,7 +101,7 @@ describe('upsertObservations', () => {
 
   it('scopes the stamp UPDATE to the current batch — pre-existing NULL-stamp residue is not touched (#505)', async () => {
     // Insert N₁ pre-existing rows directly (bypassing upsertObservations) with
-    // region_id NULL — these simulate the NULL-stamp residue that turned the
+    // silhouette_id NULL — these simulate the NULL-stamp residue that turned the
     // per-iteration stamp UPDATE into an O(table) scan on every backfill day.
     const residueRows: string[] = [];
     const residueValues: unknown[] = [];
@@ -111,29 +122,27 @@ describe('upsertObservations', () => {
        VALUES ${residueRows.join(',')}`,
       residueValues
     );
-    // Force NULL stamps on the residue rows.
-    await db.pool.query("UPDATE observations SET region_id = NULL, silhouette_id = NULL");
+    // Force NULL silhouette stamps on the residue rows.
+    await db.pool.query("UPDATE observations SET silhouette_id = NULL");
 
     // Now call upsertObservations with a small batch of M new rows.
     const count = await upsertObservations(db.pool, sample);
     expect(count).toBe(2);
 
-    // Assert: the M new rows are stamped...
+    // Assert: the M new rows have their silhouette_id stamped...
     const all = await getObservations(db.pool, {});
     const newVerm = all.find(o => o.subId === 'S100')!;
-    expect(newVerm.regionId).toBe('sky-islands-santa-ritas');
     expect(newVerm.silhouetteId).toBe('tyrannidae');
     const newAnna = all.find(o => o.subId === 'S101')!;
-    expect(newAnna.regionId).toBe('sonoran-tucson');
+    expect(newAnna.silhouetteId).toBe('trochilidae');
 
     // ...AND the N₁ pre-existing NULL residue rows are STILL NULL — proving
     // the stamp UPDATE was scoped to the batch, not the table.
-    const residueAfter = await db.pool.query<{ region_id: string | null; silhouette_id: string | null }>(
-      "SELECT region_id, silhouette_id FROM observations WHERE sub_id LIKE 'R-%'"
+    const residueAfter = await db.pool.query<{ silhouette_id: string | null }>(
+      "SELECT silhouette_id FROM observations WHERE sub_id LIKE 'R-%'"
     );
     expect(residueAfter.rows).toHaveLength(100);
     for (const r of residueAfter.rows) {
-      expect(r.region_id).toBeNull();
       expect(r.silhouette_id).toBeNull();
     }
   });
@@ -182,7 +191,7 @@ describe('getObservations filters', () => {
 });
 
 describe('runReconcileStamping', () => {
-  it('fills NULL silhouette_id / region_id on existing rows after species_meta lands', async () => {
+  it('fills NULL silhouette_id on existing rows after species_meta lands', async () => {
     // Wipe species_meta so the initial upsert leaves silhouette_id NULL (the
     // exact prod shape in #83: observations ingested before species_meta was
     // populated).
@@ -197,9 +206,6 @@ describe('runReconcileStamping', () => {
     ]);
     const before = await getObservations(db.pool, {});
     expect(before[0]?.silhouetteId).toBeNull();
-    // region_id comes from the geometry JOIN which is independent of species_meta,
-    // so it is already populated. Null it out to prove reconcile fills it too.
-    await db.pool.query("UPDATE observations SET region_id = NULL WHERE sub_id = 'S900'");
 
     // Populate species_meta (simulating a successful runTaxonomy) and reconcile.
     await db.pool.query(
@@ -211,7 +217,9 @@ describe('runReconcileStamping', () => {
 
     const after = await getObservations(db.pool, {});
     expect(after[0]?.silhouetteId).toBe('tyrannidae');
-    expect(after[0]?.regionId).toBe('sky-islands-santa-ritas');
+    // region_id is no longer stamped by reconcile as of #532 (PR-1); the
+    // column itself is dropped in PR-3.
+    expect(after[0]?.regionId).toBeNull();
   });
 
   it('is idempotent — a second run touches no rows', async () => {

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -66,12 +66,6 @@ export async function upsertObservations(
   const stampSql = `
     UPDATE observations o
     SET
-      region_id = (
-        SELECT r.id FROM regions r
-        WHERE ST_Contains(r.geom, o.geom)
-        ORDER BY ST_Area(r.geom) ASC
-        LIMIT 1
-      ),
       silhouette_id = (
         SELECT fs.id
         FROM species_meta sm
@@ -82,7 +76,7 @@ export async function upsertObservations(
     FROM (VALUES ${stampPlaceholders.join(',')}) AS batch(sub_id, species_code)
     WHERE o.sub_id = batch.sub_id
       AND o.species_code = batch.species_code
-      AND (o.region_id IS NULL OR o.silhouette_id IS NULL)
+      AND o.silhouette_id IS NULL
   `;
 
   await pool.query(insertSql, values);
@@ -91,8 +85,8 @@ export async function upsertObservations(
 }
 
 /**
- * Re-runs the region/silhouette stamping UPDATE across ALL observations whose
- * region_id or silhouette_id is still NULL. Idempotent.
+ * Re-runs the silhouette stamping UPDATE across ALL observations whose
+ * silhouette_id is still NULL. Idempotent.
  *
  * upsertObservations stamps only the rows in its own batch (the UPDATE is
  * scoped to the batch's (sub_id, species_code) pairs). Anything that was NULL
@@ -100,18 +94,16 @@ export async function upsertObservations(
  * species_meta was empty at the time, as on prod pre-#83 — stays NULL until
  * this function sweeps it. Run once at the end of a taxonomy or backfill run.
  *
+ * Note: region_id is no longer stamped here as of #532 (PR-1 of 4). The
+ * per-state ecoregion concept is being removed from the data layer; the
+ * column itself is dropped in PR-3.
+ *
  * Returns the number of rows updated.
  */
 export async function runReconcileStamping(pool: Pool): Promise<number> {
   const { rowCount } = await pool.query(`
     UPDATE observations o
     SET
-      region_id = COALESCE(o.region_id, (
-        SELECT r.id FROM regions r
-        WHERE ST_Contains(r.geom, o.geom)
-        ORDER BY ST_Area(r.geom) ASC
-        LIMIT 1
-      )),
       silhouette_id = COALESCE(o.silhouette_id, (
         SELECT fs.id
         FROM species_meta sm
@@ -119,7 +111,7 @@ export async function runReconcileStamping(pool: Pool): Promise<number> {
         WHERE sm.species_code = o.species_code
         LIMIT 1
       ))
-    WHERE o.region_id IS NULL OR o.silhouette_id IS NULL
+    WHERE o.silhouette_id IS NULL
   `);
   return rowCount ?? 0;
 }

--- a/services/ingestor/src/run-hotspots.test.ts
+++ b/services/ingestor/src/run-hotspots.test.ts
@@ -18,7 +18,7 @@ beforeEach(async () => { await db.pool.query('TRUNCATE hotspots'); });
 afterAll(async () => { server.close(); await db?.stop(); });
 
 describe('runHotspotIngest', () => {
-  it('fetches hotspots from eBird and upserts with region stamping', async () => {
+  it('fetches hotspots from eBird and upserts them (region stamping removed in #532 PR-1)', async () => {
     server.use(
       http.get('https://api.ebird.org/v2/ref/hotspot/US-AZ', () => HttpResponse.json([
         { locId: 'L1', locName: 'Madera Canyon', countryCode: 'US',

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -68,11 +68,12 @@ describe('runIngest', () => {
     const obs = await getObservations(db.pool, {});
     expect(obs).toHaveLength(2);
     const verm = obs.find(o => o.subId === 'S100')!;
-    expect(verm.regionId).toBe('sky-islands-santa-ritas');
+    // region_id no longer written by ingest as of #532 (PR-1); column dropped in PR-3.
+    expect(verm.regionId).toBeNull();
     expect(verm.silhouetteId).toBe('tyrannidae');
     expect(verm.isNotable).toBe(false);
     const anna = obs.find(o => o.subId === 'S101')!;
-    expect(anna.regionId).toBe('sonoran-tucson');
+    expect(anna.regionId).toBeNull();
     expect(anna.silhouetteId).toBe('trochilidae');
     expect(anna.isNotable).toBe(true);
 

--- a/services/ingestor/src/run-taxonomy.test.ts
+++ b/services/ingestor/src/run-taxonomy.test.ts
@@ -219,7 +219,7 @@ describe('runTaxonomy', () => {
     expect(await getSpeciesMeta(db.pool, 'z99999')).toBeNull();
   });
 
-  it('reconcile-stamps existing observations — post-run they carry silhouette_id and region_id', async () => {
+  it('reconcile-stamps existing observations — post-run they carry silhouette_id (region_id no longer stamped; #532 PR-1)', async () => {
     // Seed an observation BEFORE species_meta is populated. With an empty
     // species_meta, upsertObservations' stamping JOIN finds nothing, so
     // silhouette_id stays NULL (the exact prod bug in #83).
@@ -248,7 +248,8 @@ describe('runTaxonomy', () => {
     const after = await getObservations(db.pool, {});
     // verfly → tyrann1 → silhouette 'tyrannidae' (seeded in migration 9)
     expect(after[0]?.silhouetteId).toBe('tyrannidae');
-    expect(after[0]?.regionId).toBe('sky-islands-santa-ritas');
+    // region_id no longer stamped by reconcile as of #532 (PR-1); column dropped in PR-3.
+    expect(after[0]?.regionId).toBeNull();
     // comName now resolves through species_meta instead of falling back to code
     expect(after[0]?.comName).toBe('Vermilion Flycatcher');
   });

--- a/services/ingestor/src/run-taxonomy.ts
+++ b/services/ingestor/src/run-taxonomy.ts
@@ -66,9 +66,10 @@ export async function runTaxonomy(opts: RunTaxonomyOptions): Promise<RunTaxonomy
       speciesInserted += await upsertSpeciesMeta(opts.pool, chunk);
     }
 
-    // Fill silhouette_id / region_id on rows whose species_meta JOIN previously
-    // found nothing. Idempotent — a no-op on subsequent runs once all rows are
-    // stamped.
+    // Fill silhouette_id on rows whose species_meta JOIN previously found
+    // nothing. Idempotent — a no-op on subsequent runs once all rows are
+    // stamped. (region_id stamping was removed in #532 PR-1; the column
+    // itself is dropped in PR-3.)
     const reconciled = await runReconcileStamping(opts.pool);
 
     await finishIngestRun(opts.pool, runId, {


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ingestor
    participant Postgres

    Note over Ingestor,Postgres: BEFORE (main)
    Ingestor->>Postgres: INSERT observations
    Ingestor->>Postgres: UPDATE region_id (ST_Contains) + silhouette_id
    Ingestor->>Postgres: UPDATE hotspots.region_id (ST_Contains, table-wide)

    Note over Ingestor,Postgres: AFTER (this PR)
    Ingestor->>Postgres: INSERT observations
    Ingestor->>Postgres: UPDATE silhouette_id (region branch removed)
    Note right of Postgres: hotspots stamp UPDATE deleted entirely
```

```mermaid
graph LR
    PR1["PR-1 (this): stop writing region_id"] --> PR2["PR-2: read-API + frontend + shared-types"]
    PR1 --> PR3["PR-3: DROP COLUMN region_id + e2e seed SQL"]
    PR2 --> PR3
    PR3 --> PR4["PR-4: docs + plan refs + CLAUDE.md"]
```

## Summary

- Part of #532 (PR-1 of 4). Stops the ingest path from writing `observations.region_id` and `hotspots.region_id` so PR-3's `DROP COLUMN region_id` can land safely. `region_id` continues to exist in the schema after this PR — new rows simply leave it NULL until the column is dropped.
- Drops the region branch from both the per-batch stamp UPDATE in `upsertObservations` and the once-per-run sweep in `runReconcileStamping`. Silhouette stamping is preserved with its anti-#505 batch scoping intact (residue check tightened from `region_id IS NULL OR silhouette_id IS NULL` to `silhouette_id IS NULL`).
- Deletes the entire table-wide stamp UPDATE in `upsertHotspots` — no silhouette equivalent exists for hotspots, so the function becomes upsert-only. This is the incidental retirement of Recommendation 0C from `docs/analyses/2026-05-14-process-scale-options/phase-4/analysis-report.md`.

## Screenshots

N/A — backend only.

## Test plan

- [x] `npm test --workspace @bird-watch/db-client` — green (92 passed)
- [x] `npm test --workspace @bird-watch/ingestor` — green (139 passed)
- [x] `npm run build` for db-client, ingestor, read-api — clean
- [x] `npm run lint` — green
- [x] New regression test added: `observations.test.ts` selects `region_id` directly from the table after `upsertObservations` and asserts NULL for all newly inserted rows — proves PR-1 actually stopped writing the column (not just that the JS-side projection looks NULL).
- [x] Existing tests updated to assert `regionId === null` instead of asserting a stamped value: `observations.test.ts` (stamp UPDATE + reconcile), `run-ingest.test.ts`, `run-taxonomy.test.ts`, `run-hotspots.test.ts` (description only).

## Plan reference

Part of #532 (epic: remove per-state ecoregion concept from data layer). PR-1 of 4. Audit at `docs/analyses/2026-05-14-region-removal-audit/`. Intentionally deferred to later PRs in this sequence:

- PR-2: read-API SELECT pruning, shared-types, frontend cleanup.
- PR-3: `DROP COLUMN region_id` migration + `.github/workflows/e2e.yml` seed SQL.
- PR-4: docs / spec / CLAUDE.md cleanup; Sky-Atlas Phase-6 plan `GROUP BY region_id` triage.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)