### PR TITLE
phase 1: scaffold AdaptiveGridMarker behind VITE_FF_ADAPTIVE_GRID (#541)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ FRONTEND_ORIGINS=https://bird-maps.com,https://www.bird-maps.com
 # is required for console-cleanliness assertions in the e2e suite. Set
 # in Cloudflare Pages production env vars only.
 VITE_POSTHOG_KEY=
+
+# Adaptive cluster grid (epic #539) — flip to true for the new marker; default false until Phase 2 swap
+VITE_FF_ADAPTIVE_GRID=false

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -504,3 +504,115 @@
   line-height: 1.4;
   letter-spacing: 0.01em;
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   <AdaptiveGridMarker>
+   Cluster-grid marker primitives (epic #539, spec §4.3 badge / §4.4 hit-extender).
+   Layout (grid template + gap) and the hit-extender's per-axis top/bottom/left/right
+   come from inline style on the component — these rules cover paint, animation,
+   and the cross-basemap contrast contract for the per-cell count badge.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.adaptive-grid-marker {
+  /* The outer button. Its width/height come from inline style (driven by
+     the shape's cols/rows). Subtle drop shadow matches MosaicMarker so the
+     marker lifts off the basemap fill. */
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
+}
+
+.adaptive-grid-marker__hit {
+  /* Transparent hit-extender overlay. Sized via inline top/bottom/left/right
+     per the corrected per-axis formula from issue #541 — this rule only
+     re-states the always-true contract so the className isn't orphaned. */
+  background: transparent;
+  pointer-events: auto;
+}
+
+.adaptive-grid-marker__grid {
+  /* display: grid + template + gap come from inline style. This rule
+     reserves the className as rule-backed for the orphan-classname check. */
+  position: relative;
+}
+
+.adaptive-grid-marker__cell {
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 3px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+}
+
+.adaptive-grid-marker__cell--pending {
+  /* Shimmer skeleton for the "catalogue not loaded yet" state — distinct
+     from the per-family fallback's opacity 0.5. */
+  background: linear-gradient(
+    110deg,
+    rgba(0, 0, 0, 0.06) 30%,
+    rgba(255, 255, 255, 0.4) 50%,
+    rgba(0, 0, 0, 0.06) 70%
+  );
+  background-size: 200% 100%;
+  animation: adaptive-grid-pending-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes adaptive-grid-pending-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.adaptive-grid-marker__cell--fallback {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.adaptive-grid-marker__badge {
+  /* Per-cell observation-count badge — bottom-right, 14px tall, tabular
+     digits. The 1px white box-shadow is the WCAG 1.4.11 contrast guarantee
+     against any basemap tile underneath (spec §4.3). The inline style on
+     the React node duplicates this for jsdom test environments. */
+  position: absolute;
+  bottom: -3px;
+  right: -3px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+[data-theme='dark'] .adaptive-grid-marker__badge {
+  /* Same dark fill + same white stroke — the stroke remains the contrast
+     guarantee on dark basemaps. */
+  background: #1a1a1a;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.9);
+}
+
+.adaptive-grid-marker__overflow {
+  /* "+N more" indicator — overrides the default cell background with a
+     higher-contrast dark fill so it reads as a distinct affordance rather
+     than another silhouette tile. */
+  background: rgba(0, 0, 0, 0.78);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -1,0 +1,377 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
+import type { AdaptiveTile, ResolvedGrid, PositiveInt } from './adaptive-grid.js';
+import { toPositiveInt } from './adaptive-grid.js';
+
+// Helpers --------------------------------------------------------------------
+
+function rendered(
+  familyCode: string,
+  count: number,
+  svgData = 'M0 0L24 24Z',
+  color = '#C77A2E',
+): AdaptiveTile {
+  return { kind: 'rendered', familyCode, count, svgData, color };
+}
+
+function fallback(familyCode: string, count: number, color = '#888888'): AdaptiveTile {
+  return { kind: 'fallback', familyCode, count, color };
+}
+
+function pending(familyCode: string, count: number): AdaptiveTile {
+  return { kind: 'pending', familyCode, count };
+}
+
+const SHAPE_1x1: ResolvedGrid = { tag: 'grid', cols: 1, rows: 1 };
+const SHAPE_2x1: ResolvedGrid = { tag: 'grid', cols: 2, rows: 1 };
+const SHAPE_2x2: ResolvedGrid = { tag: 'grid', cols: 2, rows: 2 };
+const SHAPE_3x3: ResolvedGrid = { tag: 'grid', cols: 3, rows: 3 };
+const SHAPE_OVERFLOW: ResolvedGrid = {
+  tag: 'grid-overflow',
+  cols: 3,
+  rows: 3,
+  hiddenCount: toPositiveInt(4) as PositiveInt,
+};
+
+const noop = () => {};
+
+describe('AdaptiveGridMarker', () => {
+  // --- Badge visibility -----------------------------------------------------
+
+  it('renders 1×1 with NO badge when totalCount === 1 (single observation, single family)', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 1)]}
+        totalCount={1}
+        uniqueFamilies={1}
+        ariaLabel="Single observation: Cooper's Hawk."
+        onClick={noop}
+      />,
+    );
+    expect(screen.queryByTestId('adaptive-grid-marker-badge')).toBeNull();
+  });
+
+  it('renders 1×1 with badge "5" when totalCount === 5 (single-family cluster)', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 5)]}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations, 1 family. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const badges = screen.getAllByTestId('adaptive-grid-marker-badge');
+    expect(badges).toHaveLength(1);
+    expect(badges[0].textContent).toBe('5');
+  });
+
+  // --- 2×2 grid: 4 per-cell badges in descending count order --------------
+
+  it('renders 2×2 with 4 per-cell badges in descending count order', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[
+          rendered('tyrannidae', 10),
+          rendered('trochilidae', 7),
+          rendered('picidae', 4),
+          rendered('corvidae', 2),
+        ]}
+        totalCount={23}
+        uniqueFamilies={4}
+        ariaLabel="Cluster: 23 observations, 4 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const badges = screen.getAllByTestId('adaptive-grid-marker-badge');
+    expect(badges).toHaveLength(4);
+    expect(badges.map((b) => b.textContent)).toEqual(['10', '7', '4', '2']);
+  });
+
+  // --- Fallback tile opacity -----------------------------------------------
+
+  it('renders fallback tile at opacity 0.5 for tiles with kind === "fallback"', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x1}
+        tiles={[rendered('tyrannidae', 5), fallback('mimidae', 3)]}
+        totalCount={8}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 8 observations, 2 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const fallbackCell = screen.getByTestId('adaptive-grid-marker-cell-fallback');
+    // Inline style or computed opacity — accept either.
+    const opacity = fallbackCell.style.opacity || window.getComputedStyle(fallbackCell).opacity;
+    expect(Number(opacity)).toBeCloseTo(0.5, 2);
+  });
+
+  // --- Pending skeleton -----------------------------------------------------
+
+  it('renders pending skeleton (NOT opacity-0.5 fallback) when ALL tiles kind: "pending"', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[pending('a', 4), pending('b', 3), pending('c', 2), pending('d', 1)]}
+        totalCount={10}
+        uniqueFamilies={4}
+        ariaLabel="Cluster: 10 observations, 4 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const pendingCells = screen.getAllByTestId('adaptive-grid-marker-cell-pending');
+    expect(pendingCells).toHaveLength(4);
+    // No fallback cells should have rendered.
+    expect(screen.queryByTestId('adaptive-grid-marker-cell-fallback')).toBeNull();
+    // None of the pending cells should be marked opacity 0.5 (skeleton ≠ fallback).
+    for (const cell of pendingCells) {
+      const op = cell.style.opacity;
+      expect(op === '' || Number(op) !== 0.5).toBe(true);
+    }
+  });
+
+  // --- "+N more" overflow cell ---------------------------------------------
+
+  it('renders "+N more" cell when shape.tag === "grid-overflow" with the actual hiddenCount', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_OVERFLOW}
+        tiles={Array.from({ length: 8 }, (_, i) => rendered(`fam${i}`, 8 - i))}
+        totalCount={20}
+        uniqueFamilies={12}
+        ariaLabel="Cluster: 20 observations, 12 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const overflow = screen.getByTestId('adaptive-grid-marker-overflow');
+    // Must contain the actual hiddenCount (4 in our fixture).
+    expect(overflow.textContent).toMatch(/\+?4/);
+  });
+
+  // --- aria-label patterns --------------------------------------------------
+
+  it('aria-label single-observation case verbatim', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 1)]}
+        totalCount={1}
+        uniqueFamilies={1}
+        ariaLabel="Single observation: Cooper's Hawk."
+        onClick={noop}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe("Single observation: Cooper's Hawk.");
+  });
+
+  it('aria-label coincident-pair case verbatim', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 2)]}
+        totalCount={2}
+        uniqueFamilies={2}
+        ariaLabel="2 coincident observations: Cooper's Hawk and Sharp-shinned Hawk. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe(
+      "2 coincident observations: Cooper's Hawk and Sharp-shinned Hawk. Activate to zoom in.",
+    );
+  });
+
+  it('aria-label grid case verbatim', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_3x3}
+        tiles={Array.from({ length: 9 }, (_, i) => rendered(`fam${i}`, 9 - i))}
+        totalCount={47}
+        uniqueFamilies={11}
+        ariaLabel="Cluster: 47 observations, 11 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('aria-label')).toBe(
+      'Cluster: 47 observations, 11 families. Activate to zoom in.',
+    );
+  });
+
+  // --- describedby list cap -------------------------------------------------
+
+  it('aria-describedby target has at most 9 list items (8 families + "and N more")', () => {
+    const listId = 'marker-c123-families';
+    const items = [
+      'Tyrannidae: 12',
+      'Trochilidae: 9',
+      'Picidae: 7',
+      'Corvidae: 5',
+      'Mimidae: 4',
+      'Turdidae: 3',
+      'Parulidae: 2',
+      'Cardinalidae: 1',
+      'and 3 more families',
+    ];
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_3x3}
+        tiles={Array.from({ length: 9 }, (_, i) => rendered(`fam${i}`, 9 - i))}
+        totalCount={43}
+        uniqueFamilies={11}
+        ariaLabel="Cluster: 43 observations, 11 families. Activate to zoom in."
+        describedByListId={listId}
+        describedByItems={items}
+        onClick={noop}
+      />,
+    );
+    const ul = document.getElementById(listId);
+    expect(ul).not.toBeNull();
+    const lis = ul!.querySelectorAll('li');
+    expect(lis.length).toBeLessThanOrEqual(9);
+    expect(lis.length).toBe(9);
+  });
+
+  // --- Hit-extender contracts ----------------------------------------------
+
+  it('hit-extender overlay element has tabIndex === -1 (inherits MapMarkerHitLayer contract)', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[
+          rendered('a', 4),
+          rendered('b', 3),
+          rendered('c', 2),
+          rendered('d', 1),
+        ]}
+        totalCount={10}
+        uniqueFamilies={4}
+        ariaLabel="Cluster: 10 observations, 4 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    // The outer <button> IS the click surface and must be tabIndex=-1
+    // (per spec §4.7 — keyboard users navigate via the skip-link to FeedSurface).
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('per-axis hit-extender — 2×1 grid extends BOTH width AND height to ≥ 44', () => {
+    // A 2×1 grid is 52×28 visible (2*22 + 2*3 padding + 2 gap = 52 wide;
+    // 1*22 + 2*3 padding = 28 tall). The corrected per-axis hit-extender
+    // must inflate the HEIGHT to ≥44 even though width already exceeds 44.
+    // This test catches the bug from issue #541: a single-scalar `inset`
+    // using max(w,h) would leave the short axis at 28px.
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x1}
+        tiles={[rendered('a', 5), rendered('b', 3)]}
+        totalCount={8}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 8 observations, 2 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const hit = screen.getByTestId('adaptive-grid-marker-hit');
+    // The hit element uses inline `top/bottom/left/right` to extend outward.
+    // Parse the numeric pixel values (negative inset means extends OUTWARD).
+    const s = hit.style;
+    // negative px values extend the box; assert the resulting bounding extent
+    // (markerSize + |top| + |bottom|) ≥ 44 on both axes.
+    const parsePx = (v: string): number => Number(v.replace('px', '')) || 0;
+    const top = parsePx(s.top);
+    const bottom = parsePx(s.bottom);
+    const left = parsePx(s.left);
+    const right = parsePx(s.right);
+
+    const markerWidth = 2 * 22 + 1 * 2 + 2 * 3; // 52
+    const markerHeight = 1 * 22 + 0 * 2 + 2 * 3; // 28
+    const totalWidth = markerWidth + Math.abs(left) + Math.abs(right);
+    const totalHeight = markerHeight + Math.abs(top) + Math.abs(bottom);
+
+    expect(totalWidth).toBeGreaterThanOrEqual(44);
+    expect(totalHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  // --- Dark-mode badge box-shadow ------------------------------------------
+
+  it('dark-mode badge has 1px white box-shadow stroke (WCAG 1.4.11 contrast)', () => {
+    // Apply data-theme=dark to the documentElement before render.
+    const prior = document.documentElement.getAttribute('data-theme');
+    document.documentElement.setAttribute('data-theme', 'dark');
+    try {
+      render(
+        <AdaptiveGridMarker
+          shape={SHAPE_1x1}
+          tiles={[rendered('accipitridae', 5)]}
+          totalCount={5}
+          uniqueFamilies={1}
+          ariaLabel="Cluster: 5 observations, 1 family. Activate to zoom in."
+          onClick={noop}
+        />,
+      );
+      const badge = screen.getByTestId('adaptive-grid-marker-badge');
+      // Style is applied either inline OR via the .adaptive-grid-marker__badge
+      // rule (Task 1.6). jsdom does not load <link> stylesheets, but inline
+      // style on the badge is the implementation contract. Check inline first,
+      // fall back to computed.
+      const shadow =
+        badge.style.boxShadow || window.getComputedStyle(badge).boxShadow || '';
+      expect(shadow).toMatch(/(rgba\(255,\s*255,\s*255|#fff|white)/i);
+      expect(shadow).toMatch(/1px/);
+    } finally {
+      if (prior === null) document.documentElement.removeAttribute('data-theme');
+      else document.documentElement.setAttribute('data-theme', prior);
+    }
+  });
+
+  // --- Notable indicator (AC8 — inherited from StackedSilhouetteMarker) ---
+
+  it('notable indicator: isNotable=true renders amber <circle> ring inside SVG, ordered BEFORE halo path', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 1)]}
+        totalCount={1}
+        uniqueFamilies={1}
+        ariaLabel="Single observation: Cooper's Hawk."
+        isNotable={true}
+        notableSpeciesName="Cooper's Hawk"
+        onClick={noop}
+      />,
+    );
+    const circles = document.querySelectorAll('svg circle');
+    expect(circles.length).toBeGreaterThanOrEqual(1);
+    const ring = circles[0];
+    expect(ring.getAttribute('stroke')).toBe('#f59e0b');
+    expect(ring.getAttribute('fill')).toBe('none');
+    // DOM order: the circle must precede the silhouette <path> within the SVG.
+    const svg = ring.closest('svg')!;
+    const children = Array.from(svg.children);
+    const ringIdx = children.indexOf(ring);
+    const firstPathIdx = children.findIndex((c) => c.tagName.toLowerCase() === 'path');
+    expect(ringIdx).toBeLessThan(firstPathIdx);
+  });
+
+  it('notable indicator: isNotable=false (or undefined) renders NO amber circle', () => {
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('accipitridae', 1)]}
+        totalCount={1}
+        uniqueFamilies={1}
+        ariaLabel="Single observation: Cooper's Hawk."
+        isNotable={false}
+        onClick={noop}
+      />,
+    );
+    const circles = document.querySelectorAll('svg circle');
+    expect(circles.length).toBe(0);
+  });
+});

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -194,7 +194,7 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
 interface TileCellProps {
   tile: AdaptiveTile;
   showBadge: boolean;
-  isNotable?: boolean;
+  isNotable: boolean | undefined;
 }
 
 function TileCell({ tile, showBadge, isNotable }: TileCellProps) {

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -1,0 +1,292 @@
+import type { MouseEvent, CSSProperties } from 'react';
+import type { AdaptiveTile, ResolvedGrid } from './adaptive-grid.js';
+import { visibleCapacity } from './adaptive-grid.js';
+import { FALLBACK_SILHOUETTE_PATH } from './silhouette-fallback.js';
+
+/**
+ * `<AdaptiveGridMarker>` — pure display component for the adaptive cluster
+ * grid (epic #539, spec `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`
+ * §4.3–4.8, §5.1). Renders a 1×1 / 2×1 / 2×2 / 3×3 / 4×4 grid (or 3×3 with a
+ * "+N more" overflow indicator on mobile) of family silhouettes with per-cell
+ * count badges.
+ *
+ * The marker is a **pure display component**: it never inspects its own
+ * shape to choose between parent-domain actions. The caller selects the
+ * click handler (`zoomToExpansion` vs `openObsPanel`) based on
+ * `isSingleLeaf(clusterId)` before rendering — see spec §4.5.
+ *
+ * Hit-extender contract (spec §4.4, corrected per Phase 0 issue #541):
+ *   - The outer `<button>` IS the click surface.
+ *   - `tabIndex={-1}` (spec §4.7 — keyboard users use the skip-link to the
+ *     FeedSurface list landmark).
+ *   - A transparent overlay `<span class="adaptive-grid-marker__hit">`
+ *     extends OUTWARD via per-axis `top/bottom/left/right` style values
+ *     so the hit zone is ≥44×44 (fine pointer) or ≥48×48 (coarse). The
+ *     spec's prose §4.4 formula (`inset: min(0, (44-size)/2)`) is wrong on
+ *     two counts: (a) for `size < 44` the inner value is positive so the
+ *     min clamps to 0 (no extension at all), and (b) for non-square
+ *     markers a single scalar leaves the short axis under 44. The
+ *     per-axis form below is the corrected formula from issue #541.
+ *
+ * Tile variants (spec §5.1):
+ *   - `rendered`: catalogue loaded, family has CC-licensed art → paint
+ *     halo + colored path. Notable amber ring layers BEFORE the path
+ *     (spec AC8, inherited from StackedSilhouetteMarker).
+ *   - `fallback`: catalogue loaded, no art for this family → generic
+ *     placeholder shape at opacity 0.5.
+ *   - `pending`: catalogue not loaded yet → animated shimmer skeleton.
+ *     Distinct from `fallback` so a cold-load map doesn't look like a
+ *     coverage gap (spec §5.1 type comment).
+ *
+ * Two-tier ARIA (spec §4.6): the parent passes a fully-constructed
+ * `ariaLabel` plus optional `describedByListId` + `describedByItems` (an
+ * `<ul>` of up to 9 family enumerations). The marker never builds the
+ * label string itself — the parent owns the per-state label format from
+ * the §4.6 table.
+ */
+
+export interface AdaptiveGridMarkerProps {
+  /** Narrowed by the parent — pill is rendered by a sibling component. */
+  shape: ResolvedGrid;
+  /**
+   * Tiles in render order (already sorted descending count by
+   * `aggregateClusterFamilies`). Length is ≤ `visibleCapacity(shape)`;
+   * empty trailing slots render as transparent padders.
+   */
+  tiles: ReadonlyArray<AdaptiveTile>;
+  /** Cluster's full `point_count` (drives badge visibility for the 1×1 single-obs case). */
+  totalCount: number;
+  /** For aria-label parity; not currently rendered (parent threads label). */
+  uniqueFamilies: number;
+  /** Pre-built per spec §4.6 table — the parent owns label format. */
+  ariaLabel: string;
+  /** Optional id of the visually-hidden `<ul>` for two-tier disclosure. */
+  describedByListId?: string;
+  /** Up to 9 family enumeration strings (8 + "and N more families"). */
+  describedByItems?: ReadonlyArray<string>;
+  /** `useMediaQuery('(pointer: coarse)')` — raises hit zone to 48×48. */
+  isCoarsePointer?: boolean;
+  /** Phase 0 AC8 — paint amber ring before silhouette path. */
+  isNotable?: boolean;
+  /** Species name for the notable single-obs case (unused today; reserved). */
+  notableSpeciesName?: string;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+// Layout constants — match MosaicMarker's 22px tile / 2px gap (issue #248).
+const CELL_PX = 22;
+const GRID_GAP_PX = 2;
+const GRID_PADDING_PX = 3;
+
+const HIT_MIN_FINE = 44;
+const HIT_MIN_COARSE = 48;
+
+const NOTABLE_AMBER = '#f59e0b';
+
+function markerDimensions(shape: ResolvedGrid): { width: number; height: number } {
+  const width = shape.cols * CELL_PX + (shape.cols - 1) * GRID_GAP_PX + 2 * GRID_PADDING_PX;
+  const height = shape.rows * CELL_PX + (shape.rows - 1) * GRID_GAP_PX + 2 * GRID_PADDING_PX;
+  return { width, height };
+}
+
+export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
+  const {
+    shape,
+    tiles,
+    totalCount,
+    ariaLabel,
+    describedByListId,
+    describedByItems,
+    isCoarsePointer,
+    isNotable,
+    onClick,
+  } = props;
+
+  const visibleN = visibleCapacity(shape);
+  const { width: markerWidth, height: markerHeight } = markerDimensions(shape);
+
+  // Per-axis hit-extender — corrected formula from issue #541.
+  // For non-square markers (e.g. 2×1 = 52×28), a single scalar `inset` using
+  // max(w,h) would leave the short axis at 28px. Each axis extends OUTWARD
+  // by half its own deficit so BOTH dimensions reach the WCAG target.
+  const hitMin = isCoarsePointer ? HIT_MIN_COARSE : HIT_MIN_FINE;
+  const widthDeficit = Math.max(0, hitMin - markerWidth);
+  const heightDeficit = Math.max(0, hitMin - markerHeight);
+  const hitOverlayStyle: CSSProperties = {
+    position: 'absolute',
+    top: -heightDeficit / 2,
+    bottom: -heightDeficit / 2,
+    left: -widthDeficit / 2,
+    right: -widthDeficit / 2,
+    background: 'transparent',
+    pointerEvents: 'auto',
+  };
+
+  // The badge is hidden ONLY when both the cluster total is 1 AND the cell
+  // count is 1 — i.e. the single-observation case, where the marker reads
+  // identically to today's individual marker (spec §4.3).
+  const showBadgeFor = (cellCount: number): boolean => totalCount > 1 || cellCount > 1;
+
+  return (
+    <button
+      type="button"
+      tabIndex={-1}
+      data-testid="adaptive-grid-marker"
+      className="adaptive-grid-marker"
+      aria-label={ariaLabel}
+      aria-describedby={describedByListId}
+      onClick={onClick}
+      style={{
+        position: 'relative',
+        padding: 0,
+        border: 'none',
+        background: 'transparent',
+        cursor: 'pointer',
+        width: markerWidth,
+        height: markerHeight,
+      }}
+    >
+      <span
+        data-testid="adaptive-grid-marker-hit"
+        className="adaptive-grid-marker__hit"
+        aria-hidden="true"
+        style={hitOverlayStyle}
+      />
+      <div
+        className="adaptive-grid-marker__grid"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${shape.cols}, ${CELL_PX}px)`,
+          gridTemplateRows: `repeat(${shape.rows}, ${CELL_PX}px)`,
+          gap: GRID_GAP_PX,
+          padding: GRID_PADDING_PX,
+          position: 'relative',
+        }}
+      >
+        {tiles.slice(0, visibleN).map((tile, i) => (
+          <TileCell
+            key={`${tile.familyCode}-${i}`}
+            tile={tile}
+            showBadge={showBadgeFor(tile.count)}
+            isNotable={isNotable}
+          />
+        ))}
+        {shape.tag === 'grid-overflow' && (
+          <div
+            data-testid="adaptive-grid-marker-overflow"
+            className="adaptive-grid-marker__cell adaptive-grid-marker__overflow"
+          >
+            +{shape.hiddenCount}
+          </div>
+        )}
+      </div>
+      {describedByListId && describedByItems && (
+        <ul id={describedByListId} className="sr-only">
+          {describedByItems.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </button>
+  );
+}
+
+interface TileCellProps {
+  tile: AdaptiveTile;
+  showBadge: boolean;
+  isNotable?: boolean;
+}
+
+function TileCell({ tile, showBadge, isNotable }: TileCellProps) {
+  if (tile.kind === 'pending') {
+    return (
+      <div
+        data-testid="adaptive-grid-marker-cell-pending"
+        className="adaptive-grid-marker__cell adaptive-grid-marker__cell--pending"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (tile.kind === 'fallback') {
+    return (
+      <div
+        data-testid="adaptive-grid-marker-cell-fallback"
+        className="adaptive-grid-marker__cell adaptive-grid-marker__cell--fallback"
+        style={{ opacity: 0.5 }}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          width={CELL_PX}
+          height={CELL_PX}
+          aria-hidden="true"
+          focusable="false"
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <path d={FALLBACK_SILHOUETTE_PATH} fill={tile.color} />
+        </svg>
+        {showBadge && <Badge count={tile.count} />}
+      </div>
+    );
+  }
+
+  // rendered
+  return (
+    <div
+      data-testid="adaptive-grid-marker-cell-rendered"
+      className="adaptive-grid-marker__cell"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        width={CELL_PX}
+        height={CELL_PX}
+        aria-hidden="true"
+        focusable="false"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {/*
+          Paint order (back → front), matching StackedSilhouetteMarker:
+            1. Amber notable ring (only if isNotable)
+            2. White halo path (behind silhouette for contrast)
+            3. Colored silhouette path
+        */}
+        {isNotable && (
+          <circle
+            cx="12"
+            cy="12"
+            r="11"
+            fill="none"
+            stroke={NOTABLE_AMBER}
+            strokeWidth="2"
+          />
+        )}
+        <path
+          d={tile.svgData}
+          fill="none"
+          stroke="white"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        <path d={tile.svgData} fill={tile.color} />
+      </svg>
+      {showBadge && <Badge count={tile.count} />}
+    </div>
+  );
+}
+
+function Badge({ count }: { count: number }) {
+  return (
+    <span
+      data-testid="adaptive-grid-marker-badge"
+      className="adaptive-grid-marker__badge"
+      style={{
+        // Inline box-shadow keeps the 1px white stroke contract verifiable
+        // in jsdom (which does not load <link> stylesheets). The CSS rule
+        // in ds-primitives.css replicates this for the production render.
+        boxShadow: '0 0 0 1px rgba(255,255,255,0.9)',
+      }}
+    >
+      {count}
+    </span>
+  );
+}

--- a/frontend/src/components/map/adaptive-grid.test.ts
+++ b/frontend/src/components/map/adaptive-grid.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { toPositiveInt } from './adaptive-grid';
+
+describe('toPositiveInt', () => {
+  it('returns the value for a positive integer', () => {
+    expect(toPositiveInt(1)).toBe(1);
+    expect(toPositiveInt(42)).toBe(42);
+  });
+  it('throws on zero', () => {
+    expect(() => toPositiveInt(0)).toThrow(/must be a positive integer/i);
+  });
+  it('throws on negative', () => {
+    expect(() => toPositiveInt(-1)).toThrow(/must be a positive integer/i);
+  });
+  it('throws on non-integer', () => {
+    expect(() => toPositiveInt(1.5)).toThrow(/must be a positive integer/i);
+  });
+});

--- a/frontend/src/components/map/adaptive-grid.test.ts
+++ b/frontend/src/components/map/adaptive-grid.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'vitest';
-import { pickGridShape, toPositiveInt, visibleCapacity } from './adaptive-grid';
+import {
+  aggregateClusterFamilies,
+  buildAdaptiveTiles,
+  pickGridShape,
+  toPositiveInt,
+  visibleCapacity,
+  type AdaptiveTile,
+  type ClusterLeafFeature,
+  type ResolvedGrid,
+  type SilhouettesById,
+} from './adaptive-grid';
+
+function leaf(familyCode: string | null): ClusterLeafFeature {
+  return { type: 'Feature', properties: { familyCode } };
+}
+
+/** Build `n` leaves cycling through `familyCodes` in round-robin order. */
+function leafBatch(n: number, familyCodes: string[]): ClusterLeafFeature[] {
+  const out: ClusterLeafFeature[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push(leaf(familyCodes[i % familyCodes.length]));
+  }
+  return out;
+}
+
+const SHAPE_4x4: ResolvedGrid = { tag: 'grid', cols: 4, rows: 4 };
+const SHAPE_2x2: ResolvedGrid = { tag: 'grid', cols: 2, rows: 2 };
 
 describe('toPositiveInt', () => {
   it('returns the value for a positive integer', () => {
@@ -98,5 +124,155 @@ describe('visibleCapacity', () => {
     expect(
       visibleCapacity({ tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: toPositiveInt(4) }),
     ).toBe(8);
+  });
+});
+
+describe('aggregateClusterFamilies', () => {
+  it('counts leaves grouped by familyCode', () => {
+    const result = aggregateClusterFamilies([
+      leaf('tyrannidae'),
+      leaf('tyrannidae'),
+      leaf('trochilidae'),
+    ]);
+    expect(result).toEqual([
+      { familyCode: 'tyrannidae', count: 2 },
+      { familyCode: 'trochilidae', count: 1 },
+    ]);
+  });
+
+  it('sorts by descending count, then ascending familyCode for ties', () => {
+    const result = aggregateClusterFamilies([
+      leaf('picidae'),
+      leaf('picidae'),
+      // Tie at 1 — alphabetic by code wins (corvidae < tyrannidae).
+      leaf('tyrannidae'),
+      leaf('corvidae'),
+    ]);
+    expect(result).toEqual([
+      { familyCode: 'picidae', count: 2 },
+      { familyCode: 'corvidae', count: 1 },
+      { familyCode: 'tyrannidae', count: 1 },
+    ]);
+  });
+
+  it('skips leaves with null familyCode (LEFT JOIN miss per Observation contract)', () => {
+    // Copied verbatim from `cluster-mosaic.test.ts:101` per spec §4.2 — the
+    // null-familyCode dropout invariant is load-bearing for the Observation
+    // wire contract and must survive the move to adaptive-grid.ts.
+    const result = aggregateClusterFamilies([
+      leaf(null),
+      leaf('tyrannidae'),
+      leaf(null),
+    ]);
+    expect(result).toEqual([{ familyCode: 'tyrannidae', count: 1 }]);
+  });
+
+  it('returns an empty array for an empty cluster', () => {
+    expect(aggregateClusterFamilies([])).toEqual([]);
+  });
+});
+
+describe('buildAdaptiveTiles', () => {
+  // 20 unique families, full svgData coverage. Reused across several tests.
+  const FULL_CATALOGUE: SilhouettesById = new Map(
+    Array.from({ length: 20 }, (_, i) => [
+      `fam-${String(i).padStart(2, '0')}`,
+      { svgData: `M${i} ${i}Z`, color: `#${i.toString(16).padStart(2, '0').repeat(3)}` },
+    ]),
+  );
+
+  it('200 leaves with 20 families, capacity=16 → 16 tiles in descending count', () => {
+    // Even distribution: round-robin 200 leaves across 20 families gives 10
+    // each, so the descending-count tie-break is alphabetical. We assert
+    // count and order separately.
+    const leaves = leafBatch(200, Array.from(FULL_CATALOGUE.keys()));
+    const tiles = buildAdaptiveTiles(leaves, FULL_CATALOGUE, SHAPE_4x4);
+    expect(tiles).toHaveLength(16);
+    // Descending count (all equal 10 here) then alphabetic on familyCode.
+    const counts = tiles.map((t) => t.count);
+    expect(counts).toEqual(Array(16).fill(10));
+    const codes = tiles.map((t) => t.familyCode);
+    expect(codes).toEqual([...codes].sort());
+  });
+
+  it('descending count order with uneven distribution', () => {
+    const leaves: ClusterLeafFeature[] = [
+      ...Array(5).fill(leaf('fam-00')),
+      ...Array(3).fill(leaf('fam-01')),
+      ...Array(2).fill(leaf('fam-02')),
+      leaf('fam-03'),
+    ];
+    const tiles = buildAdaptiveTiles(leaves, FULL_CATALOGUE, SHAPE_2x2);
+    expect(tiles.map((t) => t.count)).toEqual([5, 3, 2, 1]);
+  });
+
+  it('drops leaves with null familyCode (preserves cluster-mosaic invariant)', () => {
+    const leaves: ClusterLeafFeature[] = [
+      leaf(null),
+      leaf('fam-00'),
+      leaf(null),
+      leaf('fam-00'),
+      leaf(null),
+    ];
+    const tiles = buildAdaptiveTiles(leaves, FULL_CATALOGUE, SHAPE_2x2);
+    expect(tiles).toHaveLength(1);
+    expect(tiles[0]).toMatchObject({ familyCode: 'fam-00', count: 2 });
+  });
+
+  it('under-capacity: 5 leaves over 2 families, capacity=4 → 2 tiles (caller pads visually)', () => {
+    const leaves: ClusterLeafFeature[] = [
+      ...Array(3).fill(leaf('fam-00')),
+      ...Array(2).fill(leaf('fam-01')),
+    ];
+    const tiles = buildAdaptiveTiles(leaves, FULL_CATALOGUE, SHAPE_2x2);
+    expect(tiles).toHaveLength(2);
+  });
+
+  it('null svgData → kind: "fallback" (preserves cluster-mosaic fallback behaviour)', () => {
+    const partial: SilhouettesById = new Map([
+      ['fam-00', { svgData: 'M0 0Z', color: '#111' }],
+      ['fam-01', { svgData: null, color: '#222' }], // catalogue row exists, art missing
+    ]);
+    const leaves = [leaf('fam-00'), leaf('fam-01')];
+    const tiles = buildAdaptiveTiles(leaves, partial, SHAPE_2x2);
+    const byFam = new Map(tiles.map((t) => [t.familyCode, t]));
+    expect(byFam.get('fam-00')?.kind).toBe('rendered');
+    expect(byFam.get('fam-01')?.kind).toBe('fallback');
+    // Fallback tile keeps the catalogue's color even though svgData is null.
+    const fb = byFam.get('fam-01') as AdaptiveTile & { kind: 'fallback' };
+    expect(fb.color).toBe('#222');
+  });
+
+  it('empty silhouettesById → every tile is kind: "pending"', () => {
+    // Distinguishes "catalogue not loaded yet" from "loaded but no art for
+    // this family" (spec §5.1 type comment + §7 component-test manifest).
+    const leaves = [leaf('fam-00'), leaf('fam-01'), leaf('fam-02')];
+    const tiles = buildAdaptiveTiles(leaves, new Map(), SHAPE_2x2);
+    expect(tiles).toHaveLength(3);
+    for (const t of tiles) {
+      expect(t.kind).toBe('pending');
+    }
+  });
+
+  it('upstream silhouette resolution: identical leaves + different catalogues → different tiles', () => {
+    // Spec §5.3 Concern C, point 3: the builder is pure — does NOT read
+    // any module-scoped ref. Two catalogues with the same family but
+    // different svgData must produce differently-resolved tiles.
+    const catalogueA: SilhouettesById = new Map([
+      ['fam-00', { svgData: 'M0 0Z', color: '#A0A0A0' }],
+    ]);
+    const catalogueB: SilhouettesById = new Map([
+      ['fam-00', { svgData: 'M9 9Z', color: '#B0B0B0' }],
+    ]);
+    const leaves = [leaf('fam-00')];
+    const a = buildAdaptiveTiles(leaves, catalogueA, SHAPE_2x2)[0];
+    const b = buildAdaptiveTiles(leaves, catalogueB, SHAPE_2x2)[0];
+    expect(a.kind).toBe('rendered');
+    expect(b.kind).toBe('rendered');
+    if (a.kind === 'rendered' && b.kind === 'rendered') {
+      expect(a.svgData).toBe('M0 0Z');
+      expect(b.svgData).toBe('M9 9Z');
+      expect(a.color).not.toBe(b.color);
+    }
   });
 });

--- a/frontend/src/components/map/adaptive-grid.test.ts
+++ b/frontend/src/components/map/adaptive-grid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toPositiveInt } from './adaptive-grid';
+import { pickGridShape, toPositiveInt, visibleCapacity } from './adaptive-grid';
 
 describe('toPositiveInt', () => {
   it('returns the value for a positive integer', () => {
@@ -14,5 +14,89 @@ describe('toPositiveInt', () => {
   });
   it('throws on non-integer', () => {
     expect(() => toPositiveInt(1.5)).toThrow(/must be a positive integer/i);
+  });
+});
+
+describe('pickGridShape', () => {
+  // Desktop, no overflow
+  it('1 family → 1×1', () => {
+    expect(pickGridShape(1, 1, false)).toEqual({ tag: 'grid', cols: 1, rows: 1 });
+  });
+  it('2 families → 2×1', () => {
+    expect(pickGridShape(2, 2, false)).toEqual({ tag: 'grid', cols: 2, rows: 1 });
+  });
+  it('3 families → 2×2', () => {
+    expect(pickGridShape(3, 3, false)).toEqual({ tag: 'grid', cols: 2, rows: 2 });
+  });
+  it('4 families → 2×2', () => {
+    expect(pickGridShape(4, 4, false)).toEqual({ tag: 'grid', cols: 2, rows: 2 });
+  });
+  it('5 families → 3×3', () => {
+    expect(pickGridShape(5, 5, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+  it('9 families → 3×3', () => {
+    expect(pickGridShape(9, 9, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+  it('10 families → 4×4', () => {
+    expect(pickGridShape(10, 10, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+  it('16 families → 4×4', () => {
+    expect(pickGridShape(16, 16, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+
+  // Pill caps — family-cap alone
+  it('family cap fires alone (17 families, 30 obs)', () => {
+    expect(pickGridShape(17, 30, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Pill caps — count-cap alone
+  it('count cap fires alone (8 families, 65 obs)', () => {
+    expect(pickGridShape(8, 65, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Boundary: count=64 inclusive
+  it('count = 64 inclusive does NOT trigger pill', () => {
+    expect(pickGridShape(8, 64, false)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+
+  // Boundary: count=65 with families=16 (locks > vs >= mutation)
+  it('count = 65 with families = 16 → pill', () => {
+    expect(pickGridShape(16, 65, false)).toEqual({ tag: 'pill' });
+  });
+
+  // Boundary: max grid
+  it('families = 16, count = 64 → 4×4 (max grid, no pill)', () => {
+    expect(pickGridShape(16, 64, false)).toEqual({ tag: 'grid', cols: 4, rows: 4 });
+  });
+
+  // Mobile cap
+  it('mobile cap: 12 families → grid-overflow 3×3 with hiddenCount 4', () => {
+    expect(pickGridShape(12, 12, true)).toEqual({
+      tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: 4,
+    });
+  });
+
+  // Mobile boundary: 8 families (no overflow)
+  it('mobile: 8 families fits 3×3 exactly, no overflow', () => {
+    expect(pickGridShape(8, 8, true)).toEqual({ tag: 'grid', cols: 3, rows: 3 });
+  });
+
+  // Mobile boundary: 9 families (first overflow)
+  it('mobile: 9 families → grid-overflow with hiddenCount 1', () => {
+    expect(pickGridShape(9, 9, true)).toEqual({
+      tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: 1,
+    });
+  });
+});
+
+describe('visibleCapacity', () => {
+  it('grid → cols * rows', () => {
+    expect(visibleCapacity({ tag: 'grid', cols: 4, rows: 4 })).toBe(16);
+    expect(visibleCapacity({ tag: 'grid', cols: 2, rows: 1 })).toBe(2);
+  });
+  it('grid-overflow → cols * rows - 1 (reserved for "+N")', () => {
+    expect(
+      visibleCapacity({ tag: 'grid-overflow', cols: 3, rows: 3, hiddenCount: toPositiveInt(4) }),
+    ).toBe(8);
   });
 });

--- a/frontend/src/components/map/adaptive-grid.ts
+++ b/frontend/src/components/map/adaptive-grid.ts
@@ -1,3 +1,14 @@
+/**
+ * Adaptive cluster-grid logic for the `<AdaptiveGridMarker>` component
+ * (epic #539, spec `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`).
+ *
+ * This module is the pure-logic + types layer that backs the marker.
+ * Phase 1A scope: branded `PositiveInt`, the `GridShape` discriminated
+ * union, `pickGridShape` encoding the §4.1 sizing-rules table, and
+ * `visibleCapacity`. `buildAdaptiveTiles` + `aggregateClusterFamilies`
+ * land in the next commit.
+ */
+
 export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
 
 export function toPositiveInt(n: number): PositiveInt {
@@ -5,4 +16,60 @@ export function toPositiveInt(n: number): PositiveInt {
     throw new TypeError(`Expected a positive integer, got ${n}. Value must be a positive integer.`);
   }
   return n as PositiveInt;
+}
+
+export type Dim = 1 | 2 | 3 | 4;
+
+export type GridShape =
+  | { tag: 'grid'; cols: Dim; rows: Dim }
+  | { tag: 'grid-overflow'; cols: Dim; rows: Dim; hiddenCount: PositiveInt }
+  | { tag: 'pill' };
+
+/** What `<AdaptiveGridMarker>` accepts — pill is rendered by a sibling component. */
+export type ResolvedGrid = Exclude<GridShape, { tag: 'pill' }>;
+
+/**
+ * Helper, not a stored field — derived deterministically from the shape's
+ * dimensions. `grid` uses every cell; `grid-overflow` reserves the last
+ * cell for the "+N more" indicator.
+ */
+export function visibleCapacity(shape: ResolvedGrid): number {
+  return shape.tag === 'grid'
+    ? shape.cols * shape.rows
+    : shape.cols * shape.rows - 1;
+}
+
+const MAX_FAMILIES = 16;
+const MAX_OBSERVATIONS = 64;
+const MOBILE_GRID_OVERFLOW_VISIBLE = 8;
+
+/**
+ * Pick the grid shape for a cluster, per spec §4.1.
+ *
+ * Order of precedence:
+ *   1. Pill fallback when uniqueFamilies > 16 OR pointCount > 64.
+ *   2. Mobile cap: on isMobile, families > 8 → 3×3 grid-overflow.
+ *   3. Desktop sizing table (1, 2, 3-4, 5-9, 10-16).
+ */
+export function pickGridShape(
+  uniqueFamilies: number,
+  pointCount: number,
+  isMobile: boolean,
+): GridShape {
+  if (uniqueFamilies > MAX_FAMILIES || pointCount > MAX_OBSERVATIONS) {
+    return { tag: 'pill' };
+  }
+  if (isMobile && uniqueFamilies > MOBILE_GRID_OVERFLOW_VISIBLE) {
+    return {
+      tag: 'grid-overflow',
+      cols: 3,
+      rows: 3,
+      hiddenCount: toPositiveInt(uniqueFamilies - MOBILE_GRID_OVERFLOW_VISIBLE),
+    };
+  }
+  if (uniqueFamilies === 1) return { tag: 'grid', cols: 1, rows: 1 };
+  if (uniqueFamilies === 2) return { tag: 'grid', cols: 2, rows: 1 };
+  if (uniqueFamilies <= 4) return { tag: 'grid', cols: 2, rows: 2 };
+  if (uniqueFamilies <= 9) return { tag: 'grid', cols: 3, rows: 3 };
+  return { tag: 'grid', cols: 4, rows: 4 };
 }

--- a/frontend/src/components/map/adaptive-grid.ts
+++ b/frontend/src/components/map/adaptive-grid.ts
@@ -1,0 +1,8 @@
+export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
+
+export function toPositiveInt(n: number): PositiveInt {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new TypeError(`Expected a positive integer, got ${n}. Value must be a positive integer.`);
+  }
+  return n as PositiveInt;
+}

--- a/frontend/src/components/map/adaptive-grid.ts
+++ b/frontend/src/components/map/adaptive-grid.ts
@@ -2,11 +2,25 @@
  * Adaptive cluster-grid logic for the `<AdaptiveGridMarker>` component
  * (epic #539, spec `docs/specs/2026-05-14-adaptive-cluster-grid-design.md`).
  *
- * This module is the pure-logic + types layer that backs the marker.
- * Phase 1A scope: branded `PositiveInt`, the `GridShape` discriminated
- * union, `pickGridShape` encoding the §4.1 sizing-rules table, and
- * `visibleCapacity`. `buildAdaptiveTiles` + `aggregateClusterFamilies`
- * land in the next commit.
+ * This module is the pure-logic + types layer that backs the marker:
+ *
+ *   - `toPositiveInt` / `PositiveInt`: branded type for `hiddenCount`, so
+ *     a `grid-overflow` shape cannot be constructed with a non-positive
+ *     hidden count (spec §4.1).
+ *   - `pickGridShape(uniqueFamilies, pointCount, isMobile) → GridShape`:
+ *     the §4.1 sizing-rules table encoded as a function. Returns a
+ *     discriminated union (`grid` / `grid-overflow` / `pill`) so callers
+ *     can narrow at the type level — `pill` is unreachable for the
+ *     marker component, which only accepts `ResolvedGrid`.
+ *   - `buildAdaptiveTiles(leaves, silhouettesById, shape) → AdaptiveTile[]`:
+ *     the pure tile-builder. Aggregates leaves by family, resolves each
+ *     family against the supplied silhouette catalogue, and produces a
+ *     `rendered | fallback | pending` tile per visible slot. Pure by
+ *     contract — does NOT read from any module-scoped ref (spec §5.3
+ *     Concern C, point 3).
+ *   - `aggregateClusterFamilies`: moved verbatim from `cluster-mosaic.ts`
+ *     (Phase 2 deletes the source). Behavior preserved: descending count,
+ *     ascending familyCode tie-break, null-familyCode dropout.
  */
 
 export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
@@ -72,4 +86,128 @@ export function pickGridShape(
   if (uniqueFamilies <= 4) return { tag: 'grid', cols: 2, rows: 2 };
   if (uniqueFamilies <= 9) return { tag: 'grid', cols: 3, rows: 3 };
   return { tag: 'grid', cols: 4, rows: 4 };
+}
+
+/**
+ * Minimal shape of a cluster leaf as returned by maplibre-gl 5.x's
+ * `GeoJSONSource.getClusterLeaves`. Only `properties.familyCode` is read;
+ * everything else (geometry, id, type discriminator) is ignored. Kept
+ * structurally typed so test fixtures don't have to construct full
+ * MapGeoJSONFeature instances.
+ *
+ * Copied from `cluster-mosaic.ts` so this module is independent of the
+ * legacy file (Phase 2 deletes that file atomically).
+ */
+export interface ClusterLeafFeature {
+  type: 'Feature';
+  properties: {
+    familyCode: string | null;
+  } & Record<string, unknown>;
+}
+
+export interface FamilyAggregate {
+  familyCode: string;
+  count: number;
+}
+
+/**
+ * Per-family lookup passed to `buildAdaptiveTiles`. The caller resolves
+ * this once per reconcile from the silhouette catalogue (the upstream
+ * silhouette-resolution rule from spec §5.3 Concern C). An empty map
+ * signals "catalogue not loaded yet" — distinct from "loaded but no art
+ * for this family" — and produces `kind: 'pending'` tiles.
+ */
+export type SilhouettesById = ReadonlyMap<
+  string,
+  { svgData: string | null; color: string }
+>;
+
+/**
+ * Per-cell datum the marker renders. Three variants:
+ *   - `rendered`: catalogue loaded, family has CC-licensed art.
+ *   - `fallback`: catalogue loaded, family has no art (uncurated /
+ *     missing). Renderer paints at opacity 0.5 with a generic shape.
+ *   - `pending`: catalogue not yet loaded for ANY family. Renderer
+ *     paints a skeleton/shimmer so a cold-load map is distinguishable
+ *     from a real coverage gap (spec §5.1 type comment).
+ */
+export type AdaptiveTile =
+  | { kind: 'rendered'; familyCode: string; svgData: string; color: string; count: number }
+  | { kind: 'fallback'; familyCode: string; color: string; count: number }
+  | { kind: 'pending'; familyCode: string; count: number };
+
+/**
+ * Reduce the leaves of a single cluster into a sorted
+ * [{familyCode, count}] list. Leaves with `properties.familyCode === null`
+ * are skipped — they cannot drive a tile (no family to look up).
+ *
+ * Sort: descending count, ascending familyCode for ties. The tie-breaker
+ * keeps tile order stable across renders; without it, two families tied
+ * at count=1 could swap positions on every reconciler pass.
+ *
+ * Moved verbatim from `cluster-mosaic.ts:80-95` per spec §6 / plan
+ * Task 1.4. The legacy file is deleted in Phase 2.
+ */
+export function aggregateClusterFamilies(
+  leaves: ClusterLeafFeature[],
+): FamilyAggregate[] {
+  const counts = new Map<string, number>();
+  for (const leaf of leaves) {
+    const code = leaf.properties.familyCode;
+    if (!code) continue;
+    counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([familyCode, count]) => ({ familyCode, count }))
+    .sort((a, b) => {
+      if (a.count !== b.count) return b.count - a.count;
+      return a.familyCode.localeCompare(b.familyCode);
+    });
+}
+
+/**
+ * Pure tile-builder for `<AdaptiveGridMarker>`. Aggregates the cluster's
+ * leaves, takes the top `visibleCapacity(shape)` families (caller pads
+ * visually if fewer families are present), and resolves each against the
+ * `silhouettesById` map to produce a discriminated-union tile.
+ *
+ * Spec §5.3 Concern C (point 3): this function MUST NOT read from any
+ * module-scoped ref. The caller threads the resolved catalogue
+ * explicitly, so an in-flight reconcile cannot pick up a newer
+ * catalogue mid-flight and produce mismatched tiles. Tests assert that
+ * identical leaves with different `silhouettesById` arguments produce
+ * differently-resolved tiles.
+ *
+ * Empty `silhouettesById` is treated as "catalogue not loaded yet" and
+ * yields all-`pending` tiles, distinct from the per-family "loaded but
+ * no art" `fallback` case.
+ */
+export function buildAdaptiveTiles(
+  leaves: ClusterLeafFeature[],
+  silhouettesById: SilhouettesById,
+  shape: ResolvedGrid,
+): ReadonlyArray<AdaptiveTile> {
+  const families = aggregateClusterFamilies(leaves);
+  const visible = families.slice(0, visibleCapacity(shape));
+  return visible.map((fam): AdaptiveTile => {
+    if (silhouettesById.size === 0) {
+      return { kind: 'pending', familyCode: fam.familyCode, count: fam.count };
+    }
+    const silhouette = silhouettesById.get(fam.familyCode);
+    if (!silhouette || silhouette.svgData === null) {
+      return {
+        kind: 'fallback',
+        familyCode: fam.familyCode,
+        color: silhouette?.color ?? '#888888',
+        count: fam.count,
+      };
+    }
+    return {
+      kind: 'rendered',
+      familyCode: fam.familyCode,
+      svgData: silhouette.svgData,
+      color: silhouette.color,
+      count: fam.count,
+    };
+  });
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
  subgraph FILE_A["adaptive-grid.ts (new)"]
    A["toPositiveInt branded type"] --> B["pickGridShape · 16 rules"]
    B --> C["GridShape | ResolvedGrid union"]
    D["aggregateClusterFamilies · moved"] --> E["buildAdaptiveTiles"]
    C --> E
    F["AdaptiveTile · rendered/fallback/pending"] --> E
  end
  subgraph FILE_B["AdaptiveGridMarker.tsx (new)"]
    G["Pure display · tabIndex=-1"] --> H["Per-axis hit-extender 44/48"]
    G --> I["Per-cell badge · 1px white stroke"]
    G --> J["Notable amber ring · AC8"]
    G --> K["+N more cell · grid-overflow"]
  end
  subgraph FLAG_OFF["VITE_FF_ADAPTIVE_GRID=false"]
    L["Dead code · unreachable behind flag"]
  end
  C --> G
  L --- G
```

## Summary

- Phase 1 of epic #539 — scaffolds the logic module + React component behind feature flag `VITE_FF_ADAPTIVE_GRID` (default off). Zero swap of existing behavior; new code reachable only when the flag is set.
- New: `adaptive-grid.ts` (toPositiveInt, pickGridShape with all spec §4.1 rules, buildAdaptiveTiles, AdaptiveTile 3-variant union, ResolvedGrid type, aggregateClusterFamilies moved verbatim from cluster-mosaic.ts). `AdaptiveGridMarker.tsx` (pure display, tabIndex=-1 inheriting MapMarkerHitLayer:14-17 contract, per-axis hit-extender per Phase 0 finding F1). CSS rules in ds-primitives.css.
- 7 commits. 48 new tests pass (33 unit + 15 component). Full suite: 819/819 green. `scripts/check-orphan-classnames.sh` PASS.

## Screenshots

N/A — flagged off (`VITE_FF_ADAPTIVE_GRID=false` default), no production UI yet. The new component is dead code reachable only via env flag. Phase 2 wires it in and flips the flag.

The orphan-className check verifies every `className` in `AdaptiveGridMarker.tsx` has a corresponding CSS rule in `frontend/src/components/ds/ds-primitives.css`:

```
$ grep -cE '^\.(adaptive-grid-marker|__hit|__grid|__cell|__cell--pending|__cell--fallback|__badge|__overflow)' \
    frontend/src/components/ds/ds-primitives.css
8
```

All 8 classes rule-backed. CSS sub-task gate (per #445) satisfied.

## Test plan

- [x] `adaptive-grid.test.ts` — 33 tests pass (`toPositiveInt` 4, `pickGridShape` 16, `visibleCapacity` 2, `aggregateClusterFamilies` 4, `buildAdaptiveTiles` 7)
- [x] `AdaptiveGridMarker.test.tsx` — 15 tests pass (per-axis hit-extender, tabIndex=-1, badge visibility rules, fallback opacity 0.5, pending skeleton, +N more overflow cell, all 4 aria-label patterns, dark-mode badge stroke, notable amber ring)
- [x] Full frontend suite: 819/819 passing
- [x] `npm run build` green (`tsc -b` + Vite, no errors)
- [x] `scripts/check-orphan-classnames.sh` PASS
- [x] CI: `test`, `lint`, `build`, `e2e`, `knip` (informational), `orphan-classname-check` all required to pass before queue

## Risk

Low. Feature flag default off → new code is unreachable in production. Phase 1A files (`adaptive-grid.ts`) are imported only by `AdaptiveGridMarker.tsx`; component is imported by nothing yet (Phase 2 wires it into `MapCanvas.tsx`).

Three deviations worth flagging:

- **Extra `fix(map):` commit** (`05d48cf`) — `exactOptionalPropertyTypes: true` rejected the internal `TileCellProps.isNotable?: boolean`; landed as a separate commit per never-amend rule. Phase 2 should use `isNotable: boolean | undefined` to avoid the same TS2375 error.
- **`sr-only` class used for visually-hidden `<ul>`** instead of the plan's draft `visually-hidden` — matches existing repo convention at `frontend/src/styles.css:1565`.
- **Inline `box-shadow` on badge** duplicates the CSS-only rule because jsdom doesn't load `<link>` stylesheets in tests. Production paint uses the CSS rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
