### PR TITLE
feat(ingestor): dual-write to SECONDARY_DATABASE_URL for Cloud SQL migration

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -9,6 +9,38 @@ resource "google_secret_manager_secret_iam_member" "ingestor_db" {
   member    = "serviceAccount:${google_service_account.ingestor.email}"
 }
 
+# ── Cloud SQL secondary URL (Neon→Cloud SQL migration, T3→T4) ───────────
+#
+# Stores the Cloud SQL pooled URL (libpq unix-socket form) so the ingester
+# can dual-write to it via SECONDARY_DATABASE_URL. While this secret is
+# populated, the ingester's dual-write wrapper fans out every INSERT/UPDATE/
+# DELETE/TRUNCATE/MERGE to Cloud SQL in addition to the primary Neon write.
+# Secondary failures self-heal via idempotent upserts on the next tick.
+# See packages/db-client/src/dual-write-pool.ts and
+# docs/plans/2026-05-17-cloud-sql-migration.md.
+#
+# This is purely additive. To decommission dual-write later (post-cutover),
+# remove the four env { name = "SECONDARY_DATABASE_URL" ... } blocks below
+# and delete this secret.
+resource "google_secret_manager_secret" "cloudsql_db_url" {
+  secret_id = "bird-watch-cloudsql-db-url"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "cloudsql_db_url" {
+  secret      = google_secret_manager_secret.cloudsql_db_url.id
+  secret_data = local.cloudsql_pooled_url
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_cloudsql_db" {
+  secret_id = google_secret_manager_secret.cloudsql_db_url.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
 resource "google_secret_manager_secret" "ebird_key" {
   secret_id = "bird-watch-ebird-key"
   replication {
@@ -120,6 +152,22 @@ resource "google_cloud_run_v2_job" "ingestor" {
             }
           }
         }
+        # SECONDARY_DATABASE_URL — Cloud SQL fan-out for the Neon→Cloud SQL
+        # migration (Stage 3, dual-write). When set, the ingester's dual-write
+        # pool fans every INSERT/UPDATE/DELETE/TRUNCATE/MERGE to this URL in
+        # addition to DATABASE_URL. Secondary failures are logged
+        # (`dual_write_secondary_failed`) and swallowed; the next tick
+        # self-heals via idempotent upserts. Remove this block (and the
+        # cloudsql_db_url secret) post-cutover to decommission Neon.
+        env {
+          name = "SECONDARY_DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cloudsql_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
         env {
           name = "EBIRD_API_KEY"
           value_source {
@@ -198,6 +246,7 @@ resource "google_cloud_run_v2_job" "ingestor" {
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_cloudsql_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
     google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]
@@ -378,6 +427,22 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
             }
           }
         }
+        # SECONDARY_DATABASE_URL — Cloud SQL fan-out for the Neon→Cloud SQL
+        # migration (Stage 3, dual-write). When set, the ingester's dual-write
+        # pool fans every INSERT/UPDATE/DELETE/TRUNCATE/MERGE to this URL in
+        # addition to DATABASE_URL. Secondary failures are logged
+        # (`dual_write_secondary_failed`) and swallowed; the next tick
+        # self-heals via idempotent upserts. Remove this block (and the
+        # cloudsql_db_url secret) post-cutover to decommission Neon.
+        env {
+          name = "SECONDARY_DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cloudsql_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
         env {
           name = "EBIRD_API_KEY"
           value_source {
@@ -451,6 +516,7 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_cloudsql_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
     google_secret_manager_secret_iam_member.ingestor_r2_endpoint,
     google_secret_manager_secret_iam_member.ingestor_r2_access_key_id,
@@ -590,6 +656,22 @@ resource "google_cloud_run_v2_job" "ingestor_descriptions" {
             }
           }
         }
+        # SECONDARY_DATABASE_URL — Cloud SQL fan-out for the Neon→Cloud SQL
+        # migration (Stage 3, dual-write). When set, the ingester's dual-write
+        # pool fans every INSERT/UPDATE/DELETE/TRUNCATE/MERGE to this URL in
+        # addition to DATABASE_URL. Secondary failures are logged
+        # (`dual_write_secondary_failed`) and swallowed; the next tick
+        # self-heals via idempotent upserts. Remove this block (and the
+        # cloudsql_db_url secret) post-cutover to decommission Neon.
+        env {
+          name = "SECONDARY_DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cloudsql_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
         env {
           name = "EBIRD_API_KEY"
           value_source {
@@ -662,6 +744,7 @@ resource "google_cloud_run_v2_job" "ingestor_descriptions" {
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_cloudsql_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
     google_secret_manager_secret_iam_member.ingestor_cloudflare_zone_id,
     google_secret_manager_secret_iam_member.ingestor_cloudflare_api_token,
@@ -771,6 +854,22 @@ resource "google_cloud_run_v2_job" "ingestor_prune" {
             }
           }
         }
+        # SECONDARY_DATABASE_URL — Cloud SQL fan-out for the Neon→Cloud SQL
+        # migration (Stage 3, dual-write). When set, the ingester's dual-write
+        # pool fans every INSERT/UPDATE/DELETE/TRUNCATE/MERGE to this URL in
+        # addition to DATABASE_URL. Secondary failures are logged
+        # (`dual_write_secondary_failed`) and swallowed; the next tick
+        # self-heals via idempotent upserts. Remove this block (and the
+        # cloudsql_db_url secret) post-cutover to decommission Neon.
+        env {
+          name = "SECONDARY_DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cloudsql_db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
         # EBIRD_API_KEY is not required for prune itself, but cli.ts enforces
         # a uniform env contract across all DB-bound kinds — wiring the same
         # secret here keeps the Job spec consistent with the shared image's
@@ -821,6 +920,7 @@ resource "google_cloud_run_v2_job" "ingestor_prune" {
   depends_on = [
     google_project_service.run,
     google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_cloudsql_db,
     google_secret_manager_secret_iam_member.ingestor_ebird,
     google_secret_manager_secret_iam_member.ingestor_healthchecks,
   ]

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -22,19 +22,10 @@ resource "google_secret_manager_secret_iam_member" "ingestor_db" {
 # This is purely additive. To decommission dual-write later (post-cutover),
 # remove the four env { name = "SECONDARY_DATABASE_URL" ... } blocks below
 # and delete this secret.
-resource "google_secret_manager_secret" "cloudsql_db_url" {
-  secret_id = "bird-watch-cloudsql-db-url"
-  replication {
-    auto {}
-  }
-  depends_on = [google_project_service.secretmanager]
-}
-
-resource "google_secret_manager_secret_version" "cloudsql_db_url" {
-  secret      = google_secret_manager_secret.cloudsql_db_url.id
-  secret_data = local.cloudsql_pooled_url
-}
-
+#
+# The secret resource itself (google_secret_manager_secret.cloudsql_db_url) is
+# defined in cloud-sql.tf alongside the Cloud SQL instance that produces its
+# value. This file only grants the ingester service account access.
 resource "google_secret_manager_secret_iam_member" "ingestor_cloudsql_db" {
   secret_id = google_secret_manager_secret.cloudsql_db_url.id
   role      = "roles/secretmanager.secretAccessor"

--- a/packages/db-client/src/dual-write-pool.test.ts
+++ b/packages/db-client/src/dual-write-pool.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createDualWritePool, isWriteSql } from './dual-write-pool.js';
+import type { Pool } from './pool.js';
+
+/**
+ * Unit tests for the dual-write pool wrapper. These tests stub two pg pools
+ * (no real Postgres) and assert the fan-out + failure-handling contract:
+ *
+ *   1. Write SQL (INSERT/UPDATE/DELETE/TRUNCATE/MERGE) is sent to BOTH pools.
+ *   2. Read SQL (SELECT/WITH) is sent ONLY to the primary.
+ *   3. If the SECONDARY write fails, the error is logged with a `dual_write_secondary_failed`
+ *      marker and the call returns the primary result without throwing.
+ *   4. If the PRIMARY write fails, the error throws as usual.
+ *
+ * Real-Postgres integration coverage for `createPool` lives in pool.test.ts;
+ * the dual-write layer is logic-only, so unit tests are sufficient.
+ */
+
+function makeFakePool(queryImpl: (sql: string) => Promise<{ rows: unknown[]; rowCount: number }>): Pool {
+  return {
+    query: vi.fn(queryImpl),
+    end: vi.fn(async () => {}),
+    // We intentionally don't model `connect`, `on`, etc. — the ingestor code
+    // only uses `.query()` and pool lifecycle is managed via createPool/closePool.
+  } as unknown as Pool;
+}
+
+describe('isWriteSql', () => {
+  it.each([
+    ['INSERT INTO foo VALUES (1)', true],
+    ['  insert into foo values (1)', true],
+    ['UPDATE foo SET x = 1', true],
+    ['DELETE FROM foo', true],
+    ['TRUNCATE foo', true],
+    ['MERGE INTO foo USING bar ON ...', true],
+    ['SELECT * FROM foo', false],
+    ['WITH x AS (SELECT 1) SELECT * FROM x', false],
+    ['VACUUM ANALYZE foo', false], // VACUUM is maintenance, not a row write — and runs OK on either DB independently
+    ['BEGIN', false],
+    ['  -- comment\nINSERT INTO foo VALUES (1)', true],
+  ])('classifies %s as write=%s', (sql, expected) => {
+    expect(isWriteSql(sql)).toBe(expected);
+  });
+});
+
+describe('createDualWritePool', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('fans out INSERT to both primary and secondary', async () => {
+    const primary = makeFakePool(async () => ({ rows: [], rowCount: 1 }));
+    const secondary = makeFakePool(async () => ({ rows: [], rowCount: 1 }));
+    const pool = createDualWritePool({ primary, secondary });
+
+    await pool.query('INSERT INTO observations (sub_id) VALUES ($1)', ['S1']);
+
+    expect(primary.query).toHaveBeenCalledTimes(1);
+    expect(secondary.query).toHaveBeenCalledTimes(1);
+    expect(primary.query).toHaveBeenCalledWith('INSERT INTO observations (sub_id) VALUES ($1)', ['S1']);
+    expect(secondary.query).toHaveBeenCalledWith('INSERT INTO observations (sub_id) VALUES ($1)', ['S1']);
+  });
+
+  it('does NOT fan out SELECT to secondary', async () => {
+    const primary = makeFakePool(async () => ({ rows: [{ n: 1 }], rowCount: 1 }));
+    const secondary = makeFakePool(async () => ({ rows: [], rowCount: 0 }));
+    const pool = createDualWritePool({ primary, secondary });
+
+    const result = await pool.query('SELECT 1 AS n');
+
+    expect(primary.query).toHaveBeenCalledTimes(1);
+    expect(secondary.query).not.toHaveBeenCalled();
+    expect(result.rows).toEqual([{ n: 1 }]);
+  });
+
+  it('swallows + logs when secondary write fails; returns primary result', async () => {
+    const primary = makeFakePool(async () => ({ rows: [], rowCount: 3 }));
+    const secondary = makeFakePool(async () => {
+      throw new Error('connection refused');
+    });
+    const pool = createDualWritePool({ primary, secondary, kind: 'recent' });
+
+    const result = await pool.query('UPDATE foo SET x = 1');
+
+    expect(result.rowCount).toBe(3);
+    expect(primary.query).toHaveBeenCalledTimes(1);
+    expect(secondary.query).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logMsg = String(logSpy.mock.calls[0][0]);
+    expect(logMsg).toContain('dual_write_secondary_failed');
+    expect(logMsg).toContain('kind=recent');
+    expect(logMsg).toContain('connection refused');
+  });
+
+  it('throws when primary write fails (does not call secondary)', async () => {
+    const primary = makeFakePool(async () => {
+      throw new Error('primary unique violation');
+    });
+    const secondary = makeFakePool(async () => ({ rows: [], rowCount: 1 }));
+    const pool = createDualWritePool({ primary, secondary });
+
+    await expect(pool.query('INSERT INTO foo VALUES (1)')).rejects.toThrow('primary unique violation');
+    expect(secondary.query).not.toHaveBeenCalled();
+  });
+
+  it('end() closes both pools', async () => {
+    const primary = makeFakePool(async () => ({ rows: [], rowCount: 0 }));
+    const secondary = makeFakePool(async () => ({ rows: [], rowCount: 0 }));
+    const pool = createDualWritePool({ primary, secondary });
+
+    await pool.end();
+    expect(primary.end).toHaveBeenCalledTimes(1);
+    expect(secondary.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/db-client/src/dual-write-pool.ts
+++ b/packages/db-client/src/dual-write-pool.ts
@@ -1,0 +1,136 @@
+import type { Pool } from './pool.js';
+
+/**
+ * Dual-write pool wrapper.
+ *
+ * Purpose: during the Neon→Cloud SQL migration (T3 → T4 in
+ * docs/plans/2026-05-17-cloud-sql-migration.md), every ingester write must
+ * land in BOTH databases so that the eventual read-cutover finds Cloud SQL
+ * already in sync. We do this at the app layer rather than via logical
+ * replication because (a) the ingester upserts are idempotent
+ * (`ON CONFLICT ... DO UPDATE`) and (b) we avoid standing up a separate
+ * replication operator and its failure modes.
+ *
+ * Contract:
+ *   - SELECT / WITH / VACUUM and other non-row-write SQL: routed to the
+ *     PRIMARY pool only. The secondary is fanned out only for actual
+ *     mutations to keep read load on Neon unchanged and to avoid spurious
+ *     divergence (a SELECT-then-write pattern reading from secondary would
+ *     drift if the two backends had divergent state during the migration).
+ *   - INSERT / UPDATE / DELETE / TRUNCATE / MERGE: executed on PRIMARY
+ *     first (its error throws as usual), then on SECONDARY. If the
+ *     secondary call throws, the error is logged with the marker
+ *     `dual_write_secondary_failed` and swallowed — the next 30-minute tick
+ *     will self-heal because the upsert is idempotent.
+ *   - No retry loop in this layer. The next tick is the retry budget.
+ *   - The `kind` field on the options tags log lines so an operator
+ *     filtering Cloud Logging can attribute drift to a specific job.
+ *
+ * Why a regex on SQL text rather than a typed write-API: the existing
+ * handlers call `pool.query(text, params)` directly with hand-written SQL
+ * (see services/ingestor/src/run-*.ts and packages/db-client/src/*.ts).
+ * Adding a write-only method would require refactoring 7 handlers and
+ * the db-client layer, which is out of scope per the constraint that
+ * upsert shape and business logic are untouched. The regex is conservative
+ * — false-negative on writes would cause silent secondary drift, so we
+ * pattern-match on the leading SQL keyword after stripping comments and
+ * whitespace.
+ */
+
+const WRITE_VERB = /^(insert|update|delete|truncate|merge)\b/i;
+
+/**
+ * Strip leading line/block comments + whitespace, then check whether the
+ * first SQL token is a write verb.
+ *
+ * Block comments are nested per Postgres semantics
+ * (https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-COMMENTS)
+ * but we don't see them in this codebase — only the `-- Up Migration` /
+ * `-- Down Migration` line comments and inline `--` notes. Handle both
+ * styles defensively rather than expanding scope.
+ */
+export function isWriteSql(sql: string): boolean {
+  let s = sql;
+  // Strip leading line comments and whitespace repeatedly.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const trimmed = s.replace(/^\s+/, '');
+    if (trimmed.startsWith('--')) {
+      const nl = trimmed.indexOf('\n');
+      if (nl === -1) return false;
+      s = trimmed.slice(nl + 1);
+      continue;
+    }
+    if (trimmed.startsWith('/*')) {
+      const end = trimmed.indexOf('*/');
+      if (end === -1) return false;
+      s = trimmed.slice(end + 2);
+      continue;
+    }
+    s = trimmed;
+    break;
+  }
+  return WRITE_VERB.test(s);
+}
+
+export interface DualWritePoolOptions {
+  primary: Pool;
+  secondary: Pool;
+  /** Tagged into the `dual_write_secondary_failed` log line for triage. */
+  kind?: string;
+}
+
+/**
+ * Returns a Pool-shaped wrapper. The shape is structurally compatible with
+ * `pg.Pool` for the methods the ingester actually uses (`.query()`, `.end()`).
+ * Other pg.Pool methods (`connect`, event emitter API) are not used by the
+ * ingestor or db-client and are not proxied — see grep for `pool.connect`
+ * in the codebase (returns nothing).
+ */
+export function createDualWritePool(opts: DualWritePoolOptions): Pool {
+  const { primary, secondary, kind } = opts;
+
+  const dual = {
+    async query(...args: unknown[]): Promise<unknown> {
+      // pg.Pool.query has multiple overloads; the ingester always passes
+      // (text, params?). We forward the args verbatim so the type-system
+      // contract at the call site is unchanged.
+      const sql = typeof args[0] === 'string'
+        ? args[0]
+        : (args[0] as { text?: string } | undefined)?.text ?? '';
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const primaryResult = await (primary.query as any)(...args);
+
+      if (isWriteSql(sql)) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (secondary.query as any)(...args);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          // Distinct marker per the migration plan — Cloud Logging filter:
+          //   resource.type="cloud_run_job" AND textPayload:"dual_write_secondary_failed"
+          // Per-call kind tag distinguishes which scheduled job drifted.
+          console.error(
+            `dual_write_secondary_failed kind=${kind ?? 'unknown'} err=${msg}`
+          );
+        }
+      }
+      return primaryResult;
+    },
+    async end(): Promise<void> {
+      // Close both pools. We await both even if one rejects so the second
+      // pool's sockets don't leak; the AggregateError surfaces both faults
+      // to the caller (the CLI's `finally` block).
+      const results = await Promise.allSettled([primary.end(), secondary.end()]);
+      const failures = results
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+        .map(r => r.reason);
+      if (failures.length === 1) throw failures[0];
+      if (failures.length > 1) throw new AggregateError(failures, 'dual pool end failures');
+    },
+  };
+
+  // We intentionally only model `.query` + `.end` — see file header.
+  return dual as unknown as Pool;
+}

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -1,5 +1,7 @@
 export { createPool, closePool } from './pool.js';
 export type { Pool, PoolOptions } from './pool.js';
+export { createDualWritePool, isWriteSql } from './dual-write-pool.js';
+export type { DualWritePoolOptions } from './dual-write-pool.js';
 export { getHotspots, upsertHotspots, type HotspotInput } from './hotspots.js';
 export {
   getObservations, upsertObservations, runReconcileStamping,

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -337,4 +337,119 @@ describe('runCli', () => {
     expect(pingSpy).toHaveBeenCalledWith('https://hc-ping.com/uuid-bf-ext', 'backfill-extended');
     delete process.env.HEALTHCHECKS_URL_BACKFILL_EXTENDED;
   });
+
+  describe('dual-write wiring (SECONDARY_DATABASE_URL)', () => {
+    // The dual-write wrapper itself is unit-tested in
+    // packages/db-client/src/dual-write-pool.test.ts. These CLI-level tests
+    // verify the wiring: that runCli builds the wrapper when SECONDARY_DATABASE_URL
+    // is set, that both pools are closed, and that the behavior degrades to
+    // single-write when the env var is absent.
+
+    it('does NOT engage dual-write when SECONDARY_DATABASE_URL is unset', async () => {
+      delete process.env.SECONDARY_DATABASE_URL;
+      const createDualSpy = vi.fn();
+      const successSummary: RunSummary = { status: 'success', fetched: 0, upserted: 0 };
+      const deps = makeDeps({
+        runIngest: vi.fn().mockResolvedValue(successSummary),
+        createDualWritePool: createDualSpy,
+      });
+
+      await runCli('recent', deps);
+
+      expect(createDualSpy).not.toHaveBeenCalled();
+      expect(deps.createPool).toHaveBeenCalledTimes(1);
+      expect(deps.closePool).toHaveBeenCalledTimes(1);
+    });
+
+    it('engages dual-write when SECONDARY_DATABASE_URL is set; both pools created and closed', async () => {
+      process.env.SECONDARY_DATABASE_URL = 'postgres://secondary';
+      const PRIMARY = Symbol('primary') as unknown as import('@bird-watch/db-client').Pool;
+      const SECONDARY = Symbol('secondary') as unknown as import('@bird-watch/db-client').Pool;
+      const WRAPPED = Symbol('wrapped') as unknown as import('@bird-watch/db-client').Pool;
+
+      // createPool is called twice — once per URL — and returns distinct pool
+      // sentinels so we can assert closePool was called on each.
+      const createPool = vi.fn()
+        .mockReturnValueOnce(PRIMARY)
+        .mockReturnValueOnce(SECONDARY);
+      const createDualWritePool = vi.fn().mockReturnValue(WRAPPED);
+      const closePool = vi.fn().mockResolvedValue(undefined);
+
+      const successSummary: RunSummary = { status: 'success', fetched: 5, upserted: 5 };
+      const runIngest = vi.fn().mockResolvedValue(successSummary);
+
+      const deps: CliDeps = {
+        createPool,
+        closePool,
+        createDualWritePool,
+        runIngest,
+        runHotspotIngest: vi.fn(),
+        runBackfill: vi.fn(),
+        runTaxonomy: vi.fn(),
+        runPhotos: vi.fn(),
+        runDescriptions: vi.fn(),
+        runPrune: vi.fn(),
+        fetchWikipediaSummary: vi.fn(),
+        fetchInatTaxon: vi.fn(),
+      };
+
+      await runCli('recent', deps);
+
+      expect(createPool).toHaveBeenNthCalledWith(1, { databaseUrl: 'postgres://x' });
+      expect(createPool).toHaveBeenNthCalledWith(2, { databaseUrl: 'postgres://secondary' });
+      expect(createDualWritePool).toHaveBeenCalledWith({
+        primary: PRIMARY,
+        secondary: SECONDARY,
+        kind: 'recent',
+      });
+      // The runner receives the WRAPPED pool (so writes fan out).
+      expect(runIngest).toHaveBeenCalledWith(expect.objectContaining({ pool: WRAPPED }));
+      // Both underlying pools get closed.
+      expect(closePool).toHaveBeenCalledWith(PRIMARY);
+      expect(closePool).toHaveBeenCalledWith(SECONDARY);
+
+      delete process.env.SECONDARY_DATABASE_URL;
+    });
+
+    it('swallows + logs when secondary closePool fails (does not mask primary outcome)', async () => {
+      process.env.SECONDARY_DATABASE_URL = 'postgres://secondary';
+      const PRIMARY = Symbol('primary') as unknown as import('@bird-watch/db-client').Pool;
+      const SECONDARY = Symbol('secondary') as unknown as import('@bird-watch/db-client').Pool;
+      const WRAPPED = Symbol('wrapped') as unknown as import('@bird-watch/db-client').Pool;
+
+      const createPool = vi.fn()
+        .mockReturnValueOnce(PRIMARY)
+        .mockReturnValueOnce(SECONDARY);
+      const closePool = vi.fn(async (p: unknown) => {
+        if (p === SECONDARY) throw new Error('secondary close blew up');
+      });
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const successSummary: RunSummary = { status: 'success', fetched: 0, upserted: 0 };
+      const deps: CliDeps = {
+        createPool,
+        closePool,
+        createDualWritePool: vi.fn().mockReturnValue(WRAPPED),
+        runIngest: vi.fn().mockResolvedValue(successSummary),
+        runHotspotIngest: vi.fn(),
+        runBackfill: vi.fn(),
+        runTaxonomy: vi.fn(),
+        runPhotos: vi.fn(),
+        runDescriptions: vi.fn(),
+        runPrune: vi.fn(),
+        fetchWikipediaSummary: vi.fn(),
+        fetchInatTaxon: vi.fn(),
+      };
+
+      // Should NOT throw — secondary lifecycle errors must not mask the
+      // primary run's success.
+      await expect(runCli('recent', deps)).resolves.toBeUndefined();
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dual_write_secondary_failed')
+      );
+
+      errSpy.mockRestore();
+      delete process.env.SECONDARY_DATABASE_URL;
+    });
+  });
 });

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 import {
   createPool as realCreatePool,
   closePool as realClosePool,
+  createDualWritePool as realCreateDualWritePool,
   type Pool,
 } from '@bird-watch/db-client';
 import { runIngest as realRunIngest, type RunSummary } from './run-ingest.js';
@@ -56,6 +57,13 @@ type AnyRunSummary =
 export interface CliDeps {
   createPool: (opts: { databaseUrl: string }) => Pool;
   closePool: (pool: Pool) => Promise<void>;
+  /**
+   * Wraps a primary + secondary Pool into a fan-out Pool. Optional dep so
+   * tests that don't exercise dual-write can omit it; when omitted at
+   * runtime, dual-write simply doesn't engage even if SECONDARY_DATABASE_URL
+   * is set. The IIFE at the bottom always injects the real implementation.
+   */
+  createDualWritePool?: (opts: { primary: Pool; secondary: Pool; kind?: string }) => Pool;
   runIngest: typeof realRunIngest;
   runHotspotIngest: typeof realRunHotspotIngest;
   runBackfill: typeof realRunBackfill;
@@ -117,7 +125,27 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
   if (!apiKey) throw new Error('EBIRD_API_KEY not set');
   if (!dbUrl) throw new Error('DATABASE_URL not set');
 
-  const pool = deps.createPool({ databaseUrl: dbUrl });
+  // Dual-write to a secondary database (Neon→Cloud SQL migration, T3→T4).
+  // When SECONDARY_DATABASE_URL is unset the behavior is unchanged: writes
+  // go only to the primary DATABASE_URL. When set, every INSERT/UPDATE/
+  // DELETE/TRUNCATE/MERGE is fanned out to the secondary; failures on the
+  // secondary are logged with `dual_write_secondary_failed` and swallowed
+  // (the next scheduled tick self-heals via idempotent upserts).
+  // See packages/db-client/src/dual-write-pool.ts for the contract.
+  const secondaryDbUrl = process.env.SECONDARY_DATABASE_URL;
+  const primaryPool = deps.createPool({ databaseUrl: dbUrl });
+  let secondaryPool: Pool | undefined;
+  let pool: Pool;
+  if (secondaryDbUrl && deps.createDualWritePool) {
+    secondaryPool = deps.createPool({ databaseUrl: secondaryDbUrl });
+    pool = deps.createDualWritePool({
+      primary: primaryPool,
+      secondary: secondaryPool,
+      kind,
+    });
+  } else {
+    pool = primaryPool;
+  }
   try {
     let summary: AnyRunSummary;
     if (kind === 'recent') {
@@ -184,7 +212,22 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       await ping(process.env[envKey], kind);
     }
   } finally {
-    await deps.closePool(pool);
+    // Close the underlying primary pool (the dual-write wrapper does not
+    // own additional sockets — it delegates .end to both underlying pools,
+    // but we only handed `closePool` the primary in the non-dual path, so
+    // we close primary + secondary explicitly here to keep the lifecycle
+    // explicit regardless of wrapping).
+    await deps.closePool(primaryPool);
+    if (secondaryPool) {
+      try {
+        await deps.closePool(secondaryPool);
+      } catch (err) {
+        // Mirror the dual_write_secondary_failed treatment: secondary
+        // lifecycle errors must not mask the primary outcome.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`dual_write_secondary_failed kind=${kind} stage=closePool err=${msg}`);
+      }
+    }
   }
 }
 
@@ -208,6 +251,7 @@ if (isEntrypoint) {
   runCli(KIND, {
     createPool: realCreatePool,
     closePool: realClosePool,
+    createDualWritePool: realCreateDualWritePool,
     runIngest: realRunIngest,
     runHotspotIngest: realRunHotspotIngest,
     runBackfill: realRunBackfill,


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler
    participant Ingestor
    participant Neon as Neon (DATABASE_URL)
    participant CloudSQL as Cloud SQL (SECONDARY_DATABASE_URL)

    Scheduler->>Ingestor: run kind=recent
    Ingestor->>Neon: INSERT/UPDATE observations (ON CONFLICT DO UPDATE)
    Note over Ingestor,Neon: primary throws on failure
    Ingestor->>CloudSQL: same INSERT/UPDATE (fanout)
    Note over Ingestor,CloudSQL: failure → log dual_write_secondary_failed,<br/>swallow, next tick self-heals
    Ingestor-->>Scheduler: summary
```

```mermaid
flowchart LR
    runCli -->|always| primaryPool[createPool DATABASE_URL]
    runCli -->|if SECONDARY_DATABASE_URL| secondaryPool[createPool SECONDARY_DATABASE_URL]
    primaryPool --> wrap{wrap?}
    secondaryPool --> wrap
    wrap -->|yes| dual[createDualWritePool]
    wrap -->|no| pass[primary only]
    dual --> handler[runIngest / runHotspots / ... / runPrune]
    pass --> handler
```

## Summary

- App-layer dual-write for the Neon→Cloud SQL migration (T3→T4): every ingester INSERT/UPDATE/DELETE/TRUNCATE/MERGE fans out to a secondary DB so the two backends stay in sync without standing up logical replication. Behind a feature flag — when `SECONDARY_DATABASE_URL` is unset, behavior is unchanged.
- Primary writes throw on failure as before; secondary failures are logged with the marker `dual_write_secondary_failed kind=<kind> err=<msg>` and swallowed. Idempotent `ON CONFLICT DO UPDATE` upserts mean the next 30-min tick self-heals any drift — no retry loop in the wrapper.
- Decommissioning Neon post-cutover is independent and trivial: remove the SECONDARY_DATABASE_URL env blocks from `infra/terraform/ingestor.tf` and delete the `bird-watch-cloudsql-db-url` secret.

## Screenshots

N/A — backend only, no UI surfaces touched.

## Test plan

- [x] `npm test --workspace @bird-watch/db-client` — 16 new tests in `dual-write-pool.test.ts` all green (stubbed pools; isWriteSql classifier + fan-out + failure-handling + lifecycle)
- [x] `npm test --workspace @bird-watch/ingestor` — 159 tests green (3 new CLI-level wiring tests: dual-write skipped when env unset, both pools created/closed when set, secondary closePool failure logged + swallowed)
- [x] `npx tsc -p packages/db-client/tsconfig.json --noEmit` — clean
- [x] `npx tsc -p services/ingestor/tsconfig.json --noEmit` — clean
- [x] `terraform validate` in `infra/terraform/` — Success! The configuration is valid.
- [x] TDD discipline: wrote `dual-write-pool.test.ts` first, confirmed `Cannot find module './dual-write-pool.js'` failure, then implemented.

## Plan reference

Out of plan — operational dual-write step for the Neon→Cloud SQL migration (Stage 3 fan-out, between T3 one-shot dump|restore and T4 secret-flip). Tracked alongside `docs/plans/2026-05-17-cloud-sql-migration.md` (referenced from terraform comments).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)