### PR TITLE
fix(read-api): raise z>=6 bbox cap to 30° x 15° (Phase 3a hotfix)

### DIFF
--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -305,20 +305,20 @@ describe('GET /api/observations', () => {
   });
 
   // #667 Scope C.2 — per-axis bbox cap on the per-observation path. zoom < 6
-  // hits aggregated mode (no cap); zoom >= 6 enforces 15° lng × 10° lat.
+  // hits aggregated mode (no cap); zoom >= 6 enforces 30° lng × 15° lat.
   describe('per-axis bbox cap (#667 Scope C.2)', () => {
     it('rejects too-wide lng span at zoom=8 with descriptive body', async () => {
       const app = createApp({ pool: db.pool });
       const res = await app.request(
-        '/api/observations?bbox=-130,30,-110,40&zoom=8',
+        '/api/observations?bbox=-140,30,-100,40&zoom=8',
       );
       expect(res.status).toBe(400);
       const body = await res.json() as {
         error: string; maxLngSpan: number; maxLatSpan: number; hint: string;
       };
       expect(body.error).toBe('bbox too large');
-      expect(body.maxLngSpan).toBe(15);
-      expect(body.maxLatSpan).toBe(10);
+      expect(body.maxLngSpan).toBe(30);
+      expect(body.maxLatSpan).toBe(15);
       expect(body.hint).toContain('zoom out');
     });
 

--- a/services/read-api/src/validate.test.ts
+++ b/services/read-api/src/validate.test.ts
@@ -138,17 +138,17 @@ describe('assertBboxAreaCap', () => {
   });
 
   it('rejects too-wide lng span at zoom >= 6', () => {
-    const r = assertBboxAreaCap([-130, 30, -110, 40], 6); // 20° × 10° — lng > 15
+    const r = assertBboxAreaCap([-140, 30, -100, 40], 6); // 40° × 10° — lng > 30
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.body.error).toBe('bbox too large');
-      expect(r.body.maxLngSpan).toBe(15);
+      expect(r.body.maxLngSpan).toBe(30);
       expect(r.log.reason).toBe('too_large');
     }
   });
 
   it('rejects too-tall lat span at zoom >= 6', () => {
-    const r = assertBboxAreaCap([-115, 25, -105, 40], 7); // 10° × 15° — lat > 10
+    const r = assertBboxAreaCap([-115, 20, -105, 45], 7); // 10° × 25° — lat > 15
     expect(r.ok).toBe(false);
   });
 

--- a/services/read-api/src/validate.ts
+++ b/services/read-api/src/validate.ts
@@ -149,16 +149,16 @@ export function parseFamily(
  * Per-axis bbox cap, applied only when `zoom >= 6` (per-observation mode).
  * At lower zooms the server uses aggregated mode so unbounded bboxes are fine.
  *
- * Caps: `maxLng - minLng <= 15` AND `maxLat - minLat <= 10`.
+ * Caps: `maxLng - minLng <= 30` AND `maxLat - minLat <= 15`.
  *
  * Reject body is descriptive so the frontend can render an affordance:
- *   { error: 'bbox too large', maxLngSpan: 15, maxLatSpan: 10,
+ *   { error: 'bbox too large', maxLngSpan: 30, maxLatSpan: 15,
  *     hint: 'zoom out for aggregated view' }
  */
 export interface BboxTooLargeBody {
   error: 'bbox too large';
-  maxLngSpan: 15;
-  maxLatSpan: 10;
+  maxLngSpan: 30;
+  maxLatSpan: 15;
   hint: 'zoom out for aggregated view';
 }
 
@@ -172,13 +172,13 @@ export function assertBboxAreaCap(
   const [minLng, minLat, maxLng, maxLat] = bbox;
   const lngSpan = maxLng - minLng;
   const latSpan = maxLat - minLat;
-  if (lngSpan <= 15 && latSpan <= 10) return { ok: true };
+  if (lngSpan <= 30 && latSpan <= 15) return { ok: true };
   return {
     ok: false,
     body: {
       error: 'bbox too large',
-      maxLngSpan: 15,
-      maxLatSpan: 10,
+      maxLngSpan: 30,
+      maxLatSpan: 15,
       hint: 'zoom out for aggregated view',
     },
     log: {


### PR DESCRIPTION
## Summary

- After Phase 3a flipped the frontend to CONUS framing, desktop users hitting z=6 produce natural bboxes ~18° lng wide, exceeding the old 15° cap from #668 → API returned 400 → map crashed.
- Raises the universal z≥6 bbox cap to 30° lng × 15° lat. Still meaningfully constrains scrape spans (CONUS is ~60° wide) while allowing every reasonable desktop viewport at z=6.
- Backend-only, no service-area change.

## Why now

Latent since #668 (yesterday); surfaced today because the Phase 3a CONUS initial viewport (`MapCanvas.tsx:274` `CONUS_ZOOM_WIDE=4`) means typical exploration crosses the z=6 boundary at much wider bboxes than the prior AZ-only framing.

## Changes

- `services/read-api/src/validate.ts` — `assertBboxAreaCap` constants 15→30, 10→15 (interface, runtime check, error body, docstring).
- `services/read-api/src/validate.test.ts` — rejection fixtures updated (40°×10° lng; 10°×25° lat).
- `services/read-api/src/app.test.ts` — request-level rejection fixture updated to 40°×10° bbox.

## Test plan

- [x] Unit: `assertBboxAreaCap` accepts within-cap, rejects wide-lng and tall-lat at z≥6
- [x] Integration: `/api/observations?bbox=-140,30,-100,40&zoom=8` returns 400 with `maxLngSpan:30, maxLatSpan:15`
- [ ] Post-deploy: `curl 'https://api.bird-maps.com/api/observations?bbox=-110,35,-92,45&zoom=6'` returns 200 (18° lng × 10° lat)
- [ ] Visual: bird-maps.com no longer crashes when zooming to z=6 on a 1408px viewport

## Screenshots

N/A — backend-only change

## Risk

Low. Cap is still load-bearing (30° lng caps roughly one-third of CONUS width; per-axis still prevents combined scrape vectors). Rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)