### PR TITLE
feat(read-api): tighten filter allowlist + drop 30d option (#667 PR 1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -117,7 +117,6 @@ export function App() {
     '1d': '1 day',
     '7d': '7 days',
     '14d': '14 days',
-    '30d': '30 days',
   };
   const period = PERIOD_LABELS[state.since];
 

--- a/frontend/src/components/FiltersBar.tsx
+++ b/frontend/src/components/FiltersBar.tsx
@@ -73,7 +73,6 @@ export function FiltersBar(props: FiltersBarProps) {
           <option value="1d">Today</option>
           <option value="7d">7 days</option>
           <option value="14d">14 days</option>
-          <option value="30d">30 days</option>
         </select>
       </label>
       <label>

--- a/frontend/src/components/ds/FilterSentence.tsx
+++ b/frontend/src/components/ds/FilterSentence.tsx
@@ -74,7 +74,6 @@ function buildSentence(
   if (terms.length === 0) return null;
   const period = filters.since === '1d' ? '1 day'
     : filters.since === '7d' ? '7 days'
-    : filters.since === '30d' ? '30 days'
     : '14 days';
   return `Showing ${terms.join(', ')} from the last ${period}.`;
 }
@@ -129,7 +128,6 @@ export function FilterSentence({ filters, familyName, speciesName }: FilterSente
           from the last{' '}
           {filters.since === '1d' ? '1 day'
             : filters.since === '7d' ? '7 days'
-            : filters.since === '30d' ? '30 days'
             : '14 days'}.
         </p>
       )}

--- a/frontend/src/data/use-bird-data.test.tsx
+++ b/frontend/src/data/use-bird-data.test.tsx
@@ -37,7 +37,7 @@ describe('useBirdData', () => {
     } as unknown as Partial<ApiClient>);
 
     const { rerender } = renderHook(
-      ({ filters }: { filters: { since: '1d' | '7d' | '14d' | '30d'; notable: boolean } }) =>
+      ({ filters }: { filters: { since: '1d' | '7d' | '14d'; notable: boolean } }) =>
         useBirdData(client, filters),
       { initialProps: { filters: { since: '14d', notable: false } } }
     );

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { analytics } from '../analytics.js';
 
-export type Since = '1d' | '7d' | '14d' | '30d';
+// #667 — `'30d'` removed from Since. The server still soft-accepts it for one
+// release window (coerced to 14d + Deprecation header), but the frontend no
+// longer emits it. Bookmarked `?since=30d` URLs fall back to default `'14d'`
+// via the existing `VALID_SINCE.has(...)` check below.
+export type Since = '1d' | '7d' | '14d';
 export type View = 'feed' | 'species' | 'map' | 'detail';
 export type BBox = readonly [number, number, number, number];
 
@@ -25,7 +29,7 @@ const DEFAULTS: UrlState = {
   bbox: null, // Phase 3 (#560) — Cluster→SpeciesDetailSurface bbox filter
 };
 
-const VALID_SINCE: ReadonlySet<string> = new Set(['1d', '7d', '14d', '30d']);
+const VALID_SINCE: ReadonlySet<string> = new Set(['1d', '7d', '14d']);
 const VALID_VIEW: ReadonlySet<string> = new Set(['feed', 'species', 'map', 'detail']);
 
 function round6(n: number): number {

--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -218,6 +218,66 @@ describe('getObservations filters', () => {
     });
     expect(rows.map(r => r.subId)).toContain('S200');
   });
+
+  // #667 Scope C.1 — defense-in-depth LIMIT 5000 on species-filtered queries.
+  // The frontend's species-deep-link (?species=<code>) fetches before
+  // MapCanvas mounts → no bbox in flight. A handful of species nationally
+  // approach ~5K observations in 14d (House Sparrow); cap there is a balance
+  // between "real users see the full slice" and "scraper can't drain the DB
+  // via species iteration".
+  it('applies LIMIT 5000 when speciesCode is set (#667 Scope C.1)', async () => {
+    // Seed 6K observations for a single species to cross the cap. Skip the
+    // upsertObservations helper's per-row stamping path (slow for 6K rows)
+    // and INSERT directly; the query under test only reads obs_dt/species_code/
+    // bbox columns, none of which depend on silhouette_id.
+    await db.pool.query('TRUNCATE observations');
+    await db.pool.query(`
+      INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+      VALUES ('hossp1', 'House Sparrow', 'Passer domesticus', 'passeridae', 'Old World Sparrows', 999999)
+      ON CONFLICT (species_code) DO NOTHING
+    `);
+    // Bulk insert via generate_series — fast vs row-by-row JS.
+    await db.pool.query(`
+      INSERT INTO observations
+        (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+      SELECT
+        'S-cap-' || g::text,
+        'hossp1',
+        31.72 + (g * 0.0001),
+        -110.88 - (g * 0.0001),
+        now() - (g * interval '1 second'),
+        'L-cap',
+        'Cap Test Loc',
+        1,
+        false
+      FROM generate_series(1, 6000) g
+    `);
+    const rows = await getObservations(db.pool, { speciesCode: 'hossp1' });
+    expect(rows).toHaveLength(5000);
+  });
+
+  it('does NOT apply LIMIT 5000 when speciesCode is absent', async () => {
+    // Sanity counterpart: same seed, query without speciesCode → no cap.
+    // (The future LIMIT 10000 for the bbox path lands in PR 2.)
+    await db.pool.query('TRUNCATE observations');
+    await db.pool.query(`
+      INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+      VALUES ('hossp1', 'House Sparrow', 'Passer domesticus', 'passeridae', 'Old World Sparrows', 999999)
+      ON CONFLICT (species_code) DO NOTHING
+    `);
+    await db.pool.query(`
+      INSERT INTO observations
+        (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+      SELECT
+        'S-uncap-' || g::text, 'hossp1',
+        31.72 + (g * 0.0001), -110.88 - (g * 0.0001),
+        now() - (g * interval '1 second'),
+        'L-uncap', 'Uncap Test Loc', 1, false
+      FROM generate_series(1, 5500) g
+    `);
+    const rows = await getObservations(db.pool, {});
+    expect(rows.length).toBeGreaterThan(5000);
+  });
 });
 
 describe('getObservationsAggregated (#627)', () => {

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -167,6 +167,14 @@ export async function getObservations(
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
+  // #667 — defense-in-depth row cap on species-filtered queries. No real
+  // species has >5K observations in 14d nationally; this cap is an emergency
+  // brake for `?species=<code>` deep links that fetch before MapCanvas mounts
+  // (no bbox + no zoom in flight). The broader LIMIT 10000 emergency brake
+  // for all per-observation queries ships in PR 2 (with a truncation banner
+  // and meta.truncated signal — see issue #667 Addendum §3).
+  const limit = f.speciesCode ? 'LIMIT 5000' : '';
+
   const sql = `
     SELECT
       o.sub_id, o.species_code, sm.com_name, sm.family_code,
@@ -176,6 +184,7 @@ export async function getObservations(
     LEFT JOIN species_meta sm ON sm.species_code = o.species_code
     ${where}
     ORDER BY o.obs_dt DESC
+    ${limit}
   `;
 
   const { rows } = await pool.query<{

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -141,7 +141,7 @@ export interface IngestRun {
 export type IngestRunTerminalStatus = Exclude<IngestRun['status'], 'running'>;
 
 export type ObservationFilters = {
-  since?: '1d' | '7d' | '14d' | '30d';
+  since?: '1d' | '7d' | '14d';
   notable?: boolean;
   speciesCode?: string;
   familyCode?: string;

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -237,9 +237,9 @@ describe('GET /api/observations', () => {
       const res = await app.request(`/api/observations?since=30d&bbox=${BBOX_AZ}`);
       expect(res.status).toBe(200);
       expect(res.headers.get('deprecation')).toBe('true');
-      expect(res.headers.get('sunset')).toBeTruthy();
-      // ISO date is acceptable for Sunset header.
-      expect(res.headers.get('sunset')).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      // Sunset header is anchored to a fixed UTC date (2026-06-01) rather
+      // than `now() + 14d`, so the deprecation window is a real deadline.
+      expect(res.headers.get('sunset')).toBe(new Date('2026-06-01T00:00:00Z').toUTCString());
       const warning = res.headers.get('warning') ?? '';
       expect(warning).toContain('299');
       expect(warning).toContain('since=30d');

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -57,19 +57,25 @@ describe('GET /api/observations', () => {
     meta: { freshestObservationAt: string | null };
   };
 
+  // Default bbox covering both seeded observations (lat 31.72/32.30, lng
+  // -110.88/-110.99). #667 Scope C.1 requires bbox OR species on every
+  // per-observation request, so seed-dependent tests pin a known-good bbox.
+  const BBOX_AZ = '-112,31,-110,33';
+
   it('returns observations with correct cache header', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d');
+    const res = await app.request(`/api/observations?since=14d&bbox=${BBOX_AZ}`);
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control'))
       .toBe('public, s-maxage=300, stale-while-revalidate=600');
     const body = await res.json() as ObsEnvelope;
-    expect(body.data).toHaveLength(2);
+    // Only S1 falls within 14d (S2 is 20d old).
+    expect(body.data).toHaveLength(1);
   });
 
   it('returns meta.freshestObservationAt as an ISO string (#456 W3-A)', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d');
+    const res = await app.request(`/api/observations?since=14d&bbox=${BBOX_AZ}`);
     expect(res.status).toBe(200);
     const body = await res.json() as ObsEnvelope;
     // freshestObservationAt must be a non-null ISO string — the table has rows
@@ -86,7 +92,7 @@ describe('GET /api/observations', () => {
     // beforeAll re-seeds for future tests in this suite.
     await db.pool.query('TRUNCATE observations');
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations');
+    const res = await app.request(`/api/observations?bbox=${BBOX_AZ}`);
     expect(res.status).toBe(200);
     const body = await res.json() as ObsEnvelope;
     expect(body.meta.freshestObservationAt).toBeNull();
@@ -103,7 +109,8 @@ describe('GET /api/observations', () => {
 
   it('projects familyCode from species_meta onto each observation (#57)', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d');
+    // No since filter → both rows returned.
+    const res = await app.request(`/api/observations?bbox=${BBOX_AZ}`);
     expect(res.status).toBe(200);
     const body = await res.json() as ObsEnvelope;
     const byId = Object.fromEntries(body.data.map(o => [o.subId, o.familyCode]));
@@ -113,28 +120,29 @@ describe('GET /api/observations', () => {
 
   it('filters by since=14d', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=14d');
+    const res = await app.request(`/api/observations?since=14d&bbox=${BBOX_AZ}`);
     const body = await res.json() as ObsEnvelope;
     expect(body.data.map(o => o.subId)).toEqual(['S1']);
   });
 
   it('filters by notable=true', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d&notable=true');
+    const res = await app.request(`/api/observations?bbox=${BBOX_AZ}&notable=true`);
     const body = await res.json() as ObsEnvelope;
     expect(body.data.map(o => o.subId)).toEqual(['S2']);
   });
 
   it('filters by species code', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d&species=vermfly');
+    // Species-filtered request needs no bbox per #667 Scope C.1.
+    const res = await app.request('/api/observations?species=vermfly');
     const body = await res.json() as ObsEnvelope;
     expect(body.data.map(o => o.subId)).toEqual(['S1']);
   });
 
-  it('filters by family code', async () => {
+  it('filters by family code (with bbox per #667 Scope C.1)', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d&family=trochilidae');
+    const res = await app.request(`/api/observations?bbox=${BBOX_AZ}&family=trochilidae`);
     const body = await res.json() as ObsEnvelope;
     expect(body.data.map(o => o.subId)).toEqual(['S2']);
   });
@@ -145,21 +153,202 @@ describe('GET /api/observations', () => {
     expect(res.status).toBe(400);
   });
 
-  // #619 — server-side bbox filtering, Phase 2 going-national pre-condition.
-  describe('bbox filtering', () => {
-    it('with NO bbox returns the full set (backward-compatible)', async () => {
-      const app = createApp({ pool: db.pool });
-      const res = await app.request('/api/observations?since=30d');
-      expect(res.status).toBe(200);
-      const body = await res.json() as ObsEnvelope;
-      expect(body.data).toHaveLength(2);
+  // #667 — strict validation of notable / species / family. Each rejection
+  // emits a single structured 'validation_400' log line (Addendum §7).
+  describe('strict allowlist validation (#667)', () => {
+    it('rejects ?notable=banana with 400 + structured log', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        const app = createApp({ pool: db.pool });
+        const res = await app.request('/api/observations?notable=banana');
+        expect(res.status).toBe(400);
+        const body = await res.json() as { error: string };
+        expect(body.error).toBe('invalid notable');
+        const log = logSpy.mock.calls
+          .map(args => args[0])
+          .filter((a): a is string => typeof a === 'string')
+          .map(s => { try { return JSON.parse(s); } catch { return null; } })
+          .find((p): p is Record<string, unknown> =>
+            !!p && p.message === 'validation_400' && p.param === 'notable');
+        expect(log).toBeDefined();
+        expect(log!.reason).toBe('not_in_allowlist');
+        // Hash, not raw value — guard against PII / scraper payload leak.
+        expect(log!.received_hash).toMatch(/^[a-f0-9]{8}$/);
+        expect(JSON.stringify(log)).not.toContain('banana');
+      } finally {
+        logSpy.mockRestore();
+      }
     });
 
+    it.each([
+      ['species', '%',                  'regex_mismatch'],
+      ['species', "' OR 1=1 --",        'regex_mismatch'],
+      ['species', 'GAMQUA',             'regex_mismatch'],
+      ['family',  '%',                  'regex_mismatch'],
+      ['family',  'TYRANNIDAE',         'regex_mismatch'],
+    ])('rejects ?%s=%s with 400 (reason=%s)', async (param, value, reason) => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        const app = createApp({ pool: db.pool });
+        const res = await app.request(
+          `/api/observations?${param}=${encodeURIComponent(value)}`,
+        );
+        expect(res.status).toBe(400);
+        const log = logSpy.mock.calls
+          .map(args => args[0])
+          .filter((a): a is string => typeof a === 'string')
+          .map(s => { try { return JSON.parse(s); } catch { return null; } })
+          .find((p): p is Record<string, unknown> =>
+            !!p && p.message === 'validation_400' && p.param === param);
+        expect(log).toBeDefined();
+        expect(log!.reason).toBe(reason);
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+
+    it.each(['accipi1', 'tyrann1', 'x00013', 'gamqua', 'cardin1'])(
+      'accepts real eBird code %s without 400',
+      async (code) => {
+        const app = createApp({ pool: db.pool });
+        const res = await app.request(`/api/observations?species=${code}`);
+        // 200 with empty data (no seeded rows for these codes) — the
+        // validation layer is what we're asserting, not the data shape.
+        expect(res.status).toBe(200);
+      },
+    );
+
+    it('does NOT echo received value or leak allowlist in 400 body', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request("/api/observations?species=' OR 1=1 --");
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).not.toContain("OR 1=1");
+      expect(text).not.toContain('allowlist');
+    });
+  });
+
+  // #667 Addendum §5 — soft-deprecation window for ?since=30d. Accepts the
+  // value, coerces to 14d internally, emits Deprecation/Sunset/Warning
+  // headers plus a NOTICE log. Next PR (≥14d post-deploy) flips to hard 400.
+  describe('?since=30d soft-deprecation (#667 Addendum §5)', () => {
+    it('returns 200 + Deprecation: true + Sunset + Warning: 299', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(`/api/observations?since=30d&bbox=${BBOX_AZ}`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('deprecation')).toBe('true');
+      expect(res.headers.get('sunset')).toBeTruthy();
+      // ISO date is acceptable for Sunset header.
+      expect(res.headers.get('sunset')).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      const warning = res.headers.get('warning') ?? '';
+      expect(warning).toContain('299');
+      expect(warning).toContain('since=30d');
+    });
+
+    it('coerces to 14d internally (S2 at 20d is excluded)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(`/api/observations?since=30d&bbox=${BBOX_AZ}`);
+      const body = await res.json() as ObsEnvelope;
+      expect(body.data.map(o => o.subId)).toEqual(['S1']);
+    });
+
+    it('emits a NOTICE log line with user_agent', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        const app = createApp({ pool: db.pool });
+        const res = await app.request(`/api/observations?since=30d&bbox=${BBOX_AZ}`, {
+          headers: { 'user-agent': 'curl/8.0' },
+        });
+        expect(res.status).toBe(200);
+        const log = logSpy.mock.calls
+          .map(args => args[0])
+          .filter((a): a is string => typeof a === 'string')
+          .map(s => { try { return JSON.parse(s); } catch { return null; } })
+          .find((p): p is Record<string, unknown> =>
+            !!p && p.message === 'deprecated_since_30d');
+        expect(log).toBeDefined();
+        expect(log!.severity).toBe('NOTICE');
+        expect(log!.user_agent).toBe('curl/8.0');
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
+  });
+
+  // #667 Scope C.1 — guard on the per-observation path: bbox OR species.
+  describe('bbox-or-species guard (#667 Scope C.1)', () => {
+    it('rejects bare /api/observations with 400 (no bbox, no species)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?since=14d');
+      expect(res.status).toBe(400);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe('specify bbox or species');
+    });
+
+    it('rejects ?family=X without bbox or species (Addendum §4 scrape vector)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?family=trochilidae');
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts ?species=X with no bbox (deep-link before MapCanvas mounts)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request('/api/observations?species=vermfly');
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts bbox with no species', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(`/api/observations?bbox=${BBOX_AZ}`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // #667 Scope C.2 — per-axis bbox cap on the per-observation path. zoom < 6
+  // hits aggregated mode (no cap); zoom >= 6 enforces 15° lng × 10° lat.
+  describe('per-axis bbox cap (#667 Scope C.2)', () => {
+    it('rejects too-wide lng span at zoom=8 with descriptive body', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(
+        '/api/observations?bbox=-130,30,-110,40&zoom=8',
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json() as {
+        error: string; maxLngSpan: number; maxLatSpan: number; hint: string;
+      };
+      expect(body.error).toBe('bbox too large');
+      expect(body.maxLngSpan).toBe(15);
+      expect(body.maxLatSpan).toBe(10);
+      expect(body.hint).toContain('zoom out');
+    });
+
+    it('accepts state-level bbox (6° × 5°) at zoom=8', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(
+        '/api/observations?bbox=-115,32,-109,37&zoom=8',
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('does NOT cap at zoom=4 (aggregated mode handles unbounded bbox)', async () => {
+      const app = createApp({ pool: db.pool });
+      const res = await app.request(
+        '/api/observations?bbox=-180,-90,180,90&zoom=4',
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // #619 — server-side bbox filtering, Phase 2 going-national pre-condition.
+  // Note: #667 Scope C.1 made bbox-or-species required on the per-observation
+  // path, so the prior "no bbox returns full set" test was deleted as
+  // contradictory.
+  describe('bbox filtering', () => {
     it('with a valid bbox narrows to in-bounds observations', async () => {
       const app = createApp({ pool: db.pool });
       // Envelope contains only S1 (31.72, -110.88); excludes S2 (32.30, -110.99)
       const res = await app.request(
-        '/api/observations?since=30d&bbox=-111,31.5,-110.85,31.9'
+        `/api/observations?bbox=-111,31.5,-110.85,31.9`
       );
       expect(res.status).toBe(200);
       const body = await res.json() as ObsEnvelope;
@@ -227,12 +416,12 @@ describe('GET /api/observations', () => {
       expect(Array.isArray(body.data)).toBe(true);
     });
 
-    it('zoom without bbox keeps per-observation mode', async () => {
+    it('zoom without bbox or species now returns 400 (#667 Scope C.1)', async () => {
+      // Pre-#667 this kept per-observation mode. The bbox-or-species guard
+      // now rejects before the aggregation branch fires.
       const app = createApp({ pool: db.pool });
       const res = await app.request('/api/observations?zoom=3');
-      expect(res.status).toBe(200);
-      const body = await res.json() as { mode: string };
-      expect(body.mode).toBe('observations');
+      expect(res.status).toBe(400);
     });
 
     it('rejects non-integer zoom with 400', async () => {
@@ -266,7 +455,7 @@ describe('GET /api/observations', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
       const app = createApp({ pool: db.pool });
-      const res = await app.request('/api/observations?since=30d');
+      const res = await app.request(`/api/observations?bbox=${BBOX_AZ}`);
       expect(res.status).toBe(200);
       const matches = logSpy.mock.calls
         .map(args => args[0])
@@ -294,7 +483,7 @@ describe('GET /api/observations', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
       const app = createApp({ pool: db.pool });
-      const res = await app.request('/api/observations');
+      const res = await app.request(`/api/observations?bbox=${BBOX_AZ}`);
       expect(res.status).toBe(200);
       const matches = logSpy.mock.calls
         .map(args => args[0])
@@ -370,7 +559,7 @@ describe('species_meta backfill for eBird hybrid/spuh codes (#484)', () => {
     })));
 
     const app = createApp({ pool: db.pool });
-    const obsRes = await app.request('/api/observations?since=30d');
+    const obsRes = await app.request('/api/observations?bbox=-112,31,-110,33');
     expect(obsRes.status).toBe(200);
     const obsBody = await obsRes.json() as {
       data: Array<{ speciesCode: string }>;
@@ -657,7 +846,7 @@ describe('gzip compression middleware', () => {
 
   it('returns content-encoding: gzip when client accepts gzip', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d', {
+    const res = await app.request('/api/observations?species=vermfly', {
       headers: { 'Accept-Encoding': 'gzip' },
     });
     expect(res.status).toBe(200);
@@ -666,7 +855,7 @@ describe('gzip compression middleware', () => {
 
   it('omits content-encoding when client does not advertise gzip', async () => {
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d');
+    const res = await app.request('/api/observations?species=vermfly');
     expect(res.status).toBe(200);
     expect(res.headers.get('content-encoding')).toBeNull();
   });
@@ -676,7 +865,7 @@ describe('gzip compression middleware', () => {
     // by Accept-Encoding so they never serve a gzip body to a client that
     // didn't negotiate it.  See #143.
     const app = createApp({ pool: db.pool });
-    const res = await app.request('/api/observations?since=30d', {
+    const res = await app.request('/api/observations?species=vermfly', {
       headers: { 'Accept-Encoding': 'gzip' },
     });
     expect(res.status).toBe(200);

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -11,6 +11,10 @@ import {
 import type { ObservationsResponse } from '@bird-watch/shared-types';
 import { cacheControlFor } from './cache-headers.js';
 import { rateLimitFromEnv } from './rate-limit.js';
+import {
+  parseSince, parseNotable, parseSpecies, parseFamily,
+  assertBboxAreaCap, assertBboxOrSpecies,
+} from './validate.js';
 
 export interface AppDeps {
   pool: Pool;
@@ -84,15 +88,55 @@ export function createApp(deps: AppDeps): Hono {
   });
 
   app.get('/api/observations', async c => {
-    const sinceRaw = c.req.query('since');
-    const validSince = ['1d', '7d', '14d', '30d'] as const;
-    if (sinceRaw !== undefined && !(validSince as readonly string[]).includes(sinceRaw)) {
-      return c.json({ error: 'invalid since' }, 400);
+    // #667 — strict allowlist validation across all filter params, with
+    // structured 400 telemetry. See services/read-api/src/validate.ts.
+
+    const sinceResult = parseSince(c.req.query('since'));
+    if (!sinceResult.ok) {
+      console.log(JSON.stringify(sinceResult.log));
+      return c.json({ error: sinceResult.error }, 400);
     }
-    const since = sinceRaw as '1d' | '7d' | '14d' | '30d' | undefined;
-    const notableParam = c.req.query('notable');
-    const speciesCode = c.req.query('species');
-    const familyCode = c.req.query('family');
+    const since = sinceResult.value;
+    // Soft-deprecation: `?since=30d` is coerced to `14d` server-side for a
+    // single release window, and we emit Deprecation/Sunset/Warning headers
+    // plus a NOTICE log so dashboards can grep for live consumers. The next
+    // release flips to hard 400. See issue #667 Addendum §5.
+    if (sinceResult.deprecated) {
+      // Sunset date: 14 days from now, ISO-date precision (HTTP date acceptable).
+      const sunset = new Date(Date.now() + 14 * 86400_000).toISOString();
+      c.header('Deprecation', 'true');
+      c.header('Sunset', sunset);
+      c.header(
+        'Warning',
+        '299 - "since=30d is deprecated; use since=14d (or omit since)"',
+      );
+      console.log(JSON.stringify({
+        severity: 'NOTICE',
+        message: 'deprecated_since_30d',
+        user_agent: c.req.header('user-agent') ?? null,
+      }));
+    }
+
+    const notableResult = parseNotable(c.req.query('notable'));
+    if (!notableResult.ok) {
+      console.log(JSON.stringify(notableResult.log));
+      return c.json({ error: notableResult.error }, 400);
+    }
+    const notable = notableResult.value;
+
+    const speciesResult = parseSpecies(c.req.query('species'));
+    if (!speciesResult.ok) {
+      console.log(JSON.stringify(speciesResult.log));
+      return c.json({ error: speciesResult.error }, 400);
+    }
+    const speciesCode = speciesResult.value;
+
+    const familyResult = parseFamily(c.req.query('family'));
+    if (!familyResult.ok) {
+      console.log(JSON.stringify(familyResult.log));
+      return c.json({ error: familyResult.error }, 400);
+    }
+    const familyCode = familyResult.value;
 
     // #619 — optional viewport-bbox filter, Phase 2 going-national
     // pre-condition. Format: bbox=minLon,minLat,maxLon,maxLat (EPSG:4326).
@@ -138,7 +182,7 @@ export function createApp(deps: AppDeps): Hono {
 
     const filters: Parameters<typeof getObservations>[1] = {};
     if (since !== undefined) filters.since = since;
-    if (notableParam === 'true') filters.notable = true;
+    if (notable === true) filters.notable = true;
     if (speciesCode !== undefined) filters.speciesCode = speciesCode;
     if (familyCode !== undefined) filters.familyCode = familyCode;
     if (bbox !== undefined) filters.bbox = bbox;
@@ -170,6 +214,28 @@ export function createApp(deps: AppDeps): Hono {
         meta: { freshestObservationAt },
       };
       return c.json(body);
+    }
+
+    // #667 Scope C.1 — per-observation path requires EITHER bbox OR species.
+    // Family-only (no bbox, no species) is the scrape vector for "all of
+    // family X nationally"; reject before hitting the DB. Aggregated mode
+    // above already returned, so this check only fires on the heavier path.
+    const guard = assertBboxOrSpecies({ bbox, speciesCode });
+    if (!guard.ok) {
+      console.log(JSON.stringify(guard.log));
+      return c.json({ error: guard.error }, 400);
+    }
+
+    // #667 Scope C.2 — per-axis bbox cap on the per-observation path.
+    // `zoom < 6` (aggregated) already returned; here `zoom` may be >=6 or
+    // undefined (deep links before MapCanvas mounts). The cap only fires
+    // when zoom >= 6.
+    if (bbox !== undefined) {
+      const cap = assertBboxAreaCap(bbox, zoom);
+      if (!cap.ok) {
+        console.log(JSON.stringify(cap.log));
+        return c.json(cap.body, 400);
+      }
     }
 
     // Run both queries in parallel — getObservations fetches the filtered rows;

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -16,6 +16,13 @@ import {
   assertBboxAreaCap, assertBboxOrSpecies,
 } from './validate.js';
 
+// Fixed sunset date for the `?since=30d` soft-deprecation window. Anchoring
+// to a concrete UTC date (rather than `now() + 14d`) means the deprecation
+// window is a real deadline that approaches, not a perpetually-rolling 14
+// days. PR 3 in the rollout flips `since=30d` to hard 400 on/before this
+// date. See issue #667 Addendum §5 and PR #668 review feedback.
+const SINCE_30D_SUNSET_DATE = new Date('2026-06-01T00:00:00Z').toUTCString();
+
 export interface AppDeps {
   pool: Pool;
 }
@@ -102,10 +109,9 @@ export function createApp(deps: AppDeps): Hono {
     // plus a NOTICE log so dashboards can grep for live consumers. The next
     // release flips to hard 400. See issue #667 Addendum §5.
     if (sinceResult.deprecated) {
-      // Sunset date: 14 days from now, ISO-date precision (HTTP date acceptable).
-      const sunset = new Date(Date.now() + 14 * 86400_000).toISOString();
+      // Sunset date: fixed UTC date (2026-06-01) — see SINCE_30D_SUNSET_DATE.
       c.header('Deprecation', 'true');
-      c.header('Sunset', sunset);
+      c.header('Sunset', SINCE_30D_SUNSET_DATE);
       c.header(
         'Warning',
         '299 - "since=30d is deprecated; use since=14d (or omit since)"',

--- a/services/read-api/src/validate.test.ts
+++ b/services/read-api/src/validate.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseSince,
+  parseNotable,
+  parseSpecies,
+  parseFamily,
+  assertBboxAreaCap,
+  assertBboxOrSpecies,
+} from './validate.js';
+
+describe('parseSince', () => {
+  it('passes through 1d / 7d / 14d', () => {
+    for (const v of ['1d', '7d', '14d'] as const) {
+      const r = parseSince(v);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.value).toBe(v);
+    }
+  });
+
+  it('accepts 30d but flags as deprecated and coerces to 14d', () => {
+    const r = parseSince('30d');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value).toBe('14d');
+      // Discriminated extra field carrying the soft-deprecation signal.
+      expect(r.deprecated).toBe(true);
+    }
+  });
+
+  it('treats absent as undefined (no filter)', () => {
+    const r = parseSince(undefined);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBeUndefined();
+  });
+
+  it('rejects garbage with a structured log payload', () => {
+    const r = parseSince('banana');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe('invalid since');
+      expect(r.log.param).toBe('since');
+      expect(r.log.reason).toBe('not_in_allowlist');
+      expect(r.log.received_hash).toMatch(/^[a-f0-9]{8}$/);
+    }
+  });
+});
+
+describe('parseNotable', () => {
+  it('accepts exactly "true" and "false"', () => {
+    const t = parseNotable('true');
+    const f = parseNotable('false');
+    expect(t.ok && t.value).toBe(true);
+    expect(f.ok && f.value).toBe(false);
+  });
+
+  it('treats absent as undefined', () => {
+    const r = parseNotable(undefined);
+    expect(r.ok && r.value === undefined).toBe(true);
+  });
+
+  it.each(['banana', 'TRUE', 'False', '1', '0', ''])(
+    'rejects %p',
+    (v) => {
+      const r = parseNotable(v);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toBe('invalid notable');
+        expect(r.log.param).toBe('notable');
+      }
+    },
+  );
+});
+
+describe('parseSpecies', () => {
+  // Real eBird codes — must all pass.
+  it.each(['accipi1', 'tyrann1', 'x00013', 'gamqua', 'cardin1', 'annhum', 'vermfly'])(
+    'accepts real code %p',
+    (v) => {
+      const r = parseSpecies(v);
+      expect(r.ok, `expected ${v} to pass`).toBe(true);
+      if (r.ok) expect(r.value).toBe(v);
+    },
+  );
+
+  it('treats absent as undefined', () => {
+    expect(parseSpecies(undefined).ok).toBe(true);
+  });
+
+  it.each([
+    '',
+    '%',
+    "' OR 1=1 --",
+    'GAMQUA',
+    'gam qua',
+    'ab',           // too short
+    'toolongcode1', // too long (12 chars)
+    '1annhum',      // starts with digit
+  ])('rejects %p', (v) => {
+    const r = parseSpecies(v);
+    expect(r.ok, `expected ${JSON.stringify(v)} to fail`).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe('invalid species');
+      expect(r.log.reason).toBe('regex_mismatch');
+    }
+  });
+});
+
+describe('parseFamily', () => {
+  it.each(['tyrannidae', 'trochilidae', 'icteridae', 'fam1'])(
+    'accepts %p',
+    (v) => {
+      const r = parseFamily(v);
+      expect(r.ok, `expected ${v} to pass`).toBe(true);
+    },
+  );
+
+  it.each(['', '%', "' OR 1=1 --", 'TYRANNIDAE', 'tyr', 'thisfamilyistoolong'])(
+    'rejects %p',
+    (v) => {
+      const r = parseFamily(v);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.log.param).toBe('family');
+    },
+  );
+});
+
+describe('assertBboxAreaCap', () => {
+  it('passes for any bbox at zoom < 6 (aggregated mode covers it)', () => {
+    const r = assertBboxAreaCap([-180, -90, 180, 90], 4);
+    expect(r.ok).toBe(true);
+  });
+
+  it('passes for a within-cap bbox at zoom >= 6', () => {
+    // Texas-ish: 13° lng × 11° lat — within 15/10 cap (actually 11 > 10 fails).
+    // Pick something within the cap.
+    const r = assertBboxAreaCap([-115, 32, -109, 37], 8); // 6° × 5°
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects too-wide lng span at zoom >= 6', () => {
+    const r = assertBboxAreaCap([-130, 30, -110, 40], 6); // 20° × 10° — lng > 15
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.body.error).toBe('bbox too large');
+      expect(r.body.maxLngSpan).toBe(15);
+      expect(r.log.reason).toBe('too_large');
+    }
+  });
+
+  it('rejects too-tall lat span at zoom >= 6', () => {
+    const r = assertBboxAreaCap([-115, 25, -105, 40], 7); // 10° × 15° — lat > 10
+    expect(r.ok).toBe(false);
+  });
+
+  it('passes when zoom is undefined (no zoom hint → treat as aggregated permissive)', () => {
+    const r = assertBboxAreaCap([-180, -90, 180, 90], undefined);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('assertBboxOrSpecies', () => {
+  it('passes when bbox is present', () => {
+    expect(assertBboxOrSpecies({
+      bbox: [-115, 32, -109, 37],
+      speciesCode: undefined,
+    }).ok).toBe(true);
+  });
+
+  it('passes when species is present (no bbox needed for species-deep-link)', () => {
+    expect(assertBboxOrSpecies({
+      bbox: undefined,
+      speciesCode: 'annhum',
+    }).ok).toBe(true);
+  });
+
+  it('rejects when neither bbox nor species is present', () => {
+    const r = assertBboxOrSpecies({ bbox: undefined, speciesCode: undefined });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe('specify bbox or species');
+      expect(r.log.param).toBe('bbox_required');
+      expect(r.log.reason).toBe('missing_required');
+    }
+  });
+});

--- a/services/read-api/src/validate.ts
+++ b/services/read-api/src/validate.ts
@@ -1,0 +1,220 @@
+// Centralized query-param validators for /api/observations.
+//
+// Issue #667 — tighten filter allowlist + anti-scrape hardening.
+//
+// Each validator returns a discriminated-union result:
+//   { ok: true, value: T }                  — accept, possibly coerced
+//   { ok: false, error: string,             — reject; caller emits a structured
+//     log: ValidationLog,                     400-telemetry log line and returns
+//     status?: 400 }                          c.json({error}, 400) to the client
+//
+// Logging contract (Addendum #7): on every rejection emit a single line of
+// JSON to stdout with the shape:
+//
+//   {severity: 'INFO', message: 'validation_400', param, received_hash, reason}
+//
+// Where `received_hash` is the first 8 hex chars of sha256(rawValue). Never
+// log the raw value — scrapers and credential-leak probes both push payloads
+// we don't want to retain in plaintext logs.
+
+import { createHash } from 'node:crypto';
+
+export type Since = '1d' | '7d' | '14d';
+
+export interface ValidationLog {
+  severity: 'INFO';
+  message: 'validation_400';
+  param: string;
+  received_hash: string;
+  reason:
+    | 'regex_mismatch'
+    | 'not_in_allowlist'
+    | 'too_large'
+    | 'missing_required'
+    | 'out_of_range'
+    | 'malformed';
+}
+
+export type Result<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string; log: ValidationLog };
+
+function hash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 8);
+}
+
+/**
+ * Parses `?since=` with a soft-deprecation window for `30d`.
+ *
+ * Accepted: `'1d' | '7d' | '14d'` pass through; `'30d'` is accepted but
+ * coerced to `'14d'` and the response should set Deprecation/Sunset/Warning
+ * headers. The caller distinguishes the coerced case by checking `deprecated`.
+ *
+ * Returns `{ok:false}` only for values outside that set.
+ */
+export function parseSince(
+  raw: string | undefined,
+): Result<Since | undefined> & { deprecated?: boolean } {
+  if (raw === undefined) return { ok: true, value: undefined };
+  if (raw === '1d' || raw === '7d' || raw === '14d') {
+    return { ok: true, value: raw };
+  }
+  if (raw === '30d') {
+    // Soft-deprecation: coerce to 14d, signal upstream to emit headers + NOTICE log.
+    return { ok: true, value: '14d', deprecated: true };
+  }
+  return {
+    ok: false,
+    error: 'invalid since',
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'since',
+      received_hash: hash(raw),
+      reason: 'not_in_allowlist',
+    },
+  };
+}
+
+/**
+ * Parses `?notable=`. Must be exactly `'true'` or `'false'` (or absent).
+ * `?notable=banana` returns 400. `?notable=` (empty) returns 400.
+ */
+export function parseNotable(
+  raw: string | undefined,
+): Result<boolean | undefined> {
+  if (raw === undefined) return { ok: true, value: undefined };
+  if (raw === 'true') return { ok: true, value: true };
+  if (raw === 'false') return { ok: true, value: false };
+  return {
+    ok: false,
+    error: 'invalid notable',
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'notable',
+      received_hash: hash(raw),
+      reason: 'not_in_allowlist',
+    },
+  };
+}
+
+// eBird species code shape. Real codes routinely end in disambiguator digits
+// (`accipi1`, `tyrann1`) and unidentified-codes start with `x` + digits
+// (`x00013`). Regex must accept those. 3-10 chars, starts with a letter,
+// lowercase alphanumeric thereafter.
+const SPECIES_RE = /^[a-z][a-z0-9]{2,9}$/;
+
+export function parseSpecies(
+  raw: string | undefined,
+): Result<string | undefined> {
+  if (raw === undefined) return { ok: true, value: undefined };
+  if (SPECIES_RE.test(raw)) return { ok: true, value: raw };
+  return {
+    ok: false,
+    error: 'invalid species',
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'species',
+      received_hash: hash(raw),
+      reason: 'regex_mismatch',
+    },
+  };
+}
+
+// Family-code shape mirrors species: lowercase alphanumeric, slightly longer
+// (4-12 chars). Real values look like `tyrannidae`, `trochilidae`, etc.
+const FAMILY_RE = /^[a-z][a-z0-9]{3,11}$/;
+
+export function parseFamily(
+  raw: string | undefined,
+): Result<string | undefined> {
+  if (raw === undefined) return { ok: true, value: undefined };
+  if (FAMILY_RE.test(raw)) return { ok: true, value: raw };
+  return {
+    ok: false,
+    error: 'invalid family',
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'family',
+      received_hash: hash(raw),
+      reason: 'regex_mismatch',
+    },
+  };
+}
+
+/**
+ * Per-axis bbox cap, applied only when `zoom >= 6` (per-observation mode).
+ * At lower zooms the server uses aggregated mode so unbounded bboxes are fine.
+ *
+ * Caps: `maxLng - minLng <= 15` AND `maxLat - minLat <= 10`.
+ *
+ * Reject body is descriptive so the frontend can render an affordance:
+ *   { error: 'bbox too large', maxLngSpan: 15, maxLatSpan: 10,
+ *     hint: 'zoom out for aggregated view' }
+ */
+export interface BboxTooLargeBody {
+  error: 'bbox too large';
+  maxLngSpan: 15;
+  maxLatSpan: 10;
+  hint: 'zoom out for aggregated view';
+}
+
+export function assertBboxAreaCap(
+  bbox: [number, number, number, number],
+  zoom: number | undefined,
+):
+  | { ok: true }
+  | { ok: false; body: BboxTooLargeBody; log: ValidationLog } {
+  if (zoom === undefined || zoom < 6) return { ok: true };
+  const [minLng, minLat, maxLng, maxLat] = bbox;
+  const lngSpan = maxLng - minLng;
+  const latSpan = maxLat - minLat;
+  if (lngSpan <= 15 && latSpan <= 10) return { ok: true };
+  return {
+    ok: false,
+    body: {
+      error: 'bbox too large',
+      maxLngSpan: 15,
+      maxLatSpan: 10,
+      hint: 'zoom out for aggregated view',
+    },
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'bbox_too_large',
+      received_hash: hash(`${lngSpan.toFixed(2)},${latSpan.toFixed(2)}`),
+      reason: 'too_large',
+    },
+  };
+}
+
+/**
+ * Per-observation requests must specify EITHER a bbox OR a species code.
+ * Family-only (no bbox, no species) is the scrape vector for "all of family X
+ * nationally" — reject with 400.
+ *
+ * This guard applies only when the request will hit the per-observation path:
+ * aggregated mode (bbox present + zoom < 6) is already cheap.
+ */
+export function assertBboxOrSpecies(args: {
+  bbox: [number, number, number, number] | undefined;
+  speciesCode: string | undefined;
+}):
+  | { ok: true }
+  | { ok: false; error: string; log: ValidationLog } {
+  if (args.bbox !== undefined || args.speciesCode !== undefined) return { ok: true };
+  return {
+    ok: false,
+    error: 'specify bbox or species',
+    log: {
+      severity: 'INFO',
+      message: 'validation_400',
+      param: 'bbox_required',
+      received_hash: hash(''),
+      reason: 'missing_required',
+    },
+  };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Req[GET /api/observations] --> Since[parseSince]
    Since -- 30d --> Coerce[coerce -> 14d<br/>+ Deprecation/Sunset/Warning headers<br/>+ NOTICE log]
    Since -- garbage --> R400[400 + validation_400 log]
    Coerce --> Notable[parseNotable]
    Since -- 1d/7d/14d --> Notable
    Notable -- bad --> R400
    Notable -- ok --> Species["parseSpecies<br/>^[a-z][a-z0-9]{2,9}$"]
    Species -- bad --> R400
    Species -- ok --> Family["parseFamily<br/>^[a-z][a-z0-9]{3,11}$"]
    Family -- bad --> R400
    Family -- ok --> Bbox[parse bbox + zoom<br/>existing strict checks]
    Bbox --> AggCheck{"bbox AND zoom<6?"}
    AggCheck -- yes --> Agg[aggregated mode<br/>no cap]
    AggCheck -- no --> Guard[assertBboxOrSpecies]
    Guard -- neither --> R400
    Guard -- ok --> Cap["assertBboxAreaCap<br/>zoom>=6: lng<=15 AND lat<=10"]
    Cap -- too large --> R400Body["400 'bbox too large'<br/>+ hint"]
    Cap -- ok --> DB[getObservations<br/>LIMIT 5000 if species set]
```

## Summary

- **Scope A.** Drops `'30d'` from the time-window filter (FiltersBar dropdown, `Since` union, `VALID_SINCE`, `ObservationFilters`, App.tsx + FilterSentence period labels). The ingester prunes >14d nightly so 30d was a dead UI option. Bookmarked deep links still degrade silently via the existing `VALID_SINCE` fallback.
- **Scope B.** Adds `services/read-api/src/validate.ts` centralizing strict allowlist validation for `notable`, `species`, `family`. Real eBird codes (`accipi1`, `tyrann1`, `x00013`, `gamqua`, `cardin1`) all pass; `'%' / "' OR 1=1 --" / 'GAMQUA'` all 400. Every rejection emits a single `{severity:'INFO', message:'validation_400', param, received_hash, reason}` log line — raw value is sha256-hashed (Addendum §7). 400 body never echoes the received value or leaks the allowlist.
- **Addendum §5 soft-deprecation.** `?since=30d` is accepted for one release window: server coerces to `14d`, returns 200 with `Deprecation: true` + `Sunset: <ISO date, 14d from deploy>` + `Warning: 299 ...` headers, and emits a `deprecated_since_30d` NOTICE log carrying `user_agent`. Hard 400 ships in PR 3 (≥14d post-deploy).
- **Scope C.1.** Per-observation path requires EITHER `bbox` OR `?species=`. Bare `/api/observations` and `?family=X` (no bbox, no species) now 400 with `{error: 'specify bbox or species'}`. `LIMIT 5000` added to `getObservations` when `speciesCode` is set, defense-in-depth against species-deep-link scrape (Addendum §4).
- **Scope C.2.** Per-axis bbox cap, zoom-conditional. `zoom >= 6` enforces `maxLng-minLng <= 15` AND `maxLat-minLat <= 10`; `zoom < 6` is uncapped (aggregation handles it). Reject body is descriptive so the frontend can render an affordance (Addendum §2).

**Not in this PR (deliberate split):** Scope C.3 (LIMIT 10000 emergency brake with truncation banner + `meta.truncated` + structured warning log) ships as PR 2 — independently revertable per Addendum §3. Cloudflare WAF per-IP daily cap (Scope C.4) remains deferred.

## Screenshots

Single visible-UI change: FiltersBar dropdown loses one option (`30 days`). Orchestrator will capture the canonical 5-viewport × 2-theme set via the user-attachments paste flow.

- [ ] Every new/renamed \`className\` in this PR has a matching CSS rule — N/A, no className additions
- [ ] Multi-viewport design QA: ≥10 `user-attachments` URLs in PR body — to be added by orchestrator

## Test plan

- [x] `npm test --workspace @bird-watch/read-api` — 132 passed, including 46 new validator tests + soft-deprecation header assertions + structured 400 telemetry + real-eBird-code acceptance
- [x] `npm test --workspace @bird-watch/db-client` — observations suite passes, including new LIMIT 5000 integration test seeded with 6K rows via generate_series
- [x] `npm test --workspace @bird-watch/frontend` — 903 passed (Since-type narrowing carries through)
- [x] `npm run lint` — clean across all workspaces
- [x] `npm run build --workspaces` — clean production build
- [x] New unit + integration tests added: `services/read-api/src/validate.test.ts` (46 cases incl. positive `accipi1/tyrann1/x00013/gamqua/cardin1` fixtures + negative `''/'%'/"' OR 1=1 --"/'GAMQUA'/'gam qua'` fixtures); new `app.test.ts` describes for `?since=30d` soft-deprecation, strict allowlist validation, bbox-or-species guard, per-axis bbox cap; `observations.test.ts` LIMIT 5000 integration test
- [ ] (UI only) Playwright MCP smoke — orchestrator handles per repo CLAUDE.md design-review contract

## Plan reference

Closes #667. Implements PR 1 of the two-PR split documented in the issue's Addendum "Updated PR shape" section. PR 2 (LIMIT 10000 emergency brake with truncation banner) is a follow-up; file pending after this lands and bakes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
