### PR TITLE
infra(monitoring): notification channel + alert policies S1..S6 + uptime check

### DIFF
--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -1,0 +1,353 @@
+# ── Notification channels ────────────────────────────────────────────────
+#
+# Single subscriber for v1: julian.kennon.d@gmail.com. SMS, PagerDuty, Slack
+# are future iterations. The channel resource is provisioned via Terraform so
+# every alert policy below can reference it without click-ops drift.
+#
+# Plan: docs/plans/2026-05-17-monitoring-and-alerts.md
+
+resource "google_monitoring_notification_channel" "email_julian" {
+  display_name = "Julian (email)"
+  type         = "email"
+  labels       = { email_address = var.alert_email }
+}
+
+# ── Healthchecks.io secret manifests ─────────────────────────────────────
+#
+# One Secret Manager secret per cron. Values are populated out-of-band:
+#   gcloud secrets versions add bird-watch-healthchecks-recent \
+#     --project=bird-maps-prod --data-file=- <<< "https://hc-ping.com/<uuid>"
+# Terraform declares the secret + IAM binding; the URL itself never lands
+# in tfvars or state. Mirrors the R2-credentials pattern in ingestor.tf.
+
+locals {
+  healthchecks_kinds = ["recent", "backfill", "hotspots", "taxonomy", "photos", "descriptions", "prune"]
+}
+
+resource "google_secret_manager_secret" "healthchecks_url" {
+  for_each  = toset(local.healthchecks_kinds)
+  secret_id = "bird-watch-healthchecks-${each.key}"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_healthchecks" {
+  for_each  = google_secret_manager_secret.healthchecks_url
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+# ── S1: Ingest job non-zero exit ─────────────────────────────────────────
+#
+# Threshold: ≥1 failed execution in rolling 1h.
+# Rationale: ingestor sets process.exitCode=1 on RunSummary.status==='failure'
+# (services/ingestor/src/cli.ts). The "42 silent failures" finding from
+# docs/analyses/2026-05-14-process-scale-options/phase-4 motivates this. 1h
+# window matches the */30 recent-ingest cron — sub-hour is below sampling
+# resolution; multi-hour delays the page past one full cron interval.
+
+resource "google_monitoring_alert_policy" "ingest_job_failure" {
+  display_name          = "Ingest job non-zero exit (S1)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "Cloud Run Job execution failed in last 1h"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/job/completed_execution_count\" AND resource.type=\"cloud_run_job\" AND metric.label.result=\"failed\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+      aggregations {
+        alignment_period   = "3600s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  alert_strategy {
+    auto_close = "604800s" # 7d — auto-closes after a week of no re-fire
+  }
+}
+
+# ── S2: Data staleness (freshestObservationAt > 6h) ──────────────────────
+#
+# Threshold: 6h. Rationale: recent-ingest cron is */30; eBird obs land within
+# 5-15min of submission; AZ has sub-hour gaps. 6h staleness => ≥12 consecutive
+# recent-ingest runs made zero forward progress on observation timestamps.
+# Below 6h is noise (legitimate quiet hours mid-day); above 12h is too late.
+#
+# The metric source is a log-based metric extracted from a structured-log
+# line emitted by the `/api/observations` handler — the endpoint that
+# actually computes and returns `meta.freshestObservationAt`
+# (services/read-api/src/app.ts). Task 5 lands the emit; the log-based metric
+# below pulls the value out as a distribution, and the alert fires when the
+# p95 over a 30min window exceeds 21600s (6h).
+
+resource "google_logging_metric" "meta_freshness_seconds" {
+  name   = "bird-meta-freshness-seconds"
+  filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\" AND jsonPayload.meta_freshness_seconds!=NULL_VALUE"
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "DISTRIBUTION"
+    unit        = "s"
+  }
+  value_extractor = "EXTRACT(jsonPayload.meta_freshness_seconds)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 60
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "data_staleness" {
+  display_name          = "Data staleness > 6h (S2)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "freshestObservationAt older than 6h for 30min"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/bird-meta-freshness-seconds\" AND resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 21600 # 6h in seconds
+      duration        = "1800s"
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+      }
+    }
+  }
+}
+
+# ── S3: Read-API 5xx rate > 1% over 5min, gated by ≥100 req/window ───────
+#
+# Threshold: >1% AND request_count ≥ 100 over the 5min window.
+# Rationale: 1% is the canonical "bad day" threshold; on its own it fires
+# constantly during low-traffic hours (1 error in 50 requests = 2%, fires).
+# The 100-request floor (~20 req/min sustained over 5min) is the
+# alert-fatigue gate. `denominator_filter` by itself produces a ratio but
+# does NOT impose a minimum-volume floor on that ratio — to gate the
+# alert on absolute traffic we combine TWO conditions via combiner = "AND":
+#   (a) 5xx_rate > 1%  AND  (b) total_request_count > 100 over the window.
+# Both conditions use the same 300s alignment, so the AND-combiner evaluates
+# them coherently. At HN-scale launch traffic condition (b) is invisible;
+# at 03:00 idle traffic it correctly suppresses the alert.
+
+resource "google_monitoring_alert_policy" "read_api_5xx" {
+  display_name          = "Read API 5xx rate > 1% (S3)"
+  combiner              = "AND"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "5xx rate >1% over 5min"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\" AND metric.label.response_code_class=\"5xx\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0.01
+      duration        = "300s"
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+      # Ratio numerator/denominator. The denominator_filter expresses the
+      # ratio; it does NOT impose a min-volume floor on its own — that's
+      # the second condition below.
+      denominator_filter = "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+      denominator_aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+
+  # Minimum-volume gate. Combined with the ratio condition via
+  # combiner = "AND" above. Threshold is 100 requests over the 5min window,
+  # expressed as a rate threshold: 100 req / 300s = 0.333 req/s.
+  conditions {
+    display_name = "request count >= 100 over 5min (min-volume floor)"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0.333 # 100 req / 300s
+      duration        = "300s"
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+}
+
+# ── S4: Read-API p95 latency > 2000ms over 10min ─────────────────────────
+#
+# Threshold: 2000ms p95. Rationale: current p95 is 150-300ms; 2000ms is the
+# "user tabs away" threshold. 10min smooths over cold-start spikes (scale-
+# to-zero) without missing a real degradation.
+
+resource "google_monitoring_alert_policy" "read_api_latency" {
+  display_name          = "Read API p95 latency > 2s (S4)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "p95 > 2000ms over 10min"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/request_latencies\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 2000
+      duration        = "600s"
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+      }
+    }
+  }
+}
+
+# ── S5: Cloud Run instance crash / OOM ───────────────────────────────────
+#
+# Log-based metric: counts severity>=ERROR messages matching the
+# Cloud Run kill phrases. Threshold ≥1 in rolling 1h batches transient
+# flaps into one notification.
+
+resource "google_logging_metric" "container_crash" {
+  name   = "bird-container-crash"
+  filter = <<-EOT
+    resource.type="cloud_run_revision" AND
+    (resource.labels.service_name=~"bird-(read-api|ingestor.*)") AND
+    severity>=ERROR AND
+    (textPayload=~"Container terminated" OR textPayload=~"out of memory" OR textPayload=~"OOMKilled")
+  EOT
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_alert_policy" "container_crash" {
+  display_name          = "Cloud Run container crash / OOM (S5)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = ">=1 crash log in 1h"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/bird-container-crash\" AND resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+      aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+}
+
+# ── S6: Neon connection failures ─────────────────────────────────────────
+#
+# Threshold: ≥3 in rolling 10min. Rationale: Neon free tier suspends idle
+# endpoints; single ENOTFOUND/ECONNREFUSED is normal cold-wake. Three in
+# 10min means the pool is genuinely broken. TIGHTEN to ≥1 once the Cloud
+# SQL migration lands (sibling plan) — Cloud SQL doesn't suspend, so any
+# connection failure is a real incident.
+
+resource "google_logging_metric" "neon_conn_fail" {
+  name   = "bird-neon-conn-fail"
+  filter = <<-EOT
+    resource.type="cloud_run_revision" AND
+    (resource.labels.service_name=~"bird-(read-api|ingestor.*)") AND
+    (textPayload=~"getaddrinfo ENOTFOUND" OR textPayload=~"ECONNREFUSED" OR textPayload=~"Connection terminated unexpectedly")
+  EOT
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_alert_policy" "neon_conn_fail" {
+  display_name          = "Neon connection failures >=3 in 10min (S6)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = ">=3 conn failures in 10min"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/bird-neon-conn-fail\" AND resource.type=\"cloud_run_revision\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 3
+      duration        = "0s"
+      aggregations {
+        alignment_period     = "600s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+}
+
+# ── Uptime check on the public read-api ─────────────────────────────────
+#
+# Synthetic monitoring: GCP regions ping /api/regions every 60s. Alert
+# fires if regions fail for consecutive checks. Catches DNS / TLS /
+# Cloud Run cold-fail issues that the request_count metric can't see
+# (because by definition there are no requests landing).
+
+resource "google_monitoring_uptime_check_config" "read_api" {
+  display_name = "read-api /api/regions"
+  timeout      = "10s"
+  period       = "60s"
+
+  http_check {
+    path           = "/api/regions"
+    port           = 443
+    use_ssl        = true
+    validate_ssl   = true
+    request_method = "GET"
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      host       = "api.bird-maps.com"
+      project_id = var.gcp_project_id
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "read_api_uptime" {
+  display_name          = "Read API uptime check failing"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "uptime check failures over 3 consecutive checks"
+    condition_threshold {
+      filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\" AND metric.label.check_id=\"${google_monitoring_uptime_check_config.read_api.uptime_check_id}\""
+      comparison      = "COMPARISON_LT"
+      threshold_value = 1
+      duration        = "180s"
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.label.*"]
+      }
+      trigger {
+        count = 2
+      }
+    }
+  }
+}

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -177,7 +177,7 @@ resource "google_monitoring_alert_policy" "read_api_5xx" {
     condition_threshold {
       filter          = "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
       comparison      = "COMPARISON_GT"
-      threshold_value = 0.333 # 100 req / 300s
+      threshold_value = 0.33 # 100 req / 300s — use 0.33 (not 0.333) so a window with exactly 100 evenly-spaced requests is unambiguously >= floor; GT 0.333 only passes 100/300s by 3.3e-5
       duration        = "300s"
       aggregations {
         alignment_period     = "300s"
@@ -287,7 +287,7 @@ resource "google_monitoring_alert_policy" "neon_conn_fail" {
     condition_threshold {
       filter          = "metric.type=\"logging.googleapis.com/user/bird-neon-conn-fail\" AND resource.type=\"cloud_run_revision\""
       comparison      = "COMPARISON_GT"
-      threshold_value = 3
+      threshold_value = 2 # GT 2 ⇒ fires at ≥3, matching plan spec "≥3 in rolling 10min" (house style: "GT (N-1)" as in S1/S5)
       duration        = "0s"
       aggregations {
         alignment_period     = "600s"
@@ -335,9 +335,14 @@ resource "google_monitoring_alert_policy" "read_api_uptime" {
   conditions {
     display_name = "uptime check failures over 3 consecutive checks"
     condition_threshold {
-      filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\" AND metric.label.check_id=\"${google_monitoring_uptime_check_config.read_api.uptime_check_id}\""
-      comparison      = "COMPARISON_LT"
-      threshold_value = 1
+      filter = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\" AND metric.label.check_id=\"${google_monitoring_uptime_check_config.read_api.uptime_check_id}\""
+      # Intent: fire when the uptime check FAILS. REDUCE_COUNT_FALSE collapses
+      # per-region check_passed=false values into a count of failing regions.
+      # COMPARISON_GT against threshold 0 => fires when ≥1 region is failing.
+      # (Previously COMPARISON_LT 1 against the same count meant "fire when
+      # ZERO regions are failing" — inverted intent.)
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
       duration        = "180s"
       aggregations {
         alignment_period     = "60s"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -8,3 +8,9 @@ cloudflare_zone_id    = "REPLACE_ME"
 ebird_api_key         = "REPLACE_ME"
 domain                = "birdwatch.example.com"
 frontend_origins      = "https://bird-maps.com,https://www.bird-maps.com"
+
+# Monitoring & alerts (Plan 2026-05-17). alert_email defaults to
+# julian.kennon.d@gmail.com — uncomment to override. Healthchecks.io URLs are
+# NOT set here; they live in Secret Manager (bird-watch-healthchecks-<kind>)
+# populated out-of-band post-`terraform apply` via `gcloud secrets versions add`.
+# alert_email           = "julian.kennon.d@gmail.com"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -48,6 +48,19 @@ variable "domain" {
   description = "Domain you control on Cloudflare, e.g. birdwatch.example.com"
 }
 
+variable "alert_email" {
+  description = "Email address to receive monitoring alerts. v1: single subscriber; team channel routing is a future iteration."
+  type        = string
+  default     = "julian.kennon.d@gmail.com"
+}
+
+# Healthchecks.io ping URLs — one per cron job. Provisioned out-of-band via
+# the Healthchecks.io web UI (free tier: 20 checks), then stored in Secret
+# Manager via `gcloud secrets versions add bird-watch-healthchecks-<kind>
+# --data-file=-`. Plan: docs/plans/2026-05-17-monitoring-and-alerts.md §S7.
+# These vars are NOT referenced by HCL — they document the secret-id contract
+# only. The secrets themselves are declared in infra/terraform/monitoring.tf.
+
 variable "frontend_origins" {
   type        = string
   default     = "https://bird-maps.com,https://www.bird-maps.com"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph CloudRun["Cloud Run / Jobs"]
        RA[bird-read-api]
        IJ[bird-ingestor*]
    end
    subgraph Logs["Cloud Logging"]
        L1[meta_freshness_seconds]
        L2[container_crash]
        L3[neon_conn_fail]
    end
    subgraph Metrics["Cloud Monitoring"]
        S1[S1 job-failure]
        S2[S2 staleness]
        S3[S3 5xx rate >1% AND >=100 req]
        S4[S4 p95 latency]
        S5[S5 crash/OOM]
        S6[S6 neon-conn]
        U[Uptime /api/regions]
    end
    Channel[Email: julian.kennon.d@gmail.com]

    RA -- request_count/latencies --> S3
    RA -- request_latencies --> S4
    RA -- jsonPayload --> L1 --> S2
    IJ -- completed_execution_count --> S1
    RA -. severity ERROR .-> L2 --> S5
    IJ -. severity ERROR .-> L2
    RA -. ENOTFOUND/ECONNREFUSED .-> L3 --> S6
    IJ -. ENOTFOUND/ECONNREFUSED .-> L3
    U --> Channel
    S1 --> Channel
    S2 --> Channel
    S3 --> Channel
    S4 --> Channel
    S5 --> Channel
    S6 --> Channel
```

## Summary

- Implements Tasks 3+4 of `docs/plans/2026-05-17-monitoring-and-alerts.md` — closes the "failure observability is rich; failure subscription is empty" gap (42 silent ingest-job failures motivated this). Pre-national-launch, $0.00 / mo on free tier.
- Six alert policies (S1..S6), a `/api/regions` uptime check, three log-based metrics (`bird-meta-freshness-seconds`, `bird-container-crash`, `bird-neon-conn-fail`), and a single email notification channel. S3 uses `combiner="AND"` with a `>=100 req/5min` floor condition to prevent low-traffic false fires.
- Seven empty `google_secret_manager_secret` resources for Healthchecks.io URLs (S7 heartbeat). Values are populated out-of-band by the operator post-merge; a follow-up PR wires `HEALTHCHECKS_URL_<KIND>` env vars into the Cloud Run Jobs (Task 6, deliberately deferred so this `terraform apply` is non-destructive to the live ingestor).

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean
- [x] `terraform validate` — Success
- [ ] `terraform plan` — to be run by operator at apply time; expect 1 channel + 7 empty secrets + 7 IAM bindings + 6 alert policies + 3 log-based metrics + 1 uptime config + 1 uptime alert added; zero replaces, zero destroys
- [ ] Smoke tests for each alert run after apply (S1 force-fail via `args=unknown-kind`, S4 synthetic load, etc.) — documented in the runbook PR (Tasks 5+7)

## Plan reference

Part of Plan `docs/plans/2026-05-17-monitoring-and-alerts.md`, Tasks 3 + 4. Tracking issue: #589. Tasks 1+2 landed via #598. Task 5 (read-api log emit) + Task 7 (runbook + smoke procedure) follow in a sibling PR. Task 6 (Healthchecks.io secret population + env-wiring) is split: secret population is out-of-band operator action post-merge; env-wiring lands in a third PR once values exist in Secret Manager (otherwise the ingestor would fail-start on missing-secret refs).

### Out-of-band operator steps after this PR merges

1. Create 7 checks at healthchecks.io (free tier, signup with `julian.kennon.d@gmail.com`):

| Check name | Schedule | Grace |
|---|---|---|
| `bird-ingest-recent` | every 30 min | 10 min |
| `bird-ingest-backfill` | cron `0 4 * * *` | 60 min |
| `bird-ingest-hotspots` | cron `0 5 * * 0` | 60 min |
| `bird-ingest-taxonomy` | cron `0 6 1 * *` | 120 min |
| `bird-ingest-photos` | cron `0 7 1 * *` | 120 min |
| `bird-ingest-descriptions` | cron `0 8 * * *` | 60 min |
| `bird-ingest-prune` | daily | 60 min |

2. Populate the secrets (each URL pasted to stdin):

```sh
for kind in recent backfill hotspots taxonomy photos descriptions prune; do
  read -r URL\?"Paste hc-ping URL for $kind: "
  printf '%s' "$URL" | gcloud secrets versions add bird-watch-healthchecks-$kind \
    --project=bird-maps-prod --data-file=-
done
```

3. Apply the follow-up env-wiring PR (Task 6 HCL).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)