### PR TITLE
fix(infra): grant roles/cloudsql.client to Cloud Run SAs

### DIFF
--- a/infra/terraform/cloud-sql.tf
+++ b/infra/terraform/cloud-sql.tf
@@ -174,3 +174,27 @@ resource "google_secret_manager_secret_version" "cloudsql_db_url" {
   secret      = google_secret_manager_secret.cloudsql_db_url.id
   secret_data = local.cloudsql_pooled_url
 }
+
+# Grant Cloud SQL client role to the service accounts whose Cloud Run workloads
+# mount the Cloud SQL Auth Proxy sidecar. Without this, the proxy fails with
+# `boss::NOT_AUTHORIZED ... missing permission cloudsql.instances.get` and the
+# downstream connection sees `connect ENOENT /cloudsql/<conn>/.s.PGSQL.5432`.
+# Surfaced 2026-05-18 when ingestor dual-write went live: T2 (#615) mounted the
+# Auth Proxy volume on every workload but the IAM grant was missed.
+resource "google_project_iam_member" "cloudsql_client_admin_api" {
+  project = var.gcp_project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.admin_api.email}"
+}
+
+resource "google_project_iam_member" "cloudsql_client_ingestor" {
+  project = var.gcp_project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_project_iam_member" "cloudsql_client_read_api" {
+  project = var.gcp_project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.read_api.email}"
+}


### PR DESCRIPTION
## Summary
- T2 (#615) mounted the Cloud SQL Auth Proxy volume on admin-api, ingestor, read-api but missed `roles/cloudsql.client` on the SAs. Surfaced 2026-05-18 08:00 UTC when ingestor dual-write went live — every secondary write logged `dual_write_secondary_failed kind=recent err=connect ENOENT /cloudsql/.../.s.PGSQL.5432` (24+ failures in the 08:00 tick alone).
- Adds three `google_project_iam_member` resources binding `roles/cloudsql.client` to `bird-admin-api`, `bird-ingestor`, `bird-read-api` SAs.

## Why
Without this grant the Auth Proxy sidecar can't authenticate to the Cloud SQL instance, so the unix socket never appears and the app sees `ENOENT`. The dual-write feature flag correctly logs+continues, but Cloud SQL stays empty — defeating the purpose of pre-T4 sync.

## Risk
Pure additive IAM grant. No write-path changes, no schema changes. Granting `cloudsql.client` is the standard Cloud Run + Cloud SQL pattern and is least-privilege (only allows connecting through the Auth Proxy, not direct API access).

## Test plan
- [ ] `terraform validate` clean (verified locally)
- [ ] CI: build, lint, test, e2e (no app code touched — should all pass)
- [ ] After apply: re-run a `/recent` tick and verify `ingest_runs.max(started_at)` advances on Cloud SQL within 5 min
- [ ] Verify no `dual_write_secondary_failed` log entries in the next ingestor execution

## Rollback
`terraform state rm google_project_iam_member.cloudsql_client_*` + `gcloud projects remove-iam-policy-binding bird-maps-prod --member=serviceAccount:<sa> --role=roles/cloudsql.client` for each. Or revert this PR. No data state changes to unwind.

## Screenshots
N/A — backend-only IAM grants, no UI surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)