### PR TITLE
fix(infra): wire HEALTHCHECKS_URL_* env vars on Cloud Run Jobs

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -129,6 +129,45 @@ resource "google_cloud_run_v2_job" "ingestor" {
             }
           }
         }
+        # Healthchecks.io ping URLs for the four kinds this shared job runs.
+        # cli.ts reads `HEALTHCHECKS_URL_<KIND>` and pings start/success/fail
+        # around each run; without these the heartbeat silently skips.
+        env {
+          name = "HEALTHCHECKS_URL_RECENT"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["recent"].secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "HEALTHCHECKS_URL_HOTSPOTS"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["hotspots"].secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "HEALTHCHECKS_URL_BACKFILL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["backfill"].secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "HEALTHCHECKS_URL_TAXONOMY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["taxonomy"].secret_id
+              version = "latest"
+            }
+          }
+        }
 
         # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
         # migration (docs/plans/2026-05-17-cloud-sql-migration.md §3.2).
@@ -160,6 +199,7 @@ resource "google_cloud_run_v2_job" "ingestor" {
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
+    google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]
 }
 
@@ -374,6 +414,16 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
             }
           }
         }
+        # Healthchecks.io ping URL for the photos kind. See cli.ts:182.
+        env {
+          name = "HEALTHCHECKS_URL_PHOTOS"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["photos"].secret_id
+              version = "latest"
+            }
+          }
+        }
 
         # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
         # migration. Additive; DATABASE_URL still points at Neon.
@@ -405,6 +455,7 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
     google_secret_manager_secret_iam_member.ingestor_r2_endpoint,
     google_secret_manager_secret_iam_member.ingestor_r2_access_key_id,
     google_secret_manager_secret_iam_member.ingestor_r2_secret_access_key,
+    google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]
 }
 
@@ -574,6 +625,16 @@ resource "google_cloud_run_v2_job" "ingestor_descriptions" {
           name  = "DESCRIPTIONS_PURGE_CACHE"
           value = "1"
         }
+        # Healthchecks.io ping URL for the descriptions kind. See cli.ts:182.
+        env {
+          name = "HEALTHCHECKS_URL_DESCRIPTIONS"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["descriptions"].secret_id
+              version = "latest"
+            }
+          }
+        }
 
         # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
         # migration. Additive; DATABASE_URL still points at Neon.
@@ -604,6 +665,7 @@ resource "google_cloud_run_v2_job" "ingestor_descriptions" {
     google_secret_manager_secret_iam_member.ingestor_ebird,
     google_secret_manager_secret_iam_member.ingestor_cloudflare_zone_id,
     google_secret_manager_secret_iam_member.ingestor_cloudflare_api_token,
+    google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]
 }
 
@@ -722,6 +784,16 @@ resource "google_cloud_run_v2_job" "ingestor_prune" {
             }
           }
         }
+        # Healthchecks.io ping URL for the prune kind. See cli.ts:182.
+        env {
+          name = "HEALTHCHECKS_URL_PRUNE"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["prune"].secret_id
+              version = "latest"
+            }
+          }
+        }
 
         # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
         # migration. Additive; DATABASE_URL still points at Neon.
@@ -750,6 +822,7 @@ resource "google_cloud_run_v2_job" "ingestor_prune" {
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
+    google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler as Cloud Scheduler
    participant Job as Cloud Run Job
    participant SM as Secret Manager
    participant HC as Healthchecks.io

    Scheduler->>Job: runWithOverrides(args=[kind])
    Job->>SM: read bird-watch-healthchecks-<kind>
    SM-->>Job: HEALTHCHECKS_URL_<KIND>
    Job->>HC: POST /<uuid>/start
    Job->>Job: run kind (recent/photos/prune/...)
    Job->>HC: POST /<uuid> (success) or /<uuid>/fail
```

## Summary

- `cli.ts:182` reads `HEALTHCHECKS_URL_<KIND>` from `process.env` to ping Healthchecks.io around each run. The seven `bird-watch-healthchecks-<kind>` secrets and the ingestor SA's accessor IAM already exist (PR #600), but the four `google_cloud_run_v2_job` blocks never referenced them in their `env` blocks — so the heartbeat silently skipped and Healthchecks.io showed "no pings received" even though every ingest completed successfully.
- Adds `HEALTHCHECKS_URL_*` env vars per the kinds each job runs: `bird-ingestor` gets recent/hotspots/backfill/taxonomy (4); `bird-ingestor-photos` gets photos; `bird-ingestor-descriptions` gets descriptions; `bird-ingestor-prune` gets prune. All use `value_source.secret_key_ref` against `google_secret_manager_secret.healthchecks_url["<kind>"]`, matching the existing `EBIRD_API_KEY` / `DATABASE_URL` pattern.
- Each job's `depends_on` picks up `google_secret_manager_secret_iam_member.ingestor_healthchecks` so the IAM binding is in place before the Job spec references the secret.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean
- [x] `terraform validate` — Success! The configuration is valid.
- [x] `git diff --name-only` — only `infra/terraform/ingestor.tf` touched
- [ ] Operator runs `terraform apply` post-merge to roll new Job revisions; first scheduled run after apply produces start+success pings on the corresponding Healthchecks.io check

## Plan reference

Out of plan — follow-up bugfix to monitoring infra shipped in PR #600. The secrets, IAM, and `cli.ts` heartbeat code all landed; this PR closes the missing env-var wiring that made the ping path a no-op at runtime.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)