### PR TITLE
feat(ingestor): Phase 3.5 per-state backfill fan-out

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -288,6 +288,75 @@ resource "google_cloud_scheduler_job" "ingest_backfill" {
   depends_on = [google_project_service.scheduler]
 }
 
+# ── Phase 3.5 per-state backfill fan-out (one-shot national 14-day backfill) ──
+#
+# Plan: ~/.claude/plans/are-we-ready-to-starry-dove.md Phase 3.5.
+#
+# 50 USPS state codes — DC and territories deliberately excluded per Julian's
+# scope call. Each Cloud Scheduler job invokes the SHARED `bird-ingestor`
+# Cloud Run Job via containerOverrides with args=["backfill", "--state=US-XX",
+# "--back=14"], matching the existing scheduler→job pattern in this file
+# (no separate per-state Cloud Run Job — there's only one shared image).
+#
+# Staggering: 50 jobs across 180 minutes ≈ 216s spacing. Cron-minute resolution
+# forces us to round to 4-minute intervals (4 min × 50 = 200 min ≤ 180 min
+# budget when packed). We compute (idx * 4) minute offsets relative to a
+# base_hour anchored at 08 UTC (≈ 00:00 PT — low traffic for eBird and Cloud
+# SQL alike). Result: index 0 fires at 08:00 UTC; index 14 at 08:56; index 15
+# at 09:00; index 49 at 11:16. Whole window: 08:00–11:16 UTC.
+#
+# All jobs ship `paused = true`. Operator unpauses manually for the one-shot,
+# then either re-pauses or removes via a follow-up PR. See plan for the unpause
+# runbook.
+locals {
+  us_states = [
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+  ]
+  backfill_per_state_base_hour = 8
+}
+
+resource "google_cloud_scheduler_job" "backfill_per_state" {
+  for_each = toset(local.us_states)
+
+  name      = "bird-ingestor-backfill-${lower(each.value)}"
+  region    = var.gcp_region
+  time_zone = "Etc/UTC"
+
+  # idx * 4 minutes from 08:00 UTC. Floor division pushes minute past 59 into
+  # the next hour (state 15 → 09:00 UTC, state 30 → 10:00 UTC, etc).
+  schedule = format(
+    "%d %d * * *",
+    (index(local.us_states, each.value) * 4) % 60,
+    local.backfill_per_state_base_hour + floor(index(local.us_states, each.value) * 4 / 60),
+  )
+
+  # Ship paused; operator unpauses for the one-shot national backfill, then
+  # either re-pauses or removes the resource via a follow-up PR.
+  paused = true
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{
+          args = ["backfill", "--state=US-${each.value}", "--back=14"]
+        }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}
+
 resource "google_cloud_scheduler_job" "ingest_hotspots" {
   name      = "bird-ingest-hotspots"
   region    = var.gcp_region

--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -354,6 +354,25 @@ resource "google_cloud_scheduler_job" "backfill_per_state" {
     }
   }
 
+  # Three attempts with exponential backoff. Handles transient HTTP 5xx from
+  # the Cloud Run Jobs control plane without the per-state scheduler giving
+  # up on the first hiccup. Bounds: 30s → 300s keeps the retry window inside
+  # the 4-minute staggering gap between schedulers.
+  retry_config {
+    retry_count          = 3
+    min_backoff_duration = "30s"
+    max_backoff_duration = "300s"
+  }
+
+  # Operator unpauses these manually for the one-shot national backfill (see
+  # `paused = true` above and the runbook in the plan). Once unpaused, an
+  # unrelated `terraform apply` mid-run would otherwise reconcile `paused`
+  # back to `true` and silently halt the fan-out. Ignore drift on this field
+  # so the operator's unpause is durable across applies.
+  lifecycle {
+    ignore_changes = [paused]
+  }
+
   depends_on = [google_project_service.scheduler]
 }
 

--- a/scripts/verify-backfill.sh
+++ b/scripts/verify-backfill.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# verify-backfill.sh — Phase 3.5 per-state backfill verifier.
+#
+# Reads Cloud Run Job executions + Cloud Logging summary lines, cross-references
+# against the 50 expected USPS state codes, and prints a per-state status table
+# with a rerun command for any failures. Read-only: no DB writes, no scheduler
+# mutations, idempotent.
+#
+# Usage:
+#   scripts/verify-backfill.sh [--since=ISO8601]
+#
+# Default --since: today 00:00 UTC.
+#
+# Requires: gcloud, jq.
+# Hardcoded for the bird-maps-prod / us-west1 deployment — adjust if reusing.
+#
+# Exit code: 0 iff all 50 states have Succeeded executions since --since.
+
+set -euo pipefail
+
+PROJECT="bird-maps-prod"
+REGION="us-west1"
+JOB="bird-ingestor"
+
+# Default --since: today 00:00 UTC.
+DEFAULT_SINCE="$(date -u +%Y-%m-%dT00:00:00Z)"
+SINCE="$DEFAULT_SINCE"
+
+for arg in "$@"; do
+  case "$arg" in
+    --since=*) SINCE="${arg#--since=}" ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in gcloud jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Required command not found: $cmd" >&2
+    exit 2
+  fi
+done
+
+# 50 USPS codes; must match infra/terraform/ingestor.tf local.us_states.
+STATES=(
+  AL AK AZ AR CA CO CT DE FL GA
+  HI ID IL IN IA KS KY LA ME MD
+  MA MI MN MS MO MT NE NV NH NJ
+  NM NY NC ND OH OK OR PA RI SC
+  SD TN TX UT VT VA WA WV WI WY
+)
+
+# Fetch all executions for the job since --since, once. Filter+map locally to
+# avoid 50 round-trips. Executions list returns yaml/json with the embedded
+# containerOverrides args, status, completion times.
+EXECUTIONS_JSON="$(gcloud run jobs executions list \
+  --job="$JOB" \
+  --region="$REGION" \
+  --project="$PROJECT" \
+  --format=json 2>/dev/null || echo '[]')"
+
+# Fetch summary log lines (bird_ingest_run_completed) for the window, with
+# state, status, duration_seconds. jsonPayload.state was added in the same PR
+# that introduced this script — older runs will have state=null and show up
+# as "missing" in the cross-reference. That's fine: this script is for the
+# Phase 3.5 one-shot going forward.
+LOGS_JSON="$(gcloud logging read \
+  "resource.type=cloud_run_job AND resource.labels.job_name=\"$JOB\" AND jsonPayload.message=\"bird_ingest_run_completed\" AND timestamp>=\"$SINCE\"" \
+  --project="$PROJECT" \
+  --format=json \
+  --limit=500 2>/dev/null || echo '[]')"
+
+printf '%-6s  %-10s  %-20s  %-10s  %s\n' STATE STATUS EXECUTION DURATION RERUN
+printf '%s\n' "----------------------------------------------------------------------------------------"
+
+succeeded=0
+failed=0
+running=0
+missing=0
+
+for state in "${STATES[@]}"; do
+  arg_match="--state=US-${state}"
+
+  # Find the most recent execution matching this state since SINCE.
+  exec_row="$(jq -r --arg since "$SINCE" --arg arg "$arg_match" '
+    [ .[]
+      | select(.metadata.creationTimestamp >= $since)
+      | select(
+          (.spec.template.spec.containers // .spec.template.template.spec.containers // [])[0].args
+          | (. // []) | tostring | contains($arg)
+        )
+    ]
+    | sort_by(.metadata.creationTimestamp) | reverse | .[0] // empty
+    | "\(.metadata.name)\t\(.status.conditions // [] | map(select(.type=="Completed"))[0].status // "Unknown")\t\(.status.conditions // [] | map(select(.type=="Completed"))[0].reason // "")"
+  ' <<<"$EXECUTIONS_JSON")"
+
+  log_row="$(jq -r --arg state "US-${state}" '
+    [ .[] | select(.jsonPayload.state == $state) ]
+    | sort_by(.timestamp) | reverse | .[0] // empty
+    | "\(.jsonPayload.status // "")\t\(.jsonPayload.duration_seconds // "")"
+  ' <<<"$LOGS_JSON")"
+
+  exec_name=""
+  exec_status=""
+  exec_reason=""
+  if [[ -n "$exec_row" ]]; then
+    exec_name="$(awk -F'\t' '{print $1}' <<<"$exec_row")"
+    exec_status="$(awk -F'\t' '{print $2}' <<<"$exec_row")"
+    exec_reason="$(awk -F'\t' '{print $3}' <<<"$exec_row")"
+  fi
+
+  log_status=""
+  log_duration=""
+  if [[ -n "$log_row" ]]; then
+    log_status="$(awk -F'\t' '{print $1}' <<<"$log_row")"
+    log_duration="$(awk -F'\t' '{print $2}' <<<"$log_row")"
+  fi
+
+  # Derive a verdict from the combination. Log line is authoritative when
+  # present; falls back to execution condition.
+  status="MISSING"
+  if [[ "$log_status" == "success" ]]; then
+    status="SUCCEEDED"
+    succeeded=$((succeeded + 1))
+  elif [[ "$log_status" == "partial" ]]; then
+    status="PARTIAL"
+    failed=$((failed + 1))
+  elif [[ "$log_status" == "failure" ]]; then
+    status="FAILED"
+    failed=$((failed + 1))
+  elif [[ "$exec_status" == "True" ]]; then
+    status="SUCCEEDED"
+    succeeded=$((succeeded + 1))
+  elif [[ "$exec_status" == "False" ]]; then
+    status="FAILED"
+    failed=$((failed + 1))
+  elif [[ -n "$exec_name" ]]; then
+    status="RUNNING"
+    running=$((running + 1))
+  else
+    missing=$((missing + 1))
+  fi
+
+  rerun=""
+  if [[ "$status" == "FAILED" || "$status" == "PARTIAL" || "$status" == "MISSING" ]]; then
+    rerun="gcloud run jobs execute $JOB --region=$REGION --project=$PROJECT --args=backfill,--state=US-${state},--back=14"
+  fi
+
+  printf '%-6s  %-10s  %-20s  %-10s  %s\n' \
+    "US-${state}" "$status" "${exec_name:-—}" "${log_duration:-—}" "$rerun"
+done
+
+printf '\n50 states: %d succeeded, %d failed, %d running, %d missing\n' \
+  "$succeeded" "$failed" "$running" "$missing"
+
+if [[ "$succeeded" -eq 50 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -164,6 +164,32 @@ describe('runCli', () => {
       );
     });
 
+    it('emits structured `state` field on the run-completion log for per-state backfill', async () => {
+      // Phase 3.5: scripts/verify-backfill.sh and Cloud Logging dashboards
+      // partition by jsonPayload.state. The summary line must carry `state`
+      // as a top-level field, not embedded in a message string.
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA', '--back=14'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 14,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      const emitted = logSpy.mock.calls
+        .map((args: unknown[]): unknown => {
+          try { return JSON.parse(args[0] as string); } catch { return null; }
+        })
+        .filter((o: unknown): o is Record<string, unknown> =>
+          typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'bird_ingest_run_completed'
+        );
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toMatchObject({
+        message: 'bird_ingest_run_completed',
+        kind: 'backfill',
+        status: 'success',
+        state: 'US-CA',
+      });
+    });
+
     it('rejects --back=31 (above eBird /recent 30-day cap)', async () => {
       process.argv = ['node', 'cli.ts', 'backfill', '--back=31'];
       const runBackfillSpy = vi.fn();

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -111,6 +111,69 @@ describe('runCli', () => {
     expect(deps.closePool).toHaveBeenCalledWith(POOL_SENTINEL);
   });
 
+  // ── Phase 3.5 per-state backfill flags ────────────────────────────────────
+  // CLI accepts --state=US-XX and --back=N for the `backfill` kind so the
+  // Terraform fan-out can target one state per scheduler job. Defaults preserve
+  // the legacy no-flag prod scheduler (regionCode=US-AZ, days=19).
+  describe('backfill flag parsing (Phase 3.5)', () => {
+    it('default no-flag invocation preserves regionCode=US-AZ, days=19', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 19,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-AZ', days: 19 })
+      );
+    });
+
+    it('accepts --state=US-CA', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA', '--back=14'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 14,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-CA', days: 14 })
+      );
+    });
+
+    it('rejects --state=US-ZZ-style malformed regions', async () => {
+      // Non-existent USPS code; regex enforces /^US-[A-Z]{2}$/ shape but does
+      // not enumerate. ZZ is intentionally shape-valid here for parity with the
+      // simpler rejection path — we use a clearly malformed value instead.
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-ZZZ'];
+      const runBackfillSpy = vi.fn();
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runBackfillSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts --back=14', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--back=14'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 14,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-AZ', days: 14 })
+      );
+    });
+
+    it('rejects --back=31 (above eBird /recent 30-day cap)', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--back=31'];
+      const runBackfillSpy = vi.fn();
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runBackfillSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('throws if EBIRD_API_KEY is not set', async () => {
     delete process.env.EBIRD_API_KEY;
     const deps = makeDeps();

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -208,7 +208,57 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (kind === 'backfill') {
-      summary = await deps.runBackfill({ pool, apiKey, regionCode: 'US-AZ', days: 19 });
+      // Phase 3.5 per-state fan-out (plan: ~/.claude/plans/are-we-ready-to-starry-dove.md).
+      // Optional CLI flags --state=US-XX (default US-AZ to preserve the
+      // existing prod scheduler's no-flag invocation) and --back=N (default
+      // 19 with no flags, so the legacy daily backfill keeps its current
+      // window; new per-state schedulers pass --back=14 explicitly).
+      // argv shape: ["node", "cli.ts", "backfill", "--state=US-CA", "--back=14"].
+      const flags = process.argv.slice(3);
+      let regionCode = 'US-AZ';
+      let days = 19;
+      for (const f of flags) {
+        if (f.startsWith('--state=')) {
+          const v = f.slice('--state='.length);
+          if (!/^US-[A-Z]{2}$/.test(v)) {
+            console.log(JSON.stringify({
+              severity: 'ERROR',
+              message: 'bird_ingest_invalid_flag',
+              flag: '--state',
+              value: v,
+              expected: 'US-XX (USPS two-letter state code)',
+            }));
+            process.exitCode = 1;
+            return;
+          }
+          regionCode = v;
+        } else if (f.startsWith('--back=')) {
+          const raw = f.slice('--back='.length);
+          const n = Number.parseInt(raw, 10);
+          if (!Number.isInteger(n) || n < 1 || n > 30 || String(n) !== raw) {
+            console.log(JSON.stringify({
+              severity: 'ERROR',
+              message: 'bird_ingest_invalid_flag',
+              flag: '--back',
+              value: raw,
+              expected: 'integer 1-30 (eBird /data/obs/{region}/recent cap)',
+            }));
+            process.exitCode = 1;
+            return;
+          }
+          days = n;
+        } else {
+          console.log(JSON.stringify({
+            severity: 'ERROR',
+            message: 'bird_ingest_invalid_flag',
+            flag: f,
+            expected: '--state=US-XX or --back=N',
+          }));
+          process.exitCode = 1;
+          return;
+        }
+      }
+      summary = await deps.runBackfill({ pool, apiKey, regionCode, days });
     } else if (kind === 'backfill-extended') {
       // 'backfill-extended': one-shot 365-day backfill at 1 rps; this is NOT
       // scheduled — it's an operator-triggered one-shot to populate historical

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -203,6 +203,12 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
   const startedAt = Date.now();
   try {
     let summary: AnyRunSummary;
+    // For the per-state backfill fan-out, capture the resolved regionCode so
+    // the run-completion summary log carries `state` as a structured
+    // jsonPayload field. Cloud Logging queries like
+    // `jsonPayload.state="US-CA"` then partition per-state runs cleanly —
+    // see scripts/verify-backfill.sh.
+    let backfillState: string | undefined;
     if (kind === 'recent') {
       summary = await deps.runIngest({ pool, apiKey, regionCode: 'US' });
     } else if (kind === 'hotspots') {
@@ -258,6 +264,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
           return;
         }
       }
+      backfillState = regionCode;
       summary = await deps.runBackfill({ pool, apiKey, regionCode, days });
     } else if (kind === 'backfill-extended') {
       // 'backfill-extended': one-shot 365-day backfill at 1 rps; this is NOT
@@ -318,6 +325,10 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       kind,
       status: summary.status,
       duration_seconds: durationSeconds,
+      // Per-state backfill (Phase 3.5): emit `state` as a top-level jsonPayload
+      // field so Cloud Logging can filter by `jsonPayload.state="US-CA"`.
+      // Omitted for non-backfill kinds to keep the structured shape minimal.
+      ...(backfillState !== undefined && { state: backfillState }),
     }));
     if (summary.status === 'failure') {
       // Flag the process as failed without killing the loop mid-pool-close.


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Scheduler["Cloud Scheduler (50 jobs, paused)"]
        S0["bird-ingestor-backfill-al<br/>08:00 UTC"]
        S1["bird-ingestor-backfill-ak<br/>08:04 UTC"]
        Sdots["…48 more…"]
        S49["bird-ingestor-backfill-wy<br/>11:16 UTC"]
    end
    Job["bird-ingestor<br/>(shared Cloud Run Job)"]
    CLI["cli.ts backfill<br/>--state=US-XX --back=14"]
    eBird["eBird /data/obs/{region}/recent"]
    PG[("Cloud SQL<br/>observations")]

    S0 -->|containerOverrides args| Job
    S1 -->|containerOverrides args| Job
    Sdots --> Job
    S49 --> Job
    Job --> CLI
    CLI --> eBird
    CLI --> PG
```

## Summary

- Implements Phase 3.5 of `~/.claude/plans/are-we-ready-to-starry-dove.md`: a one-shot 14-day national backfill staged across all 50 US states, `/recent` only (no `/notable`), staggered over ~3 hours so eBird and Cloud SQL stay gentle.
- CLI `backfill` kind now parses `--state=US-XX` and `--back=N`. Defaults preserve the existing prod scheduler verbatim (`US-AZ`, 19 days) — no behavioral change for the legacy daily backfill.
- Adds `google_cloud_scheduler_job.backfill_per_state` (`for_each` over 50 USPS codes) targeting the shared `bird-ingestor` Cloud Run Job via `containerOverrides`. Ships `paused = true`; operator unpauses manually for the one-shot, then re-pauses or removes via follow-up PR.

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm test --workspace @bird-watch/ingestor -- cli.test` — 27 passed (5 new flag-parsing tests covering default behavior, `--state=US-CA` accept, malformed state reject, `--back=14` accept, `--back=31` reject)
- [x] `terraform validate` (infra/terraform) — Success
- [x] `terraform fmt` clean
- [x] `npm run build --workspace @bird-watch/ingestor` — clean tsc
- [x] `npm run lint` — clean
- [ ] Manual unpause + one-shot execution — deliberately out of scope for this PR; operator runbook lives in the plan
- [ ] After unpausing the schedulers and waiting ~3h, run `scripts/verify-backfill.sh` — expects `50 states: 50 succeeded, 0 failed`. The script is read-only (no DB writes, no scheduler mutations) and prints a per-state STATUS / EXECUTION / DURATION table plus a `gcloud run jobs execute` rerun command for any non-success row.

## Plan reference

Part of Phase 3.5, plan `~/.claude/plans/are-we-ready-to-starry-dove.md` (orchestrator-local plan; not checked into this repo). Out-of-tree plan documents Julian's national-rollout sequence; this PR ships the implementation artifacts only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
