### PR TITLE
feat(read-api): server-side bbox filtering on /api/observations (#619)

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -21,6 +21,27 @@ describe('ApiClient', () => {
     expect(url).toContain('species=vermfly');
   });
 
+  // #619 — server-side bbox filtering, viewport-driven from MapCanvas.
+  it('encodes bbox as a single comma-separated query param', async () => {
+    const envelope = JSON.stringify({ data: [], meta: { freshestObservationAt: null } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getObservations({ bbox: [-112, 31, -110, 33] });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    const url = call[0];
+    // URL-encoded comma is %2C; assert against either form for robustness
+    expect(url).toMatch(/bbox=-112(%2C|,)31(%2C|,)-110(%2C|,)33/);
+  });
+
+  it('omits bbox when not provided (backward-compatible)', async () => {
+    const envelope = JSON.stringify({ data: [], meta: { freshestObservationAt: null } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getObservations({ since: '14d' });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    expect(String(call[0])).not.toContain('bbox=');
+  });
+
   it('throws on non-2xx response', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
     const client = new ApiClient({ baseUrl: '' });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,6 +30,7 @@ export class ApiClient {
     if (f.notable === true) url.searchParams.set('notable', 'true');
     if (f.speciesCode) url.searchParams.set('species', f.speciesCode);
     if (f.familyCode) url.searchParams.set('family', f.familyCode);
+    if (f.bbox) url.searchParams.set('bbox', f.bbox.join(','));
     // Defensive: the server may still return a bare Observation[] array during
     // the deployment window before the read-api is updated. Auto-wrap to the
     // ObservationsResponse envelope so the frontend never crashes on old responses.

--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -183,6 +183,40 @@ describe('getObservations filters', () => {
     const rows = await getObservations(db.pool, { familyCode: 'trochilidae' });
     expect(rows.map(r => r.subId)).toEqual(['S201']);
   });
+
+  // #619 — server-side bbox filtering (Phase 2 going-national pre-condition).
+  // Fixture lat/lng:
+  //   S200 = (31.72, -110.88)
+  //   S201 = (32.30, -110.99)
+  //   S202 = (32.30, -110.99)
+  it('filters by bbox: narrow envelope around S200 returns only S200', async () => {
+    const rows = await getObservations(db.pool, {
+      bbox: [-111.0, 31.5, -110.8, 31.9],
+    });
+    expect(rows.map(r => r.subId)).toEqual(['S200']);
+  });
+
+  it('filters by bbox: wide envelope returns all in-bounds', async () => {
+    const rows = await getObservations(db.pool, {
+      bbox: [-112.0, 31.0, -110.0, 33.0],
+    });
+    expect(rows.map(r => r.subId).sort()).toEqual(['S200', 'S201', 'S202']);
+  });
+
+  it('filters by bbox: envelope outside fixture returns empty', async () => {
+    const rows = await getObservations(db.pool, {
+      bbox: [-80.0, 25.0, -79.0, 26.0],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('filters by bbox: boundary point is inclusive', async () => {
+    // S200 at exactly (31.72, -110.88) — envelope edge passes through it.
+    const rows = await getObservations(db.pool, {
+      bbox: [-110.88, 31.72, -110.0, 32.0],
+    });
+    expect(rows.map(r => r.subId)).toContain('S200');
+  });
 });
 
 describe('runReconcileStamping', () => {

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -141,6 +141,27 @@ export async function getObservations(
     );
     params.push(f.familyCode);
   }
+  if (f.bbox) {
+    // PostGIS spatial filter (#619). The `&&` operator uses the obs_geom_idx
+    // GIST index for fast bbox-overlap; ST_Intersects is then layered on top
+    // to remove false-positives at the envelope boundary (the `&&` shortcut
+    // is a bounding-box test, not a true geometric intersect, so on its own
+    // it can include features that touch the envelope MBR but not its
+    // interior). For axis-aligned POINTs the two predicates collapse to the
+    // same set, but the planner still uses the GIST index via `&&` — keep
+    // both to stay correct if/when non-point geometries land.
+    const i1 = params.length + 1;
+    const i2 = params.length + 2;
+    const i3 = params.length + 3;
+    const i4 = params.length + 4;
+    conditions.push(
+      `geom && ST_MakeEnvelope($${i1}, $${i2}, $${i3}, $${i4}, 4326)`
+    );
+    conditions.push(
+      `ST_Intersects(geom, ST_MakeEnvelope($${i1}, $${i2}, $${i3}, $${i4}, 4326))`
+    );
+    params.push(f.bbox[0], f.bbox[1], f.bbox[2], f.bbox[3]);
+  }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -145,6 +145,17 @@ export type ObservationFilters = {
   notable?: boolean;
   speciesCode?: string;
   familyCode?: string;
+  /**
+   * Viewport bounding box [minLon, minLat, maxLon, maxLat] in EPSG:4326.
+   * When present, the result is narrowed via PostGIS
+   * `geom && ST_MakeEnvelope(...) AND ST_Intersects(geom, ST_MakeEnvelope(...))`
+   * — the `&&` predicate is index-friendly (uses obs_geom_idx GIST) and
+   * `ST_Intersects` removes false-positives at the envelope boundary.
+   * Added 2026-05-17 (#619) as a Phase 2 pre-condition for the going-national
+   * flip — without it, the national observation set ships ~24 MB JSON per
+   * map load.
+   */
+  bbox?: [number, number, number, number];
 };
 
 /**

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -145,6 +145,56 @@ describe('GET /api/observations', () => {
     expect(res.status).toBe(400);
   });
 
+  // #619 — server-side bbox filtering, Phase 2 going-national pre-condition.
+  describe('bbox filtering', () => {
+    it('with NO bbox returns the full set (backward-compatible)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?since=30d');
+      expect(res.status).toBe(200);
+      const body = await res.json() as ObsEnvelope;
+      expect(body.data).toHaveLength(2);
+    });
+
+    it('with a valid bbox narrows to in-bounds observations', async () => {
+      const app = createApp({ pool: db.pool });
+      // Envelope contains only S1 (31.72, -110.88); excludes S2 (32.30, -110.99)
+      const res = await app.request(
+        '/api/observations?since=30d&bbox=-111,31.5,-110.85,31.9'
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json() as ObsEnvelope;
+      expect(body.data.map(o => o.subId)).toEqual(['S1']);
+    });
+
+    it('with a malformed bbox (too few values) returns 400', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?bbox=1,2,3');
+      expect(res.status).toBe(400);
+    });
+
+    it('with a non-numeric bbox returns 400', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?bbox=a,b,c,d');
+      expect(res.status).toBe(400);
+    });
+
+    it('with out-of-range lat/lon returns 400', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?bbox=-200,-100,200,100');
+      expect(res.status).toBe(400);
+    });
+
+    it('preserves the s-maxage=300 cache header when bbox present', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(
+        '/api/observations?bbox=-112,31,-110,33'
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get('cache-control'))
+        .toBe('public, s-maxage=300, stale-while-revalidate=600');
+    });
+  });
+
   // Plan 2026-05-17, Task 5 / S2 alert source. The data-staleness alert
   // (google_logging_metric.meta_freshness_seconds) pulls
   // jsonPayload.meta_freshness_seconds out of the read-api's stdout — this

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -93,11 +93,41 @@ export function createApp(deps: AppDeps): Hono {
     const speciesCode = c.req.query('species');
     const familyCode = c.req.query('family');
 
+    // #619 — optional viewport-bbox filter, Phase 2 going-national
+    // pre-condition. Format: bbox=minLon,minLat,maxLon,maxLat (EPSG:4326).
+    // Backward-compatible: no bbox param → full set unchanged. The bbox
+    // becomes part of the canonical URL so Cloudflare caches per-bbox under
+    // the existing s-maxage=300.
+    const bboxRaw = c.req.query('bbox');
+    let bbox: [number, number, number, number] | undefined;
+    if (bboxRaw !== undefined) {
+      const parts = bboxRaw.split(',');
+      if (parts.length !== 4) {
+        return c.json({ error: 'invalid bbox: expected 4 comma-separated floats' }, 400);
+      }
+      const nums = parts.map(p => Number(p));
+      if (nums.some(n => !Number.isFinite(n))) {
+        return c.json({ error: 'invalid bbox: non-numeric value' }, 400);
+      }
+      const [minLon, minLat, maxLon, maxLat] = nums as [number, number, number, number];
+      if (
+        minLon < -180 || minLon > 180 || maxLon < -180 || maxLon > 180 ||
+        minLat < -90  || minLat > 90  || maxLat < -90  || maxLat > 90
+      ) {
+        return c.json({ error: 'invalid bbox: out of range (lon ∈ [-180,180], lat ∈ [-90,90])' }, 400);
+      }
+      if (minLon > maxLon || minLat > maxLat) {
+        return c.json({ error: 'invalid bbox: min must be <= max on each axis' }, 400);
+      }
+      bbox = [minLon, minLat, maxLon, maxLat];
+    }
+
     const filters: Parameters<typeof getObservations>[1] = {};
     if (since !== undefined) filters.since = since;
     if (notableParam === 'true') filters.notable = true;
     if (speciesCode !== undefined) filters.speciesCode = speciesCode;
     if (familyCode !== undefined) filters.familyCode = familyCode;
+    if (bbox !== undefined) filters.bbox = bbox;
 
     // Run both queries in parallel — getObservations fetches the filtered rows;
     // getFreshestObservationAt provides MAX(ingested_at) for the freshness


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Frontend
    participant CDN as Cloudflare
    participant ReadAPI as Read API (Hono)
    participant PG as Postgres + PostGIS

    Frontend->>CDN: GET /api/observations?bbox=minLon,minLat,maxLon,maxLat
    CDN->>ReadAPI: cache miss → forward (per-bbox cache key)
    ReadAPI->>ReadAPI: parse + validate bbox (4 floats, range, ordering)
    ReadAPI->>PG: SELECT ... WHERE geom && ST_MakeEnvelope($1,$2,$3,$4,4326)<br/>AND ST_Intersects(geom, ST_MakeEnvelope(...))
    PG-->>ReadAPI: rows narrowed via obs_geom_idx (GIST)
    ReadAPI-->>CDN: JSON + Cache-Control: s-maxage=300
    CDN-->>Frontend: response cached per-bbox

    Note over Frontend,ReadAPI: No bbox param → existing full-set response (backward-compatible)
```

## Summary

- Closes #619. Adds optional `bbox=minLon,minLat,maxLon,maxLat` (EPSG:4326) on `/api/observations`. Without the param, behavior is unchanged.
- PostGIS predicate uses both `geom &&` (uses `obs_geom_idx` GIST, fast) and `ST_Intersects` (correctness vs the bbox-only shortcut). Backend-only payload optimization — eliminates the ~24 MB national-scale JSON identified as the next bottleneck in the hotspot-density viability report.
- `ApiClient.getObservations()` gains an opt-in `bbox` arg. MapCanvas viewport-driven auto-fetch is deliberately deferred to a follow-up PR (changes visible rendering → requires the 10-screenshot UI verification protocol).

## Screenshots

N/A — server-side optimization, no visual change. The frontend `ApiClient` change is an opt-in parameter; no caller is wired to send it in this PR, so observation rendering is identical.

## Test plan

- [x] `npx vitest run` (read-api) — 40 passed, including 6 new bbox cases (no-bbox unchanged, valid bbox narrows, malformed → 400, non-numeric → 400, out-of-range → 400, s-maxage preserved)
- [x] `npx vitest run` (db-client) — 4 new PostGIS spatial tests against real Postgres + PostGIS via testcontainers (narrow envelope, wide envelope, outside-envelope, boundary inclusivity)
- [x] `npx vitest run src/api/client.test.ts` (frontend) — 8 passed, includes bbox encoding + backward-compat omission
- [x] `npm run build` (frontend) — clean production build
- [x] `npm run -s build --workspace @bird-watch/{shared-types,db-client,read-api}` — green
- N/A — Playwright MCP smoke (server-side change; ApiClient `bbox` is opt-in and no caller sends it)

## Plan reference

Phase 2 hard pre-condition per amended umbrella plan PR #618 (R4). See `docs/plans/2026-05-17-going-national.md` §5 / R4 and `docs/analyses/2026-05-17-hotspot-density-100k-viability/report.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)