### PR TITLE
fix(map): AdaptiveGridMarker badge hidden when cell.count===1 (#552)

### DIFF
--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -71,6 +71,27 @@ describe('AdaptiveGridMarker', () => {
 
   // --- 2×2 grid: 4 per-cell badges in descending count order --------------
 
+  it('hides badge for cells with count === 1 even in multi-cell clusters', () => {
+    // Regression for issue #552: per spec §4.3 line 124 the badge is hidden
+    // when `cell.count === 1`, regardless of the cluster's total. The prior
+    // `totalCount > 1 || cellCount > 1` guard caused every count=1 cell in
+    // a multi-cell cluster to render a "1" badge. Fixture uses ties at 1 so
+    // we pin "count=1 → silhouette-only" rather than just descending order.
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[rendered('a', 3), rendered('b', 1), rendered('c', 1), rendered('d', 1)]}
+        totalCount={6}
+        uniqueFamilies={4}
+        ariaLabel="Cluster: 6 observations, 4 families. Activate to zoom in."
+        onClick={noop}
+      />,
+    );
+    const badges = screen.queryAllByTestId('adaptive-grid-marker-badge');
+    expect(badges).toHaveLength(1); // only the count=3 cell gets a badge
+    expect(badges[0].textContent).toBe('3');
+  });
+
   it('renders 2×2 with 4 per-cell badges in descending count order', () => {
     render(
       <AdaptiveGridMarker

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -54,7 +54,12 @@ export interface AdaptiveGridMarkerProps {
    * empty trailing slots render as transparent padders.
    */
   tiles: ReadonlyArray<AdaptiveTile>;
-  /** Cluster's full `point_count` (drives badge visibility for the 1×1 single-obs case). */
+  /**
+   * Cluster's full `point_count`. Not used for badge visibility (per spec
+   * §4.3 that's a per-cell decision driven by `cellCount > 1`) but kept on
+   * the public prop shape because callers thread it for aria-label
+   * construction and parity with sibling marker components.
+   */
   totalCount: number;
   /** For aria-label parity; not currently rendered (parent threads label). */
   uniqueFamilies: number;
@@ -93,7 +98,6 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
   const {
     shape,
     tiles,
-    totalCount,
     ariaLabel,
     describedByListId,
     describedByItems,
@@ -122,10 +126,11 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
     pointerEvents: 'auto',
   };
 
-  // The badge is hidden ONLY when both the cluster total is 1 AND the cell
-  // count is 1 — i.e. the single-observation case, where the marker reads
-  // identically to today's individual marker (spec §4.3).
-  const showBadgeFor = (cellCount: number): boolean => totalCount > 1 || cellCount > 1;
+  // Per spec §4.3 line 124: hidden when cell.count === 1 (regardless of the
+  // cluster's total observation count). In a 1×1 single-observation marker,
+  // this collapses to the same outcome as the prior "totalCount > 1" guard
+  // because cellCount === totalCount === 1.
+  const showBadgeFor = (cellCount: number): boolean => cellCount > 1;
 
   return (
     <button


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
  A["showBadgeFor cellCount"] -- "before: totalCount>1 || cellCount>1" --> B["badge on every cell in multi-cell cluster"]
  A -- "after: cellCount > 1" --> C["badge hidden when cell.count === 1"]
  D["spec §4.3 line 124"] -- "Hidden when cell.count === 1" --> C
  E["regression test: 2x2 [3,1,1,1]"] -- "asserts exactly 1 badge text=3" --> C
```

## Summary

- Fixes #552: `AdaptiveGridMarker` rendered a "1" badge on every count=1 cell in multi-cell clusters, contradicting spec §4.3 line 124 ("Hidden when `cell.count === 1`").
- Root cause: `showBadgeFor` at `AdaptiveGridMarker.tsx:128` had `totalCount > 1 || cellCount > 1` — the OR clause short-circuited the per-cell rule. Fix: drop `totalCount > 1 ||`. In the 1×1 single-observation case the outcome is unchanged (cellCount === totalCount === 1 → no badge).
- New regression test uses the strengthened `[3,1,1,1]` 2×2 fixture from issue #552's round-1 bot-review refinement: asserts exactly 1 badge with text "3" rather than 4 badges with mixed text.

## Screenshots

Before (production, shipped via PR #546) — every count=1 cell carries a redundant "1" badge per the buggy OR clause:

![bug example](https://github.com/user-attachments/assets/baf80b1d-cee5-4ce9-92f6-03b10857fcab)

After: the new regression test pins the corrected behavior. Marker visual: silhouette-only for count=1 cells, badge only for count>1.

N/A for the canonical 5-viewport × 2-theme capture — this is a one-line behavior fix to existing component; visual diff is the badges disappearing on count=1 cells.

## Test plan

- [x] New regression test in `AdaptiveGridMarker.test.tsx`: `"hides badge for cells with count === 1 even in multi-cell clusters"` — fixture `[3,1,1,1]`, asserts `badges.length === 1` and `badges[0].textContent === '3'`
- [x] Existing 15 tests in `AdaptiveGridMarker.test.tsx` still pass (16/16 total green)
- [x] `aggregateClusterFamilies` boundary check: confirmed via `grep -n "count" adaptive-grid.ts` — no count filter applied to families. Bug is purely in the marker layer.
- [x] `npm run build` green (tsc -b + vite build clean)

## Risk

Minimal. One-line change to a pure rendering predicate. No memoization, no state, no API surface change.

Small scope-add: dropped the now-unused `totalCount` from the destructured props (kept on the public interface for aria-label parity). Doc-comment updated to record that `totalCount` is no longer load-bearing for badge visibility.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
