### PR TITLE
feat(tools): going-national status dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ terraform.tfstate.backup
 
 # Throwaway directory for Phase 0 prototype gating — deleted in Task 0.4.
 prototype/
+
+# national-dashboard local tool
+tools/national-dashboard/node_modules/
+tools/national-dashboard/package-lock.json

--- a/tools/national-dashboard/README.md
+++ b/tools/national-dashboard/README.md
@@ -1,0 +1,20 @@
+# national-dashboard
+
+Local, read-only status dashboard for the going-national rollout
+(`docs/plans/2026-05-17-going-national.md`). Polls GitHub (via `gh`), live
+production endpoints (`api.bird-maps.com`, `bird-maps.com`), and GCP (via
+`gcloud`) every 30s server-side; the browser refreshes every 5s and shows
+color-coded status pills per phase item.
+
+## Run
+
+```sh
+cd tools/national-dashboard
+npm install
+npm start
+# open http://localhost:7777
+```
+
+Uses your existing `gh` + `gcloud` auth. No secrets are read, written, or
+committed. Listens only on `127.0.0.1:7777`. Not deployed; not in CI; not
+shipped to production.

--- a/tools/national-dashboard/package.json
+++ b/tools/national-dashboard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@bird-watch/national-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Local read-only dashboard for the going-national project rollout.",
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/tools/national-dashboard/public/index.html
+++ b/tools/national-dashboard/public/index.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>going-national status</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <header>
+    <h1>going-national status</h1>
+    <div class="meta">
+      Last updated: <strong id="last-updated">—</strong>
+      &nbsp;·&nbsp; Next poll: <strong id="next-poll">—</strong>
+      &nbsp;·&nbsp; Server poll: <strong id="poll-ms">—</strong>
+    </div>
+    <div class="health-pills" id="health-pills"></div>
+  </header>
+  <main>
+    <div id="error-bar"></div>
+    <div id="phases" class="loading">Loading…</div>
+  </main>
+
+  <script>
+    // All rendering uses DOM APIs (createElement / textContent) — no innerHTML
+    // with server-derived data. The dashboard is local-only and the server
+    // controls all data, but defense in depth is cheap here.
+
+    const STATUS_ORDER = ["done", "in-flight", "user-action", "not-started", "blocked"];
+
+    function el(tag, opts = {}, children = []) {
+      const node = document.createElement(tag);
+      if (opts.className) node.className = opts.className;
+      if (opts.text != null) node.textContent = String(opts.text);
+      if (opts.href) { node.href = opts.href; node.target = "_blank"; node.rel = "noopener"; }
+      for (const c of children) if (c != null) node.appendChild(c);
+      return node;
+    }
+
+    function pill(status, label) {
+      const s = STATUS_ORDER.includes(status) ? status : "not-started";
+      return el("span", { className: `pill ${s}`, text: label || s });
+    }
+
+    function fmtTime(iso) {
+      if (!iso) return "—";
+      const d = new Date(iso);
+      const now = Date.now();
+      const diff = Math.round((d.getTime() - now) / 1000);
+      const hhmm = d.toLocaleTimeString();
+      if (Math.abs(diff) < 90) {
+        if (diff <= 0) return `${hhmm} (${-diff}s ago)`;
+        return `${hhmm} (in ${diff}s)`;
+      }
+      return hhmm;
+    }
+
+    function renderHealth(container, health) {
+      container.replaceChildren();
+      if (!health) return;
+      for (const [k, v] of Object.entries(health)) {
+        container.appendChild(pill(v.status, `${k}: ${v.status}`));
+      }
+    }
+
+    function renderSubItems(sub) {
+      if (!sub || !sub.length) return null;
+      const div = el("div", { className: "sub" });
+      for (const s of sub) {
+        const ok = s.status === "done";
+        div.appendChild(el("span", {
+          className: ok ? "ok" : "bad",
+          text: `${ok ? "✓" : "✗"} ${s.name}`,
+        }));
+      }
+      return div;
+    }
+
+    function renderPhase(phase) {
+      const counts = {};
+      for (const it of phase.items) counts[it.status] = (counts[it.status] || 0) + 1;
+      const summary = STATUS_ORDER
+        .filter(s => counts[s])
+        .map(s => `${counts[s]} ${s}`).join(" · ");
+
+      const h2 = el("h2", {}, [
+        el("span", { text: phase.title }),
+        el("span", { className: "meta", text: summary }),
+      ]);
+
+      const table = el("table");
+      for (const it of phase.items) {
+        const statusTd = el("td", { className: "status" }, [pill(it.status)]);
+        const nameNode = it.url
+          ? el("a", { href: it.url, text: it.name })
+          : el("span", { text: it.name });
+        const nameTd = el("td", { className: "name" }, [nameNode, renderSubItems(it.sub)]);
+        const detailTd = el("td", { className: "detail", text: it.detail || "" });
+        table.appendChild(el("tr", {}, [statusTd, nameTd, detailTd]));
+      }
+
+      return el("section", {}, [h2, table]);
+    }
+
+    async function refresh() {
+      try {
+        const res = await fetch("/api/status");
+        const data = await res.json();
+        document.getElementById("last-updated").textContent = fmtTime(data.lastUpdated);
+        document.getElementById("next-poll").textContent = fmtTime(data.nextPollAt);
+        document.getElementById("poll-ms").textContent = data.pollMs ? `${data.pollMs}ms` : "—";
+        renderHealth(document.getElementById("health-pills"), data.health);
+
+        const phases = document.getElementById("phases");
+        phases.classList.remove("loading");
+        phases.replaceChildren();
+        if (!data.phases || !data.phases.length) {
+          phases.appendChild(el("p", { text: "Waiting for first poll to complete…" }));
+        } else {
+          for (const p of data.phases) phases.appendChild(renderPhase(p));
+        }
+
+        const errBar = document.getElementById("error-bar");
+        errBar.replaceChildren();
+        if (data.lastError) {
+          errBar.appendChild(el("div", { className: "error", text: `Poll error: ${data.lastError}` }));
+        }
+      } catch (e) {
+        const errBar = document.getElementById("error-bar");
+        errBar.replaceChildren(el("div", { className: "error", text: `Fetch failed: ${e.message}` }));
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 5_000);
+  </script>
+</body>
+</html>

--- a/tools/national-dashboard/public/styles.css
+++ b/tools/national-dashboard/public/styles.css
@@ -1,0 +1,99 @@
+:root {
+  --bg: #0f172a;
+  --panel: #1e293b;
+  --panel-2: #273449;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: #334155;
+  --done: #22c55e;
+  --in-flight: #3b82f6;
+  --user-action: #eab308;
+  --not-started: #64748b;
+  --blocked: #ef4444;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.45;
+}
+header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+  flex-wrap: wrap;
+  background: var(--panel);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+header h1 { margin: 0; font-size: 18px; }
+header .meta { color: var(--muted); font-size: 12px; }
+header .meta strong { color: var(--text); font-weight: 500; }
+.health-pills { display: flex; gap: 8px; margin-left: auto; }
+main { padding: 16px 24px 48px; max-width: 1400px; }
+section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+section h2 {
+  margin: 0;
+  padding: 12px 16px;
+  font-size: 14px;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+}
+table { width: 100%; border-collapse: collapse; }
+td {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+tr:last-child td { border-bottom: none; }
+td.name { width: 38%; font-weight: 500; }
+td.detail { color: var(--muted); }
+td.status { width: 130px; }
+.pill {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #0f172a;
+}
+.pill.done { background: var(--done); }
+.pill.in-flight { background: var(--in-flight); color: white; }
+.pill.user-action { background: var(--user-action); }
+.pill.not-started { background: var(--not-started); color: white; }
+.pill.blocked { background: var(--blocked); color: white; }
+a { color: #93c5fd; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.sub {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.sub span { margin-right: 10px; white-space: nowrap; }
+.sub .ok { color: var(--done); }
+.sub .bad { color: var(--blocked); }
+.error {
+  background: #7f1d1d;
+  color: #fecaca;
+  padding: 8px 16px;
+  border-radius: 4px;
+  margin: 8px 0;
+}
+.loading { opacity: 0.6; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }

--- a/tools/national-dashboard/server.mjs
+++ b/tools/national-dashboard/server.mjs
@@ -1,0 +1,349 @@
+// Local read-only dashboard server for the going-national rollout.
+// Polls GitHub (via `gh`), production HTTP endpoints, and GCP (via `gcloud`)
+// every POLL_INTERVAL_MS, caches the result, and serves it at /api/status.
+//
+// Run: npm install && npm start ; open http://localhost:7777
+//
+// Uses the user's existing gh + gcloud auth. No secrets read or written.
+
+import express from "express";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PORT = 7777;
+const POLL_INTERVAL_MS = 30_000;
+const REPO = "julianken/bird-sight-system";
+const GCP_PROJECT = "bird-maps-prod";
+
+const UMBRELLA_ISSUES = [588, 589, 593, 596, 533, 604, 608, 611];
+const HEALTHCHECK_SECRETS = [
+  "bird-watch-healthchecks-recent",
+  "bird-watch-healthchecks-notable",
+  "bird-watch-healthchecks-hotspots",
+  "bird-watch-healthchecks-taxonomy",
+  "bird-watch-healthchecks-prune",
+  "bird-watch-healthchecks-silhouettes",
+  "bird-watch-healthchecks-shape2-probe",
+];
+
+// ----- helpers -----
+
+async function sh(cmd, args, opts = {}) {
+  try {
+    const { stdout } = await execFileP(cmd, args, { timeout: 20_000, ...opts });
+    return { ok: true, stdout: stdout.trim() };
+  } catch (e) {
+    return { ok: false, error: e.message, stdout: (e.stdout || "").trim(), stderr: (e.stderr || "").trim() };
+  }
+}
+
+async function curlHeaders(url) {
+  const r = await sh("curl", ["-sS", "-I", "--max-time", "10", url]);
+  if (!r.ok) return { ok: false, error: r.error };
+  const headers = {};
+  for (const line of r.stdout.split(/\r?\n/)) {
+    const m = line.match(/^([^:]+):\s*(.*)$/);
+    if (m) headers[m[1].toLowerCase()] = m[2];
+  }
+  const statusLine = r.stdout.split(/\r?\n/)[0] || "";
+  const sm = statusLine.match(/\s(\d{3})\s/);
+  return { ok: true, status: sm ? Number(sm[1]) : null, headers };
+}
+
+// ----- per-source pollers (each returns a list of items with .status) -----
+
+async function pollGhIssues() {
+  const r = await sh("gh", [
+    "issue", "list",
+    "--repo", REPO,
+    "--state", "all",
+    "--limit", "100",
+    "--json", "number,title,state,labels,url",
+  ]);
+  if (!r.ok) return { error: r.error, items: [] };
+  let all;
+  try { all = JSON.parse(r.stdout); } catch { return { error: "parse", items: [] }; }
+  const wanted = new Set(UMBRELLA_ISSUES);
+  return {
+    items: all
+      .filter(i => wanted.has(i.number))
+      .map(i => ({
+        number: i.number,
+        title: i.title,
+        state: i.state,
+        url: i.url,
+        labels: (i.labels || []).map(l => l.name),
+      })),
+  };
+}
+
+async function pollGhPrs() {
+  const r = await sh("gh", [
+    "pr", "list",
+    "--repo", REPO,
+    "--state", "open",
+    "--limit", "50",
+    "--json", "number,title,headRefName,url,isDraft,labels",
+  ]);
+  if (!r.ok) return { error: r.error, items: [] };
+  let all;
+  try { all = JSON.parse(r.stdout); } catch { return { error: "parse", items: [] }; }
+  const filter = /going-national|cloud-sql|monitoring|rate-limit|national|cutover/i;
+  return {
+    items: all.filter(p =>
+      filter.test(p.title) ||
+      filter.test(p.headRefName) ||
+      (p.labels || []).some(l => filter.test(l.name))
+    ),
+    total_open: all.length,
+  };
+}
+
+async function pollRecentCommits() {
+  const r = await sh("git", ["log", "--oneline", "origin/main", "-10"]);
+  if (!r.ok) return { error: r.error, items: [] };
+  return { items: r.stdout.split("\n").filter(Boolean) };
+}
+
+async function pollApiTtl() {
+  const r = await curlHeaders("https://api.bird-maps.com/api/observations");
+  if (!r.ok) return { status: "blocked", detail: r.error };
+  const cc = r.headers["cache-control"] || "";
+  const ok = /s-maxage=300/.test(cc);
+  return {
+    status: ok ? "done" : "blocked",
+    httpStatus: r.status,
+    cacheControl: cc,
+    detail: ok ? "s-maxage=300 present" : `cache-control: ${cc || "(missing)"}`,
+  };
+}
+
+async function pollFrontend() {
+  const r = await curlHeaders("https://bird-maps.com/");
+  if (!r.ok) return { status: "blocked", detail: r.error };
+  return {
+    status: r.status && r.status < 400 ? "done" : "blocked",
+    httpStatus: r.status,
+    detail: `HTTP ${r.status}`,
+  };
+}
+
+async function pollUptimeChecks() {
+  const r = await sh("gcloud", [
+    "monitoring", "uptime", "list-configs",
+    `--project=${GCP_PROJECT}`,
+    "--format=value(displayName)",
+  ]);
+  if (!r.ok) return { status: "blocked", detail: r.stderr || r.error };
+  const names = r.stdout.split("\n").filter(Boolean);
+  return {
+    status: names.length > 0 ? "done" : "not-started",
+    count: names.length,
+    detail: names.length ? `${names.length} uptime checks configured` : "none",
+  };
+}
+
+async function pollSecret(name) {
+  const r = await sh("gcloud", [
+    "secrets", "versions", "list", name,
+    `--project=${GCP_PROJECT}`,
+    "--limit=1",
+    "--format=value(name)",
+  ]);
+  if (!r.ok) return { name, status: "blocked", detail: r.stderr || r.error };
+  return {
+    name,
+    status: r.stdout ? "done" : "not-started",
+    detail: r.stdout ? "≥1 version" : "no versions",
+  };
+}
+
+async function pollHealthcheckSecrets() {
+  const items = await Promise.all(HEALTHCHECK_SECRETS.map(pollSecret));
+  const ok = items.filter(i => i.status === "done").length;
+  return {
+    items,
+    summary: `${ok}/${HEALTHCHECK_SECRETS.length} populated`,
+    status: ok === HEALTHCHECK_SECRETS.length ? "done" : ok === 0 ? "not-started" : "in-flight",
+  };
+}
+
+async function pollCloudSql() {
+  const r = await sh("gcloud", [
+    "sql", "instances", "describe", "birdwatch-pg16",
+    `--project=${GCP_PROJECT}`,
+    "--format=value(state)",
+  ]);
+  if (!r.ok) return { status: "blocked", detail: r.stderr || r.error };
+  const state = r.stdout;
+  return {
+    status: state === "RUNNABLE" ? "done" : "in-flight",
+    detail: `state=${state || "unknown"}`,
+  };
+}
+
+// ----- phase model -----
+
+function statusForIssue(issueByNumber, num) {
+  const i = issueByNumber.get(num);
+  if (!i) return { status: "not-started", detail: `#${num} not found` };
+  if (i.state === "CLOSED") return { status: "done", detail: `#${num} closed`, url: i.url };
+  return { status: "not-started", detail: `#${num} open`, url: i.url };
+}
+
+function buildPhases(snapshot) {
+  const issuesByNumber = new Map((snapshot.issues.items || []).map(i => [i.number, i]));
+
+  const prsTouching = (re) => snapshot.prs.items.filter(p => re.test(p.title) || re.test(p.headRefName));
+
+  return [
+    {
+      id: "phase-0",
+      title: "Phase 0 — pre-conditions to flip",
+      items: [
+        { name: "Prune job", status: "done", detail: "live (Cloud Scheduler)" },
+        { name: "TTL caching", ...snapshot.apiTtl, detail: "verify s-maxage=300 on api.bird-maps.com — " + snapshot.apiTtl.detail },
+        { name: "Rate-limit Layer 1 (CF edge)", status: "done", detail: "cloudflare_ruleset.read_api_rate_limit" },
+        { name: "Rate-limit Layer 2 (WAF managed)", status: "user-action", detail: "manual CF dashboard step" },
+        { name: "Rate-limit Layer 3 (Hono middleware)", status: "done", detail: "live in services/read-api" },
+        { name: "Shape-2 probe", status: "done", detail: "GH Actions workflow live" },
+        { name: "Monitoring code", status: "done", detail: "live" },
+        { name: "Monitoring infra", ...snapshot.uptime, detail: "GCP alert policies — " + snapshot.uptime.detail },
+        { name: "Healthchecks.io secrets", status: snapshot.healthchecks.status, detail: snapshot.healthchecks.summary, sub: snapshot.healthchecks.items },
+        { name: "Workers Paid plan", status: "done", detail: "purchased" },
+        { name: "Cloud SQL provisioned", ...snapshot.cloudSql, detail: "birdwatch-pg16 " + snapshot.cloudSql.detail },
+        { name: "Cornell ToS email", status: "user-action", detail: "awaiting Julian send" },
+      ],
+    },
+    {
+      id: "phase-1",
+      title: "Phase 1 — Cloud SQL cutover",
+      items: [
+        { name: "Stage 1 — provision", status: "done", detail: "merged" },
+        { name: "Stage 2 — Auth Proxy mounts", status: "done", detail: "PR #615 merged" },
+        { name: "T3 — operator dump+restore", status: "user-action", detail: "pending operator run" },
+        { name: "Stage 3 — secret flip", status: "user-action", detail: "user-gated cutover" },
+        { name: "Stage 4 — Neon teardown", status: "not-started", detail: "T+48h after Stage 3" },
+      ],
+    },
+    {
+      id: "phase-2",
+      title: "Phase 2 — frontend + ingestor",
+      items: [
+        { name: "CONUS viewport", status: "done" },
+        { name: "Region-table drop", status: "done" },
+        { name: "iNat place_id", status: "done" },
+        { name: "Phenology UTC", status: "done" },
+        { name: "Silhouette colorDark", status: "done" },
+        { name: "AZ branding sweep", ...statusForIssue(issuesByNumber, 533) },
+        { name: "Server-side bbox filtering", status: "not-started", detail: "no issue / PR yet" },
+      ],
+    },
+    {
+      id: "phase-3",
+      title: "Phase 3 — the flip",
+      items: [
+        { name: "regionCode US-AZ → US", status: "user-action", detail: "user-triggered flip" },
+        { name: "Per-state backfill fan-out", status: "not-started", detail: "T+30d follow-up" },
+      ],
+    },
+    {
+      id: "phase-4",
+      title: "Phase 4 — post-flip",
+      items: [
+        { name: "+7d cost review", status: "not-started" },
+        { name: "+30d cost review", status: "not-started" },
+      ],
+    },
+    {
+      id: "umbrella-issues",
+      title: "Umbrella issues",
+      items: UMBRELLA_ISSUES.map(n => {
+        const i = issuesByNumber.get(n);
+        if (!i) return { name: `#${n}`, status: "blocked", detail: "not found via gh" };
+        return {
+          name: `#${n} ${i.title}`,
+          status: i.state === "CLOSED" ? "done" : "not-started",
+          detail: i.state,
+          url: i.url,
+        };
+      }),
+    },
+    {
+      id: "open-prs",
+      title: "Open PRs (national / cloud-sql / monitoring)",
+      items: snapshot.prs.items.length
+        ? snapshot.prs.items.map(p => ({
+            name: `#${p.number} ${p.title}`,
+            status: p.isDraft ? "in-flight" : "in-flight",
+            detail: p.isDraft ? "draft" : "open",
+            url: p.url,
+          }))
+        : [{ name: "(none)", status: "done", detail: "no open PRs match filter" }],
+    },
+    {
+      id: "recent-commits",
+      title: "Recent commits on origin/main",
+      items: (snapshot.commits.items || []).map(line => ({ name: line, status: "done" })),
+    },
+  ];
+}
+
+// ----- cache + polling loop -----
+
+let cache = {
+  startedAt: new Date().toISOString(),
+  lastUpdated: null,
+  lastError: null,
+  nextPollAt: null,
+  phases: [],
+  raw: null,
+};
+
+async function pollAll() {
+  const t0 = Date.now();
+  const [issues, prs, commits, apiTtl, frontend, uptime, healthchecks, cloudSql] = await Promise.all([
+    pollGhIssues(),
+    pollGhPrs(),
+    pollRecentCommits(),
+    pollApiTtl(),
+    pollFrontend(),
+    pollUptimeChecks(),
+    pollHealthcheckSecrets(),
+    pollCloudSql(),
+  ]);
+  const snapshot = { issues, prs, commits, apiTtl, frontend, uptime, healthchecks, cloudSql };
+  cache.phases = buildPhases(snapshot);
+  cache.raw = snapshot;
+  cache.lastUpdated = new Date().toISOString();
+  cache.nextPollAt = new Date(Date.now() + POLL_INTERVAL_MS).toISOString();
+  cache.lastError = null;
+  cache.pollMs = Date.now() - t0;
+  // Also surface api/frontend as their own top-level health pills
+  cache.health = {
+    api: { status: apiTtl.status, detail: apiTtl.detail },
+    frontend: { status: frontend.status, detail: frontend.detail },
+  };
+}
+
+async function pollLoop() {
+  try { await pollAll(); }
+  catch (e) { cache.lastError = e.message; }
+  setTimeout(pollLoop, POLL_INTERVAL_MS);
+}
+
+// ----- server -----
+
+const app = express();
+app.use(express.static(path.join(__dirname, "public")));
+app.get("/api/status", (_req, res) => res.json(cache));
+
+app.listen(PORT, "127.0.0.1", () => {
+  console.log(`national-dashboard listening on http://localhost:${PORT}`);
+  pollLoop();
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Browser["Browser :7777<br/>poll /api/status every 5s"]
    Server["Express server.mjs<br/>poll loop every 30s"]
    GH["gh CLI<br/>issues + PRs"]
    Prod["api.bird-maps.com<br/>bird-maps.com"]
    GCP["gcloud<br/>uptime / secrets / sql"]
    Git["git log origin/main"]

    Browser -->|GET /api/status| Server
    Server --> GH
    Server --> Prod
    Server --> GCP
    Server --> Git
    Server -->|cached JSON| Browser
```

## Summary

- Local, read-only Express dashboard at `tools/national-dashboard/` that mirrors `docs/plans/2026-05-17-going-national.md` LIVE by polling GitHub (`gh`), production HTTP (`curl`), and GCP (`gcloud`) every 30s server-side; browser refreshes every 5s.
- Why: at-a-glance status across Phase 0–4 of the going-national rollout without re-running `gh` / `curl` / `gcloud` by hand. Color-coded pills (done / in-flight / user-action / not-started / blocked) per phase item.
- Not deployed, not in CI, no Dockerfile — auxiliary tooling only. Listens on `127.0.0.1:7777`. Uses existing `gh` + `gcloud` auth; no secrets read or written; `node_modules` + `package-lock.json` gitignored.

## Screenshots

N/A — not UI (auxiliary local-only tool under `tools/`, no changes under `frontend/**`).

## Test plan

- [x] `npm install && npm start` from `tools/national-dashboard/` boots cleanly on `localhost:7777`
- [x] `GET /` returns the HTML (200), `GET /styles.css` returns the stylesheet (200), `GET /api/status` returns the live JSON snapshot
- [x] First poll completes in ~1.3s against live sources; `lastUpdated` advances; `health.api.status === "done"` (TTL `s-maxage=300` confirmed against `api.bird-maps.com`); `health.frontend.status === "done"` (HTTP 200 against `bird-maps.com`)
- [x] All 8 phase sections render with expected item counts (Phase 0: 12, Phase 1: 5, Phase 2: 7, Phase 3: 2, Phase 4: 2, Umbrella: 8, Open PRs, Recent commits)
- [x] No secrets, env files, or credentials touched

## Plan reference

Out of plan — auxiliary developer tooling supporting the `docs/plans/2026-05-17-going-national.md` rollout (operational visibility, not a deliverable).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)