### PR TITLE
infra: Cloud SQL Stage 2 — Auth Proxy socket mount (cutover-safe)

### DIFF
--- a/infra/terraform/admin-api.tf
+++ b/infra/terraform/admin-api.tf
@@ -182,6 +182,21 @@ resource "google_cloud_run_v2_service" "admin_api" {
         name  = "API_HOST"
         value = "api.${var.domain}"
       }
+
+      # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+      # migration (docs/plans/2026-05-17-cloud-sql-migration.md §3.2). Mount
+      # is additive — DATABASE_URL still points at Neon until Stage 3.
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+    }
+
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.birdwatch.connection_name]
+      }
     }
   }
 

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -129,6 +129,21 @@ resource "google_cloud_run_v2_job" "ingestor" {
             }
           }
         }
+
+        # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+        # migration (docs/plans/2026-05-17-cloud-sql-migration.md §3.2).
+        # Additive: DATABASE_URL still points at Neon until Stage 3.
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.birdwatch.connection_name]
+        }
       }
     }
   }
@@ -359,6 +374,20 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
             }
           }
         }
+
+        # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+        # migration. Additive; DATABASE_URL still points at Neon.
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.birdwatch.connection_name]
+        }
       }
     }
   }
@@ -545,6 +574,20 @@ resource "google_cloud_run_v2_job" "ingestor_descriptions" {
           name  = "DESCRIPTIONS_PURGE_CACHE"
           value = "1"
         }
+
+        # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+        # migration. Additive; DATABASE_URL still points at Neon.
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.birdwatch.connection_name]
+        }
       }
     }
   }
@@ -678,6 +721,20 @@ resource "google_cloud_run_v2_job" "ingestor_prune" {
               version = "latest"
             }
           }
+        }
+
+        # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+        # migration. Additive; DATABASE_URL still points at Neon.
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.birdwatch.connection_name]
         }
       }
     }

--- a/infra/terraform/read-api.tf
+++ b/infra/terraform/read-api.tf
@@ -71,6 +71,25 @@ resource "google_cloud_run_v2_service" "read_api" {
         name  = "RATE_LIMIT_ENABLED"
         value = "true"
       }
+
+      # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
+      # migration (docs/plans/2026-05-17-cloud-sql-migration.md §3.2). The
+      # mount is purely additive: DATABASE_URL still points at Neon, so the
+      # socket sits unused at /cloudsql/<connection_name>/.s.PGSQL.5432 until
+      # Stage 3 flips the secret. This unblocks the cutover without a code
+      # or image change — a Stage-3 Secret Manager version bump is all it
+      # takes to switch traffic.
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+    }
+
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [google_sql_database_instance.birdwatch.connection_name]
+      }
     }
   }
 


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
  subgraph CloudRun["Cloud Run services + jobs"]
    RA[read-api]
    AA[admin-api]
    IG[ingestor]
    IGP[ingestor-photos]
    IGD[ingestor-descriptions]
    IGPR[ingestor-prune]
  end

  RA -- DATABASE_URL --> NEON[(Neon — live traffic)]
  AA -- DATABASE_URL --> NEON
  IG -- DATABASE_URL --> NEON
  IGP -- DATABASE_URL --> NEON
  IGD -- DATABASE_URL --> NEON
  IGPR -- DATABASE_URL --> NEON

  RA -. "/cloudsql socket (idle)" .-> CSQL[(Cloud SQL — birdwatch-pg16)]
  AA -. "/cloudsql socket (idle)" .-> CSQL
  IG -. "/cloudsql socket (idle)" .-> CSQL
  IGP -. "/cloudsql socket (idle)" .-> CSQL
  IGD -. "/cloudsql socket (idle)" .-> CSQL
  IGPR -. "/cloudsql socket (idle)" .-> CSQL
```

Solid lines = live traffic (Neon, unchanged). Dotted lines = Auth Proxy socket mounted but idle until Stage 3 flips `DATABASE_URL` via a Secret Manager version bump.

## Summary

- Stage 2 of the Neon→Cloud SQL migration: adds `cloud_sql_instance` volume + `/cloudsql` `volume_mounts` to all 2 Cloud Run services and all 4 Cloud Run Jobs. Cutover-safe — `DATABASE_URL` is unchanged.
- Mounting the Auth Proxy ahead of time means Stage 3 cutover is a single Secret Manager version bump, not a coordinated 6-resource Terraform apply.
- Depends on Stage 1 (`cloud-sql.tf`) being applied in prod so `google_sql_database_instance.birdwatch.connection_name` resolves at apply time.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean
- [x] `terraform validate` — Success
- [ ] Operator runs `terraform plan` — expects 6 in-place updates (2 services + 4 jobs), no replacements, no destroys
- [ ] Operator runs `terraform apply` — Cloud Run revisions roll forward; existing connections unaffected since DATABASE_URL is unchanged
- [ ] Post-apply smoke: `gcloud run services describe bird-read-api --region us-west1 --format='value(spec.template.spec.volumes)'` shows the cloudsql volume

## Plan reference

Part of Plan `docs/plans/2026-05-17-cloud-sql-migration.md`, Stage 2 (§3.2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)