### PR TITLE
infra: bird-watch overview dashboard + ingest log-based metrics + audit hook

### DIFF
--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -208,3 +208,38 @@ Temporarily set the check `path` to `/does-not-exist` in HCL; `terraform apply`.
 | Uptime | — | — | Pending. |
 
 Smoke tests are deliberate, opt-in operator work — do not run them on autopilot. Each one perturbs prod briefly; coordinate before firing.
+
+## Dashboard
+
+URL: `https://console.cloud.google.com/monitoring/dashboards/custom/<id>?project=bird-maps-prod` (the `dashboard_url` output from `terraform apply` shows the exact path).
+
+Single-pane operator view: open incidents, ingest health, read-api latency, Cloud SQL, system signals. Designed for un-paged triage — when an operator opens it during a routine check, they should resolve "is anything currently on fire", "did everything that was supposed to run, run", and "is anything trending toward unhealthy" in under 30 seconds. If they cannot, the dashboard is the wrong shape and we should re-cut it; the 30-day audit (below) is the falsifier.
+
+### Maintenance landmines
+
+- **L1 — `dashboard_json` diff-suppression silently drops remove-only edits.** Pair any remove with a trivial concomitant change (rename a title, etc.) so the provider sees a non-empty diff. Source: F4 in the analysis report; `phase-2/iterator-2-hcl-schema-validation.md:148-194`.
+- **L6 — `mosaicLayout.columns` is an INTEGER** (not a string like `gridLayout.columns`). Type mismatch yields a low-quality server-side 400 at Apply. Source: F4; `iterator-2:188`.
+
+Also: `terraform validate` does NOT validate the contents of `dashboard_json`. Invented widget types pass validate but fail at Apply. Cross-check new widget structs against the Google Monitoring v3 schema (or copy a known-good widget from an existing dashboard) before adding new tile shapes.
+
+### Emit-shape contract
+
+The dashboard's per-kind ingest widgets (Row 2.1 + 2.2) consume the new log-based metrics `bird-ingest-run-completed` (counter) and `bird-ingest-run-duration-seconds` (distribution). Both extract fields from a structured log emitted by `services/ingestor/src/cli.ts:174`. The emit shape is a contract:
+
+```json
+{
+  "severity": "INFO" | "ERROR",
+  "message": "bird_ingest_run_completed",
+  "kind": "recent" | "backfill" | "hotspots" | "taxonomy" | "photos" | "descriptions" | "prune" | "backfill-extended",
+  "status": "success" | "partial" | "failure",
+  "duration_seconds": <number>
+}
+```
+
+Future refactors of `cli.ts:174` must preserve this shape. Field renames break the dashboard silently — the metric filters look for `jsonPayload.message="bird_ingest_run_completed"` and extract `kind`, `status`, `duration_seconds` by name. The `!=NULL_VALUE` guards in the metric filters drop malformed entries rather than landing garbage in the metric stream, so a partial regression shows as "zero entries" not "wrong entries".
+
+### Audit hook (`monitoring.dashboards.get`)
+
+Data Access audit logs for `monitoring.googleapis.com` are enabled via `google_project_iam_audit_config.monitoring_data_read` (PR #642). The log-based metric `bird-watch-dashboard-opened` counts opens; the 30-day audit follow-up issue (filed at PR-2 merge time per Contract C4 of the analysis report) reviews engagement and decides whether the dashboard earns its place. At T+90d, the same audit kills the dashboard if quarterly opens ≤ 1.
+
+After the first Apply, narrow the metric filter to this dashboard by uncommenting the `protoPayload.resourceName=~"projects/.+/dashboards/<DASHBOARD_ID>"` clause in `monitoring.tf` (the dashboard ID isn't known until after Apply).

--- a/infra/terraform/monitoring-dashboard.tf
+++ b/infra/terraform/monitoring-dashboard.tf
@@ -1,0 +1,328 @@
+# ── bird-watch overview dashboard ─────────────────────────────────────────
+#
+# Single-pane operator view: open incidents, ingest health, read-api latency,
+# Cloud SQL, system signals. Designed for un-paged triage — when an operator
+# opens this during a routine check, they should resolve "is anything
+# currently on fire", "did everything that was supposed to run, run", and
+# "is anything trending toward unhealthy" in under 30 seconds.
+#
+# Landmines (per docs/analyses/2026-05-18-monitoring-dashboard-issue-638
+# /phase-4/analysis-report.md §F4 / Iterator 2):
+#   L1: `terraform validate` does NOT validate dashboard_json content.
+#       Invented widget types pass validate but fail at Apply. Cross-check
+#       widget structs against the live Google Monitoring v3 schema (or copy
+#       a known-good widget from an existing dashboard) before adding new
+#       tile shapes.
+#   L6: `mosaicLayout.columns` is INTEGER (12), not string. `gridLayout
+#       .columns` IS a string — different schemas. This dashboard uses
+#       mosaicLayout exclusively; mixing the two produces a low-quality
+#       server-side 400 at Apply.
+#
+# Diff-suppression caveat: legitimate remove-only edits to `dashboard_json`
+# are silently dropped by the provider unless paired with a non-removal
+# change. To remove a widget cleanly, touch a title or description in the
+# same Apply so the provider sees a non-empty diff.
+
+resource "google_monitoring_dashboard" "bird_watch_overview" {
+  project = var.gcp_project_id
+  dashboard_json = jsonencode({
+    displayName = "bird-watch overview"
+    mosaicLayout = {
+      columns = 12
+      tiles = [
+        # Row 1: API health (read-api)
+        # Tile 1.1 — req/s by status class
+        {
+          xPos   = 0
+          yPos   = 0
+          width  = 4
+          height = 4
+          widget = {
+            title = "Read-API request rate by status class"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"run.googleapis.com/request_count\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_RATE"
+                      crossSeriesReducer = "REDUCE_SUM"
+                      groupByFields      = ["metric.label.response_code_class"]
+                    }
+                  }
+                }
+                plotType = "STACKED_AREA"
+              }]
+            }
+          }
+        },
+        # Tile 1.2 — p95 latency
+        {
+          xPos   = 4
+          yPos   = 0
+          width  = 4
+          height = 4
+          widget = {
+            title = "Read-API p95 latency (ms)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"run.googleapis.com/request_latencies\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                      crossSeriesReducer = "REDUCE_MAX"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              thresholds = [{ value = 2000 }]
+              yAxis = {
+                label = "ms"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Tile 1.3 — open incidents (firing alert policies)
+        {
+          xPos   = 8
+          yPos   = 0
+          width  = 4
+          height = 4
+          widget = {
+            title = "Open incidents (S1–S5 + uptime)"
+            incidentList = {
+              monitoredResources = []
+              policyNames        = []
+            }
+          }
+        },
+        # Row 2: Ingester health
+        # Tile 2.1 — completed runs by kind+status (replaces by-job_name)
+        {
+          xPos   = 0
+          yPos   = 4
+          width  = 4
+          height = 4
+          widget = {
+            title = "Ingest runs by kind+status (1h buckets)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-run-completed\" AND resource.type=\"cloud_run_job\""
+                    aggregation = {
+                      alignmentPeriod    = "3600s"
+                      perSeriesAligner   = "ALIGN_SUM"
+                      crossSeriesReducer = "REDUCE_SUM"
+                      groupByFields      = ["metric.label.kind", "metric.label.status"]
+                    }
+                  }
+                }
+                plotType = "STACKED_BAR"
+              }]
+            }
+          }
+        },
+        # Tile 2.2 — p95 duration by kind
+        {
+          xPos   = 4
+          yPos   = 4
+          width  = 4
+          height = 4
+          widget = {
+            title = "Ingest run p95 duration by kind"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-run-duration-seconds\" AND resource.type=\"cloud_run_job\""
+                    aggregation = {
+                      alignmentPeriod    = "300s"
+                      perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                      crossSeriesReducer = "REDUCE_MAX"
+                      groupByFields      = ["metric.label.kind"]
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              yAxis = {
+                label = "seconds"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Tile 2.3 — data staleness gauge (existing meta_freshness metric)
+        {
+          xPos   = 8
+          yPos   = 4
+          width  = 4
+          height = 4
+          widget = {
+            title = "Data freshness p95 (meta_freshness_seconds)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-meta-freshness-seconds\" AND resource.type=\"cloud_run_revision\""
+                    aggregation = {
+                      alignmentPeriod    = "300s"
+                      perSeriesAligner   = "ALIGN_PERCENTILE_95"
+                      crossSeriesReducer = "REDUCE_MAX"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              thresholds = [{ value = 21600 }]
+              yAxis = {
+                label = "seconds"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Row 3: Cloud SQL
+        # Tile 3.1 — CPU
+        {
+          xPos   = 0
+          yPos   = 8
+          width  = 4
+          height = 4
+          widget = {
+            title = "Cloud SQL CPU utilization"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"cloudsql.googleapis.com/database/cpu/utilization\" AND resource.type=\"cloudsql_database\" AND resource.labels.database_id=\"${var.gcp_project_id}:birdwatch-pg16\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_MEAN"
+                      crossSeriesReducer = "REDUCE_MAX"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              thresholds = [{ value = 0.8 }]
+            }
+          }
+        },
+        # Tile 3.2 — active connections
+        {
+          xPos   = 4
+          yPos   = 8
+          width  = 4
+          height = 4
+          widget = {
+            title = "Cloud SQL active connections"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"cloudsql.googleapis.com/database/postgresql/num_backends\" AND resource.type=\"cloudsql_database\" AND resource.labels.database_id=\"${var.gcp_project_id}:birdwatch-pg16\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_MEAN"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+            }
+          }
+        },
+        # Tile 3.3 — disk utilization
+        {
+          xPos   = 8
+          yPos   = 8
+          width  = 4
+          height = 4
+          widget = {
+            title = "Cloud SQL disk utilization"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"cloudsql.googleapis.com/database/disk/utilization\" AND resource.type=\"cloudsql_database\" AND resource.labels.database_id=\"${var.gcp_project_id}:birdwatch-pg16\""
+                    aggregation = {
+                      alignmentPeriod    = "300s"
+                      perSeriesAligner   = "ALIGN_MEAN"
+                      crossSeriesReducer = "REDUCE_MAX"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              thresholds = [{ value = 0.8 }]
+            }
+          }
+        },
+        # Row 4: System signals
+        # Tile 4.1 — container crashes / OOM
+        {
+          xPos   = 0
+          yPos   = 12
+          width  = 4
+          height = 4
+          widget = {
+            title = "Container crash / OOM (1h sum)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-container-crash\" AND resource.type=\"cloud_run_revision\""
+                    aggregation = {
+                      alignmentPeriod    = "3600s"
+                      perSeriesAligner   = "ALIGN_SUM"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "STACKED_BAR"
+              }]
+            }
+          }
+        },
+        # Tile 4.2 — uptime check (failing regions)
+        {
+          xPos   = 4
+          yPos   = 12
+          width  = 4
+          height = 4
+          widget = {
+            title = "Read-API uptime — failing regions"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND resource.type=\"uptime_url\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_NEXT_OLDER"
+                      crossSeriesReducer = "REDUCE_COUNT_FALSE"
+                      groupByFields      = ["resource.label.*"]
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+            }
+          }
+        },
+      ]
+    }
+  })
+}
+
+output "dashboard_url" {
+  value = "https://console.cloud.google.com/monitoring/dashboards/custom/${trimprefix(google_monitoring_dashboard.bird_watch_overview.id, "projects/${var.gcp_project_id}/dashboards/")}?project=${var.gcp_project_id}"
+}

--- a/infra/terraform/monitoring-dashboard.tf
+++ b/infra/terraform/monitoring-dashboard.tf
@@ -8,20 +8,20 @@
 #
 # Landmines (per docs/analyses/2026-05-18-monitoring-dashboard-issue-638
 # /phase-4/analysis-report.md §F4 / Iterator 2):
-#   L1: `terraform validate` does NOT validate dashboard_json content.
-#       Invented widget types pass validate but fail at Apply. Cross-check
-#       widget structs against the live Google Monitoring v3 schema (or copy
-#       a known-good widget from an existing dashboard) before adding new
-#       tile shapes.
+#   L1: `dashboard_json` diff-suppression silently drops remove-only edits.
+#       To remove a widget cleanly, pair the removal with a non-removal
+#       change (touch a title or description in the same Apply) — otherwise
+#       Terraform reports a clean diff but the widget remains.
 #   L6: `mosaicLayout.columns` is INTEGER (12), not string. `gridLayout
 #       .columns` IS a string — different schemas. This dashboard uses
 #       mosaicLayout exclusively; mixing the two produces a low-quality
 #       server-side 400 at Apply.
 #
-# Diff-suppression caveat: legitimate remove-only edits to `dashboard_json`
-# are silently dropped by the provider unless paired with a non-removal
-# change. To remove a widget cleanly, touch a title or description in the
-# same Apply so the provider sees a non-empty diff.
+# Also: `terraform validate` does NOT validate the contents of
+# `dashboard_json`. Invented widget types pass validate but fail at Apply.
+# Cross-check widget structs against the live Google Monitoring v3 schema
+# (or copy a known-good widget from an existing dashboard) before adding
+# new tile shapes.
 
 resource "google_monitoring_dashboard" "bird_watch_overview" {
   project = var.gcp_project_id

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -314,3 +314,130 @@ resource "google_monitoring_alert_policy" "read_api_uptime" {
     }
   }
 }
+
+# ── Per-kind ingest completion counter ────────────────────────────────────
+#
+# Counter log-based metric extracted from the compact structured emit at
+# services/ingestor/src/cli.ts:174 (`bird_ingest_run_completed`). Powers the
+# Row 2.1 widget on the bird-watch overview dashboard
+# (infra/terraform/monitoring-dashboard.tf).
+#
+# Emit-shape contract (must remain stable — see docs/runbooks/monitoring.md):
+#   { message: "bird_ingest_run_completed", kind, status, duration_seconds }
+# The two `!=NULL_VALUE` clauses drop malformed entries during a future
+# emit-shape regression rather than landing garbage into the metric stream.
+
+resource "google_logging_metric" "ingest_run_completed" {
+  name = "bird-ingest-run-completed"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "resource.labels.job_name=~\"^bird-ingestor\"",
+    "jsonPayload.message=\"bird_ingest_run_completed\"",
+    "jsonPayload.kind!=NULL_VALUE",
+    "jsonPayload.status!=NULL_VALUE",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Ingest run completions by kind+status"
+    labels {
+      key         = "kind"
+      value_type  = "STRING"
+      description = "Ingest kind"
+    }
+    labels {
+      key         = "status"
+      value_type  = "STRING"
+      description = "Terminal status"
+    }
+  }
+  label_extractors = {
+    "kind"   = "EXTRACT(jsonPayload.kind)"
+    "status" = "EXTRACT(jsonPayload.status)"
+  }
+}
+
+# ── Per-kind ingest duration distribution ─────────────────────────────────
+#
+# Distribution metric extracting `duration_seconds` from the same emit.
+# Powers the Row 2.2 widget (p95 duration by kind). Bucket layout:
+# exponential(scale=1, growth=2, finite=32) covers 1s..~4×10^9 s — comfortably
+# spans the slowest ingest kind (`backfill-extended`, multi-hour) without
+# wasting bucket density at the fast end.
+
+resource "google_logging_metric" "ingest_run_duration_seconds" {
+  name = "bird-ingest-run-duration-seconds"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "resource.labels.job_name=~\"^bird-ingestor\"",
+    "jsonPayload.message=\"bird_ingest_run_completed\"",
+    "jsonPayload.kind!=NULL_VALUE",
+    "jsonPayload.duration_seconds!=NULL_VALUE",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "DISTRIBUTION"
+    unit         = "s"
+    display_name = "Ingest run duration by kind"
+    labels {
+      key         = "kind"
+      value_type  = "STRING"
+      description = "Ingest kind"
+    }
+  }
+  value_extractor = "EXTRACT(jsonPayload.duration_seconds)"
+  label_extractors = {
+    "kind" = "EXTRACT(jsonPayload.kind)"
+  }
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 1
+    }
+  }
+}
+
+# ── Dashboard-opens audit (for 30-day stickiness review) ──────────────────
+#
+# Counts `monitoring.dashboards.get` audit-log calls; powers the audit
+# follow-up that decides at T+30d whether the dashboard is being used (and
+# at T+90d whether to kill it if quarterly opens ≤ 1). The filter currently
+# matches dashboard opens project-wide — after the first Apply, narrow to
+# our specific dashboard ID by uncommenting the `resourceName=~...` clause
+# below (the dashboard ID is not known until after Apply).
+
+resource "google_logging_metric" "bird_watch_dashboard_opened" {
+  name = "bird-watch-dashboard-opened"
+  filter = join(" AND ", [
+    "logName=~\"cloudaudit.googleapis.com\"",
+    "protoPayload.methodName=\"monitoring.dashboards.get\"",
+    # Filter to OUR dashboard only; uncomment after first Apply once the
+    # dashboard ID is known:
+    # "protoPayload.resourceName=~\"projects/.+/dashboards/<DASHBOARD_ID>\"",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Bird-watch dashboard opens (Cloud Audit)"
+  }
+}
+
+# ── Enable Data Access audit logs for Cloud Monitoring ────────────────────
+#
+# Required for `monitoring.dashboards.get` to land in audit logs (Data Access
+# audit logs are off by default for all GCP services). Marginal cost is ~$0
+# against current monitoring traffic — dashboard reads are low-volume and
+# count against the same audit-log ingest quota that admin-activity logs use.
+# This must be paired with `google_logging_metric.bird_watch_dashboard_opened`
+# above; the metric extracts events that this resource enables.
+
+resource "google_project_iam_audit_config" "monitoring_data_read" {
+  project = var.gcp_project_id
+  service = "monitoring.googleapis.com"
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph "Ingestor (cli.ts:174)"
        A["bird_ingest_run_completed<br/>{kind,status,duration_seconds}"]
    end

    subgraph "Cloud Logging"
        B[(jsonPayload filter)]
    end

    subgraph "Log-based metrics"
        C["bird-ingest-run-completed<br/>DELTA INT64, labels: kind,status"]
        D["bird-ingest-run-duration-seconds<br/>DELTA DISTRIBUTION s, label: kind"]
        E["bird-watch-dashboard-opened<br/>DELTA INT64"]
    end

    subgraph "Audit pipeline"
        F["google_project_iam_audit_config<br/>monitoring.googleapis.com DATA_READ"]
        G["Cloud Audit Log<br/>monitoring.dashboards.get"]
    end

    subgraph "Dashboard (mosaicLayout, 12 cols)"
        H["Row 1: API health<br/>req-rate · p95 latency · open incidents"]
        I["Row 2: Ingester<br/>runs by kind+status · p95 dur · freshness"]
        J["Row 3: Cloud SQL<br/>CPU · connections · disk"]
        K["Row 4: System<br/>crashes/OOM · uptime regions"]
    end

    A --> B --> C
    A --> B --> D
    F --> G --> E
    C --> I
    D --> I
    E -.->|"30-day audit (Contract C4)"| L["Stickiness review"]
```

## Summary

- Adds `google_monitoring_dashboard.bird_watch_overview` (mosaicLayout, 12 cols, 11 tiles) — single-pane operator view replacing the 8-page click-around triage.
- Adds two log-based metrics extracted from the compact `bird_ingest_run_completed` emit shipping in PR-1 (#641): a counter (kind+status) and a duration distribution (kind). Both filters guard with `!=NULL_VALUE` so a future emit-shape regression shows as "zero entries" not garbage.
- Enables Data Access audit logs for `monitoring.googleapis.com` and a log-based metric on `monitoring.dashboards.get` — wires the falsifier for the 30-day stickiness review (kills the dashboard at T+90d if quarterly opens ≤ 1).

Closes #642. Refs #638 (epic).

### Dependency on #641

The two new ingest log-based metrics extract fields from the compact JSON emit at `services/ingestor/src/cli.ts:174` shipping in #641. **This PR must NOT be queued until #641 is merged AND the new emit has produced ≥1 log entry in prod.** Verify with:

```
gcloud logging read 'jsonPayload.message="bird_ingest_run_completed"' --limit 1 --freshness=2h --project=bird-maps-prod
```

If this returns ≥1 entry, the data dependency is satisfied. Post `@Mergifyio queue` only after.

### S0.1 spike result — SKIPPED

The pre-HCL spike could not be run in this implementation session: no clearly-throwaway sandbox GCP project was available to the agent (`gcloud projects list` showed only `bird-maps-prod`, `detached-node`, `poli-gap`, and `galvanic-kit-114503` — none labeled sandbox; enabling Data Access audit logs in any of those without operator confirmation would be a side-channel for the PR).

**Operator action required before Apply:** run the spike in a true throwaway project (or accept the unverified audit hook). Procedure per #642 §S0.1:

```hcl
resource "google_project_iam_audit_config" "monitoring_data_read_sandbox" {
  project = "<sandbox-project-id>"
  service = "monitoring.googleapis.com"
  audit_log_config { log_type = "DATA_READ" }
}
```

Apply, wait ~2 min, open a dashboard via Console, then:

```
gcloud logging read 'logName=~"cloudaudit.googleapis.com" AND protoPayload.methodName="monitoring.dashboards.get"' \
  --project=<sandbox-project-id> --limit=10 --freshness=15m --format=json
```

If ≥1 entry: spike passes, proceed with Apply. If 0 entries: STOP — the audit hook design needs revision (`bird_watch_dashboard_opened` metric will sit at zero). Tear down the sandbox audit-config block after.

## Screenshots

N/A — not UI. Infra-only PR; the dashboard renders in Cloud Console only after Apply (post-merge, operator-side).

## Test plan

- [x] `terraform fmt -check` exits 0 (ran in `infra/terraform/`)
- [x] `terraform validate` exits 0 (ran with backendless `init`; cleaned `.terraform/` after)
- [x] Knip clean against this branch (pre-existing findings only — confirmed identical via `git stash` baseline)
- [ ] CI green: test, lint, build, e2e
- [ ] Post-Apply Console smoke check: dashboard renders without "no data" placeholders on all 11 widgets (allow up to 24h for metric backfill on the new log-based metrics)
- [ ] `monitoring.dashboards.get` audit events land in the `bird-watch-dashboard-opened` metric after the first manual open
- [ ] Issue #638 body amendments verified present: `gh issue view 638 --repo julianken/bird-sight-system --json body --jq '.body' | grep -c '~~'` returns ≥4
- [ ] After first Apply: narrow the `bird-watch-dashboard-opened` filter to the specific dashboard ID (uncomment the `protoPayload.resourceName=~...` line in `monitoring.tf`) and re-apply

## Plan reference

Implements PR-2 of #638 (monitoring dashboard epic). See #642 issue body for the full round-0 through round-2 amended spec (Implementation Contract C2, landmines L1/L6).

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

