### PR TITLE
infra(read-api): T4 cutover — flip db_url secret from Neon to Cloud SQL

### DIFF
--- a/infra/terraform/read-api.tf
+++ b/infra/terraform/read-api.tf
@@ -1,4 +1,4 @@
-# Store the Neon pooled URL in Secret Manager so we don't ship it in plain env.
+# Store the read-api DATABASE_URL in Secret Manager so we don't ship it in plain env.
 resource "google_secret_manager_secret" "db_url" {
   secret_id = "bird-watch-db-url"
   replication {
@@ -7,9 +7,15 @@ resource "google_secret_manager_secret" "db_url" {
   depends_on = [google_project_service.secretmanager]
 }
 
+# T4 cutover 2026-05-18: flipped read path from Neon to Cloud SQL.
+# Writes continue going to both DBs via the dual-write fanout in the ingester
+# (#632) and admin-api (#631); Neon stays alive as warm rollback. To roll back
+# this cutover, change `local.cloudsql_pooled_url` back to `local.neon_pooled_url`,
+# `terraform apply`, and the next read-api revision picks up the reverted secret.
+# T5 (Neon teardown + dropping SECONDARY_DATABASE_URL) is tracked separately.
 resource "google_secret_manager_secret_version" "db_url" {
   secret      = google_secret_manager_secret.db_url.id
-  secret_data = local.neon_pooled_url
+  secret_data = local.cloudsql_pooled_url
 }
 
 # Service account the Read API runs as.


### PR DESCRIPTION
## Summary
- Flips the `bird-watch-db-url` secret-version `secret_data` from `local.neon_pooled_url` → `local.cloudsql_pooled_url`.
- read-api's DATABASE_URL env-var uses `secret_key_ref` with `version = "latest"`, so the next Cloud Run revision picks up Cloud SQL automatically (~30s on cold start).
- Single line of HCL changes; the rest of the diff is comment explaining the cutover + rollback.

## Why
Cloud SQL has been the dual-write target since 2026-05-18 10:00 UTC (PRs #631 + #632 + #633). Observations parity confirmed (9,479 = 9,479). T4 flips the read path so prod traffic actually exercises Cloud SQL; writes continue going to both DBs so Neon remains a warm rollback.

## Test plan
- [ ] CI green (build/lint/test/e2e/knip/orphan-classname-check/perf-gate)
- [ ] After `terraform apply`:
  - `curl -s "https://api.bird-maps.com/api/observations?since=14d&bbox=-115,32,-109,37&zoom=4" | jq '.buckets | length, .mode'` → ~150 buckets, mode="aggregated"
  - `curl -s "https://api.bird-maps.com/api/meta" | jq '.freshestObservationAt'` advances over next 30-min ingest cycle
  - Cloud SQL query logs show connections from read-api SA
  - Healthchecks.io S7 (heartbeat-miss) stays green

## Rollback (RTO ~15 min)
1. `git revert` this commit, queue, merge
2. `terraform apply` rolls back the secret-version
3. Cloud Run revision restart picks up reverted secret on next request
4. Reads return to Neon — no data loss either direction because dual-write kept Neon current throughout

## Screenshots
N/A — backend infrastructure, no UI surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)