### PR TITLE
chore(ingestor): emit compact single-line JSON from cli

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -334,10 +334,12 @@ describe('runCli', () => {
     await runCli('recent', deps);
 
     const emitted = logSpy.mock.calls
-      .map((args: unknown[]) => {
+      .map((args: unknown[]): unknown => {
         try { return JSON.parse(args[0] as string); } catch { return null; }
       })
-      .filter((o): o is Record<string, unknown> => o?.message === 'bird_ingest_run_completed');
+      .filter((o: unknown): o is Record<string, unknown> =>
+        typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'bird_ingest_run_completed'
+      );
     expect(emitted).toHaveLength(1);
     expect(emitted[0]).toMatchObject({
       severity: 'INFO',
@@ -372,10 +374,12 @@ describe('runCli', () => {
     await runCli('taxonomy', deps);
 
     const emitted = logSpy.mock.calls
-      .map((args: unknown[]) => {
+      .map((args: unknown[]): unknown => {
         try { return JSON.parse(args[0] as string); } catch { return null; }
       })
-      .filter((o): o is Record<string, unknown> => o?.message === 'bird_ingest_run_completed');
+      .filter((o: unknown): o is Record<string, unknown> =>
+        typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'bird_ingest_run_completed'
+      );
     expect(emitted).toHaveLength(1);
     expect(emitted[0]).toMatchObject({
       severity: 'ERROR',

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -321,6 +321,71 @@ describe('runCli', () => {
     expect(pingSpy).not.toHaveBeenCalled();
   });
 
+  // ── Structured emit shape (issue #641, epic #638 PR-2) ────────────────
+  // The main-path emit at cli.ts:174 must be a single compact JSON line — not
+  // pretty-printed — so Cloud Logging's `jsonPayload.*` extraction picks up
+  // the fields the dashboard's log-based metrics depend on. Snapshotting the
+  // payload directly would flap on `duration_seconds` (computed from
+  // Date.now()); parse-then-toMatchObject + expect.any(Number) is stable.
+  it('emits compact structured JSON with bird_ingest_run_completed message on success', async () => {
+    const successSummary: RunSummary = { status: 'success', fetched: 1, upserted: 1 };
+    const deps = makeDeps({ runIngest: vi.fn().mockResolvedValue(successSummary) });
+
+    await runCli('recent', deps);
+
+    const emitted = logSpy.mock.calls
+      .map((args: unknown[]) => {
+        try { return JSON.parse(args[0] as string); } catch { return null; }
+      })
+      .filter((o): o is Record<string, unknown> => o?.message === 'bird_ingest_run_completed');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      severity: 'INFO',
+      message: 'bird_ingest_run_completed',
+      kind: 'recent',
+      status: 'success',
+      duration_seconds: expect.any(Number),
+    });
+    // Single-line emit: the stringified payload must not contain a newline,
+    // otherwise Cloud Logging will split it back into separate textPayload
+    // entries — which is exactly what this PR fixes.
+    const rawLine = logSpy.mock.calls.find(
+      (args: unknown[]) =>
+        typeof args[0] === 'string' && args[0].includes('bird_ingest_run_completed')
+    )?.[0] as string;
+    expect(rawLine).not.toContain('\n');
+  });
+
+  it('emits severity=ERROR in the structured line when summary.status === "failure"', async () => {
+    const failureSummary: RunTaxonomySummary = {
+      status: 'failure',
+      totalFetched: 0,
+      speciesInserted: 0,
+      nonSpeciesFiltered: 0,
+      reconciled: 0,
+      error: 'boom',
+    };
+    const deps = makeDeps({
+      runTaxonomy: vi.fn().mockResolvedValue(failureSummary),
+    });
+
+    await runCli('taxonomy', deps);
+
+    const emitted = logSpy.mock.calls
+      .map((args: unknown[]) => {
+        try { return JSON.parse(args[0] as string); } catch { return null; }
+      })
+      .filter((o): o is Record<string, unknown> => o?.message === 'bird_ingest_run_completed');
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      severity: 'ERROR',
+      message: 'bird_ingest_run_completed',
+      kind: 'taxonomy',
+      status: 'failure',
+      duration_seconds: expect.any(Number),
+    });
+  });
+
   it('uppercases and replaces hyphens in kind when computing env-var name', async () => {
     process.env.HEALTHCHECKS_URL_BACKFILL_EXTENDED = 'https://hc-ping.com/uuid-bf-ext';
     const partialSummary = {

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -118,6 +118,9 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
   if (!dbUrl) throw new Error('DATABASE_URL not set');
 
   const pool = deps.createPool({ databaseUrl: dbUrl });
+  // Capture wall-clock start AFTER probe early-returns and env-guard checks so
+  // `duration_seconds` measures only real run work — not setup or probe paths.
+  const startedAt = Date.now();
   try {
     let summary: AnyRunSummary;
     if (kind === 'recent') {
@@ -171,7 +174,21 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else {
       throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | probe-taxon | probe-wiki`);
     }
-    console.log(JSON.stringify(summary, null, 2));
+    // Cloud Run / Cloud Logging splits stdout on newlines and treats each
+    // resulting line as its own `textPayload` entry — pretty-printed JSON
+    // therefore shreds into N rows with zero `jsonPayload.*` coverage, and
+    // any log-based metric that depends on `jsonPayload.message` is silently
+    // empty. Emit a single compact line carrying the fields the dashboard's
+    // log-based metrics extract (see issue #641 + epic #638, PR-2 in #642).
+    // Sibling pattern: `services/read-api/src/app.ts:161` (meta_freshness).
+    const durationSeconds = Math.round((Date.now() - startedAt) / 1000);
+    console.log(JSON.stringify({
+      severity: summary.status === 'failure' ? 'ERROR' : 'INFO',
+      message: 'bird_ingest_run_completed',
+      kind,
+      status: summary.status,
+      duration_seconds: durationSeconds,
+    }));
     if (summary.status === 'failure') {
       // Flag the process as failed without killing the loop mid-pool-close.
       process.exitCode = 1;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Job as Cloud Run Job
    participant Cli as cli.ts
    participant Logging as Cloud Logging
    participant Metric as log-based metric<br/>(bird_ingest_run_completed)

    Job->>Cli: invoke runCli(kind)
    Note over Cli: const startedAt = Date.now()
    Cli->>Cli: dispatch by kind (recent / hotspots / taxonomy / ...)
    Note over Cli: BEFORE: console.log(JSON.stringify(summary, null, 2))<br/>multi-line → split into N textPayload entries
    Note over Cli: AFTER: console.log(JSON.stringify({severity, message, kind,<br/>status, duration_seconds}))  ← single compact line
    Cli->>Logging: stdout (one line per run)
    Logging->>Metric: jsonPayload.message == "bird_ingest_run_completed" ✓
```

## Summary

- Replace pretty-printed `JSON.stringify(summary, null, 2)` at `cli.ts:174` with a compact single-line structured emit carrying `severity`, `message`, `kind`, `status`, `duration_seconds`.
- Cloud Run splits stdout on newlines and treats each line as its own `textPayload` entry; pretty-printed JSON therefore has zero `jsonPayload.*` coverage and silently breaks log-based metrics. The compact line matches the working sibling pattern at `services/read-api/src/app.ts:161` (meta_freshness).
- Unblocks the two new `google_logging_metric` resources tracked in #642 (`bird-ingest-run-completed` + `bird-ingest-run-duration-seconds`).

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — green (158/158 tests pass, including 2 new)
- [x] `npm run lint --workspaces --if-present` — green (ingestor workspace has no lint script; root command exits 0)
- [x] `npm run build --workspace @bird-watch/ingestor` — green (`tsc` clean)
- [x] `npx knip` — no new findings (one unrelated pre-existing config hint)
- [x] New unit test added: structural assertion on the parsed emit (NOT a snapshot — snapshots would flap on `Date.now()`). Two cases: success → `severity: INFO`, failure → `severity: ERROR`.
- [x] Existing tests at `cli.test.ts:63`, `:197`, `:155` continue to pass (they assert `logSpy.toHaveBeenCalled()` and probe-wiki shape, both unchanged by this PR).
- [ ] CI green: `test`, `lint`, `build`, `e2e`

## Plan reference

Out of plan — implements issue #641 (PR-1 / emit-fix) under epic #638 (monitoring dashboard). Per Implementation Contract C1 in `docs/analyses/2026-05-18-monitoring-dashboard-issue-638/phase-4/analysis-report.md` §H, and recommendation R7 (structural assertion in lieu of snapshot test).

Out of scope: `cli.ts:93` (probe-wiki) and `cli.ts:105` (probe-taxon) remain pretty-printed — operator triage tools, not scheduled production paths. See #641 "Out of scope" section.

Closes #641. Refs #638 (epic), #642 (downstream metric Terraform).

---

Generated with [Claude Code](https://claude.com/claude-code)
