### PR TITLE
infra: final Neon teardown — drop provider, S6 alert, neon_conn_fail metric

### DIFF
--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -2,7 +2,7 @@
 
 Operator runbook for the alerts provisioned by Plan
 [`2026-05-17-monitoring-and-alerts`](../plans/2026-05-17-monitoring-and-alerts.md).
-Lives at `infra/terraform/monitoring.tf` (six alert policies, three log-based
+Lives at `infra/terraform/monitoring.tf` (five alert policies, two log-based
 metrics, one uptime check, one notification channel). The S7 heartbeat layer
 is hosted at Healthchecks.io; the read-api `meta_freshness` log emit is in
 `services/read-api/src/app.ts`.
@@ -20,7 +20,6 @@ alert lands in one inbox.
 | S3 | Read-API 5xx rate | `run.googleapis.com/request_count` filtered by `response_code_class="5xx"` | >1% over rolling 5min **AND** request_count ≥ 100 over the same window | 1% is the canonical "bad day" threshold; the 100-req floor (~20 req/min) prevents single-error fires at idle traffic. At HN-scale traffic the floor is invisible. |
 | S4 | Read-API p95 latency | `run.googleapis.com/request_latencies` distribution, p95 | >2000ms over rolling 10min | Current p95 is 150-300ms. 2000ms is "user tabs away". 10min smooths cold-start spikes (scale-to-zero) without missing real degradation. |
 | S5 | Cloud Run instance crash / OOM | Log-based metric `bird-container-crash` on `severity>=ERROR` matching `Container terminated` OR `out of memory` | ≥1 in rolling 1h | Crashes are always notable. 1h batches transient flaps into one notification. |
-| S6 | Neon connection failure | Log-based metric `bird-neon-conn-fail` on `getaddrinfo ENOTFOUND` OR `ECONNREFUSED` OR `Connection terminated unexpectedly` | ≥3 in rolling 10min | Neon free tier suspends idle endpoints; one ENOTFOUND is normal cold-wake. Three in 10min means the pool is genuinely broken. Tighten to ≥1 once Cloud SQL lands. |
 | S7 | Heartbeat miss — ingest cron didn't fire | Healthchecks.io check per cron | No ping in 40min (cron 30min + 10min grace) | Cloud Monitoring cannot detect "scheduled invocation that never happened" — Healthchecks.io is the inverse trigger. |
 | Uptime | Public read-api unreachable | Uptime check on `https://api.bird-maps.com/api/regions` | failures across regions for ≥3 consecutive checks (~3min) | Catches DNS / TLS / Cloud Run cold-fail issues invisible to `request_count` (no requests landing = no metric). |
 
@@ -54,7 +53,6 @@ gcloud logging read \
 
 Common causes:
 - Transient eBird 5xx (single execution recovers on the next `*/30` cron — acknowledge and wait).
-- Neon endpoint suspended at job start (S6 likely co-fires; resume in Neon console).
 - A bad migration. Check the latest commit to `migrations/` against the failing execution start time.
 
 ### S2: Data staleness > 6h
@@ -87,7 +85,7 @@ gcloud logging read \
 ```
 
 Common causes:
-- Pool exhaustion (S6 likely co-fires). Check `bird-read-api` revision concurrency settings.
+- Pool exhaustion. Check `bird-read-api` revision concurrency settings.
 - Bad SQL from a recent migration / db-client change.
 - Cloud Run revision serving without a fresh image (look for ECONNREFUSED in startup probes).
 
@@ -95,7 +93,7 @@ Common causes:
 
 What it means: p95 latency exceeded 2000ms for 10min.
 
-Common causes: missing index after a query change, Neon endpoint cold-waking under load, CDN bypass on a hot route.
+Common causes: missing index after a query change, CDN bypass on a hot route, slow SQL after a query change.
 
 ```sh
 # p95 by route in last hour, via metric explorer or:
@@ -111,16 +109,6 @@ What it means: a Cloud Run container hit `Container terminated` or `out of memor
 If OOM: bump `resources.limits.memory` on the affected service/job (currently
 `512Mi` for ingestor, `256Mi` for read-api). If unhandled exception: read
 the preceding stack trace from the same log entry; fix the code.
-
-### S6: Neon connection failures ≥3 in 10min
-
-What it means: three or more `ENOTFOUND` / `ECONNREFUSED` / `Connection terminated unexpectedly` log lines in the last 10min.
-
-First moves: Neon console → endpoints → check status. If suspended, resume.
-If consistently up but errors persist, rotate the pooler / inspect Neon's
-status page.
-
-When the Cloud SQL migration lands, tighten this threshold to ≥1.
 
 ### S7: Heartbeat miss (Healthchecks.io)
 
@@ -153,7 +141,7 @@ dig api.bird-maps.com
 
 ## Muting / snoozing during planned maintenance
 
-- **Cloud Monitoring policies (S1..S6, uptime):** Cloud Monitoring console → Alerting → Policies → select the policy → "Snooze". Pick a duration. Snoozes are click-ops; record the rationale in the policy's notes field for audit.
+- **Cloud Monitoring policies (S1..S5, uptime):** Cloud Monitoring console → Alerting → Policies → select the policy → "Snooze". Pick a duration. Snoozes are click-ops; record the rationale in the policy's notes field for audit.
 - **Healthchecks.io (S7):** healthchecks.io dashboard → select the check → "Pause". Resume manually when work completes (a paused check never fires regardless of ping cadence).
 
 Never disable a policy permanently as a workaround. If a policy is too noisy, file a follow-up to retune the threshold per the plan's kill-threshold metric (60-day window, < 40% fixed-rate triggers retro at `docs/analyses/<date>-alert-fatigue-retrospective.md`).
@@ -199,10 +187,6 @@ hey -z 11m -c 50 https://api.bird-maps.com/api/observations?since=30d
 
 Temporarily lower `resources.limits.memory` on `bird-read-api` to `64Mi` in HCL; `terraform apply`; trigger a normal request; container OOMs and the kill phrase lands in logs. Restore `256Mi` and reapply immediately.
 
-### S6 — force Neon disconnect
-
-Suspend the Neon endpoint via the Neon console; the next read-api pool checkout fails with `ECONNREFUSED`. Repeat three times within 10min by tail-curling a route that exercises the pool, then resume the endpoint.
-
 ### S7 — force heartbeat miss
 
 Pause `bird-ingest-recent` in Cloud Scheduler. After 40min (30min cadence + 10min grace) Healthchecks.io emails. Resume the scheduler.
@@ -220,7 +204,6 @@ Temporarily set the check `path` to `/does-not-exist` in HCL; `terraform apply`.
 | S3 | — | — | Pending. |
 | S4 | — | — | Pending. |
 | S5 | — | — | Pending. |
-| S6 | — | — | Pending. |
 | S7 | — | — | Pending — depends on Task 6 secret population + env-wiring. |
 | Uptime | — | — | Pending. |
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -8,15 +8,6 @@ provider "google" {
   user_project_override = true
 }
 
-# Neon provider — retained ONLY to allow terraform to plan/apply the destroy
-# of the remaining `neon_project` / `neon_database` resources still in state
-# from PRs prior to this Neon decommission. A follow-up PR removes this block
-# (and the corresponding entries in versions.tf / variables.tf) once
-# `terraform apply` confirms the state is clean.
-provider "neon" {
-  api_key = var.neon_api_key
-}
-
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -256,48 +256,6 @@ resource "google_monitoring_alert_policy" "container_crash" {
   }
 }
 
-# ── S6: Neon connection failures ─────────────────────────────────────────
-#
-# Threshold: ≥3 in rolling 10min. Rationale: Neon free tier suspends idle
-# endpoints; single ENOTFOUND/ECONNREFUSED is normal cold-wake. Three in
-# 10min means the pool is genuinely broken. TIGHTEN to ≥1 once the Cloud
-# SQL migration lands (sibling plan) — Cloud SQL doesn't suspend, so any
-# connection failure is a real incident.
-
-resource "google_logging_metric" "neon_conn_fail" {
-  name   = "bird-neon-conn-fail"
-  filter = <<-EOT
-    resource.type="cloud_run_revision" AND
-    (resource.labels.service_name=~"bird-(read-api|ingestor.*)") AND
-    (textPayload=~"getaddrinfo ENOTFOUND" OR textPayload=~"ECONNREFUSED" OR textPayload=~"Connection terminated unexpectedly")
-  EOT
-  metric_descriptor {
-    metric_kind = "DELTA"
-    value_type  = "INT64"
-  }
-}
-
-resource "google_monitoring_alert_policy" "neon_conn_fail" {
-  display_name          = "Neon connection failures >=3 in 10min (S6)"
-  combiner              = "OR"
-  notification_channels = [google_monitoring_notification_channel.email_julian.id]
-
-  conditions {
-    display_name = ">=3 conn failures in 10min"
-    condition_threshold {
-      filter          = "metric.type=\"logging.googleapis.com/user/bird-neon-conn-fail\" AND resource.type=\"cloud_run_revision\""
-      comparison      = "COMPARISON_GT"
-      threshold_value = 2 # GT 2 ⇒ fires at ≥3, matching plan spec "≥3 in rolling 10min" (house style: "GT (N-1)" as in S1/S5)
-      duration        = "0s"
-      aggregations {
-        alignment_period     = "600s"
-        per_series_aligner   = "ALIGN_SUM"
-        cross_series_reducer = "REDUCE_SUM"
-      }
-    }
-  }
-}
-
 # ── Uptime check on the public read-api ─────────────────────────────────
 #
 # Synthetic monitoring: GCP regions ping /api/regions every 60s. Alert

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -2,9 +2,6 @@ gcp_project_id        = "REPLACE_ME"
 gcp_region            = "us-west1"
 # Find with `gcloud beta billing accounts list`. Required by budget.tf.
 gcp_billing_account_id = "REPLACE_ME"
-# Retained for the Neon-destroy apply only; removed in follow-up PR.
-neon_api_key          = "REPLACE_ME"
-neon_org_id           = "REPLACE_ME"
 cloudflare_account_id = "REPLACE_ME"
 cloudflare_api_token  = "REPLACE_ME"
 cloudflare_zone_id    = "REPLACE_ME"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -9,21 +9,6 @@ variable "gcp_region" {
   description = "Cloud Run + Artifact Registry region. us-west1 keeps latency to AZ users low."
 }
 
-# Retained for the Neon-destroy apply only. The neon provider block in main.tf
-# still requires this value to plan destroys of remaining `neon_project` /
-# `neon_database` state entries. Follow-up PR removes both this variable and
-# the provider block once destroy is confirmed clean.
-variable "neon_api_key" {
-  type        = string
-  sensitive   = true
-  description = "Neon API key (Neon dashboard → Settings → API keys). Decommission-only."
-}
-
-variable "neon_org_id" {
-  type        = string
-  description = "Neon organization ID. Decommission-only; no resources reference it after this PR."
-}
-
 variable "cloudflare_account_id" {
   type        = string
   description = "Cloudflare account ID (used for Pages + DNS only)."

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -10,12 +10,6 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 7.30"
     }
-    # Retained only to plan/apply the destroy of remaining neon_* resources
-    # in state. Removed in a follow-up PR after destroy is confirmed clean.
-    neon = {
-      source  = "kislerdm/neon"
-      version = "~> 0.7"
-    }
     cloudflare = {
       source  = "cloudflare/cloudflare"
       version = "~> 4.20"


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    A[provider neon main.tf] -->|deleted| X[removed]
    B[kislerdm/neon versions.tf] -->|deleted| X
    C[var.neon_api_key + var.neon_org_id] -->|deleted| X
    D[google_logging_metric.neon_conn_fail] -->|terraform destroy| X
    E[google_monitoring_alert_policy.neon_conn_fail S6] -->|terraform destroy| X
    F[docs/runbooks/monitoring.md S6 sections] -->|deleted| X
```

## Summary

- PR #637 used `terraform state rm` to drop Neon resources (free-tier quota blocked the provider-driven destroy). This is the follow-up cleanup that removes the now-dead provider block, the two unused variables, the `neon_conn_fail` log-based metric + S6 alert policy, and the corresponding runbook sections.
- `terraform plan` against the real GCP backend: **0 add, 0 change, 2 destroy** — exactly the metric + alert policy. No other resources affected.
- Comment-style "still in state" notes deleted outright rather than rewritten (bot SUGGESTION 2). S6 runbook sections beyond the table row also dropped (bot SUGGESTION 1) — they referenced infra that no longer exists.

## Screenshots

N/A — backend infrastructure.

## Test plan

- [x] `cd infra/terraform && terraform init -upgrade` — succeeds; lockfile already lacked the `kislerdm/neon` entry on `origin/main`, so no further lockfile diff was needed in this PR.
- [x] `terraform fmt && terraform validate` — clean.
- [x] `terraform plan -var-file=terraform.tfvars` — **Plan: 0 to add, 0 to change, 2 to destroy** (`google_logging_metric.neon_conn_fail` + `google_monitoring_alert_policy.neon_conn_fail`).
- [x] Narrowed acceptance grep (per bot IMPORTANT — original `'neon|Neon'` is unachievable given legitimate historical-migration comments in `admin-api.tf`, `cloud-sql.tf`, `ingestor.tf`, `read-api.tf`, `rate-limit.tf`):

  ```sh
  grep -rE '^[^#]*\b(neon_|var\.neon_|provider "neon")' infra/terraform/*.tf
  ```

  returns **zero hits** on this branch.
- [x] No `frontend/**` touched; no UI verification or Playwright MCP applicable.
- [x] No code touched — pure terraform + docs.

### Plan output (verbatim, abbreviated)

```
Terraform will perform the following actions:

  # google_logging_metric.neon_conn_fail will be destroyed
  # (because google_logging_metric.neon_conn_fail is not in configuration)
  - resource "google_logging_metric" "neon_conn_fail" {
      - name = "bird-neon-conn-fail" -> null
      ...
    }

  # google_monitoring_alert_policy.neon_conn_fail will be destroyed
  # (because google_monitoring_alert_policy.neon_conn_fail is not in configuration)
  - resource "google_monitoring_alert_policy" "neon_conn_fail" {
      - display_name = "Neon connection failures >=3 in 10min (S6)" -> null
      ...
    }

Plan: 0 to add, 0 to change, 2 to destroy.
```

## Plan reference

Out of plan — final cleanup pass after PR #637's split-decision Neon decommission. Closes #639.

### Bot review findings addressed

- **IMPORTANT** (unachievable grep): narrowed the acceptance criterion to match HCL code only, not narrative comments. New grep returns zero. See Test plan above.
- **SUGGESTION 1** (runbook S6 sections beyond table row): dropped the S6 triage section, the S6 chaos-drill, the S6 smoke-log row, the S1/S3 cross-references to S6, and adjusted the "five alert policies, two log-based metrics" preamble + the `S1..S5` muting list.
- **SUGGESTION 2** (delete stale comments outright): the three "still in state" comments in `main.tf`, `versions.tf`, `variables.tf` are gone, not rewritten.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)