### PR TITLE
feat(ingestor): heartbeat module + cli wiring (monitoring plan Tasks 1-2)

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -271,4 +271,70 @@ describe('runCli', () => {
     const deps = makeDeps();
     await expect(runCli('bogus', deps)).rejects.toThrow(/prune/);
   });
+
+  // ── Heartbeat wiring (S7) ──────────────────────────────────────────────
+  // Plan: docs/plans/2026-05-17-monitoring-and-alerts.md §"Heartbeat strategy".
+  // Heartbeat must fire on success and on partial, and MUST NOT fire on failure
+  // — the absence of a heartbeat is the failure signal Healthchecks.io alerts on.
+
+  it('pings heartbeat on success with HEALTHCHECKS_URL_<KIND> env value', async () => {
+    process.env.HEALTHCHECKS_URL_RECENT = 'https://hc-ping.com/uuid-recent';
+    const successSummary: RunSummary = {
+      status: 'success',
+      regionCode: 'US-AZ',
+      observationsFetched: 0,
+      observationsUpserted: 0,
+      checklistsUpserted: 0,
+      speciesUpserted: 0,
+      notableObservationCount: 0,
+    } as unknown as RunSummary;
+    const pingSpy = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      runIngest: vi.fn().mockResolvedValue(successSummary),
+      pingHeartbeat: pingSpy,
+    });
+
+    await runCli('recent', deps);
+
+    expect(pingSpy).toHaveBeenCalledTimes(1);
+    expect(pingSpy).toHaveBeenCalledWith('https://hc-ping.com/uuid-recent', 'recent');
+    delete process.env.HEALTHCHECKS_URL_RECENT;
+  });
+
+  it('does NOT ping heartbeat on failure', async () => {
+    const failureSummary: RunTaxonomySummary = {
+      status: 'failure',
+      totalFetched: 0,
+      speciesInserted: 0,
+      nonSpeciesFiltered: 0,
+      reconciled: 0,
+      error: 'boom',
+    };
+    const pingSpy = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      runTaxonomy: vi.fn().mockResolvedValue(failureSummary),
+      pingHeartbeat: pingSpy,
+    });
+
+    await runCli('taxonomy', deps);
+
+    expect(pingSpy).not.toHaveBeenCalled();
+  });
+
+  it('uppercases and replaces hyphens in kind when computing env-var name', async () => {
+    process.env.HEALTHCHECKS_URL_BACKFILL_EXTENDED = 'https://hc-ping.com/uuid-bf-ext';
+    const partialSummary = {
+      status: 'partial',
+    } as unknown as Awaited<ReturnType<typeof import('./run-backfill.js').runBackfill>>;
+    const pingSpy = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      runBackfill: vi.fn().mockResolvedValue(partialSummary),
+      pingHeartbeat: pingSpy,
+    });
+
+    await runCli('backfill-extended', deps);
+
+    expect(pingSpy).toHaveBeenCalledWith('https://hc-ping.com/uuid-bf-ext', 'backfill-extended');
+    delete process.env.HEALTHCHECKS_URL_BACKFILL_EXTENDED;
+  });
 });

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -32,6 +32,7 @@ import {
 } from './run-prune.js';
 import { fetchWikipediaSummary as realFetchWikipediaSummary } from './wikipedia/client.js';
 import { fetchInatTaxon as realFetchInatTaxon } from './inat/taxon-client.js';
+import { pingHeartbeat as realPingHeartbeat } from './heartbeat.js';
 
 /**
  * Every run summary discriminates on `status`. `RunBackfillSummary` can also be
@@ -64,6 +65,7 @@ export interface CliDeps {
   runPrune: typeof realRunPrune;
   fetchWikipediaSummary: typeof realFetchWikipediaSummary;
   fetchInatTaxon: typeof realFetchInatTaxon;
+  pingHeartbeat?: typeof realPingHeartbeat;
 }
 
 /**
@@ -173,6 +175,13 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     if (summary.status === 'failure') {
       // Flag the process as failed without killing the loop mid-pool-close.
       process.exitCode = 1;
+    } else {
+      // Success or partial: ping the per-kind heartbeat. Healthchecks.io
+      // (or equivalent) fires alerts on MISSED pings, so we MUST NOT ping
+      // on failure — see docs/plans/2026-05-17-monitoring-and-alerts.md §S7.
+      const envKey = `HEALTHCHECKS_URL_${kind.toUpperCase().replace(/-/g, '_')}`;
+      const ping = deps.pingHeartbeat ?? realPingHeartbeat;
+      await ping(process.env[envKey], kind);
     }
   } finally {
     await deps.closePool(pool);

--- a/services/ingestor/src/heartbeat.test.ts
+++ b/services/ingestor/src/heartbeat.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { pingHeartbeat } from './heartbeat.js';
+
+describe('pingHeartbeat', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('is a no-op when url is undefined', async () => {
+    const fetcher = vi.fn();
+    await pingHeartbeat(undefined, 'recent', fetcher as unknown as typeof fetch);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('POSTs to the configured url on success', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: true, status: 200 } as Response);
+    await pingHeartbeat('https://hc.io/abc', 'recent', fetcher as unknown as typeof fetch);
+    expect(fetcher).toHaveBeenCalledWith('https://hc.io/abc', { method: 'POST' });
+  });
+
+  it('swallows 5xx without throwing', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: false, status: 502 } as Response);
+    await expect(
+      pingHeartbeat('https://hc.io/abc', 'recent', fetcher as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('swallows network errors without throwing', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(
+      pingHeartbeat('https://hc.io/abc', 'recent', fetcher as unknown as typeof fetch),
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/services/ingestor/src/heartbeat.ts
+++ b/services/ingestor/src/heartbeat.ts
@@ -1,0 +1,31 @@
+/**
+ * Best-effort heartbeat ping to Healthchecks.io (or equivalent).
+ *
+ * Pings are fire-and-forget: a failure to ping does not change the ingest
+ * job's exit code. The semantics are inverse-of-presence: if Healthchecks.io
+ * sees a ping, the job ran to success; if it doesn't, Healthchecks.io fires
+ * the alert (we never need to fire one ourselves).
+ *
+ * Why `fetcher` is injectable: lets tests pass a mock without touching
+ * global fetch state, which is otherwise leaked across tests in the same
+ * vitest worker.
+ *
+ * See docs/plans/2026-05-17-monitoring-and-alerts.md §S7 for the design
+ * rationale (out-of-band heartbeat vs. Cloud Monitoring custom-metric
+ * absent-for).
+ */
+export async function pingHeartbeat(
+  url: string | undefined,
+  kind: string,
+  fetcher: typeof fetch = fetch,
+): Promise<void> {
+  if (!url) return;
+  try {
+    const res = await fetcher(url, { method: 'POST' });
+    if (!res.ok) {
+      console.warn(`[heartbeat] ${kind}: non-2xx response ${res.status}`);
+    }
+  } catch (err) {
+    console.warn(`[heartbeat] ${kind}: network error`, err);
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler as Cloud Scheduler
    participant Job as bird-ingestor Job
    participant CLI as cli.ts (runCli)
    participant HC as Healthchecks.io

    Scheduler->>Job: invoke (cron: */30)
    Job->>CLI: runCli('recent', deps)
    alt summary.status === 'failure'
        CLI->>CLI: process.exitCode = 1
        Note over CLI,HC: no ping — absence IS the S7 signal
    else success | partial
        CLI->>HC: POST $HEALTHCHECKS_URL_RECENT
        Note over CLI,HC: best-effort — network errors swallowed
    end
```

## Summary

- First PR of the monitoring-and-alerts plan (#589). Lands the pure-code half — the heartbeat primitive and its cli wiring — ahead of the Terraform PR that provisions the Secret Manager values and the alert policies.
- `pingHeartbeat(url, kind, fetcher)` is best-effort: undefined URL is a no-op, network and 5xx errors are logged and swallowed, exit code is never touched. The failure branch of `runCli` is intentionally silent — heartbeat *absence* is what Healthchecks.io alerts on; pinging on failure would mask cron no-shows.
- Lands without infra side-effects. `HEALTHCHECKS_URL_<KIND>` is unset in prod until the Terraform PR adds the env wiring, so `pingHeartbeat(undefined, ...)` is a no-op on every current job execution.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test --workspace @bird-watch/ingestor -- cli heartbeat` — 57/57 pass (4 new heartbeat tests, 3 new cli wiring tests).
- [x] `npm run build --workspace @bird-watch/ingestor` — clean tsc.
- [x] New unit tests added covering: undefined URL no-op, success POST, 5xx swallow, network-error swallow, success-path ping, failure-path no-ping, hyphenated-kind env-name normalisation.

## Plan reference

Part of Plan `docs/plans/2026-05-17-monitoring-and-alerts.md`, Tasks 1-2.
Tracking issue: #589. Plan PR: #591.

Next PR in sequence (per plan §Sequencing): Task 5 — `meta_freshness_seconds` structured-log emit in read-api — followed by Task 3 (Terraform notification channel + secret manifests).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
