### PR TITLE
feat(ingestor): bump backfill eBird request timeout 30s -> 120s

### DIFF
--- a/services/ingestor/src/run-backfill.test.ts
+++ b/services/ingestor/src/run-backfill.test.ts
@@ -315,4 +315,56 @@ describe('runBackfill', () => {
     const runs = await getRecentIngestRuns(db.pool, 10);
     expect(runs[0]?.status).toBe('failure');
   });
+
+  it('default-constructs EbirdClient with requestTimeoutMs=120000 when o.client is omitted', async () => {
+    // The /historic endpoint regularly exceeds the 30s default on high-density
+    // states (CA/FL/TX/NY) — entire CA backfill runs failed reproducibly with
+    // `eBird server error 0: Request timed out after 30000ms` across all 14
+    // days. Scoping the 120s timeout to backfill (rather than the EbirdClient
+    // global default) preserves /recent and /hotspots failure detection at
+    // 30s. This test pins that contract so a future refactor can't silently
+    // drop the override.
+    //
+    // TS `private` is a compile-time fiction; the field is reachable at
+    // runtime. We do a behavioral run-through (runBackfill with no o.client)
+    // so the constructor path actually executes, then assert the field on
+    // the client run-backfill built. To get a handle on that client without
+    // refactoring run-backfill to expose it, intercept via a Proxy on the
+    // imported class. ESM namespace objects are mutable under vitest's
+    // loader, so re-binding the export propagates to run-backfill's
+    // `EbirdClient` reference for the duration of this test.
+    const ebirdModule = await import('./ebird/client.js');
+    const Real = ebirdModule.EbirdClient;
+    let constructed: { requestTimeoutMs: number } | undefined;
+    const Proxied = new Proxy(Real, {
+      construct(target, args) {
+        const instance = Reflect.construct(target, args);
+        constructed = instance as unknown as { requestTimeoutMs: number };
+        return instance;
+      },
+    });
+    Object.defineProperty(ebirdModule, 'EbirdClient', {
+      value: Proxied, configurable: true, writable: true,
+    });
+
+    try {
+      server.use(
+        http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
+          () => HttpResponse.json([])),
+        http.get('https://api.ebird.org/v2/data/obs/US-AZ/historic/:y/:m/:d',
+          () => HttpResponse.json([])),
+      );
+      const today = new Date('2026-04-16T00:00:00Z');
+      await runBackfill({
+        pool: db.pool, apiKey: 'k', regionCode: 'US-AZ', days: 1, today,
+      });
+    } finally {
+      Object.defineProperty(ebirdModule, 'EbirdClient', {
+        value: Real, configurable: true, writable: true,
+      });
+    }
+
+    expect(constructed).toBeDefined();
+    expect(constructed!.requestTimeoutMs).toBe(120_000);
+  });
 });

--- a/services/ingestor/src/run-backfill.ts
+++ b/services/ingestor/src/run-backfill.ts
@@ -29,7 +29,12 @@ export interface RunBackfillSummary {
 }
 
 export async function runBackfill(o: RunBackfillOptions): Promise<RunBackfillSummary> {
-  const client = o.client ?? new EbirdClient({ apiKey: o.apiKey });
+  // 120s (not the 30s default) accommodates /historic slowness on high-density
+  // states (CA/FL/TX/NY) where per-day responses regularly exceed 30s. The
+  // /historic endpoint's only paging knob — maxResults — is already at the
+  // 10000 API ceiling, so client-side timeout is the remaining lever. Scoped
+  // to backfill so /recent and /hotspots keep their 30s failure-detection.
+  const client = o.client ?? new EbirdClient({ apiKey: o.apiKey, requestTimeoutMs: 120_000 });
   const runId = await startIngestRun(o.pool, 'backfill');
   const today = o.today ?? new Date();
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler
    participant runBackfill
    participant EbirdClient
    participant eBird /historic

    Scheduler->>runBackfill: invoke (no o.client)
    Note over runBackfill: o.client undefined -><br/>construct EbirdClient
    runBackfill->>EbirdClient: new EbirdClient({ apiKey,<br/>requestTimeoutMs: 120_000 })
    loop per day (1..N)
        EbirdClient->>eBird /historic: GET .../historic/Y/M/D (AbortSignal.timeout=120s)
        eBird /historic-->>EbirdClient: 200 (was timing out at 30s on CA)
    end
```

## Summary

- 2026-05-19 CA backfill failed reproducibly with `eBird server error 0: Request timed out after 30000ms` on every one of the 14 days — `/historic` is slow for high-density states (CA, FL, TX, NY) and `maxResults` is already pinned at the 10000 API ceiling, so the only remaining lever is the client-side request timeout.
- Bump from 30s to 120s, scoped to the `run-backfill.ts` construction site only — `/recent` and `/hotspots` keep their 30s failure-detection bound for the recurring scheduled ingest paths.
- New test pins the contract: a default-constructed (no `o.client`) backfill client carries `requestTimeoutMs: 120_000`. Verified by stashing the prod change and confirming the test fails with `expected 30000 to be 120000`.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — 19 files, 177 tests passed (including the new one)
- [x] New unit test added: `default-constructs EbirdClient with requestTimeoutMs=120000 when o.client is omitted` — captures the constructed instance via an ESM-binding Proxy swap, then asserts the runtime field
- [x] Regression check: stashed the `run-backfill.ts` change, re-ran the new test, confirmed it fails with `AssertionError: expected 30000 to be 120000`
- [x] `npm run build` — clean across all workspaces

## Plan reference

Out of plan — operational hotfix for 2026-05-19 CA backfill timeout failure. The eBird `/historic` slowness on high-density states isn't covered by any open plan.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)