### PR TITLE
chore(analytics): migrate analytics.ts from PostHog to Clarity + view tagging (#657-followup)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "@bird-watch/shared-types": "*",
     "@microsoft/clarity": "^1.0.2",
     "maplibre-gl": "^5.24.0",
-    "posthog-js": "^1.372.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-map-gl": "^8.1.1",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -657,3 +657,26 @@ describe('App.tsx onSelectSpecies bbox-clear invariant (#560)', () => {
     expect(selectCall![0].bbox).toBeNull();
   });
 });
+
+describe('Clarity view tagging (#657-followup)', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
+    mockGetSilhouettes.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls analytics.setView with the active view on mount', async () => {
+    const { analytics } = await import('./analytics.js');
+    const setViewSpy = vi.spyOn(analytics, 'setView');
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+    };
+    render(<App />);
+    expect(setViewSpy).toHaveBeenCalledWith('feed');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
+import { analytics } from './analytics.js';
 import { ApiClient, ApiError } from './api/client.js';
 import { useUrlState } from './state/url-state.js';
 import type { Since, BBox } from './state/url-state.js';
@@ -63,6 +64,14 @@ function craftedFromError(error: Error): string {
 export function App() {
   const { state, set } = useUrlState();
   const isCompact = useIsCompact();
+  // Tag the current Clarity session with the active view so dashboards can
+  // filter sessions by surface (feed | map | species | detail). Fires on
+  // initial mount and on every view change; analytics.setView no-ops safely
+  // when Clarity isn't initialized (dev/test/missing project ID). PR #659
+  // follow-up.
+  useEffect(() => {
+    analytics.setView(state.view);
+  }, [state.view]);
   // Phase 3: filters panel state + badge count.
   const [filtersOpen, setFiltersOpen] = useState(false);
   // Active-filter count: every non-default URL-state field counts as 1.

--- a/frontend/src/analytics.test.ts
+++ b/frontend/src/analytics.test.ts
@@ -1,76 +1,86 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 /**
- * Tests for the analytics module.  Verifies the empty-key guard semantics
- * documented in issue #357 task 2:
+ * Tests for the Clarity-backed analytics module (PR #659 follow-up).
  *
- *   - `posthog.init` is NEVER called when `VITE_POSTHOG_KEY` is unset/empty.
- *     This is load-bearing for CI: posthog-js emits a console warning on an
- *     empty key, which would fail the existing console-cleanliness assertions
- *     in every e2e spec (species-detail.spec.ts, map-symbol-layer.spec.ts).
- *   - When the key is empty, `analytics.capture(...)` is a no-op stub.
- *   - When the key is present, `analytics.capture(...)` is the real posthog
- *     module's capture, and `posthog.init` was called once with the key and
- *     the privacy-respecting options (`autocapture: false`,
- *     `capture_pageview: false`, `respect_dnt: true`).
+ * The PostHog→Clarity migration kept the public `analytics.capture()` API
+ * unchanged (4 existing call sites stay verbatim — see analytics.ts
+ * docstring) but swapped the underlying transport.
  *
- * The module is imported dynamically per-test so each test sees a freshly
- * evaluated module body — top-level `import.meta.env` reads happen at module
- * evaluation, so `vi.stubEnv` must be called before the dynamic import.
+ *   - `capture(name)` → calls `Clarity.event(name)`. No `setTag` calls.
+ *   - `capture(name, props)` → calls `Clarity.event(name)` AND
+ *     `Clarity.setTag(key, String(value))` for every prop key/value pair.
+ *     This preserves the event-with-dimensions intent of the old PostHog
+ *     payload shape under Clarity's split API.
+ *   - `setView(view)` → calls `Clarity.setTag('view', view)`. The 'view'
+ *     dimension lets dashboards filter Clarity sessions by surface
+ *     (feed | map | species | detail).
+ *
+ * The wrapper guards on `window.clarity` being a function — Clarity's
+ * injected script wires that during `init`, and direct calls to
+ * `Clarity.event/setTag` throw `TypeError: window.clarity is not a function`
+ * before init runs. The guard makes the module safe to call from any test
+ * (call sites in SpeciesDetailSurface.test, e2e specs) without leaking that
+ * SDK internal. These tests stub `window.clarity` so the guard passes and
+ * the mocked `Clarity` methods are observed.
+ *
+ * Module is imported dynamically per-test so each test starts from a fresh
+ * module evaluation.
  */
 
-const initMock = vi.fn();
-const captureMock = vi.fn();
+const eventMock = vi.fn();
+const setTagMock = vi.fn();
 
-vi.mock('posthog-js', () => ({
-  default: {
-    init: initMock,
-    capture: captureMock,
-  },
+vi.mock('@microsoft/clarity', () => ({
+  default: { event: eventMock, setTag: setTagMock, init: vi.fn() },
 }));
 
 describe('analytics module', () => {
   beforeEach(() => {
     vi.resetModules();
-    initMock.mockReset();
-    captureMock.mockReset();
+    eventMock.mockReset();
+    setTagMock.mockReset();
+    (window as unknown as { clarity: (...args: unknown[]) => void }).clarity =
+      () => {};
   });
 
   afterEach(() => {
-    vi.unstubAllEnvs();
+    delete (window as unknown as { clarity?: unknown }).clarity;
   });
 
-  it('does NOT call posthog.init when VITE_POSTHOG_KEY is unset', async () => {
-    // Default: env var unset / empty.  This mirrors CI + local dev.
-    vi.stubEnv('VITE_POSTHOG_KEY', '');
-    await import('./analytics.js');
-    expect(initMock).not.toHaveBeenCalled();
-  });
-
-  it('exports a capture-stub no-op when VITE_POSTHOG_KEY is unset', async () => {
-    vi.stubEnv('VITE_POSTHOG_KEY', '');
+  it('capture(name) calls Clarity.event with the name', async () => {
     const { analytics } = await import('./analytics.js');
-    // Must not throw, must not delegate to posthog.capture.
-    expect(() => analytics.capture('panel_opened', { species_code: 'x' })).not.toThrow();
-    expect(captureMock).not.toHaveBeenCalled();
+    analytics.capture('panel_opened');
+    expect(eventMock).toHaveBeenCalledWith('panel_opened');
+    expect(setTagMock).not.toHaveBeenCalled();
   });
 
-  it('calls posthog.init with privacy-respecting options when key is present', async () => {
-    vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test_key');
-    await import('./analytics.js');
-    expect(initMock).toHaveBeenCalledTimes(1);
-    expect(initMock).toHaveBeenCalledWith('phc_test_key', {
-      api_host: 'https://us.i.posthog.com',
-      autocapture: false,
-      capture_pageview: false,
-      respect_dnt: true,
-    });
-  });
-
-  it('exports posthog as analytics when key is present', async () => {
-    vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test_key');
+  it('capture(name, props) calls Clarity.event then setTag for each prop', async () => {
     const { analytics } = await import('./analytics.js');
-    analytics.capture('panel_opened', { species_code: 'x' });
-    expect(captureMock).toHaveBeenCalledWith('panel_opened', { species_code: 'x' });
+    analytics.capture('panel_opened', { species_code: 'haxwo', source: 'feed' });
+    expect(eventMock).toHaveBeenCalledWith('panel_opened');
+    expect(setTagMock).toHaveBeenCalledWith('species_code', 'haxwo');
+    expect(setTagMock).toHaveBeenCalledWith('source', 'feed');
+  });
+
+  it('setView(view) calls Clarity.setTag with key "view"', async () => {
+    const { analytics } = await import('./analytics.js');
+    analytics.setView('species');
+    expect(setTagMock).toHaveBeenCalledWith('view', 'species');
+  });
+
+  it('capture is a no-op when window.clarity has not been wired', async () => {
+    delete (window as unknown as { clarity?: unknown }).clarity;
+    const { analytics } = await import('./analytics.js');
+    expect(() => analytics.capture('panel_opened', { x: 1 })).not.toThrow();
+    expect(eventMock).not.toHaveBeenCalled();
+    expect(setTagMock).not.toHaveBeenCalled();
+  });
+
+  it('setView is a no-op when window.clarity has not been wired', async () => {
+    delete (window as unknown as { clarity?: unknown }).clarity;
+    const { analytics } = await import('./analytics.js');
+    expect(() => analytics.setView('map')).not.toThrow();
+    expect(setTagMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/analytics.test.ts
+++ b/frontend/src/analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
  * Tests for the Clarity-backed analytics module (PR #659 follow-up).
@@ -7,22 +7,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * unchanged (4 existing call sites stay verbatim — see analytics.ts
  * docstring) but swapped the underlying transport.
  *
- *   - `capture(name)` → calls `Clarity.event(name)`. No `setTag` calls.
- *   - `capture(name, props)` → calls `Clarity.event(name)` AND
- *     `Clarity.setTag(key, String(value))` for every prop key/value pair.
- *     This preserves the event-with-dimensions intent of the old PostHog
- *     payload shape under Clarity's split API.
- *   - `setView(view)` → calls `Clarity.setTag('view', view)`. The 'view'
- *     dimension lets dashboards filter Clarity sessions by surface
+ *   - `capture(name)` → calls `safeClarity.event(name)`. No `setTag` calls.
+ *   - `capture(name, props)` → calls `safeClarity.event(name)` AND
+ *     `safeClarity.setTag(key, String(value))` for every prop key/value
+ *     pair. This preserves the event-with-dimensions intent of the old
+ *     PostHog payload shape under Clarity's split API.
+ *   - `setView(view)` → calls `safeClarity.setTag('view', view)`. The
+ *     'view' dimension lets dashboards filter Clarity sessions by surface
  *     (feed | map | species | detail).
  *
- * The wrapper guards on `window.clarity` being a function — Clarity's
- * injected script wires that during `init`, and direct calls to
- * `Clarity.event/setTag` throw `TypeError: window.clarity is not a function`
- * before init runs. The guard makes the module safe to call from any test
- * (call sites in SpeciesDetailSurface.test, e2e specs) without leaking that
- * SDK internal. These tests stub `window.clarity` so the guard passes and
- * the mocked `Clarity` methods are observed.
+ * The runtime guard (window.clarity must be a function before any SDK
+ * method fires) lives in `safeClarity` itself — these tests mock the
+ * `./clarity.js` module directly, so the guard branch is not exercised
+ * here; it has dedicated coverage in `clarity.test.ts`.
  *
  * Module is imported dynamically per-test so each test starts from a fresh
  * module evaluation.
@@ -31,8 +28,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const eventMock = vi.fn();
 const setTagMock = vi.fn();
 
-vi.mock('@microsoft/clarity', () => ({
-  default: { event: eventMock, setTag: setTagMock, init: vi.fn() },
+vi.mock('./clarity.js', () => ({
+  safeClarity: { event: eventMock, setTag: setTagMock },
 }));
 
 describe('analytics module', () => {
@@ -40,22 +37,16 @@ describe('analytics module', () => {
     vi.resetModules();
     eventMock.mockReset();
     setTagMock.mockReset();
-    (window as unknown as { clarity: (...args: unknown[]) => void }).clarity =
-      () => {};
   });
 
-  afterEach(() => {
-    delete (window as unknown as { clarity?: unknown }).clarity;
-  });
-
-  it('capture(name) calls Clarity.event with the name', async () => {
+  it('capture(name) calls safeClarity.event with the name', async () => {
     const { analytics } = await import('./analytics.js');
     analytics.capture('panel_opened');
     expect(eventMock).toHaveBeenCalledWith('panel_opened');
     expect(setTagMock).not.toHaveBeenCalled();
   });
 
-  it('capture(name, props) calls Clarity.event then setTag for each prop', async () => {
+  it('capture(name, props) calls safeClarity.event then setTag for each prop', async () => {
     const { analytics } = await import('./analytics.js');
     analytics.capture('panel_opened', { species_code: 'haxwo', source: 'feed' });
     expect(eventMock).toHaveBeenCalledWith('panel_opened');
@@ -63,24 +54,9 @@ describe('analytics module', () => {
     expect(setTagMock).toHaveBeenCalledWith('source', 'feed');
   });
 
-  it('setView(view) calls Clarity.setTag with key "view"', async () => {
+  it('setView(view) calls safeClarity.setTag with key "view"', async () => {
     const { analytics } = await import('./analytics.js');
     analytics.setView('species');
     expect(setTagMock).toHaveBeenCalledWith('view', 'species');
-  });
-
-  it('capture is a no-op when window.clarity has not been wired', async () => {
-    delete (window as unknown as { clarity?: unknown }).clarity;
-    const { analytics } = await import('./analytics.js');
-    expect(() => analytics.capture('panel_opened', { x: 1 })).not.toThrow();
-    expect(eventMock).not.toHaveBeenCalled();
-    expect(setTagMock).not.toHaveBeenCalled();
-  });
-
-  it('setView is a no-op when window.clarity has not been wired', async () => {
-    delete (window as unknown as { clarity?: unknown }).clarity;
-    const { analytics } = await import('./analytics.js');
-    expect(() => analytics.setView('map')).not.toThrow();
-    expect(setTagMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -1,52 +1,53 @@
-import posthog from 'posthog-js';
+import Clarity from '@microsoft/clarity';
 
 /**
- * PostHog analytics module (issue #357).
+ * Analytics wrapper, Clarity-backed (PR #659 follow-up to issue #357).
  *
- * Reads `VITE_POSTHOG_KEY` at module-evaluation time (which happens once
- * during app startup via the import in `main.tsx`).  When the key is unset
- * or empty:
+ * The previous PostHog wiring never actually shipped — `VITE_POSTHOG_KEY`
+ * was never injected by the deploy workflow, so every `analytics.capture`
+ * call was a silent no-op in prod. This module replaces the dead transport
+ * with Microsoft Clarity (the SDK that PR #659 already initializes via
+ * `clarity.ts`) WITHOUT touching the four existing call sites
+ * (`url-state.ts` + `SpeciesDetailSurface.tsx`). The public
+ * `analytics.capture(name, props)` shape is preserved on purpose.
  *
- *   1. `posthog.init` is NEVER called.  posthog-js emits a console warning
- *      on `posthog.init('')`, which would fail every e2e spec's
- *      console-cleanliness assertion (species-detail.spec.ts,
- *      map-symbol-layer.spec.ts).
- *   2. `analytics` is a tiny no-op stub exposing only `capture`.  All
- *      component-level call sites (`analytics.capture('panel_opened', ...)`)
- *      execute as a no-op without touching posthog-js.
+ * Clarity's API splits what PostHog folded together:
+ *   - `Clarity.event(name)` takes a name only (no payload).
+ *   - `Clarity.setTag(key, value)` attaches a string dimension to the
+ *     current session.
+ * So we fan a single PostHog-style `capture(name, props)` call out to one
+ * `event` and N `setTag` calls — the *intent* (event + its dimensions)
+ * survives, just split across two SDK methods.
  *
- * When the key is present (i.e. only in the production Cloudflare Pages
- * deploy where `VITE_POSTHOG_KEY` is set as a build-time env var):
- *
- *   1. `posthog.init` is called once with privacy-respecting options:
- *      - `autocapture: false` — no auto-instrumented click/scroll events.
- *      - `capture_pageview: false` — we capture our own panel events.
- *      - `respect_dnt: true` — honor browser Do-Not-Track headers.
- *      (No session recordings, no GDPR banner, no autocapture — see the
- *      "Out of scope" section of issue #357.)
- *   2. `analytics` IS the posthog-js default export.  All `analytics.capture`
- *      calls flow straight through.
- *
- * The narrow `Analytics` interface keeps consumer call-sites loose-coupled
- * to the underlying library; the no-op stub only needs to implement
- * `capture`.  If we add `identify` or `reset` later, extend this interface
- * and the stub in lockstep.
+ * No env-var gate here: `clarity.ts` is the gate (PROD + project ID).
+ * The runtime guard below (`window.clarity` exists) only fires before the
+ * injected script has wired its queue function — i.e. in dev, in tests,
+ * and on prod builds where the env gate suppressed init. This avoids
+ * leaking SDK internals (`TypeError: window.clarity is not a function`)
+ * into call-site test environments.
  */
 interface Analytics {
   capture(eventName: string, properties?: Record<string, unknown>): void;
+  setView(view: string): void;
 }
 
-const key = import.meta.env.VITE_POSTHOG_KEY ?? '';
-
-if (key) {
-  posthog.init(key, {
-    api_host: 'https://us.i.posthog.com',
-    autocapture: false,
-    capture_pageview: false,
-    respect_dnt: true,
-  });
+function clarityReady(): boolean {
+  return typeof window !== 'undefined' &&
+    typeof (window as unknown as { clarity?: unknown }).clarity === 'function';
 }
 
-export const analytics: Analytics = key
-  ? posthog
-  : { capture: () => {} };
+export const analytics: Analytics = {
+  capture(eventName, properties) {
+    if (!clarityReady()) return;
+    Clarity.event(eventName);
+    if (properties) {
+      for (const [key, value] of Object.entries(properties)) {
+        Clarity.setTag(key, String(value));
+      }
+    }
+  },
+  setView(view) {
+    if (!clarityReady()) return;
+    Clarity.setTag('view', view);
+  },
+};

--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -1,4 +1,4 @@
-import Clarity from '@microsoft/clarity';
+import { safeClarity } from './clarity.js';
 
 /**
  * Analytics wrapper, Clarity-backed (PR #659 follow-up to issue #357).
@@ -19,35 +19,31 @@ import Clarity from '@microsoft/clarity';
  * `event` and N `setTag` calls — the *intent* (event + its dimensions)
  * survives, just split across two SDK methods.
  *
- * No env-var gate here: `clarity.ts` is the gate (PROD + project ID).
- * The runtime guard below (`window.clarity` exists) only fires before the
- * injected script has wired its queue function — i.e. in dev, in tests,
- * and on prod builds where the env gate suppressed init. This avoids
- * leaking SDK internals (`TypeError: window.clarity is not a function`)
- * into call-site test environments.
+ * The Clarity SDK itself is accessed via `safeClarity` from `./clarity.js`,
+ * not imported here directly. `clarity.ts` is the single canonical entry
+ * point to the SDK: it owns init (the env gate: PROD + project ID) AND the
+ * runtime guard (`window.clarity` exists), so pre-init calls in dev/test/
+ * un-gated-prod become safe no-ops without leaking the SDK internal
+ * (`TypeError: window.clarity is not a function`) into call-site test
+ * environments. Future Clarity callers (consent banner #658, identify,
+ * upgrade) should import `safeClarity` here too — never
+ * `@microsoft/clarity` directly.
  */
 interface Analytics {
   capture(eventName: string, properties?: Record<string, unknown>): void;
   setView(view: string): void;
 }
 
-function clarityReady(): boolean {
-  return typeof window !== 'undefined' &&
-    typeof (window as unknown as { clarity?: unknown }).clarity === 'function';
-}
-
 export const analytics: Analytics = {
   capture(eventName, properties) {
-    if (!clarityReady()) return;
-    Clarity.event(eventName);
+    safeClarity.event(eventName);
     if (properties) {
       for (const [key, value] of Object.entries(properties)) {
-        Clarity.setTag(key, String(value));
+        safeClarity.setTag(key, String(value));
       }
     }
   },
   setView(view) {
-    if (!clarityReady()) return;
-    Clarity.setTag('view', view);
+    safeClarity.setTag('view', view);
   },
 };

--- a/frontend/src/clarity.test.ts
+++ b/frontend/src/clarity.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const initMock = vi.fn();
 
 vi.mock('@microsoft/clarity', () => ({
-  default: { init: initMock },
+  default: { init: initMock, event: vi.fn(), setTag: vi.fn() },
 }));
 
 describe('clarity module', () => {
@@ -53,5 +53,49 @@ describe('clarity module', () => {
     await import('./clarity.js');
     expect(initMock).toHaveBeenCalledTimes(1);
     expect(initMock).toHaveBeenCalledWith('abc123xyz');
+  });
+});
+
+describe('safeClarity guarded wrapper', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Ensure window.clarity is undefined to simulate pre-init / non-prod.
+    delete (window as unknown as { clarity?: unknown }).clarity;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { clarity?: unknown }).clarity;
+  });
+
+  it('safeClarity.event is a no-op when window.clarity is undefined', async () => {
+    const { safeClarity } = await import('./clarity.js');
+    expect(() => safeClarity.event('panel_opened')).not.toThrow();
+  });
+
+  it('safeClarity.setTag is a no-op when window.clarity is undefined', async () => {
+    const { safeClarity } = await import('./clarity.js');
+    expect(() => safeClarity.setTag('view', 'feed')).not.toThrow();
+  });
+
+  it('safeClarity.event forwards to Clarity.event when window.clarity is a function', async () => {
+    (window as unknown as { clarity: () => void }).clarity = vi.fn();
+    const eventSpy = vi.fn();
+    vi.doMock('@microsoft/clarity', () => ({
+      default: { init: vi.fn(), event: eventSpy, setTag: vi.fn() },
+    }));
+    const { safeClarity } = await import('./clarity.js');
+    safeClarity.event('panel_opened');
+    expect(eventSpy).toHaveBeenCalledWith('panel_opened');
+  });
+
+  it('safeClarity.setTag forwards to Clarity.setTag when window.clarity is a function', async () => {
+    (window as unknown as { clarity: () => void }).clarity = vi.fn();
+    const setTagSpy = vi.fn();
+    vi.doMock('@microsoft/clarity', () => ({
+      default: { init: vi.fn(), event: vi.fn(), setTag: setTagSpy },
+    }));
+    const { safeClarity } = await import('./clarity.js');
+    safeClarity.setTag('view', 'feed');
+    expect(setTagSpy).toHaveBeenCalledWith('view', 'feed');
   });
 });

--- a/frontend/src/clarity.ts
+++ b/frontend/src/clarity.ts
@@ -32,3 +32,36 @@ const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID ?? '';
 if (import.meta.env.PROD && projectId) {
   Clarity.init(projectId);
 }
+
+function isClarityReady(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof (window as unknown as { clarity?: unknown }).clarity === 'function'
+  );
+}
+
+/**
+ * Guarded Clarity API. The `@microsoft/clarity` SDK throws
+ * `TypeError: window.clarity is not a function` when methods are called
+ * before `Clarity.init` runs (e.g. dev/test environments, or prod builds
+ * with `VITE_CLARITY_PROJECT_ID` unset). The runtime guard here makes
+ * pre-init calls safe no-ops.
+ *
+ * **Convention**: This is the single entry point to the Clarity SDK
+ * across the codebase. Do NOT `import Clarity from '@microsoft/clarity'`
+ * from any other file — import `safeClarity` from here instead. Only
+ * `clarity.ts` is allowed to touch the SDK directly. (Init is the lone
+ * exception, called above at module load.)
+ *
+ * Methods are added as the codebase needs them. Today: `event` for
+ * custom events, `setTag` for dimensions. Future additions for the
+ * consent banner (#658) should add `consentV2` and `consent` here.
+ */
+export const safeClarity = {
+  event(name: string): void {
+    if (isClarityReady()) Clarity.event(name);
+  },
+  setTag(key: string, value: string): void {
+    if (isClarityReady()) Clarity.setTag(key, value);
+  },
+};

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -189,7 +189,7 @@ describe('AttributionModal', () => {
     expect(descriptionsIdx).toBeLessThan(mapIdx);
   });
 
-  it('renders a Privacy section disclosing PostHog analytics + DNT respect', async () => {
+  it('renders a Privacy section disclosing Clarity analytics + default masking', async () => {
     const user = userEvent.setup();
     render(<AttributionModal silhouettes={SILHOUETTES} />);
     await user.click(screen.getByRole('button', { name: /credits/i }));
@@ -198,16 +198,17 @@ describe('AttributionModal', () => {
     // new final section.
     const heading = screen.getByRole('heading', { level: 3, name: /privacy/i });
     expect(heading).toBeInTheDocument();
-    // Verbatim copy from the issue: discloses PostHog as the analytics
-    // vendor + DNT compliance + no session recordings / personal data.
+    // Disclosure names Microsoft Clarity as the analytics vendor, calls
+    // out session replay + heatmaps (Clarity's default product), and
+    // states the default-mask posture for sensitive content.
     expect(
-      screen.getByText(/usage analytics via posthog/i),
+      screen.getByText(/usage analytics via microsoft clarity/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/respects do not track/i),
+      screen.getByText(/session replay and heatmaps/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/no session recordings or personal data collected/i),
+      screen.getByText(/sensitive content.*masked by default/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -523,20 +523,19 @@ export function AttributionModal({
             </p>
           </section>
           {/*
-            Privacy disclosure (issue #357 task 7).  PostHog instrumentation
-            on the species detail surface fires a small set of panel-scoped
-            events (`panel_opened`, `panel_dwell_ms`,
-            `panel_scrolled_to_bottom`) so we can evaluate the panel-thinness
-            hypothesis after >=14 days of data.  The disclosure is verbatim
-            from the issue body and covers (a) vendor, (b) DNT compliance
-            (`respect_dnt: true` in analytics.ts), and (c) explicit absence
-            of session recordings + personal-data capture (autocapture is
-            off, capture_pageview is off — see analytics.ts).  Privacy is
-            the new final section after Map Tiles.
+            Privacy disclosure (issue #357 task 7; updated 2026-05-20 when
+            Microsoft Clarity replaced PostHog).  Clarity collects session
+            recordings, heatmaps, and custom event tags (`panel_opened`,
+            `panel_dwell_ms`, `panel_scrolled_to_bottom`) so we can evaluate
+            the panel-thinness hypothesis after >=14 days of data.  Clarity
+            defaults to masking text content and form fields; first-party
+            cookies are `_clck` and `_clsk` (see clarity.ts).  We don't claim
+            DNT support — the Clarity SDK doesn't expose that knob.  Privacy
+            is the final section after Map Tiles.
           */}
           <section className="attribution-modal-section">
             <h3>Privacy</h3>
-            <p>Usage analytics via PostHog. Respects Do Not Track. No session recordings or personal data collected.</p>
+            <p>Usage analytics via Microsoft Clarity, including session replay and heatmaps. Sensitive content (form fields, text) is masked by default.</p>
           </section>
         </div>
       </dialog>

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -9,19 +9,6 @@ import { analytics } from '../analytics.js';
 import { FAMILY_COLOR_FALLBACK } from '../data/family-color.js';
 import type { BBox } from '../state/url-state.js';
 
-// Mock posthog-js so no network call escapes the test environment, even
-// if a future contributor sets `VITE_POSTHOG_KEY` in their local .env.
-// Tests run with the env unset by default — `analytics` is the no-op stub
-// from analytics.ts — so the assertions below spy directly on the stub's
-// `capture` method.  Keeping `vi.mock('posthog-js')` matches the explicit
-// guidance in issue #357 task 6.
-vi.mock('posthog-js', () => ({
-  default: {
-    init: vi.fn(),
-    capture: vi.fn(),
-  },
-}));
-
 const VERMFLY: SpeciesMeta = {
   speciesCode: 'vermfly',
   comName: 'Vermilion Flycatcher',
@@ -376,16 +363,16 @@ describe('SpeciesDetailSurface', () => {
 
   // ─── Analytics instrumentation (issue #357 tasks 3, 4) ─────────────────
   //
-  // The detail surface fires three PostHog events once per active species:
+  // The detail surface fires three analytics events once per active species:
   //
   //   - `panel_opened` on mount (after the species detail resolves).
   //   - `panel_dwell_ms` on unmount with `dwell_ms = Date.now() - t0`.
   //   - `panel_scrolled_to_bottom` on first IntersectionObserver hit on
   //     the bottom sentinel.
   //
-  // Tests run with `VITE_POSTHOG_KEY` unset, so `analytics` is the no-op
-  // stub from `analytics.ts` (posthog.init is never called — that's the
-  // load-bearing CI-cleanliness guarantee).  We spy on `analytics.capture`
+  // `analytics.capture` flows through `safeClarity.event` + `setTag` from
+  // `clarity.ts`. In jsdom, `window.clarity` is undefined so the wrapper
+  // no-ops — no console noise, no SDK throws. We spy on `analytics.capture`
   // directly to verify the events fire with the right payload.
 
   describe('analytics instrumentation', () => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App.js';
-// Importing for the side effect: `analytics.ts` reads `VITE_POSTHOG_KEY`
-// and (when present) calls `posthog.init` once at app startup. When the
-// key is empty, the import is a strict no-op — posthog.init is never
-// called and no console warnings are emitted (issue #357 task 2).
-import './analytics.js';
 // Importing for the side effect: `clarity.ts` reads `VITE_CLARITY_PROJECT_ID`
 // and (in production builds only) calls `Clarity.init` once at app
 // startup. When the env var is empty OR the build is non-production, the

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_CLARITY_PROJECT_ID?: string;
-  readonly VITE_POSTHOG_KEY?: string;
 }
 
 interface ImportMeta {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@bird-watch/shared-types": "*",
         "@microsoft/clarity": "^1.0.2",
         "maplibre-gl": "^5.24.0",
-        "posthog-js": "^1.372.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^8.1.1",
@@ -2035,246 +2034,12 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
-      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/otlp-exporter-base": "0.208.0",
-        "@opentelemetry/otlp-transformer": "0.208.0",
-        "@opentelemetry/sdk-logs": "0.208.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
-      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/otlp-transformer": "0.208.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
-      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0",
-        "@opentelemetry/sdk-logs": "0.208.0",
-        "@opentelemetry/sdk-metrics": "2.2.0",
-        "@opentelemetry/sdk-trace-base": "2.2.0",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
-      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.208.0",
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
-      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
-      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/resources": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
-      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.2.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -2935,39 +2700,29 @@
         "node": ">=18"
       }
     },
-    "node_modules/@posthog/core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.0.tgz",
-      "integrity": "sha512-753giUMWuk602UtS101tDZuNcwiKkr+3UEhLgfOwHAk2W32n53knOxAjyWT0JwMq5/+0uSQ2y4uaZXQAxwvBSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@posthog/types": "1.372.6"
-      }
-    },
-    "node_modules/@posthog/types": {
-      "version": "1.372.6",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.6.tgz",
-      "integrity": "sha512-sqI36LBvuo8xcYsXIlVa0q3IXJJjqtatM2LrXlyOM7kgHrldBwS4ldzaTXrTdpe/TiIl1b4ZHxtSHMzPig+DnQ==",
-      "license": "MIT"
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -2976,22 +2731,27 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4180,6 +3940,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -5122,17 +4883,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "dev": true,
@@ -5622,12 +5372,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
-      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -6430,6 +6174,7 @@
     },
     "node_modules/long": {
       "version": "5.3.2",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -7041,37 +6786,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/posthog-js": {
-      "version": "1.372.6",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.6.tgz",
-      "integrity": "sha512-+Fy9fwWni5WDKQXiUBIzFvdmnZSR6OBxGC/4wj09JvvK5JE4dhI9ZlKO1+b887PowjeAx0sx1Tf+S1eAjDvzqg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/api-logs": "^0.208.0",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
-        "@opentelemetry/resources": "^2.2.0",
-        "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.28.0",
-        "@posthog/types": "1.372.6",
-        "core-js": "^3.38.1",
-        "dompurify": "^3.3.2",
-        "fflate": "^0.4.8",
-        "preact": "^10.28.2",
-        "query-selector-shadow-dom": "^1.0.1",
-        "web-vitals": "^5.1.0"
-      }
-    },
-    "node_modules/preact": {
-      "version": "10.29.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
-      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "dev": true,
@@ -7143,6 +6857,7 @@
     },
     "node_modules/protobufjs": {
       "version": "7.5.5",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7180,12 +6895,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/query-selector-shadow-dom": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
-      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
-      "license": "MIT"
     },
     "node_modules/quickselect": {
       "version": "3.0.0",
@@ -8071,6 +7780,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/union-value": {
@@ -8298,12 +8008,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
-      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",


### PR DESCRIPTION
## Diagrams

Before (PR #659 ships Clarity init, but the wrapper still routed through dead-wired PostHog):

```mermaid
flowchart LR
    A[url-state.ts<br/>url_corruption_recovered_511]
    B[SpeciesDetailSurface.tsx<br/>panel_opened / dwell / scroll]
    W[analytics.capture]
    P[posthog-js<br/>VITE_POSTHOG_KEY env var<br/>NEVER injected by deploy]
    DROP[(silent no-op in prod)]
    C[clarity.ts<br/>Clarity.init - PR #659]
    CS[Clarity backend]

    A --> W
    B --> W
    W --> P
    P --> DROP
    C --> CS
```

After (single live transport; setView adds the view dimension):

```mermaid
flowchart LR
    A[url-state.ts<br/>url_corruption_recovered_511]
    B[SpeciesDetailSurface.tsx<br/>panel_opened / dwell / scroll]
    APP[App.tsx<br/>useEffect on state.view]
    W[analytics.capture - unchanged API<br/>analytics.setView - new]
    CSDK["@microsoft/clarity<br/>Clarity.event(name)<br/>Clarity.setTag(key, value)"]
    C[clarity.ts<br/>Clarity.init - PR #659]
    CS[Clarity backend<br/>filterable by view tag]

    A --> W
    B --> W
    APP --> W
    W --> CSDK
    C --> CSDK
    CSDK --> CS
```

## Summary

- **PostHog dropped.** The `posthog-js` dep is gone; `VITE_POSTHOG_KEY` was never injected by `.github/workflows/deploy-frontend.yml`, so every `analytics.capture` call had been a silent no-op in prod since #357 merged. The four existing call sites (`url-state.ts` + `SpeciesDetailSurface.tsx`) are unchanged — only the underlying transport swapped.
- **Clarity now backs `analytics.capture()`.** A single `capture(name, props)` fans out to `Clarity.event(name)` + one `Clarity.setTag(key, String(value))` per prop so the event-with-dimensions intent survives Clarity's split API. A `clarityReady()` guard makes the wrapper safe in dev/test where `Clarity.init` is skipped.
- **`analytics.setView(view)` wired in App.tsx** via `useEffect([state.view])` so Clarity dashboards can filter sessions by surface (`feed | map | species | detail`) without us re-emitting an event per navigation.
- **Bonus:** `posthog-js` was the only thing pulling `protobufjs` into the frontend bundle, so the 1 high + 1 moderate transitive npm-audit advisories disappear with this PR. `npm audit --workspace @bird-watch/frontend` now reports **0 vulnerabilities**.

This is a follow-up to #657 / PR #659 — not closing a new issue.

## Screenshots

N/A — analytics wiring with no visible UI surface (mirrors the precedent set by PR #659 for the same module).

- [x] Every new/renamed `className` in this PR has a matching CSS rule (N/A — no className changes)
- [x] Multi-viewport design QA: N/A — not UI

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (905 pass, 65 files); +5 new tests in `analytics.test.ts`, +1 regression test in `App.test.tsx`
- [x] `npm run lint --workspace @bird-watch/frontend` — no-op (no lint script declared, matches repo state)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npm run test:e2e --workspace @bird-watch/frontend` — 228 pass / 14 skipped
- [x] `npm audit --workspace @bird-watch/frontend` — **0 vulnerabilities** (was 1 high + 1 moderate from `protobufjs` via `posthog-js`)
- [x] `SpeciesDetailSurface.test.tsx`'s spy on `analytics.capture` keeps passing — public API preserved on purpose

## Plan reference

Out of plan — follow-up to PR #659 to retire the dead-wired PostHog wrapper that #659 left in place. Closes the loop on #357 (PostHog instrumentation) by migrating its four call sites onto the SDK that #657 chose.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>