### PR TITLE
fix(infra): uptime check probes /health instead of nonexistent /api/regions

### DIFF
--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -263,18 +263,18 @@ resource "google_monitoring_alert_policy" "container_crash" {
 
 # ── Uptime check on the public read-api ─────────────────────────────────
 #
-# Synthetic monitoring: GCP regions ping /api/regions every 60s. Alert
+# Synthetic monitoring: GCP regions ping /health every 60s. Alert
 # fires if regions fail for consecutive checks. Catches DNS / TLS /
 # Cloud Run cold-fail issues that the request_count metric can't see
 # (because by definition there are no requests landing).
 
 resource "google_monitoring_uptime_check_config" "read_api" {
-  display_name = "read-api /api/regions"
+  display_name = "read-api /health"
   timeout      = "10s"
   period       = "60s"
 
   http_check {
-    path           = "/api/regions"
+    path           = "/health"
     port           = 443
     use_ssl        = true
     validate_ssl   = true


### PR DESCRIPTION
## Summary

The read-api uptime check was probing `/api/regions` — a path the Hono app never registered. Every probe returned 404; 6 GCP regions × 1 probe/min = ~360 404s/hour for 29 days since first ship on 2026-04-19. Real user traffic is unaffected.

## Closes

Refs #638. The bird-watch overview dashboard (shipped via #645) surfaced this as a "4xx storm" — diagnosed at `docs/analyses/2026-05-18-read-api-4xx-storm/diagnosis.md`.

## Implementation

- `infra/terraform/monitoring.tf` — single line: `path = "/api/regions"` → `path = "/health"`. `/health` is registered at `services/read-api/src/app.ts:78`.

## Test plan

- [ ] `terraform fmt -check` exits 0
- [ ] `terraform validate` exits 0
- [ ] `terraform plan` shows: 1 to change (`google_monitoring_uptime_check_config.read_api`), 0 to add / destroy

Post-Apply:
- [ ] Next uptime check cycle (~1 min) shows `check_passed=true`
- [ ] Dashboard W11 ("Read-API uptime — failing regions") drops to 0
- [ ] Dashboard W1 shifts from ~100% 4xx to ~100% 2xx for synthetic probes

## Separate critical finding

The notification channel for ALL alerts (S1–S5 + Uptime) is **UNVERIFIED**. Audit log confirms no `SendNotificationChannelVerificationCode` was ever issued. Result: 30+ hours of all alerts firing into a black hole. Operator must re-verify the channel via GCP Console → Monitoring → Notification Channels → Edit → Send Verification. Out of scope for this PR — flagging here for visibility.

## Screenshots

N/A — not UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
