### PR TITLE
feat(analytics): wire Microsoft Clarity (prod-only, env-gated)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build frontend
         env:
           VITE_API_BASE_URL: https://api.bird-maps.com
+          VITE_CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
         run: npm run build -w @bird-watch/frontend
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,6 +7,8 @@
 # VITE_REGION_CODE=US-AZ
 
 # Microsoft Clarity project ID (https://clarity.microsoft.com).
-# Set to a non-empty value only in production deploys; dev/test builds
-# never load Clarity because `import.meta.env.PROD` is false.
+# Inject at CI build time only — do NOT put a real project ID in
+# `.env.local`. `vite preview` and `npm run build` run in PROD mode, so a
+# local build with the prod ID set would emit real sessions from
+# localhost to the prod Clarity project.
 # VITE_CLARITY_PROJECT_ID=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,8 @@
 # `frontend/src/config/region.ts`. Default is `US-AZ` ("Arizona").
 # Set to `US` for the national/USA flip; unknown codes pass through as-is.
 # VITE_REGION_CODE=US-AZ
+
+# Microsoft Clarity project ID (https://clarity.microsoft.com).
+# Set to a non-empty value only in production deploys; dev/test builds
+# never load Clarity because `import.meta.env.PROD` is false.
+# VITE_CLARITY_PROJECT_ID=

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@bird-watch/shared-types": "*",
+    "@microsoft/clarity": "^1.0.2",
     "maplibre-gl": "^5.24.0",
     "posthog-js": "^1.372.6",
     "react": "^18.2.0",

--- a/frontend/src/clarity.test.ts
+++ b/frontend/src/clarity.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for the clarity module. Verifies the env-gating contract from
+ * issue #657:
+ *
+ *   - `Clarity.init` is NEVER called when `VITE_CLARITY_PROJECT_ID` is
+ *     unset/empty.
+ *   - `Clarity.init` is NEVER called in non-production builds
+ *     (`import.meta.env.PROD === false`).
+ *   - `Clarity.init` IS called exactly once with the project ID when both
+ *     conditions hold.
+ *
+ * The module is imported dynamically per-test so each test sees a freshly
+ * evaluated module body — top-level `import.meta.env` reads happen at
+ * module evaluation, so env stubs must be in place before the dynamic
+ * import.
+ */
+
+const initMock = vi.fn();
+
+vi.mock('@microsoft/clarity', () => ({
+  default: { init: initMock },
+}));
+
+describe('clarity module', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does NOT call Clarity.init when VITE_CLARITY_PROJECT_ID is unset', async () => {
+    vi.stubEnv('PROD', true);
+    vi.stubEnv('VITE_CLARITY_PROJECT_ID', '');
+    await import('./clarity.js');
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call Clarity.init in non-production builds', async () => {
+    vi.stubEnv('PROD', false);
+    vi.stubEnv('VITE_CLARITY_PROJECT_ID', 'abc123xyz');
+    await import('./clarity.js');
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  it('calls Clarity.init with the project ID in prod when key is set', async () => {
+    vi.stubEnv('PROD', true);
+    vi.stubEnv('VITE_CLARITY_PROJECT_ID', 'abc123xyz');
+    await import('./clarity.js');
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock).toHaveBeenCalledWith('abc123xyz');
+  });
+});

--- a/frontend/src/clarity.ts
+++ b/frontend/src/clarity.ts
@@ -1,0 +1,34 @@
+import Clarity from '@microsoft/clarity';
+
+/**
+ * Microsoft Clarity init (issue #657).
+ *
+ * Reads `VITE_CLARITY_PROJECT_ID` at module-evaluation time (which happens
+ * once during app startup via the side-effect import in `main.tsx`).
+ *
+ * `Clarity.init` is called only when:
+ *   - `import.meta.env.PROD` is true (production build only — dev/test
+ *     never load Clarity; otherwise the SDK injects a `<script>` that
+ *     races HMR and spams the Clarity project with junk sessions).
+ *   - `VITE_CLARITY_PROJECT_ID` is a non-empty string.
+ *
+ * The SDK is idempotent — its injector checks for an existing
+ * `<script id="clarity-script">` before inserting, so this is safe to
+ * call exactly once at startup.
+ *
+ * No SPA route tracking is wired: bird-maps.com uses query-string view
+ * state (no react-router), and Clarity's auto-SPA detection captures
+ * virtual navigations without manual `Clarity.identify()` calls.
+ *
+ * No masking config: Clarity's default-mask is ON, which is correct for
+ * bird-maps.com (public bird sighting data; no PII rendered).
+ *
+ * No consent gate: bird-watch has no consent banner today (matches the
+ * existing PostHog wiring). EEA traffic is near-zero given the current
+ * US-AZ region lock — tracked for revisit in #658.
+ */
+const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID ?? '';
+
+if (import.meta.env.PROD && projectId) {
+  Clarity.init(projectId);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,11 @@ import { App } from './App.js';
 // key is empty, the import is a strict no-op — posthog.init is never
 // called and no console warnings are emitted (issue #357 task 2).
 import './analytics.js';
+// Importing for the side effect: `clarity.ts` reads `VITE_CLARITY_PROJECT_ID`
+// and (in production builds only) calls `Clarity.init` once at app
+// startup. When the env var is empty OR the build is non-production, the
+// import is a strict no-op (issue #657).
+import './clarity.js';
 import './styles/tokens.css';
 import './styles.css';
 import './styles/motion.css';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_CLARITY_PROJECT_ID?: string;
   readonly VITE_POSTHOG_KEY?: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@bird-watch/shared-types": "*",
+        "@microsoft/clarity": "^1.0.2",
         "maplibre-gl": "^5.24.0",
         "posthog-js": "^1.372.6",
         "react": "^18.2.0",
@@ -1952,6 +1953,12 @@
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.6",


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Build["CI build (deploy-frontend.yml)"]
      Secret["secrets.CLARITY_PROJECT_ID"] -->|env: VITE_CLARITY_PROJECT_ID| Vite["vite build"]
      Vite -->|bakes into bundle| Bundle["dist/assets/*.js"]
    end

    subgraph Runtime["Browser (production only)"]
      MainTsx["main.tsx side-effect import"] --> Clarity["clarity.ts"]
      Clarity -->|"if import.meta.env.PROD && projectId"| Init["Clarity.init(projectId)"]
      Init --> Inject["SDK injects <script id='clarity-script'>"]
      Inject --> ClarityMs["clarity.ms (session replay + heatmaps)"]
    end

    Bundle --> MainTsx
```

Dev/test builds skip the `if` branch entirely (`import.meta.env.PROD === false`), so `Clarity.init` is never called and no `<script>` is injected.

## Summary

- Adds Microsoft Clarity (session replay + heatmaps) via the official `@microsoft/clarity` SDK, mirroring the existing `frontend/src/analytics.ts` PostHog pattern (env-gated, no-op when key empty).
- Double-gated: `import.meta.env.PROD === true` AND `VITE_CLARITY_PROJECT_ID` non-empty. Dev/test builds never load Clarity (avoids HMR races + junk sessions to the Clarity project).
- Build secret `CLARITY_PROJECT_ID` is plumbed into `deploy-frontend.yml` at build time; will be set out-of-band on the repo by the maintainer. Unset secret is safe — Vite bakes an empty string and the `if` guard short-circuits.

## Screenshots

N/A — analytics wiring with no visible UI surface (mirrors `frontend/src/analytics.ts` pattern; no rendered component, no DOM change in non-prod builds).

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, no className added
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`) — N/A — not UI

## Test plan

- [x] `npm test` — green (904 frontend + 168 db-client + 65 read-api + ingestor suites; new `clarity.test.ts` adds 3 passing tests covering empty key, dev mode, and prod-with-key paths)
- [x] New unit tests added — `frontend/src/clarity.test.ts` mirrors `analytics.test.ts` pattern (dynamic import + `vi.mock` + `vi.stubEnv`); confirmed RED → GREEN per TDD cycle
- [x] `npm run lint` — no-op (no workspace defines a lint script)
- [x] `npm run build` — clean production build (113 modules transformed, no new warnings beyond the pre-existing maplibre-gl chunk-size note)
- [x] `npm run test:e2e` — all three Playwright projects green:
      - `dev-server` — 231 passed, 13 skipped
      - `preview-build` — 1 passed
      - `coarse-pointer` — 1 passed, 1 skipped
- [x] Verified no `clarity.ms` requests during e2e runs (Clarity gated out in dev mode, confirmed by inspecting `.playwright-out/`)
- [x] (UI only) N/A — analytics wiring with no rendered surface (per CLAUDE.md § Testing's `N/A — not UI` carve-out for test-only / type-only / non-UI frontend changes)

## Plan reference

Out of plan — directly closes #657. Reference implementation pattern on sibling repo: `julianken/detached-node` PRs #406 + #408 (Next.js inline snippet; here we use the official SDK to mirror the established `frontend/src/analytics.ts` PostHog wiring).

Closes #657.

Out of scope / follow-ups: cookie consent banner + privacy policy disclosure deferred to #658 (Microsoft enforcement of consent mode for EEA/UK/CH started 2025-10-31; bird-maps.com is currently US-AZ region-locked, so practical EEA traffic is near-zero — same posture as the existing PostHog wiring).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)