### PR TITLE
fix(read-api): size z>=6 bbox cap to actual map viewport (45° × 25°)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -277,6 +277,24 @@ const CONUS_ZOOM_NARROW = 3;
 const CONUS_ZOOM_WIDE = 4;
 const CONUS_NARROW_BREAKPOINT_PX = 700;
 
+/**
+ * Pan/zoom bounds for the map. Kept consistent with the server-side bbox cap
+ * in `services/read-api/src/validate.ts` (45° lng × 25° lat at z>=6 / per-obs
+ * mode) so the natural viewport at z=6 stays under the cap on any canonical
+ * viewport (1920×1080 → 42.2° × 23.7°).
+ *
+ * - `MIN_ZOOM = 3` matches `CONUS_ZOOM_NARROW`: users can't zoom out past the
+ *   mobile-default CONUS view. At z<6 the API is in aggregated mode anyway,
+ *   so unbounded bboxes don't matter; this bound is purely a UX floor.
+ * - `MAX_BOUNDS` keeps pan inside CONUS + a margin for coastal/border obs.
+ *   AK and HI are out of frame for Phase 3a; revisit when ingest expands.
+ */
+const MIN_ZOOM = CONUS_ZOOM_NARROW;
+const MAX_BOUNDS: [[number, number], [number, number]] = [
+  [-130, 20],
+  [-65, 52],
+];
+
 function pickInitialZoom(): number {
   if (typeof window === 'undefined') return CONUS_ZOOM_WIDE;
   return window.innerWidth < CONUS_NARROW_BREAKPOINT_PX
@@ -1399,6 +1417,8 @@ export function MapCanvas({
       <MapView
         ref={mapRef}
         initialViewState={INITIAL_VIEW}
+        minZoom={MIN_ZOOM}
+        maxBounds={MAX_BOUNDS}
         style={{ width: '100%', height: '100%' }}
         mapStyle={
           typeof document !== 'undefined' &&

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -305,20 +305,20 @@ describe('GET /api/observations', () => {
   });
 
   // #667 Scope C.2 — per-axis bbox cap on the per-observation path. zoom < 6
-  // hits aggregated mode (no cap); zoom >= 6 enforces 30° lng × 15° lat.
+  // hits aggregated mode (no cap); zoom >= 6 enforces 45° lng × 25° lat.
   describe('per-axis bbox cap (#667 Scope C.2)', () => {
     it('rejects too-wide lng span at zoom=8 with descriptive body', async () => {
       const app = createApp({ pool: db.pool });
       const res = await app.request(
-        '/api/observations?bbox=-140,30,-100,40&zoom=8',
+        '/api/observations?bbox=-140,30,-90,40&zoom=8',
       );
       expect(res.status).toBe(400);
       const body = await res.json() as {
         error: string; maxLngSpan: number; maxLatSpan: number; hint: string;
       };
       expect(body.error).toBe('bbox too large');
-      expect(body.maxLngSpan).toBe(30);
-      expect(body.maxLatSpan).toBe(15);
+      expect(body.maxLngSpan).toBe(45);
+      expect(body.maxLatSpan).toBe(25);
       expect(body.hint).toContain('zoom out');
     });
 

--- a/services/read-api/src/validate.test.ts
+++ b/services/read-api/src/validate.test.ts
@@ -131,24 +131,30 @@ describe('assertBboxAreaCap', () => {
   });
 
   it('passes for a within-cap bbox at zoom >= 6', () => {
-    // Texas-ish: 13° lng × 11° lat — within 15/10 cap (actually 11 > 10 fails).
-    // Pick something within the cap.
     const r = assertBboxAreaCap([-115, 32, -109, 37], 8); // 6° × 5°
     expect(r.ok).toBe(true);
   });
 
+  it('passes for natural 1920x1080 viewport at z=6 (~42.2° × 23.7°)', () => {
+    // Largest canonical viewport at the per-obs zoom boundary. The cap is
+    // sized to allow this exact case — if you bump 1920×1080 out of the
+    // canonical set, you can shrink the cap.
+    const r = assertBboxAreaCap([-119.7, 27.9, -77.5, 51.6], 6);
+    expect(r.ok).toBe(true);
+  });
+
   it('rejects too-wide lng span at zoom >= 6', () => {
-    const r = assertBboxAreaCap([-140, 30, -100, 40], 6); // 40° × 10° — lng > 30
+    const r = assertBboxAreaCap([-140, 30, -90, 40], 6); // 50° × 10° — lng > 45
     expect(r.ok).toBe(false);
     if (!r.ok) {
       expect(r.body.error).toBe('bbox too large');
-      expect(r.body.maxLngSpan).toBe(30);
+      expect(r.body.maxLngSpan).toBe(45);
       expect(r.log.reason).toBe('too_large');
     }
   });
 
   it('rejects too-tall lat span at zoom >= 6', () => {
-    const r = assertBboxAreaCap([-115, 20, -105, 45], 7); // 10° × 25° — lat > 15
+    const r = assertBboxAreaCap([-115, 15, -105, 45], 7); // 10° × 30° — lat > 25
     expect(r.ok).toBe(false);
   });
 

--- a/services/read-api/src/validate.ts
+++ b/services/read-api/src/validate.ts
@@ -149,16 +149,24 @@ export function parseFamily(
  * Per-axis bbox cap, applied only when `zoom >= 6` (per-observation mode).
  * At lower zooms the server uses aggregated mode so unbounded bboxes are fine.
  *
- * Caps: `maxLng - minLng <= 30` AND `maxLat - minLat <= 15`.
+ * Caps: `maxLng - minLng <= 45` AND `maxLat - minLat <= 25`.
+ *
+ * Sizing matches the largest natural viewport at the per-obs zoom boundary.
+ * Web mercator: degrees-per-pixel at z=6 = 360 / (256 * 2^6) = 0.02197°/px.
+ * 1920×1080 (largest canonical viewport, see frontend/CLAUDE.md) at z=6 is
+ * 42.2° lng × 23.7° lat. 45° × 25° clears that with a small safety margin
+ * yet is still load-bearing: CONUS is 60° wide, so one request can only
+ * grab ~75% of east-west extent; per-axis cap prevents combining axes
+ * into a whole-country scrape.
  *
  * Reject body is descriptive so the frontend can render an affordance:
- *   { error: 'bbox too large', maxLngSpan: 30, maxLatSpan: 15,
+ *   { error: 'bbox too large', maxLngSpan: 45, maxLatSpan: 25,
  *     hint: 'zoom out for aggregated view' }
  */
 export interface BboxTooLargeBody {
   error: 'bbox too large';
-  maxLngSpan: 30;
-  maxLatSpan: 15;
+  maxLngSpan: 45;
+  maxLatSpan: 25;
   hint: 'zoom out for aggregated view';
 }
 
@@ -172,13 +180,13 @@ export function assertBboxAreaCap(
   const [minLng, minLat, maxLng, maxLat] = bbox;
   const lngSpan = maxLng - minLng;
   const latSpan = maxLat - minLat;
-  if (lngSpan <= 30 && latSpan <= 15) return { ok: true };
+  if (lngSpan <= 45 && latSpan <= 25) return { ok: true };
   return {
     ok: false,
     body: {
       error: 'bbox too large',
-      maxLngSpan: 30,
-      maxLatSpan: 15,
+      maxLngSpan: 45,
+      maxLatSpan: 25,
       hint: 'zoom out for aggregated view',
     },
     log: {


### PR DESCRIPTION
## Summary

Two-commit PR — couples the frontend map config with the server bbox cap so they're self-consistent.

**Commit 1 — server: size cap to actual viewport at z=6 (45° × 25°)**

PR #671 raised cap to 30°×15° but desktop viewports still overflowed: 1440×900 @ z=6 = 31.6° lng, 1920×1080 @ z=6 = 42.2° × 23.7°. Sizes to canonical viewport set (max 1920×1080 from frontend/CLAUDE.md) plus margin: **45° lng × 25° lat**. Derivation captured in validate.ts docstring.

**Commit 2 — frontend: minZoom + maxBounds to match the cap**

- `minZoom = CONUS_ZOOM_NARROW (3)` — UX floor; can't zoom out past mobile-default CONUS view
- `maxBounds = [[-130, 20], [-65, 52]]` — CONUS with margin for coastal/border obs
- At any reachable zoom inside these bounds, natural bbox stays under the cap
- AK/HI out of frame for Phase 3a; revisit when ingest expands

## Why this size

| Viewport at z=6 | lng span | lat span (max, equator) |
|---|---|---|
| 390×844 (mobile) | 8.6° | 18.5° |
| 1024×768 | 22.5° | 16.9° |
| 1440×900 | 31.6° | 19.8° |
| **1920×1080** | **42.2°** | **23.7°** |

Web mercator: `viewport_px × 360 / (256 × 2^6)` at the per-obs zoom boundary. 45° × 25° clears all canonical viewports with margin.

Still load-bearing: CONUS is ~60° wide, so a single z>=6 request grabs at most 75% of east-west extent. Per-axis cap prevents combining axes into a whole-country scrape.

## Evidence — what crashed live

Failing request from the live map at desktop z=6:

`bbox=-124.93,32.31,-93.22,44.66` → 31.7° lng × 12.4° lat → 400 under the post-#671 30° cap.

Console: `API error 400: {"error":"bbox too large","maxLngSpan":30,"maxLatSpan":15,"hint":"zoom out for aggregated view"}` → map crashed.

## Test plan

- [x] Unit: `assertBboxAreaCap` accepts a literal 1920×1080 z=6 bbox (~42°×24°)
- [x] Unit: rejects 50°×10° lng and 10°×30° lat
- [x] Integration: `/api/observations?bbox=-140,30,-90,40&zoom=8` returns 400 with `maxLngSpan:45, maxLatSpan:25`
- [ ] Post-deploy live: Playwright at 1920×1080, zoom to z=6, pan across CONUS — zero 400s
- [ ] Post-deploy live: minZoom = 3 enforced (no zoom-out below CONUS view)
- [ ] Post-deploy live: maxBounds enforced (pan stops at CONUS+margin edges)

## Screenshots

N/A — backend-only + map config change (visual identical at normal usage; new constraints only surface at panning/zooming edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)