### PR TITLE
docs(read-api,frontend): clarify bbox cap derivation + maxBounds linkage

### DIFF
--- a/frontend/e2e/surface-title.spec.ts
+++ b/frontend/e2e/surface-title.spec.ts
@@ -2,19 +2,19 @@ import { test, expect, VERMFLY } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 test.describe('dynamic <title> per surface', () => {
-  test('map surface shows "Bird Maps · Arizona"', async ({ page }) => {
+  test('map surface shows "Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=map');
-    await expect(page).toHaveTitle('Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Bird Maps · USA');
   });
 
-  test('feed surface shows "Feed — Bird Maps · Arizona"', async ({ page }) => {
+  test('feed surface shows "Feed — Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=feed');
-    await expect(page).toHaveTitle('Feed — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Feed — Bird Maps · USA');
   });
 
-  test('species surface shows "Species — Bird Maps · Arizona"', async ({ page }) => {
+  test('species surface shows "Species — Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=species');
-    await expect(page).toHaveTitle('Species — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Species — Bird Maps · USA');
   });
 
   test('detail surface with loaded species shows species name in title', async ({ page, apiStub }) => {
@@ -26,15 +26,15 @@ test.describe('dynamic <title> per surface', () => {
       // Fallback: wait for detail panel heading to be visible
     });
     // The title should update once species meta loads
-    await expect(page).toHaveTitle(/Vermilion Flycatcher — Bird Maps · Arizona/, { timeout: 10_000 });
+    await expect(page).toHaveTitle(/Vermilion Flycatcher — Bird Maps · USA/, { timeout: 10_000 });
   });
 
   test('title updates when navigating between surfaces', async ({ page }) => {
     await page.goto('/?view=feed');
-    await expect(page).toHaveTitle('Feed — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Feed — Bird Maps · USA');
     const app = new AppPage(page);
     // Navigate to species via SurfaceNav
     await app.selectView('species');
-    await expect(page).toHaveTitle('Species — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Species — Bird Maps · USA');
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
       // `preserveDrawingBuffer: true` to the MapLibre WebGL context so that
       // pixel-sample e2e specs (e.g. basemap-dark-flip.spec.ts) can read
       // rendered canvas pixels via a 2D-canvas drawImage copy. See PR #582.
-      command: 'VITE_E2E_PRESERVE_BUFFER=true npm run dev',
+      command: 'VITE_E2E_PRESERVE_BUFFER=true VITE_REGION_CODE=US npm run dev',
       cwd: __dirname,
       url: 'http://localhost:5173',
       reuseExistingServer: !process.env.CI,

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -287,7 +287,12 @@ const CONUS_NARROW_BREAKPOINT_PX = 700;
  *   mobile-default CONUS view. At z<6 the API is in aggregated mode anyway,
  *   so unbounded bboxes don't matter; this bound is purely a UX floor.
  * - `MAX_BOUNDS` keeps pan inside CONUS + a margin for coastal/border obs.
- *   AK and HI are out of frame for Phase 3a; revisit when ingest expands.
+ *   This is the client-side enforcement of the server's bbox cap: if the
+ *   server cap in `services/read-api/src/validate.ts` (see cap derivation)
+ *   changes, this constant must change too — they're a linked pair.
+ *   AK and HI are out of frame because of these map bounds (ingest already
+ *   pulls `/recent/US` per PR #669); widening bounds to include them is
+ *   the unblock, not an ingest change.
  */
 const MIN_ZOOM = CONUS_ZOOM_NARROW;
 const MAX_BOUNDS: [[number, number], [number, number]] = [

--- a/services/read-api/src/validate.ts
+++ b/services/read-api/src/validate.ts
@@ -152,12 +152,17 @@ export function parseFamily(
  * Caps: `maxLng - minLng <= 45` AND `maxLat - minLat <= 25`.
  *
  * Sizing matches the largest natural viewport at the per-obs zoom boundary.
- * Web mercator: degrees-per-pixel at z=6 = 360 / (256 * 2^6) = 0.02197°/px.
- * 1920×1080 (largest canonical viewport, see frontend/CLAUDE.md) at z=6 is
- * 42.2° lng × 23.7° lat. 45° × 25° clears that with a small safety margin
- * yet is still load-bearing: CONUS is 60° wide, so one request can only
- * grab ~75% of east-west extent; per-axis cap prevents combining axes
- * into a whole-country scrape.
+ * Web mercator: degrees-per-pixel at z=6 = 360 / (256 * 2^6) = 0.02197°/px
+ * along the equator. 1920px wide at z=6 → 42.2° lng span (latitude-invariant
+ * in mercator-x). Latitude is trickier: mercator-y is non-uniform, so a 25°
+ * lat *span* near the CONUS top (~50°N) projects to roughly 25° × sec(50°)
+ * ≈ 39° of *visual* (mercator-pixel) extent. The 25° cap is therefore a
+ * numeric-degree cap, not a visual-pixel cap; the 1080px viewport at z=6
+ * resolves only ~23.7° of numeric latitude even when centered high in
+ * CONUS, so the cap clears the worst case with margin. 45° × 25° is still
+ * load-bearing: CONUS is 60° wide, so one request can only grab ~75% of
+ * east-west extent; per-axis cap prevents combining axes into a
+ * whole-country scrape.
  *
  * Reject body is descriptive so the frontend can render an affordance:
  *   { error: 'bbox too large', maxLngSpan: 45, maxLatSpan: 25,

--- a/services/read-api/src/validate.ts
+++ b/services/read-api/src/validate.ts
@@ -158,8 +158,9 @@ export function parseFamily(
  * lat *span* near the CONUS top (~50°N) projects to roughly 25° × sec(50°)
  * ≈ 39° of *visual* (mercator-pixel) extent. The 25° cap is therefore a
  * numeric-degree cap, not a visual-pixel cap; the 1080px viewport at z=6
- * resolves only ~23.7° of numeric latitude even when centered high in
- * CONUS, so the cap clears the worst case with margin. 45° × 25° is still
+ * resolves ≤23.7° of numeric latitude (less at higher latitudes due to
+ * the same mercator-y stretch), so the cap clears the worst case with
+ * margin. 45° × 25° is still
  * load-bearing: CONUS is 60° wide, so one request can only grab ~75% of
  * east-west extent; per-axis cap prevents combining axes into a
  * whole-country scrape.


### PR DESCRIPTION
## Diagrams

N/A — doc-string + test-config sync; no data flow, state, or topology change.

## Summary

- Addresses two SUGGESTION-tier docstring nits from the PR #672 bot review (already-merged hotfix that landed the 45°×25° bbox cap + minZoom/maxBounds).
- `services/read-api/src/validate.ts`: cap-derivation comment now names the Mercator-y stretch — at ~50°N (CONUS top), a 25° lat *span* projects to ~25° × sec(50°) ≈ 39° of mercator-pixel extent. The 25° cap is a numeric-degree cap, not a visual-pixel cap. Follow-up fix to the bot's SUGGESTION on the first review: the "≤23.7° at 1080px" figure now carries an explicit "less at higher latitudes" qualifier so the prose isn't wrong in the direction the original #672 review flagged.
- `frontend/src/components/map/MapCanvas.tsx`: `MAX_BOUNDS` comment now states explicitly that the constant is the client-side enforcement of the server's bbox cap and must move in lockstep with `validate.ts`. Also corrects the stale AK/HI note (ingest already pulls `/recent/US` per PR #669 — bounds, not ingest, are the unblock).
- **Test-config sync (additional scope, disclosed)**: `frontend/e2e/surface-title.spec.ts` renames the expected document title `Bird Maps · Arizona` → `Bird Maps · USA` across 5 e2e cases, and `frontend/playwright.config.ts` prepends `VITE_REGION_CODE=US` to the webServer command. Both are necessary follow-ups to PR #670's region flip — without them the e2e suite would fail against the new prod-default region. Carried in this PR rather than split because the working-tree state included them at branch-create time and CI is green with them present; pulling them out would leave main's e2e suite red until a separate PR lands.

## Screenshots

N/A — not UI. Per CLAUDE.md, comment-only + test-only + config-only changes are exempt from the design QA gate. `MapCanvas.tsx` change is comment-only; `validate.ts` is comment-only; `surface-title.spec.ts` is a test-only string update; `playwright.config.ts` is a config-only env-var addition.

## Test plan

- [x] `npm run lint` — green
- [x] All four required CI checks green at HEAD (`test`, `lint`, `build`, `e2e`) — verified via `gh pr view 676 --json statusCheckRollup`
- [x] No behavior change in `validate.ts` or `MapCanvas.tsx` (comments only)
- [x] `surface-title.spec.ts` + `playwright.config.ts` sync verified by green `e2e` check (the title rename is what the rendered app already produces post-#670)

## Plan reference

Out of plan — follow-up doc nits from #672 review, plus a test-config sync to PR #670's region flip. Closes #62.