### PR TITLE
infra(monitoring): budget alerts + CF Pages request tripwire (Phase 0 finishers)

### DIFF
--- a/.github/workflows/cf-pages-request-tripwire.yml
+++ b/.github/workflows/cf-pages-request-tripwire.yml
@@ -5,19 +5,36 @@ name: cf-pages-request-tripwire
 #
 # Approach B (chosen): scheduled GitHub Actions job that queries the
 # Cloudflare GraphQL Analytics API for yesterday's request count against
-# the Pages project. Emits a workflow annotation at 80k/day and fails the
-# job at 95k/day. Workflow failure triggers GitHub's default
+# the bird-maps.com zone. Emits a workflow annotation at 80k/day and fails
+# the job at 95k/day. Workflow failure triggers GitHub's default
 # workflow-failure email to the repo owner — same human as the GCP email
 # channel without extra plumbing.
 #
+# GraphQL node: httpRequestsAdaptiveGroups (zone-level). We measure total
+# zone HTTP requests for bird-maps.com — this includes Pages static asset
+# hits AND Pages Functions invocations. At HN-scale the 80k/95k thresholds
+# are the right granularity because static asset traffic is the bottleneck
+# against Cloudflare's free-tier 100k req/day Pages cap; the Functions-only
+# node (pagesFunctionsInvocationsAdaptiveGroups) would miss static hits and
+# under-count. An earlier revision of this workflow referenced a fabricated
+# `pagesProjectRequestsAdaptiveGroups` node that does not exist in CF's
+# schema; this version corrects that.
+#
 # Why not Approach A (cloudflare_notification_policy)? The v4 provider's
-# alert_type enum does not expose a per-Pages-project request-count
-# threshold. billing_usage_alert is account-level; pages_event_alert fires
-# on deployment events. A custom GH Actions check is the only path that
+# alert_type enum does not expose a per-zone request-count threshold.
+# billing_usage_alert is account-level; pages_event_alert fires on
+# deployment events. A custom GH Actions check is the only path that
 # meets the §7 exit-gate criteria on the current provider.
 #
 # Free Cloudflare Pages quota: 100k requests/day. Warn at 80% (80k),
 # critical at 95% (95k).
+#
+# Required GitHub Actions secrets (operator step — not created by this
+# workflow):
+#   - CLOUDFLARE_API_TOKEN   API token with Zone:Analytics:Read on bird-maps.com
+#   - CLOUDFLARE_ZONE_ID     Zone ID for bird-maps.com (mirrors the value
+#                            stored in Secret Manager as
+#                            `bird-watch-cloudflare-zone-id`)
 #
 # Security: no untrusted github.event.* fields reach run: blocks. All
 # external values flow through env: vars (recommended pattern). Token is
@@ -38,28 +55,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      # Pages project name. The deploy-frontend workflow targets the same
-      # project; if that changes, update both.
-      CF_PAGES_PROJECT: bird-watch-frontend
+      CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       WARN_THRESHOLD: '80000'
       CRIT_THRESHOLD: '95000'
     steps:
-      - name: Query yesterday's Pages request count
+      - name: Query yesterday's zone request count
         run: |
           set -euo pipefail
           start=$(date -u -d 'yesterday' +%Y-%m-%dT00:00:00Z)
           end=$(date -u -d 'yesterday' +%Y-%m-%dT23:59:59Z)
 
-          query='query ($accountTag: string!, $project: string!, $start: Time!, $end: Time!) { viewer { accounts(filter: {accountTag: $accountTag}) { pagesProjectRequestsAdaptiveGroups(filter: {projectName: $project, datetime_geq: $start, datetime_leq: $end}, limit: 1) { sum { requests } } } } }'
+          query='query ($zoneTag: string!, $start: Time!, $end: Time!) { viewer { zones(filter: {zoneTag: $zoneTag}) { httpRequestsAdaptiveGroups(filter: {datetime_geq: $start, datetime_leq: $end}, limit: 1) { sum { requests } } } } }'
 
           payload=$(jq -n \
             --arg query "$query" \
-            --arg accountTag "$CF_ACCOUNT_ID" \
-            --arg project "$CF_PAGES_PROJECT" \
+            --arg zoneTag "$CF_ZONE_ID" \
             --arg start "$start" \
             --arg end "$end" \
-            '{query: $query, variables: {accountTag: $accountTag, project: $project, start: $start, end: $end}}')
+            '{query: $query, variables: {zoneTag: $zoneTag, start: $start, end: $end}}')
 
           resp=$(curl -sS -X POST https://api.cloudflare.com/client/v4/graphql \
             -H "Authorization: Bearer $CF_API_TOKEN" \
@@ -72,14 +85,14 @@ jobs:
             exit 1
           fi
 
-          count=$(echo "$resp" | jq -r '(.data.viewer.accounts[0].pagesProjectRequestsAdaptiveGroups[0].sum.requests // 0)')
+          count=$(echo "$resp" | jq -r '(.data.viewer.zones[0].httpRequestsAdaptiveGroups[0].sum.requests // 0)')
 
-          echo "Pages requests for ${CF_PAGES_PROJECT} on ${start%T*}: $count"
+          echo "Zone requests for bird-maps.com on ${start%T*}: $count"
           echo "warn threshold: $WARN_THRESHOLD  critical threshold: $CRIT_THRESHOLD"
 
           if [ "$count" -ge "$CRIT_THRESHOLD" ]; then
-            echo "::error::Pages requests ($count) crossed CRITICAL threshold ($CRIT_THRESHOLD/day). Free-tier cap is 100k/day."
+            echo "::error::Zone requests ($count) crossed CRITICAL threshold ($CRIT_THRESHOLD/day). Free-tier Pages cap is 100k/day."
             exit 1
           elif [ "$count" -ge "$WARN_THRESHOLD" ]; then
-            echo "::warning::Pages requests ($count) crossed WARN threshold ($WARN_THRESHOLD/day). Free-tier cap is 100k/day; investigate."
+            echo "::warning::Zone requests ($count) crossed WARN threshold ($WARN_THRESHOLD/day). Free-tier Pages cap is 100k/day; investigate."
           fi

--- a/.github/workflows/cf-pages-request-tripwire.yml
+++ b/.github/workflows/cf-pages-request-tripwire.yml
@@ -1,0 +1,85 @@
+name: cf-pages-request-tripwire
+
+# P0.l — Cloudflare Pages request-count tripwire. Phase 0 finisher for the
+# going-national plan §7.
+#
+# Approach B (chosen): scheduled GitHub Actions job that queries the
+# Cloudflare GraphQL Analytics API for yesterday's request count against
+# the Pages project. Emits a workflow annotation at 80k/day and fails the
+# job at 95k/day. Workflow failure triggers GitHub's default
+# workflow-failure email to the repo owner — same human as the GCP email
+# channel without extra plumbing.
+#
+# Why not Approach A (cloudflare_notification_policy)? The v4 provider's
+# alert_type enum does not expose a per-Pages-project request-count
+# threshold. billing_usage_alert is account-level; pages_event_alert fires
+# on deployment events. A custom GH Actions check is the only path that
+# meets the §7 exit-gate criteria on the current provider.
+#
+# Free Cloudflare Pages quota: 100k requests/day. Warn at 80% (80k),
+# critical at 95% (95k).
+#
+# Security: no untrusted github.event.* fields reach run: blocks. All
+# external values flow through env: vars (recommended pattern). Token is
+# only ever passed via curl Authorization header, never echoed.
+
+on:
+  schedule:
+    # 12:00 UTC = 04:00 America/Phoenix. Runs an hour after the GCP
+    # drift-check so the morning triage batch is contiguous.
+    - cron: '0 12 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check-pages-requests:
+    runs-on: ubuntu-latest
+    env:
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Pages project name. The deploy-frontend workflow targets the same
+      # project; if that changes, update both.
+      CF_PAGES_PROJECT: bird-watch-frontend
+      WARN_THRESHOLD: '80000'
+      CRIT_THRESHOLD: '95000'
+    steps:
+      - name: Query yesterday's Pages request count
+        run: |
+          set -euo pipefail
+          start=$(date -u -d 'yesterday' +%Y-%m-%dT00:00:00Z)
+          end=$(date -u -d 'yesterday' +%Y-%m-%dT23:59:59Z)
+
+          query='query ($accountTag: string!, $project: string!, $start: Time!, $end: Time!) { viewer { accounts(filter: {accountTag: $accountTag}) { pagesProjectRequestsAdaptiveGroups(filter: {projectName: $project, datetime_geq: $start, datetime_leq: $end}, limit: 1) { sum { requests } } } } }'
+
+          payload=$(jq -n \
+            --arg query "$query" \
+            --arg accountTag "$CF_ACCOUNT_ID" \
+            --arg project "$CF_PAGES_PROJECT" \
+            --arg start "$start" \
+            --arg end "$end" \
+            '{query: $query, variables: {accountTag: $accountTag, project: $project, start: $start, end: $end}}')
+
+          resp=$(curl -sS -X POST https://api.cloudflare.com/client/v4/graphql \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "$payload")
+
+          if echo "$resp" | jq -e '.errors' >/dev/null 2>&1; then
+            echo "::error::Cloudflare GraphQL returned errors:"
+            echo "$resp" | jq '.errors'
+            exit 1
+          fi
+
+          count=$(echo "$resp" | jq -r '(.data.viewer.accounts[0].pagesProjectRequestsAdaptiveGroups[0].sum.requests // 0)')
+
+          echo "Pages requests for ${CF_PAGES_PROJECT} on ${start%T*}: $count"
+          echo "warn threshold: $WARN_THRESHOLD  critical threshold: $CRIT_THRESHOLD"
+
+          if [ "$count" -ge "$CRIT_THRESHOLD" ]; then
+            echo "::error::Pages requests ($count) crossed CRITICAL threshold ($CRIT_THRESHOLD/day). Free-tier cap is 100k/day."
+            exit 1
+          elif [ "$count" -ge "$WARN_THRESHOLD" ]; then
+            echo "::warning::Pages requests ($count) crossed WARN threshold ($WARN_THRESHOLD/day). Free-tier cap is 100k/day; investigate."
+          fi

--- a/.github/workflows/cf-pages-request-tripwire.yml
+++ b/.github/workflows/cf-pages-request-tripwire.yml
@@ -65,7 +65,15 @@ jobs:
           start=$(date -u -d 'yesterday' +%Y-%m-%dT00:00:00Z)
           end=$(date -u -d 'yesterday' +%Y-%m-%dT23:59:59Z)
 
-          query='query ($zoneTag: string!, $start: Time!, $end: Time!) { viewer { zones(filter: {zoneTag: $zoneTag}) { httpRequestsAdaptiveGroups(filter: {datetime_geq: $start, datetime_leq: $end}, limit: 1) { sum { requests } } } } }'
+          # Round-2 bot finding (PR #620): httpRequestsAdaptiveGroups exposes
+          # the request total at the top-level `count` field, NOT under
+          # `sum.requests`. The `sum` sub-selection holds visits /
+          # edgeResponseBytes / etc. — selecting `sum { requests }` would be a
+          # GraphQL error or silently 0 under the `// 0` jq default, masking
+          # the tripwire. Source: Cloudflare GraphQL Analytics API schema
+          # (johnspurlock-skymethod/cloudflare-graphql-mirror) and CF docs at
+          # developers.cloudflare.com/analytics/graphql-api/features/data-sets.
+          query='query ($zoneTag: string!, $start: Time!, $end: Time!) { viewer { zones(filter: {zoneTag: $zoneTag}) { httpRequestsAdaptiveGroups(filter: {datetime_geq: $start, datetime_leq: $end}, limit: 1) { count } } } }'
 
           payload=$(jq -n \
             --arg query "$query" \
@@ -85,7 +93,7 @@ jobs:
             exit 1
           fi
 
-          count=$(echo "$resp" | jq -r '(.data.viewer.zones[0].httpRequestsAdaptiveGroups[0].sum.requests // 0)')
+          count=$(echo "$resp" | jq -r '(.data.viewer.zones[0].httpRequestsAdaptiveGroups[0].count // 0)')
 
           echo "Zone requests for bird-maps.com on ${start%T*}: $count"
           echo "warn threshold: $WARN_THRESHOLD  critical threshold: $CRIT_THRESHOLD"

--- a/infra/terraform/budget.tf
+++ b/infra/terraform/budget.tf
@@ -1,0 +1,60 @@
+# ── P0.k: GCP billing budget alerts ──────────────────────────────────────
+#
+# Phase 0 finisher for the going-national plan §7. Single $100/month budget
+# scoped to project `bird-maps-prod`, with two thresholds:
+#   - 0.5  (warn at  $50 of $100 — early signal)
+#   - 1.0  (critical at $100 — at-budget, page-worthy)
+#
+# Notifications route to the existing
+# google_monitoring_notification_channel.email_julian declared in
+# monitoring.tf. Default IAM recipients are disabled so the alert fans out
+# only via the explicit channel — keeps spam off the billing-admin role.
+#
+# Operator action required before `terraform apply`:
+#   1. Run `gcloud beta billing accounts list` to find the billing account ID
+#      (shape: 0XXXXX-0XXXXX-0XXXXX). Confirm it's the one linked to
+#      bird-maps-prod via `gcloud beta billing projects describe bird-maps-prod`.
+#   2. Set `gcp_billing_account_id` in terraform.tfvars (see *.example).
+#
+# Provider note: google_billing_budget shape verified against
+# hashicorp/google ~> 7.30 via context7 on 2026-05-17.
+
+data "google_billing_account" "account" {
+  billing_account = var.gcp_billing_account_id
+}
+
+resource "google_billing_budget" "monthly_spend" {
+  billing_account = data.google_billing_account.account.id
+  display_name    = "bird-maps-prod monthly spend ($100)"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.current.number}"]
+    # Default: includes all services in the project. Cross-project spend
+    # is excluded by the projects filter above.
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = "100"
+    }
+  }
+
+  # Warn at 50% ($50), critical at 100% ($100). Both fire on CURRENT_SPEND;
+  # FORECASTED_SPEND would page earlier in the month and is overkill for v1.
+  threshold_rules {
+    threshold_percent = 0.5
+    spend_basis       = "CURRENT_SPEND"
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "CURRENT_SPEND"
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.email_julian.id,
+    ]
+    disable_default_iam_recipients = true
+  }
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,5 +1,7 @@
 gcp_project_id        = "REPLACE_ME"
 gcp_region            = "us-west1"
+# Find with `gcloud beta billing accounts list`. Required by budget.tf.
+gcp_billing_account_id = "REPLACE_ME"
 neon_api_key          = "REPLACE_ME"
 neon_org_id           = "REPLACE_ME"
 cloudflare_account_id = "REPLACE_ME"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -48,6 +48,11 @@ variable "domain" {
   description = "Domain you control on Cloudflare, e.g. birdwatch.example.com"
 }
 
+variable "gcp_billing_account_id" {
+  type        = string
+  description = "GCP billing account ID linked to gcp_project_id (shape: 0XXXXX-0XXXXX-0XXXXX). Find via `gcloud beta billing accounts list`; confirm linkage via `gcloud beta billing projects describe <project>`. Used only by the billing budget in budget.tf (Phase 0 finisher, going-national plan §7)."
+}
+
 variable "alert_email" {
   description = "Email address to receive monitoring alerts. v1: single subscriber; team channel routing is a future iteration."
   type        = string


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    GCP[GCP billing<br/>bird-maps-prod]
    Budget[google_billing_budget<br/>$100/mo]
    NC[email_julian<br/>notification channel]
    CF[Cloudflare Pages<br/>bird-watch-frontend]
    GHA[GH Actions cron<br/>cf-pages-request-tripwire]
    Email["julian.kennon.d@gmail.com"]

    GCP -->|spend| Budget
    Budget -->|0.5 warn / 1.0 crit| NC --> Email
    CF -->|GraphQL Analytics| GHA
    GHA -->|::warning:: 80k<br/>fail @ 95k| Email
```

## Summary

- Closes Phase 0 exit gates **P0.k** and **P0.l** on the amended going-national umbrella plan §7 (PR #618).
- **P0.k** — `google_billing_budget` ($100/mo, 0.5 + 1.0 thresholds) on `bird-maps-prod`, routed to the existing `email_julian` monitoring channel; default IAM recipients disabled to avoid billing-admin spam.
- **P0.l** — Daily GH Actions cron (`cf-pages-request-tripwire.yml`) queries the Cloudflare GraphQL Analytics API for the `bird-watch-frontend` Pages project; warns at 80k req/day, fails the job at 95k req/day. Approach B chosen because the v4 `cloudflare_notification_policy` `alert_type` enum has no per-Pages-project request-count threshold (`billing_usage_alert` is account-level; `pages_event_alert` covers deployments, not traffic).

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` in `infra/terraform` — clean
- [x] `terraform validate` in `infra/terraform` — `Success! The configuration is valid.`
- [ ] Operator: before next `terraform apply`, add `gcp_billing_account_id` to `terraform.tfvars` (find via `gcloud beta billing accounts list`; confirm linkage via `gcloud beta billing projects describe bird-maps-prod`).
- [ ] Operator: after first `terraform apply`, verify the budget appears under GCP Console → Billing → Budgets & alerts.
- [ ] Post-merge: trigger `cf-pages-request-tripwire` once via `workflow_dispatch` to confirm the GraphQL query path works end-to-end against the live Pages project.

## Plan reference

Out of plan — Phase 0 finishers for the going-national umbrella plan §7 (PR #618 amendment). The umbrella plan listed P0.k and P0.l as explicit Phase-0 exit gates; this PR closes both.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
