### PR TITLE
plan: adaptive cluster grid — retire mosaic + auto-spider

### DIFF
--- a/docs/plans/2026-05-14-adaptive-cluster-grid.md
+++ b/docs/plans/2026-05-14-adaptive-cluster-grid.md
@@ -36,7 +36,7 @@ Before opening a PR for any phase, check off each item or cite a deferral doc wi
 - [ ] `PositiveInt` branded type with `toPositiveInt(n)` constructor that throws on n < 1, n is non-integer
 - [ ] 3-variant `AdaptiveTile` discriminated union: `rendered` | `fallback` | `pending`
 - [ ] All className references in `AdaptiveGridMarker.tsx` have CSS rules in `styles.css` or `ds-primitives.css`
-- [ ] Feature flag `VITE_FF_ADAPTIVE_GRID` declared in `frontend/.env.example` (default off in `.env`)
+- [ ] Feature flag `VITE_FF_ADAPTIVE_GRID` declared in `.env.example` (default off in `.env`)
 - [ ] 20 unit tests pass (`adaptive-grid.test.ts` — pickGridShape rules, boundaries, mobile cap, tile builder edges, memoization concerns)
 - [ ] 12 component tests pass (`AdaptiveGridMarker.test.tsx` — render, badge visibility, aria-label patterns, hit-extender, dark-mode contrast, notable indicator, empty-catalogue)
 - [ ] CI green on PR1 — no swap yet, all legacy code paths intact
@@ -61,7 +61,7 @@ Before opening a PR for any phase, check off each item or cite a deferral doc wi
 
 - [ ] `docs/specs/2026-04-16-bird-watch-design.md §Frontend` updated to reference adaptive-grid design
 - [ ] Epic GitHub issue closed; 3 child issues closed
-- [ ] `frontend/.env.example` flag entry annotated with removal-date comment
+- [ ] `.env.example` flag entry annotated with removal-date comment
 
 ---
 
@@ -96,7 +96,7 @@ Canonical: `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`. Sections ref
 | `frontend/src/components/map/AdaptiveGridMarker.tsx` | 1 | Pure display component |
 | `frontend/src/components/map/AdaptiveGridMarker.test.tsx` | 1 | Component tests |
 | `frontend/src/styles.css` OR `frontend/src/components/ds/ds-primitives.css` | 1 | CSS rules for every className in `AdaptiveGridMarker.tsx` |
-| `frontend/.env.example`, `frontend/.env` | 1 | `VITE_FF_ADAPTIVE_GRID=false` initially |
+| `.env.example`, `frontend/.env` | 1 | `VITE_FF_ADAPTIVE_GRID=false` initially |
 | `frontend/src/components/map/MapCanvas.tsx` | 2 | Wire AdaptiveGridMarker; raise clusterMaxZoom; add 3-layer memo; delete auto-spider block |
 | `frontend/src/components/map/observation-layers.ts` | 2 | Drop CMP=8; bump CLUSTER_MAX_ZOOM; remove inStack plumbing |
 | `frontend/e2e/map-adaptive-grid.spec.ts` | 2 | New e2e suite (replaces map-cluster-mosaic.spec.ts and map-stack-fanout.spec.ts) |
@@ -179,13 +179,43 @@ Title: `phase 3: documentation linkbacks for adaptive cluster grid`. Body: copy 
 
 **Gate rule (from CLAUDE.md):** No Phase 1 task may begin until all four prototype gates pass on a working prototype. Scope: 2–4 hours.
 
-### Task 0.1: Scaffold throwaway prototype directory
+**Branching contract for Phase 0:** Cut `feat/adaptive-cluster-grid` from `main` BEFORE any prototype work. The branch is then used for both (a) the throwaway prototype commits (which get reverted in Task 0.3) AND (b) the persistent learnings note. Reason: `main` has branch protection requiring PR review + 4 CI checks — direct commits will be rejected by the remote. The prototype directory itself is added to `.gitignore` so commits during Phase 0 are limited to the gitignore entry and the learnings note; the directory itself never lands in history.
+
+### Task 0.1: Cut feature branch + gitignore prototype dir
 
 **Files:**
-- Create: `prototype/adaptive-grid/index.html`
-- Create: `prototype/adaptive-grid/main.tsx`
-- Create: `prototype/adaptive-grid/canned-obs.json` (≥ 344 rows)
-- Create: `prototype/adaptive-grid/package.json` (Vite local)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Cut feature branch from main**
+
+```bash
+git switch main && git pull --ff-only
+git switch -c feat/adaptive-cluster-grid
+```
+
+- [ ] **Step 2: Add prototype dir to `.gitignore`**
+
+Append to `.gitignore`:
+
+```
+# Throwaway directory for Phase 0 prototype gating — deleted in Task 0.3.
+prototype/
+```
+
+- [ ] **Step 3: Commit the gitignore entry**
+
+```bash
+git add .gitignore
+git commit -m "chore(plan): gitignore prototype/ dir for adaptive-grid Phase 0"
+```
+
+### Task 0.2: Scaffold throwaway prototype directory (NOT committed)
+
+**Files (created but uncommitted, blocked by `.gitignore`):**
+- `prototype/adaptive-grid/index.html`
+- `prototype/adaptive-grid/main.tsx`
+- `prototype/adaptive-grid/canned-obs.json` (≥ 344 rows)
+- `prototype/adaptive-grid/package.json` (Vite local)
 
 - [ ] **Step 1: Generate canned data**
 
@@ -198,7 +228,7 @@ curl -s 'https://api.bird-maps.com/api/observations' | jq '.data[0:500]' \
 wc -l prototype/adaptive-grid/canned-obs.json
 ```
 
-Expected: file exists with at least 344 observation objects matching the `Observation` shape from `packages/shared-types/src/index.ts:10-37`.
+Expected: file exists with at least 344 observation objects matching the `Observation` shape from `packages/shared-types/src/index.ts:10-37`. Confirm `git status` does NOT list these files (gitignore working).
 
 - [ ] **Step 2: Build a minimal Vite app that mounts MapCanvas-equivalent**
 
@@ -212,17 +242,10 @@ cd prototype/adaptive-grid && npm install && npm run dev
 
 Expected: dev server at http://localhost:5173 renders the map with grid markers.
 
-- [ ] **Step 4: Commit prototype scaffolding**
-
-```bash
-git add prototype/adaptive-grid/
-git commit -m "plan(adaptive-grid): scaffold prototype validation"
-```
-
-### Task 0.2: Run the 4 prototype gates
+### Task 0.3: Run the 4 prototype gates
 
 **Files:**
-- Modify: `prototype/adaptive-grid/main.tsx` (add `performance.mark` instrumentation)
+- Modify: `prototype/adaptive-grid/main.tsx` (add `performance.mark` instrumentation, uncommitted)
 
 - [ ] **Step 1: Add reconcile-time instrumentation**
 
@@ -242,12 +265,12 @@ For each viewport (390×844, 768×1024, 1024×768, 1440×900, 1920×1080) AND ea
 1. `mcp__plugin_playwright_playwright__browser_navigate` to http://localhost:5173
 2. `mcp__plugin_playwright_playwright__browser_resize` to the viewport
 3. Pinch-zoom z=8 → z=15 via `browser_evaluate` driving `map.setZoom()`
-4. Read `performance.getEntriesByName('mosaic-reconcile').map(e => e.duration)` — compute p99
-5. Count visible markers: `document.querySelectorAll('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').length`
-6. Sample 5 markers' `getBoundingClientRect()` — assert `width ≥ 44 && height ≥ 44` (or 48 on coarse-pointer emulation)
-7. `mcp__plugin_playwright_playwright__browser_console_messages` — assert empty array
+4. Read `performance.getEntriesByName('mosaic-reconcile').map(e => e.duration)` — compute p99 (Gate 1 pass: < 16ms at 390×844)
+5. Count visible markers: `document.querySelectorAll('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').length` (Gate 2 pass: ≤ 2,500 at every viewport)
+6. Sample 5 markers' `getBoundingClientRect()` — assert `width ≥ 44 && height ≥ 44` (or 48 on coarse-pointer emulation) (Gate 3 pass)
+7. `mcp__plugin_playwright_playwright__browser_console_messages` — assert returned array is empty (Gate 4 pass: 0 errors AND 0 warnings)
 
-Record results in a table.
+Record results in a 10-row × 4-column table (viewport×theme × 4 gates).
 
 - [ ] **Step 3: Write the 5-line learnings note**
 
@@ -260,29 +283,35 @@ git add docs/plans/2026-05-14-adaptive-cluster-grid/prototype-learnings.md
 git commit -m "plan(adaptive-grid): prototype learnings — 4/4 gates PASS"
 ```
 
-- [ ] **Step 5: GATE — all four pass?**
+- [ ] **Step 5: GATE — all four pass at every viewport × theme?**
 
-If ANY gate fails, stop. Open a discussion issue, revisit spec §10, do not proceed to Phase 1. The prototype is the cheap escape hatch.
+If ANY gate fails on ANY of the 10 captures, stop. Open a discussion issue, revisit spec §10, do not proceed to Phase 1. The prototype is the cheap escape hatch.
 
-### Task 0.3: Tear down prototype + scaffold the real feature branch
+### Task 0.4: Tear down prototype directory + open Phase 0 PR
 
-- [ ] **Step 1: Remove prototype directory** (we keep the learnings note in `docs/plans/`):
-
-```bash
-git rm -r prototype/adaptive-grid
-git commit -m "plan(adaptive-grid): tear down prototype (gates passed)"
-```
-
-- [ ] **Step 2: Cut feature branch from main**
+- [ ] **Step 1: Delete the prototype dir from the working tree**
 
 ```bash
-git switch main && git pull
-git switch -c feat/adaptive-cluster-grid
+rm -rf prototype/adaptive-grid
 ```
 
-- [ ] **Step 3: Update Epic issue**
+(Gitignore already prevented commits; no `git rm` needed.)
 
-Check off the Phase 0 box on the Epic; reference the learnings note commit SHA.
+- [ ] **Step 2: Push the branch + open PR**
+
+```bash
+git push -u origin feat/adaptive-cluster-grid
+```
+
+Open a Phase 0 PR via `creating-prs` skill. The PR contains exactly two commits: the gitignore entry (Task 0.1) and the learnings note (Task 0.3). Screenshots `N/A — Phase 0 prototype (gated, not user-facing UI)` referencing the 10-capture results table inline.
+
+- [ ] **Step 3: Bot review + queue**
+
+`julianken-bot` reviews; `@Mergifyio queue` after approval.
+
+- [ ] **Step 4: After Phase 0 PR merges, update Epic**
+
+Check off the Phase 0 box on the Epic; reference the learnings note commit SHA. Phase 1 can now begin.
 
 ---
 
@@ -297,24 +326,26 @@ Check off the Phase 0 box on the Epic; reference the learnings note commit SHA.
 ### Task 1.1: Declare feature flag in env files
 
 **Files:**
-- Modify: `frontend/.env.example`
-- Modify: `frontend/.env` (gitignored locally — also `.env.development` if it exists)
+- Modify: `.env.example` (repo root — this is the project's unified env-example file; `.env.example` does NOT exist and must not be created)
+- Modify: local `.env` (gitignored — parity only, not committed)
 
-- [ ] **Step 1: Add flag line to `.env.example`**
+- [ ] **Step 1: Add flag line to root `.env.example`**
 
-Append at the end of `frontend/.env.example`:
+Append at the end of `/Users/j/repos/bird-watch/.env.example`:
 
 ```
-# Adaptive cluster grid (epic #N) — flip to true for the new marker; default false until Phase 2 swap
+# Adaptive cluster grid (epic #539) — flip to true for the new marker; default false until Phase 2 swap
 VITE_FF_ADAPTIVE_GRID=false
 ```
+
+Vite picks up `VITE_` prefixed vars from the project root `.env` files when the dev server is launched via `npm run dev --workspace @bird-watch/frontend` (the workspace command resolves env relative to the repo root, not the workspace dir).
 
 - [ ] **Step 2: Add to local `.env`** (do NOT commit if `.env` is gitignored; just keep parity)
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add frontend/.env.example
+git add .env.example
 git commit -m "feat(map): add VITE_FF_ADAPTIVE_GRID feature flag (off by default)"
 ```
 
@@ -1058,7 +1089,7 @@ git rm frontend/e2e/map-cluster-mosaic.spec.ts
 
 - [ ] **Step 4: Flip feature flag default to `true`**
 
-In `frontend/.env.example`:
+In `.env.example`:
 
 ```
 VITE_FF_ADAPTIVE_GRID=true  # default-on; flag itself will be removed in a follow-up
@@ -1235,7 +1266,7 @@ git commit -m "docs(spec): cross-reference adaptive-grid design from architectur
 
 ### Task 3.2: Annotate feature flag with removal date
 
-**Files:** modify `frontend/.env.example`.
+**Files:** modify `.env.example`.
 
 - [ ] **Step 1: Add removal-date comment**
 
@@ -1248,7 +1279,7 @@ VITE_FF_ADAPTIVE_GRID=true
 - [ ] **Step 2: Commit + close child issues + close epic**
 
 ```bash
-git add frontend/.env.example
+git add .env.example
 git commit -m "docs(map): annotate adaptive-grid flag with removal date"
 ```
 

--- a/docs/plans/2026-05-14-adaptive-cluster-grid.md
+++ b/docs/plans/2026-05-14-adaptive-cluster-grid.md
@@ -1,0 +1,1291 @@
+# AdaptiveGridMarker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace today's `<MosaicMarker>` + `<ClusterPill>` + auto-spider with one component `<AdaptiveGridMarker>` whose shape scales 1×1 → 4×4 by unique-family count, with per-cell observation-count badges. Raise `clusterMaxZoom` 14 → 22 so the same component renders at every zoom and coincident-point disambiguation comes from the grid never decomposing.
+
+**Architecture:** Three phases mapped to three PRs against `main` from feature branch `feat/adaptive-cluster-grid`. Phase 0 (prototype) is a throwaway validation pass that must clear four gates before Phase 1 begins. Phase 1 lands new files behind a feature flag (`VITE_FF_ADAPTIVE_GRID`, default off). Phase 2 atomically flips the flag, wires `MapCanvas`, and deletes the auto-spider + legacy mosaic subsystems in one PR (splitting it leaves a knip-broken intermediate state — see spec §11). Phase 3 updates documentation linkbacks.
+
+**Tech Stack:** React 18, TypeScript, Vite 8, MapLibre GL 5 (via `react-map-gl`), Vitest 4, `@playwright/test`. No new npm dependencies.
+
+**Spec:** `docs/specs/2026-05-14-adaptive-cluster-grid-design.md` — read end-to-end before starting. Section references throughout this plan (§4.1, §5.1, etc.) point at the spec.
+
+---
+
+## Quantified plan literals (implementer checklist)
+
+Before opening a PR for any phase, check off each item or cite a deferral doc with a lexically-matching subject (per R13 T7, issue #461):
+
+### Phase 0 — prototype gates
+
+- [ ] Prototype renders ≥ 344 canned observation rows from JSON matching production API shape
+- [ ] Prototype tested at 5 canonical viewports: 390×844, 768×1024, 1024×768, 1440×900, 1920×1080
+- [ ] Prototype tested at 2 themes (light + dark via `data-theme` attribute toggle)
+- [ ] Gate 1: p99 `mosaic-reconcile` < 16ms at 390×844 during scripted z=8 → z=15 pinch-zoom
+- [ ] Gate 2: ≤ 2,500 visible markers at every canonical viewport during overview load
+- [ ] Gate 3: every visible marker's hit overlay measures ≥ 44×44 (desktop) / ≥ 48×48 (coarse pointer)
+- [ ] Gate 4: zero console errors AND zero console warnings during every interaction at every viewport
+- [ ] 5-line learnings note written to `docs/plans/2026-05-14-adaptive-cluster-grid/prototype-learnings.md`
+
+### Phase 1 — scaffolding behind feature flag
+
+- [ ] 1 new component file: `frontend/src/components/map/AdaptiveGridMarker.tsx`
+- [ ] 1 new logic module: `frontend/src/components/map/adaptive-grid.ts`
+- [ ] 5 marker shapes supported: 1×1, 2×1, 2×2, 3×3, 4×4 (per spec §4.1 rules table)
+- [ ] 1 mobile shape variant: `grid-overflow` with `hiddenCount: PositiveInt`
+- [ ] `PositiveInt` branded type with `toPositiveInt(n)` constructor that throws on n < 1, n is non-integer
+- [ ] 3-variant `AdaptiveTile` discriminated union: `rendered` | `fallback` | `pending`
+- [ ] All className references in `AdaptiveGridMarker.tsx` have CSS rules in `styles.css` or `ds-primitives.css`
+- [ ] Feature flag `VITE_FF_ADAPTIVE_GRID` declared in `frontend/.env.example` (default off in `.env`)
+- [ ] 20 unit tests pass (`adaptive-grid.test.ts` — pickGridShape rules, boundaries, mobile cap, tile builder edges, memoization concerns)
+- [ ] 12 component tests pass (`AdaptiveGridMarker.test.tsx` — render, badge visibility, aria-label patterns, hit-extender, dark-mode contrast, notable indicator, empty-catalogue)
+- [ ] CI green on PR1 — no swap yet, all legacy code paths intact
+
+### Phase 2 — atomic cutover
+
+- [ ] 14 files deleted: `MosaicMarker.tsx`, `MosaicMarker.test.tsx`, `cluster-mosaic.ts`, `cluster-mosaic.test.ts`, `StackedSilhouetteMarker.tsx`, `StackedSilhouetteMarker.test.tsx`, `use-auto-spider.ts`, `use-auto-spider.test.ts`, `stack-fanout.ts`, `stack-fanout.test.ts`, `fan-layout.ts`, `fan-layout.test.ts`, `map-stack-fanout.spec.ts`, `map-cluster-mosaic.spec.ts`
+- [ ] 3 files modified: `MapCanvas.tsx`, `observation-layers.ts`, `axe.spec.ts`
+- [ ] `clusterMaxZoom` raised from 14 → 22 in `observation-layers.ts:152`
+- [ ] `CLUSTER_MOSAIC_MAX_POINTS` constant removed from `observation-layers.ts:163`
+- [ ] `inStack` property removed from GeoJSON feature shape (`observation-layers.ts:42-61`)
+- [ ] All 4 filter clauses on `inStack` removed (`observation-layers.ts:121-126, 278, 336`)
+- [ ] Feature flag default flipped to `on` in this PR; flag itself can be removed in a follow-up
+- [ ] Memoization layers from spec §5.3 implemented in `MapCanvas.tsx`: `useMemo` (Concern A), module-scoped async cache (Concern B), `cacheGeneration` + monotonic `silhouettesVersion` (Concern C)
+- [ ] New e2e: `map-adaptive-grid.spec.ts` — 8 scenarios per spec §7
+- [ ] `axe.spec.ts:55` aria-label assertion extended to grid + describedby
+- [ ] Design-review subagent dispatched at 5 viewports × 2 themes = 10 screenshots, all PASS
+- [ ] `julianken-bot` review pass before queueing
+- [ ] CI green on PR2: `test`, `lint`, `build`, `e2e`, `knip`, `orphan-classname-check` all pass
+
+### Phase 3 — documentation
+
+- [ ] `docs/specs/2026-04-16-bird-watch-design.md §Frontend` updated to reference adaptive-grid design
+- [ ] Epic GitHub issue closed; 3 child issues closed
+- [ ] `frontend/.env.example` flag entry annotated with removal-date comment
+
+---
+
+## Spec reference
+
+Canonical: `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`. Sections referenced in this plan:
+
+- §3 Decision (Approach A — Grid Everywhere)
+- §4.1 Adaptive grid shape (types + sizing rules)
+- §4.3 Per-cell badge (visual + contrast contract)
+- §4.4 Hit-extender overlay
+- §4.5 Tap behavior — parent routes the click
+- §4.6 Two-tier ARIA disclosure
+- §5.1 `AdaptiveGridMarker.tsx` component API
+- §5.2 `adaptive-grid.ts` module API
+- §5.3 Memoization (Concerns A, B, C)
+- §6 File map
+- §7 Test strategy
+- §10 Prototype-phase gates
+- §11 Sequencing
+
+---
+
+## File structure
+
+| File | Phase | Role |
+|---|---|---|
+| `prototype/adaptive-grid/index.html`, `main.tsx`, `canned-obs.json` | 0 | Throwaway prototype; deleted after gates pass |
+| `docs/plans/2026-05-14-adaptive-cluster-grid/prototype-learnings.md` | 0 | 5-line note; committed to repo |
+| `frontend/src/components/map/adaptive-grid.ts` | 1 | `pickGridShape`, `buildAdaptiveTiles`, `aggregateClusterFamilies` (moved), `toPositiveInt`, types |
+| `frontend/src/components/map/adaptive-grid.test.ts` | 1 | Unit tests for the module |
+| `frontend/src/components/map/AdaptiveGridMarker.tsx` | 1 | Pure display component |
+| `frontend/src/components/map/AdaptiveGridMarker.test.tsx` | 1 | Component tests |
+| `frontend/src/styles.css` OR `frontend/src/components/ds/ds-primitives.css` | 1 | CSS rules for every className in `AdaptiveGridMarker.tsx` |
+| `frontend/.env.example`, `frontend/.env` | 1 | `VITE_FF_ADAPTIVE_GRID=false` initially |
+| `frontend/src/components/map/MapCanvas.tsx` | 2 | Wire AdaptiveGridMarker; raise clusterMaxZoom; add 3-layer memo; delete auto-spider block |
+| `frontend/src/components/map/observation-layers.ts` | 2 | Drop CMP=8; bump CLUSTER_MAX_ZOOM; remove inStack plumbing |
+| `frontend/e2e/map-adaptive-grid.spec.ts` | 2 | New e2e suite (replaces map-cluster-mosaic.spec.ts and map-stack-fanout.spec.ts) |
+| `frontend/e2e/axe.spec.ts` | 2 | Extend aria-label assertion |
+| `.github/workflows/perf-gate.yml` | 2 | Dedicated workflow for the `CI_PERF_GATE`-gated wall-clock assertion (per spec §7 E2E) |
+| `docs/specs/2026-04-16-bird-watch-design.md` | 3 | §Frontend cross-reference to adaptive-grid spec |
+
+Files **deleted in Phase 2** (14 total) are enumerated in the Phase 2 manifest above.
+
+---
+
+## Branch + workflow
+
+**Branch:** `feat/adaptive-cluster-grid`, cut from current `main` immediately before Phase 0 begins. All PRs land back to `main`. No long-lived sub-branches per phase — each phase commits to the feature branch, and the PR is opened against `main` with `git push origin feat/adaptive-cluster-grid` from a phase-specific tip.
+
+**Each PR:**
+
+1. Cherry-pick or commit the phase's work onto a phase-specific branch off `main` (e.g., `feat/adaptive-cluster-grid-phase-1`), OR open three PRs from the same branch sequentially after each phase's commit set.
+2. PR body uses `.github/PULL_REQUEST_TEMPLATE.md` verbatim (5 sections). Screenshots REQUIRED on `frontend/**` changes via `pr-screenshots-via-user-attachments` skill (paste-flow, never commit PNGs).
+3. Bot review via `julianken-bot` subagent (per `reviewing-as-julianken-bot` skill) — never `gh pr review` from the main session.
+4. After bot approval, post `@Mergifyio queue` literal-string comment. Never `gh pr merge`.
+5. CI gate before queue: `test`, `lint`, `build`, `e2e`, `knip` informational. Plus `orphan-classname-check` from Phase 1 onward.
+
+**Recommended sub-skill for execution:** `superpowers:subagent-driven-development`. Each phase becomes one or more subagent dispatches. The implementer reviews between tasks.
+
+---
+
+## Epic + issue structure
+
+Open these via `gh issue create --repo julianken/bird-sight-system` immediately after the plan is approved.
+
+### Epic — AdaptiveGridMarker redesign
+
+Title: `epic: adaptive cluster grid — retire mosaic + auto-spider, one marker for all zooms`
+
+Labels: `epic`, `frontend`, `tracker`
+
+Body skeleton:
+
+```markdown
+Track the implementation of the AdaptiveGridMarker redesign per spec
+`docs/specs/2026-05-14-adaptive-cluster-grid-design.md` and plan
+`docs/plans/2026-05-14-adaptive-cluster-grid.md`.
+
+Child issues (in order):
+
+- [ ] #N+1 — Phase 0 · Prototype validation (4 gates)
+- [ ] #N+2 — Phase 1 · Scaffold AdaptiveGridMarker behind feature flag
+- [ ] #N+3 — Phase 2 · Atomic cutover (swap + delete legacy)
+- [ ] #N+4 — Phase 3 · Documentation linkbacks
+
+Gates and conventions:
+- Prototype gates documented in spec §10 — Phase 1 cannot start until all 4 pass
+- 5-viewport × 2-theme design review required at end of Phase 2
+- Phase 2 must be a single PR (knip mid-state otherwise — see spec §11)
+
+Closes when all child issues are closed AND the design-review subagent
+PASSes at every canonical viewport.
+```
+
+### Phase 0 issue
+
+Title: `phase 0: prototype the adaptive cluster grid and clear 4 gates`. Body: copy Phase 0 task list from this plan.
+
+### Phase 1 issue
+
+Title: `phase 1: scaffold AdaptiveGridMarker + adaptive-grid.ts behind feature flag`. Body: copy Phase 1 task list.
+
+### Phase 2 issue
+
+Title: `phase 2: atomic cutover — wire AdaptiveGridMarker, delete auto-spider + legacy mosaic`. Body: copy Phase 2 task list.
+
+### Phase 3 issue
+
+Title: `phase 3: documentation linkbacks for adaptive cluster grid`. Body: copy Phase 3 task list.
+
+---
+
+# Phase 0 · Prototype validation
+
+**Gate rule (from CLAUDE.md):** No Phase 1 task may begin until all four prototype gates pass on a working prototype. Scope: 2–4 hours.
+
+### Task 0.1: Scaffold throwaway prototype directory
+
+**Files:**
+- Create: `prototype/adaptive-grid/index.html`
+- Create: `prototype/adaptive-grid/main.tsx`
+- Create: `prototype/adaptive-grid/canned-obs.json` (≥ 344 rows)
+- Create: `prototype/adaptive-grid/package.json` (Vite local)
+
+- [ ] **Step 1: Generate canned data**
+
+Fetch ≥ 344 representative observations from the live API for the AZ dataset:
+
+```bash
+mkdir -p prototype/adaptive-grid
+curl -s 'https://api.bird-maps.com/api/observations' | jq '.data[0:500]' \
+  > prototype/adaptive-grid/canned-obs.json
+wc -l prototype/adaptive-grid/canned-obs.json
+```
+
+Expected: file exists with at least 344 observation objects matching the `Observation` shape from `packages/shared-types/src/index.ts:10-37`.
+
+- [ ] **Step 2: Build a minimal Vite app that mounts MapCanvas-equivalent**
+
+Copy the relevant subset of `frontend/src/components/map/` into `prototype/adaptive-grid/src/` and stub the API call with a static import of `canned-obs.json`. Implement a quick-and-dirty `AdaptiveGridMarker` (no need for tests yet — this is throwaway code).
+
+- [ ] **Step 3: Run prototype locally**
+
+```bash
+cd prototype/adaptive-grid && npm install && npm run dev
+```
+
+Expected: dev server at http://localhost:5173 renders the map with grid markers.
+
+- [ ] **Step 4: Commit prototype scaffolding**
+
+```bash
+git add prototype/adaptive-grid/
+git commit -m "plan(adaptive-grid): scaffold prototype validation"
+```
+
+### Task 0.2: Run the 4 prototype gates
+
+**Files:**
+- Modify: `prototype/adaptive-grid/main.tsx` (add `performance.mark` instrumentation)
+
+- [ ] **Step 1: Add reconcile-time instrumentation**
+
+Wrap the equivalent of `MapCanvas.tsx:716`'s `setMosaics` call:
+
+```ts
+performance.mark('mosaic-reconcile-start');
+// ... reconciler runs ...
+performance.mark('mosaic-reconcile-end');
+performance.measure('mosaic-reconcile', 'mosaic-reconcile-start', 'mosaic-reconcile-end');
+```
+
+- [ ] **Step 2: Drive Playwright MCP through the 4 gates at 5 viewports × 2 themes**
+
+For each viewport (390×844, 768×1024, 1024×768, 1440×900, 1920×1080) AND each theme (light, dark via `document.documentElement.setAttribute('data-theme', 'dark')`):
+
+1. `mcp__plugin_playwright_playwright__browser_navigate` to http://localhost:5173
+2. `mcp__plugin_playwright_playwright__browser_resize` to the viewport
+3. Pinch-zoom z=8 → z=15 via `browser_evaluate` driving `map.setZoom()`
+4. Read `performance.getEntriesByName('mosaic-reconcile').map(e => e.duration)` — compute p99
+5. Count visible markers: `document.querySelectorAll('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').length`
+6. Sample 5 markers' `getBoundingClientRect()` — assert `width ≥ 44 && height ≥ 44` (or 48 on coarse-pointer emulation)
+7. `mcp__plugin_playwright_playwright__browser_console_messages` — assert empty array
+
+Record results in a table.
+
+- [ ] **Step 3: Write the 5-line learnings note**
+
+Create `docs/plans/2026-05-14-adaptive-cluster-grid/prototype-learnings.md` with exactly 5 lines summarizing what worked, what surprised you, what changed about the proposed design (if anything), and the measured numbers per gate.
+
+- [ ] **Step 4: Commit the learnings note**
+
+```bash
+git add docs/plans/2026-05-14-adaptive-cluster-grid/prototype-learnings.md
+git commit -m "plan(adaptive-grid): prototype learnings — 4/4 gates PASS"
+```
+
+- [ ] **Step 5: GATE — all four pass?**
+
+If ANY gate fails, stop. Open a discussion issue, revisit spec §10, do not proceed to Phase 1. The prototype is the cheap escape hatch.
+
+### Task 0.3: Tear down prototype + scaffold the real feature branch
+
+- [ ] **Step 1: Remove prototype directory** (we keep the learnings note in `docs/plans/`):
+
+```bash
+git rm -r prototype/adaptive-grid
+git commit -m "plan(adaptive-grid): tear down prototype (gates passed)"
+```
+
+- [ ] **Step 2: Cut feature branch from main**
+
+```bash
+git switch main && git pull
+git switch -c feat/adaptive-cluster-grid
+```
+
+- [ ] **Step 3: Update Epic issue**
+
+Check off the Phase 0 box on the Epic; reference the learnings note commit SHA.
+
+---
+
+# Phase 1 · Scaffold AdaptiveGridMarker behind feature flag
+
+**Branch:** `feat/adaptive-cluster-grid` (continuing).
+**PR target:** `main`.
+**PR title:** `feat(map): scaffold AdaptiveGridMarker behind VITE_FF_ADAPTIVE_GRID (issue N+2)`.
+
+**Strategy:** Write the new files; do NOT modify `MapCanvas.tsx` yet. The new component is dead code at the end of this phase — reachable only when the env flag is set. CI green throughout because no swap happens.
+
+### Task 1.1: Declare feature flag in env files
+
+**Files:**
+- Modify: `frontend/.env.example`
+- Modify: `frontend/.env` (gitignored locally — also `.env.development` if it exists)
+
+- [ ] **Step 1: Add flag line to `.env.example`**
+
+Append at the end of `frontend/.env.example`:
+
+```
+# Adaptive cluster grid (epic #N) — flip to true for the new marker; default false until Phase 2 swap
+VITE_FF_ADAPTIVE_GRID=false
+```
+
+- [ ] **Step 2: Add to local `.env`** (do NOT commit if `.env` is gitignored; just keep parity)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/.env.example
+git commit -m "feat(map): add VITE_FF_ADAPTIVE_GRID feature flag (off by default)"
+```
+
+### Task 1.2: Implement `toPositiveInt` branded type
+
+**Files:**
+- Create: `frontend/src/components/map/adaptive-grid.ts`
+- Create: `frontend/src/components/map/adaptive-grid.test.ts`
+
+- [ ] **Step 1: Write failing tests for `toPositiveInt`**
+
+```ts
+// adaptive-grid.test.ts
+import { describe, expect, it } from 'vitest';
+import { toPositiveInt } from './adaptive-grid';
+
+describe('toPositiveInt', () => {
+  it('returns the value for a positive integer', () => {
+    expect(toPositiveInt(1)).toBe(1);
+    expect(toPositiveInt(42)).toBe(42);
+  });
+
+  it('throws on zero', () => {
+    expect(() => toPositiveInt(0)).toThrow(/must be a positive integer/i);
+  });
+
+  it('throws on negative', () => {
+    expect(() => toPositiveInt(-1)).toThrow(/must be a positive integer/i);
+  });
+
+  it('throws on non-integer', () => {
+    expect(() => toPositiveInt(1.5)).toThrow(/must be a positive integer/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+```bash
+npm run -w @bird-watch/frontend test -- adaptive-grid.test.ts
+```
+
+Expected: 4 FAIL (`toPositiveInt` not found).
+
+- [ ] **Step 3: Implement minimal `toPositiveInt`**
+
+Create `adaptive-grid.ts` with just:
+
+```ts
+export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
+
+export function toPositiveInt(n: number): PositiveInt {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new TypeError(`Expected a positive integer, got ${n}. Value must be a positive integer.`);
+  }
+  return n as PositiveInt;
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/map/adaptive-grid.ts frontend/src/components/map/adaptive-grid.test.ts
+git commit -m "feat(map): add toPositiveInt branded-type constructor"
+```
+
+### Task 1.3: Implement `pickGridShape` with all shape rules
+
+**Files:** modify `adaptive-grid.ts` and `adaptive-grid.test.ts`.
+
+- [ ] **Step 1: Write failing tests covering every rule from the spec §7 manifest**
+
+```ts
+import { pickGridShape } from './adaptive-grid';
+
+describe('pickGridShape', () => {
+  // Desktop, no overflow
+  it('1 family → 1×1', () => {
+    expect(pickGridShape(1, 1, false)).toEqual({ tag: 'grid', cols: 1, rows: 1 });
+  });
+  it('2 families → 2×1', () => {
+    expect(pickGridShape(2, 2, false)).toEqual({ tag: 'grid', cols: 2, rows: 1 });
+  });
+  it('3 families → 2×2', () => {
+    expect(pickGridShape(3, 3, false)).toEqual({ tag: 'grid', cols: 2, rows: 2 });
+  });
+  it('4 families → 2×2', () => {
+    expect(pickGridShape(4, 4, false)).toEqual({ tag: 'grid', cols: 2, rows: 2 });
+  });
+  it('5 families → 3×3', () => {
+    expect(pickGridShape(5, 5, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+  it('9 families → 3×3', () => {
+    expect(pickGridShape(9, 9, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+  it('10 families → 4×4', () => {
+    expect(pickGridShape(10, 10, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+  it('16 families → 4×4', () => {
+    expect(pickGridShape(16, 16, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+
+  // Pill caps — family-cap alone
+  it('family cap fires alone (17 families, 30 obs)', () => {
+    expect(pickGridShape(17, 30, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Pill caps — count-cap alone
+  it('count cap fires alone (8 families, 65 obs)', () => {
+    expect(pickGridShape(8, 65, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Boundary: count=64 inclusive
+  it('count = 64 inclusive does NOT trigger pill', () => {
+    expect(pickGridShape(8, 64, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+
+  // Boundary: count=65 with families=16 (locks > vs >= mutation)
+  it('count = 65 with families = 16 → pill', () => {
+    expect(pickGridShape(16, 65, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Boundary: max grid
+  it('families = 16, count = 64 → 4×4 (max grid, no pill)', () => {
+    expect(pickGridShape(16, 64, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+
+  // Mobile cap
+  it('mobile cap: 12 families → grid-overflow 3×3 with hiddenCount 4', () => {
+    expect(pickGridShape(12, 12, true)).toEqual({
+      tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: 4,
+    });
+  });
+
+  // Mobile boundary: 8 families (no overflow)
+  it('mobile: 8 families fits 3×3 exactly, no overflow', () => {
+    expect(pickGridShape(8, 8, true)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+
+  // Mobile boundary: 9 families (first overflow)
+  it('mobile: 9 families → grid-overflow with hiddenCount 1', () => {
+    expect(pickGridShape(9, 9, true)).toEqual({
+      tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: 1,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Expected: 16 FAIL.
+
+- [ ] **Step 3: Implement `pickGridShape`**
+
+Add to `adaptive-grid.ts`:
+
+```ts
+export type Dim = 1 | 2 | 3 | 4;
+
+export type GridShape =
+  | { tag: 'grid'; cols: Dim; rows: Dim }
+  | { tag: 'grid-overflow'; cols: Dim; rows: Dim; hiddenCount: PositiveInt }
+  | { tag: 'pill' };
+
+export type ResolvedGrid = Exclude<GridShape, { tag: 'pill' }>;
+
+export function visibleCapacity(shape: ResolvedGrid): number {
+  return shape.tag === 'grid'
+    ? shape.cols * shape.rows
+    : shape.cols * shape.rows - 1;
+}
+
+const MAX_FAMILIES = 16;
+const MAX_OBSERVATIONS = 64;
+const MOBILE_GRID_OVERFLOW_VISIBLE = 8;
+
+export function pickGridShape(
+  uniqueFamilies: number,
+  pointCount: number,
+  isMobile: boolean,
+): GridShape {
+  if (uniqueFamilies > MAX_FAMILIES || pointCount > MAX_OBSERVATIONS) {
+    return { tag: 'pill' };
+  }
+  if (isMobile && uniqueFamilies > MOBILE_GRID_OVERFLOW_VISIBLE) {
+    return {
+      tag: 'grid-overflow',
+      cols: 3,
+      rows: 3,
+      hiddenCount: toPositiveInt(uniqueFamilies - MOBILE_GRID_OVERFLOW_VISIBLE),
+    };
+  }
+  if (uniqueFamilies === 1) return { tag: 'grid', cols: 1, rows: 1 };
+  if (uniqueFamilies === 2) return { tag: 'grid', cols: 2, rows: 1 };
+  if (uniqueFamilies <= 4) return { tag: 'grid', cols: 2, rows: 2 };
+  if (uniqueFamilies <= 9) return { tag: 'grid', cols: 3, rows: 3 };
+  return { tag: 'grid', cols: 4, rows: 4 };
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Expected: all 16 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/map/adaptive-grid.ts frontend/src/components/map/adaptive-grid.test.ts
+git commit -m "feat(map): add pickGridShape with all spec §4.1 rules"
+```
+
+### Task 1.4: Move `aggregateClusterFamilies` + implement `buildAdaptiveTiles`
+
+**Files:** modify `adaptive-grid.ts` and `adaptive-grid.test.ts`.
+
+- [ ] **Step 1: Write failing tests for `buildAdaptiveTiles`**
+
+Cover the 4 spec §7 tile-builder rules (200 leaves descending, null-familyCode dropout, under-capacity, null-svgData → fallback) plus the upstream silhouette resolution test.
+
+(See spec §7 for exact assertions. The test code follows the same `it()` pattern as Task 1.3.)
+
+- [ ] **Step 2: Run, confirm fail**
+
+- [ ] **Step 3: Move `aggregateClusterFamilies` from `cluster-mosaic.ts` verbatim**
+
+Copy lines 80-95 of `cluster-mosaic.ts` into `adaptive-grid.ts`. Do NOT delete from the source file in this phase — Phase 2 deletes the legacy file atomically.
+
+- [ ] **Step 4: Implement `buildAdaptiveTiles(leaves, silhouettesById, shape)`**
+
+```ts
+import type { ObservationFeature } from './observation-layers';  // adjust import path
+
+export type AdaptiveTile =
+  | { kind: 'rendered'; familyCode: string; svgData: string; color: string; count: number }
+  | { kind: 'fallback'; familyCode: string; color: string; count: number }
+  | { kind: 'pending'; familyCode: string; count: number };
+
+export type SilhouettesById = ReadonlyMap<string, { svgData: string | null; color: string }>;
+
+export function buildAdaptiveTiles(
+  leaves: ObservationFeature[],
+  silhouettesById: SilhouettesById,
+  shape: ResolvedGrid,
+): ReadonlyArray<AdaptiveTile> {
+  const families = aggregateClusterFamilies(leaves);
+  const visible = families.slice(0, visibleCapacity(shape));
+  return visible.map((fam) => {
+    if (silhouettesById.size === 0) {
+      return { kind: 'pending', familyCode: fam.familyCode, count: fam.count };
+    }
+    const silhouette = silhouettesById.get(fam.familyCode);
+    if (!silhouette || silhouette.svgData === null) {
+      return {
+        kind: 'fallback',
+        familyCode: fam.familyCode,
+        color: silhouette?.color ?? '#999',
+        count: fam.count,
+      };
+    }
+    return {
+      kind: 'rendered',
+      familyCode: fam.familyCode,
+      svgData: silhouette.svgData,
+      color: silhouette.color,
+      count: fam.count,
+    };
+  });
+}
+```
+
+- [ ] **Step 5: Run, confirm pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/map/adaptive-grid.ts frontend/src/components/map/adaptive-grid.test.ts
+git commit -m "feat(map): add buildAdaptiveTiles + move aggregateClusterFamilies"
+```
+
+### Task 1.5: Implement `AdaptiveGridMarker` component
+
+**Files:**
+- Create: `frontend/src/components/map/AdaptiveGridMarker.tsx`
+- Create: `frontend/src/components/map/AdaptiveGridMarker.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Cover all 12 assertions from spec §7 component section. Use `@testing-library/react` and the existing test setup. Specifically:
+
+- Renders 1×1 with NO badge when totalCount === 1
+- Renders 1×1 with badge "5" when totalCount === 5
+- Renders 2×2 with 4 per-cell badges in descending count order
+- Renders fallback tile opacity 0.5 for `kind: 'fallback'`
+- Renders pending skeleton (NOT opacity-0.5 fallback) when ALL tiles `kind: 'pending'`
+- Renders "+N more" cell when `shape.tag === 'grid-overflow'` — assert the rendered text contains the actual `hiddenCount`
+- aria-label single-observation case verbatim
+- aria-label coincident-pair case verbatim
+- aria-label grid case verbatim
+- aria-label pill case verbatim (parent renders ClusterPill but for parity test the label)
+- aria-describedby target has at most 9 list items
+- Hit-extender overlay `tabIndex === -1`
+- Hit-extender overlay `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
+- Dark-mode badge `boxShadow` contains 1px white stroke
+- Notable indicator (AC8): amber circle for `isNotable: true`, absent for `false`, paints before halo path
+
+- [ ] **Step 2: Run, confirm fail**
+
+- [ ] **Step 3: Implement `AdaptiveGridMarker.tsx`**
+
+```tsx
+import type { MouseEvent } from 'react';
+import type { AdaptiveTile, ResolvedGrid } from './adaptive-grid';
+import { visibleCapacity } from './adaptive-grid';
+
+export interface AdaptiveGridMarkerProps {
+  shape: ResolvedGrid;
+  tiles: ReadonlyArray<AdaptiveTile>;
+  totalCount: number;
+  uniqueFamilies: number;
+  ariaLabel: string;
+  describedByListId?: string;
+  describedByItems?: ReadonlyArray<string>;
+  isCoarsePointer?: boolean;
+  isNotable?: boolean;
+  notableSpeciesName?: string;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
+  const {
+    shape, tiles, totalCount, ariaLabel, describedByListId, describedByItems,
+    isCoarsePointer, isNotable, onClick,
+  } = props;
+
+  const visibleN = visibleCapacity(shape);
+  const cellSize = 22;
+  const gap = 2;
+  const padding = 3;
+  const markerWidth = shape.cols * cellSize + (shape.cols - 1) * gap + 2 * padding;
+  const markerHeight = shape.rows * cellSize + (shape.rows - 1) * gap + 2 * padding;
+  const hitSize = isCoarsePointer ? 48 : 44;
+  const overlayInset = Math.min(0, (hitSize - Math.max(markerWidth, markerHeight)) / 2);
+
+  return (
+    <button
+      type="button"
+      tabIndex={-1}
+      data-testid="adaptive-grid-marker"
+      className="adaptive-grid-marker"
+      aria-label={ariaLabel}
+      aria-describedby={describedByListId}
+      onClick={onClick}
+      style={{
+        width: markerWidth,
+        height: markerHeight,
+        position: 'relative',
+      }}
+    >
+      <span
+        className="adaptive-grid-marker__hit"
+        style={{ inset: overlayInset, position: 'absolute' }}
+      />
+      <div
+        className="adaptive-grid-marker__grid"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${shape.cols}, ${cellSize}px)`,
+          gridTemplateRows: `repeat(${shape.rows}, ${cellSize}px)`,
+          gap,
+          padding,
+        }}
+      >
+        {tiles.slice(0, visibleN).map((tile, i) => (
+          <Cell key={`${tile.familyCode}-${i}`} tile={tile} showBadge={totalCount > 1 || tile.count > 1} isNotable={isNotable} />
+        ))}
+        {shape.tag === 'grid-overflow' && (
+          <div className="adaptive-grid-marker__cell adaptive-grid-marker__overflow">
+            +{shape.hiddenCount}
+          </div>
+        )}
+      </div>
+      {describedByListId && describedByItems && (
+        <ul id={describedByListId} className="visually-hidden">
+          {describedByItems.map((item, i) => <li key={i}>{item}</li>)}
+        </ul>
+      )}
+    </button>
+  );
+}
+
+function Cell({ tile, showBadge, isNotable }: {
+  tile: AdaptiveTile; showBadge: boolean; isNotable?: boolean;
+}) {
+  if (tile.kind === 'pending') {
+    return <div className="adaptive-grid-marker__cell adaptive-grid-marker__cell--pending" />;
+  }
+  if (tile.kind === 'fallback') {
+    return (
+      <div className="adaptive-grid-marker__cell adaptive-grid-marker__cell--fallback" style={{ opacity: 0.5 }}>
+        {showBadge && <span className="adaptive-grid-marker__badge">{tile.count}</span>}
+      </div>
+    );
+  }
+  // rendered
+  return (
+    <div className="adaptive-grid-marker__cell">
+      <svg viewBox="0 0 24 24" width="22" height="22">
+        {isNotable && <circle cx="12" cy="12" r="11" stroke="#f59e0b" strokeWidth="2" fill="none" />}
+        <path d={tile.svgData} fill={tile.color} stroke="white" strokeWidth="1.5" />
+      </svg>
+      {showBadge && <span className="adaptive-grid-marker__badge">{tile.count}</span>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/map/AdaptiveGridMarker.tsx frontend/src/components/map/AdaptiveGridMarker.test.tsx
+git commit -m "feat(map): add AdaptiveGridMarker pure display component"
+```
+
+### Task 1.6: Write CSS rules for AdaptiveGridMarker (CSS sub-task — REQUIRED per project rule)
+
+**Files:**
+- Modify: `frontend/src/components/ds/ds-primitives.css` (preferred — marker is a DS primitive)
+
+In `frontend/src/components/ds/ds-primitives.css`, add rules for every className introduced in `AdaptiveGridMarker.tsx`. Exhaustive class list:
+
+`.adaptive-grid-marker`, `.adaptive-grid-marker__hit`, `.adaptive-grid-marker__grid`, `.adaptive-grid-marker__cell`, `.adaptive-grid-marker__cell--pending`, `.adaptive-grid-marker__cell--fallback`, `.adaptive-grid-marker__badge`, `.adaptive-grid-marker__overflow`
+
+- [ ] **Step 1: Add the rules**
+
+```css
+.adaptive-grid-marker {
+  background: var(--color-bg-surface);
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.adaptive-grid-marker__hit {
+  /* Transparent hit-extender — sized via inline `inset` per props */
+  background: transparent;
+  pointer-events: auto;
+}
+
+.adaptive-grid-marker__grid {
+  /* Inline display: grid; template + gap come from props */
+}
+
+.adaptive-grid-marker__cell {
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+}
+
+.adaptive-grid-marker__cell--pending {
+  background: linear-gradient(110deg, rgba(0,0,0,0.06) 30%, rgba(255,255,255,0.4) 50%, rgba(0,0,0,0.06) 70%);
+  background-size: 200% 100%;
+  animation: adaptive-grid-pending-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes adaptive-grid-pending-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.adaptive-grid-marker__cell--fallback {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.adaptive-grid-marker__badge {
+  position: absolute;
+  bottom: -3px;
+  right: -3px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+[data-theme="dark"] .adaptive-grid-marker__badge {
+  background: #1a1a1a;
+  /* same box-shadow stroke — works on dark basemaps too */
+}
+
+.adaptive-grid-marker__overflow {
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+```
+
+- [ ] **Step 2: Verify every class has at least one rule**
+
+```bash
+grep -cE '^\.(adaptive-grid-marker|adaptive-grid-marker__hit|adaptive-grid-marker__grid|adaptive-grid-marker__cell|adaptive-grid-marker__cell--pending|adaptive-grid-marker__cell--fallback|adaptive-grid-marker__badge|adaptive-grid-marker__overflow)' \
+  frontend/src/styles.css \
+  frontend/src/components/ds/ds-primitives.css
+```
+
+Expected: non-zero count for every class. If any returns 0, add the missing rule before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ds/ds-primitives.css
+git commit -m "feat(map): CSS rules for AdaptiveGridMarker primitives"
+```
+
+### Task 1.7: Open PR1
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/adaptive-cluster-grid
+```
+
+- [ ] **Step 2: Open PR via gh CLI with full template**
+
+Use `creating-prs` skill. Body must include all 5 sections from `.github/PULL_REQUEST_TEMPLATE.md`. Screenshots: this is dead code behind a flag, but the new component is testable in isolation — capture the 5-viewport × 2-theme grid demo via the Storybook-like test harness OR mark Screenshots `N/A — flagged off, no production UI yet` with a note pointing to the Phase 0 prototype screenshots.
+
+- [ ] **Step 3: Dispatch julianken-bot review**
+
+Per `reviewing-as-julianken-bot` skill.
+
+- [ ] **Step 4: After bot approval, queue**
+
+Post `@Mergifyio queue` literal-string comment.
+
+---
+
+# Phase 2 · Atomic cutover
+
+**Branch:** continue on `feat/adaptive-cluster-grid` after Phase 1 merges. Pull main, rebase, push.
+**PR target:** `main`.
+**PR title:** `feat(map): adaptive cluster grid cutover — delete auto-spider + mosaic (issue N+3)`.
+
+**Strategy:** Single PR. Splitting it leaves `cluster-mosaic.ts` with a dead `aggregateClusterFamilies` export, knip fires, Mergify queue blocks. The diff is large but the conceptual change is atomic: "use the new component everywhere; delete the old."
+
+### Task 2.1: Implement memoization layers in MapCanvas.tsx
+
+**Files:** modify `frontend/src/components/map/MapCanvas.tsx`.
+
+- [ ] **Step 1: Add module-scoped cache + generation counter**
+
+At the top of `MapCanvas.tsx` (after imports, before the component):
+
+```ts
+// Module-scoped Concern B + Concern C state. NOT multi-instance safe.
+// Test isolation: call __resetAdaptiveGridCacheForTesting() in beforeEach.
+const leafCache = new Map<string, Promise<ReadonlyArray<AdaptiveTile>>>();
+const warnedRejections = new Set<string>();
+let cacheGeneration = 0;
+
+export function __resetAdaptiveGridCacheForTesting(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('Test-only API');
+  }
+  leafCache.clear();
+  warnedRejections.clear();
+  cacheGeneration = 0;
+}
+```
+
+- [ ] **Step 2: Write the 4 memoization tests in `MapCanvas.test.tsx`**
+
+Per spec §7 manifest: cache hit on identical `(zoom, cluster_id, point_count)`, bust on point_count change, zoom-prefix collision test, rejected-Promise eviction, generation-counter no-op, `silhouettesVersion` invalidation.
+
+- [ ] **Step 3: Run, confirm fail**
+
+- [ ] **Step 4: Implement the three concerns**
+
+Replace the reconciler at `MapCanvas.tsx:691-742` with the new shape. Key points:
+- Capture `const myGen = cacheGeneration` at top of `reconcile`.
+- Use zoom-prefixed key `${Math.floor(zoom)}:${clusterId}:${pointCount}` for `leafCache.get/set`.
+- Attach `.catch()` cleanup at the same site as `.set()` to evict rejected Promises in the same microtask. Log via `console.warn` rate-limited by `warnedRejections.has(key) ? skip : warn-and-add`.
+- Before `setMosaics(next)`, check `myGen === cacheGeneration` — no-op the commit if advanced.
+- At the end of the idle handler, evict entries whose `zoom:cluster_id` is not in the current visible feature-set.
+- Increment `cacheGeneration` + `leafCache.clear()` in the effect re-registration callback (the `silhouettes.length` deps trigger at line 760).
+- Add a monotonic `silhouettesVersion` state variable; increment when the catalogue effect fires.
+
+- [ ] **Step 5: Run, confirm pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/map/MapCanvas.tsx frontend/src/components/map/MapCanvas.test.tsx
+git commit -m "feat(map): three-layer memoization for adaptive-grid reconciler"
+```
+
+### Task 2.2: Wire AdaptiveGridMarker into MapCanvas; raise clusterMaxZoom
+
+**Files:** modify `MapCanvas.tsx`, `observation-layers.ts`.
+
+- [ ] **Step 1: Write failing integration test asserting the new marker renders**
+
+In `MapCanvas.test.tsx`, mount with `VITE_FF_ADAPTIVE_GRID=true` and a canned cluster of 4 families, assert `screen.queryByTestId('adaptive-grid-marker')` is present and `queryByTestId('mosaic-marker')` is absent.
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement the swap**
+
+In `MapCanvas.tsx` around line 716 (the existing marker render site):
+
+```tsx
+// Parent routes the click. Marker stays pure.
+const onClick = isSingleLeaf(entry.clusterId)
+  ? () => openObsPanel(entry.subId)
+  : () => zoomToExpansion(entry.clusterId);
+
+const shape = pickGridShape(entry.uniqueFamilies, entry.pointCount, isMobile);
+if (shape.tag === 'pill') {
+  return <ClusterPill key={entry.clusterId} count={entry.pointCount} onClick={onClick} />;
+}
+return (
+  <AdaptiveGridMarker
+    key={entry.clusterId}
+    shape={shape}
+    tiles={entry.tiles}
+    totalCount={entry.pointCount}
+    uniqueFamilies={entry.uniqueFamilies}
+    ariaLabel={buildAriaLabel(entry)}
+    describedByListId={`marker-${entry.clusterId}-families`}
+    describedByItems={buildDescribedByItems(entry)}
+    isCoarsePointer={isCoarsePointer}
+    isNotable={entry.isNotable}
+    notableSpeciesName={entry.notableSpeciesName}
+    onClick={onClick}
+  />
+);
+```
+
+`isSingleLeaf(clusterId)` is a helper that returns `cluster.point_count === 1`.
+
+- [ ] **Step 4: Raise `CLUSTER_MAX_ZOOM` 14 → 22 in `observation-layers.ts:152`**
+
+- [ ] **Step 5: Run all tests**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/map/MapCanvas.tsx frontend/src/components/map/MapCanvas.test.tsx frontend/src/components/map/observation-layers.ts
+git commit -m "feat(map): wire AdaptiveGridMarker; raise clusterMaxZoom 14→22"
+```
+
+### Task 2.3: Delete auto-spider subsystem
+
+**Files (delete entirely):**
+- `frontend/src/components/map/use-auto-spider.ts`
+- `frontend/src/components/map/use-auto-spider.test.ts`
+- `frontend/src/components/map/stack-fanout.ts`
+- `frontend/src/components/map/stack-fanout.test.ts`
+- `frontend/src/components/map/fan-layout.ts`
+- `frontend/src/components/map/fan-layout.test.ts`
+- `frontend/src/components/map/StackedSilhouetteMarker.tsx`
+- `frontend/src/components/map/StackedSilhouetteMarker.test.tsx`
+- `frontend/e2e/map-stack-fanout.spec.ts`
+
+**Files modified:**
+- `MapCanvas.tsx` — remove the auto-spider block at lines 1073-1100 plus the `import StackedSilhouetteMarker` at line 43 plus the `auto-spider-leader-lines-layer` source/layer adds.
+- `observation-layers.ts` — remove `inStack` plumbing at lines 42-61, 121-126, 278, 336.
+
+- [ ] **Step 1: Delete the 9 files**
+
+```bash
+git rm frontend/src/components/map/{use-auto-spider,stack-fanout,fan-layout,StackedSilhouetteMarker}.{ts,tsx,test.ts,test.tsx} 2>/dev/null
+git rm frontend/e2e/map-stack-fanout.spec.ts
+```
+
+- [ ] **Step 2: Remove imports and consuming blocks from MapCanvas.tsx**
+
+Delete the import at line 43 and the JSX block at 1073-1100 (the `<StackedSilhouetteMarker>` mapping). Delete the `auto-spider-leader-lines-layer` source/layer additions wherever they appear in the file.
+
+- [ ] **Step 3: Remove `inStack` plumbing in observation-layers.ts**
+
+Drop the `inStack: boolean` field from the `ObservationProperties` type; drop the property assignment in `observationsToGeoJson`; drop the four filter clauses that branch on `inStack`.
+
+- [ ] **Step 4: Run all tests; build; knip**
+
+```bash
+npm -w @bird-watch/frontend run test
+npm -w @bird-watch/frontend run build
+npm run knip
+```
+
+Expected: all green. `knip` MUST be clean — if it reports dead exports, the cleanup is incomplete. Fix and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A frontend/
+git commit -m "feat(map): delete auto-spider subsystem (replaced by grid disambiguation)"
+```
+
+### Task 2.4: Delete legacy mosaic files
+
+**Files (delete entirely):**
+- `frontend/src/components/map/MosaicMarker.tsx`
+- `frontend/src/components/map/MosaicMarker.test.tsx`
+- `frontend/src/components/map/cluster-mosaic.ts`
+- `frontend/src/components/map/cluster-mosaic.test.ts`
+- `frontend/e2e/map-cluster-mosaic.spec.ts`
+
+- [ ] **Step 1: Delete the 5 files**
+
+```bash
+git rm frontend/src/components/map/{MosaicMarker.tsx,MosaicMarker.test.tsx,cluster-mosaic.ts,cluster-mosaic.test.ts}
+git rm frontend/e2e/map-cluster-mosaic.spec.ts
+```
+
+- [ ] **Step 2: Drop `CLUSTER_MOSAIC_MAX_POINTS = 8` in observation-layers.ts:163**
+
+- [ ] **Step 3: Drop `import MosaicMarker` and any remaining references in MapCanvas.tsx**
+
+- [ ] **Step 4: Flip feature flag default to `true`**
+
+In `frontend/.env.example`:
+
+```
+VITE_FF_ADAPTIVE_GRID=true  # default-on; flag itself will be removed in a follow-up
+```
+
+- [ ] **Step 5: Run all tests; build; knip; orphan-classname-check**
+
+```bash
+npm -w @bird-watch/frontend run test
+npm -w @bird-watch/frontend run build
+npm run knip
+bash scripts/check-orphan-classnames.sh
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A frontend/
+git commit -m "feat(map): delete legacy mosaic + flip VITE_FF_ADAPTIVE_GRID default to on"
+```
+
+### Task 2.5: Write the new e2e suite
+
+**Files:**
+- Create: `frontend/e2e/map-adaptive-grid.spec.ts`
+
+- [ ] **Step 1: Write the 8 scenarios from spec §7 E2E**
+
+```ts
+// map-adaptive-grid.spec.ts
+import { test, expect } from '@playwright/test';
+import { App } from './pages/app';
+
+test.describe('adaptive cluster grid', () => {
+  test('AZ overview at z=8: at least one pill visible', async ({ page }) => { /* ... */ });
+  test('z=12: at least one 4×4 grid visible', async ({ page }) => { /* ... */ });
+  test('z=16: at least one 2×1 or 1×1 grid visible', async ({ page }) => { /* ... */ });
+  test('z=8→z=15 pinch-zoom: no auto-spider-leader-lines-layer', async ({ page }) => { /* ... */ });
+  test('z=8→z=15: no inStack-keyed DOM attributes', async ({ page }) => { /* ... */ });
+  test('count=1 1×1 has no [data-fallback="true"]', async ({ page }) => { /* ... */ });
+  test('aria-describedby contents axe-clean', async ({ page }) => { /* ... */ });
+  test('DOM marker count ≤ 2500 at every canonical viewport', async ({ page }) => { /* ... */ });
+});
+```
+
+- [ ] **Step 2: Add the perf-gate workflow file**
+
+Create `.github/workflows/perf-gate.yml`:
+
+```yaml
+name: perf-gate
+on:
+  pull_request:
+    paths:
+      - 'frontend/src/components/map/**'
+      - 'frontend/e2e/map-adaptive-grid.spec.ts'
+jobs:
+  perf:
+    runs-on: ubuntu-latest-4-cores
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm -w @bird-watch/frontend run build
+      - run: CI_PERF_GATE=1 npm -w @bird-watch/frontend run test:e2e -- --grep "@perf"
+```
+
+In `map-adaptive-grid.spec.ts`, tag the wall-clock-based test with `@perf` so only the perf workflow runs it.
+
+- [ ] **Step 3: Run e2e locally**
+
+```bash
+npm -w @bird-watch/frontend run test:e2e
+```
+
+- [ ] **Step 4: Extend `axe.spec.ts:55`**
+
+Add an assertion for the adaptive-grid aria-label and aria-describedby `<ul>` contents.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/e2e/map-adaptive-grid.spec.ts frontend/e2e/axe.spec.ts .github/workflows/perf-gate.yml
+git commit -m "test(e2e): adaptive-grid suite + dedicated perf-gate workflow"
+```
+
+### Task 2.6: Multi-viewport design review (10 screenshots)
+
+Per `frontend/**` review protocol (CLAUDE.md). Plan-mandated step — issue #445.
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev -w @bird-watch/frontend
+```
+
+- [ ] **Step 2: Drive Playwright MCP through 5 viewports × 2 themes**
+
+For each viewport (390×844, 768×1024, 1024×768, 1440×900, 1920×1080) and each theme:
+
+- `browser_resize` to viewport
+- `browser_evaluate` to set `[data-theme]`
+- Navigate to surfaces touched (map view at z=8, z=12, z=16)
+- `browser_console_messages` — assert empty (errors AND warnings)
+- `browser_take_screenshot` — save locally for the PR body
+
+- [ ] **Step 3: Upload screenshots via `pr-screenshots-via-user-attachments` skill**
+
+Generate 10 `user-attachments/assets/<uuid>` URLs by simulated paste in chrome-devtools-mcp. NEVER commit PNGs to the repo.
+
+- [ ] **Step 4: Dispatch design-review subagent**
+
+```
+Task(
+  description: "adaptive-grid 10-screenshot design review",
+  subagent_type: "ui-design:ui-designer",
+  model: "opus",
+  prompt: <brief naming PR URL, spec path, 10 screenshot URLs, AC reference, verdict format: PASS/FAIL with file:line-equivalent evidence, cap 3 findings per viewport>
+)
+```
+
+- [ ] **Step 5: GATE — all 5 viewports PASS?**
+
+If FAIL: revise per findings, re-capture, re-dispatch. Do NOT proceed to bot review with any viewport FAIL.
+
+### Task 2.7: Open PR2
+
+- [ ] **Step 1: Push** `git push origin feat/adaptive-cluster-grid`
+- [ ] **Step 2: Open PR via `creating-prs` skill** — all 5 sections, 10 inline screenshots, link to Phase 1 PR
+- [ ] **Step 3: Dispatch `julianken-bot` review subagent**
+- [ ] **Step 4: After bot approval, post `@Mergifyio queue`**
+- [ ] **Step 5: Watch CI — all required checks plus `perf-gate` workflow MUST pass before queue merges**
+
+---
+
+# Phase 3 · Documentation linkbacks
+
+**Branch:** new branch `docs/adaptive-grid-spec-linkback` off `main` after Phase 2 merges.
+
+### Task 3.1: Update architecture spec cross-reference
+
+**Files:** modify `docs/specs/2026-04-16-bird-watch-design.md`.
+
+- [ ] **Step 1: In the §Frontend section, replace any mention of `<MosaicMarker>` or auto-spider with a reference to the adaptive-grid design**
+
+Add a paragraph after the existing frontend-architecture paragraph:
+
+```markdown
+**Cluster marker:** A single `<AdaptiveGridMarker>` component handles every
+cluster at every zoom level. Shape adapts from 1×1 to 4×4 based on unique-family
+count; clusters exceeding 16 unique families OR 64 observations render as a
+numeric `<ClusterPill>`. See `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`
+for the full design.
+```
+
+- [ ] **Step 2: Update the spec headline / dependency table if it counts components**
+
+Run:
+
+```bash
+grep -n "MosaicMarker\|auto-spider\|cluster-mosaic" docs/specs/2026-04-16-bird-watch-design.md
+```
+
+For each match, decide: replace with the new reference, or delete if obsolete.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/specs/2026-04-16-bird-watch-design.md
+git commit -m "docs(spec): cross-reference adaptive-grid design from architecture spec"
+```
+
+### Task 3.2: Annotate feature flag with removal date
+
+**Files:** modify `frontend/.env.example`.
+
+- [ ] **Step 1: Add removal-date comment**
+
+```
+# Adaptive cluster grid — default ON since 2026-05-NN.
+# Remove this flag (along with all gated code paths) after 2026-08-NN if no rollback needed.
+VITE_FF_ADAPTIVE_GRID=true
+```
+
+- [ ] **Step 2: Commit + close child issues + close epic**
+
+```bash
+git add frontend/.env.example
+git commit -m "docs(map): annotate adaptive-grid flag with removal date"
+```
+
+After PR3 merges, close issues #N+1, #N+2, #N+3, #N+4 with cross-links to merged PRs. Close the epic.
+
+### Task 3.3: Open PR3
+
+- [ ] **Step 1: Push** `git push -u origin docs/adaptive-grid-spec-linkback`
+- [ ] **Step 2: Open PR — Screenshots `N/A — docs-only`**
+- [ ] **Step 3: Dispatch bot review**
+- [ ] **Step 4: Queue via Mergify**
+- [ ] **Step 5: After merge, close Epic + child issues**
+
+---
+
+## Self-review notes (plan author, not implementer)
+
+**Spec coverage:** Every spec §4–§8 requirement maps to a task. Specifically:
+- §4.1 sizing rules → Task 1.3 tests + impl
+- §4.3 badge contrast → Task 1.6 CSS + Task 1.5 dark-mode test
+- §4.4 hit-extender → Task 1.5 component impl + Task 1.5 component test
+- §4.5 parent-routed click → Task 2.2 wire-in
+- §4.6 two-tier aria → Task 1.5 component tests
+- §4.7 inherited tabIndex → Task 1.5 component test
+- §5.3 three memo concerns → Task 2.1
+- §6 file map → Phase 2 manifest + Tasks 2.3, 2.4
+- §7 test strategy → Tasks 1.3, 1.4, 1.5, 2.5
+- §10 four gates → Phase 0 Task 0.2
+
+**Placeholder scan:** Run `grep -nE "TBD|TODO|fill in|implement later" docs/plans/2026-05-14-adaptive-cluster-grid.md` — must return zero before publication.
+
+**Type consistency:** `pickGridShape`, `buildAdaptiveTiles`, `AdaptiveGridMarker`, `AdaptiveTile`, `GridShape`, `ResolvedGrid`, `PositiveInt`, `toPositiveInt`, `visibleCapacity` — all match between tasks. `silhouettesById: ReadonlyMap<string, ...>` is consistent in Tasks 1.4 and 2.1. The `aggregateClusterFamilies` move is captured in Task 1.4 (copy) + Task 2.4 (delete source).
+
+**className gate check** (per project CSS-sub-task rule):
+
+```bash
+grep -n "className" docs/plans/2026-05-14-adaptive-cluster-grid.md | grep -v "CSS rules\|Step\|grep\|grid-marker\|---"
+```
+
+Plan author verified: every className introduced in Task 1.5 has a matching rule in Task 1.6.

--- a/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
+++ b/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
@@ -81,10 +81,12 @@ The brainstorm considered three approaches. **Approach A** was chosen because it
 
 ```ts
 type Dim = 1 | 2 | 3 | 4;
+type PositiveInt = number & { readonly __brand: 'PositiveInt' };
+declare function toPositiveInt(n: number): PositiveInt;  // throws on n < 1
 
 type GridShape =
   | { tag: 'grid'; cols: Dim; rows: Dim }                      // visibleCapacity = cols*rows
-  | { tag: 'grid-overflow'; cols: Dim; rows: Dim; hiddenCount: number }   // visibleCapacity = cols*rows - 1 (reserved for "+N")
+  | { tag: 'grid-overflow'; cols: Dim; rows: Dim; hiddenCount: PositiveInt }   // visibleCapacity = cols*rows - 1 (reserved for "+N")
   | { tag: 'pill' };
 
 type ResolvedGrid = Exclude<GridShape, { tag: 'pill' }>;       // what AdaptiveGridMarker receives
@@ -187,9 +189,13 @@ interface AdaptiveGridMarkerProps {
 // Discriminated union — matches existing MosaicTile precedent at cluster-mosaic.ts:42-58.
 // Keeps the field name `svgData` (consistent with FamilySilhouette.svgData in shared-types/index.ts);
 // no surprise rename. Fallback variant carries only the fields actually rendered.
+// `pending` distinguishes "catalogue not loaded yet" from "loaded but no art for this family" —
+// without it both cases render as fallback (opacity 0.5) and a cold-load map is indistinguishable
+// from a real coverage gap.
 type AdaptiveTile =
   | { kind: 'rendered'; familyCode: string; svgData: string; color: string; count: number }
-  | { kind: 'fallback'; familyCode: string; color: string; count: number };
+  | { kind: 'fallback'; familyCode: string; color: string; count: number }     // catalogue loaded, no art for this family
+  | { kind: 'pending'; familyCode: string; count: number };                     // catalogue not loaded yet (render skeleton)
 ```
 
 The marker takes a `ResolvedGrid` (pill is unreachable at the type level — `Exclude<GridShape, { tag: 'pill' }>`). The parent renders `<ClusterPill>` directly for `shape.tag === 'pill'`. `isMobileViewport` is no longer threaded — the mobile cap is already encoded in `shape.tag === 'grid-overflow'`.
@@ -224,13 +230,13 @@ There are **three separable caching concerns** the implementation must address:
 
 **Concern A — Render-pass stability.** The derived `tiles: ReadonlyArray<AdaptiveTile>` passed to `<AdaptiveGridMarker>` should not be a new identity on every render when the inputs haven't changed, or `React.memo` on the marker is defeated. Solution: `useMemo` at the parent keyed on `[zoom, cluster_id, point_count, silhouettesVersion]` (see Concern C for the version token). Garbage-collected by React when the cluster leaves the viewport. Idiomatic React.
 
-**Concern B — Async-call avoidance across idle ticks.** `getClusterLeaves` is an async supercluster call. Running it for every visible cluster on every `idle` event is the actual perf hot path. This caching layer lives *outside* React render — a module-scoped `Map<string, Promise<AdaptiveTile[]>>` in `MapCanvas.tsx` keyed on **`${zoom}:${cluster_id}:${point_count}`**. The zoom prefix is load-bearing: supercluster's integer `cluster_id` values can collide across zoom levels, and without it the cache will silently return a stale tile array from a different zoom's leaf set. Eviction: at the end of each `idle` handler, drop entries whose `zoom:cluster_id` is not present in the current viewport's feature set.
+**Concern B — Async-call avoidance across idle ticks.** `getClusterLeaves` is an async supercluster call. Running it for every visible cluster on every `idle` event is the actual perf hot path. This caching layer lives *outside* React render — a module-scoped `Map<string, Promise<AdaptiveTile[]>>` in `MapCanvas.tsx` keyed on **`${zoom}:${cluster_id}:${point_count}`** (zoom is `Math.floor(map.getZoom())` to handle fractional values from continuous-zoom devices). The zoom prefix is load-bearing: supercluster's integer `cluster_id` values can collide across zoom levels, and without it the cache will silently return a stale tile array from a different zoom's leaf set. Eviction: at the end of each `idle` handler, drop entries whose `zoom:cluster_id` is not present in the current viewport's feature set. **Rejected-Promise eviction**: if a stored Promise rejects, the cache entry is deleted in the same microtask (a `.catch()` cleanup at insert time) so a transient supercluster failure does not poison the cache for the lifetime of the cluster. The rejection is logged once via the project's standard error path; tests assert that a retry after rejection re-invokes `getClusterLeaves` rather than returning the rejected Promise.
 
-**Concern C — Catalogue rebuild invalidation.** Supercluster's index is rebuilt when `silhouettes.length` changes (this is the existing effect-deps trigger at `MapCanvas.tsx:760`). After a rebuild, spatially equivalent clusters can be assigned different `cluster_id` values, and downstream `aggregateClusterFamilies` may resolve different `svgData` for the same family if the catalogue rows changed. The implementation must:
+**Concern C — Catalogue rebuild invalidation.** Supercluster's index is rebuilt when `silhouettes.length` changes (this is the existing effect-deps trigger at `MapCanvas.tsx:760`). After a rebuild, spatially equivalent clusters can be assigned different `cluster_id` values, and downstream silhouette resolution may produce different `svgData` for the same family if the catalogue rows changed. The implementation must:
 
-1. Wholesale-clear the Concern B `Map` whenever the effect re-registers (i.e., on `silhouettes.length` change). One line at the top of the effect body.
-2. Include a `silhouettesVersion` token (`silhouettes.length` is sufficient as a coarse proxy — increments on catalogue load) in the Concern A `useMemo` key. This is the third dependency named above.
-3. Resolve silhouette `svgData` for each family **upstream** of `buildAdaptiveTiles` rather than reading `silhouettesRef.current` inside the tile-builder. Today's `buildMosaicTiles` does the wrong thing at `MapCanvas.tsx:714` — reading from a ref bypasses every memo key. Move silhouette resolution to a pure transformation: `(leaves, silhouettesById) → tiles`. Tests pass `silhouettesById` explicitly.
+1. **Generation counter + race-safe commit.** Introduce a module-scoped monotonic `cacheGeneration: number` in `MapCanvas.tsx`. The effect body increments this counter and wholesale-clears the Concern B `Map` whenever it re-registers. Each `reconcile` invocation captures `const myGen = cacheGeneration` at its top; before calling `setMosaics(next)`, it checks `myGen === cacheGeneration` and no-ops the commit if the generation has advanced. This closes the race where an in-flight reconcile from the prior catalogue commits stale tiles after a refresh.
+2. **`silhouettesVersion` is a monotonic integer, not `silhouettes.length`.** A length-only proxy misses in-place row replacement (same count, different `svgData` — Phylopic refreshes, low-res→hi-res swaps). The version increments on every catalogue write in the same place where supercluster's index is rebuilt. The useMemo key carries `silhouettesVersion`, not `silhouettes.length`.
+3. **Upstream silhouette resolution.** Resolve silhouette `svgData` for each family **upstream** of `buildAdaptiveTiles` rather than reading `silhouettesRef.current` inside the tile-builder. Today's `buildMosaicTiles` does the wrong thing at `MapCanvas.tsx:714` — reading from a ref bypasses every memo key. The new signature is pure: `buildAdaptiveTiles(leaves, silhouettesById, shape) → ReadonlyArray<AdaptiveTile>`. The caller resolves `silhouettesById` once per reconcile and threads it explicitly. Tests pass `silhouettesById` as an argument and verify identical-leaf inputs with different catalogues produce different `svgData`.
 
 All three are **functional requirements** — the §10 Gate 1 p99 bound depends on hitting Concern B's cache for unchanged clusters AND on the catalogue not silently invalidating it on every load. The plan body's first task is to write the failing perf assertion, then add the three layers to make it pass.
 
@@ -306,7 +312,7 @@ Tile-builder rules:
 - `buildAdaptiveTiles(200 leaves, 20 unique families, capacity=16) → 16 tiles, descending count`
 - **Null-familyCode dropout** (LEFT JOIN miss per `Observation` contract): leaves with `familyCode === null` are silently dropped — copied verbatim from `cluster-mosaic.test.ts` so the invariant is preserved
 - **Under-capacity** when fewer families than capacity: `buildAdaptiveTiles(5 leaves, 2 families, capacity=4) → 2 tiles` (not 4 — caller pads visually)
-- **Fallback by null `svgData`**: leaves with `silhouetteSrc === null` produce tiles with `isFallback === true` — preserved from prior `cluster-mosaic.test.ts`
+- **Fallback by null `svgData`**: leaves whose resolved silhouette `svgData === null` produce tiles with `kind === 'fallback'` — preserved from prior `cluster-mosaic.test.ts`
 
 Memoization (Concerns A, B, C from §5.3):
 
@@ -316,7 +322,10 @@ Memoization (Concerns A, B, C from §5.3):
 - **Cache uses zoom-prefixed key** — `${zoom}:${cluster_id}:${point_count}` — and a test asserts that the same `cluster_id:point_count` at two different zoom levels produces two independent cache entries (catches collisions silent in an unprefixed key)
 - Cache evicts entries whose `zoom:cluster_id` is not in the current viewport feature-set
 - **Catalogue invalidation**: when `silhouettes.length` changes (catalogue load / refresh), the module-scoped `Map` is wholesale-cleared and `useMemo` recomputes (silhouettesVersion delta busts the key)
-- **Upstream silhouette resolution**: `buildAdaptiveTiles(leaves, silhouettesById)` is pure — it does NOT read from any ref. A regression test asserts that calling it with two different `silhouettesById` arguments returns differently-resolved tiles, even with identical `leaves`
+- **Upstream silhouette resolution**: `buildAdaptiveTiles(leaves, silhouettesById, shape)` is pure — it does NOT read from any ref. A regression test asserts that calling it with two different `silhouettesById` arguments returns differently-resolved tiles, even with identical `leaves`
+- **Rejected-Promise eviction**: `getClusterLeaves` rejection on a cache key removes the entry in the same microtask. A retry on the same key re-invokes the underlying call (does NOT return the rejected Promise). Test name: `"Concern B cache: rejected getClusterLeaves promise is evicted, retry invokes the underlying call"`
+- **Race-safe commit**: the `cacheGeneration` counter increments on every effect re-registration; an in-flight reconcile captures its generation at entry and no-ops `setMosaics` if the generation has advanced. Test name: `"reconcile does not commit tiles when cacheGeneration advanced mid-flight"`
+- **`silhouettesVersion` invalidates on in-place replacement**: two catalogue snapshots with identical `length` but different `svgData` for the same `familyCode` bust the useMemo key. Test name: `"silhouettesVersion bump invalidates memo even when silhouettes.length is unchanged"`
 
 ### Component (`AdaptiveGridMarker.test.tsx`)
 
@@ -334,6 +343,7 @@ Memoization (Concerns A, B, C from §5.3):
 - Hit-extender overlay element has `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
 - **Dark-mode badge contrast**: with `data-theme="dark"` applied, badge's `getComputedStyle().boxShadow` includes the 1px white stroke specified in §4.3
 - **Notable indicator preserved (AC8, inherited from `StackedSilhouetteMarker.test.tsx:183-221`)**: a 1×1 grid for an `isNotable: true` leaf renders an amber `<circle>` ring inside the tile SVG; a non-notable leaf does NOT render the circle; the circle's DOM order precedes the halo path (z-order test)
+- **Empty-catalogue render path**: when `silhouettesById` is empty (catalogue not loaded yet — distinct from "loaded but this family has no art"), the marker MUST NOT render as a 100%-fallback grid (visually indistinguishable from a real coverage gap). Spec choice: introduce a third `AdaptiveTile` variant `{ kind: 'pending'; familyCode; count }` for the catalogue-unloaded case, rendered as a skeleton/shimmer rather than the opacity-0.5 fallback. Test name: `"empty silhouette catalogue: renders skeleton, NOT a 100%-fallback grid"`
 
 ### E2E (`map-adaptive-grid.spec.ts`)
 

--- a/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
+++ b/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
@@ -81,27 +81,29 @@ The brainstorm considered three approaches. **Approach A** was chosen because it
 
 ```ts
 type GridShape =
-  | { tag: 'grid'; cols: number; rows: number; capacity: number }
+  | { tag: 'grid'; cols: number; rows: number; capacity: number; overflow: number }
   | { tag: 'pill' };
 ```
 
+`overflow` is the count of families hidden beyond `capacity` (≥ 0). When `overflow > 0`, the renderer reserves the last cell as an inline "+N more" indicator (see mobile cap below).
+
 Rules (desktop · viewport > 480px):
 
-| Unique families | Shape | Footprint |
-|---|---|---|
-| 1 | 1×1 | 28×28 |
-| 2 | 2×1 | 52×28 |
-| 3–4 | 2×2 | 52×52 |
-| 5–9 | 3×3 | 78×78 |
-| 10–16 | 4×4 | 104×104 |
+| Unique families | Shape | Capacity | Overflow |
+|---|---|---|---|
+| 1 | 1×1 | 1 | 0 |
+| 2 | 2×1 | 2 | 0 |
+| 3–4 | 2×2 | 4 | 0 |
+| 5–9 | 3×3 | 9 | 0 |
+| 10–16 | 4×4 | 16 | 0 |
 
 **Pill fallback** when `uniqueFamilies > 16 OR point_count > 64`. The observation-count cap exists because raising `clusterMaxZoom` to 22 produces dense low-zoom clusters whose DOM cost as 4×4 grids regresses against today's lightweight pills (see §10 Gate 2). The Tucson 1640-obs cluster stays a pill at z = 8; as the user zooms in, smaller fragments emerge with `point_count ≤ 64` and `uniqueFamilies ≤ 16` and become grids.
 
-**Mobile cap** at viewport ≤ 480px: the 4×4 case collapses to 3×3 with the top-8 silhouettes plus an inline "+N more" cell. Prevents adjacent 104×104 markers from overlapping on 390-wide viewports.
+**Mobile cap** at viewport ≤ 480px: the 4×4 case collapses to 3×3 with the top-8 silhouettes plus an inline "+N more" cell driven by `overflow > 0`. Concretely, `pickGridShape(12, /*pointCount*/ 12, /*isMobile*/ true) → {tag:'grid', cols:3, rows:3, capacity:8, overflow:4}`. Prevents adjacent 104×104 markers from overlapping on 390-wide viewports.
 
 ### 4.2 Family ordering
 
-Existing logic in `aggregateClusterFamilies` (`cluster-mosaic.ts:80-95`) is correct: descending by observation count, alphabetical tiebreak on `familyCode`. The new `adaptive-grid.ts` re-exports it.
+Existing logic in `aggregateClusterFamilies` (`cluster-mosaic.ts:80-95`) is correct: descending by observation count, alphabetical tiebreak on `familyCode`. The function moves unchanged into `adaptive-grid.ts` (see §5.2). Behavioral invariants preserved verbatim — including the null-familyCode dropout case from `Observation`'s LEFT-JOIN contract — and explicitly retested (§7).
 
 ### 4.3 Per-cell observation-count badge
 
@@ -116,7 +118,7 @@ Marker visual geometry (28 / 52 / 78 / 104) is independent of the hit zone. A tr
 
 - `pointer:fine` → 44×44 min (WCAG 2.5.5 AAA target size, matching existing `MapMarkerHitLayer.tsx:53` `HIT_SIZE_DESKTOP=40` — proposed raised to 44 to clear AAA).
 - `pointer:coarse` → 48×48 min (matches existing `HIT_SIZE_COARSE=48`).
-- Positioned via `inset: max(0, (44 - markerSize) / -2)` so a 4×4 (104×104) marker's hit zone is its own bounding box (no shrinkage).
+- Positioned via `inset: min(0, (44 - markerSize) / 2)` (a negative value extends the box outward by half the deficit). A 1×1 (28×28) marker gets `inset: -8` → 44×44 hit zone. A 4×4 (104×104) marker gets `inset: 0` → its own bounding box.
 - The overlay is the `<button>`; the visual marker is its child. ARIA attributes live on the overlay.
 
 ### 4.5 Tap behavior — parent routes the click
@@ -207,9 +209,13 @@ export function aggregateClusterFamilies(
 
 `MapCanvas.tsx:704-722` runs the cluster-leaves + family-aggregation chain on every map `idle` (registered at `MapCanvas.tsx:742`). Today this is bounded by `CLUSTER_MOSAIC_MAX_POINTS=8`; the redesign removes that ceiling, so worst-case is 1640 leaves iterated per marker per idle for the Tucson hotspot.
 
-**Mitigation**: a `useRef`-backed cache in `MapCanvas.tsx` keyed on the tuple `(cluster_id, point_count)`. Cache survives pan; busts only when supercluster reports a different cluster id or a different point count. The aggregate result is small (≤ 16 tiles) and pure-function in its inputs — memoization is correct.
+There are **two separable caching concerns** the implementation must address — conflated in earlier brainstorming, separated here:
 
-This is a **functional requirement of the redesign**, not a nice-to-have. The plan body asserts a `performance.mark` p99 bound (§10 Gate 1) that depends on this cache.
+**Concern A — Render-pass stability.** The derived `tiles: AdaptiveTile[]` array passed to `<AdaptiveGridMarker>` should not be a new identity on every render when the inputs haven't changed, or React.memo on the marker is defeated. Solution: `useMemo` keyed on `[cluster_id, point_count]` at the parent. Garbage-collected when the cluster leaves the viewport. Idiomatic React.
+
+**Concern B — Async-call avoidance across idle ticks.** `getClusterLeaves` is an async supercluster call. Running it for every visible cluster on every `idle` event is the actual perf hot path. This caching layer lives *outside* React render — a module-scoped `Map<string, Promise<AdaptiveTile[]>>` keyed on `${cluster_id}:${point_count}` in `MapCanvas.tsx`. Evicted when the corresponding cluster_id leaves the current viewport's feature set (computed once per idle).
+
+Both layers are **functional requirements** — the §10 Gate 1 p99 bound depends on hitting Concern B's cache for unchanged clusters and skipping the leaf iteration entirely. The plan body's first task is to write the failing perf assertion, then add the cache to make it pass.
 
 ## 6. File map
 
@@ -223,14 +229,16 @@ This is a **functional requirement of the redesign**, not a nice-to-have. The pl
 | `frontend/src/components/map/adaptive-grid.test.ts` | Shape-picker rules, tile-builder edges |
 | `frontend/e2e/map-adaptive-grid.spec.ts` | E2E for grid render, pill fallback, zoom progression |
 
-### Deleted (8)
+### Deleted (13)
 
 | File | Reason |
 |---|---|
 | `frontend/src/components/map/MosaicMarker.tsx` | Superseded by `AdaptiveGridMarker` |
 | `frontend/src/components/map/MosaicMarker.test.tsx` | Replaced |
 | `frontend/src/components/map/cluster-mosaic.ts` | Constants and `aggregateClusterFamilies` moved into `adaptive-grid.ts` |
-| `frontend/src/components/map/cluster-mosaic.test.ts` | Replaced |
+| `frontend/src/components/map/cluster-mosaic.test.ts` | Behaviors copied into `adaptive-grid.test.ts` (see §7) |
+| `frontend/src/components/map/StackedSilhouetteMarker.tsx` | Single-purpose marker for auto-spider fan leaves (#277); orphaned by auto-spider deletion |
+| `frontend/src/components/map/StackedSilhouetteMarker.test.tsx` | |
 | `frontend/src/components/map/use-auto-spider.ts` | Auto-spider deleted |
 | `frontend/src/components/map/use-auto-spider.test.ts` | |
 | `frontend/src/components/map/stack-fanout.ts` | |
@@ -239,14 +247,12 @@ This is a **functional requirement of the redesign**, not a nice-to-have. The pl
 | `frontend/src/components/map/fan-layout.test.ts` | |
 | `frontend/e2e/map-stack-fanout.spec.ts` | |
 
-(Net: 5 new, 11 deleted — the "8" cited in the brainstorm collapsed `.ts` + `.test.ts` pairs.)
-
 ### Modified (3)
 
 | File | Changes |
 |---|---|
-| `frontend/src/components/map/MapCanvas.tsx` | Raise `clusterMaxZoom` 14 → 22 (1016-1023). Remove auto-spider block (1073-1100). Swap `<MosaicMarker>` for `<AdaptiveGridMarker>`. Raise `getClusterLeaves` limit (706) from `CLUSTER_MOSAIC_MAX_POINTS` to `point_count`. Add `(cluster_id, point_count)`-keyed memo cache. Audit effect-deps array around line 760 (currently re-registers only on `silhouettes.length`/`mapReady`). |
-| `frontend/src/components/map/observation-layers.ts` | Drop `CLUSTER_MOSAIC_MAX_POINTS = 8` (163). Bump `CLUSTER_MAX_ZOOM` 14 → 22 (152). Remove `inStack` plumbing (42-61, 121-126, 278, 336). |
+| `frontend/src/components/map/MapCanvas.tsx` | Raise `clusterMaxZoom` 14 → 22 (1016-1023). Remove auto-spider block (1073-1100), including `import StackedSilhouetteMarker` at line 43. Swap `<MosaicMarker>` for `<AdaptiveGridMarker>`. Raise `getClusterLeaves` limit (706) from `CLUSTER_MOSAIC_MAX_POINTS` to `point_count`. Add the two memo layers from §5.3. Audit effect-deps array around line 760 (currently re-registers only on `silhouettes.length`/`mapReady`). |
+| `frontend/src/components/map/observation-layers.ts` | Drop `CLUSTER_MOSAIC_MAX_POINTS = 8` (163). Bump `CLUSTER_MAX_ZOOM` 14 → 22 (152). Remove `inStack` plumbing (42-61, 121-126, 278, 336) — both the property declarations in the GeoJSON feature type AND every filter clause that branches on it. This is a public GeoJSON-feature-shape change; cross-check `frontend/src/components/map/**` for any other reader of the `inStack` property. |
 | `frontend/e2e/axe.spec.ts` | Extend `:55` aria-label assertion to cover grid marker labels and the visually-hidden `<ul>` describedby target. |
 
 ### Kept
@@ -261,13 +267,43 @@ This is a **functional requirement of the redesign**, not a nice-to-have. The pl
 
 ### Unit (`adaptive-grid.test.ts`)
 
-- `pickGridShape(1, 1, false) → {tag:'grid', cols:1, rows:1, capacity:1}`
-- `pickGridShape(2, …) → 2×1`; `pickGridShape(3, …) → 2×2`; `pickGridShape(4, …) → 2×2`
+Shape-picker rules (each test name pins one rule):
+
+- `pickGridShape(1, 1, false) → {tag:'grid', cols:1, rows:1, capacity:1, overflow:0}`
+- `pickGridShape(2, …)`, `pickGridShape(3, …) → 2×2`, `pickGridShape(4, …) → 2×2` (and 2 → 2×1 explicitly)
 - `pickGridShape(5..9, …) → 3×3`; `pickGridShape(10..16, …) → 4×4`
-- `pickGridShape(17, 17, false) → {tag:'pill'}`
-- `pickGridShape(5, 65, false) → {tag:'pill'}` (observation-count cap fires)
-- Mobile cap: `pickGridShape(12, 12, true) → 3×3, capacity 8 + overflow`
-- `buildAdaptiveTiles(200 leaves with 20 unique families, capacity=16) → 16 tiles, descending count`
+- **Family-cap fires alone**: `pickGridShape(17, 30, false) → {tag:'pill'}` (uniqueFamilies > 16, pointCount well under 64)
+- **Count-cap fires alone**: `pickGridShape(8, 65, false) → {tag:'pill'}` (family rule alone would give 3×3; pointCount > 64 forces pill)
+- **Boundary**: `pickGridShape(8, 64, false) → {tag:'grid', 3×3}` (count = 64 inclusive, no pill)
+- **Boundary**: `pickGridShape(16, 64, false) → {tag:'grid', 4×4, overflow:0}` (max grid)
+- **Mobile cap**: `pickGridShape(12, 12, true) → {tag:'grid', cols:3, rows:3, capacity:8, overflow:4}`
+
+Tile-builder rules:
+
+- `buildAdaptiveTiles(200 leaves, 20 unique families, capacity=16) → 16 tiles, descending count`
+- **Null-familyCode dropout** (LEFT JOIN miss per `Observation` contract): leaves with `familyCode === null` are silently dropped — copied verbatim from `cluster-mosaic.test.ts` so the invariant is preserved
+- **Under-capacity** when fewer families than capacity: `buildAdaptiveTiles(5 leaves, 2 families, capacity=4) → 2 tiles` (not 4 — caller pads visually)
+- **Fallback by null `svgData`**: leaves with `silhouetteSrc === null` produce tiles with `isFallback === true` — preserved from prior `cluster-mosaic.test.ts`
+
+Memoization (Concern A and B from §5.3):
+
+- `useMemo` reuses tile-array identity when `(cluster_id, point_count)` is unchanged
+- Module-scoped async cache returns the cached `Promise<tiles>` and skips the `getClusterLeaves` call when both keys match
+- Cache invalidates when `point_count` changes for the same `cluster_id`
+- Cache evicts entries whose `cluster_id` is not in the current viewport feature-set
+
+### Component (`AdaptiveGridMarker.test.tsx`)
+
+- Renders 1×1 with NO badge when `totalCount === 1`
+- Renders 1×1 with badge "5" when `totalCount === 5` (single-family cluster)
+- Renders 2×2 with 4 per-cell badges in descending count order
+- Renders fallback tile (opacity 0.5) when `silhouetteSrc === null` — existing behavior preserved
+- Renders "+N more" cell when `shape.overflow > 0` (mobile 3×3 case)
+- aria-label matches the patterns in §4.6
+- aria-describedby target exists for grids and pills, has at most 9 list items (8 families + "and N more")
+- **Hit-extender overlay element has `tabIndex === -1`** (inherits the §4.7 contract — load-bearing, easy to silently break)
+- Hit-extender overlay element has `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
+- **Dark-mode badge contrast**: with `data-theme="dark"` applied, badge's `getComputedStyle().boxShadow` includes the 1px white stroke specified in §4.3
 
 ### Component (`AdaptiveGridMarker.test.tsx`)
 
@@ -284,9 +320,11 @@ This is a **functional requirement of the redesign**, not a nice-to-have. The pl
 - AZ overview at z=8: at least one pill visible (Tucson hotspot)
 - Zoom to z=12: at least one 4×4 grid visible
 - Zoom to z=16: at least one 2×1 or 1×1 grid visible
-- Pinch-zoom z=8 → z=15: no `auto-spider-leader-lines-layer` in rendered layer list
+- Pinch-zoom z=8 → z=15: no `auto-spider-leader-lines-layer` in rendered layer list; no `inStack`-keyed DOM attributes anywhere on the page
 - No DOM `[data-fallback="true"]` in a count=1 1×1 (single-observation shouldn't be a fallback)
 - Axe assertions on aria-describedby contents
+- **Perf-budget regression assertion (Gate 1 in CI)**: `performance.measure('mosaic-reconcile')` p99 < 16ms during a scripted pinch-zoom z=8 → z=15 at 390×844 with ≥ 344 seeded rows. Fails CI if exceeded — turns Gate 1 from a one-shot prototype check into a continuous regression guard.
+- **DOM-marker-count regression assertion (Gate 2 in CI)**: visible-marker count via `page.locator('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').count()` ≤ 2500 at each canonical viewport. Fails CI if exceeded.
 
 ## 8. Inherited and preserved behavior
 
@@ -306,7 +344,7 @@ The redesign deliberately preserves several pieces of today's UX that the surfac
 | Risk | Resolution |
 |---|---|
 | Per-cell tap targets create AC surface explosion | Whole marker is one tap target |
-| Null-return sentinel from `pickGridShape` | Use discriminated union `{tag:'grid'} | {tag:'pill'}` |
+| Null-return sentinel from `pickGridShape` | Use discriminated union `{tag:'grid'} \| {tag:'pill'}` |
 | Tap-routing logic in display component | Parent (MapCanvas) routes; marker stays pure |
 | WCAG 2.5.5 at 28×28 | Hit-extender overlay at 44/48 |
 | Badge contrast in dark mode | 1px white box-shadow stroke |
@@ -324,7 +362,7 @@ The redesign deliberately preserves several pieces of today's UX that the surfac
 
 ### Tier-2 refactors
 
-These are not blockers for shipping but should land in or near this work:
+*Tier-2* here means: real but not gating the prototype gate or first ship. Land in this work if convenient, otherwise file as follow-ups.
 
 - Add a `useMediaQuery('(pointer: coarse)')` hook if one doesn't exist (the hit-layer already needs it)
 - Add a `useMediaQuery('(max-width: 480px)')` hook for the mobile 3×3 cap
@@ -362,7 +400,10 @@ Instrument `performance.mark` brackets around the `mosaics` state update in `Map
 After all four gates pass on the prototype:
 
 1. The plan body (`docs/plans/<date>-adaptive-cluster-grid.md`) is authored via `superpowers:writing-plans`.
-2. The plan is decomposed into independent PRs at the right level of CI gate granularity (per `feedback_plan_ci_coupling`). Likely structure: PR1 adds `adaptive-grid.ts` + `AdaptiveGridMarker.tsx` behind a feature flag; PR2 wires the parent and deletes auto-spider; PR3 deletes legacy mosaic files; PR4 documentation + spec linkbacks.
+2. The plan is decomposed into independent PRs at the right level of CI gate granularity (per `feedback_plan_ci_coupling`). Likely structure:
+   - **PR1** — Add `adaptive-grid.ts` + `AdaptiveGridMarker.tsx` behind a feature flag (default off). Add the new unit + component tests. No `MapCanvas.tsx` wiring yet. CI green throughout — the new code is unreachable without the flag.
+   - **PR2** — Atomically: flip the flag default to on, wire `AdaptiveGridMarker` into `MapCanvas.tsx`, delete the auto-spider subsystem (use-auto-spider, stack-fanout, fan-layout, leader-lines layer, StackedSilhouetteMarker), AND delete the legacy mosaic files (`MosaicMarker.tsx`, `cluster-mosaic.ts` + their tests, `map-stack-fanout.spec.ts`). Single PR because splitting it leaves an intermediate state where `cluster-mosaic.ts`'s `aggregateClusterFamilies` export is dead — knip fires and blocks the Mergify queue.
+   - **PR3** — Documentation + spec linkbacks. Update `docs/specs/2026-04-16-bird-watch-design.md §Frontend` to reference this design.
 3. Each PR follows the project's PR workflow (`pr-workflow` skill) and passes the canonical 5-viewport × 2-theme screenshot capture (`pr-screenshots-via-user-attachments`).
 4. Bot review via `julianken-bot` subagent before queueing.
 

--- a/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
+++ b/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
@@ -1,0 +1,377 @@
+# AdaptiveGridMarker — design
+
+Replace today's split `<MosaicMarker>` (≤8 obs, fixed 2×2 + single overall badge) and `<ClusterPill>` (≥9 obs, numeric pill) with one component, `<AdaptiveGridMarker>`, whose shape scales with the cluster's unique-family count and whose cells carry per-family observation counts. Delete auto-spider entirely; raise `clusterMaxZoom` from 14 → 22 so the same component renders at every zoom level, including coincident-point disambiguation that auto-spider previously handled.
+
+Status: **brainstorming complete, plan-body authorship pending prototype gates** (see §10).
+
+## 1. Background
+
+### What exists today
+
+- `frontend/src/components/map/MapCanvas.tsx:1016-1023` configures MapLibre clustering with `clusterMaxZoom=14, clusterRadius=50`. Constants in `observation-layers.ts:152-153`.
+- Clusters with `point_count ≤ 8` render as `<MosaicMarker>` — 2×2 CSS grid of family silhouettes, single overall observation-count badge (`MosaicMarker.tsx:108-175`). Limit `CLUSTER_MOSAIC_MAX_POINTS=8` at `observation-layers.ts:163`.
+- Clusters with `point_count ≥ 9` render as `<ClusterPill>` in three tiers (`sky`/`sand`/`ember`) — numeric pill like "1640".
+- At `z ≥ 14`: individual `<PresentationMarker>` per observation. An **auto-spider** reconciler (`use-auto-spider.ts`) fans coincident points on a 70px ring, capped at 8 leaves (`fan-layout.ts:33`). Click-driven spidering was deleted in #280; what exists is the always-on auto-fan reconciler.
+- Family aggregation: `aggregateClusterFamilies` in `cluster-mosaic.ts:80-95` sorts descending by family count, alphabetical tiebreak. `MosaicTile.count` (`cluster-mosaic.ts:52`) is computed and threaded to the renderer **but never displayed**.
+
+### Why this is wrong now
+
+Three concrete problems surfaced in the 2026-05-14 investigation:
+
+1. **Box-of-4 carries an overall observation-count badge, not per-family counts.** The user sees "7" overlaid on four silhouettes but cannot tell which family contributes which observations. The per-cell count is already in `MosaicTile.count` — just not rendered.
+2. **Cluster previews disappear above 8 observations.** The dominant visual at AZ overview zoom is numeric pills (e.g. "1640"), giving zero species-composition signal. The mosaic is reserved for the smallest clusters where it's least needed.
+3. **Auto-spider has a hard cap of 8 leaves.** At dense hotspots (Tucson 1640 obs, Madera Canyon 1085 obs, Ash Canyon 1132 obs), the fan is essentially decorative — users cycle through pill → smaller pill → mosaic → 8-leaf fan over multiple click-and-zoom cycles before reaching individual silhouettes.
+
+### Measured data shape (informs sizing)
+
+From `https://api.bird-maps.com/api/observations` on 2026-05-14 (18,086 AZ observations, clustered with production config):
+
+| Zoom band | p50 species/cluster | p90 | p95 | p99 | Max |
+|---|---|---|---|---|---|
+| 8–10 (state view) | 4 | 34 | 58 | 112 | 168 |
+| 11–13 (county view) | 2 | 15 | 23 | 53 | 112 |
+| 14–16 (hotspot detail) | 2 | 12 | 18 | 40 | 88 |
+
+Cumulative grid coverage (% of clusters whose species fit, no overflow):
+
+| Grid size | z 8–10 | z 11–13 | z 14–16 |
+|---|---|---|---|
+| 2×2 (today) | 50.4% | 68.5% | 74.8% |
+| 3×3 | 67.0% | 83.5% | 87.4% |
+| 4×3 | 72.0% | 87.9% | 91.3% |
+| 4×4 | 77.4% | 92.1% | 94.4% |
+| 6×6 | ~91% | ~98% | ~99% |
+
+Top-10 worst clusters in AZ are well-known hotspots (Portal/Chiricahuas, Ash Canyon, Paton Center, Sweetwater Wetlands, Madera Canyon, etc.) with 100–168 species each.
+
+**Implication:** no grid size retires overflow at state view. Spidering can be retired at z ≥ 11 with a 4×4 grid (92%+ coverage); state-view long-tail clusters need a pill fallback regardless.
+
+## 2. Goals · Non-goals
+
+**Goals**
+
+1. One marker component handles every cluster, at every zoom level, with no UX mode switch.
+2. Each cell carries the observation count for that family in the cluster.
+3. Per-cell coverage scales with the cluster's unique-family count (1×1 → 4×4 grid · then pill fallback).
+4. Auto-spider disappears entirely. Coincident-point disambiguation comes from the cluster grid never decomposing.
+5. No measurable regression at the bird-maps.com data volume on canonical viewports (390×844, 768×1024, 1024×768, 1440×900, 1920×1080).
+
+**Non-goals**
+
+- Per-cell tap targets. The whole marker is one tap target.
+- API changes. Per-family counts already derivable client-side from `getClusterLeaves` + `aggregateClusterFamilies`.
+- Changes to the observation panel, the FeedSurface, or any non-marker map UI.
+- Changes to the basemap, attribution layout, or floating "Bird families in view" component.
+
+## 3. Decision: Approach A — Grid Everywhere
+
+The brainstorm considered three approaches. **Approach A** was chosen because it is the only approach where "retire spidering, let the grid handle disambiguation" is literally true at every zoom level.
+
+| Approach | Coincident points at z ≥ 14 | Auto-spider | Trade-off |
+|---|---|---|---|
+| **A · Grid Everywhere (chosen)** | Cluster into a 2×1 or larger grid (clusterMaxZoom=22) | Deleted entirely | One marker model end-to-end; perf cost addressed in §10 |
+| B · Two-tier, accept stack regression | Stack pixel-perfectly | Deleted | Reintroduces the problem auto-spider solved |
+| C · Two-tier + stack-badge popover | Single marker with "×N" badge + tap-to-list popover | Replaced with popover | Three marker types; new UI component; contradicts the grid-as-disambiguator principle |
+
+## 4. Design
+
+### 4.1 Adaptive grid shape
+
+`pickGridShape(uniqueFamilies, pointCount) → GridShape` returns a discriminated union:
+
+```ts
+type GridShape =
+  | { tag: 'grid'; cols: number; rows: number; capacity: number }
+  | { tag: 'pill' };
+```
+
+Rules (desktop · viewport > 480px):
+
+| Unique families | Shape | Footprint |
+|---|---|---|
+| 1 | 1×1 | 28×28 |
+| 2 | 2×1 | 52×28 |
+| 3–4 | 2×2 | 52×52 |
+| 5–9 | 3×3 | 78×78 |
+| 10–16 | 4×4 | 104×104 |
+
+**Pill fallback** when `uniqueFamilies > 16 OR point_count > 64`. The observation-count cap exists because raising `clusterMaxZoom` to 22 produces dense low-zoom clusters whose DOM cost as 4×4 grids regresses against today's lightweight pills (see §10 Gate 2). The Tucson 1640-obs cluster stays a pill at z = 8; as the user zooms in, smaller fragments emerge with `point_count ≤ 64` and `uniqueFamilies ≤ 16` and become grids.
+
+**Mobile cap** at viewport ≤ 480px: the 4×4 case collapses to 3×3 with the top-8 silhouettes plus an inline "+N more" cell. Prevents adjacent 104×104 markers from overlapping on 390-wide viewports.
+
+### 4.2 Family ordering
+
+Existing logic in `aggregateClusterFamilies` (`cluster-mosaic.ts:80-95`) is correct: descending by observation count, alphabetical tiebreak on `familyCode`. The new `adaptive-grid.ts` re-exports it.
+
+### 4.3 Per-cell observation-count badge
+
+- Visual: bottom-right of each cell, 14px tall pill, `#1a1a1a` background, white tabular digits.
+- **Box-shadow stroke** `0 0 0 1px rgba(255,255,255,0.9)` for guaranteed 3:1 contrast against any basemap tile underneath. Resolves the WCAG 1.4.11 contrast concern that today's `#ffffffd9` tile alpha cannot guarantee against varied terrain.
+- **Hidden when `cell.count === 1`.** A 1×1 grid with count=1 looks visually identical to today's individual observation marker. Default to silence; only show count when count > 1.
+- Counts are integers, no thousand-separators (cells max out at three digits in practice — the largest cell would be the Tucson cluster's dominant family at ≈800 obs of one family).
+
+### 4.4 Hit-extender overlay
+
+Marker visual geometry (28 / 52 / 78 / 104) is independent of the hit zone. A transparent overlay element wraps each marker:
+
+- `pointer:fine` → 44×44 min (WCAG 2.5.5 AAA target size, matching existing `MapMarkerHitLayer.tsx:53` `HIT_SIZE_DESKTOP=40` — proposed raised to 44 to clear AAA).
+- `pointer:coarse` → 48×48 min (matches existing `HIT_SIZE_COARSE=48`).
+- Positioned via `inset: max(0, (44 - markerSize) / -2)` so a 4×4 (104×104) marker's hit zone is its own bounding box (no shrinkage).
+- The overlay is the `<button>`; the visual marker is its child. ARIA attributes live on the overlay.
+
+### 4.5 Tap behavior — parent routes the click
+
+The marker is a **pure display component**. `MapCanvas.tsx` selects the click handler before rendering:
+
+```ts
+const onClick = isSingleLeaf(clusterId)
+  ? () => openObsPanel(subId)
+  : () => zoomToExpansion(clusterId);
+
+<AdaptiveGridMarker shape={shape} tiles={tiles} onClick={onClick} … />
+```
+
+The marker never inspects its own data shape to choose between two parent-domain actions. `isSingleLeaf(clusterId)` is a one-liner helper in `MapCanvas.tsx` that returns `true` iff the supercluster feature reports `point_count === 1`. The behavior collapses to "tapping a single-observation marker opens its obs panel directly" — identical to today's individual-marker UX, no regression.
+
+### 4.6 Two-tier ARIA disclosure
+
+Concise label (always announced) plus a visually-hidden enumeration. Pattern:
+
+| Marker state | `aria-label` | `aria-describedby` target |
+|---|---|---|
+| 1×1, count=1 | `"Single observation: Cooper's Hawk."` | none |
+| 1×1, count=2 (coincident) | `"2 coincident observations: Cooper's Hawk and Sharp-shinned Hawk. Activate to zoom in."` | none |
+| Grid (any size) | `"Cluster: 47 observations, 11 families. Activate to zoom in."` | `#marker-${clusterId}-families` |
+| Pill | `"Cluster: 1640 observations, 47 families. Activate to zoom in."` | `#marker-${clusterId}-families` |
+
+The describedby target is a `<ul class="visually-hidden">` rendered inside the button. Up to 8 list items; if the cluster has more, the 9th item reads `"and N more families"`. This caps the label at scannable length while preserving information-equivalence with sighted users (per WCAG 1.3.1).
+
+The count=2 coincident case explicitly names both species — recovering disambiguation that auto-spider previously gave SR users via separate fanned buttons.
+
+### 4.7 Inherited tab-order contract
+
+The hit layer is **intentionally NOT in the global Tab order** (`tabIndex={-1}`), per the existing comment at `MapMarkerHitLayer.tsx:14-17`. A skip-link in `MapSurface` routes Tab traffic to the `FeedSurface` list landmark, which is the proper keyboard-navigable surface for a 7,000+ marker view.
+
+The redesign inherits this. **The spec re-states this explicitly** because a future implementer could reasonably assume `tabIndex={0}` for buttons and break the existing contract.
+
+### 4.8 Marker remount keying
+
+`AdaptiveGridMarker` is keyed by `cluster_id` (supercluster's stable ID). Supercluster issues different IDs at different zoom levels, so zoom transitions naturally remount markers. This is the existing `MosaicMarker` contract and is preserved.
+
+## 5. Component API
+
+### 5.1 `AdaptiveGridMarker.tsx`
+
+```ts
+interface AdaptiveGridMarkerProps {
+  shape: GridShape;             // already resolved by parent — never 'pill' here
+  tiles: AdaptiveTile[];        // capacity-sized, sorted by aggregateClusterFamilies
+  totalCount: number;           // point_count
+  uniqueFamilies: number;       // for aria-label
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  isCoarsePointer?: boolean;    // wired via useMediaQuery('(pointer: coarse)')
+  isMobileViewport?: boolean;   // for the 3×3 cap at ≤480px
+}
+
+interface AdaptiveTile {
+  familyCode: string;
+  silhouetteSrc: string | null;  // null → fallback shape (existing pattern)
+  color: string;
+  count: number;
+}
+```
+
+The marker takes a resolved `shape` — it does not call `pickGridShape` internally. Pill fallback is selected by the parent and renders `<ClusterPill>` directly.
+
+### 5.2 `adaptive-grid.ts`
+
+```ts
+export function pickGridShape(
+  uniqueFamilies: number,
+  pointCount: number,
+  isMobileViewport: boolean
+): GridShape
+
+export function buildAdaptiveTiles(
+  leaves: ObservationFeature[],
+  capacity: number
+): AdaptiveTile[]
+
+// moved unchanged from cluster-mosaic.ts:80-95
+export function aggregateClusterFamilies(
+  leaves: ObservationFeature[]
+): FamilyAggregate[]
+```
+
+### 5.3 Memoization
+
+`MapCanvas.tsx:704-722` runs the cluster-leaves + family-aggregation chain on every map `idle` (registered at `MapCanvas.tsx:742`). Today this is bounded by `CLUSTER_MOSAIC_MAX_POINTS=8`; the redesign removes that ceiling, so worst-case is 1640 leaves iterated per marker per idle for the Tucson hotspot.
+
+**Mitigation**: a `useRef`-backed cache in `MapCanvas.tsx` keyed on the tuple `(cluster_id, point_count)`. Cache survives pan; busts only when supercluster reports a different cluster id or a different point count. The aggregate result is small (≤ 16 tiles) and pure-function in its inputs — memoization is correct.
+
+This is a **functional requirement of the redesign**, not a nice-to-have. The plan body asserts a `performance.mark` p99 bound (§10 Gate 1) that depends on this cache.
+
+## 6. File map
+
+### New (5)
+
+| File | Purpose |
+|---|---|
+| `frontend/src/components/map/AdaptiveGridMarker.tsx` | Pure display component for 1×1 through 4×4 grids |
+| `frontend/src/components/map/AdaptiveGridMarker.test.tsx` | Render assertions: per-cell badge, badge-hidden-at-1, sizing, mobile cap |
+| `frontend/src/components/map/adaptive-grid.ts` | `pickGridShape`, `buildAdaptiveTiles`, re-export `aggregateClusterFamilies` |
+| `frontend/src/components/map/adaptive-grid.test.ts` | Shape-picker rules, tile-builder edges |
+| `frontend/e2e/map-adaptive-grid.spec.ts` | E2E for grid render, pill fallback, zoom progression |
+
+### Deleted (8)
+
+| File | Reason |
+|---|---|
+| `frontend/src/components/map/MosaicMarker.tsx` | Superseded by `AdaptiveGridMarker` |
+| `frontend/src/components/map/MosaicMarker.test.tsx` | Replaced |
+| `frontend/src/components/map/cluster-mosaic.ts` | Constants and `aggregateClusterFamilies` moved into `adaptive-grid.ts` |
+| `frontend/src/components/map/cluster-mosaic.test.ts` | Replaced |
+| `frontend/src/components/map/use-auto-spider.ts` | Auto-spider deleted |
+| `frontend/src/components/map/use-auto-spider.test.ts` | |
+| `frontend/src/components/map/stack-fanout.ts` | |
+| `frontend/src/components/map/stack-fanout.test.ts` | |
+| `frontend/src/components/map/fan-layout.ts` | |
+| `frontend/src/components/map/fan-layout.test.ts` | |
+| `frontend/e2e/map-stack-fanout.spec.ts` | |
+
+(Net: 5 new, 11 deleted — the "8" cited in the brainstorm collapsed `.ts` + `.test.ts` pairs.)
+
+### Modified (3)
+
+| File | Changes |
+|---|---|
+| `frontend/src/components/map/MapCanvas.tsx` | Raise `clusterMaxZoom` 14 → 22 (1016-1023). Remove auto-spider block (1073-1100). Swap `<MosaicMarker>` for `<AdaptiveGridMarker>`. Raise `getClusterLeaves` limit (706) from `CLUSTER_MOSAIC_MAX_POINTS` to `point_count`. Add `(cluster_id, point_count)`-keyed memo cache. Audit effect-deps array around line 760 (currently re-registers only on `silhouettes.length`/`mapReady`). |
+| `frontend/src/components/map/observation-layers.ts` | Drop `CLUSTER_MOSAIC_MAX_POINTS = 8` (163). Bump `CLUSTER_MAX_ZOOM` 14 → 22 (152). Remove `inStack` plumbing (42-61, 121-126, 278, 336). |
+| `frontend/e2e/axe.spec.ts` | Extend `:55` aria-label assertion to cover grid marker labels and the visually-hidden `<ul>` describedby target. |
+
+### Kept
+
+| File | Why |
+|---|---|
+| `frontend/src/components/ds/ClusterPill.tsx` + `.test.tsx` | Used by parent for pill fallback (>16 families OR >64 obs). Existing tier visuals (sky/sand/ember) unchanged. |
+| `frontend/src/components/map/MapMarkerHitLayer.tsx` | Pattern reused for the hit-extender overlay |
+| `frontend/e2e/ds-primitives.spec.ts` | ClusterPill tier preview tests unchanged |
+
+## 7. Test strategy
+
+### Unit (`adaptive-grid.test.ts`)
+
+- `pickGridShape(1, 1, false) → {tag:'grid', cols:1, rows:1, capacity:1}`
+- `pickGridShape(2, …) → 2×1`; `pickGridShape(3, …) → 2×2`; `pickGridShape(4, …) → 2×2`
+- `pickGridShape(5..9, …) → 3×3`; `pickGridShape(10..16, …) → 4×4`
+- `pickGridShape(17, 17, false) → {tag:'pill'}`
+- `pickGridShape(5, 65, false) → {tag:'pill'}` (observation-count cap fires)
+- Mobile cap: `pickGridShape(12, 12, true) → 3×3, capacity 8 + overflow`
+- `buildAdaptiveTiles(200 leaves with 20 unique families, capacity=16) → 16 tiles, descending count`
+
+### Component (`AdaptiveGridMarker.test.tsx`)
+
+- Renders 1×1 with NO badge when `totalCount === 1`
+- Renders 1×1 with badge "5" when `totalCount === 5` (single-family cluster)
+- Renders 2×2 with 4 per-cell badges in descending count order
+- Renders fallback tile (opacity 0.5) when `silhouetteSrc === null` — existing behavior preserved
+- aria-label matches the patterns in §4.6
+- aria-describedby target exists for grids and pills, has at most 9 list items (8 families + "and N more")
+- Hit-extender overlay element has `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
+
+### E2E (`map-adaptive-grid.spec.ts`)
+
+- AZ overview at z=8: at least one pill visible (Tucson hotspot)
+- Zoom to z=12: at least one 4×4 grid visible
+- Zoom to z=16: at least one 2×1 or 1×1 grid visible
+- Pinch-zoom z=8 → z=15: no `auto-spider-leader-lines-layer` in rendered layer list
+- No DOM `[data-fallback="true"]` in a count=1 1×1 (single-observation shouldn't be a fallback)
+- Axe assertions on aria-describedby contents
+
+## 8. Inherited and preserved behavior
+
+The redesign deliberately preserves several pieces of today's UX that the surface area might otherwise sweep up:
+
+- Fallback silhouettes (opacity 0.5) for families without Phylopic art
+- ClusterPill tier visuals (`sky`/`sand`/`ember`)
+- Map skip-link routing keyboard Tab traffic to FeedSurface
+- Hit-layer `tabIndex={-1}` contract
+- MutationObserver on `[data-theme]` for basemap style change
+- Light + dark theme parity
+
+## 9. Risks and open questions
+
+### Resolved during brainstorm
+
+| Risk | Resolution |
+|---|---|
+| Per-cell tap targets create AC surface explosion | Whole marker is one tap target |
+| Null-return sentinel from `pickGridShape` | Use discriminated union `{tag:'grid'} | {tag:'pill'}` |
+| Tap-routing logic in display component | Parent (MapCanvas) routes; marker stays pure |
+| WCAG 2.5.5 at 28×28 | Hit-extender overlay at 44/48 |
+| Badge contrast in dark mode | 1px white box-shadow stroke |
+| 16-cell aria-label too long | Two-tier disclosure with visually-hidden `<ul>` (max 8 items + "N more") |
+| SR disambiguation loss from spider deletion | Coincident-pairs get rich label naming both species |
+| Mobile grid overlap | 3×3 cap at ≤480px |
+
+### Open — deferred to plan body
+
+| Risk | Where it gets answered |
+|---|---|
+| `clusterMaxZoom=22` perf cost (supercluster init, DOM marker count) | Prototype phase, §10 Gate 1 and Gate 2 |
+| Effect-deps audit at `MapCanvas.tsx:760` | Plan body implementation task |
+| Supercluster's 1-point-cluster edge case (does it emit `point_count=1` clusters or fall back to raw points at max zoom?) | Prototype phase, documented learning |
+
+### Tier-2 refactors
+
+These are not blockers for shipping but should land in or near this work:
+
+- Add a `useMediaQuery('(pointer: coarse)')` hook if one doesn't exist (the hit-layer already needs it)
+- Add a `useMediaQuery('(max-width: 480px)')` hook for the mobile 3×3 cap
+
+## 10. Prototype-phase gates
+
+Per `CLAUDE.md`'s Prototype Gate convention, the plan body cannot be authored until all four gates pass on a working prototype.
+
+### Gate 1 · Reconcile time (perf)
+
+Instrument `performance.mark` brackets around the `mosaics` state update in `MapCanvas.tsx:716` and `performance.measure` between them.
+
+- **Pass**: p99 measure duration < 16ms (one frame budget) at 390×844 with ≥ 344 canned rows during a pinch-zoom from z=8 → z=15.
+- **Fail**: reduce `clusterMaxZoom` cap, or tighten the observation-count pill threshold below 64.
+
+### Gate 2 · DOM-marker ceiling (perf, NEW)
+
+`observation-layers.ts:163` carries an explicit comment that "HTML markers don't scale beyond ~5k visible (DOM perf)."
+
+- **Pass**: ≤ 2,500 visible markers at each canonical viewport (5 viewports × 2 themes = 10 captures). 50% safety margin against the documented ceiling.
+- **Fail**: tighten observation-count or unique-family thresholds, or re-evaluate `clusterMaxZoom` cap.
+
+### Gate 3 · Hit-target size (a11y)
+
+- **Pass**: `getBoundingClientRect()` of every `[data-testid=adaptive-grid-marker]`'s overlay element is ≥ 44×44 on `pointer:fine` and ≥ 48×48 on `pointer:coarse`, asserted in e2e.
+- **Fail**: hit-extender CSS is wrong; fix and re-measure.
+
+### Gate 4 · Console hygiene (CLAUDE.md)
+
+- **Pass**: 0 errors and 0 warnings via `browser_console_messages` at every canonical viewport, during pan and pinch-zoom, light and dark themes.
+- **Fail**: dirty console is a Tier-1 reviewer finding regardless of cause.
+
+## 11. Sequencing
+
+After all four gates pass on the prototype:
+
+1. The plan body (`docs/plans/<date>-adaptive-cluster-grid.md`) is authored via `superpowers:writing-plans`.
+2. The plan is decomposed into independent PRs at the right level of CI gate granularity (per `feedback_plan_ci_coupling`). Likely structure: PR1 adds `adaptive-grid.ts` + `AdaptiveGridMarker.tsx` behind a feature flag; PR2 wires the parent and deletes auto-spider; PR3 deletes legacy mosaic files; PR4 documentation + spec linkbacks.
+3. Each PR follows the project's PR workflow (`pr-workflow` skill) and passes the canonical 5-viewport × 2-theme screenshot capture (`pr-screenshots-via-user-attachments`).
+4. Bot review via `julianken-bot` subagent before queueing.
+
+## 12. References
+
+- Investigation findings (live visual, code, density): conducted 2026-05-14, summarized in the brainstorming session that produced this spec
+- Three specialist critique passes (React, perf, a11y): all returned REVISE; findings folded in
+- Validation pass (cross-tier React specialist): confirmed 7/9 findings, identified 1 overstatement (P3) and 1 missing blocker (P4 — 5k DOM ceiling, now Gate 2)
+- Existing visual companion mockups: `.superpowers/brainstorm/9350-1778805841/content/` (gitignored)
+- Related prior plan: `docs/plans/2026-04-26-spider-v2/` (the deletion of click-driven spidering #280)
+- Architecture spec: `docs/specs/2026-04-16-bird-watch-design.md` §Frontend
+- Token mapping (relevant to badge/tile colors): `docs/specs/2026-05-09-v3-token-mapping.md`

--- a/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
+++ b/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
@@ -310,6 +310,7 @@ Shape-picker rules (each test name pins one rule):
 Tile-builder rules:
 
 - `buildAdaptiveTiles(200 leaves, 20 unique families, capacity=16) → 16 tiles, descending count`
+- **`toPositiveInt` invariant**: `toPositiveInt(1) → 1 (typed)`, `toPositiveInt(0)` throws, `toPositiveInt(-1)` throws, `toPositiveInt(1.5)` throws (constructor enforces positive *integer* domain)
 - **Null-familyCode dropout** (LEFT JOIN miss per `Observation` contract): leaves with `familyCode === null` are silently dropped — copied verbatim from `cluster-mosaic.test.ts` so the invariant is preserved
 - **Under-capacity** when fewer families than capacity: `buildAdaptiveTiles(5 leaves, 2 families, capacity=4) → 2 tiles` (not 4 — caller pads visually)
 - **Fallback by null `svgData`**: leaves whose resolved silhouette `svgData === null` produce tiles with `kind === 'fallback'` — preserved from prior `cluster-mosaic.test.ts`
@@ -324,6 +325,7 @@ Memoization (Concerns A, B, C from §5.3):
 - **Catalogue invalidation**: when `silhouettes.length` changes (catalogue load / refresh), the module-scoped `Map` is wholesale-cleared and `useMemo` recomputes (silhouettesVersion delta busts the key)
 - **Upstream silhouette resolution**: `buildAdaptiveTiles(leaves, silhouettesById, shape)` is pure — it does NOT read from any ref. A regression test asserts that calling it with two different `silhouettesById` arguments returns differently-resolved tiles, even with identical `leaves`
 - **Rejected-Promise eviction**: `getClusterLeaves` rejection on a cache key removes the entry in the same microtask. A retry on the same key re-invokes the underlying call (does NOT return the rejected Promise). Test name: `"Concern B cache: rejected getClusterLeaves promise is evicted, retry invokes the underlying call"`
+- **Rejection log channel**: a single `console.warn` per `${zoom}:${cluster_id}` per session (rate-limited via a `Set<string>` of warned keys) — matches the existing `MapCanvas.tsx:187` pattern. Tests assert exactly one warning emitted for repeated rejections on the same key
 - **Race-safe commit**: the `cacheGeneration` counter increments on every effect re-registration; an in-flight reconcile captures its generation at entry and no-ops `setMosaics` if the generation has advanced. Test name: `"reconcile does not commit tiles when cacheGeneration advanced mid-flight"`
 - **`silhouettesVersion` invalidates on in-place replacement**: two catalogue snapshots with identical `length` but different `svgData` for the same `familyCode` bust the useMemo key. Test name: `"silhouettesVersion bump invalidates memo even when silhouettes.length is unchanged"`
 

--- a/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
+++ b/docs/specs/2026-05-14-adaptive-cluster-grid-design.md
@@ -80,26 +80,36 @@ The brainstorm considered three approaches. **Approach A** was chosen because it
 `pickGridShape(uniqueFamilies, pointCount) → GridShape` returns a discriminated union:
 
 ```ts
+type Dim = 1 | 2 | 3 | 4;
+
 type GridShape =
-  | { tag: 'grid'; cols: number; rows: number; capacity: number; overflow: number }
+  | { tag: 'grid'; cols: Dim; rows: Dim }                      // visibleCapacity = cols*rows
+  | { tag: 'grid-overflow'; cols: Dim; rows: Dim; hiddenCount: number }   // visibleCapacity = cols*rows - 1 (reserved for "+N")
   | { tag: 'pill' };
+
+type ResolvedGrid = Exclude<GridShape, { tag: 'pill' }>;       // what AdaptiveGridMarker receives
+
+// Helper, not a stored field — derived deterministically:
+declare function visibleCapacity(shape: ResolvedGrid): number;
+// grid       → cols * rows
+// grid-overflow → cols * rows - 1
 ```
 
-`overflow` is the count of families hidden beyond `capacity` (≥ 0). When `overflow > 0`, the renderer reserves the last cell as an inline "+N more" indicator (see mobile cap below).
+The separate `grid-overflow` tag is deliberate: the previous `{ tag:'grid'; capacity; overflow }` shape made it constructible to express nonsense (`overflow > 0` with `capacity === cols*rows`, or `capacity` inconsistent with `cols*rows`). The discriminated union makes "overflow reserves a cell" representable only via the dedicated tag. `Dim` typing prevents arbitrary integers in dimension fields.
 
 Rules (desktop · viewport > 480px):
 
-| Unique families | Shape | Capacity | Overflow |
-|---|---|---|---|
-| 1 | 1×1 | 1 | 0 |
-| 2 | 2×1 | 2 | 0 |
-| 3–4 | 2×2 | 4 | 0 |
-| 5–9 | 3×3 | 9 | 0 |
-| 10–16 | 4×4 | 16 | 0 |
+| Unique families | Shape | Visible capacity |
+|---|---|---|
+| 1 | `{tag:'grid', cols:1, rows:1}` | 1 |
+| 2 | `{tag:'grid', cols:2, rows:1}` | 2 |
+| 3–4 | `{tag:'grid', cols:2, rows:2}` | 4 |
+| 5–9 | `{tag:'grid', cols:3, rows:3}` | 9 |
+| 10–16 | `{tag:'grid', cols:4, rows:4}` | 16 |
 
 **Pill fallback** when `uniqueFamilies > 16 OR point_count > 64`. The observation-count cap exists because raising `clusterMaxZoom` to 22 produces dense low-zoom clusters whose DOM cost as 4×4 grids regresses against today's lightweight pills (see §10 Gate 2). The Tucson 1640-obs cluster stays a pill at z = 8; as the user zooms in, smaller fragments emerge with `point_count ≤ 64` and `uniqueFamilies ≤ 16` and become grids.
 
-**Mobile cap** at viewport ≤ 480px: the 4×4 case collapses to 3×3 with the top-8 silhouettes plus an inline "+N more" cell driven by `overflow > 0`. Concretely, `pickGridShape(12, /*pointCount*/ 12, /*isMobile*/ true) → {tag:'grid', cols:3, rows:3, capacity:8, overflow:4}`. Prevents adjacent 104×104 markers from overlapping on 390-wide viewports.
+**Mobile cap** at viewport ≤ 480px: the 4×4 case collapses to `{tag:'grid-overflow', cols:3, rows:3, hiddenCount: uniqueFamilies - 8}`. Concretely, `pickGridShape(12, /*pointCount*/ 12, /*isMobile*/ true) → {tag:'grid-overflow', cols:3, rows:3, hiddenCount: 4}`. Visible capacity is 8 (the 9th cell is the "+N more" indicator). Prevents adjacent 104×104 markers from overlapping on 390-wide viewports.
 
 ### 4.2 Family ordering
 
@@ -166,24 +176,25 @@ The redesign inherits this. **The spec re-states this explicitly** because a fut
 
 ```ts
 interface AdaptiveGridMarkerProps {
-  shape: GridShape;             // already resolved by parent — never 'pill' here
-  tiles: AdaptiveTile[];        // capacity-sized, sorted by aggregateClusterFamilies
-  totalCount: number;           // point_count
-  uniqueFamilies: number;       // for aria-label
+  shape: ResolvedGrid;                // narrowed by parent — pill rendered separately
+  tiles: ReadonlyArray<AdaptiveTile>;  // length ≤ visibleCapacity(shape), sorted by aggregateClusterFamilies
+  totalCount: number;                  // point_count
+  uniqueFamilies: number;              // for aria-label
   onClick: (e: MouseEvent<HTMLButtonElement>) => void;
-  isCoarsePointer?: boolean;    // wired via useMediaQuery('(pointer: coarse)')
-  isMobileViewport?: boolean;   // for the 3×3 cap at ≤480px
+  isCoarsePointer?: boolean;           // wired via useMediaQuery('(pointer: coarse)')
 }
 
-interface AdaptiveTile {
-  familyCode: string;
-  silhouetteSrc: string | null;  // null → fallback shape (existing pattern)
-  color: string;
-  count: number;
-}
+// Discriminated union — matches existing MosaicTile precedent at cluster-mosaic.ts:42-58.
+// Keeps the field name `svgData` (consistent with FamilySilhouette.svgData in shared-types/index.ts);
+// no surprise rename. Fallback variant carries only the fields actually rendered.
+type AdaptiveTile =
+  | { kind: 'rendered'; familyCode: string; svgData: string; color: string; count: number }
+  | { kind: 'fallback'; familyCode: string; color: string; count: number };
 ```
 
-The marker takes a resolved `shape` — it does not call `pickGridShape` internally. Pill fallback is selected by the parent and renders `<ClusterPill>` directly.
+The marker takes a `ResolvedGrid` (pill is unreachable at the type level — `Exclude<GridShape, { tag: 'pill' }>`). The parent renders `<ClusterPill>` directly for `shape.tag === 'pill'`. `isMobileViewport` is no longer threaded — the mobile cap is already encoded in `shape.tag === 'grid-overflow'`.
+
+`tiles.length` may be less than `visibleCapacity(shape)` when fewer families are present than the grid can hold. Empty slots render as transparent padders in the marker (existing behavior, preserved). When `shape.tag === 'grid-overflow'`, the last visible slot is always the "+N more" indicator using `shape.hiddenCount` — never a tile.
 
 ### 5.2 `adaptive-grid.ts`
 
@@ -209,13 +220,21 @@ export function aggregateClusterFamilies(
 
 `MapCanvas.tsx:704-722` runs the cluster-leaves + family-aggregation chain on every map `idle` (registered at `MapCanvas.tsx:742`). Today this is bounded by `CLUSTER_MOSAIC_MAX_POINTS=8`; the redesign removes that ceiling, so worst-case is 1640 leaves iterated per marker per idle for the Tucson hotspot.
 
-There are **two separable caching concerns** the implementation must address — conflated in earlier brainstorming, separated here:
+There are **three separable caching concerns** the implementation must address:
 
-**Concern A — Render-pass stability.** The derived `tiles: AdaptiveTile[]` array passed to `<AdaptiveGridMarker>` should not be a new identity on every render when the inputs haven't changed, or React.memo on the marker is defeated. Solution: `useMemo` keyed on `[cluster_id, point_count]` at the parent. Garbage-collected when the cluster leaves the viewport. Idiomatic React.
+**Concern A — Render-pass stability.** The derived `tiles: ReadonlyArray<AdaptiveTile>` passed to `<AdaptiveGridMarker>` should not be a new identity on every render when the inputs haven't changed, or `React.memo` on the marker is defeated. Solution: `useMemo` at the parent keyed on `[zoom, cluster_id, point_count, silhouettesVersion]` (see Concern C for the version token). Garbage-collected by React when the cluster leaves the viewport. Idiomatic React.
 
-**Concern B — Async-call avoidance across idle ticks.** `getClusterLeaves` is an async supercluster call. Running it for every visible cluster on every `idle` event is the actual perf hot path. This caching layer lives *outside* React render — a module-scoped `Map<string, Promise<AdaptiveTile[]>>` keyed on `${cluster_id}:${point_count}` in `MapCanvas.tsx`. Evicted when the corresponding cluster_id leaves the current viewport's feature set (computed once per idle).
+**Concern B — Async-call avoidance across idle ticks.** `getClusterLeaves` is an async supercluster call. Running it for every visible cluster on every `idle` event is the actual perf hot path. This caching layer lives *outside* React render — a module-scoped `Map<string, Promise<AdaptiveTile[]>>` in `MapCanvas.tsx` keyed on **`${zoom}:${cluster_id}:${point_count}`**. The zoom prefix is load-bearing: supercluster's integer `cluster_id` values can collide across zoom levels, and without it the cache will silently return a stale tile array from a different zoom's leaf set. Eviction: at the end of each `idle` handler, drop entries whose `zoom:cluster_id` is not present in the current viewport's feature set.
 
-Both layers are **functional requirements** — the §10 Gate 1 p99 bound depends on hitting Concern B's cache for unchanged clusters and skipping the leaf iteration entirely. The plan body's first task is to write the failing perf assertion, then add the cache to make it pass.
+**Concern C — Catalogue rebuild invalidation.** Supercluster's index is rebuilt when `silhouettes.length` changes (this is the existing effect-deps trigger at `MapCanvas.tsx:760`). After a rebuild, spatially equivalent clusters can be assigned different `cluster_id` values, and downstream `aggregateClusterFamilies` may resolve different `svgData` for the same family if the catalogue rows changed. The implementation must:
+
+1. Wholesale-clear the Concern B `Map` whenever the effect re-registers (i.e., on `silhouettes.length` change). One line at the top of the effect body.
+2. Include a `silhouettesVersion` token (`silhouettes.length` is sufficient as a coarse proxy — increments on catalogue load) in the Concern A `useMemo` key. This is the third dependency named above.
+3. Resolve silhouette `svgData` for each family **upstream** of `buildAdaptiveTiles` rather than reading `silhouettesRef.current` inside the tile-builder. Today's `buildMosaicTiles` does the wrong thing at `MapCanvas.tsx:714` — reading from a ref bypasses every memo key. Move silhouette resolution to a pure transformation: `(leaves, silhouettesById) → tiles`. Tests pass `silhouettesById` explicitly.
+
+All three are **functional requirements** — the §10 Gate 1 p99 bound depends on hitting Concern B's cache for unchanged clusters AND on the catalogue not silently invalidating it on every load. The plan body's first task is to write the failing perf assertion, then add the three layers to make it pass.
+
+**Test-only escape hatch.** The module-scoped `Map` of Concern B is not multi-instance safe and survives `afterEach` unless explicitly cleared. Export a `__resetCacheForTesting()` function from `MapCanvas.tsx` (gated by `if (process.env.NODE_ENV === 'test')` to keep it out of prod bundles) and call it in a `beforeEach`. This avoids state leakage between unit tests and avoids the surprise during Vite HMR sessions in dev.
 
 ## 6. File map
 
@@ -229,7 +248,7 @@ Both layers are **functional requirements** — the §10 Gate 1 p99 bound depend
 | `frontend/src/components/map/adaptive-grid.test.ts` | Shape-picker rules, tile-builder edges |
 | `frontend/e2e/map-adaptive-grid.spec.ts` | E2E for grid render, pill fallback, zoom progression |
 
-### Deleted (13)
+### Deleted (14)
 
 | File | Reason |
 |---|---|
@@ -246,6 +265,7 @@ Both layers are **functional requirements** — the §10 Gate 1 p99 bound depend
 | `frontend/src/components/map/fan-layout.ts` | |
 | `frontend/src/components/map/fan-layout.test.ts` | |
 | `frontend/e2e/map-stack-fanout.spec.ts` | |
+| `frontend/e2e/map-cluster-mosaic.spec.ts` | Renamed and rewritten as `map-adaptive-grid.spec.ts`; old spec deleted in same commit |
 
 ### Modified (3)
 
@@ -269,14 +289,17 @@ Both layers are **functional requirements** — the §10 Gate 1 p99 bound depend
 
 Shape-picker rules (each test name pins one rule):
 
-- `pickGridShape(1, 1, false) → {tag:'grid', cols:1, rows:1, capacity:1, overflow:0}`
-- `pickGridShape(2, …)`, `pickGridShape(3, …) → 2×2`, `pickGridShape(4, …) → 2×2` (and 2 → 2×1 explicitly)
+- `pickGridShape(1, 1, false) → {tag:'grid', cols:1, rows:1}`
+- `pickGridShape(2, …) → 2×1`, `pickGridShape(3, …) → 2×2`, `pickGridShape(4, …) → 2×2`
 - `pickGridShape(5..9, …) → 3×3`; `pickGridShape(10..16, …) → 4×4`
 - **Family-cap fires alone**: `pickGridShape(17, 30, false) → {tag:'pill'}` (uniqueFamilies > 16, pointCount well under 64)
 - **Count-cap fires alone**: `pickGridShape(8, 65, false) → {tag:'pill'}` (family rule alone would give 3×3; pointCount > 64 forces pill)
-- **Boundary**: `pickGridShape(8, 64, false) → {tag:'grid', 3×3}` (count = 64 inclusive, no pill)
-- **Boundary**: `pickGridShape(16, 64, false) → {tag:'grid', 4×4, overflow:0}` (max grid)
-- **Mobile cap**: `pickGridShape(12, 12, true) → {tag:'grid', cols:3, rows:3, capacity:8, overflow:4}`
+- **Boundary (count)**: `pickGridShape(8, 64, false) → {tag:'grid', cols:3, rows:3}` (count = 64 inclusive, no pill)
+- **Boundary (family + count co-fire)**: `pickGridShape(16, 65, false) → {tag:'pill'}` (locks count-cap at the family-cap boundary — catches a `>` vs `>=` boundary mutation)
+- **Boundary (max grid)**: `pickGridShape(16, 64, false) → {tag:'grid', cols:4, rows:4}`
+- **Mobile cap**: `pickGridShape(12, 12, true) → {tag:'grid-overflow', cols:3, rows:3, hiddenCount: 4}`
+- **Mobile boundary**: `pickGridShape(8, 8, true) → {tag:'grid', cols:3, rows:3}` (no overflow when families fit)
+- **Mobile boundary**: `pickGridShape(9, 9, true) → {tag:'grid-overflow', cols:3, rows:3, hiddenCount: 1}` (first overflow case)
 
 Tile-builder rules:
 
@@ -285,35 +308,32 @@ Tile-builder rules:
 - **Under-capacity** when fewer families than capacity: `buildAdaptiveTiles(5 leaves, 2 families, capacity=4) → 2 tiles` (not 4 — caller pads visually)
 - **Fallback by null `svgData`**: leaves with `silhouetteSrc === null` produce tiles with `isFallback === true` — preserved from prior `cluster-mosaic.test.ts`
 
-Memoization (Concern A and B from §5.3):
+Memoization (Concerns A, B, C from §5.3):
 
-- `useMemo` reuses tile-array identity when `(cluster_id, point_count)` is unchanged
-- Module-scoped async cache returns the cached `Promise<tiles>` and skips the `getClusterLeaves` call when both keys match
-- Cache invalidates when `point_count` changes for the same `cluster_id`
-- Cache evicts entries whose `cluster_id` is not in the current viewport feature-set
+- `useMemo` reuses tile-array identity when `[zoom, cluster_id, point_count, silhouettesVersion]` is unchanged
+- Module-scoped async cache returns the cached `Promise<tiles>` and skips the `getClusterLeaves` call when all four key components match
+- Cache invalidates when `point_count` changes for the same `cluster_id` at the same `zoom`
+- **Cache uses zoom-prefixed key** — `${zoom}:${cluster_id}:${point_count}` — and a test asserts that the same `cluster_id:point_count` at two different zoom levels produces two independent cache entries (catches collisions silent in an unprefixed key)
+- Cache evicts entries whose `zoom:cluster_id` is not in the current viewport feature-set
+- **Catalogue invalidation**: when `silhouettes.length` changes (catalogue load / refresh), the module-scoped `Map` is wholesale-cleared and `useMemo` recomputes (silhouettesVersion delta busts the key)
+- **Upstream silhouette resolution**: `buildAdaptiveTiles(leaves, silhouettesById)` is pure — it does NOT read from any ref. A regression test asserts that calling it with two different `silhouettesById` arguments returns differently-resolved tiles, even with identical `leaves`
 
 ### Component (`AdaptiveGridMarker.test.tsx`)
 
 - Renders 1×1 with NO badge when `totalCount === 1`
 - Renders 1×1 with badge "5" when `totalCount === 5` (single-family cluster)
 - Renders 2×2 with 4 per-cell badges in descending count order
-- Renders fallback tile (opacity 0.5) when `silhouetteSrc === null` — existing behavior preserved
-- Renders "+N more" cell when `shape.overflow > 0` (mobile 3×3 case)
-- aria-label matches the patterns in §4.6
+- Renders fallback tile (opacity 0.5) for tiles with `kind === 'fallback'` (preserved from `cluster-mosaic` behavior — see §5.1 type)
+- Renders "+N more" cell when `shape.tag === 'grid-overflow'` (mobile 3×3 case)
+- **aria-label single-observation case**: `"Single observation: Cooper's Hawk."` exactly when `totalCount === 1`
+- **aria-label coincident-pair case**: `"2 coincident observations: <comName1> and <comName2>. Activate to zoom in."` exactly when `totalCount === 2` and `cols === 1`
+- **aria-label grid case**: `"Cluster: 47 observations, 11 families. Activate to zoom in."` for any multi-cell grid
+- **aria-label pill case**: identical-format label when `shape.tag === 'pill'`
 - aria-describedby target exists for grids and pills, has at most 9 list items (8 families + "and N more")
 - **Hit-extender overlay element has `tabIndex === -1`** (inherits the §4.7 contract — load-bearing, easy to silently break)
 - Hit-extender overlay element has `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
 - **Dark-mode badge contrast**: with `data-theme="dark"` applied, badge's `getComputedStyle().boxShadow` includes the 1px white stroke specified in §4.3
-
-### Component (`AdaptiveGridMarker.test.tsx`)
-
-- Renders 1×1 with NO badge when `totalCount === 1`
-- Renders 1×1 with badge "5" when `totalCount === 5` (single-family cluster)
-- Renders 2×2 with 4 per-cell badges in descending count order
-- Renders fallback tile (opacity 0.5) when `silhouetteSrc === null` — existing behavior preserved
-- aria-label matches the patterns in §4.6
-- aria-describedby target exists for grids and pills, has at most 9 list items (8 families + "and N more")
-- Hit-extender overlay element has `getBoundingClientRect()` ≥ 44×44 (`pointer:fine`) or ≥ 48×48 (`pointer:coarse`)
+- **Notable indicator preserved (AC8, inherited from `StackedSilhouetteMarker.test.tsx:183-221`)**: a 1×1 grid for an `isNotable: true` leaf renders an amber `<circle>` ring inside the tile SVG; a non-notable leaf does NOT render the circle; the circle's DOM order precedes the halo path (z-order test)
 
 ### E2E (`map-adaptive-grid.spec.ts`)
 
@@ -323,8 +343,9 @@ Memoization (Concern A and B from §5.3):
 - Pinch-zoom z=8 → z=15: no `auto-spider-leader-lines-layer` in rendered layer list; no `inStack`-keyed DOM attributes anywhere on the page
 - No DOM `[data-fallback="true"]` in a count=1 1×1 (single-observation shouldn't be a fallback)
 - Axe assertions on aria-describedby contents
-- **Perf-budget regression assertion (Gate 1 in CI)**: `performance.measure('mosaic-reconcile')` p99 < 16ms during a scripted pinch-zoom z=8 → z=15 at 390×844 with ≥ 344 seeded rows. Fails CI if exceeded — turns Gate 1 from a one-shot prototype check into a continuous regression guard.
-- **DOM-marker-count regression assertion (Gate 2 in CI)**: visible-marker count via `page.locator('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').count()` ≤ 2500 at each canonical viewport. Fails CI if exceeded.
+- **Perf-budget regression assertion (Gate 1)**: wall-clock-based `performance.measure('mosaic-reconcile')` p99 < 16ms during a scripted pinch-zoom z=8 → z=15 at 390×844 with ≥ 344 seeded rows. **Gated by `process.env.CI_PERF_GATE`** and runs in a dedicated `.github/workflows/perf-gate.yml` workflow with a `runs-on: ubuntu-latest-4-cores` runner (or the smallest stable larger runner the project's plan supports). Wall-clock perf budgets on the default 2-vCPU runner are too flaky for the project's `retries: 0` policy.
+- **DOM-marker-count regression assertion (Gate 2 in default CI)**: visible-marker count via `page.locator('[data-testid=adaptive-grid-marker], [data-testid=cluster-pill]').count()` ≤ 2500 at each canonical viewport. Deterministic counter, not wall-clock — safe in the default Mergify-gated `e2e` workflow.
+- **Cache-hit-rate proxy assertion (alternative to wall-clock)**: instrumented counter via a test hook exposes `getClusterLeavesCallCount` per pinch-zoom session; asserts call count ≤ 2× the visible-cluster count over the entire gesture (i.e., cache hits dominate). Deterministic, safe in default CI.
 
 ## 8. Inherited and preserved behavior
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  A[Spec: 2026-05-14-adaptive-cluster-grid-design.md] --> B[Plan: 2026-05-14-adaptive-cluster-grid.md]
  B --> C0[Phase 0: Prototype + 4 gates]
  C0 --> C1[Phase 1 / PR1: scaffold behind VITE_FF_ADAPTIVE_GRID]
  C1 --> C2[Phase 2 / PR2: atomic cutover · delete auto-spider + mosaic]
  C2 --> C3[Phase 3 / PR3: docs linkbacks]
```

## Summary

- Adds the spec for the AdaptiveGridMarker redesign (one component replaces `<MosaicMarker>` + `<ClusterPill>` + auto-spider; raises `clusterMaxZoom` 14→22 so the same component renders at every zoom).
- Adds the implementation plan structured as Phase 0 (prototype gates) → 3 PRs, with epic + 4 child GitHub issues for subagent-driven pickup later.
- Spec survived 4 review rounds (12 specialist dispatches across architect, perf, a11y, type-design, state-mgmt, test-coverage, silent-failure lenses). Final round: 3× GREENLIGHT. No implementation work in this PR.

## Screenshots

N/A — docs-only

## Test plan

- [x] `grep -nE "TBD|TODO|fill in|implement later" docs/plans/2026-05-14-adaptive-cluster-grid.md` returns zero (only the self-review note instructing the reader to run the grep)
- [x] Every spec section §4–§10 maps to a task in the plan (verified in plan's self-review section)
- [x] CSS sub-task included for the only new component (`AdaptiveGridMarker`, Task 1.6)
- [x] Multi-viewport design-review gate included for Phase 2 (5 viewports × 2 themes = 10 screenshots)
- [x] Quantified plan literals manifest covers all 4 phases
- [x] Prototype gates (§10) included as blocking Phase 0 tasks before any Phase 1 work begins

## Risk

Docs-only — zero runtime impact. The plan defers all implementation to subsequent PRs, each individually CI-gated. The biggest hidden risk in the design itself (raising `clusterMaxZoom` 14→22 causing DOM-marker / perf regressions) is gated by Phase 0's four prototype measurements — if any gate fails, the plan stops and the spec gets revisited rather than the plan body advancing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
