### PR TITLE
chore(frontend): flip VITE_REGION_CODE=US (Phase 3a frontend)

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=https://api.bird-maps.com
+VITE_REGION_CODE=US


### PR DESCRIPTION
## Summary
- Adds `VITE_REGION_CODE=US` to `frontend/.env.production`. Vite bakes it in at build time → `REGION_CODE='US'` → `REGION_LABEL='USA'` per `frontend/src/config/region.ts`.
- Wordmark, lede, and `<title>` flip from "Arizona" to "USA" on the next CF Pages deploy.

## Companion to #669
- #669 flipped the ingester `/recent` regionCode to `US` (merged 01:04 UTC).
- This PR completes Phase 3a frontend-side.
- Julian asked to flip the frontend now in parallel with waiting for first national tick at 01:30 UTC; accepting a ~15-min "USA branding but only AZ data" window.

## Rollback
Single-line revert. CF Pages picks up reverted bundle on next deploy. ~5 min RTO.

## Screenshots
N/A — visible text change in header but no layout/component change. Manual smoke after deploy: visit bird-maps.com, confirm header reads "Bird Maps · USA".

🤖 Generated with [Claude Code](https://claude.com/claude-code)