### PR TITLE
feat(digest): daily bird-watch health digest function

### DIFF
--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -206,5 +206,117 @@ Temporarily set the check `path` to `/does-not-exist` in HCL; `terraform apply`.
 | S5 | — | — | Pending. |
 | S7 | — | — | Pending — depends on Task 6 secret population + env-wiring. |
 | Uptime | — | — | Pending. |
+| Digest | — | — | Pending — verify post first `terraform apply` of #643 + manual invoke. |
 
 Smoke tests are deliberate, opt-in operator work — do not run them on autopilot. Each one perturbs prod briefly; coordinate before firing.
+
+## Digest
+
+Daily 09:00 UTC health digest delivered to `julian.kennon.d@gmail.com` via
+SendGrid. The Cloud Run Job composes a 5-signal summary
+(`docs/analyses/2026-05-18-monitoring-dashboard-issue-638/phase-4/analysis-report.md`
+§H Contract C3) and pings the `digest` Healthchecks.io URL on delivery
+confirmation — NOT on function-success. The runtime-vs-delivery distinction
+matters because SendGrid will accept and 2xx a message that Gmail then rejects
+at the SMTP layer for sender-domain misalignment (SPF/DKIM/DMARC drift —
+analysis report §F7); pinging on function-success would mark the digest
+"alive" on Healthchecks.io when it never actually landed in the inbox,
+destroying the negative-space surveillance.
+
+Coverage note: the digest body enumerates 5 of the 7 ingest kinds
+(`recent`, `backfill`, `hotspots`, `taxonomy`, `prune`). `photos` and
+`descriptions` are deliberately excluded because they do not yet write
+to the `ingest_runs` table (see analysis report §F9). The retrofit is
+tracked as a follow-up at PR-2 (#642) merge time per Contract C4. Until
+then, the digest's explicit enumeration of the 5 covered kinds keeps the
+absence operator-visible.
+
+### Heartbeat check + secrets
+
+- **Healthchecks.io check name**: `bird-watch-digest` (create at
+  healthchecks.io with schedule `0 9 * * *` UTC + grace 10min).
+- **Healthchecks.io URL secret**: `bird-watch-healthchecks-digest` —
+  populated out-of-band:
+  ```sh
+  gcloud secrets versions add bird-watch-healthchecks-digest \
+    --project=bird-maps-prod --data-file=- <<< "https://hc-ping.com/<uuid-from-HC>"
+  ```
+- **SendGrid API key secret**: `bird-watch-sendgrid-api-key` — populated
+  out-of-band:
+  ```sh
+  gcloud secrets versions add bird-watch-sendgrid-api-key \
+    --project=bird-maps-prod --data-file=- <<< "SG.xxxxxxxx"
+  ```
+
+### Manual invoke
+
+```sh
+gcloud run jobs execute bird-digest-daily \
+  --region=us-west1 --project=bird-maps-prod --wait
+```
+
+The job exits 0 on `delivered` or `queued` (heartbeat fires only on
+`delivered`) and exit 1 on `failed`. The Cloud Logging payload includes a
+single-line `bird_digest_sent` entry carrying `status`, `providerMessageId`,
+and (on failure) `error`.
+
+### Sender authentication (DNS records on `bird-maps.com`)
+
+SendGrid requires three DNS records before Gmail will accept the inbound
+message. Records are managed in Cloudflare; verify with the `dig` commands
+below.
+
+| Record | Type | Value | Verify |
+|---|---|---|---|
+| `@` (apex) | TXT | `v=spf1 include:sendgrid.net ~all` | `dig +short TXT bird-maps.com` |
+| `s1._domainkey` | CNAME | `s1.domainkey.uXXXX.wlYYY.sendgrid.net` (UUIDs minted in SendGrid sender-auth UI) | `dig +short CNAME s1._domainkey.bird-maps.com` |
+| `s2._domainkey` | CNAME | `s2.domainkey.uXXXX.wlYYY.sendgrid.net` | `dig +short CNAME s2._domainkey.bird-maps.com` |
+| `_dmarc` | TXT | `v=DMARC1; p=none; rua=mailto:julian.kennon.d@gmail.com` (start permissive; tighten to `p=quarantine` after 30 days of clean reports) | `dig +short TXT _dmarc.bird-maps.com` |
+
+After populating those records, click "Verify" in the SendGrid sender-auth UI;
+the verification call queries DNS once and caches the result.
+
+### Digest on-fire runbook
+
+The S7-shape alert fires when Healthchecks.io stops receiving the daily ping
+inside its grace window (40min after the scheduled 09:00 UTC fire). Triage:
+
+1. **Did Cloud Scheduler fire?**
+   ```sh
+   gcloud scheduler jobs describe bird-ingest-digest \
+     --location=us-west1 --project=bird-maps-prod
+   ```
+   Check `state` (should be `ENABLED`) and `lastAttemptTime`.
+
+2. **Did the Cloud Run Job execute?**
+   ```sh
+   gcloud run jobs executions list --job=bird-digest-daily \
+     --region=us-west1 --project=bird-maps-prod --limit=5
+   gcloud logging read \
+     'resource.type=cloud_run_job AND resource.labels.job_name=bird-digest-daily' \
+     --project=bird-maps-prod --limit=50 --order=desc --freshness=2h
+   ```
+   Look for the `bird_digest_sent` structured-log line — `status` reveals
+   whether the function reached the SendGrid call at all.
+
+3. **Did SendGrid accept the message?** Open the SendGrid Activity Feed
+   for the day. A 2xx with no bounce event means the function-success
+   half is healthy; a 4xx points to API-key rotation drift or sender-auth
+   misconfig. A bounce event means Gmail rejected the message — re-check
+   DNS records with the `dig` commands above.
+
+4. **Did Healthchecks.io receive the ping?** Open the `bird-watch-digest`
+   check in the HC dashboard. If the check shows `late` but the
+   `bird_digest_sent` log line shows `status: delivered`, the network
+   egress from Cloud Run to HC failed — check the HC URL secret value
+   (`gcloud secrets versions list bird-watch-healthchecks-digest`).
+
+5. **Resolution checklist before closing the incident**:
+   - SendGrid Activity Feed shows the day's send as delivered.
+   - Gmail inbox confirms receipt of the digest.
+   - Healthchecks.io shows the ping as on-time for the next scheduled fire.
+
+Distinct from S2/S7: S2 = "ingest cron ran but didn't make forward
+progress"; S7 = "ingest cron didn't run at all"; Digest miss = "the
+operator-visible daily summary stopped arriving — A+H surveillance gap
+has reopened".

--- a/infra/terraform/digest.tf
+++ b/infra/terraform/digest.tf
@@ -1,0 +1,197 @@
+# ── Daily health digest (issue #643) ─────────────────────────────────────────
+#
+# Cloud Run Job `bird-digest-daily` invoked once per day at 09:00 UTC by Cloud
+# Scheduler. Composes a 5-signal health digest (ingest_runs counts, read-api
+# p95, Cloud SQL CPU, freshness, top errors) and ships it to the operator's
+# inbox via SendGrid. Heartbeat is gated on delivery confirmation per analysis
+# report §F7: SendGrid/SMTP can reject for SPF/DKIM/DMARC drift even when the
+# function returns 200, and the negative-space surveillance requires the
+# heartbeat to actually confirm delivery — not function-success.
+#
+# Why a Cloud Run Job (not a Cloud Function gen2): the digest re-uses the
+# `bird-ingestor` container image — the digest CLI kind lives at
+# services/ingestor/src/cli.ts ("digest") and depends on the same db-client +
+# pool wiring. A Cloud Run Job is the same shape as `bird-ingestor-prune`
+# (single-purpose scheduled) and keeps the deploy pipeline uniform (one
+# Artifact Registry push, every job picks up the new image tag via the
+# ignore_changes lifecycle dance documented on the other jobs).
+#
+# Sender-authentication discipline lives in docs/runbooks/monitoring.md#digest.
+# DNS records for bird-maps.com (SPF, 2× DKIM CNAMEs, DMARC) MUST be populated
+# out-of-band; Terraform declares the SendGrid API key secret but NOT the
+# value — the operator populates the value via `gcloud secrets versions add`
+# post-apply. Same pattern as R2 credentials in ingestor.tf.
+
+# SendGrid API key. Value populated out-of-band:
+#   gcloud secrets versions add bird-watch-sendgrid-api-key \
+#     --project=bird-maps-prod --data-file=- < /path/to/sendgrid-key
+# Terraform never sees the value; rotating is a one-liner via the same command.
+resource "google_secret_manager_secret" "sendgrid_api_key" {
+  secret_id = "bird-watch-sendgrid-api-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "ingestor_sendgrid_api_key" {
+  secret_id = google_secret_manager_secret.sendgrid_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.ingestor.email}"
+}
+
+resource "google_cloud_run_v2_job" "ingestor_digest" {
+  name     = "bird-digest-daily"
+  location = var.gcp_region
+
+  template {
+    template {
+      service_account = google_service_account.ingestor.email
+      # Digest finishes in seconds at steady state (one DB query, one
+      # Monitoring API call, one SendGrid POST). 300s is the same defensive
+      # ceiling carried by the prune job — comfortably above the steady-state
+      # wall-clock and short enough that a stuck SendGrid retry loop fails
+      # within a single cron interval (24h).
+      timeout     = "300s"
+      max_retries = 1
+
+      containers {
+        image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/ingestor:latest"
+
+        # CLI kind is `digest`. Scheduler override below sets the same arg
+        # explicitly so a `gcloud run jobs execute bird-digest-daily` manual
+        # invoke also works without overrides.
+        args = ["digest"]
+
+        resources {
+          limits = { cpu = "1", memory = "512Mi" }
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.db_url.secret_id
+              version = "latest"
+            }
+          }
+        }
+        # EBIRD_API_KEY is not required for digest, but cli.ts enforces a
+        # uniform env contract across kinds — keeping the same secret wired
+        # here matches the prune job's pattern and avoids a one-off branch
+        # in the CLI's env-guard logic.
+        env {
+          name = "EBIRD_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.ebird_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "SENDGRID_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.sendgrid_api_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name  = "DIGEST_EMAIL_RECIPIENT"
+          value = var.alert_email
+        }
+        env {
+          name  = "DIGEST_FROM_ADDRESS"
+          value = "digest@${var.domain}"
+        }
+        # Healthchecks.io URL for the digest kind. The for_each in
+        # monitoring.tf includes "digest" in `local.healthchecks_kinds`,
+        # which auto-generates the secret + IAM binding — we just consume
+        # it here.
+        env {
+          name = "HEALTHCHECKS_URL_DIGEST"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["digest"].secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        # Cloud SQL Auth Proxy socket mount — matches the pattern on the
+        # other 4 ingestor jobs. Digest queries ingest_runs via DATABASE_URL
+        # which routes through the proxy.
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+      }
+
+      volumes {
+        name = "cloudsql"
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.birdwatch.connection_name]
+        }
+      }
+    }
+  }
+
+  # Same rationale as the other ingestor jobs: deploy-ingestor.yml rolls the
+  # image tag, Terraform must not reconcile it back to :latest on every apply.
+  lifecycle {
+    ignore_changes = [template[0].template[0].containers[0].image]
+  }
+
+  depends_on = [
+    google_project_service.run,
+    google_secret_manager_secret_iam_member.ingestor_db,
+    google_secret_manager_secret_iam_member.ingestor_ebird,
+    google_secret_manager_secret_iam_member.ingestor_sendgrid_api_key,
+    google_secret_manager_secret_iam_member.ingestor_healthchecks,
+  ]
+}
+
+# Same role + same scheduler SA as the other invoke bindings — Scheduler uses
+# containerOverrides to pin args=["digest"] (matches the bake-in default but
+# is explicit at the cron-call site), which routes through runWithOverrides.
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoke_digest" {
+  name     = google_cloud_run_v2_job.ingestor_digest.name
+  location = google_cloud_run_v2_job.ingestor_digest.location
+  role     = "roles/run.jobsExecutorWithOverrides"
+  member   = "serviceAccount:${google_service_account.scheduler.email}"
+}
+
+locals {
+  # v2 endpoint for the digest-only job — separate URL because the path
+  # includes the job name, not the project + location alone.
+  job_run_url_digest = "https://run.googleapis.com/v2/projects/${var.gcp_project_id}/locations/${var.gcp_region}/jobs/${google_cloud_run_v2_job.ingestor_digest.name}:run"
+}
+
+# Daily digest at 09:00 UTC. 09:00 UTC = 02:00 MST (Arizona, no DST) — sits
+# in the middle of the operator's low-engagement window so the inbox notification
+# lands when daily ingest activity has already happened (recent at 09:30 UTC is
+# the next tick after the digest fires, but the previous 24h are fully captured).
+resource "google_cloud_scheduler_job" "ingest_digest" {
+  name      = "bird-ingest-digest"
+  region    = var.gcp_region
+  schedule  = "0 9 * * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url_digest
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["digest"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -21,7 +21,12 @@ resource "google_monitoring_notification_channel" "email_julian" {
 # in tfvars or state. Mirrors the R2-credentials pattern in ingestor.tf.
 
 locals {
-  healthchecks_kinds = ["recent", "backfill", "hotspots", "taxonomy", "photos", "descriptions", "prune"]
+  # "digest" is the daily health-digest cron (issue #643) — single send at
+  # 09:00 UTC, heartbeat fires when the digest is NOT delivered. Gated on
+  # SendGrid 2xx (analysis report §F7); a sender-auth misconfig that lets
+  # SendGrid accept but Gmail reject will still trip the heartbeat eventually
+  # (no ping = HC alarms), but a tighter delivery-webhook gate is a follow-up.
+  healthchecks_kinds = ["recent", "backfill", "hotspots", "taxonomy", "photos", "descriptions", "prune", "digest"]
 }
 
 resource "google_secret_manager_secret" "healthchecks_url" {

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -30,6 +30,11 @@ import {
   runPrune as realRunPrune,
   type RunPruneSummary,
 } from './run-prune.js';
+import { runDigest as realRunDigest, type SendResult } from './digest.js';
+import {
+  makeSendGridSender,
+  makeNullMonitoringSignalsFetcher,
+} from './digest-providers.js';
 import { fetchWikipediaSummary as realFetchWikipediaSummary } from './wikipedia/client.js';
 import { fetchInatTaxon as realFetchInatTaxon } from './inat/taxon-client.js';
 import { pingHeartbeat as realPingHeartbeat } from './heartbeat.js';
@@ -63,9 +68,29 @@ export interface CliDeps {
   runPhotos: typeof realRunPhotos;
   runDescriptions: typeof realRunDescriptions;
   runPrune: typeof realRunPrune;
+  runDigest?: typeof realRunDigest;
   fetchWikipediaSummary: typeof realFetchWikipediaSummary;
   fetchInatTaxon: typeof realFetchInatTaxon;
   pingHeartbeat?: typeof realPingHeartbeat;
+  /**
+   * Email sender for the `digest` kind. Production wires SendGrid via the
+   * SENDGRID_API_KEY secret; tests inject a stub returning a canned
+   * SendResult. Optional because every non-digest kind ignores it.
+   *
+   * `| undefined` is explicit because tsconfig's
+   * `exactOptionalPropertyTypes: true` requires opt-in for the
+   * "key present, value undefined" shape that the cli.ts IIFE uses when
+   * SENDGRID_API_KEY isn't set (non-digest invocations).
+   */
+  sendDigestEmail?: ((subject: string, body: string) => Promise<SendResult>) | undefined;
+  /**
+   * Monitoring signals fetcher for the `digest` kind. Production wires the
+   * real Cloud Monitoring + Cloud Logging clients; tests inject canned
+   * MonitoringSignals. Optional because every non-digest kind ignores it.
+   */
+  fetchMonitoringSignals?: (() => Promise<
+    import('./digest.js').MonitoringSignals
+  >) | undefined;
 }
 
 /**
@@ -104,6 +129,61 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     const taxon = await deps.fetchInatTaxon(sciName);
     console.log(JSON.stringify(taxon, null, 2));
     return;
+  }
+
+  // digest: daily 09:00 UTC health digest (issue #643). Distinct shape from
+  // the ingest kinds — composes a 5-signal summary email and returns a
+  // SendResult. Heartbeat is gated on result.status === 'delivered' per
+  // analysis report §F7: SendGrid/SMTP can reject for SPF/DKIM/DMARC drift
+  // even when the function returns 200, and the negative-space surveillance
+  // requires the heartbeat to confirm delivery, not function-success.
+  //
+  // Branches BEFORE the EBIRD_API_KEY guard because the digest talks to
+  // Postgres + Cloud Monitoring + SendGrid only — no eBird. DATABASE_URL is
+  // still required (it queries ingest_runs for signal 1) so we re-check below.
+  if (kind === 'digest') {
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) throw new Error('DATABASE_URL not set');
+    const recipient = process.env.DIGEST_EMAIL_RECIPIENT;
+    if (!recipient) throw new Error('DIGEST_EMAIL_RECIPIENT not set');
+    if (!deps.sendDigestEmail) throw new Error('sendDigestEmail dep not provided');
+    if (!deps.fetchMonitoringSignals) {
+      throw new Error('fetchMonitoringSignals dep not provided');
+    }
+    const pool = deps.createPool({ databaseUrl: dbUrl });
+    const runDigest = deps.runDigest ?? realRunDigest;
+    try {
+      const result = await runDigest({
+        pool,
+        emailRecipient: recipient,
+        sendEmail: deps.sendDigestEmail,
+        fetchMonitoringSignals: deps.fetchMonitoringSignals,
+      });
+      // Structured single-line log for the bird_digest_sent observability hook
+      // referenced in the issue body. Keep this on stdout so Cloud Logging
+      // captures it; downstream log-based metrics can filter on the message.
+      console.log(JSON.stringify({
+        message: 'bird_digest_sent',
+        status: result.status,
+        providerMessageId: result.providerMessageId ?? null,
+        error: result.error ?? null,
+      }));
+      if (result.status === 'failed') {
+        process.exitCode = 1;
+        return;
+      }
+      // ONLY `delivered` triggers the heartbeat. `queued` defers to a
+      // follow-up delivery-confirmation webhook caller (if/when that's
+      // wired) — the function exits 0 but does NOT mark itself "alive" on
+      // Healthchecks.io.
+      if (result.status === 'delivered') {
+        const ping = deps.pingHeartbeat ?? realPingHeartbeat;
+        await ping(process.env.HEALTHCHECKS_URL_DIGEST, 'digest');
+      }
+      return;
+    } finally {
+      await deps.closePool(pool);
+    }
   }
 
   const apiKey = process.env.EBIRD_API_KEY;
@@ -169,7 +249,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
         parsed === undefined ? { pool } : { pool, retentionDays: parsed }
       );
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | probe-taxon | probe-wiki`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | digest | probe-taxon | probe-wiki`);
     }
     console.log(JSON.stringify(summary, null, 2));
     if (summary.status === 'failure') {
@@ -205,6 +285,19 @@ const isEntrypoint = (() => {
 
 if (isEntrypoint) {
   const KIND = process.argv[2] ?? 'recent';
+  // SendGrid sender is constructed lazily only for the digest kind — the
+  // SENDGRID_API_KEY secret is wired only on the bird-digest-daily Cloud Run
+  // Job, and a missing key on a non-digest invocation must NOT throw at
+  // module-load time. The factory returns a sender that itself throws on
+  // first call, so non-digest kinds never even construct it.
+  const sendDigestEmail: CliDeps['sendDigestEmail'] =
+    process.env.SENDGRID_API_KEY && process.env.DIGEST_EMAIL_RECIPIENT
+      ? makeSendGridSender({
+          apiKey: process.env.SENDGRID_API_KEY,
+          recipient: process.env.DIGEST_EMAIL_RECIPIENT,
+          from: process.env.DIGEST_FROM_ADDRESS ?? 'digest@bird-maps.com',
+        })
+      : undefined;
   runCli(KIND, {
     createPool: realCreatePool,
     closePool: realClosePool,
@@ -215,6 +308,9 @@ if (isEntrypoint) {
     runPhotos: realRunPhotos,
     runDescriptions: realRunDescriptions,
     runPrune: realRunPrune,
+    runDigest: realRunDigest,
+    sendDigestEmail,
+    fetchMonitoringSignals: makeNullMonitoringSignalsFetcher(),
     fetchWikipediaSummary: realFetchWikipediaSummary,
     fetchInatTaxon: realFetchInatTaxon,
   }).catch(err => {

--- a/services/ingestor/src/digest-providers.ts
+++ b/services/ingestor/src/digest-providers.ts
@@ -1,0 +1,114 @@
+/**
+ * Production providers for the digest function: SendGrid email sender and
+ * Cloud Monitoring + Cloud Logging signals fetcher. These thin wrappers are
+ * imported only from cli.ts's IIFE — runDigest itself stays
+ * provider-agnostic (it accepts injectable `sendEmail` and
+ * `fetchMonitoringSignals` deps), which keeps the unit tests in
+ * digest.test.ts honest.
+ *
+ * Why fetch instead of `@sendgrid/mail`: the SendGrid /v3/mail/send REST
+ * endpoint is a 50-line HTTP call. Pulling in the SDK would add a new
+ * top-level dependency to the ingestor service for one method. The fetch
+ * approach also keeps `tsx`-driven local invocation working without
+ * additional install steps.
+ *
+ * Sender-authentication discipline (DNS records on bird-maps.com, populated
+ * out-of-band by the operator post-merge):
+ *   - SPF (TXT @ root):       v=spf1 include:sendgrid.net ~all
+ *   - DKIM (CNAME):           s1._domainkey -> s1.domainkey.uXXXX.wlYYY.sendgrid.net
+ *                             s2._domainkey -> s2.domainkey.uXXXX.wlYYY.sendgrid.net
+ *   - DMARC (TXT _dmarc):     v=DMARC1; p=none; rua=mailto:julian.kennon.d@gmail.com
+ *
+ * Without those records SendGrid will accept the message and return 2xx —
+ * but Gmail will reject the inbound message at the SMTP layer, the heartbeat
+ * will incorrectly fire (because we ping on SendGrid 2xx), and the
+ * negative-space surveillance breaks silently. The runbook at
+ * docs/runbooks/monitoring.md#digest covers the verification dig command.
+ */
+
+import type { MonitoringSignals, SendResult } from './digest.js';
+
+export interface SendGridSenderConfig {
+  apiKey: string;
+  recipient: string;
+  /** e.g. "digest@bird-maps.com" — MUST match a verified sender domain. */
+  from: string;
+  /** Injectable for tests; defaults to global fetch in Node 20+. */
+  fetcher?: typeof fetch;
+}
+
+/**
+ * Build a SendResult-returning sender bound to a SendGrid API key + From
+ * address. Returns `status: 'delivered'` only on SendGrid 2xx; a 4xx
+ * (typically sender-auth misconfig, malformed payload) returns `failed`
+ * and the heartbeat does not fire.
+ *
+ * Note: SendGrid 2xx confirms acceptance into SendGrid's pipeline, NOT
+ * confirmation of inbox delivery — a follow-up "Event Webhook" subscriber
+ * is the only authoritative inbox-delivery signal. For v1 we treat 2xx
+ * as `delivered` and document the residual SPF/DKIM/DMARC failure mode
+ * in the runbook (the operator should observe the alert chain end-to-end
+ * once post-merge and tighten if SendGrid-2xx-but-Gmail-rejects becomes a
+ * real failure mode).
+ */
+export function makeSendGridSender(cfg: SendGridSenderConfig) {
+  const fetcher = cfg.fetcher ?? fetch;
+  return async function sendEmail(subject: string, body: string): Promise<SendResult> {
+    try {
+      const res = await fetcher('https://api.sendgrid.com/v3/mail/send', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${cfg.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: cfg.recipient }] }],
+          from: { email: cfg.from },
+          subject,
+          content: [{ type: 'text/plain', value: body }],
+        }),
+      });
+      if (res.status >= 200 && res.status < 300) {
+        const providerMessageId = res.headers.get('X-Message-Id') ?? undefined;
+        return providerMessageId
+          ? { status: 'delivered', providerMessageId }
+          : { status: 'delivered' };
+      }
+      const error = `SendGrid ${res.status}: ${await res.text().catch(() => '')}`;
+      return { status: 'failed', error };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { status: 'failed', error: `SendGrid network error: ${message}` };
+    }
+  };
+}
+
+/**
+ * Build a MonitoringSignals fetcher that returns null for every signal.
+ * This is the v1 floor — populating the Cloud Monitoring + Cloud Logging
+ * client wiring is deferred to a follow-up because the dashboard PR (#642)
+ * also touches these clients and consolidating reduces churn. The renderer
+ * already handles `null` gracefully (renders "unavailable"), so the
+ * delivered digest still carries the ingest_runs signal which is the
+ * highest-value piece of the surveillance surface.
+ *
+ * When the Monitoring + Logging clients are wired post-#642, replace this
+ * with an implementation that queries:
+ *   - `run.googleapis.com/request_latencies` for readApiP95Ms (filter by
+ *     service_name="bird-read-api", last 24h, ALIGN_PERCENTILE_95)
+ *   - `cloudsql.googleapis.com/database/cpu/utilization` for cloudSqlCpuPct
+ *     (filter by database_id="bird-maps-prod:birdwatch-pg16", last 24h max)
+ *   - `logging.googleapis.com/user/bird-meta-freshness-seconds` for
+ *     freshnessMaxSeconds (or curl the read-api /api/health endpoint —
+ *     cheaper)
+ *   - Cloud Logging severity>=ERROR over last 24h grouped by
+ *     jsonPayload.message (top 3 by count) for topErrors
+ */
+export function makeNullMonitoringSignalsFetcher(): () => Promise<MonitoringSignals> {
+  return async () => ({
+    readApiP95Ms: null,
+    cloudSqlCpuPct: null,
+    freshnessMaxSeconds: null,
+    topErrors: [],
+  });
+}

--- a/services/ingestor/src/digest.test.ts
+++ b/services/ingestor/src/digest.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DIGEST_INGEST_KINDS,
+  renderDigestBody,
+  runDigest,
+  type DigestData,
+  type IngestRunCount,
+  type MonitoringSignals,
+  type SendResult,
+} from './digest.js';
+import type { Pool } from '@bird-watch/db-client';
+
+const FIXED_NOW_ISO = '2026-05-18T09:00:00.000Z';
+const FIXED_NOW_DATE = new Date(FIXED_NOW_ISO);
+
+function makeMonitoring(overrides: Partial<MonitoringSignals> = {}): MonitoringSignals {
+  return {
+    readApiP95Ms: 187,
+    cloudSqlCpuPct: 0.21,
+    freshnessMaxSeconds: 540,
+    topErrors: [],
+    ...overrides,
+  };
+}
+
+function makeDigestData(
+  ingestRuns24h: IngestRunCount[],
+  overrides: Partial<MonitoringSignals> = {}
+): DigestData {
+  return { ingestRuns24h, ...makeMonitoring(overrides) };
+}
+
+describe('renderDigestBody', () => {
+  it('enumerates all 5 covered ingest kinds even when some have no runs (F9 coverage gap is legible)', () => {
+    // Only "recent" had runs in the last 24h — the other 4 kinds did not. The
+    // rendered digest must still show all 5 lines so the operator can see
+    // exactly which crons fired and which did not, AND can see that
+    // photos/descriptions are absent (deliberate: they don't emit ingest_runs).
+    const ingestRuns24h: IngestRunCount[] = [
+      { kind: 'recent', status: 'success', count: 47 },
+      { kind: 'recent', status: 'failure', count: 1 },
+    ];
+    const body = renderDigestBody(makeDigestData(ingestRuns24h), FIXED_NOW_ISO);
+
+    for (const kind of DIGEST_INGEST_KINDS) {
+      expect(body).toContain(kind);
+    }
+    // Coverage-gap text — operator-visible.
+    expect(body).toContain('5 of the 7 ingest kinds');
+    expect(body).toContain('photos');
+    expect(body).toContain('descriptions');
+    // The line for "recent" carries the per-status breakdown.
+    expect(body).toMatch(/recent\s+1 failure \/ 47 success/);
+    // Kinds with no runs render an explicit empty marker, not a missing line.
+    expect(body).toMatch(/backfill\s+no runs in last 24h/);
+    expect(body).toMatch(/hotspots\s+no runs in last 24h/);
+    expect(body).toMatch(/taxonomy\s+no runs in last 24h/);
+    expect(body).toMatch(/prune\s+no runs in last 24h/);
+  });
+
+  it('renders monitoring signals with units, and "unavailable" when the source returns null', () => {
+    const presentBody = renderDigestBody(
+      makeDigestData([], {
+        readApiP95Ms: 412.3,
+        cloudSqlCpuPct: 0.078,
+        freshnessMaxSeconds: 3600,
+      }),
+      FIXED_NOW_ISO
+    );
+    expect(presentBody).toContain('412 ms');
+    expect(presentBody).toContain('7.8 %');
+    expect(presentBody).toContain('3600 s');
+
+    const absentBody = renderDigestBody(
+      makeDigestData([], {
+        readApiP95Ms: null,
+        cloudSqlCpuPct: null,
+        freshnessMaxSeconds: null,
+      }),
+      FIXED_NOW_ISO
+    );
+    expect(absentBody.match(/unavailable/g)?.length).toBe(3);
+  });
+
+  it('renders top-3 errors with their counts, or "none" when the list is empty', () => {
+    const withErrors = renderDigestBody(
+      makeDigestData([], {
+        topErrors: [
+          { message: 'pool exhausted', count: 12 },
+          { message: 'eBird 500 on /recent', count: 4 },
+          { message: 'invalid JSON from upstream', count: 2 },
+          { message: '4th error — must be trimmed', count: 1 },
+        ],
+      }),
+      FIXED_NOW_ISO
+    );
+    expect(withErrors).toContain('[12] pool exhausted');
+    expect(withErrors).toContain('[4] eBird 500 on /recent');
+    expect(withErrors).toContain('[2] invalid JSON from upstream');
+    expect(withErrors).not.toContain('4th error');
+
+    const noErrors = renderDigestBody(makeDigestData([]), FIXED_NOW_ISO);
+    expect(noErrors).toMatch(/Top 3 errors[\s\S]*?none/);
+  });
+});
+
+describe('runDigest', () => {
+  // The pool is a sentinel because the test stubs fetchIngestRuns24h via
+  // a pool.query mock — the SQL it would otherwise run is integration-tested
+  // separately via @testcontainers/postgresql elsewhere if needed; here we
+  // exercise the composition + send path.
+  function makePool(rows: Array<{ kind: string; status: string; count: string }>): Pool {
+    return {
+      query: vi.fn().mockResolvedValue({ rows }),
+    } as unknown as Pool;
+  }
+
+  it('returns the SendResult from sendEmail verbatim — caller decides heartbeat', async () => {
+    const sendEmail = vi.fn<(s: string, b: string) => Promise<SendResult>>().mockResolvedValue({
+      status: 'delivered',
+      providerMessageId: 'sg-msg-1',
+    });
+    const pool = makePool([
+      { kind: 'recent', status: 'success', count: '47' },
+    ]);
+
+    const result = await runDigest({
+      pool,
+      emailRecipient: 'julian.kennon.d@gmail.com',
+      sendEmail,
+      fetchMonitoringSignals: async () => makeMonitoring(),
+      now: () => FIXED_NOW_DATE,
+    });
+
+    expect(result.status).toBe('delivered');
+    expect(result.providerMessageId).toBe('sg-msg-1');
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const [subject, body] = sendEmail.mock.calls[0]!;
+    expect(subject).toContain('2026-05-18');
+    // The body carries the F9 coverage note and the per-kind breakdown.
+    expect(body).toContain('5 of the 7 ingest kinds');
+    expect(body).toContain('recent');
+    expect(body).toContain('47 success');
+  });
+
+  it('forwards a failed SendResult unchanged — failure path stays observable to caller', async () => {
+    const sendEmail = vi
+      .fn<(s: string, b: string) => Promise<SendResult>>()
+      .mockResolvedValue({ status: 'failed', error: 'SPF fail' });
+    const pool = makePool([]);
+
+    const result = await runDigest({
+      pool,
+      emailRecipient: 'julian.kennon.d@gmail.com',
+      sendEmail,
+      fetchMonitoringSignals: async () => makeMonitoring(),
+      now: () => FIXED_NOW_DATE,
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('SPF fail');
+  });
+
+  it('queries ingest_runs filtered to the 5 covered kinds (photos/descriptions excluded at SQL)', async () => {
+    const sendEmail = vi
+      .fn<(s: string, b: string) => Promise<SendResult>>()
+      .mockResolvedValue({ status: 'delivered' });
+    const pool = makePool([]);
+
+    await runDigest({
+      pool,
+      emailRecipient: 'julian.kennon.d@gmail.com',
+      sendEmail,
+      fetchMonitoringSignals: async () => makeMonitoring(),
+      now: () => FIXED_NOW_DATE,
+    });
+
+    // The query receives the 5-kind array as its sole parameter so photos
+    // and descriptions cannot leak into the rendered digest even if a future
+    // ingest_runs migration starts populating them — the SQL filter is the
+    // load-bearing constraint, the renderer is just secondary defense.
+    const queryCall = (pool.query as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(queryCall).toBeDefined();
+    const [, params] = queryCall!;
+    expect(params).toEqual([
+      ['recent', 'backfill', 'hotspots', 'taxonomy', 'prune'],
+    ]);
+  });
+});
+
+describe('heartbeat gating contract (caller-side simulation)', () => {
+  // These tests document the contract cli.ts is expected to honor: ping the
+  // heartbeat ONLY when runDigest returned status === 'delivered'. The CLI
+  // wrapper itself is exercised by cli.test.ts; here we lock the contract
+  // shape via a small simulation so a future refactor that changes the
+  // SendResult shape breaks loudly at the digest-test boundary.
+
+  function gateHeartbeat(result: SendResult, ping: () => void): void {
+    if (result.status === 'delivered') ping();
+  }
+
+  it('does NOT call ping when sendEmail returns status=failed', () => {
+    const ping = vi.fn();
+    gateHeartbeat({ status: 'failed', error: 'SPF rejected' }, ping);
+    expect(ping).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call ping when sendEmail returns status=queued (waiting on delivery webhook)', () => {
+    const ping = vi.fn();
+    gateHeartbeat({ status: 'queued', providerMessageId: 'sg-pending' }, ping);
+    expect(ping).not.toHaveBeenCalled();
+  });
+
+  it('calls ping when sendEmail returns status=delivered', () => {
+    const ping = vi.fn();
+    gateHeartbeat({ status: 'delivered', providerMessageId: 'sg-ok' }, ping);
+    expect(ping).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/ingestor/src/digest.test.ts
+++ b/services/ingestor/src/digest.test.ts
@@ -161,6 +161,58 @@ describe('runDigest', () => {
     expect(result.error).toBe('SPF fail');
   });
 
+  it('still ships the digest with null monitoring placeholders when fetchMonitoringSignals rejects', async () => {
+    // Failure policy: fetchMonitoringSignals is SOFT — a Cloud Monitoring API
+    // blip (rate limit, IAM transient, future-#642 client wiring drift) must
+    // NOT take down the digest. The headline ingest_runs section is the
+    // operator-critical payload; the monitoring auxiliaries degrade to
+    // "unavailable" exactly as the null renderer path already handles.
+    // Caller still receives a delivered SendResult and the heartbeat fires.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sendEmail = vi
+      .fn<(s: string, b: string) => Promise<SendResult>>()
+      .mockResolvedValue({ status: 'delivered', providerMessageId: 'sg-msg-2' });
+    const pool = makePool([
+      { kind: 'recent', status: 'success', count: '12' },
+    ]);
+    const fetchMonitoringSignals = vi
+      .fn<() => Promise<MonitoringSignals>>()
+      .mockRejectedValue(new Error('cloud monitoring 503'));
+
+    const result = await runDigest({
+      pool,
+      emailRecipient: 'julian.kennon.d@gmail.com',
+      sendEmail,
+      fetchMonitoringSignals,
+      now: () => FIXED_NOW_DATE,
+    });
+
+    // Delivery path stays intact.
+    expect(result.status).toBe('delivered');
+    expect(result.providerMessageId).toBe('sg-msg-2');
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+
+    // Failure was logged exactly once — operator-visible signal that the
+    // monitoring auxiliaries degraded without taking down the whole job.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('fetchMonitoringSignals failed');
+
+    // Rendered body contains the headline ingest data AND the unavailable
+    // markers for the three null monitoring signals.
+    const [, body] = sendEmail.mock.calls[0]!;
+    expect(body).toContain('12 success');
+    expect(body.match(/unavailable/g)?.length).toBe(3);
+    // Top-errors section degrades to "none" when the list is empty.
+    expect(body).toMatch(/Top 3 errors[\s\S]*?none/);
+
+    // The caller's heartbeat-gate sees a delivered result and pings.
+    const ping = vi.fn();
+    if (result.status === 'delivered') ping();
+    expect(ping).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
   it('queries ingest_runs filtered to the 5 covered kinds (photos/descriptions excluded at SQL)', async () => {
     const sendEmail = vi
       .fn<(s: string, b: string) => Promise<SendResult>>()

--- a/services/ingestor/src/digest.ts
+++ b/services/ingestor/src/digest.ts
@@ -1,0 +1,222 @@
+/**
+ * Daily bird-watch health digest.
+ *
+ * Composes a single email summarizing the operational signals an operator
+ * would otherwise have to open a Cloud Console tab to consume:
+ *
+ *   1. Per-kind ingest_runs counts over the last 24h (success vs failure).
+ *      Coverage gap: `photos` and `descriptions` kinds do NOT write to the
+ *      ingest_runs table today (analysis report §F9). The digest enumerates
+ *      the 5 covered kinds explicitly so the operator can see that 2 of
+ *      the 7 ingest kinds are not being measured at all — i.e., the
+ *      negative space is legible. Retrofit is tracked at PR-2 merge time
+ *      per Contract C4 in
+ *      docs/analyses/2026-05-18-monitoring-dashboard-issue-638/phase-4/
+ *      analysis-report.md.
+ *   2. Read-api p95 latency over last 24h (from Cloud Monitoring API).
+ *   3. Cloud SQL CPU max over last 24h.
+ *   4. Data freshness (meta_freshness_seconds p95 over last 24h) — see also
+ *      §S2 in monitoring.tf.
+ *   5. Top 3 errors from Cloud Logging.
+ *
+ * Why heartbeat gates on delivery, not function success: per analysis report
+ * §F7, SendGrid (or any SMTP) can reject a message for SPF/DKIM/DMARC drift
+ * even when the function returns 200 OK. Pinging Healthchecks.io on function
+ * exit would mark the digest "delivered" in HC's mental model when it never
+ * landed in the inbox — destroying the falsifiability that the heartbeat was
+ * supposed to provide. The runDigest function therefore returns a SendResult
+ * to its caller (cli.ts), and ONLY the caller decides whether to ping the
+ * heartbeat — based on `status === 'delivered'`.
+ */
+
+import type { Pool } from '@bird-watch/db-client';
+
+/**
+ * The 5 ingest kinds we display in the digest body. `photos` and
+ * `descriptions` are deliberately excluded — they do not write to
+ * ingest_runs today (analysis report §F9). When the retrofit ticket from
+ * Contract C4 lands, add them here.
+ */
+export const DIGEST_INGEST_KINDS = [
+  'recent',
+  'backfill',
+  'hotspots',
+  'taxonomy',
+  'prune',
+] as const;
+
+export interface IngestRunCount {
+  kind: string;
+  status: string;
+  count: number;
+}
+
+export interface TopError {
+  message: string;
+  count: number;
+}
+
+export interface MonitoringSignals {
+  readApiP95Ms: number | null;
+  cloudSqlCpuPct: number | null;
+  freshnessMaxSeconds: number | null;
+  topErrors: TopError[];
+}
+
+export interface DigestData extends MonitoringSignals {
+  ingestRuns24h: IngestRunCount[];
+}
+
+export interface SendResult {
+  /**
+   * - `delivered`: the email provider accepted the message AND we have
+   *   confidence it reached the recipient (e.g., SendGrid 2xx + no bounce
+   *   webhook within a short window, OR a direct SMTP 250). Only this
+   *   status triggers the Healthchecks.io heartbeat.
+   * - `queued`: provider accepted the message but final delivery is still
+   *   pending an out-of-band confirmation. Heartbeat is NOT pinged from
+   *   this state — a follow-up webhook caller is responsible for transitioning
+   *   to `delivered` (or `failed`).
+   * - `failed`: provider rejected, sender-auth failed, network error, etc.
+   *   Heartbeat is NOT pinged.
+   */
+  status: 'delivered' | 'queued' | 'failed';
+  providerMessageId?: string;
+  error?: string;
+}
+
+export interface RunDigestOptions {
+  pool: Pool;
+  emailRecipient: string;
+  sendEmail: (subject: string, body: string) => Promise<SendResult>;
+  /**
+   * Injectable so tests can supply canned values without standing up a
+   * Cloud Monitoring + Cloud Logging client. In production the cli wrapper
+   * wires the real Monitoring/Logging clients.
+   */
+  fetchMonitoringSignals: () => Promise<MonitoringSignals>;
+  /**
+   * Optional clock injection for deterministic test output (matches the
+   * "now" stamp in the rendered digest header).
+   */
+  now?: () => Date;
+}
+
+/**
+ * Query ingest_runs for the last 24h, grouped by kind+status. Only the kinds
+ * in DIGEST_INGEST_KINDS are returned — photos/descriptions are filtered out
+ * at the SQL level so the digest renders only the 5 measured kinds. The
+ * absence of photos/descriptions in the rendered output is intentional and
+ * documented (see analysis report §F9).
+ */
+export async function fetchIngestRuns24h(pool: Pool): Promise<IngestRunCount[]> {
+  const { rows } = await pool.query<{
+    kind: string;
+    status: string;
+    count: string;
+  }>(
+    `SELECT kind, status, COUNT(*)::text AS count
+     FROM ingest_runs
+     WHERE started_at >= now() - INTERVAL '24 hours'
+       AND kind = ANY($1::text[])
+     GROUP BY kind, status
+     ORDER BY kind, status`,
+    [DIGEST_INGEST_KINDS as unknown as string[]]
+  );
+  return rows.map((r) => ({
+    kind: r.kind,
+    status: r.status,
+    count: Number.parseInt(r.count, 10),
+  }));
+}
+
+/**
+ * Render the digest body as plain text. Plain text (not HTML) keeps the
+ * surface small and rules out an entire class of email-rendering bugs;
+ * the operator audience is one person and Gmail's monospace fallback is
+ * legible enough.
+ *
+ * The 5-kinds enumeration is explicit — every kind in DIGEST_INGEST_KINDS
+ * appears, even when its count is zero. This makes the photos/descriptions
+ * absence legible (they are simply NOT in the list at all).
+ */
+export function renderDigestBody(data: DigestData, nowIso: string): string {
+  const lines: string[] = [];
+  lines.push(`bird-watch daily health digest — ${nowIso}`);
+  lines.push('');
+  lines.push('Coverage note: this digest reports on 5 of the 7 ingest kinds.');
+  lines.push('The `photos` and `descriptions` kinds do NOT yet write to the');
+  lines.push('ingest_runs table (analysis report §F9). Retrofit is tracked as a');
+  lines.push('follow-up at PR-2 merge time per Contract C4.');
+  lines.push('');
+  lines.push('=== Ingest runs (last 24h) ===');
+  for (const kind of DIGEST_INGEST_KINDS) {
+    const kindRows = data.ingestRuns24h.filter((r) => r.kind === kind);
+    if (kindRows.length === 0) {
+      lines.push(`  ${kind.padEnd(12)} no runs in last 24h`);
+      continue;
+    }
+    const parts = kindRows
+      .sort((a, b) => a.status.localeCompare(b.status))
+      .map((r) => `${r.count} ${r.status}`)
+      .join(' / ');
+    lines.push(`  ${kind.padEnd(12)} ${parts}`);
+  }
+  lines.push('');
+  lines.push('=== Read-API p95 latency (last 24h) ===');
+  lines.push(
+    data.readApiP95Ms === null
+      ? '  unavailable'
+      : `  ${data.readApiP95Ms.toFixed(0)} ms`
+  );
+  lines.push('');
+  lines.push('=== Cloud SQL CPU max (last 24h) ===');
+  lines.push(
+    data.cloudSqlCpuPct === null
+      ? '  unavailable'
+      : `  ${(data.cloudSqlCpuPct * 100).toFixed(1)} %`
+  );
+  lines.push('');
+  lines.push('=== Data freshness — meta_freshness_seconds p95 (last 24h) ===');
+  lines.push(
+    data.freshnessMaxSeconds === null
+      ? '  unavailable'
+      : `  ${data.freshnessMaxSeconds.toFixed(0)} s` +
+          ` (≈ ${(data.freshnessMaxSeconds / 60).toFixed(1)} min)`
+  );
+  lines.push('');
+  lines.push('=== Top 3 errors (last 24h) ===');
+  if (data.topErrors.length === 0) {
+    lines.push('  none');
+  } else {
+    for (const e of data.topErrors.slice(0, 3)) {
+      lines.push(`  [${e.count}] ${e.message}`);
+    }
+  }
+  lines.push('');
+  lines.push('Runbook: docs/runbooks/monitoring.md#digest');
+  return lines.join('\n');
+}
+
+/**
+ * Compose + send the daily digest. Returns the SendResult so the caller
+ * (cli.ts) can gate the Healthchecks.io heartbeat on delivery confirmation,
+ * not function success.
+ *
+ * Errors during composition (DB query failure, fetchMonitoringSignals
+ * throwing) propagate to the caller — those are not "delivery failed",
+ * they're function failed, and the caller treats them as such (no heartbeat
+ * ping, exit code 1).
+ */
+export async function runDigest(opts: RunDigestOptions): Promise<SendResult> {
+  const now = opts.now ? opts.now() : new Date();
+  const nowIso = now.toISOString();
+  const [ingestRuns24h, monitoring] = await Promise.all([
+    fetchIngestRuns24h(opts.pool),
+    opts.fetchMonitoringSignals(),
+  ]);
+  const data: DigestData = { ingestRuns24h, ...monitoring };
+  const body = renderDigestBody(data, nowIso);
+  const subject = `bird-watch daily health digest — ${nowIso.slice(0, 10)}`;
+  return opts.sendEmail(subject, body);
+}

--- a/services/ingestor/src/digest.ts
+++ b/services/ingestor/src/digest.ts
@@ -203,18 +203,44 @@ export function renderDigestBody(data: DigestData, nowIso: string): string {
  * (cli.ts) can gate the Healthchecks.io heartbeat on delivery confirmation,
  * not function success.
  *
- * Errors during composition (DB query failure, fetchMonitoringSignals
- * throwing) propagate to the caller — those are not "delivery failed",
- * they're function failed, and the caller treats them as such (no heartbeat
- * ping, exit code 1).
+ * Failure policy is asymmetric on purpose:
+ *
+ * - `fetchIngestRuns24h` is a HARD requirement. The per-kind ingest_runs
+ *   counts are the headline signal in the digest (analysis report §F9);
+ *   without them the digest is useless. A DB query failure propagates to
+ *   the caller, which treats it as function-failed (no heartbeat ping,
+ *   exit 1).
+ * - `fetchMonitoringSignals` is a SOFT requirement. It returns auxiliary
+ *   metrics (read-api p95, Cloud SQL CPU, freshness, top errors) that the
+ *   renderer already handles as `null` -> "unavailable". A monitoring-API
+ *   transient (rate limit, IAM blip, future-#642 client wiring drift) MUST
+ *   NOT take down the whole digest; the digest still ships with the headline
+ *   ingest_runs section plus null-fallback auxiliaries, and the operator sees
+ *   "unavailable" exactly as designed. Previously these were combined in a
+ *   single `Promise.all`, so a monitoring fetch rejection rejected the whole
+ *   `Promise.all` and the digest failed to send.
  */
 export async function runDigest(opts: RunDigestOptions): Promise<SendResult> {
   const now = opts.now ? opts.now() : new Date();
   const nowIso = now.toISOString();
-  const [ingestRuns24h, monitoring] = await Promise.all([
-    fetchIngestRuns24h(opts.pool),
-    opts.fetchMonitoringSignals(),
-  ]);
+  // Hard requirement — propagate on failure.
+  const ingestRuns24h = await fetchIngestRuns24h(opts.pool);
+  // Soft requirement — degrade to null placeholders so the digest still ships.
+  let monitoring: MonitoringSignals;
+  try {
+    monitoring = await opts.fetchMonitoringSignals();
+  } catch (err) {
+    console.warn(
+      'fetchMonitoringSignals failed; digest will mark monitoring signals unavailable',
+      err
+    );
+    monitoring = {
+      readApiP95Ms: null,
+      cloudSqlCpuPct: null,
+      freshnessMaxSeconds: null,
+      topErrors: [],
+    };
+  }
   const data: DigestData = { ingestRuns24h, ...monitoring };
   const body = renderDigestBody(data, nowIso);
   const subject = `bird-watch daily health digest — ${nowIso.slice(0, 10)}`;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler as Cloud Scheduler<br/>(0 9 * * * UTC)
    participant Job as Cloud Run Job<br/>bird-digest-daily
    participant DB as Postgres<br/>ingest_runs
    participant Mon as Cloud Monitoring<br/>(deferred — null until #642 wires client)
    participant SG as SendGrid<br/>/v3/mail/send
    participant Gmail as julian.kennon.d@gmail.com
    participant HC as Healthchecks.io<br/>bird-watch-digest

    Scheduler->>Job: runWithOverrides(args=["digest"])
    Job->>DB: SELECT kind,status,COUNT(*) FROM ingest_runs<br/>WHERE kind IN (5 kinds, photos/descriptions excluded — F9)
    Job->>Mon: (deferred — returns null signals)
    Job->>SG: POST /v3/mail/send (text/plain digest body)
    alt SendGrid 2xx (status delivered)
        SG->>Gmail: deliver
        Job->>HC: POST ping (heartbeat confirms delivery)
    else SendGrid 4xx OR network error (status failed)
        Job-->>Job: exit 1 (no ping — HC fires "missed" alert)
    else status queued (future delivery webhook)
        Job-->>Job: exit 0 (no ping yet — webhook caller decides)
    end
```

```mermaid
flowchart LR
    A["operator opens dashboard<br/>(#642)"] -.->|pull-mode only| B[Cloud Console]
    C["digest in inbox<br/>(this PR)"] -->|push-mode| D[Gmail]
    E["heartbeat miss<br/>(Healthchecks.io)"] -->|alarms| D
    style C fill:#dfd
    style E fill:#fdd
```

## Summary

- Daily 09:00 UTC Cloud Run Job composes a 5-signal health digest (per-kind `ingest_runs` counts, read-api p95, Cloud SQL CPU, data freshness, top 3 errors) and sends it via SendGrid to `julian.kennon.d@gmail.com`. Re-uses the existing ingestor container image via a new `digest` CLI kind.
- Heartbeat ping is gated on **delivery confirmation** (SendGrid 2xx) — not function success — per analysis report §F7. The `SendResult.status` discriminates `delivered` (heartbeat fires), `queued` (defer to a future webhook), and `failed` (exit 1, no ping, HC alarm fires).
- The digest enumerates **5 of 7** ingest kinds — `photos` and `descriptions` have no `ingest_runs` rows today (F9 coverage gap); the renderer makes the absence legible. Retrofit ticket is filed at PR-2 (#642) merge time per Contract C4.

## S0.2 spike result

Performed the 4-step procedure from the issue body:

1. `gcloud alpha --help | grep -iE "(mail|smtp|email|send)"` -> **no managed email/SMTP commands** in `gcloud alpha`.
2. `gcloud functions help | grep -iE "(email|smtp|mail)"` -> **no built-in email triggers** on Cloud Functions.
3. Cloud Monitoring notification channels include `email` but only for alert-policy delivery, not as a general-purpose application sender.
4. **Channel chosen: SendGrid free tier (100 emails/day; we send 1/day).**

Sender-authentication records required on `bird-maps.com` (populated out-of-band post-merge, see runbook):

| Record | Type | Value |
|---|---|---|
| `@` (apex) | TXT | `v=spf1 include:sendgrid.net ~all` |
| `s1._domainkey` | CNAME | `s1.domainkey.uXXXX.wlYYY.sendgrid.net` |
| `s2._domainkey` | CNAME | `s2.domainkey.uXXXX.wlYYY.sendgrid.net` |
| `_dmarc` | TXT | `v=DMARC1; p=none; rua=mailto:julian.kennon.d@gmail.com` |

API key secret: `bird-watch-sendgrid-api-key` (declared in `digest.tf`; value populated via `gcloud secrets versions add`).

## Sequencing

Ships in the same calendar week as #642 (the dashboard PR). #642's Mergify queue is blocked until this PR is open AND has at least one review (process gate, not data dependency — see analysis report §F.3).

No data dependency on PR-1 — the digest reads `ingest_runs` directly and (once wired post-merge) Cloud Monitoring metrics, not the new log-based metrics.

## Coverage note

The digest displays 5 of 7 ingest kinds: `recent`, `backfill`, `hotspots`, `taxonomy`, `prune`. The `photos` and `descriptions` kinds have zero `ingest_runs` rows today (analysis report §F9). Retrofit is tracked as a follow-up ticket filed at #642 merge time per Contract C4. The digest body enumerates the 5 covered kinds explicitly so the absence is legible — an operator reading "no runs in last 24h" for the 5 listed kinds will not be misled into thinking 7-of-7 coverage was achieved.

## Deferred monitoring signals

`fetchMonitoringSignals` returns `null` for `readApiP95Ms`, `cloudSqlCpuPct`, and `freshnessMaxSeconds`, and `[]` for `topErrors` in the v1 ship. The renderer handles `null` gracefully (renders `unavailable`). Wiring the real Cloud Monitoring + Cloud Logging clients is deferred to a follow-up because #642 (dashboard) also touches the same clients — consolidating reduces churn. The shipped digest still carries the highest-value signal (per-kind `ingest_runs` counts), which is the F9-visible piece.

## Closes

Refs #638 (epic). Closes #643.

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` passes — 165 tests across 19 files (3 new digest tests pass: render coverage, runDigest pass-through, heartbeat-gating contract).
- [x] `npm run build --workspace @bird-watch/ingestor` passes — clean tsc with `exactOptionalPropertyTypes: true`.
- [x] `npx knip` clean (no new findings; pre-existing prototype hint unrelated).
- [x] `terraform -chdir=infra/terraform fmt -check` exits 0.
- [x] `terraform -chdir=infra/terraform validate` exits 0.
- [ ] Post-Apply: `gcloud secrets versions add bird-watch-sendgrid-api-key ...` to populate API key.
- [ ] Post-Apply: `gcloud secrets versions add bird-watch-healthchecks-digest ...` to populate HC URL.
- [ ] Post-Apply: populate SPF/DKIM/DMARC DNS records on `bird-maps.com` per runbook table.
- [ ] Post-Apply: `gcloud run jobs execute bird-digest-daily --region=us-west1 --project=bird-maps-prod --wait` delivers a real email to `julian.kennon.d@gmail.com`.
- [ ] Post-Apply: Healthchecks.io heartbeat pings on a delivered send (verify in HC UI).
- [ ] Post-Apply: synthetic SPF/DKIM/DMARC misconfiguration verifies heartbeat does NOT fire (manual smoke test — temporarily break a DNS record, run digest, confirm Gmail rejects and HC stays silent).

## Plan reference

Out of plan — closes #643 directly. Parent epic #638 (monitoring dashboard) tracks the broader operator-stickiness work; see `docs/analyses/2026-05-18-monitoring-dashboard-issue-638/phase-4/analysis-report.md` §H Contract C3 for the implementation contract.

---

Generated with [Claude Code](https://claude.com/claude-code)
