### PR TITLE
fix(infra): pin Cloud SQL edition=ENTERPRISE for db-g1-small (hotfix)

### DIFF
--- a/infra/terraform/cloud-sql.tf
+++ b/infra/terraform/cloud-sql.tf
@@ -31,6 +31,7 @@ resource "google_sql_database_instance" "birdwatch" {
   deletion_protection = true
 
   settings {
+    edition               = "ENTERPRISE" # db-g1-small is invalid under ENTERPRISE_PLUS (the GCP default for new instances)
     tier                  = "db-g1-small"
     availability_type     = "ZONAL" # single-zone; flip to REGIONAL later if traffic warrants
     disk_type             = "PD_SSD"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[terraform apply] -->|create instance| B{Cloud SQL API}
    B -->|default edition| C[ENTERPRISE_PLUS]
    C -->|reject tier db-g1-small| D[400 Invalid Tier]
    A2[terraform apply<br/>+ edition=ENTERPRISE] -->|create instance| B2{Cloud SQL API}
    B2 -->|edition=ENTERPRISE| E[accepts db-g1-small]
    E --> F[birdwatch-pg16 created]
```

## Summary

- Production `terraform apply` failed: `Invalid Tier (db-g1-small) for (ENTERPRISE_PLUS) Edition`. GCP now defaults new Cloud SQL Postgres instances to ENTERPRISE_PLUS, which does not accept legacy shared-core tiers.
- Hotfix pins `settings.edition = "ENTERPRISE"` in `infra/terraform/cloud-sql.tf`. No change to `tier`, `disk_size`, `disk_autoresize`, or any other setting approved in PR #613.
- Preserves the cost profile from plan #590 §1 — that plan's break-even math was computed against ENTERPRISE pricing.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check infra/terraform/cloud-sql.tf` — clean
- [ ] `terraform validate` — not run locally (requires `terraform init` against remote providers; user will run apply after merge per task brief)
- [x] Diff scope verified: only `edition = "ENTERPRISE"` added inside `settings { ... }`; no other attributes touched

## Plan reference

Hotfix for plan #590 / PR #613 (`docs/plans/2026-05-17-cloud-sql-migration.md` §1). Out-of-plan emergency repair for the production apply error.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)