### PR TITLE
chore(frontend): regionalize hardcoded Arizona labels via VITE_REGION_CODE

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,7 @@
+# Frontend build-time environment variables (Vite reads at build time).
+# Copy to `.env.local` for local dev overrides, or set in CI for deploys.
+
+# Region code drives the wordmark / lede / page-title label via
+# `frontend/src/config/region.ts`. Default is `US-AZ` ("Arizona").
+# Set to `US` for the national/USA flip; unknown codes pass through as-is.
+# VITE_REGION_CODE=US-AZ

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -11,6 +11,7 @@ import { FilterSentence } from './ds/FilterSentence.js';
 import { SortLabel } from './ds/SortLabel.js';
 import type { Freshness } from './MapLede.js';
 import { buildFamilyColorResolver, buildFamilyPathResolver } from '../data/family-color.js';
+import { REGION_LABEL } from '../config/region.js';
 
 export interface FeedSurfaceFilters {
   notable: boolean;
@@ -213,7 +214,7 @@ export function FeedSurface(props: FeedSurfaceProps) {
     onSelectSpecies,
     speciesIndex,
     observationCount,
-    regionLabel = 'Arizona',
+    regionLabel = REGION_LABEL,
     period = '14 days',
     speciesName,
     familyName,

--- a/frontend/src/components/SurfaceTitleSync.tsx
+++ b/frontend/src/components/SurfaceTitleSync.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 import type { View } from '../state/url-state.js';
+import { REGION_LABEL } from '../config/region.js';
 
 interface SurfaceTitleSyncProps {
   view: View;
   speciesCommonName: string | null;
 }
 
-const SITE_SUFFIX = 'Bird Maps · Arizona';
+const SITE_SUFFIX = `Bird Maps · ${REGION_LABEL}`;
 
 function buildTitle(view: View, speciesCommonName: string | null): string {
   switch (view) {

--- a/frontend/src/config/region.test.ts
+++ b/frontend/src/config/region.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { REGION_LABEL } from './region.js';
+import { REGION_LABEL, REGION_CODE } from './region.js';
 
 describe('REGION_LABEL', () => {
-  it('is the string "Arizona"', () => {
+  it('defaults to "Arizona" when VITE_REGION_CODE is unset (test env)', () => {
+    // In the test env no VITE_REGION_CODE is set, so REGION_CODE falls back
+    // to 'US-AZ' which maps to 'Arizona'. This guards the default deploy
+    // behavior — AZ shipped builds must keep this label.
+    expect(REGION_CODE).toBe('US-AZ');
     expect(REGION_LABEL).toBe('Arizona');
   });
 

--- a/frontend/src/config/region.ts
+++ b/frontend/src/config/region.ts
@@ -3,9 +3,21 @@
  *
  * REGION_LABEL is the source of truth for the region name used in the
  * wordmark ("Bird Maps · Arizona"), the lede, and any region claim in
- * the UI. Change this string to relocate the application to a different
- * region — downstream consumers read it from here.
+ * the UI.
+ *
+ * The label is derived from the build-time env var `VITE_REGION_CODE`
+ * via a small mapping table. Default is `US-AZ` → "Arizona", which keeps
+ * the current AZ deploy unchanged. To flip the build to national/USA,
+ * set `VITE_REGION_CODE=US` at build time — no code change required.
  *
  * Spec: docs/design/01-spec/architecture.md §Cross-cutting structures
  */
-export const REGION_LABEL = 'Arizona' as const;
+export const REGION_CODE: string =
+  (import.meta.env.VITE_REGION_CODE as string | undefined) ?? 'US-AZ';
+
+const REGION_LABELS: Record<string, string> = {
+  'US-AZ': 'Arizona',
+  US: 'USA',
+};
+
+export const REGION_LABEL: string = REGION_LABELS[REGION_CODE] ?? REGION_CODE;


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  ENV[VITE_REGION_CODE<br/>build-time env] --> REGION[REGION_CODE]
  REGION --> MAP{REGION_LABELS<br/>mapping}
  MAP -->|US-AZ| AZ[Arizona]
  MAP -->|US| US[USA]
  MAP -->|other| PT[code passthrough]
  AZ --> LABEL[REGION_LABEL]
  US --> LABEL
  PT --> LABEL
  LABEL --> WORD[AppHeader wordmark]
  LABEL --> TITLE[SurfaceTitleSync &lt;title&gt;]
  LABEL --> LEDE[MapLede / FeedSurface lede]
```

## Summary

- Phase 2 of the going-national flip (#533). "Arizona" was hardcoded in four live frontend paths (wordmark, page title, feed-lede default, map-lede already-via-REGION_LABEL). This makes `REGION_LABEL` env-driven instead of a string literal.
- Default stays `US-AZ` → "Arizona" so existing AZ deploys are unchanged. The AZ→US flip is now a single envvar change at deploy time (Phase 3 — separate PR).
- No DOM/CSS/component changes. All 893 frontend unit tests pass unchanged (including the existing `AppHeader.test.tsx`, `SurfaceTitleSync.test.tsx`, `MapLede.test.tsx`, `FeedSurface.test.tsx` assertions on "Arizona").

## Screenshots

5 viewports × 2 themes = 10 captures, taken against `npm run dev --workspace @bird-watch/frontend` at the PR head, with Vite proxying `/api` to the live `https://api.bird-maps.com` backend so the app renders real data. The header wordmark ("Bird Maps · Arizona"), MapLede region label ("356 species seen across Arizona in the last 14 days."), and FeedSurface region label all visibly include "Arizona" through the new env-driven `REGION_LABEL` code path. Dark theme applied via `document.documentElement.setAttribute('data-theme', 'dark')`.

<img width="390" height="844" alt="v390-light" src="https://github.com/user-attachments/assets/e09f3da5-d79a-4750-abe4-422c77f118e8" />
<img width="390" height="844" alt="v390-dark" src="https://github.com/user-attachments/assets/6dffb193-3827-4e2b-bab9-81e308854557" />
<img width="768" height="1024" alt="v768-light" src="https://github.com/user-attachments/assets/0cb16863-3d5d-40eb-bea3-d5cbea10bf32" />
<img width="768" height="1024" alt="v768-dark" src="https://github.com/user-attachments/assets/49f88da4-1275-4c09-9a99-bff941a81bbe" />
<img width="1024" height="768" alt="v1024-light" src="https://github.com/user-attachments/assets/ea73c3e6-f70c-4365-9fa9-fa855143ed5d" />
<img width="1024" height="768" alt="v1024-dark" src="https://github.com/user-attachments/assets/8a24a931-63c4-44f7-a54c-92991a4f25b8" />
<img width="1440" height="900" alt="v1440-light" src="https://github.com/user-attachments/assets/6a2a53ab-0430-47e4-b9ac-8ee18d442a0a" />
<img width="1440" height="900" alt="v1440-dark" src="https://github.com/user-attachments/assets/8e562fb2-fdab-48be-bae2-9d5440105438" />
<img width="1920" height="1080" alt="v1920-light" src="https://github.com/user-attachments/assets/5426ca31-5667-4db4-a91a-d1751685d6d4" />
<img width="1920" height="1080" alt="v1920-dark" src="https://github.com/user-attachments/assets/eb655f0e-ec9e-4706-9f05-40b5a7d673f3" />

- [ ] N/A — no new/renamed classNames in this PR (pure refactor of a string source-of-truth)
- [x] Multi-viewport design QA: 10 user-attachments URLs above demonstrate the rendered "Arizona" label at every site this PR touches

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 893/893 green
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npm run lint` (workspaces) — clean
- [x] No new tests required: behavior is unchanged at the default config; existing tests pin "Arizona" rendering. Added a `REGION_CODE` assertion to `region.test.ts` to guard the default deploy.
- [x] Playwright MCP smoke ran at all 5 canonical viewports × 2 themes against the live API proxy; AppHeader wordmark, MapLede label, and FeedSurface label all render "Arizona" via the new env-driven path. Zero console errors at all viewports.

## Plan reference

Out of plan — Phase 2 of issue #533 (going-national branding sweep, follow-up to PR #618 amended umbrella plan).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)