### PR TITLE
docs: remove region concept references from CLAUDE.md, spec, README, plan banners (#532 PR-4 of 4)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ sequenceDiagram
 
     Ingestor->>eBird: GET /data/obs/US-AZ/recent
     Ingestor->>eBird: GET /data/obs/US-AZ/recent/notable
-    Ingestor->>Postgres: INSERT observations (with ST_Contains region stamp)
+    Ingestor->>Postgres: INSERT observations (upsert + silhouette stamp)
 ```
 
 ## Summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,9 @@ Plan 1 must run first because it scaffolds the monorepo. Plans 2–4 can run in 
 
 ## Architecture (when code lands)
 
-Three external dependencies (eBird API, Phylopic, EPA/BCR ecoregion data) feed four internal services: an Ingestor (scheduled), a Read API (HTTP, behind CDN), Postgres + PostGIS, and a static React frontend. The full architecture, data model, API contract, caching strategy, error-handling, and testing strategy are in the spec — read it before making structural changes.
+Two external dependencies (eBird API, Phylopic) feed four internal services: an Ingestor (scheduled), a Read API (HTTP, behind CDN), Postgres + PostGIS, and a static React frontend. The full architecture, data model, API contract, caching strategy, error-handling, and testing strategy are in the spec — read it before making structural changes.
 
-Two design choices that are easy to violate accidentally:
-- **Region assignment happens at ingest, not at request time.** PostGIS `ST_Contains` stamps `region_id` on each observation when it lands. Don't add point-in-polygon math to the read path.
+One design choice that is easy to violate accidentally:
 - **The Read API is platform-agnostic.** It's a `Hono` app exported from `services/read-api/src/app.ts`. Cloud-specific wrappers (Cloud Run entry, AWS Lambda handler, etc.) live in separate files and only adapt the entry point.
 
 ## Conventions baked into the plans
@@ -167,7 +166,7 @@ control dependencies, and this suite has none.
 **Navigation contract.** Every test begins by issuing `page.goto(...)`
 (optionally with query params or a preceding `page.route` stub) — tests never
 rely on state left over from a prior test. Tests that expect a healthy map
-wait for the 9-region render before asserting (`app.waitForMapLoad()` via the
+wait for the map render before asserting (`app.waitForMapLoad()` via the
 Page Object Model); tests that deliberately fail the API skip that wait and
 assert directly on `.error-screen`.
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A web app that renders recent eBird observations across Arizona on a MapLibre GL
 
 ## Architecture
 
-Three external dependencies + four internal services. Monorepo. Everything provisioned by Terraform.
+Two external dependencies + four internal services. Monorepo. Everything provisioned by Terraform.
 
 - **eBird API** → polled every 30 min by the Ingestor
-- **Phylopic** + **EPA / BCR ecoregions** → one-time seed
-- **Ingestor** (GCP Cloud Run Job, Cloud Scheduler-triggered) → upserts to Postgres, stamps `region_id` via PostGIS
+- **Phylopic** → one-time seed of family silhouettes
+- **Ingestor** (GCP Cloud Run Job, Cloud Scheduler-triggered) → upserts to Postgres, stamps `silhouette_id` via family-code lookup
 - **Read API** (GCP Cloud Run Service, scale-to-zero) → serves typed JSON with per-endpoint cache TTLs
 - **Postgres + PostGIS** (Neon, serverless, scale-to-zero) → persistent rolling store, analytics-ready
 - **Frontend** (React + Vite, Cloudflare Pages) → MapLibre GL JS real-geographic map, StackedSilhouetteMarker clustering, FamilyLegend, FiltersBar

--- a/docs/plans/2026-04-16-plan-1-db-foundation.md
+++ b/docs/plans/2026-04-16-plan-1-db-foundation.md
@@ -1,5 +1,7 @@
 # Database Foundation Implementation Plan
 
+> **Update 2026-05-14:** the `regions` table and `region_id` columns on `observations` / `hotspots` were dropped via epic #532 (PRs #534, #535, #536; audit at `docs/analyses/2026-05-14-region-removal-audit/`). Task 5 (`regions` table), Task 11 (Arizona ecoregion seed), and every `region_id` line in Tasks 6, 7, 8, and the reconcile-UPDATE example below describe the original plan as executed and are preserved for historical traceability. The live schema no longer carries these concepts.
+
 > **Status: superseded by current monorepo state** — executed 2026-04-19; schema has evolved through migration 19700 (added `creator` and `common_name` to `family_silhouettes`); `packages/family-mapping` (Task 14) was deleted in PR #192. Do not re-execute verbatim.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/plans/2026-04-16-plan-2-ingestor.md
+++ b/docs/plans/2026-04-16-plan-2-ingestor.md
@@ -1,5 +1,7 @@
 # Ingestor Service Implementation Plan
 
+> **Update 2026-05-14:** the `regions` table and `region_id` stamping path were removed via epic #532 (PRs #534, #535, #536; audit at `docs/analyses/2026-05-14-region-removal-audit/`). Every `regionId` / `region_id` reference below describes the original plan as executed and is preserved for historical traceability. The live ingestor no longer writes `region_id`; only `silhouette_id` is stamped. Note: `regionCode: 'US-AZ'` in test fixtures refers to the eBird API's region path-parameter (an external API surface, not the internal region concept) and is still valid.
+
 > **Status: superseded by current ingestor implementation** — executed 2026-04-19; Epic-251 added `run-taxonomy` and `run-hotspots` ingest layers post-plan (family silhouettes pipeline). Do not re-execute verbatim.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/plans/2026-05-09-sky-atlas-phase-6-metadata-voice.md
+++ b/docs/plans/2026-05-09-sky-atlas-phase-6-metadata-voice.md
@@ -109,17 +109,17 @@ Verify that `REGION_LABEL` ("Arizona") accurately describes actual coverage befo
 
 **Files:** none modified unless G2 reveals inaccuracy (in which case `frontend/src/config/region.ts` is updated).
 
-- [ ] **Step 1: Query coverage by county or ecoregion.**
+- [ ] **Step 1: Query coverage by location.**
 
-The ingestor calls `/data/obs/US-AZ/recent` (confirmed in CLAUDE.md), which covers all of Arizona by design. Verify this is a genuine statewide pull rather than a de facto sub-region pull:
+The ingestor calls `/data/obs/US-AZ/recent` (confirmed in CLAUDE.md), which covers all of Arizona by design. Verify this is a genuine statewide pull rather than a de facto sub-region pull. The schema no longer carries `region_id` (dropped in epic #532 / PR-3 #536), so group by `loc_name` — eBird location names typically embed town/county, which is sufficient to spot-check distribution:
 
 ```bash
-# Count observations per eBird region code in the DB (run from services/read-api or with a local DB connection)
+# Top-20 most-observed locations (run from services/read-api or with a local DB connection)
 # Expected: broad distribution across AZ counties (Maricopa, Pima, Cochise, Yavapai, etc.)
-psql $DATABASE_URL -c "SELECT region_id, COUNT(*) FROM observations GROUP BY region_id ORDER BY COUNT(*) DESC LIMIT 20;"
+psql $DATABASE_URL -c "SELECT loc_name, COUNT(*) FROM observations GROUP BY loc_name ORDER BY COUNT(*) DESC LIMIT 20;"
 ```
 
-If coverage is concentrated (<10% of records outside Maricopa + Pima counties), consult with the maintainer before using "Arizona" as the `REGION_LABEL`. If the distribution is genuinely statewide, `REGION_LABEL = 'Arizona'` stands.
+If coverage is concentrated (<10% of records outside Maricopa + Pima counties — eyeball the city/county tokens in `loc_name`), consult with the maintainer before using "Arizona" as the `REGION_LABEL`. If the distribution is genuinely statewide, `REGION_LABEL = 'Arizona'` stands.
 
 - [ ] **Step 2: Update `docs/design/01-spec/open-questions.md` G2 row.**
 

--- a/docs/specs/2026-04-16-bird-watch-design.md
+++ b/docs/specs/2026-04-16-bird-watch-design.md
@@ -11,7 +11,7 @@ The system is treated as a microservice architecture, not a single app. The user
 
 ## Architecture
 
-Three external dependencies + four internal services.
+Two external dependencies + four internal services.
 
 ### External (consumed, not owned)
 

--- a/docs/specs/2026-04-16-bird-watch-design.md
+++ b/docs/specs/2026-04-16-bird-watch-design.md
@@ -19,13 +19,12 @@ Three external dependencies + four internal services.
 |---|---|---|
 | **eBird API** | Source of all observation and hotspot data for Arizona | Polled every 30 min |
 | **Phylopic** | Bird family silhouettes (CC-licensed) | One-time seed |
-| **EPA / BCR** | Ecoregion polygon GeoJSON for Arizona | One-time seed |
 
 ### Internal (owned, in monorepo)
 
 | Service | Type | Responsibility |
 |---|---|---|
-| **Ingestor** | Serverless function, scheduled trigger | Pulls eBird data every 30 min, plus daily back-fill; upserts into the DB; stamps each observation with its `region_id` (via PostGIS `ST_Contains`) and `silhouette_id` (via family-code lookup) |
+| **Ingestor** | Serverless function, scheduled trigger | Pulls eBird data every 30 min, plus daily back-fill; upserts into the DB; stamps each observation with its `silhouette_id` (via family-code lookup) |
 | **Read API** | Serverless function, HTTP, behind CDN | Serves typed JSON to the frontend; sets per-endpoint cache TTLs |
 | **PostgreSQL + PostGIS** | Managed serverless database | Persistent rolling store of all observations + reference data; analytics-ready |
 | **Frontend** | Static React + Vite, served from CDN | Stylized map UI, badges, inline-expansion drill-in, filter bar |
@@ -57,7 +56,7 @@ The Plan-4 SVG-ecoregion renderer was deleted in PR #166 and replaced with a Map
 |---|---|
 | `handler` | Scheduled-trigger entry point |
 | `ebird-client` | Wraps eBird API calls; handles auth header, retries, response shape |
-| `upsert` | Inserts/updates observations and hotspots; PostGIS handles region assignment in SQL |
+| `upsert` | Inserts/updates observations and hotspots |
 
 ### Read API (`services/read-api/`)
 
@@ -73,7 +72,7 @@ The Plan-4 SVG-ecoregion renderer was deleted in PR #166 and replaced with a Map
 
 | Package | Purpose |
 |---|---|
-| `shared-types` | TypeScript shapes for Observation, Region, Species, Hotspot, FamilySilhouette — used by all internal services |
+| `shared-types` | TypeScript shapes for Observation, Species, Hotspot, FamilySilhouette — used by all internal services |
 | `db-client` | Typed query layer over Postgres; used by Ingestor and Read API |
 
 `familyCode → color` and `familyCode → svgData` are no longer a compile-time lookup table: they live in the `family_silhouettes` DB table (see Data model) and are served to the frontend via `GET /api/silhouettes` (PR #172). The previous `@bird-watch/family-mapping` package was deleted in PR #192.
@@ -86,7 +85,7 @@ The Plan-4 SVG-ecoregion renderer was deleted in PR #166 and replaced with a Map
 2. Ingestor calls `eBird-client.fetchRecent("US-AZ", { back: 14 })` → returns up to 10K obs with lat/lng.
 3. Ingestor calls `eBird-client.fetchNotable("US-AZ", { back: 14 })` → returns the subset flagged as notable (rare for the area). The set of `(sub_id, species_code)` keys here is used to compute `is_notable=true` on the upsert.
 4. For each obs, Ingestor builds an upsert row keyed on `(sub_id, species_code)` to dedup re-fetches; sets `is_notable` based on membership in the notable set.
-5. Single SQL `INSERT ... ON CONFLICT ... DO UPDATE` writes all rows. Same query computes `region_id` via `ST_Contains((SELECT geom FROM regions WHERE ST_Contains(geom, ST_MakePoint(lng, lat))), point)` and `silhouette_id` via JOIN against `family_silhouettes`.
+5. Single SQL `INSERT ... ON CONFLICT ... DO UPDATE` writes all rows. Same query computes `silhouette_id` via JOIN against `family_silhouettes`.
 6. Ingestor logs run metadata to `ingest_runs` table.
 
 Ingestor does **not** trigger a CDN purge in MVP. Cache freshness is bounded by the `/observations` TTL (30 min), which matches the ingest cadence — so data is never more than ~30 min stale either way. Adding tag-based purge is a future enhancement (see Open questions).
@@ -118,29 +117,13 @@ CREATE TABLE observations (
   loc_name        TEXT,
   how_many        INTEGER,
   is_notable      BOOLEAN DEFAULT false,
-  region_id       TEXT REFERENCES regions(id),
   silhouette_id   TEXT REFERENCES family_silhouettes(id),
   ingested_at     TIMESTAMPTZ DEFAULT now(),
   PRIMARY KEY (sub_id, species_code)
 );
-CREATE INDEX obs_region ON observations (region_id);
 CREATE INDEX obs_species ON observations (species_code);
 CREATE INDEX obs_dt ON observations (obs_dt DESC);
 CREATE INDEX obs_geom ON observations USING GIST (geom);
-```
-
-### `regions`
-
-```sql
-CREATE TABLE regions (
-  id          TEXT PRIMARY KEY,             -- e.g. "sky-islands-santa-ritas"
-  name        TEXT NOT NULL,
-  parent_id   TEXT REFERENCES regions(id),  -- null for top-level ecoregions
-  geom        GEOMETRY(MULTIPOLYGON, 4326) NOT NULL,
-  display_color TEXT NOT NULL,              -- hex
-  svg_path    TEXT NOT NULL                 -- stylized poligap-style path
-);
-CREATE INDEX regions_geom ON regions USING GIST (geom);
 ```
 
 ### `hotspots`
@@ -152,12 +135,10 @@ CREATE TABLE hotspots (
   lat                 DOUBLE PRECISION NOT NULL,
   lng                 DOUBLE PRECISION NOT NULL,
   geom                GEOMETRY(POINT, 4326) GENERATED ALWAYS AS (ST_MakePoint(lng, lat)) STORED,
-  region_id           TEXT REFERENCES regions(id),
   num_species_alltime INTEGER,
   latest_obs_dt       TIMESTAMPTZ
 );
 CREATE INDEX hotspots_geom ON hotspots USING GIST (geom);
-CREATE INDEX hotspots_region ON hotspots (region_id);
 ```
 
 ### `species_meta`
@@ -245,7 +226,7 @@ Frontend exposes four filters in the FiltersBar; all map to `/api/observations` 
 | Species search | `?species=:code` (autocomplete UI on common name → submits species code) | unset |
 | Family filter | `?family=:code` (dropdown of AZ families derived from `species_meta`) | unset |
 
-URL state mirrors the filter state in addition to `region` and `species`, so a fully-filtered view is shareable.
+URL state mirrors the filter state in addition to `species`, so a fully-filtered view is shareable.
 
 ## Error handling
 
@@ -268,7 +249,7 @@ URL state mirrors the filter state in addition to `region` and `species`, so a f
 | `Ingestor handler` | Integration: scheduled trigger → mock eBird → real DB → assert upserted rows | Vitest + Testcontainers |
 | `Read API routes` | Integration: HTTP call → real DB → assert response shape + cache headers | Vitest, supertest |
 | `Frontend components` | Unit + interaction tests | Vitest, React Testing Library |
-| `Frontend map flow` | E2E: load → click region → verify expansion + URL update | Playwright |
+| `Frontend map flow` | E2E: load → click cluster → verify expansion + URL update | Playwright |
 
 Tests do not mock the database — they hit a real Postgres (containerized in CI). The ingest path is too geometry-dependent to mock meaningfully.
 
@@ -302,9 +283,8 @@ bird-watch/
     family-mapping/
   migrations/
     1700000001000_enable_postgis.sql
-    1700000002000_regions.sql
     1700000003000_family_silhouettes.sql
-    … (20 files total, timestamp-prefixed)
+    … (45 files total, timestamp-prefixed)
   infra/
     terraform/
       main.tf

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -258,8 +258,9 @@ resource "google_cloud_scheduler_job" "ingest_hotspots" {
 
 # Monthly refresh of species_meta from eBird's taxonomy endpoint. eBird ships a
 # new taxonomy version yearly, so monthly is comfortably ahead of drift. After
-# upsert, the job also reconciles region_id / silhouette_id across observations
-# that lacked a species_meta row at original ingest time (the #83 fix path).
+# upsert, the job also reconciles silhouette_id across observations that lacked
+# a species_meta row at original ingest time (the #83 fix path; region_id
+# reconcile was retired with the regions table in #532 PR-3 #536).
 resource "google_cloud_scheduler_job" "ingest_taxonomy" {
   name      = "bird-ingest-taxonomy"
   region    = var.gcp_region


### PR DESCRIPTION
## Diagrams

N/A — docs-only PR (no runtime risk; no diagram-worthy structural change). For traceability, this PR closes the docs gap left by the three runtime PRs:

```mermaid
graph LR
    PR1["PR-1 #534<br/>stop writing region_id"] --> PR2["PR-2 #535<br/>drop regionId from wire shape"]
    PR2 --> PR3["PR-3 #536<br/>drop column + table"]
    PR3 --> PR4["PR-4 (this PR)<br/>docs cleanup"]
```

## Summary

Part of #532 (PR-4 of 4, completes the epic).

- The region concept was removed from the data layer via PRs #534 / #535 / #536. The repo's writing (`CLAUDE.md`, the live spec, `README.md`, the PR template, two executed plans, and the not-yet-executed Sky-Atlas Phase-6 plan) still described region as a live concept — this PR aligns the writing with reality.
- **Docs-only — no source code changes** (one infra comment in `infra/terraform/ingestor.tf` updated; the resource block is unchanged). No runtime risk.
- Executed plans (`plan-1-db-foundation`, `plan-2-ingestor`) get an **Update 2026-05-14 banner** at the top per repo convention — bodies are preserved verbatim as historical records. The Sky-Atlas Phase-6 plan is **not yet executed**, so the `GROUP BY region_id` example query is rewritten inline to `GROUP BY loc_name`.

## Screenshots

N/A — not UI.

## Test plan

- [x] `grep` for `region_id`, `regionId`, `ecoregion`, `EPA Level`, `BCR`, `regions.geom`, `regions.id` across non-historical files — every remaining hit is intentional (defensive `not.toHaveProperty('regionId')` regression tests in `frontend/src/state/url-state.test.ts`, source-code comments that point at this epic, the Neon `region_id = "aws-us-west-2"` config, GCP `region`, and the audit's own directory).
- [x] CLAUDE.md verified clean of region references after edits.
- [x] Spec verified clean (line 41 keeps the historical "Plan-4 SVG-ecoregion renderer was deleted in PR #166" pointer per audit; line 95 keeps eBird API's `regionCode` path-parameter; both are external-API surface, not the internal region concept).
- [x] No CI-relevant code touched — type check / test / build / e2e gates should be no-ops on this diff.

## Plan reference

Closes the documentation tail of epic #532 (region removal). The audit at `docs/analyses/2026-05-14-region-removal-audit/05-tests-infra.md` enumerated the change sites; the orchestrator concession comment on #532 added the Sky-Atlas Phase-6 plan to the file list (IMPORTANT-2 from the bot's spec review).

Files touched (`git diff --stat`):

```
.github/PULL_REQUEST_TEMPLATE.md                   |  2 +-
CLAUDE.md                                          |  7 ++---
README.md                                          |  6 ++--
docs/plans/2026-04-16-plan-1-db-foundation.md      |  2 ++
docs/plans/2026-04-16-plan-2-ingestor.md           |  2 ++
docs/plans/2026-05-09-sky-atlas-phase-6-metadata-voice.md | 10 +++----
docs/specs/2026-04-16-bird-watch-design.md         | 34 +++++-----------------
infra/terraform/ingestor.tf                        |  5 ++--
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)