### PR TITLE
feat(ingestor): per-day diagnostic logging in backfill loop

### DIFF
--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -329,6 +329,11 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // field so Cloud Logging can filter by `jsonPayload.state="US-CA"`.
       // Omitted for non-backfill kinds to keep the structured shape minimal.
       ...(backfillState !== undefined && { state: backfillState }),
+      // Surface the first per-day error (or fatal pre-loop error) in the
+      // run-completed summary so Cloud Logging triage doesn't require
+      // joining against the per-day bird_ingest_day_failed lines.
+      ...(summary.status !== 'success' && 'error' in summary && typeof summary.error === 'string'
+        && { firstError: summary.error.slice(0, 500) }),
     }));
     if (summary.status === 'failure') {
       // Flag the process as failed without killing the loop mid-pool-close.

--- a/services/ingestor/src/run-backfill.test.ts
+++ b/services/ingestor/src/run-backfill.test.ts
@@ -195,6 +195,110 @@ describe('runBackfill', () => {
     setTimeoutSpy.mockRestore();
   });
 
+  it('emits bird_ingest_day_failed with phase=fetch when a day\'s fetch errors', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json([])),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/historic/:y/:m/:d', ({ params }) => {
+        const day = Number(params['d']);
+        if (day === 14) return new HttpResponse('eBird exploded', { status: 500 });
+        return HttpResponse.json([
+          { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+            sciName: 'Pyrocephalus rubinus', locId: `LF${day}`, locName: 'X',
+            obsDt: `2026-04-${String(day).padStart(2, '0')} 08:00`,
+            howMany: 1, lat: 31.72, lng: -110.88,
+            obsValid: true, obsReviewed: false, locationPrivate: false,
+            subId: `SF${day}` },
+        ]);
+      }),
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const today = new Date('2026-04-16T00:00:00Z');
+    const client = new EbirdClient({ apiKey: 'k', maxRetries: 0 });
+    const summary = await runBackfill({
+      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
+      days: 3, today, client,
+    });
+    expect(summary.status).toBe('partial');
+
+    const warnObjs = warnSpy.mock.calls
+      .map(([a]) => { try { return JSON.parse(String(a)); } catch { return null; } })
+      .filter((o): o is Record<string, unknown> => !!o && (o as Record<string, unknown>).message === 'bird_ingest_day_failed');
+    expect(warnObjs).toHaveLength(1);
+    expect(warnObjs[0]).toMatchObject({
+      kind: 'backfill', message: 'bird_ingest_day_failed',
+      state: 'US-AZ', phase: 'fetch', dayOffset: 2, date: '2026-04-14',
+    });
+    expect(String(warnObjs[0]?.['error'])).toMatch(/500|server|exploded/i);
+
+    const okObjs = logSpy.mock.calls
+      .map(([a]) => { try { return JSON.parse(String(a)); } catch { return null; } })
+      .filter((o): o is Record<string, unknown> => !!o && (o as Record<string, unknown>).message === 'bird_ingest_day_succeeded');
+    expect(okObjs).toHaveLength(2);
+    expect(okObjs[0]).toMatchObject({
+      kind: 'backfill', message: 'bird_ingest_day_succeeded',
+      state: 'US-AZ', fetched: 1,
+    });
+
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('emits bird_ingest_day_failed with phase=upsert when upsertObservations throws mid-loop', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json([])),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/historic/:y/:m/:d', () =>
+        HttpResponse.json([
+          { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+            sciName: 'Pyrocephalus rubinus', locId: 'LU2', locName: 'X',
+            obsDt: '2026-04-15 08:00', howMany: 1, lat: 31.72, lng: -110.88,
+            obsValid: true, obsReviewed: false, locationPrivate: false,
+            subId: 'SU2' },
+        ])
+      ),
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Wrap real pool: pass through startIngestRun/finishIngestRun (which use
+    // INSERT/UPDATE on ingest_runs) but throw on the observations multi-row INSERT.
+    const realQuery = db.pool.query.bind(db.pool);
+    const wrappedPool = new Proxy(db.pool, {
+      get(target, prop) {
+        if (prop === 'query') {
+          return (text: string, params?: unknown[]) => {
+            const sql = typeof text === 'string' ? text : (text as { text?: string }).text ?? '';
+            if (sql.includes('observations') && /INSERT/i.test(sql)) {
+              return Promise.reject(new Error('synthetic upsert failure'));
+            }
+            return realQuery(text as never, params as never);
+          };
+        }
+        return (target as unknown as Record<string | symbol, unknown>)[prop as string];
+      },
+    });
+
+    const today = new Date('2026-04-16T00:00:00Z');
+    const summary = await runBackfill({
+      pool: wrappedPool, apiKey: 'k', regionCode: 'US-AZ',
+      days: 1, today,
+    });
+    expect(summary.status).toBe('failure');
+    expect(summary.error).toMatch(/synthetic upsert failure/);
+
+    const warnObjs = warnSpy.mock.calls
+      .map(([a]) => { try { return JSON.parse(String(a)); } catch { return null; } })
+      .filter((o): o is Record<string, unknown> => !!o && (o as Record<string, unknown>).message === 'bird_ingest_day_failed');
+    expect(warnObjs).toHaveLength(1);
+    expect(warnObjs[0]).toMatchObject({
+      kind: 'backfill', message: 'bird_ingest_day_failed',
+      state: 'US-AZ', phase: 'upsert', dayOffset: 1,
+    });
+    expect(String(warnObjs[0]?.['error'])).toMatch(/synthetic upsert failure/);
+
+    warnSpy.mockRestore();
+  });
+
   it('records failure when pre-loop fetchNotable throws exhausted retries', async () => {
     server.use(
       http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () =>

--- a/services/ingestor/src/run-backfill.ts
+++ b/services/ingestor/src/run-backfill.ts
@@ -52,20 +52,65 @@ export async function runBackfill(o: RunBackfillOptions): Promise<RunBackfillSum
       const y = date.getUTCFullYear();
       const m = date.getUTCMonth() + 1;
       const d = date.getUTCDate();
+      const dateStr = `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+      // Pace successive eBird calls. Skip the wait before the first call;
+      // otherwise a 365-day run sits idle for paceMs * 365 when paceMs *
+      // (365 - 1) would do. Mirrors run-photos.ts:113-116.
+      if (!firstCall && (o.paceMs ?? 0) > 0) await sleep(o.paceMs!);
+      firstCall = false;
+
+      // Per-day diagnostic logging (issue #TBD): the prior single-catch
+      // block hid which phase failed (fetch vs upsert) and produced no
+      // per-day visibility — a long backfill that died early left only
+      // `daysProcessed=0` in the run-completed summary. Split phases and
+      // emit one compact structured line per day.
+      let obs;
       try {
-        // Pace successive eBird calls. Skip the wait before the first call;
-        // otherwise a 365-day run sits idle for paceMs * 365 when paceMs *
-        // (365 - 1) would do. Mirrors run-photos.ts:113-116.
-        if (!firstCall && (o.paceMs ?? 0) > 0) await sleep(o.paceMs!);
-        firstCall = false;
-        const obs = await client.fetchHistoric(o.regionCode, y, m, d);
+        obs = await client.fetchHistoric(o.regionCode, y, m, d);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(JSON.stringify({
+          severity: 'WARNING',
+          kind: 'backfill',
+          message: 'bird_ingest_day_failed',
+          state: o.regionCode,
+          dayOffset: i,
+          date: dateStr,
+          phase: 'fetch',
+          error: msg.slice(0, 500),
+        }));
+        if (!firstError) firstError = msg;
+        continue;
+      }
+      try {
         const inputs = obs.map(eb => toObservationInput(eb, notableKeys));
         const upserted = await upsertObservations(o.pool, inputs);
         totalFetched += obs.length;
         totalUpserted += upserted;
         daysProcessed++;
+        console.log(JSON.stringify({
+          severity: 'INFO',
+          kind: 'backfill',
+          message: 'bird_ingest_day_succeeded',
+          state: o.regionCode,
+          dayOffset: i,
+          date: dateStr,
+          fetched: obs.length,
+          upserted,
+        }));
       } catch (err) {
-        if (!firstError) firstError = err instanceof Error ? err.message : String(err);
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(JSON.stringify({
+          severity: 'WARNING',
+          kind: 'backfill',
+          message: 'bird_ingest_day_failed',
+          state: o.regionCode,
+          dayOffset: i,
+          date: dateStr,
+          phase: 'upsert',
+          error: msg.slice(0, 500),
+        }));
+        if (!firstError) firstError = msg;
       }
     }
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ingestor
    participant eBird
    participant Postgres
    participant CloudLogging

    loop per day in backfill window
        Ingestor->>eBird: GET /data/obs/{state}/historic/y/m/d
        alt fetch fails
            Ingestor->>CloudLogging: WARNING bird_ingest_day_failed (phase=fetch)
        else fetch ok
            Ingestor->>Postgres: upsertObservations
            alt upsert fails
                Ingestor->>CloudLogging: WARNING bird_ingest_day_failed (phase=upsert)
            else upsert ok
                Ingestor->>CloudLogging: INFO bird_ingest_day_succeeded (fetched, upserted)
            end
        end
    end
    Ingestor->>CloudLogging: bird_ingest_run_completed (status, firstError?)
```

## Summary

- Today's US-CA backfill failed twice (status=failure, duration=1693s) with zero per-day visibility — the single `bird_ingest_run_completed` line named neither which day died nor whether the fetch or the upsert was the cause. This PR adds per-day structured logging so Cloud Logging triage can answer that question without rerunning the job.
- Split the per-day try/catch into a fetch phase and an upsert phase. Emits `bird_ingest_day_failed` (WARNING) with `state`, `dayOffset`, `date`, `phase` (`fetch`|`upsert`), and an error truncated to 500 chars; emits `bird_ingest_day_succeeded` (INFO) on the happy path with `fetched` + `upserted` counts.
- Threads the existing `firstError` through the run-completed summary so `jsonPayload.firstError` lands alongside `status=failure`/`partial`. The variable already existed; only the final `console.log` was missing it.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — relevant suites green (`run-backfill.test.ts` 7/7, `cli.test.ts` 28/28)
- [x] New unit tests added: fetch-phase failure, upsert-phase failure (via SQL-routing pool proxy), and successful-day INFO emission
- [ ] New Playwright e2e spec added (N/A — backend-only change)
- [x] `npm run -w @bird-watch/ingestor build` — clean
- [x] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — production diagnostic improvement triggered by the US-CA backfill failures on 2026-05-20. Follow-ups (timeout tuning, retry budget surfacing) will be filed once the per-day logs identify the actual failure mode.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)