### PR TITLE
feat(ingestor): add list-subregions CLI kind for county fanout seeding

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -528,6 +528,130 @@ describe('runCli', () => {
     });
   });
 
+  // ── list-subregions kind ──────────────────────────────────────────────
+  // Operator helper that prints the eBird-canonical subnational2 county
+  // list for a given state. Used to seed per-county backfill fanout for
+  // big states whose state-level /historic returns HTTP 500. No DB writes,
+  // no DATABASE_URL required; EBIRD_API_KEY is required.
+  describe('list-subregions kind', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Stub global fetch — the kind hits eBird's /ref/region/list/subnational2
+      // endpoint directly (read-only, no shared client needed).
+      fetchSpy = vi.spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('emits one INFO log per county plus a summary count', async () => {
+      process.argv = ['node', 'cli.ts', 'list-subregions', '--state=US-CO'];
+      delete process.env.DATABASE_URL; // proves no DB needed
+      const counties = [
+        { code: 'US-CO-001', name: 'Adams' },
+        { code: 'US-CO-003', name: 'Alamosa' },
+        { code: 'US-CO-014', name: 'Broomfield' },
+      ];
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(counties), { status: 200 })
+      );
+      const deps = makeDeps();
+
+      await runCli('list-subregions', deps);
+
+      const emitted = logSpy.mock.calls
+        .map((args: unknown[]): unknown => {
+          try { return JSON.parse(args[0] as string); } catch { return null; }
+        })
+        .filter((o: unknown): o is Record<string, unknown> =>
+          typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'list-subregions'
+        );
+      // 3 per-county lines + 1 summary line = 4 emits
+      expect(emitted).toHaveLength(4);
+      expect(emitted[0]).toMatchObject({
+        message: 'list-subregions',
+        kind: 'list-subregions',
+        state: 'US-CO',
+        subregionCode: 'US-CO-001',
+        subregionName: 'Adams',
+      });
+      expect(emitted[2]).toMatchObject({
+        subregionCode: 'US-CO-014',
+        subregionName: 'Broomfield',
+      });
+      expect(emitted[3]).toMatchObject({
+        message: 'list-subregions',
+        state: 'US-CO',
+        count: 3,
+      });
+      // No DB pool was created — early-return path.
+      expect(deps.createPool).not.toHaveBeenCalled();
+    });
+
+    it('passes X-eBirdApiToken header to the eBird ref endpoint', async () => {
+      process.env.EBIRD_API_KEY = 'fake-key-123';
+      process.argv = ['node', 'cli.ts', 'list-subregions', '--state=US-FL'];
+      fetchSpy.mockResolvedValueOnce(new Response('[]', { status: 200 }));
+      const deps = makeDeps();
+
+      await runCli('list-subregions', deps);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.ebird.org/v2/ref/region/list/subnational2/US-FL',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-ebirdapitoken': 'fake-key-123',
+          }),
+        })
+      );
+    });
+
+    it('rejects --state=US-CA-001 (county code is invalid input here)', async () => {
+      process.argv = ['node', 'cli.ts', 'list-subregions', '--state=US-CA-001'];
+      const deps = makeDeps();
+
+      await runCli('list-subregions', deps);
+
+      expect(process.exitCode).toBe(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing --state flag', async () => {
+      process.argv = ['node', 'cli.ts', 'list-subregions'];
+      const deps = makeDeps();
+
+      await runCli('list-subregions', deps);
+
+      expect(process.exitCode).toBe(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('sets exitCode=1 on eBird HTTP error', async () => {
+      process.argv = ['node', 'cli.ts', 'list-subregions', '--state=US-TX'];
+      fetchSpy.mockResolvedValueOnce(new Response('upstream barfed', { status: 500 }));
+      const deps = makeDeps();
+
+      await runCli('list-subregions', deps);
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('throws if EBIRD_API_KEY is not set', async () => {
+      delete process.env.EBIRD_API_KEY;
+      process.argv = ['node', 'cli.ts', 'list-subregions', '--state=US-NY'];
+      const deps = makeDeps();
+
+      await expect(runCli('list-subregions', deps)).rejects.toThrow(/EBIRD_API_KEY/);
+    });
+  });
+
+  it("Unknown-kind error string includes 'list-subregions' so operators see the new kind", async () => {
+    const deps = makeDeps();
+    await expect(runCli('bogus', deps)).rejects.toThrow(/list-subregions/);
+  });
+
   it('uppercases and replaces hyphens in kind when computing env-var name', async () => {
     process.env.HEALTHCHECKS_URL_BACKFILL_EXTENDED = 'https://hc-ping.com/uuid-bf-ext';
     const partialSummary = {

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -131,6 +131,102 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     return;
   }
 
+  // list-subregions is an operator helper that prints the eBird-canonical
+  // subnational2 (county) list for a given state. Used to seed per-county
+  // backfill fanout for big states whose state-level /historic returns
+  // HTTP 500 (CA, FL, TX, etc. — see /tmp/backfill-fanout.log lineage).
+  //
+  // No DB writes; needs EBIRD_API_KEY only. Early-returns ahead of the
+  // DATABASE_URL guard so an operator can run it from a Cloud Run job that
+  // doesn't have DATABASE_URL wired — but the eBird key IS required, so
+  // re-check inline.
+  //
+  // Output: one structured INFO log per county (subregionCode +
+  // subregionName), plus a summary log with the count. Operator fetches the
+  // codes from Cloud Logging via:
+  //   gcloud logging read 'jsonPayload.message="list-subregions" AND
+  //     jsonPayload.state="US-XX" AND jsonPayload.subregionCode:*'
+  if (kind === 'list-subregions') {
+    const flags = process.argv.slice(3);
+    let state: string | undefined;
+    for (const f of flags) {
+      if (f.startsWith('--state=')) {
+        const v = f.slice('--state='.length);
+        // State codes only — county codes (US-XX-NNN) make no sense here
+        // because the eBird /ref/region/list/subnational2 endpoint takes
+        // a state and returns its counties.
+        if (!/^US-[A-Z]{2}$/.test(v)) {
+          console.log(JSON.stringify({
+            severity: 'ERROR',
+            message: 'bird_ingest_invalid_flag',
+            flag: '--state',
+            value: v,
+            expected: 'US-XX (state code only; counties are the output)',
+          }));
+          process.exitCode = 1;
+          return;
+        }
+        state = v;
+      } else {
+        console.log(JSON.stringify({
+          severity: 'ERROR',
+          message: 'bird_ingest_invalid_flag',
+          flag: f,
+          expected: '--state=US-XX',
+        }));
+        process.exitCode = 1;
+        return;
+      }
+    }
+    if (!state) {
+      console.log(JSON.stringify({
+        severity: 'ERROR',
+        message: 'bird_ingest_invalid_flag',
+        flag: '--state',
+        expected: '--state=US-XX is required',
+      }));
+      process.exitCode = 1;
+      return;
+    }
+    const apiKey = process.env.EBIRD_API_KEY;
+    if (!apiKey) throw new Error('EBIRD_API_KEY not set');
+    const url = `https://api.ebird.org/v2/ref/region/list/subnational2/${state}`;
+    const res = await fetch(url, {
+      headers: { 'x-ebirdapitoken': apiKey, accept: 'application/json' },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      console.log(JSON.stringify({
+        severity: 'ERROR',
+        message: 'list-subregions',
+        state,
+        httpStatus: res.status,
+        error: body.slice(0, 500),
+      }));
+      process.exitCode = 1;
+      return;
+    }
+    const counties = (await res.json()) as Array<{ code: string; name: string }>;
+    for (const c of counties) {
+      console.log(JSON.stringify({
+        severity: 'INFO',
+        message: 'list-subregions',
+        kind: 'list-subregions',
+        state,
+        subregionCode: c.code,
+        subregionName: c.name,
+      }));
+    }
+    console.log(JSON.stringify({
+      severity: 'INFO',
+      message: 'list-subregions',
+      kind: 'list-subregions',
+      state,
+      count: counties.length,
+    }));
+    return;
+  }
+
   // digest: daily 09:00 UTC health digest (issue #643). Distinct shape from
   // the ingest kinds — composes a 5-signal summary email and returns a
   // SendResult. Heartbeat is gated on result.status === 'delivered' per
@@ -315,7 +411,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
         parsed === undefined ? { pool } : { pool, retentionDays: parsed }
       );
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | digest | probe-taxon | probe-wiki`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | digest | probe-taxon | probe-wiki | list-subregions`);
     }
     // Cloud Run / Cloud Logging splits stdout on newlines and treats each
     // resulting line as its own `textPayload` entry — pretty-printed JSON


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Op as Operator
    participant CR as Cloud Run Job
    participant CLI as ingestor CLI
    participant eBird as eBird ref API
    participant Log as Cloud Logging

    Op->>CR: execute bird-ingestor --args=list-subregions,--state=US-CO
    CR->>CLI: argv = [list-subregions, --state=US-CO]
    CLI->>eBird: GET /v2/ref/region/list/subnational2/US-CO
    eBird-->>CLI: [{code:"US-CO-001",name:"Adams"}, ...]
    loop one per county
        CLI->>Log: INFO {message:"list-subregions", state:"US-CO", subregionCode:"US-CO-NNN"}
    end
    CLI->>Log: INFO {message:"list-subregions", state:"US-CO", count:N}
    Op->>Log: gcloud logging read 'jsonPayload.subregionCode:*'
    Log-->>Op: county codes (sort -u)
```

## Summary

- Adds a new `list-subregions` CLI kind that delegates to eBird's `/ref/region/list/subnational2/{state}` endpoint to enumerate counties for a given state.
- Unblocks per-county backfill fanout for the 14 remaining big states (CO, FL, MA, MI, NC, NY, OH, OR, PA, TX, WA, VA, WI, IL) whose state-level `/historic` returns HTTP 500.
- Source-of-truth approach instead of hardcoded FIPS — handles city-counties (Broomfield CO), independent cities (VA), and any naming drift.

## Screenshots

N/A — not UI (CLI-only change in `services/ingestor/`).

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no frontend changes
- [x] Multi-viewport design QA — N/A, not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — 188 passed (39 in cli.test.ts incl. 6 new for list-subregions)
- [x] `npm run build --workspace @bird-watch/ingestor` — clean tsc compile
- [x] New unit tests added covering: happy-path emit shape, header wiring, county-code rejection, missing-flag rejection, HTTP-error exit code, EBIRD_API_KEY guard
- [x] No new e2e spec (CLI helper, no user-visible UI)
- [ ] Post-merge: operator runs `gcloud run jobs execute bird-ingestor --args=list-subregions,--state=US-XX` per big state to seed `/tmp/counties-US-XX.txt`

## Plan reference

Out of plan — operator helper to unblock the in-flight national-coverage backfill fanout. Sibling PR #686 (county code support in `--state`) is the upstream dependency; this PR provides the canonical source for those county codes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)