### PR TITLE
fix(ci): retarget deploy-migrations from Neon to Cloud SQL via Auth Proxy

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -1,14 +1,22 @@
 name: deploy-migrations
 
 # Partial-failure contract: if any `-- Up Migration` statement errors, this
-# workflow exits non-zero and leaves Neon in whatever state the runner reached
-# up to the last committed migration. It does NOT auto-rollback. A human must
-# inspect and either fix-forward with a new migration or manually revert.
+# workflow exits non-zero and leaves Cloud SQL in whatever state the runner
+# reached up to the last committed migration. It does NOT auto-rollback. A
+# human must inspect and either fix-forward with a new migration or manually
+# revert.
 #
 # Ordering with app code: if a schema-changing migration ships alongside a
 # read-api or ingestor code change that depends on the new column, (1) ship
 # the migration PR, (2) wait for this workflow to succeed, (3) ship the code
 # in a follow-up PR. Not enforced in YAML — developer discipline.
+#
+# Connection model: this workflow does NOT talk to Cloud SQL over a public IP.
+# Cloud SQL's `ip_configuration` (infra/terraform/cloud-sql.tf:53-58) has no
+# `authorized_networks` block, by design. We connect via the Cloud SQL Auth
+# Proxy v2 binary started in-job, listening on 127.0.0.1:5432. The proxy
+# authenticates with GCP via Workload Identity Federation (same WIF provider
+# the other deploy-* workflows use) and tunnels to the instance.
 
 on:
   push:
@@ -26,6 +34,18 @@ concurrency:
   group: deploy-migrations-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  GCP_PROJECT: bird-maps-prod
+  GCP_REGION: us-west1
+  # Cloud SQL instance connection name. Format: <project>:<region>:<instance>.
+  # Sourced from `terraform output cloudsql_connection_name`
+  # (infra/terraform/cloud-sql.tf:148-150).
+  CLOUDSQL_INSTANCE: bird-maps-prod:us-west1:birdwatch-pg16
+  # Cloud SQL Auth Proxy v2 release. Pin to a specific version so workflow
+  # behaviour stays deterministic — upgrade via PR, not via GitHub's "latest"
+  # alias.
+  CLOUDSQL_PROXY_VERSION: v2.14.2
+
 jobs:
   deploy:
     name: deploy
@@ -33,8 +53,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      # No id-token: write needed — Neon auth is via DATABASE_URL password,
-      # not GCP WIF like the read-api / ingestor workflows.
+      id-token: write   # required for WIF auth to GCP (Cloud SQL Auth Proxy)
     steps:
       - uses: actions/checkout@v6
 
@@ -45,21 +64,79 @@ jobs:
 
       - run: npm ci
 
-      - name: Verify DATABASE_URL uses Neon pooled endpoint
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SA_EMAIL }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Install Cloud SQL Auth Proxy v2
+        # Download the official linux/amd64 binary. The Cloud SQL Auth Proxy is
+        # statically linked; no further setup required. We prefer the binary
+        # over the container image because GHA can't easily run a sidecar
+        # alongside the main job step.
         run: |
-          if [[ -z "${DATABASE_URL:-}" ]]; then
-            echo "::error::DATABASE_URL secret is not set"
-            exit 1
+          set -euo pipefail
+          sudo curl -sSfLo /usr/local/bin/cloud-sql-proxy \
+            "https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CLOUDSQL_PROXY_VERSION}/cloud-sql-proxy.linux.amd64"
+          sudo chmod +x /usr/local/bin/cloud-sql-proxy
+          cloud-sql-proxy --version
+
+      - name: Start Cloud SQL Auth Proxy
+        # Listen on TCP 127.0.0.1:5432 so migrate-deploy.sh's psql/pg client
+        # libraries can connect via a normal `postgres://...:5432/...` URL.
+        # The proxy inherits ADC from the `auth` step above (WIF token).
+        # Run in the background; we wait for readiness in the next step.
+        run: |
+          set -euo pipefail
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 5432 \
+            "${CLOUDSQL_INSTANCE}" &
+          echo "PROXY_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for Cloud SQL Auth Proxy to accept connections
+        # Poll with pg_isready (preinstalled on ubuntu-latest). Max ~30s; if
+        # the proxy hasn't come up by then something is structurally wrong
+        # (IAM grant missing, instance stopped, WIF token rejected) and
+        # waiting longer won't help.
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if pg_isready -h 127.0.0.1 -p 5432 -q; then
+              echo "Cloud SQL Auth Proxy is ready (after ${i}s)."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Cloud SQL Auth Proxy did not become ready within 30s."
+          # Surface the proxy state to aid debugging.
+          if [ -n "${PROXY_PID:-}" ]; then
+            kill -0 "${PROXY_PID}" 2>/dev/null \
+              && echo "Proxy process is still alive (PID ${PROXY_PID})." \
+              || echo "Proxy process exited before becoming ready."
           fi
-          if [[ ! "$DATABASE_URL" =~ -pooler ]]; then
-            echo "::error::DATABASE_URL must use Neon pooled endpoint (-pooler suffix). See infra/terraform/db.tf locals.neon_pooled_url."
-            exit 1
-          fi
-          echo "DATABASE_URL points at a pooled endpoint (host contains '-pooler')."
+          exit 1
 
       - name: Apply migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # The proxy is listening on 127.0.0.1:5432 in plaintext (the proxy
+          # itself terminates TLS to Cloud SQL); sslmode=disable on the
+          # client side is correct here and is the documented contract for
+          # Auth Proxy v2. The user/password are the same `birdwatch_app`
+          # credentials Cloud Run services use at runtime, sourced from the
+          # repository secrets that the rotation runbook keeps in sync with
+          # `google_sql_user.app` in infra/terraform/cloud-sql.tf.
+          DATABASE_URL: "postgres://${{ secrets.CLOUDSQL_APP_USER }}:${{ secrets.CLOUDSQL_APP_PASSWORD }}@127.0.0.1:5432/birdwatch?sslmode=disable"
         run: ./scripts/migrate-deploy.sh
+
+      - name: Stop Cloud SQL Auth Proxy
+        # Best-effort cleanup; the job is about to terminate anyway, but
+        # graceful shutdown lets the proxy flush its own logs.
+        if: always()
+        run: |
+          if [ -n "${PROXY_PID:-}" ]; then
+            kill "${PROXY_PID}" 2>/dev/null || true
+          fi

--- a/.github/workflows/terraform-plan-drift-check.yml
+++ b/.github/workflows/terraform-plan-drift-check.yml
@@ -106,6 +106,11 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           TF_VAR_ebird_api_key: ${{ secrets.EBIRD_API_KEY }}
+          # Added 2026-05-18 alongside `google_project_iam_member.cloudsql_client_deployer`
+          # in cloud-sql.tf. Required for `terraform plan` to validate even
+          # though the nightly drift workflow won't apply the grant — without
+          # this the plan errors out with `No value for required variable`.
+          TF_VAR_deployer_service_account_email: ${{ secrets.GCP_DEPLOY_SA_EMAIL }}
         run: |
           set +e
           terraform plan -detailed-exitcode -input=false -lock-timeout=60s \

--- a/infra/terraform/cloud-sql.tf
+++ b/infra/terraform/cloud-sql.tf
@@ -177,3 +177,18 @@ resource "google_project_iam_member" "cloudsql_client_read_api" {
   role    = "roles/cloudsql.client"
   member  = "serviceAccount:${google_service_account.read_api.email}"
 }
+
+# The fourth grant covers the GHA deploy-* workflows' identity, not a Cloud
+# Run runtime SA. The `deploy-migrations` workflow starts the Cloud SQL Auth
+# Proxy in-job and connects to it via TCP 127.0.0.1:5432 to run
+# `node-pg-migrate up`. Without `cloudsql.client`, the proxy fails before it
+# can accept connections (`boss::NOT_AUTHORIZED ... missing permission
+# cloudsql.instances.get`) and pg_isready times out. Surfaced 2026-05-18 when
+# the post-cutover deploy-migrations workflow exit-2'd on every push to main
+# — the previous Neon-direct workflow needed no GCP IAM, so this grant had no
+# parallel until cutover.
+resource "google_project_iam_member" "cloudsql_client_deployer" {
+  project = var.gcp_project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${var.deployer_service_account_email}"
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -9,6 +9,12 @@ ebird_api_key         = "REPLACE_ME"
 domain                = "birdwatch.example.com"
 frontend_origins      = "https://bird-maps.com,https://www.bird-maps.com"
 
+# Email of the GHA WIF-impersonated deployer SA. Matches the value stored in
+# the `GCP_DEPLOY_SA_EMAIL` repository secret. Used by cloud-sql.tf to grant
+# `roles/cloudsql.client` so the deploy-migrations workflow can connect via
+# the Cloud SQL Auth Proxy.
+deployer_service_account_email = "REPLACE_ME@REPLACE_ME.iam.gserviceaccount.com"
+
 # Monitoring & alerts (Plan 2026-05-17). alert_email defaults to
 # julian.kennon.d@gmail.com — uncomment to override. Healthchecks.io URLs are
 # NOT set here; they live in Secret Manager (bird-watch-healthchecks-<kind>)

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -62,3 +62,12 @@ variable "frontend_origins" {
   # Production-only origins. Local dev relies on the hardcoded fallback in
   # services/read-api/src/app.ts; dev origins must NOT be added here.
 }
+
+variable "deployer_service_account_email" {
+  type        = string
+  description = "Email of the GCP service account impersonated by GitHub Actions deploy-* workflows via Workload Identity Federation. Stored in the GHA `GCP_DEPLOY_SA_EMAIL` secret. Used by `infra/terraform/cloud-sql.tf` to grant `roles/cloudsql.client` so the deployer can connect through the Cloud SQL Auth Proxy from CI. The SA itself is provisioned out-of-band (predates Terraform-managed IAM here)."
+  # Out-of-band today. If we ever pull SA provisioning under Terraform, add the
+  # `google_service_account` resource alongside the existing service-account
+  # blocks in read-api.tf / admin-api.tf / ingestor.tf and reference its
+  # `.email` attribute here.
+}

--- a/scripts/migrate-deploy.sh
+++ b/scripts/migrate-deploy.sh
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Applies pending `-- Up Migration` SQL files under migrations/ against the
+# Postgres pointed at by $DATABASE_URL via node-pg-migrate. Designed to run
+# against Cloud SQL (Postgres 16) through the Cloud SQL Auth Proxy started by
+# .github/workflows/deploy-migrations.yml, but it works against any Postgres
+# URL — PostGIS is created by migration 1700000001000_enable_postgis.sql
+# rather than by an out-of-band `CREATE EXTENSION`, so the only environmental
+# requirement is a reachable database the connecting user can write to.
+#
+# Partial-failure contract: non-zero exit on the first migration that errors,
+# matching the workflow's contract (no auto-rollback).
+
 cd "$(dirname "$0")/.."
 
 if [ -z "${DATABASE_URL:-}" ]; then
   echo "DATABASE_URL not set" >&2
-  echo "Hint: export DATABASE_URL=\$(cd infra/terraform && terraform output -raw neon_db_url)" >&2
   exit 1
 fi
-
-echo "Enabling PostGIS on Neon..."
-# NOTE: redundant with migrations/1700000001000_enable_postgis.sql, which runs
-# CREATE EXTENSION IF NOT EXISTS postgis via the migrations ledger. Kept for
-# belt-and-suspenders on brand-new Neon branches where the ledger is empty.
-# Safe to delete in a follow-up cleanup (see issue #65 Gotchas, "optional").
-psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 
 echo "Running migrations..."
 # -d (a.k.a. --database-url-var) takes the NAME of the env var, not the URL value.


### PR DESCRIPTION
## Diagrams

Before — workflow connects directly to a dead Neon endpoint and exit-2's:

```mermaid
sequenceDiagram
    participant GHA as deploy-migrations job
    participant Neon as ep-crimson-pond-akx7mwc8-pooler.neon.tech<br/>(quota-exhausted, post-cutover)

    GHA->>GHA: psql ON_ERROR_STOP=1<br/>CREATE EXTENSION postgis
    GHA->>Neon: TCP 5432
    Neon-->>GHA: ERROR: data transfer quota exceeded
    Note over GHA: exit 2 — migration 48000<br/>never applied to prod
```

After — workflow tunnels through Cloud SQL Auth Proxy v2 to the live instance:

```mermaid
sequenceDiagram
    participant GHA as deploy-migrations job
    participant WIF as google-github-actions/auth@v3<br/>(WIF -> GCP_DEPLOY_SA_EMAIL)
    participant Proxy as cloud-sql-proxy v2.14.2<br/>(in-job, 127.0.0.1:5432)
    participant CSQL as Cloud SQL<br/>bird-maps-prod:us-west1:birdwatch-pg16

    GHA->>WIF: workload_identity_provider<br/>+ service_account
    WIF-->>GHA: ADC token
    GHA->>Proxy: spawn (background)
    Proxy->>CSQL: mTLS via Auth Proxy<br/>(roles/cloudsql.client)
    GHA->>GHA: pg_isready poll loop (max 30s)
    GHA->>Proxy: postgres://birdwatch_app:***<br/>@127.0.0.1:5432/birdwatch?sslmode=disable
    Proxy->>CSQL: tunneled
    CSQL-->>GHA: node-pg-migrate applies 1700000048000
```

## Summary

- The deploy-migrations workflow still pointed at the dead Neon pooled endpoint after the T3 Cloud SQL cutover (#634). Every push to main touching migrations has been exit-2'ing with ``Your project has exceeded the data transfer quota``. Migration 1700000048000 (Phylopic national-coverage, #673) is in the repo on main but NOT applied to prod — ``family_silhouettes`` still shows the 65-row pre-#673 state.
- The fix retargets the workflow to Cloud SQL via Cloud SQL Auth Proxy v2 — same auth model the other deploy-* workflows already use (WIF -> ``GCP_DEPLOY_SA_EMAIL``). DATABASE_URL is composed in-step from two new GHA secrets, ``CLOUDSQL_APP_USER`` and ``CLOUDSQL_APP_PASSWORD``, matching the ``google_sql_user.app`` resource in cloud-sql.tf.
- Adds the fourth ``google_project_iam_member`` for ``roles/cloudsql.client`` covering the deployer SA. The existing three grants cover Cloud Run runtime SAs only. Wired through a new ``deployer_service_account_email`` Terraform variable; the nightly drift-check workflow gets the matching ``TF_VAR_`` pass-through so its plan validation doesn't break.

## Screenshots

N/A — CI/infra-only.

## Test plan

- [x] ``python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-migrations.yml'))"`` — parses cleanly.
- [x] ``python3 -c "import yaml; yaml.safe_load(open('.github/workflows/terraform-plan-drift-check.yml'))"`` — parses cleanly.
- [x] ``bash -n scripts/migrate-deploy.sh`` — no syntax errors.
- [x] ``terraform -chdir=infra/terraform validate`` — ``Success! The configuration is valid.``
- [x] ``terraform -chdir=infra/terraform fmt -check -diff`` — clean.
- [x] All ``secrets.*`` referenced (``GCP_WIF_PROVIDER``, ``GCP_DEPLOY_SA_EMAIL``, ``CLOUDSQL_APP_USER``, ``CLOUDSQL_APP_PASSWORD``) verified against existing usages or noted as new. The first two are already used by ``deploy-{read,admin,ingestor}-api.yml``. The two ``CLOUDSQL_*`` secrets are new — to be created in GitHub repo settings by the orchestrator before the next push to main.
- [ ] **Post-merge**: ``terraform apply`` (handled out-of-band by the orchestrator) to land the new ``google_project_iam_member.cloudsql_client_deployer`` grant. Until that apply runs, the next ``deploy-migrations`` run will still fail with ``cloudsql.instances.get`` denied.
- [ ] **Post-merge**: orchestrator adds ``CLOUDSQL_APP_USER`` (= ``birdwatch_app``) and ``CLOUDSQL_APP_PASSWORD`` (= ``random_password.cloudsql_app_user.result``, also available as Secret Manager secret ``bird-watch-db-url``'s password component) as GHA repo secrets.
- [ ] **Post-merge**: trigger the workflow via ``gh workflow run deploy-migrations.yml`` (workflow_dispatch). The single pending migration ``1700000048000_national_coverage_silhouettes.sql`` applies; verify with ``gcloud sql connect birdwatch-pg16 --user=postgres -d birdwatch -- -c 'SELECT COUNT(*) FROM family_silhouettes;'`` (expect 97 rows, up from 65 — 32 INSERTs from migration 48000).

### Mergify exception

This PR touches ``.github/workflows/`` AND ``infra/terraform/`` AND ``scripts/``. The nightly ``terraform-plan-drift-check`` will surface ``google_project_iam_member.cloudsql_client_deployer`` as drift until the apply happens. That is expected and intentional — the apply is out-of-band per ``docs/plans/2026-05-17-cloud-sql-migration.md`` discipline (the orchestrator handles infra apply outside the PR cycle).

## Plan reference

Out of plan — hotfix for the silent-failure regression introduced by the T3 cutover in #634. The cutover plan (docs/plans/2026-05-17-cloud-sql-migration.md) flipped the read-api / admin-api / ingestor DATABASE_URL secret to Cloud SQL but did not include the GHA deploy-migrations workflow in scope, which is how the workflow kept pointing at the now-quota-exhausted Neon endpoint.

---

Generated with [Claude Code](https://claude.com/claude-code)
