### PR TITLE
chore(cleanup): drop CF-WAF-blocked post-deploy check + sweep stale PostHog narrative

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,6 @@ DATABASE_URL=postgres://birdwatch:birdwatch@localhost:5432/birdwatch
 EBIRD_API_KEY=your-ebird-api-key-here
 FRONTEND_ORIGINS=https://bird-maps.com,https://www.bird-maps.com
 
-# PostHog instrumentation (issue #357). Leave empty in CI / local dev —
-# `frontend/src/analytics.ts` skips `posthog.init` on an empty key, which
-# is required for console-cleanliness assertions in the e2e suite. Set
-# in Cloudflare Pages production env vars only.
-VITE_POSTHOG_KEY=
-
 # Adaptive cluster grid — default ON since 2026-05-15.
 # Remove this flag (along with all gated code paths) after 2026-08-13 if no rollback needed.
 VITE_FF_ADAPTIVE_GRID=true

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -40,25 +40,3 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy frontend/dist --project-name=birdwatch --branch=main --commit-dirty=true
-      - name: Post-deploy bundle-hash check
-        run: |
-          set -euo pipefail
-          # Fetch the live site, extract the first /assets/*.js path, fetch that
-          # bundle, grep for the production API base URL. If the deployed bundle
-          # does not bake in api.bird-maps.com, the build env did not propagate
-          # and the site is broken - fail the workflow so the previous CF Pages
-          # deployment stays live (fail-forward).
-          HTML=$(curl -sSf --retry 5 --retry-delay 3 --retry-all-errors https://bird-maps.com/)
-          ASSET=$(printf '%s' "$HTML" | grep -oE '/assets/[^"]+\.js' | head -1)
-          if [ -z "$ASSET" ]; then
-            echo "ERROR: no /assets/*.js found in served HTML" >&2
-            printf '%s\n' "$HTML" | head -40 >&2
-            exit 1
-          fi
-          echo "Checking bundle: $ASSET"
-          COUNT=$(curl -sSf --retry 5 --retry-delay 3 --retry-all-errors "https://bird-maps.com$ASSET" | grep -c 'api.bird-maps.com' || true)
-          echo "api.bird-maps.com occurrences in bundle: $COUNT"
-          if [ "$COUNT" -lt 1 ]; then
-            echo "ERROR: deployed bundle does not contain api.bird-maps.com" >&2
-            exit 1
-          fi

--- a/frontend/src/clarity.ts
+++ b/frontend/src/clarity.ts
@@ -23,9 +23,9 @@ import Clarity from '@microsoft/clarity';
  * No masking config: Clarity's default-mask is ON, which is correct for
  * bird-maps.com (public bird sighting data; no PII rendered).
  *
- * No consent gate: bird-watch has no consent banner today (matches the
- * existing PostHog wiring). EEA traffic is near-zero given the current
- * US-AZ region lock — tracked for revisit in #658.
+ * No consent gate: bird-watch has no consent banner today. EEA traffic
+ * is near-zero given the current US-AZ region lock — tracked for
+ * revisit in #658.
  */
 const projectId = import.meta.env.VITE_CLARITY_PROJECT_ID ?? '';
 

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -114,7 +114,7 @@ describe('AttributionModal', () => {
     await user.click(screen.getByRole('button', { name: /credits/i }));
     // eBird, Family Silhouettes (Phylopic), Species descriptions
     // (Wikipedia — #373), Map Tiles (OSM/OpenFreeMap), Privacy
-    // (PostHog disclosure — issue #357 task 7). Photos is optional and
+    // (Clarity disclosure — issue #657). Photos is optional and
     // not rendered without photoAttribution + photoLicense.
     expect(screen.getByRole('heading', { level: 3, name: /bird sightings data/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: /family silhouettes/i })).toBeInTheDocument();

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -395,7 +395,7 @@ describe('SpeciesDetailSurface', () => {
 
     // Issue #373 task 6: stratify the panel-thinness analysis post-hoc by
     // tagging `panel_opened` with `has_description: !!data.descriptionBody`.
-    // The dwell event shape stays unchanged (PostHog's UI lets the analyst
+    // The dwell event shape stays unchanged (Clarity's UI lets the analyst
     // group on the open-event property at query time).
     it('fires panel_opened with has_description=true when descriptionBody is present', async () => {
       const captureSpy = vi.spyOn(analytics, 'capture');

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -91,7 +91,7 @@ function readUrl(): UrlState {
         ? `${window.location.pathname}?${cq}`
         : window.location.pathname;
       window.history.replaceState({}, '', canonicalUrl);
-      // Instrumentation: log + PostHog event so the real emitter can be
+      // Instrumentation: log + Clarity event so the real emitter can be
       // identified in production. Root cause is unidentified — see #511
       // and PR #517. Follow-up issue: #518.
       console.warn('[#511 guard] Corrupted URL detected and recovered:', corruptedUrl);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[deploy-frontend workflow] --> B[wrangler-action]
    B --> C[CF Pages deploy]
    C -.removed.-> D[Post-deploy bundle-hash check<br/>403 from CF WAF]
    style D stroke-dasharray: 5 5,stroke:#888
```

Workflow change drops the dead step; comment edits don't lend themselves to a diagram (no flow change). The flowchart above shows the deploy path after this PR — the dashed node is the removed step.

## Summary

- Closes #681 by dropping the post-deploy bundle-hash check that has 403'd on 6+ consecutive deploys because Cloudflare's WAF blocks the GitHub Actions runner IP. Its intended failure mode (wrangler succeeds + Vite silently strips an env var) is vanishingly rare; the check is dead weight hiding real deploy failures behind a recurring red ✗.
- Sweeps four stale present-tense PostHog comments flagged by @julianken-bot R7 SUGGESTION on #682 (`clarity.ts`, `state/url-state.ts`, `SpeciesDetailSurface.test.tsx`, `AttributionModal.test.tsx`). Migration-history comments in `analytics.ts` and `AttributionModal.tsx` are deliberate provenance and stay.

## Screenshots

N/A — workflow change + comment-only edits, no visible UI surface.

- [x] Every new/renamed `className` in this PR has a matching CSS rule (N/A — no className changes)
- [x] Multi-viewport design QA: N/A — not UI

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (907 tests, 65 suites)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] No new unit/integration tests needed — comment-only edits don't change behavior; test assertions themselves don't reference PostHog text
- [x] No new Playwright e2e spec needed — non-UI change
- [x] Live confirmation of the workflow drop: the next merged PR's `deploy-frontend` run will be the proof point — no more ✗ on the Post-deploy bundle-hash step

## Plan reference

Out of plan — loose-ends cleanup addressing #681 (dead CI check) and the R7 SUGGESTION trail from #682's bot review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)