### PR TITLE
chore(infra): fix dashboard_url output + narrow audit filter (closes #653)

### DIFF
--- a/docs/runbooks/monitoring.md
+++ b/docs/runbooks/monitoring.md
@@ -212,7 +212,7 @@ Smoke tests are deliberate, opt-in operator work — do not run them on autopilo
 
 ## Dashboard
 
-URL: `https://console.cloud.google.com/monitoring/dashboards/custom/<id>?project=bird-maps-prod` (the `dashboard_url` output from `terraform apply` shows the exact path).
+URL: `https://console.cloud.google.com/monitoring/dashboards/custom/a6aa8bcb-2849-4e8e-85ba-1ef38648947d?project=bird-maps-prod` (the `dashboard_url` output from `terraform apply` echoes this path).
 
 Single-pane operator view: open incidents, ingest health, read-api latency, Cloud SQL, system signals. Designed for un-paged triage — when an operator opens it during a routine check, they should resolve "is anything currently on fire", "did everything that was supposed to run, run", and "is anything trending toward unhealthy" in under 30 seconds. If they cannot, the dashboard is the wrong shape and we should re-cut it; the 30-day audit (below) is the falsifier.
 
@@ -241,9 +241,7 @@ Future refactors of `cli.ts:174` must preserve this shape. Field renames break t
 
 ### Audit hook (`monitoring.dashboards.get`)
 
-Data Access audit logs for `monitoring.googleapis.com` are enabled via `google_project_iam_audit_config.monitoring_data_read` (PR #642). The log-based metric `bird-watch-dashboard-opened` counts opens; the 30-day audit follow-up issue (filed at PR-2 merge time per Contract C4 of the analysis report) reviews engagement and decides whether the dashboard earns its place. At T+90d, the same audit kills the dashboard if quarterly opens ≤ 1.
-
-After the first Apply, narrow the metric filter to this dashboard by uncommenting the `protoPayload.resourceName=~"projects/.+/dashboards/<DASHBOARD_ID>"` clause in `monitoring.tf` (the dashboard ID isn't known until after Apply).
+Data Access audit logs for `monitoring.googleapis.com` are enabled via `google_project_iam_audit_config.monitoring_data_read` (PR #642). The log-based metric `bird-watch-dashboard-opened` counts opens against the specific dashboard ID `a6aa8bcb-2849-4e8e-85ba-1ef38648947d` (see the `resourceName` clause in `monitoring.tf`); the 30-day audit follow-up issue (filed at PR-2 merge time per Contract C4 of the analysis report) reviews engagement and decides whether the dashboard earns its place. At T+90d, the same audit kills the dashboard if quarterly opens ≤ 1.
 
 ## Digest
 

--- a/infra/terraform/monitoring-dashboard.tf
+++ b/infra/terraform/monitoring-dashboard.tf
@@ -324,5 +324,6 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
 }
 
 output "dashboard_url" {
-  value = "https://console.cloud.google.com/monitoring/dashboards/custom/${trimprefix(google_monitoring_dashboard.bird_watch_overview.id, "projects/${var.gcp_project_id}/dashboards/")}?project=${var.gcp_project_id}"
+  description = "Console URL for the bird-watch overview dashboard"
+  value       = "https://console.cloud.google.com/monitoring/dashboards/custom/${reverse(split("/", google_monitoring_dashboard.bird_watch_overview.id))[0]}?project=${var.gcp_project_id}"
 }

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -408,19 +408,17 @@ resource "google_logging_metric" "ingest_run_duration_seconds" {
 #
 # Counts `monitoring.dashboards.get` audit-log calls; powers the audit
 # follow-up that decides at T+30d whether the dashboard is being used (and
-# at T+90d whether to kill it if quarterly opens ≤ 1). The filter currently
-# matches dashboard opens project-wide — after the first Apply, narrow to
-# our specific dashboard ID by uncommenting the `resourceName=~...` clause
-# below (the dashboard ID is not known until after Apply).
+# at T+90d whether to kill it if quarterly opens ≤ 1). The resourceName
+# clause narrows the count to OUR dashboard only — project-wide audit calls
+# on other dashboards (alert-policy debugging, ad-hoc chart exploration) do
+# not inflate the stickiness signal.
 
 resource "google_logging_metric" "bird_watch_dashboard_opened" {
   name = "bird-watch-dashboard-opened"
   filter = join(" AND ", [
     "logName=~\"cloudaudit.googleapis.com\"",
     "protoPayload.methodName=\"monitoring.dashboards.get\"",
-    # Filter to OUR dashboard only; uncomment after first Apply once the
-    # dashboard ID is known:
-    # "protoPayload.resourceName=~\"projects/.+/dashboards/<DASHBOARD_ID>\"",
+    "protoPayload.resourceName=~\"projects/.+/dashboards/a6aa8bcb-2849-4e8e-85ba-1ef38648947d\"",
   ])
   metric_descriptor {
     metric_kind  = "DELTA"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[google_monitoring_dashboard.bird_watch_overview.id<br/>projects/752470000665/dashboards/UUID] --> B{output dashboard_url}
    B -->|"BEFORE: trimprefix(textual project_id)<br/>match fails → entire string echoed"| C[malformed /custom/projects/.../dashboards/UUID<br/>404 in Console]
    B -->|"AFTER: reverse(split('/'))[0]<br/>always picks last segment"| D[correct /custom/UUID<br/>opens dashboard]

    E[Cloud Audit log<br/>monitoring.dashboards.get on ANY dashboard] --> F{log-based metric<br/>bird_watch_dashboard_opened}
    F -->|"BEFORE: broad filter,<br/>counts every dashboard"| G[noisy stickiness signal]
    F -->|"AFTER: resourceName=~/dashboards/UUID"| H[counts only our dashboard]
```

## Summary

Two small follow-ups to epic #638, folded into one PR because both touch the same infra files.

- `dashboard_url` Terraform output was malformed (`trimprefix` against textual project ID, but GCP returns the resource name with numeric project ID) — fixed with `reverse(split("/", ...))[0]`, robust to either format.
- `bird_watch_dashboard_opened` log-based metric filter narrowed from project-wide to the specific dashboard ID `a6aa8bcb-2849-4e8e-85ba-1ef38648947d` now that the ID is known post-Apply (#653).
- `docs/runbooks/monitoring.md` Dashboard section updated to use the literal dashboard URL and the Audit-hook subsection reflects that the filter is now narrowed in HCL (no longer "after the first Apply, uncomment ...").

## Screenshots

N/A — not UI.

## Test plan

- [x] `terraform fmt -check` exits 0
- [x] `terraform validate` exits 0 (after `terraform init -backend=false`)
- [ ] CI green: test, lint, build, e2e

Post-Apply verification (orchestrator runs after merge):
- [ ] `terraform output dashboard_url` returns `https://console.cloud.google.com/monitoring/dashboards/custom/a6aa8bcb-2849-4e8e-85ba-1ef38648947d?project=bird-maps-prod`
- [ ] `terraform plan` shows: 1 to change (`google_logging_metric.bird_watch_dashboard_opened` filter narrowed); `dashboard_url` output value updates
- [ ] Open the dashboard once; query `gcloud monitoring metrics-descriptors describe logging.googleapis.com/user/bird-watch-dashboard-opened`; confirm metric still produces data and the count increments by 1

## Plan reference

Out of plan — follow-ups discovered after epic #638 deployed. Refs #638 (epic). Closes #653.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
