### PR TITLE
test(e2e): update surface-title assertions Arizona -> USA

### DIFF
--- a/frontend/e2e/surface-title.spec.ts
+++ b/frontend/e2e/surface-title.spec.ts
@@ -2,19 +2,19 @@ import { test, expect, VERMFLY } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 test.describe('dynamic <title> per surface', () => {
-  test('map surface shows "Bird Maps · Arizona"', async ({ page }) => {
+  test('map surface shows "Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=map');
-    await expect(page).toHaveTitle('Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Bird Maps · USA');
   });
 
-  test('feed surface shows "Feed — Bird Maps · Arizona"', async ({ page }) => {
+  test('feed surface shows "Feed — Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=feed');
-    await expect(page).toHaveTitle('Feed — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Feed — Bird Maps · USA');
   });
 
-  test('species surface shows "Species — Bird Maps · Arizona"', async ({ page }) => {
+  test('species surface shows "Species — Bird Maps · USA"', async ({ page }) => {
     await page.goto('/?view=species');
-    await expect(page).toHaveTitle('Species — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Species — Bird Maps · USA');
   });
 
   test('detail surface with loaded species shows species name in title', async ({ page, apiStub }) => {
@@ -26,15 +26,15 @@ test.describe('dynamic <title> per surface', () => {
       // Fallback: wait for detail panel heading to be visible
     });
     // The title should update once species meta loads
-    await expect(page).toHaveTitle(/Vermilion Flycatcher — Bird Maps · Arizona/, { timeout: 10_000 });
+    await expect(page).toHaveTitle(/Vermilion Flycatcher — Bird Maps · USA/, { timeout: 10_000 });
   });
 
   test('title updates when navigating between surfaces', async ({ page }) => {
     await page.goto('/?view=feed');
-    await expect(page).toHaveTitle('Feed — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Feed — Bird Maps · USA');
     const app = new AppPage(page);
     // Navigate to species via SurfaceNav
     await app.selectView('species');
-    await expect(page).toHaveTitle('Species — Bird Maps · Arizona');
+    await expect(page).toHaveTitle('Species — Bird Maps · USA');
   });
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
       // `preserveDrawingBuffer: true` to the MapLibre WebGL context so that
       // pixel-sample e2e specs (e.g. basemap-dark-flip.spec.ts) can read
       // rendered canvas pixels via a 2D-canvas drawImage copy. See PR #582.
-      command: 'VITE_E2E_PRESERVE_BUFFER=true npm run dev',
+      command: 'VITE_E2E_PRESERVE_BUFFER=true VITE_REGION_CODE=US npm run dev',
       cwd: __dirname,
       url: 'http://localhost:5173',
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[VITE_REGION_CODE=US<br/>in .env.production<br/>(PR #670)] --> B[REGION_LABEL = 'USA'<br/>via region.ts mapping]
    B --> C[Document &lt;title&gt;<br/>'Bird Maps · USA']
    C --> D[surface-title.spec.ts<br/>asserts on 'USA' ✓]
    E[playwright.config.ts<br/>VITE_REGION_CODE=US<br/>on dev webServer] --> B
```

## Summary

- Phase 3a flipped `VITE_REGION_CODE=US` in `frontend/.env.production`, which makes `REGION_LABEL` resolve to `"USA"` via the mapping in `frontend/src/config/region.ts`. The five assertions in `frontend/e2e/surface-title.spec.ts` still expected `"Arizona"` and would fail against the production-equivalent build.
- Threads `VITE_REGION_CODE=US` through the dev-server `webServer` command in `playwright.config.ts` so the e2e bundle matches the production region label — Vite dev mode does not load `.env.production`, so without this the dev fallback (`'US-AZ' → 'Arizona'`) would silently mask the drift.

## Screenshots

N/A — not UI (test-only PR under `frontend/**`, exempt per repo CLAUDE.md).

## Test plan

- [x] `npm run test:e2e --workspace @bird-watch/frontend -- surface-title.spec.ts --project=dev-server` — 5 passed (16.7s)
- [ ] Full e2e suite — CI will run on PR

## Plan reference

Out of plan — Phase 3a national-rollout follow-up: align e2e assertions with the live region label.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)