### PR TITLE
chore(ingestor): bump photos-job timeout 600s→900s and refresh stale AZ-era comment

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -442,8 +442,18 @@ resource "google_cloud_run_v2_job" "ingestor_photos" {
   template {
     template {
       service_account = google_service_account.ingestor.email
-      timeout         = "600s"
-      max_retries     = 1
+      # 900s (Cloud Run Jobs hard cap is 86400s but the practical sizing is
+      # set by the photos-cohort wall-clock). Bumped from 600s (2026-05-20)
+      # after PR #679 dropped INAT_PLACE_ID to '' for national coverage: the
+      # post-flip cohort is ~715 observed species (vs. ~344 in AZ-only era),
+      # and the first national run timed out at 600s mid-cascade. With 1s
+      # pacing between species, 715 × ~1.2s = ~858s worst-case for a
+      # cold-cache run; 900s leaves a small headroom margin. Subsequent runs
+      # skip species with a row in `species_photos`, so steady-state finishes
+      # in seconds — the 900s budget only matters for cold starts or after a
+      # large taxonomy expansion.
+      timeout     = "900s"
+      max_retries = 1
 
       containers {
         image = "${google_artifact_registry_repository.birdwatch.location}-docker.pkg.dev/${var.gcp_project_id}/${google_artifact_registry_repository.birdwatch.repository_id}/ingestor:latest"

--- a/services/ingestor/src/run-photos.ts
+++ b/services/ingestor/src/run-photos.ts
@@ -71,14 +71,25 @@ export async function runPhotos(args: RunPhotosArgs): Promise<RunPhotosSummary> 
   // LEFT JOIN. One round-trip beats N queries for the per-row "do you
   // already have a photo?" check.
   //
-  // The EXISTS filter narrows the iteration to species we have actually
-  // observed in Arizona. The taxonomy ingest writes the *full* eBird
-  // taxonomy (~24k species) to species_meta, but the iNat client filters
-  // photo lookups by place_id=40 (Arizona) — so for species never observed
-  // in AZ, every iteration would be a no-op iNat round-trip that returns
-  // null. With the filter, the photos job iterates only the ~344 species
-  // actually present in `observations`, fitting comfortably inside the
-  // 600s Cloud Run job timeout.
+  // The EXISTS filter narrows the iteration to species actually observed in
+  // the ingest region. The taxonomy ingest writes the *full* eBird taxonomy
+  // (~24k species) to species_meta, but only ~715 of those have rows in
+  // `observations` under national (CONUS) ingest as of 2026-05 (was ~344 in
+  // the AZ-only era pre-flip). Without the filter, every iteration of an
+  // unobserved species would be a no-op iNat round-trip — the filter caps
+  // wall-clock at the observed cohort.
+  //
+  // PR #679 (2026-05-20) set `INAT_PLACE_ID=''` on the Cloud Run Job, so the
+  // iNat cascade in `inat/client.ts` now starts at Tier 2 (US) rather than
+  // Tier 1 (region=AZ). Combined with the Wikipedia lead-image fallback
+  // (#483), the post-backfill coverage is 708/715 = 99.0% — the 7 residuals
+  // are all named hybrids that neither source tracks under the combined
+  // binomial, and the family-silhouette fallback renders for them.
+  //
+  // Wall-clock budget: ~715 species × ~1.2s/species (US-tier hit + 1s pace +
+  // R2 upload) ≈ 858s worst-case cold-cache. The Cloud Run Job timeout is
+  // 900s (`infra/terraform/ingestor.tf`), bumped from 600s after the first
+  // post-flip backfill timed out mid-cascade and relied on max_retries=1.
   //
   // `inat_taxon_id` is projected so the Wikipedia lead-image fallback (added
   // in #483) can re-use the cached taxon id when present — saving one iNat


### PR DESCRIPTION
## Diagrams

N/A — single env-value bump (`timeout = "600s"` → `"900s"`) and one comment-block refresh on the photos backfill orchestrator. No data-flow change.

## Summary

- **Why now:** the first post-national photos backfill (executed 2026-05-20 after #679 merged) timed out at 600s mid-cascade. `max_retries=1` + the per-species idempotent commit shape saved the run — the retry skipped species already photographed and finished cleanly — but relying on the retry as a wall-clock crutch is fragile. 715 observed species × ~1.2s/species (US-tier iNat hit + 1s pace + R2 PUT) ≈ 858s worst-case cold-cache; 900s leaves a small headroom margin.
- **Comment refresh:** `services/ingestor/src/run-photos.ts:74-81` still referenced the AZ-only world (~344 species, `place_id=40`, 600s). Updated to document the actual CONUS cohort, `INAT_PLACE_ID=''` cascade shape, post-backfill 99.0% coverage, and the new 900s timeout. Both findings came from the julianken-bot review on #679 (SUGGESTION tier).
- **Out of scope:** `services/ingestor/src/run-descriptions.ts` has a similar stale "~344 AZ-observed species" comment from the same era; that's a separate runner with its own monthly cohort budget and gets its own follow-up.

## Screenshots

N/A — backend infra + code-comment only, no `frontend/**` touched.

## Test plan

- [x] `terraform fmt -check infra/terraform/ingestor.tf` — clean
- [x] No code-behavior change in `run-photos.ts` — only the comment block above the `pool.query` call is touched; existing tests still pass unchanged.
- [x] Mergify gate (`test`, `lint`, `build`, `e2e`) — expect green.

## Post-merge operator step

`terraform -chdir=infra/terraform apply` to deploy the timeout bump. No job execution required — the 2026-06-01 monthly cron will pick up the new timeout. The current Cloud Run Job revision (deployed in #679) still has 600s baked in.

## Plan reference

Out of plan — follow-up to PR #679 SUGGESTIONs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)