### PR TITLE
feat(ingestor): accept eBird county codes in backfill --state flag

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -198,6 +198,55 @@ describe('runCli', () => {
       expect(process.exitCode).toBe(1);
       expect(runBackfillSpy).not.toHaveBeenCalled();
     });
+
+    // ── County (subnational2) codes ──────────────────────────────────────
+    // A per-day full-state /historic call can blow past eBird's response-size
+    // limit (observed: HTTP 500 on CA backfill), and the mitigation is to fan
+    // out per county. The --state flag must accept the subnational2 shape
+    // US-XX-NNN (numeric FIPS) and US-XX-AAA (alpha sub-codes) without
+    // dropping rejection on truly malformed values.
+
+    it('accepts --state=US-CA-001 (numeric county FIPS subnational2 code)', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA-001', '--back=14'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 14,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-CA-001', days: 14 })
+      );
+    });
+
+    it('accepts --state=US-CA-LAS (alphabetic subnational2 sub-code)', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA-LAS', '--back=14'];
+      const runBackfillSpy = vi.fn().mockResolvedValue({
+        status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 14,
+      });
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-CA-LAS', days: 14 })
+      );
+    });
+
+    it('rejects --state=US-CA- (trailing hyphen, empty subnational2 segment)', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA-'];
+      const runBackfillSpy = vi.fn();
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runBackfillSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects --state=US-CA-001-x (more than one subnational segment)', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA-001-x'];
+      const runBackfillSpy = vi.fn();
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runBackfillSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('throws if EBIRD_API_KEY is not set', async () => {

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -219,20 +219,26 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // existing prod scheduler's no-flag invocation) and --back=N (default
       // 19 with no flags, so the legacy daily backfill keeps its current
       // window; new per-state schedulers pass --back=14 explicitly).
-      // argv shape: ["node", "cli.ts", "backfill", "--state=US-CA", "--back=14"].
+      // --state also accepts eBird subnational2 (county) codes of the form
+      // US-XX-NNN or US-XX-AAA — needed because a per-day full-state
+      // /historic call can blow past eBird's response-size limit (HTTP 500
+      // on large states like CA), and the mitigation is to fan out per
+      // county.
+      // argv shape: ["node", "cli.ts", "backfill", "--state=US-CA", "--back=14"]
+      //         or: ["node", "cli.ts", "backfill", "--state=US-CA-001", "--back=14"].
       const flags = process.argv.slice(3);
       let regionCode = 'US-AZ';
       let days = 19;
       for (const f of flags) {
         if (f.startsWith('--state=')) {
           const v = f.slice('--state='.length);
-          if (!/^US-[A-Z]{2}$/.test(v)) {
+          if (!/^US-[A-Z]{2}(-[A-Z0-9]+)?$/.test(v)) {
             console.log(JSON.stringify({
               severity: 'ERROR',
               message: 'bird_ingest_invalid_flag',
               flag: '--state',
               value: v,
-              expected: 'US-XX (USPS two-letter state code)',
+              expected: 'US-XX (state) or US-XX-NNN (county/subnational2)',
             }));
             process.exitCode = 1;
             return;
@@ -258,7 +264,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
             severity: 'ERROR',
             message: 'bird_ingest_invalid_flag',
             flag: f,
-            expected: '--state=US-XX or --back=N',
+            expected: '--state=US-XX[-NNN] or --back=N',
           }));
           process.exitCode = 1;
           return;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Operator
    participant CLI as ingestor CLI
    participant eBird

    Note over Operator,eBird: BEFORE — per-state /historic on large states 500s
    Operator->>CLI: --state=US-CA --back=14
    CLI->>eBird: GET /data/obs/US-CA/historic/2026/05/19
    eBird-->>CLI: HTTP 500 (response too large)

    Note over Operator,eBird: AFTER — per-county fan-out
    Operator->>CLI: --state=US-CA-001 --back=14
    CLI->>CLI: regex /^US-[A-Z]{2}(-[A-Z0-9]+)?$/ accepts
    CLI->>eBird: GET /data/obs/US-CA-001/historic/2026/05/19
    eBird-->>CLI: 200 OK (per-county slice fits)
```

## Summary

- CA backfill failed today with eBird HTTP 500 on per-day `/historic` calls — the full-state response exceeds eBird's response-size limit on large states. Mitigation is to fan out per county (e.g. `/historic/US-CA-001/...`) rather than per state.
- The ingestor CLI's `--state` flag previously enforced `/^US-[A-Z]{2}$/`, which rejected eBird subnational2 codes like `US-CA-001` (numeric FIPS) and `US-CA-LAS` (alphabetic sub-codes). This blocked the per-county mitigation strategy.
- Loosened the regex to `/^US-[A-Z]{2}(-[A-Z0-9]+)?$/` so the same flag accepts both state and county codes, while still rejecting malformed inputs (trailing hyphen `US-CA-`, multi-segment `US-CA-001-x`). Error-message `expected:` field updated to mention both shapes.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test --workspace @bird-watch/ingestor -- --run src/cli.test.ts` — green (32 passed, 4 new)
- [x] New unit tests added — 4 cases covering the relaxed regex (accept county FIPS, accept alpha sub-code, reject trailing hyphen, reject double-segment)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, CLI-only change
- [x] `npm run build --workspace @bird-watch/ingestor` — clean
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` changes

## Plan reference

Out of plan — operational hotfix unblocking today's CA per-county backfill. The per-state fan-out infrastructure landed in PR #675 (Phase 3.5); this PR relaxes the validator so the same fan-out can target counties when a state response is too large for eBird to serve.

---

Generated with [Claude Code](https://claude.com/claude-code)