### PR TITLE
ci(probe): shape-2 rollup probe (Plan 2026-05-17 / Issue #593)

### DIFF
--- a/.github/workflows/shape-2-rollup-probe.yml
+++ b/.github/workflows/shape-2-rollup-probe.yml
@@ -1,0 +1,132 @@
+name: shape-2-rollup-probe
+
+# Weekly probe of the /data/obs/{region}/recent species-rollup contract.
+# See docs/plans/2026-05-17-shape-2-rollup-probe.md and
+# docs/runbooks/shape-2-rollup-probe.md.
+#
+# This workflow is NOT in the Mergify queue gate (it runs on a schedule, not on
+# PRs). A red probe blocks no PRs; it emails the repo admin and files a
+# drift:automated issue.
+#
+# Security note: only constant github.* context (server_url, repository,
+# run_id, ref_name) is substituted into run blocks. No user-controlled event
+# data (issue titles, PR bodies, commit messages, head_ref) is referenced --
+# this workflow is not exposed to any pull_request or issue trigger.
+
+on:
+  schedule:
+    # Every Monday 14:00 UTC. Weekly through fall migration (Sep-Oct 2026);
+    # cadence drops to quarterly in 2027 per the plan re-tuning task.
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+    inputs:
+      skip_alert_during_maintenance:
+        description: 'If true, do not file an issue on band miss this run.'
+        type: boolean
+        default: false
+
+concurrency:
+  group: shape-2-rollup-probe
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # append the CSV
+  issues:  write    # file the alert issue on fail
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run probe
+        id: probe
+        env:
+          # Repo secret is named EBIRD_API_KEY (already provisioned for ingestor/terraform);
+          # script reads it as EBIRD_KEY.
+          EBIRD_KEY: ${{ secrets.EBIRD_API_KEY }}
+        run: ./scripts/shape-2-probe.sh
+        continue-on-error: true
+
+      - name: Commit probe-history CSV
+        if: always()
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv
+          if git diff --cached --quiet; then
+            echo "No CSV change to commit."
+            exit 0
+          fi
+          git commit -m "chore(probe): o2 probe run $(date -u +%Y-%m-%d)"
+          # Rebase onto latest ref in case a concurrent commit landed while
+          # the probe was running. The retry guards against transient
+          # fast-forward rejections.
+          for attempt in 1 2 3; do
+            if git pull --rebase origin "$REF_NAME"; then
+              if git push origin "HEAD:$REF_NAME"; then
+                exit 0
+              fi
+            fi
+            echo "Push attempt $attempt failed; retrying after 5s."
+            sleep 5
+          done
+          echo "::warning::CSV commit could not be pushed after 3 attempts; row is in workflow log."
+          exit 0
+
+      - name: File issue on band miss
+        if: steps.probe.outcome == 'failure' && inputs.skip_alert_during_maintenance != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          today="$(date -u +%Y-%m-%d)"
+          # Build the issue body in a file. Unquoted heredoc so the exported
+          # env vars ($RUN_URL, $REPO) expand; backticks are escaped because
+          # they are literal markdown, not shell.
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          ## Shape 2 rollup-probe band miss
+
+          The weekly probe of \`/data/obs/{region}/recent\` returned at least one
+          row count outside its expected band. See
+          [the workflow run]($RUN_URL) for per-curl details and
+          [the probe-history CSV](https://github.com/$REPO/blob/main/docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv)
+          for trend data.
+
+          ## Playbook
+
+          1. **Re-run manually.** Click "Re-run failed jobs" on the workflow.
+             If it passes, close this issue with \`false-positive (retry green)\`.
+          2. **If retry fails:** check eBird's API changelog
+             (https://documenter.getpostman.com/view/664302/S1ENwy59) and the
+             eBird forum (https://groups.io/g/ebird-api) for \`/recent\` behavior
+             changes in the last 7 days.
+          3. **If no announcement:** post to the eBird forum (subject:
+             "Behavior change on /data/obs/{region}/recent — single-row-per-species
+             vs all observations?"). Include per-curl counts.
+          4. **If forum confirms a deliberate change OR counts stay off:** Shape
+             2 is dead. File a follow-up plan to re-cost the 50-state path under
+             Shape 1. See
+             \`docs/plans/2026-05-17-shape-2-rollup-probe.md\` §"Playbook" steps
+             4–5.
+
+          Close with: \`false-positive (retry green)\`, \`eBird-announced contract change\`, \`forum-confirmed silent change\`, or \`shape-2-deprecated\`.
+          EOF
+          gh issue create \
+            --repo "$REPO" \
+            --title "drift(o2-probe): Shape 2 rollup contract band miss $today" \
+            --label "drift:automated" \
+            --label "area:ingestor" \
+            --label "o2-probe" \
+            --body-file "$body_file"
+
+      - name: Fail job if probe failed and not in maintenance mode
+        if: steps.probe.outcome == 'failure' && inputs.skip_alert_during_maintenance != true
+        run: exit 1

--- a/docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv
+++ b/docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv
@@ -1,0 +1,1 @@
+ts,curl_1_us_back1,curl_2_us_back1_max100,curl_3_us_az_back1_max5_full,curl_4_us_ca_back1_max5,curl_5_us_ca_back1_max10k,curl_6_us_az_back1_max10k,curl_7_us_wy_back1_max10k,curl_8_us_back14,curl_9_us_az_back14,all_pass

--- a/docs/plans/2026-05-17-monitoring-and-alerts.md
+++ b/docs/plans/2026-05-17-monitoring-and-alerts.md
@@ -74,11 +74,7 @@ The phase-4 report's Open Question O2 calls for a recurring re-sample of the spe
 2. **Different infra surface.** Cloud Monitoring's alerts live in `infra/terraform/`; an HTTP-probe-with-JSON-shape-assertion lives more naturally in `.github/workflows/` as a scheduled workflow (the eBird API key is already a CI secret, the assertion logic is plain TypeScript or jq). Folding it into Terraform would require either a custom Cloud Run Job (overkill) or a synthetic Cloud Monitoring uptime check (can't express shape assertions, only response-code/keyword match).
 3. **Independent execution.** The Shape 2 probe can ship before or after this plan with zero dependency.
 
-The sibling plan stub:
-
-- **File:** `docs/plans/2026-05-17-shape-2-rollup-probe.md` (write this as a separate plan; outside this plan's scope).
-- **Shape:** GitHub Actions workflow, `cron: '0 14 * * 1'` (every Monday 14:00 UTC). 9 curls against `/data/obs/{US-AZ,US-TX,US-CA,US-NY,US-FL,US-WA,US-MA,US-IL,US-CO}/recent` (the 9-region sample matches the O2 spec). Asserts on row-count parity with the per-species rollup endpoint. Single boolean + per-region counts to job output; fails the workflow (and therefore emails) on falsy.
-- **Cost:** $0 (GitHub Actions free tier covers it; 1 workflow × 4 runs/mo × <1min wallclock).
+Implemented in `docs/plans/2026-05-17-shape-2-rollup-probe.md` (workflow file: `.github/workflows/shape-2-rollup-probe.yml`; probe script: `scripts/shape-2-probe.sh`; runbook: `docs/runbooks/shape-2-rollup-probe.md`).
 
 This plan does not block on the sibling plan landing.
 

--- a/docs/runbooks/shape-2-rollup-probe.md
+++ b/docs/runbooks/shape-2-rollup-probe.md
@@ -1,0 +1,49 @@
+# Runbook — Shape 2 Rollup Probe
+
+The Shape 2 rollup probe (`.github/workflows/shape-2-rollup-probe.yml`)
+re-runs Iterator 1's 9 curls weekly and asserts row counts fall inside
+expected bands. See `docs/plans/2026-05-17-shape-2-rollup-probe.md` for
+the design.
+
+## When the probe fires
+
+You will receive (1) a GitHub Actions workflow-failure email and (2) a
+`drift:automated` issue. Follow the playbook in the issue body verbatim.
+
+## Manual re-run
+
+```
+gh workflow run shape-2-rollup-probe --repo julianken/bird-sight-system
+```
+
+## Suppressing during eBird maintenance
+
+```
+gh workflow run shape-2-rollup-probe \
+  --repo julianken/bird-sight-system \
+  -f skip_alert_during_maintenance=true
+```
+
+The probe still runs and still appends to the CSV; only the issue
+creation is suppressed.
+
+## Re-tuning bands
+
+After 12 months of clean data (~52 rows in the CSV), revisit
+`scripts/shape-2-bands.json`. For each `band`-mode curl, compute P5 and
+P95 across the 12-month history; new band = `[0.5 × P5, 1.5 × P95]`.
+Land as a single-file PR.
+
+## Cadence change (weekly → quarterly)
+
+After spring 2027 (one full year covering both migration windows), edit
+the cron in `.github/workflows/shape-2-rollup-probe.yml` from
+`0 14 * * 1` to `0 14 1 1,4,7,10 *` (1st of Jan/Apr/Jul/Oct, 14:00 UTC).
+
+## When the probe is dead (Shape 2 deprecated)
+
+If a fire confirms the species-rollup contract is gone, file a follow-up
+plan to re-cost the 50-state path under Shape 1, archive this workflow
+(set `on: workflow_dispatch:` only, drop the cron), and add an addendum
+to `docs/analyses/2026-05-14-process-scale-options/phase-4/analysis-report.md`
+Theme 2 / Opportunity O1.

--- a/scripts/shape-2-bands.json
+++ b/scripts/shape-2-bands.json
@@ -1,0 +1,13 @@
+{
+  "curls": [
+    { "id": 1, "name": "us_back1",             "path": "/v2/data/obs/US/recent?back=1&maxResults=10000",            "mode": "band",  "low":  340, "high": 1400 },
+    { "id": 2, "name": "us_back1_max100",      "path": "/v2/data/obs/US/recent?back=1&maxResults=100",              "mode": "exact", "value": 100 },
+    { "id": 3, "name": "us_az_back1_max5_full","path": "/v2/data/obs/US-AZ/recent?back=1&maxResults=5&detail=full", "mode": "exact", "value": 5 },
+    { "id": 4, "name": "us_ca_back1_max5",     "path": "/v2/data/obs/US-CA/recent?back=1&maxResults=5",             "mode": "exact", "value": 5 },
+    { "id": 5, "name": "us_ca_back1_max10k",   "path": "/v2/data/obs/US-CA/recent?back=1&maxResults=10000",         "mode": "band",  "low":  200, "high":  700 },
+    { "id": 6, "name": "us_az_back1_max10k",   "path": "/v2/data/obs/US-AZ/recent?back=1&maxResults=10000",         "mode": "band",  "low":  150, "high":  550 },
+    { "id": 7, "name": "us_wy_back1_max10k",   "path": "/v2/data/obs/US-WY/recent?back=1&maxResults=10000",         "mode": "band",  "low":   80, "high":  400 },
+    { "id": 8, "name": "us_back14",            "path": "/v2/data/obs/US/recent?back=14&maxResults=10000",           "mode": "band",  "low":  600, "high": 1800 },
+    { "id": 9, "name": "us_az_back14",         "path": "/v2/data/obs/US-AZ/recent?back=14&maxResults=10000",        "mode": "band",  "low":  250, "high":  800 }
+  ]
+}

--- a/scripts/shape-2-probe.sh
+++ b/scripts/shape-2-probe.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Shape-2 rollup-probe: re-runs Iterator 1's 9 curls against
+# /data/obs/{region}/recent and asserts each row count falls inside an
+# expected band. See docs/plans/2026-05-17-shape-2-rollup-probe.md.
+#
+# Inputs:
+#   $EBIRD_KEY     — required, eBird API key (GitHub Actions secret).
+#   $HISTORY_CSV   — optional path to append a row to; default
+#                    docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv
+# Output:
+#   $GITHUB_OUTPUT — writes all_pass=true|false and counts_json=[...]
+#                    when running under GitHub Actions; harmless locally.
+# Exit:
+#   0 if all 9 curls pass their band; 1 otherwise; 2 on missing key.
+
+set -euo pipefail
+
+BANDS_FILE="$(dirname "$0")/shape-2-bands.json"
+HISTORY_CSV="${HISTORY_CSV:-docs/analyses/2026-05-14-process-scale-options/o2-probe-history.csv}"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ -z "${EBIRD_KEY:-}" ]]; then
+  echo "EBIRD_KEY not set" >&2
+  exit 2
+fi
+
+fetch_count() {
+  # Issues a single curl, returns the JSON-array length. Retries once after
+  # 60s on non-200 or non-array body.
+  local path="$1"
+  local attempt body count
+  for attempt in 1 2; do
+    body=$(curl -sS -H "X-eBirdApiToken: $EBIRD_KEY" "https://api.ebird.org${path}" || echo '')
+    count=$(echo "$body" | jq 'if type == "array" then length else -1 end' 2>/dev/null || echo -1)
+    if [[ "$count" -ge 0 ]]; then
+      echo "$count"
+      return 0
+    fi
+    if [[ $attempt -eq 1 ]]; then sleep 60; fi
+  done
+  echo -1
+}
+
+declare -a counts
+all_pass=true
+n=$(jq '.curls | length' "$BANDS_FILE")
+for i in $(seq 0 $((n - 1))); do
+  path=$(jq -r ".curls[$i].path" "$BANDS_FILE")
+  mode=$(jq -r ".curls[$i].mode" "$BANDS_FILE")
+  name=$(jq -r ".curls[$i].name" "$BANDS_FILE")
+  c=$(fetch_count "$path")
+  counts+=("$c")
+  if [[ "$mode" == "exact" ]]; then
+    want=$(jq -r ".curls[$i].value" "$BANDS_FILE")
+    if [[ "$c" -ne "$want" ]]; then
+      echo "FAIL curl $((i+1)) $name: got $c, want exactly $want" >&2
+      all_pass=false
+    else
+      echo "PASS curl $((i+1)) $name: $c"
+    fi
+  else
+    low=$(jq -r ".curls[$i].low" "$BANDS_FILE")
+    high=$(jq -r ".curls[$i].high" "$BANDS_FILE")
+    if [[ "$c" -lt "$low" || "$c" -gt "$high" ]]; then
+      echo "FAIL curl $((i+1)) $name: got $c, want [$low..$high]" >&2
+      all_pass=false
+    else
+      echo "PASS curl $((i+1)) $name: $c in [$low..$high]"
+    fi
+  fi
+done
+
+# Append CSV row (works locally and in CI).
+row="$TS"
+for c in "${counts[@]}"; do row="$row,$c"; done
+row="$row,$all_pass"
+mkdir -p "$(dirname "$HISTORY_CSV")"
+if [[ ! -f "$HISTORY_CSV" ]]; then
+  echo "ts,curl_1_us_back1,curl_2_us_back1_max100,curl_3_us_az_back1_max5_full,curl_4_us_ca_back1_max5,curl_5_us_ca_back1_max10k,curl_6_us_az_back1_max10k,curl_7_us_wy_back1_max10k,curl_8_us_back14,curl_9_us_az_back14,all_pass" > "$HISTORY_CSV"
+fi
+echo "$row" >> "$HISTORY_CSV"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "all_pass=$all_pass" >> "$GITHUB_OUTPUT"
+  printf 'counts_json=[%s]\n' "$(IFS=,; echo "${counts[*]}")" >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$all_pass" == "true" ]]; then exit 0; else exit 1; fi


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    cron[GitHub Actions cron<br/>Mon 14:00 UTC] --> wf[shape-2-rollup-probe.yml]
    dispatch[workflow_dispatch] --> wf
    wf --> script[scripts/shape-2-probe.sh]
    script -->|9 curls| ebird[eBird /data/obs/.../recent]
    ebird -->|counts| script
    script -->|compare to| bands[scripts/shape-2-bands.json]
    script --> csv[o2-probe-history.csv<br/>append + commit]
    script -->|exit 1 on band miss| fail{any band miss?}
    fail -->|yes| issue[gh issue create<br/>drift:automated, area:ingestor, o2-probe]
    fail -->|yes| email[workflow-fail email<br/>repo admin]
    fail -->|no| green[green]
```

## Summary

- Implements the Shape 2 rollup-probe plan (`docs/plans/2026-05-17-shape-2-rollup-probe.md`, merged in #594) so an undocumented eBird contract that the 50-state Shape 2 architecture depends on doesn't silently regress: 9 curls, weekly, per-curl band assertion, drift-issue + email on miss.
- Addresses the `julianken-bot` **IMPORTANT** finding from PR #594's review: the issue-body heredoc is now unquoted with `$RUN_URL` and `$REPO` pre-built via the step `env:` block from `github.server_url`/`github.repository`/`github.run_id`, so the link actually points at the failing run instead of containing the literal string `$GITHUB_SERVER_URL`. Backticks inside the markdown are escaped so the shell doesn't try to execute them.
- Addresses both `julianken-bot` **SUGGESTION**s: curl #1 lower band tuned 400 → 340 (~50% of Iterator-1's 683, off the tight edge of the 40-60% generous-low rule); CSV-commit step does `git pull --rebase` + retry × 3 on push to handle concurrent commits on `main`, then degrades to a `::warning::` rather than failing the run if the push still won't go through.

## Screenshots

N/A — not UI. This PR adds a scheduled GitHub Actions workflow, a bash probe script + JSON band definitions, a runbook, and a one-line edit to the monitoring plan's sibling-plan stub. No files touched under `frontend/**`.

- [ ] Every new/renamed `className` in this PR has a matching CSS rule — N/A (no `frontend/**` files)
- [ ] Multi-viewport design QA — N/A — not UI

## Test plan

- [x] `actionlint .github/workflows/shape-2-rollup-probe.yml` — clean
- [x] `shellcheck scripts/shape-2-probe.sh` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/shape-2-rollup-probe.yml'))"` — parses
- [x] Confirmed repo secret `EBIRD_API_KEY` exists (`gh secret list`); workflow exposes it to the script as `EBIRD_KEY` per the script's input contract
- [x] Confirmed labels: `drift:automated` and `area:ingestor` already exist on the repo; `o2-probe` created during execution
- [ ] (operator, post-merge) `gh workflow run shape-2-rollup-probe --repo julianken/bird-sight-system` — manual baseline dispatch per Plan §"Task 3". Expect: 9 PASS lines, one CSV row appended with `all_pass=true`, workflow green, counts within an order of magnitude of Iterator 1's 2026-05-14 numbers.

The probe runs on cron/dispatch only, not on PRs, so there is no `pull_request` interaction to verify pre-merge. CI gate checks (`test`, `lint`, `build`, `e2e`) are not affected by this change.

## Plan reference

Part of `docs/plans/2026-05-17-shape-2-rollup-probe.md`, tasks 1, 2, and 4 (the implementation tasks). Task 3 is a post-merge manual workflow dispatch by the operator. Tracking issue: #593. Plan PR: #594.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)