### PR TITLE
fix(frontend): zoom/bbox state race produces "bbox too large" 400 mid-zoom-in

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { LngLatBounds } from 'maplibre-gl';
 
 // Phase 4 / #663: useIsCompact calls window.matchMedia. JSDOM does not
 // implement it — polyfill with a stub that returns non-compact (wide
@@ -18,7 +19,13 @@ vi.stubGlobal('matchMedia', (query: string) => ({
 }));
 
 // Hoist mock fns so they exist before any module-level code runs.
-const { mockGetHotspots, mockGetObservations, mockGetSilhouettes, mockUrlState } = vi.hoisted(() => ({
+const {
+  mockGetHotspots,
+  mockGetObservations,
+  mockGetSilhouettes,
+  mockUrlState,
+  mapSurfaceRef,
+} = vi.hoisted(() => ({
   mockGetHotspots: vi.fn(),
   mockGetObservations: vi.fn(),
   mockGetSilhouettes: vi.fn(),
@@ -32,6 +39,15 @@ const { mockGetHotspots, mockGetObservations, mockGetSilhouettes, mockUrlState }
     },
     set: vi.fn(),
   },
+  // Capture handle for the zoom/bbox state-race regression (issue #690).
+  // The MapSurface stub assigns the latest `onViewportChange` prop here on
+  // every render so the test can drive App.tsx's viewport callback the same
+  // way MapCanvas's `idle` event would.
+  mapSurfaceRef: {
+    onViewportChange: null as
+      | ((bounds: unknown, zoom: number) => void)
+      | null,
+  },
 }));
 
 // Stub url-state before App imports it.
@@ -44,10 +60,20 @@ vi.mock('./state/url-state.js', () => ({
 // color-SOT wiring added a silhouettes fetch that runs concurrently with
 // App's initial render, the 'map' view aria-busy test is now reliably hot
 // enough to trigger MapSurface's maplibre import — which fails in jsdom
-// because `window.URL.createObjectURL` isn't polyfilled. The test only
-// cares about the `<main aria-busy>` attribute, not the map itself.
+// because `window.URL.createObjectURL` isn't polyfilled. Most tests in this
+// file only care about the `<main aria-busy>` attribute, not the map itself.
+//
+// Issue #690: the stub additionally captures the latest `onViewportChange`
+// prop into `mapSurfaceRef.onViewportChange` so the zoom/bbox state-race
+// regression test can invoke it directly. Mirrors the `MapSurface.test.tsx`
+// pattern at lines 18–29.
 vi.mock('./components/MapSurface.js', () => ({
-  MapSurface: () => null,
+  MapSurface: (props: {
+    onViewportChange?: (bounds: unknown, zoom: number) => void;
+  }) => {
+    mapSurfaceRef.onViewportChange = props.onViewportChange ?? null;
+    return null;
+  },
 }));
 
 // Stub the ApiClient constructor so useBirdData receives a controllable mock.
@@ -678,5 +704,114 @@ describe('Clarity view tagging (#657-followup)', () => {
     };
     render(<App />);
     expect(setViewSpy).toHaveBeenCalledWith('feed');
+  });
+});
+
+describe('Zoom/bbox state-race regression (#690)', () => {
+  // Build a duck-typed LngLatBounds for the onViewportChange callback. App.tsx
+  // only ever calls .getWest/.getSouth/.getEast/.getNorth on the value, so a
+  // plain object with those methods is sufficient and lets us avoid pulling in
+  // maplibre-gl in jsdom (the same constraint that drives the MapSurface stub
+  // above).
+  function makeBounds(
+    west: number, south: number, east: number, north: number,
+  ): LngLatBounds {
+    return {
+      getWest: () => west,
+      getSouth: () => south,
+      getEast: () => east,
+      getNorth: () => north,
+    } as unknown as LngLatBounds;
+  }
+
+  // CONUS framing (≈61.9° lng × 23.7° lat) — the bbox MapCanvas reports on
+  // the initial `idle` from the default zoom-4 view. Span exceeds the server's
+  // 45° lng / 25° lat cap, so any /api/observations call carrying this bbox
+  // with zoom ≥ 6 is the bad combination this regression guards against.
+  const CONUS_BOUNDS = makeBounds(-125, 24, -66, 50);
+  // San Jose framing (≈7.8° lng × 3.1° lat) — well inside the cap at any zoom.
+  const SJ_BOUNDS = makeBounds(-125.8, 35.8, -118.0, 38.9);
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({
+      data: [], meta: { freshestObservationAt: null },
+    });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mapSurfaceRef.onViewportChange = null;
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map',
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('never emits a {bbox: CONUS, zoom: ≥6} fetch when zooming from CONUS into San Jose', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    render(<App />);
+
+    // Wait for App to finish mounting and render <MapSurface>. The stub
+    // captures onViewportChange on each render; we poll until the handle is
+    // populated so the rest of the test can drive viewport changes.
+    await waitFor(() => {
+      expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+    });
+    const onViewportChange = mapSurfaceRef.onViewportChange!;
+
+    // Step 1: simulate the initial CONUS settle at zoom 4. App schedules the
+    // 250ms bbox debounce; setDebouncedZoom fires immediately.
+    await act(async () => {
+      onViewportChange(CONUS_BOUNDS, 4);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    // Step 2: simulate jumpTo({center: SJ, zoom: 7}) — MapCanvas emits a
+    // single onViewportChange(SJ, 7) on the next idle.
+    await act(async () => {
+      onViewportChange(SJ_BOUNDS, 7);
+    });
+    // The bug — if present — fires a synchronous re-render with
+    // {bbox: CONUS, zoom: 7} BEFORE the 250ms timeout drains. Drain any
+    // microtasks so useBirdData's effect runs against the current state.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Step 3: drain the bbox debounce — App now commits {bbox: SJ, zoom: 7},
+    // which is a consistent pairing under the cap.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    // Assert every fetch carries a consistent {bbox, zoom} pair: either the
+    // span fits the server's 45° lng cap, or the zoom is below the gating
+    // threshold (cap at services/read-api/src/validate.ts only fires when
+    // zoom ≥ 6). The pre-fix race produces a call with lngSpan ≈ 59 AND
+    // zoom = 7 — violating both halves of the predicate.
+    const calls = mockGetObservations.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [filters] of calls) {
+      const { bbox, zoom } = filters as {
+        bbox?: [number, number, number, number];
+        zoom?: number;
+      };
+      // The initial mount call may omit bbox/zoom; the assertion only applies
+      // once a viewport-derived pair has been threaded through.
+      if (!bbox || zoom === undefined) continue;
+      const lngSpan = bbox[2] - bbox[0];
+      const consistent = lngSpan <= 45 || zoom < 6;
+      expect(
+        consistent,
+        `inconsistent fetch: bbox=${bbox.join(',')} (lngSpan=${lngSpan.toFixed(2)}), zoom=${zoom}`,
+      ).toBe(true);
+    }
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,7 +181,6 @@ export function App() {
   );
   const onViewportChange = useCallback((bounds: LngLatBounds, zoom: number) => {
     setViewportBounds(bounds);
-    setDebouncedZoom(zoom);
     const next: [number, number, number, number] = [
       bounds.getWest(),
       bounds.getSouth(),
@@ -190,6 +189,17 @@ export function App() {
     ];
     if (bboxDebounceRef.current !== null) clearTimeout(bboxDebounceRef.current);
     bboxDebounceRef.current = setTimeout(() => {
+      // Issue #690: setDebouncedZoom MUST fire inside the same task as
+      // setDebouncedBbox so {bbox, zoom} stays paired in the useBirdData
+      // filters. Firing the zoom setter synchronously above (outside the
+      // timeout) decoupled the pair — during the 250ms window the effect
+      // would re-run with {bbox: STALE_previous_viewport, zoom: NEW_zoom},
+      // which trips the server's bbox-area cap (services/read-api/src/
+      // validate.ts assertBboxAreaCap: zoom ≥ 6 && lngSpan > 45 → 400
+      // "bbox too large") on any zoom-in across the < 6 → ≥ 6 boundary.
+      // React 18 automatic batching coalesces both setters into a single
+      // render so useBirdData re-fires exactly once with a consistent pair.
+      setDebouncedZoom(zoom);
       setDebouncedBbox(prev => {
         // No-op guard: skip the state update (and the consequent refetch)
         // if the bbox hasn't moved meaningfully. ~1e-4 degrees ≈ 10m at


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant MapCanvas
    participant App as App.tsx<br/>onViewportChange
    participant State as React state<br/>(debouncedBbox, debouncedZoom)
    participant useBirdData
    participant ReadAPI as /api/observations

    Note over MapCanvas,ReadAPI: BEFORE (race) — jumpTo CONUS@z=4 -> SJ@z=7

    MapCanvas->>App: idle(SJ_bounds, 7)
    App->>State: setDebouncedZoom(7)  [sync]
    Note over State: {bbox: CONUS_STALE, zoom: 7}
    State-->>useBirdData: deps change (zoom)
    useBirdData->>ReadAPI: GET ?bbox=CONUS&zoom=7
    ReadAPI-->>useBirdData: 400 "bbox too large"
    Note over App: ...250ms later
    App->>State: setDebouncedBbox(SJ)
    State-->>useBirdData: deps change (bbox)
    useBirdData->>ReadAPI: GET ?bbox=SJ&zoom=7
    ReadAPI-->>useBirdData: 200 OK

    Note over MapCanvas,ReadAPI: AFTER (paired) — same jumpTo

    MapCanvas->>App: idle(SJ_bounds, 7)
    Note over App: clearTimeout then setTimeout 250ms
    Note over App: ...250ms later
    App->>State: setDebouncedZoom(7) + setDebouncedBbox(SJ)<br/>(React 18 batched: 1 render)
    State-->>useBirdData: deps change (bbox, zoom together)
    useBirdData->>ReadAPI: GET ?bbox=SJ&zoom=7
    ReadAPI-->>useBirdData: 200 OK
```

## Summary

- `onViewportChange` was firing `setDebouncedZoom(zoom)` synchronously while the bbox setter sat behind a 250ms trailing-edge debounce. The two halves of the viewport snapshot decoupled — during the 250ms window `useBirdData` re-ran with `{bbox: STALE_previous_viewport, zoom: NEW_zoom}`, tripping `services/read-api/src/validate.ts` `assertBboxAreaCap` (zoom >= 6 AND lngSpan > 45 -> 400 "bbox too large") on every zoom-in across the < 6 -> >= 6 boundary.
- Fix: move `setDebouncedZoom(zoom)` inside the existing `setTimeout` so both setters fire in the same task. React 18 automatic batching coalesces them into a single render and `useBirdData` re-fires exactly once with a consistent `{bbox, zoom}` pair. Rate-limit intent at the existing `bboxDebounceRef` comment is preserved.
- Regression test in `App.test.tsx` drives `onViewportChange(CONUS_BOUNDS, 4)` -> advance 250ms -> `onViewportChange(SJ_BOUNDS, 7)` with vitest fake timers, then asserts every observed fetch satisfies `lngSpan <= 45 OR zoom < 6`. Pre-fix the test fails on the second viewport change (observed `bbox=CONUS lngSpan=59, zoom=7`); post-fix it is green.

## Screenshots

N/A — not UI. This fix removes a transient 400 from the network log; the rendered map is pixel-identical before and after.

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css` (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)  — N/A, no className changes
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs (5 viewports x 2 themes per #445). Verify: ... — N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — green (`npm test --workspace @bird-watch/frontend` -> 65 files, 908 tests passed)
- [x] New unit / integration tests added (if behavior changed) — `Zoom/bbox state-race regression (#690)` describe block in `frontend/src/App.test.tsx`; fails on `main` SHA `21cdf14` with `inconsistent fetch: bbox=-125,24,-66,50 (lngSpan=59.00), zoom=7`, green on this branch.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A; the only user-visible effect is the absence of a console 400. The existing live-MCP verification below covers that.
- [x] `npm run build` — clean production build (`tsc -b && vite build`, exit 0; pre-existing maplibre chunk size warning unchanged)
- [x] (UI only) Playwright MCP smoke — N/A by repo CLAUDE.md exemption (no visible UI change). Live fix-verification ran against a local stack (read-api -> Cloud SQL proxy -> bird-maps-prod, frontend at `http://localhost:5173`):
  1. Loaded `/`, confirmed mount at CONUS (zoom=4, bounds `[-129.52, 26.96, -67.64, 50.67]`).
  2. `window.__birdMap.jumpTo({ center: [-121.89, 37.34], zoom: 7 })`.
  3. Filtered network log to `/api/observations` — observed two post-jump fetches: one CONUS@z=4 (200), then one SJ-bbox@z=7 (`-125.76,35.79,-118.02,38.86`, 200). **No `bbox=CONUS, zoom=7` request anywhere.** Two aborted requests (z=3 mount-time fetches superseded by the post-mount idle) are benign.
  4. `browser_console_messages` returned 0 errors, 0 warnings post-jump.

## Plan reference

Out of plan — bug fix surfaced by user-driven live-MCP reproduction on bird-maps.com (2026-05-20). Closes #690.

---

Generated with [Claude Code](https://claude.com/claude-code)
