### PR TITLE
feat(ingestor): flip /recent regionCode US-AZ → US (Phase 3a)

### DIFF
--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -204,7 +204,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
   try {
     let summary: AnyRunSummary;
     if (kind === 'recent') {
-      summary = await deps.runIngest({ pool, apiKey, regionCode: 'US-AZ' });
+      summary = await deps.runIngest({ pool, apiKey, regionCode: 'US' });
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (kind === 'backfill') {

--- a/services/ingestor/src/handler.test.ts
+++ b/services/ingestor/src/handler.test.ts
@@ -73,7 +73,7 @@ describe('handleScheduled', () => {
     expect(runIngestMock).toHaveBeenCalledWith({
       pool: POOL_SENTINEL,
       apiKey: 'test-key',
-      regionCode: 'US-AZ',
+      regionCode: 'US',
     });
     expect(result).toBe(summary);
     expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);

--- a/services/ingestor/src/handler.ts
+++ b/services/ingestor/src/handler.ts
@@ -39,7 +39,7 @@ export async function handleScheduled(
   try {
     switch (kind) {
       case 'recent':
-        return await runIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ' });
+        return await runIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US' });
       case 'hotspots':
         return await runHotspotIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ' });
       case 'backfill':


### PR DESCRIPTION
## Summary
- **The flip.** `/recent` eBird endpoint call now passes `regionCode: 'US'` instead of `'US-AZ'`. Next Cloud Scheduler tick (every :00 / :30 UTC) ingests national observations into Cloud SQL.
- Scope is narrow: only the `recent` kind. `/hotspots` stays on US-AZ until step 3b (~24h after this lands stable).
- Frontend rebuild via `VITE_REGION_CODE=US` in CF Pages happens **separately**, after we verify the first national /recent tick lands non-AZ rows. Sequencing keeps "UI says USA but data is AZ-only" under 30 min.

## Why now

Per readiness plan at `/Users/j/.claude/plans/are-we-ready-to-starry-dove.md`. Every Phase 0-2 pre-condition shipped + verified live today:
- Cloud SQL is the sole DB (#634 T4 + #637/#640 Neon teardown)
- Zoom-aware aggregation (#630) caps CONUS payloads at z<6 to 25-65 KB
- Anti-scrape hardening (#668) restricts mid-zoom dense viewports + 400s bad input
- Healthchecks.io + budget alerts armed
- Cloudflare 60 req/min/IP across 3 layers

## Test plan
- [ ] CI green (test, lint, build, e2e, knip, orphan-classname-check)
- [ ] After `terraform apply` (no-op — no infra changes here, just image rebuild):
  - Next `/recent` Cloud Scheduler tick at :00 or :30 UTC fires successfully (Healthchecks.io heartbeat lands)
  - Cloud SQL observations widen beyond AZ:
    ```sh
    psql "$(cat /tmp/cloudsql_local_url)" -tA -c "
      SELECT count(*), min(lng), max(lng) FROM observations
      WHERE obs_dt > now() - interval '1 hour';"
    # Expect: lng range widens from AZ (-115 to -109) toward CONUS (-125 to -66)
    ```
  - Then orchestrator flips `VITE_REGION_CODE=US` in CF Pages env config

## Rollback (RTO ~30 min)
1. `git revert` this commit on a new branch, queue, Mergify lands
2. Next Cloud Scheduler tick picks up reverted code → back to US-AZ
3. National observations age out via 14-day prune; no schema cleanup needed

## Screenshots
N/A — backend-only (zero frontend touch in this PR). The frontend branding change (Bird Maps · USA) ships via the CF Pages env var update after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)