### PR TITLE
chore(frontend): remove Feed view — tab, close-handler redirect, skip-link

### DIFF
--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -43,58 +43,12 @@ test.describe('Path A happy path', () => {
     await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 10_000 });
   });
 
-  test('feed surface loads when navigating to ?view=feed', async ({ page }) => {
-    const app = new AppPage(page);
-    await app.goto('view=feed');
-    await app.waitForAppReady();
-
-    // At least one observation row is present. The seeded dev DB has 11
-    // observations, and `.feed-row` is set on <a> inside each
-    // ObservationFeedRow — see components/ObservationFeedRow.tsx.
-    await expect(page.locator('.feed-row').first()).toBeVisible({ timeout: 10_000 });
-    const rowCount = await page.locator('.feed-row').count();
-    expect(rowCount).toBeGreaterThanOrEqual(1);
-
-    // Feed tab is the selected SurfaceNav item. The accessible name is
-    // "Feed view" to avoid collision with the FiltersBar labels.
-    const feedTab = page.getByRole('tab', { name: 'Feed view' });
-    await expect(feedTab).toHaveAttribute('aria-selected', 'true');
-  });
-
-  test('filters narrow the feed', async ({ page }) => {
-    const app = new AppPage(page);
-    await app.goto('view=feed');
-    await app.waitForAppReady();
-
-    await expect(page.locator('.feed-row').first()).toBeVisible({ timeout: 10_000 });
-    const baselineCount = await page.locator('.feed-row').count();
-
-    // Phase 3: FiltersBar is inside a panel triggered from AppHeader.
-    await app.openFilters();
-    await app.filters.toggleNotable(true);
-    await expect
-      .poll(() => app.getUrlParams().get('notable'), { timeout: 5_000 })
-      .toBe('true');
-    // Wait for data refetch + re-render before measuring again.
-    await app.waitForAppReady();
-
-    const filteredCount = await page.locator('.feed-row').count();
-
-    // Expected: filteredCount < baselineCount. Log & continue on equality
-    // so an all-notable seed does not flake this test — the narrow-by-
-    // filter contract is asserted by the URL write above and by
-    // frontend/e2e/filters.spec.ts.
-    if (filteredCount === baselineCount) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[happy-path] notable filter kept all ${baselineCount} rows — ` +
-          `fixture is all-notable, asserting filteredCount <= baselineCount only.`,
-      );
-      expect(filteredCount).toBeLessThanOrEqual(baselineCount);
-    } else {
-      expect(filteredCount).toBeLessThan(baselineCount);
-    }
-  });
+  // Issue #662: Feed removed as a user-visible surface. The legacy
+  // ?view=feed URL handling is preserved (so old bookmarks still load),
+  // but the Feed tab is gone from the header and there is no longer a
+  // tab to assert as selected. The feed-row click flow is still covered
+  // by the "feed row click opens detail surface" test below, which uses
+  // ?view=feed to reach the dead-code feed branch.
 
   test('species deep link cold-loads to search surface with filter active', async ({ page }) => {
     const app = new AppPage(page);
@@ -126,11 +80,10 @@ test.describe('Path A happy path', () => {
     // Phase 4: detail surface renders in a dialog/sheet outside <main>.
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
 
-    // No SurfaceNav tab is selected (detail is nav-hidden).
-    const feedTab = page.getByRole('tab', { name: 'Feed view' });
+    // No SurfaceNav tab is selected (detail is nav-hidden). Feed tab
+    // removed in #662.
     const speciesTab = page.getByRole('tab', { name: 'Species view' });
     const mapTab = page.getByRole('tab', { name: 'Map view' });
-    await expect(feedTab).toHaveAttribute('aria-selected', 'false');
     await expect(speciesTab).toHaveAttribute('aria-selected', 'false');
     await expect(mapTab).toHaveAttribute('aria-selected', 'false');
   });

--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -264,18 +264,18 @@ test('cross-surface stale-bbox clear: detail→feed→detail leaves no bbox', as
   await closeBtn.waitFor({ state: 'visible', timeout: 10_000 });
   await closeBtn.click();
 
-  // After close, the URL clears `?view=detail` automatically (onClose flips
-  // to feed view per App.tsx onCloseDetail). NOTE: onCloseDetail does NOT
-  // clear bbox (it only sets view:'feed', detail:null) — so bbox is still
-  // present in the URL at this point. Assert view=detail is gone but DO NOT
-  // assert bbox is gone yet (it will be tested after the feed-row click below).
+  // After close, the URL clears `?view=detail` automatically (onClose
+  // returns to map per App.tsx onCloseDetail, #662). bbox is preserved
+  // — it is only cleared by the subsequent feed-row onSelectSpecies()
+  // call without bbox.
   await expect(page).not.toHaveURL(/[?&]view=detail/, { timeout: 5_000 });
 
-  // Navigate to feed via the tab bar (may be a no-op if onCloseDetail already
-  // landed us on feed view, but clicking an already-selected tab is harmless).
-  const feedTab = page.getByRole('tab', { name: 'Feed view' });
-  await feedTab.waitFor({ state: 'visible', timeout: 10_000 });
-  await feedTab.click();
+  // Issue #662: the Feed tab no longer exists in the header. Navigate
+  // directly to the legacy feed URL to reach the dead-code feed branch
+  // (preserved for bookmark compat per the same issue) so we can click
+  // a feed row.
+  await page.goto('/?view=feed');
+  await page.waitForLoadState('domcontentloaded');
 
   // Wait for feed surface to load and show at least one row.
   const feedRow = page.locator('.feed-row').first();

--- a/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
+++ b/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
@@ -3,29 +3,20 @@ import { AppPage } from './pages/app-page.js';
 import type { Observation } from '@bird-watch/shared-types';
 
 /**
- * Issues #247 (skip-link + hit-target overlay) narrowed by #277 (Spider v2).
+ * Hit-target overlay test (was issue #247 + #277).
  *
- * Originally map-spiderfy.spec.ts. Spider v2 (issue #277) removed the
- * click-driven Escape handler from MapCanvas.tsx (Task 5) and replaced
- * click-spiderfy with the auto-spider always-on fan. The Escape test
- * (formerly test 4) was deleted; its contract is now dead code.
+ * Issue #662 removed the Feed view as a user-visible surface, which made
+ * the "Skip to species list" skip-link (and its three e2e tests) dead
+ * code — there is no longer a Feed landmark to skip to. The MapSurface
+ * keyboard bypass is now covered by the "Explore map markers" skip-link
+ * (Phase 1, #558), exercised in map-cell-popover.spec.ts.
  *
- * Tests preserved here:
- *   1. Skip-link reachable via Tab (desktop 1440x900)
- *   2. Skip-link preserves filter state on view switch
- *   3. Skip-link reachable on mobile (390x844)
- *   4. (was test 5) Hit-target overlay layer mounts when map renders
- *
- * The click-driven spiderfy assertions from the original spec are now
- * covered by Tasks 3–5's unit tests (MapCanvas.test.tsx, stack-fanout.test.ts)
- * and the new map-stack-fanout.spec.ts e2e spec.
+ * The hit-target overlay test below was unrelated to Feed and is kept.
  */
 
 /**
  * Two observations near Sweetwater Wetlands — enough to satisfy the non-empty
- * stub requirement and verify the hit-layer wraps multiple buttons. The
- * 6-observation cluster fixture was load-bearing only for the deleted Escape
- * test (former test 4, removed in Spider v2 Task 5).
+ * stub requirement and verify the hit-layer wraps multiple buttons.
  */
 function clusterableObs(): Observation[] {
   return [
@@ -60,125 +51,7 @@ function clusterableObs(): Observation[] {
   ];
 }
 
-test.describe('Map skip-link + hit-target overlay (#247, #277)', () => {
-  test('skip-link is visually hidden but reachable via Tab and routes to feed (1440x900)', async ({
-    page,
-    apiStub,
-  }) => {
-    test.setTimeout(60_000);
-    await apiStub.stubEmpty();
-    await apiStub.stubObservations(clusterableObs());
-    await page.setViewportSize({ width: 1440, height: 900 });
-    const app = new AppPage(page);
-    await app.goto('view=map');
-    await app.waitForAppReady();
-
-    // The skip-link should be in the DOM but visually hidden until focused.
-    // It is a <button> (NOT an <a>) — App.tsx mounts surfaces mutually-
-    // exclusive so anchor-based navigation doesn't switch view state.
-    const skipLink = page.getByRole('button', { name: /Skip to species list/i });
-    await expect(skipLink).toHaveCount(1);
-    expect(await skipLink.evaluate((el) => el.tagName)).toBe('BUTTON');
-
-    // Tab from a non-skip-link starting point. Body→Tab moves to the
-    // first focusable element; depending on FiltersBar tab order the
-    // skip-link may not be first — but it MUST be reachable. We tab a
-    // bounded number of times and assert focus eventually lands on it.
-    await page.locator('body').focus();
-    let focused = false;
-    for (let i = 0; i < 30; i += 1) {
-      await page.keyboard.press('Tab');
-      const isSkip = await page.evaluate(() => {
-        const el = document.activeElement as HTMLElement | null;
-        return Boolean(el?.matches('.skip-link'));
-      });
-      if (isSkip) {
-        focused = true;
-        break;
-      }
-    }
-    expect(focused, 'Tab must reach the skip-link').toBe(true);
-
-    // Activate the link via keyboard (Enter == native button activation).
-    await page.keyboard.press('Enter');
-
-    // URL should switch to view=feed; the previous map URL parameters
-    // (notable / since / etc.) are preserved by the partial-merge
-    // semantics of useUrlState.set.
-    //
-    // Phase 0: DEFAULTS.view is now 'map', so switching to 'feed' IS a
-    // non-default value and writeUrl WILL emit ?view=feed in the URL.
-    await expect.poll(() => app.getUrlParams().get('view'), {
-      timeout: 5_000,
-    }).toBe('feed');
-    await expect(
-      page.getByRole('tab', { name: 'Feed view' }),
-    ).toHaveAttribute('aria-selected', 'true');
-
-    // The Feed surface's <ol class="feed"> landmark is now focused so
-    // sighted-keyboard users see a clear focus jump. The setTimeout(_, 0)
-    // in App.tsx defers focus past the React commit; poll briefly for it.
-    await expect.poll(async () =>
-      page.evaluate(() => {
-        const el = document.activeElement as HTMLElement | null;
-        return el?.tagName ?? '';
-      }), { timeout: 2_000 }).toBe('OL');
-  });
-
-  test('skip-link preserves filter state on view switch (1440x900)', async ({
-    page,
-    apiStub,
-  }) => {
-    await apiStub.stubEmpty();
-    await apiStub.stubObservations(clusterableObs());
-    await page.setViewportSize({ width: 1440, height: 900 });
-    const app = new AppPage(page);
-    await app.goto('view=map&notable=true&since=7d');
-    await app.waitForAppReady();
-
-    const skipLink = page.getByRole('button', { name: /Skip to species list/i });
-    await skipLink.focus();
-    await page.keyboard.press('Enter');
-
-    // After view switch, the Feed tab is selected and ?notable=true /
-    // ?since=7d must still be set. (?view=feed is omitted from the URL
-    // because 'feed' is the default for that param — see writeUrl in
-    // url-state.ts.)
-    await expect(
-      page.getByRole('tab', { name: 'Feed view' }),
-    ).toHaveAttribute('aria-selected', 'true', { timeout: 5_000 });
-    await expect.poll(() => app.getUrlParams().get('notable'), {
-      timeout: 5_000,
-    }).toBe('true');
-    expect(app.getUrlParams().get('since')).toBe('7d');
-  });
-
-  test('mobile viewport (390x844): skip-link still reachable + routes to feed', async ({
-    page,
-    apiStub,
-  }) => {
-    await apiStub.stubEmpty();
-    await apiStub.stubObservations(clusterableObs());
-    await page.setViewportSize({ width: 390, height: 844 });
-    const app = new AppPage(page);
-    await app.goto('view=map');
-    await app.waitForAppReady();
-
-    const skipLink = page.getByRole('button', { name: /Skip to species list/i });
-    await expect(skipLink).toHaveCount(1);
-
-    // Activate via focus + Enter (the keyboard path; visual click on a
-    // visually-hidden element is brittle in Playwright — element renders
-    // as a 1×1 clipped box until focus reveals it). The skip-link is by
-    // design only ever activated by keyboard users (mouse users don't
-    // see it), so the keyboard path is the right thing to assert.
-    await skipLink.focus();
-    await page.keyboard.press('Enter');
-    await expect(
-      page.getByRole('tab', { name: 'Feed view' }),
-    ).toHaveAttribute('aria-selected', 'true', { timeout: 5_000 });
-  });
-
+test.describe('Map hit-target overlay (#247, #277)', () => {
   test('hit-target overlay layer mounts when map renders (1440x900)', async ({
     page,
     apiStub,

--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -136,16 +136,16 @@ test.describe('MOB-4 — AppHeader buttons ≥ 44×44pt', () => {
     expect(box!.width, 'Attribution button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 
-  test('Feed tab button is ≥ 44px tall', async ({ page, apiStub }) => {
+  test('Species tab button is ≥ 44px tall (Feed tab removed in #662)', async ({ page, apiStub }) => {
     await apiStub.stubEmpty();
     const app = new AppPage(page);
-    await app.goto('view=feed');
+    await app.goto('view=species');
     await app.waitForAppReady();
 
-    const tab = page.getByRole('tab', { name: 'Feed view' });
+    const tab = page.getByRole('tab', { name: 'Species view' });
     const box = await tab.boundingBox();
-    expect(box, 'Feed tab bounding box must exist').not.toBeNull();
-    expect(box!.height, 'Feed tab height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(box, 'Species tab bounding box must exist').not.toBeNull();
+    expect(box!.height, 'Species tab height must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 
   // Regression guard: round-1 fix used font-size:0 which produced empty

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -7,7 +7,7 @@ export class AppPage {
   readonly errorScreen: Locator;
   /** Persistent header chrome — wordmark, tablist, action buttons. */
   readonly appHeader: Locator;
-  /** The three surface tabs inside appHeader (Map, Species, Feed). */
+  /** Surface tabs inside appHeader (Species, Map). Feed removed in #662. */
   readonly appHeaderTabs: Locator;
   /** Filters trigger button in appHeader (badge shows active-filter count). */
   readonly filtersTrigger: Locator;
@@ -51,9 +51,9 @@ export class AppPage {
     }
   }
 
-  /** Navigate to a surface by tab name. */
-  async selectView(view: 'feed' | 'species' | 'map'): Promise<void> {
-    const labelMap = { feed: 'Feed view', species: 'Species view', map: 'Map view' };
+  /** Navigate to a surface by tab name. Feed removed from header in #662. */
+  async selectView(view: 'species' | 'map'): Promise<void> {
+    const labelMap = { species: 'Species view', map: 'Map view' };
     await this.appHeader.getByRole('tab', { name: labelMap[view] }).click();
   }
 

--- a/frontend/e2e/sheet-snap.spec.ts
+++ b/frontend/e2e/sheet-snap.spec.ts
@@ -59,8 +59,10 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     await page.mouse.move(startX, startY + 200, { steps: 20 });
     await page.mouse.up();
 
-    // URL must flip away from detail
-    await expect(page).toHaveURL(/view=feed/);
+    // URL must flip away from detail. Issue #662: onCloseDetail returns
+    // to the Map surface ('map' is DEFAULTS.view so writeUrl omits ?view).
+    await expect(page).not.toHaveURL(/view=detail/);
+    await expect(page).not.toHaveURL(/detail=/);
     await expect(page.locator('[data-testid=species-detail-sheet]')).toHaveCount(0);
   });
 });

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -80,15 +80,16 @@ test.describe('species detail surface (#151)', () => {
     // species= should be set (filter narrowing).
     await expect.poll(() => app.getUrlParams().get('species'), { timeout: 5_000 }).toBe('vermfly');
 
-    // detail= should NOT be set. View should stay on feed.
-    // Phase 0: DEFAULTS.view is now 'map', so 'feed' is a non-default view
-    // and writeUrl WILL emit ?view=feed in the URL.
+    // detail= should NOT be set. View should stay on the feed dead-code
+    // branch (preserved per #662 for legacy bookmark compatibility).
     expect(app.getUrlParams().get('detail')).toBeNull();
     expect(app.getUrlParams().get('view')).toBe('feed');
 
-    // Feed tab remains selected.
-    const feedTab = page.getByRole('tab', { name: 'Feed view' });
-    await expect(feedTab).toHaveAttribute('aria-selected', 'true');
+    // Feed tab no longer exists in the header (issue #662), but the
+    // ?view=feed URL state is preserved and no other tab is selected.
+    await expect(page.getByRole('tab', { name: 'Feed view' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveAttribute('aria-selected', 'false');
+    await expect(page.getByRole('tab', { name: 'Species view' })).toHaveAttribute('aria-selected', 'false');
   });
 
   test('network failure shows inline error on detail surface', async ({ page, apiStub }) => {
@@ -99,7 +100,7 @@ test.describe('species detail surface (#151)', () => {
     await expect(page.getByText('Could not load species details')).toBeVisible({ timeout: 10_000 });
   });
 
-  test('ESC closes the detail dialog/sheet and returns to feed', async ({ page, apiStub }) => {
+  test('ESC closes the detail dialog/sheet and returns to map (#662)', async ({ page, apiStub }) => {
     await apiStub.stubEmpty();
     await apiStub.stubSpecies('vermfly', VERMFLY);
     const app = new AppPage(page);
@@ -111,11 +112,14 @@ test.describe('species detail surface (#151)', () => {
     // the bottom-sheet on mobile (at full snap) or dismisses it at peek/half.
     await page.keyboard.press('Escape');
 
-    // After ESC from a fresh open (peek state on mobile, open on desktop),
-    // view flips back to feed and the detail surface is gone.
+    // Issue #662: onCloseDetail now returns to the Map surface (the
+    // default route) rather than Feed, which was removed from the header.
+    // 'map' is the DEFAULTS.view value so writeUrl omits ?view=map from
+    // the URL — assert by reading url-state via the absence of the param.
     await expect.poll(() => new URL(page.url()).searchParams.get('view'), { timeout: 5_000 })
-      .toBe('feed');
+      .toBeNull();
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveAttribute('aria-selected', 'true');
   });
 
   test('detail surface has no legacy complementary landmark or overlay', async ({ page, apiStub }) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -286,38 +286,14 @@ export function App() {
     set({ bbox: null });
   }, [set]);
 
-  // Close callback for detail modal/sheet wrappers — flips back to feed view.
+  // Close callback for detail modal/sheet wrappers — returns to the Map
+  // surface (the default route). Issue #662 removed Feed as a user-visible
+  // surface, so the previous `view: 'feed'` redirect would dump users onto
+  // a hidden surface; Map is now the consistent landing point.
   const onCloseDetail = useCallback(
-    () => set({ view: 'feed', detail: null }),
+    () => set({ view: 'map', detail: null }),
     [set],
   );
-
-  /**
-   * Skip-link handler (issue #247): switch to the feed view AND move
-   * keyboard focus to the FeedSurface `<ol class="feed">` landmark so
-   * (a) sighted-keyboard users see a clear focus jump, and (b) screen-
-   * reader users get a landmark announcement. The setTimeout(_, 0)
-   * defers the focus call past the next React commit, when the FeedSurface
-   * `<ol>` has actually mounted. Using `requestAnimationFrame` would also
-   * work; a 0ms timeout is the more portable signal across React 18 +
-   * jsdom test environments.
-   */
-  const onSkipToFeed = useCallback(() => {
-    set({ view: 'feed' });
-    setTimeout(() => {
-      const feedList = document.querySelector(
-        'ol.feed[aria-label="Observations"]',
-      );
-      if (feedList instanceof HTMLElement) {
-        // Lists are not focusable by default — set tabIndex first so the
-        // browser actually moves focus and emits a focus event.
-        if (!feedList.hasAttribute('tabindex')) {
-          feedList.setAttribute('tabindex', '-1');
-        }
-        feedList.focus({ preventScroll: false });
-      }
-    }, 0);
-  }, [set]);
 
   // Log raw error details for debugging; show only a friendly message in UI.
   useEffect(() => {
@@ -413,7 +389,6 @@ export function App() {
             silhouettes={silhouettes}
             familyCode={state.familyCode}
             onFamilyToggle={onFamilyToggle}
-            onSkipToFeed={onSkipToFeed}
             onSelectSpecies={onSelectSpecies}
             onViewportChange={onViewportChange}
             onExploreMapMarkers={() => {

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -19,11 +19,16 @@ describe('<AppHeader>', () => {
     expect(link).toHaveTextContent(/Bird Maps · Arizona/);
   });
 
-  it('renders three tabs in stable order: Feed, Species, Map', () => {
+  it('renders two tabs in stable order: Species, Map (Feed removed per #662)', () => {
     render(<AppHeader {...baseProps} />);
     const tablist = screen.getByRole('tablist', { name: /Surface/i });
     const tabs = within(tablist).getAllByRole('tab');
-    expect(tabs.map(t => t.textContent)).toEqual(['Feed', 'Species', 'Map']);
+    expect(tabs.map(t => t.textContent)).toEqual(['Species', 'Map']);
+  });
+
+  it('does not render a Feed tab (issue #662)', () => {
+    render(<AppHeader {...baseProps} />);
+    expect(screen.queryByRole('tab', { name: /Feed view/i })).toBeNull();
   });
 
   it('marks the active tab via aria-selected and is-active class', () => {
@@ -36,17 +41,17 @@ describe('<AppHeader>', () => {
   it('clicking an inactive tab calls onSelectView with that view', async () => {
     const onSelectView = vi.fn();
     render(<AppHeader {...baseProps} onSelectView={onSelectView} activeView="map" />);
-    await userEvent.click(screen.getByRole('tab', { name: /Feed view/i }));
-    expect(onSelectView).toHaveBeenCalledWith('feed');
+    await userEvent.click(screen.getByRole('tab', { name: /Species view/i }));
+    expect(onSelectView).toHaveBeenCalledWith('species');
   });
 
   it('ArrowRight on a focused tab moves focus + activation to the next tab', async () => {
     const onSelectView = vi.fn();
-    render(<AppHeader {...baseProps} onSelectView={onSelectView} activeView="feed" />);
-    const feedTab = screen.getByRole('tab', { name: /Feed view/i });
-    feedTab.focus();
+    render(<AppHeader {...baseProps} onSelectView={onSelectView} activeView="species" />);
+    const speciesTab = screen.getByRole('tab', { name: /Species view/i });
+    speciesTab.focus();
     await userEvent.keyboard('{ArrowRight}');
-    expect(onSelectView).toHaveBeenCalledWith('species');
+    expect(onSelectView).toHaveBeenCalledWith('map');
   });
 
   it('renders Filters trigger without badge when filterCount === 0', () => {

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -24,7 +24,6 @@ interface TabDef {
 }
 
 const TABS: readonly TabDef[] = [
-  { value: 'feed', label: 'Feed', accessibleName: 'Feed view' },
   { value: 'species', label: 'Species', accessibleName: 'Species view' },
   { value: 'map', label: 'Map', accessibleName: 'Map view' },
 ];

--- a/frontend/src/components/MapSurface.test.tsx
+++ b/frontend/src/components/MapSurface.test.tsx
@@ -75,46 +75,14 @@ const baseProps = {
   freshnessLabel: 'Updated just now · Source: eBird',
 };
 
-describe('MapSurface skip-link', () => {
-  it('renders a "Skip to species list" button as the first interactive element', () => {
-    render(<MapSurface {...baseProps} onSkipToFeed={vi.fn()} />);
-    const skip = screen.getByRole('button', { name: /Skip to species list/i });
-    expect(skip).toBeInTheDocument();
-    expect(skip.tagName).toBe('BUTTON');
-  });
-
-  it('uses class="skip-link" so the global stylesheet rule applies', () => {
-    render(<MapSurface {...baseProps} onSkipToFeed={vi.fn()} />);
-    const skip = screen.getByRole('button', { name: /Skip to species list/i });
-    expect(skip.className).toContain('skip-link');
-  });
-
-  it('is a <button> (not an <a href="#feed-surface">) — App.tsx mounts surfaces mutually-exclusive so anchors do not exist', () => {
-    render(<MapSurface {...baseProps} onSkipToFeed={vi.fn()} />);
-    // No <a href="#feed-surface"> anywhere in this surface.
-    expect(screen.queryByRole('link', { name: /Skip to species list/i })).toBeNull();
-  });
-
-  it('invokes onSkipToFeed when activated (the URL-state setter is wired by App.tsx)', () => {
-    const onSkip = vi.fn();
-    render(<MapSurface {...baseProps} onSkipToFeed={onSkip} />);
-    const skip = screen.getByRole('button', { name: /Skip to species list/i });
-    fireEvent.click(skip);
-    expect(onSkip).toHaveBeenCalledTimes(1);
-  });
-
-  it('also fires onSkipToFeed via Enter / Space (native <button> default)', () => {
-    const onSkip = vi.fn();
-    render(<MapSurface {...baseProps} onSkipToFeed={onSkip} />);
-    const skip = screen.getByRole('button', { name: /Skip to species list/i });
-    skip.focus();
-    fireEvent.keyDown(skip, { key: 'Enter' });
-    // jsdom does not synthesise a click on Enter for <button>, so explicitly
-    // simulate the click that the browser default would dispatch. The point
-    // of this test is to confirm the handler is wired to the click event,
-    // which `fireEvent.click` exercises.
-    fireEvent.click(skip);
-    expect(onSkip).toHaveBeenCalled();
+// Issue #662: the "Skip to species list" skip-link + its `onSkipToFeed`
+// prop were removed with the Feed view. The "Explore map markers"
+// skip-link below (covered in its own describe block) is now the sole
+// keyboard-bypass entry point on the map surface.
+describe('MapSurface — no Feed skip-link (issue #662)', () => {
+  it('does not render a "Skip to species list" button', () => {
+    render(<MapSurface {...baseProps} />);
+    expect(screen.queryByRole('button', { name: /Skip to species list/i })).toBeNull();
   });
 });
 
@@ -281,7 +249,6 @@ describe('MapSurface — cell popover skip-link (Phase 1, #558)', () => {
     render(
       <MapSurface
         {...baseProps}
-        onSkipToFeed={vi.fn()}
         onExploreMapMarkers={vi.fn()}
         hasMarkers={true}
       />
@@ -294,7 +261,6 @@ describe('MapSurface — cell popover skip-link (Phase 1, #558)', () => {
     render(
       <MapSurface
         {...baseProps}
-        onSkipToFeed={vi.fn()}
         onExploreMapMarkers={vi.fn()}
         hasMarkers={true}
       />
@@ -309,7 +275,6 @@ describe('MapSurface — cell popover skip-link (Phase 1, #558)', () => {
     render(
       <MapSurface
         {...baseProps}
-        onSkipToFeed={vi.fn()}
         onExploreMapMarkers={onExplore}
         hasMarkers={true}
       />
@@ -323,7 +288,6 @@ describe('MapSurface — cell popover skip-link (Phase 1, #558)', () => {
     render(
       <MapSurface
         {...baseProps}
-        onSkipToFeed={vi.fn()}
         onExploreMapMarkers={vi.fn()}
         hasMarkers={false}
       />

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -70,18 +70,11 @@ export interface MapSurfaceProps {
    * Threaded down to FamilyLegend.
    */
   onFamilyToggle: (familyCode: string) => void;
-  /**
-   * Skip-link handler (issue #247). App.tsx wires this to
-   * `set({ view: 'feed' })` so the URL-state setter routes the keyboard
-   * user from the map to the FeedSurface landmark (which is fully
-   * list-navigable). Filter state preservation is automatic via
-   * `useUrlState`'s partial-merge.
-   *
-   * Optional so existing callers (e.g. tests, future surface composers)
-   * that don't pass it still type-check; the skip-link button is then
-   * hidden (no a11y bypass without a destination).
-   */
-  onSkipToFeed?: () => void;
+  // Issue #662: the `onSkipToFeed` prop + the "Skip to species list"
+  // skip-link were intentionally REMOVED here. Feed is no longer a
+  // user-visible surface, so there is no destination to skip to. The
+  // Explore-map-markers skip-link below remains as the keyboard-bypass
+  // entry point.
   /**
    * Issue #246: ObservationPopover detail link. App.tsx wires this to
    * `set({ view: 'detail', detail: speciesCode })` via `useUrlState`
@@ -137,19 +130,12 @@ export interface MapSurfaceProps {
  *      out of the main bundle.
  *   2. Error boundary — isolates WebGL / tile / style failures.
  *   3. Loading skeleton while the chunk downloads.
- *   4. "Skip to species list" button (issue #247) — first interactive
- *      element in tab order on the map view, visually hidden until
- *      focused. WCAG 2.4.1 (Bypass Blocks) compliance: keyboard users
- *      can skip past the 344-marker map canvas (which is intentionally
- *      NOT in the global tab order — see MapMarkerHitLayer rationale)
- *      to the FeedSurface list landmark.
- *
- *      MUST be a <button>, NOT an <a href="#feed-surface">: App.tsx
- *      mounts the surfaces mutually-exclusive (FeedSurface only renders
- *      when `view === 'feed'`), so there is no `#feed-surface` anchor
- *      target while `view === 'map'`. Anchor-based navigation also
- *      doesn't switch view state. A button with onClick={() =>
- *      set({ view: 'feed' })} is the only correct form.
+ *   4. "Explore map markers" skip-link (Phase 1, #558) — first interactive
+ *      element in tab order on the map view, visually hidden until focused.
+ *      WCAG 2.4.1 (Bypass Blocks) compliance for keyboard users to bypass
+ *      the map canvas and land on the first marker cell. The original
+ *      "Skip to species list" skip-link was removed with the Feed view in
+ *      #662.
  */
 export function MapSurface({
   observations,
@@ -157,7 +143,6 @@ export function MapSurface({
   silhouettes,
   familyCode,
   onFamilyToggle,
-  onSkipToFeed,
   onSelectSpecies,
   onViewportChange,
   onExploreMapMarkers,
@@ -197,19 +182,9 @@ export function MapSurface({
         </div>
       }
     >
-      {/* Skip-link: first interactive element on the map view. Visually
-          hidden until focus reveals it; lives outside the .map-surface
-          wrapper so its absolute positioning anchors to the page rather
-          than to the map's relative-positioned container. */}
-      {onSkipToFeed && (
-        <button
-          type="button"
-          className="skip-link"
-          onClick={onSkipToFeed}
-        >
-          Skip to species list
-        </button>
-      )}
+      {/* Issue #662: the "Skip to species list" skip-link was deleted with
+          the Feed view. The Explore-map-markers skip-link below is now the
+          first interactive element on the map view. */}
       {onExploreMapMarkers && (
         <button
           type="button"

--- a/frontend/src/components/SurfaceNav.test.tsx
+++ b/frontend/src/components/SurfaceNav.test.tsx
@@ -3,35 +3,40 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SurfaceNav } from './SurfaceNav.js';
 
+// Issue #662: Feed removed from SurfaceNav (legacy duplicate of AppHeader's
+// TABS). Tests rewritten to cover the 2-tab [Map, Species] order.
+
 describe('SurfaceNav', () => {
-  it('renders three tabs with the active one marked aria-selected="true"', () => {
-    render(<SurfaceNav activeView="feed" onSelectView={() => {}} />);
+  it('renders two tabs with the active one marked aria-selected="true"', () => {
+    render(<SurfaceNav activeView="map" onSelectView={() => {}} />);
 
     const tablist = screen.getByRole('tablist', { name: 'Surface' });
     expect(tablist).toBeInTheDocument();
 
-    const feedTab = screen.getByRole('tab', { name: 'Feed view' });
     const speciesTab = screen.getByRole('tab', { name: 'Species view' });
     const mapTab = screen.getByRole('tab', { name: 'Map view' });
 
-    expect(feedTab).toHaveAttribute('aria-selected', 'true');
+    expect(mapTab).toHaveAttribute('aria-selected', 'true');
     expect(speciesTab).toHaveAttribute('aria-selected', 'false');
-    expect(mapTab).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('renders tabs in [Map, Species, Feed] order (Sky Atlas Phase 0)', () => {
+  it('does not render a Feed tab (issue #662)', () => {
+    render(<SurfaceNav activeView="map" onSelectView={() => {}} />);
+    expect(screen.queryByRole('tab', { name: 'Feed view' })).toBeNull();
+  });
+
+  it('renders tabs in [Map, Species] order', () => {
     render(<SurfaceNav activeView="map" onSelectView={() => {}} />);
     const tabs = screen.getAllByRole('tab');
     expect(tabs.map(t => t.getAttribute('aria-label'))).toEqual([
       'Map view',
       'Species view',
-      'Feed view',
     ]);
   });
 
   it('tracks aria-selected as activeView changes', () => {
     const { rerender } = render(
-      <SurfaceNav activeView="feed" onSelectView={() => {}} />
+      <SurfaceNav activeView="map" onSelectView={() => {}} />
     );
     expect(screen.getByRole('tab', { name: 'Species view' })).toHaveAttribute(
       'aria-selected',
@@ -39,10 +44,6 @@ describe('SurfaceNav', () => {
     );
 
     rerender(<SurfaceNav activeView="species" onSelectView={() => {}} />);
-    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveAttribute(
-      'aria-selected',
-      'false'
-    );
     expect(screen.getByRole('tab', { name: 'Species view' })).toHaveAttribute(
       'aria-selected',
       'true'
@@ -54,8 +55,8 @@ describe('SurfaceNav', () => {
   });
 
   it('associates each tab with the main surface via aria-controls', () => {
-    render(<SurfaceNav activeView="feed" onSelectView={() => {}} />);
-    for (const name of ['Feed view', 'Species view', 'Map view']) {
+    render(<SurfaceNav activeView="map" onSelectView={() => {}} />);
+    for (const name of ['Map view', 'Species view']) {
       const tab = screen.getByRole('tab', { name });
       expect(tab).toHaveAttribute('aria-controls', 'main-surface');
     }
@@ -64,7 +65,7 @@ describe('SurfaceNav', () => {
   it('fires onSelectView when a non-active tab is clicked', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
-    render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
+    render(<SurfaceNav activeView="map" onSelectView={onSelectView} />);
     await user.click(screen.getByRole('tab', { name: 'Species view' }));
     expect(onSelectView).toHaveBeenCalledWith('species');
   });
@@ -79,9 +80,8 @@ describe('SurfaceNav', () => {
 
   it('active tab has tabindex=0; inactive tabs have tabindex=-1 (roving tabindex)', () => {
     render(<SurfaceNav activeView="species" onSelectView={() => {}} />);
-    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveAttribute('tabindex', '-1');
-    expect(screen.getByRole('tab', { name: 'Species view' })).toHaveAttribute('tabindex', '0');
     expect(screen.getByRole('tab', { name: 'Map view' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: 'Species view' })).toHaveAttribute('tabindex', '0');
   });
 
   it('ArrowRight on the active tab moves focus AND fires onSelectView with the next value', async () => {
@@ -114,10 +114,10 @@ describe('SurfaceNav', () => {
   it('ArrowRight wraps from the last tab to the first', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
-    render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
+    render(<SurfaceNav activeView="species" onSelectView={onSelectView} />);
 
-    const feedTab = screen.getByRole('tab', { name: 'Feed view' });
-    feedTab.focus();
+    const speciesTab = screen.getByRole('tab', { name: 'Species view' });
+    speciesTab.focus();
 
     await user.keyboard('{ArrowRight}');
     expect(onSelectView).toHaveBeenCalledWith('map');
@@ -133,14 +133,14 @@ describe('SurfaceNav', () => {
     mapTab.focus();
 
     await user.keyboard('{ArrowLeft}');
-    expect(onSelectView).toHaveBeenCalledWith('feed');
-    expect(screen.getByRole('tab', { name: 'Feed view' })).toHaveFocus();
+    expect(onSelectView).toHaveBeenCalledWith('species');
+    expect(screen.getByRole('tab', { name: 'Species view' })).toHaveFocus();
   });
 
   it('Enter on a focused tab activates it', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
-    render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
+    render(<SurfaceNav activeView="species" onSelectView={onSelectView} />);
 
     const mapTab = screen.getByRole('tab', { name: 'Map view' });
     mapTab.focus();
@@ -151,7 +151,7 @@ describe('SurfaceNav', () => {
   it('Space on a focused tab activates it', async () => {
     const onSelectView = vi.fn();
     const user = userEvent.setup();
-    render(<SurfaceNav activeView="feed" onSelectView={onSelectView} />);
+    render(<SurfaceNav activeView="map" onSelectView={onSelectView} />);
 
     const speciesTab = screen.getByRole('tab', { name: 'Species view' });
     speciesTab.focus();

--- a/frontend/src/components/SurfaceNav.tsx
+++ b/frontend/src/components/SurfaceNav.tsx
@@ -22,7 +22,6 @@ interface TabDef {
 const TABS: readonly TabDef[] = [
   { value: 'map', label: 'Map', accessibleName: 'Map view' },
   { value: 'species', label: 'Species', accessibleName: 'Species view' },
-  { value: 'feed', label: 'Feed', accessibleName: 'Feed view' },
 ];
 
 export function SurfaceNav(props: SurfaceNavProps) {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A[AppHeader TABS] -->|before| B[Feed / Species / Map]
    A -->|after #662| C[Species / Map]
    D[onCloseDetail] -->|before| E[view: feed]
    D -->|after #662| F[view: map]
    G[MapSurface] -->|deleted| H[onSkipToFeed prop + Skip to species list button]
    I[FeedSurface component + ?view=feed URL handling] -->|preserved as dead code| J[Bookmark compat]
```

## Summary

- Drop the Feed tab from `AppHeader` and the legacy duplicate in `SurfaceNav`. Why: Feed duplicated content already on Map (root route) and Species Detail; the tab competed with the primary surfaces for header real estate.
- Re-point `onCloseDetail` to `view: 'map'` so closing a species detail modal returns to the default route rather than a now-hidden Feed surface.
- Explicitly delete the MapSurface `onSkipToFeed` prop, its docstring, the `Skip to species list` button, and the `onSkipToFeed` `useCallback` in `App.tsx`. No dead config left behind; the diff shows the skip-link going away in one place.
- `FeedSurface`, the `state.view === 'feed'` render branch, and `?view=feed` URL handling are preserved per the issue — legacy bookmarks still resolve.

## Screenshots

<!-- ORCHESTRATOR: paste 10 user-attachments URLs here from the PNGs at
     `/Users/j/repos/bird-watch/phase2-feed-screenshots/`:
       - 390x844-light.png    - 390x844-dark.png
       - 768x1024-light.png   - 768x1024-dark.png
       - 1024x768-light.png   - 1024x768-dark.png
       - 1440x900-light.png   - 1440x900-dark.png
       - 1920x1080-light.png  - 1920x1080-dark.png
     Use the `pr-screenshots-via-user-attachments` paste flow. -->

PNG paths captured by implementer (orchestrator to upload via paste flow):

- `/Users/j/repos/bird-watch/phase2-feed-screenshots/390x844-light.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/390x844-dark.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/768x1024-light.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/768x1024-dark.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1024x768-light.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1024x768-dark.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1440x900-light.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1440x900-dark.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1920x1080-light.png`
- `/Users/j/repos/bird-watch/phase2-feed-screenshots/1920x1080-dark.png`

- [x] Every new/renamed `className` in this PR has a matching CSS rule (N/A — no new classNames; this PR removes elements only)
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445). Pending orchestrator upload.

## Test plan

- [x] `npm test --workspaces` — green (902 frontend tests passed)
- [x] New unit / integration tests added — `AppHeader.test`, `SurfaceNav.test`, `MapSurface.test` rewritten for 2-tab header + no skip-link; added explicit "does not render Feed tab" regression tests
- [x] E2E specs touching Feed rewritten/trimmed (7 spec files): `happy-path`, `species-detail`, `mobile-bundle-e`, `map-cell-popover`, `map-skip-link-and-hit-layer`, `sheet-snap`, `pages/app-page.ts`. Specs that only `goto('view=feed')` without asserting on the header tab kept as-is (URL handling preserved)
- [x] `npm run build --workspaces` — clean production build
- [x] Playwright MCP smoke — drove the feature via `mcp__plugin_playwright_playwright__browser_*` at all 5 canonical viewports × 2 themes against `npm run dev` with `VITE_DEV_API_TARGET=https://api.bird-maps.com`. `browser_console_messages` returns no errors and only a pre-existing maplibre `circle-11` sprite warning (unrelated to this PR)
- [x] `npx knip --no-progress` — clean
- [x] `bash scripts/check-orphan-classnames.sh` — PASS

## Follow-ups (out of scope per the issue)

- Deleting `FeedSurface.tsx` and the dead-code `view === 'feed'` branch (separate cleanup issue once bookmark traffic to `?view=feed` is confirmed low).
- Restoring the user's previous non-detail view (Map vs Species) when closing a detail modal — bot SUGGESTION; would require tracking the previous view in URL or session state.

## Plan reference

Out of plan — direct issue execution (#662).

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)