### PR TITLE
feat(ingestor): cold storage T2-T4 — archive-then-delete with Parquet on GCS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1757,6 +1757,73 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.19.0.tgz",
+      "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "dev": true,
@@ -3875,6 +3942,15 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3891,6 +3967,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3940,7 +4022,6 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3986,6 +4067,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
       }
     },
     "node_modules/@types/set-cookie-parser": {
@@ -4045,6 +4138,12 @@
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -4226,7 +4325,6 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -4484,6 +4582,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "dev": true,
@@ -4517,6 +4624,30 @@
     "node_modules/async-lock": {
       "version": "1.4.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/aws-sdk-client-mock": {
@@ -4638,7 +4769,6 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4670,6 +4800,15 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bl": {
@@ -4768,6 +4907,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buildcheck": {
       "version": "0.0.7",
       "dev": true,
@@ -4797,6 +4942,19 @@
       "license": "MIT",
       "dependencies": {
         "typewise-core": "^1.2"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -4850,6 +5008,18 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
@@ -5007,6 +5177,15 @@
       "version": "10.6.0",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "dev": true,
@@ -5144,10 +5323,59 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5156,7 +5384,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5174,12 +5401,57 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -5241,7 +5513,6 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5272,6 +5543,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
@@ -5388,6 +5665,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/formatly": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
@@ -5421,12 +5715,89 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-port": {
@@ -5438,6 +5809,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5483,6 +5867,44 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -5496,6 +5918,19 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5504,6 +5939,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/headers-polyfill": {
@@ -5535,6 +6009,22 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5591,8 +6081,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/int53": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
+      "integrity": "sha512-a5jlKftS7HUOhkUyYD7j2sJ/ZnvWiNlZS1ldR+g1ifQ+/UuZXIE+YTc/lK1qGj/GwAU5F8Z0e1eVq2t1J5Ob2g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
@@ -5630,7 +6125,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5807,6 +6301,15 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-stringify-pretty-compact": {
       "version": "3.0.0",
       "license": "MIT"
@@ -5817,6 +6320,27 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/knip": {
       "version": "6.11.0",
@@ -6215,11 +6739,53 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -6390,6 +6956,54 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
+      "integrity": "sha512-bLdNOp5SYyqfDz/ssGHt2OTg8u+jEkCx4EoZIzprqeonFIUhlSBrKu40e/x6hIFYJx4ZEt64/9IZJyafvhGZrw==",
+      "license": "MIT"
+    },
     "node_modules/node-pg-migrate": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/node-pg-migrate/-/node-pg-migrate-8.0.4.tgz",
@@ -6437,7 +7051,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6528,10 +7141,40 @@
         "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parquetjs-lite": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/parquetjs-lite/-/parquetjs-lite-0.8.7.tgz",
+      "integrity": "sha512-L0tdHzvy0btLJvAFZvjO0+ru+FL8tHPqiVE90KEnMy5jDqv+WmEy9Ii8SjiC+exAOi3RGyPYIdgJvFijYyEahA==",
+      "license": "MIT",
+      "dependencies": {
+        "int53": "^0.2.4",
+        "node-int64": "^0.3.3",
+        "snappyjs": "^0.6.0",
+        "varint": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=7.6"
+      }
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -7051,6 +7694,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.11.8",
       "dev": true,
@@ -7103,7 +7760,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7226,6 +7882,12 @@
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
       }
+    },
+    "node_modules/snappyjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
+      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
+      "license": "MIT"
     },
     "node_modules/sort-asc": {
       "version": "0.2.0",
@@ -7360,6 +8022,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.25.0",
       "dev": true,
@@ -7377,7 +8054,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7469,6 +8145,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7532,6 +8214,75 @@
         "react-native-b4a": {
           "optional": true
         }
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/teex": {
@@ -7780,7 +8531,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/union-value": {
@@ -7806,7 +8556,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -7820,6 +8569,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -8105,7 +8860,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xml-name-validator": {
@@ -8171,6 +8925,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-stream": {
@@ -8425,7 +9191,9 @@
         "@aws-sdk/client-s3": "^3.1041.0",
         "@bird-watch/db-client": "*",
         "@bird-watch/shared-types": "*",
-        "isomorphic-dompurify": "^2.30.0"
+        "@google-cloud/storage": "^7.19.0",
+        "isomorphic-dompurify": "^2.30.0",
+        "parquetjs-lite": "^0.8.7"
       },
       "devDependencies": {
         "@testcontainers/postgresql": "^10.7.0",

--- a/services/ingestor/package.json
+++ b/services/ingestor/package.json
@@ -13,7 +13,9 @@
     "@aws-sdk/client-s3": "^3.1041.0",
     "@bird-watch/db-client": "*",
     "@bird-watch/shared-types": "*",
-    "isomorphic-dompurify": "^2.30.0"
+    "@google-cloud/storage": "^7.19.0",
+    "isomorphic-dompurify": "^2.30.0",
+    "parquetjs-lite": "^0.8.7"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.7.0",

--- a/services/ingestor/src/archive/gcs-uploader.test.ts
+++ b/services/ingestor/src/archive/gcs-uploader.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from 'vitest';
+import { archiveAndUpload } from './gcs-uploader.js';
+import type { ArchivableRow } from './select-archivable.js';
+
+const fakeRow: ArchivableRow = {
+  sub_id: 'S1', species_code: 'vermfly',
+  obs_dt: new Date('2026-05-01T12:00:00Z'),
+  lng: -110.88, lat: 31.72,
+  obs_count: 2, is_notable: false,
+  loc_id: 'L1', loc_name: 'A',
+  common_name: 'Vermilion Flycatcher', sci_name: 'Pyrocephalus rubinus',
+  family_code: 'tyrannidae', family_name: 'Tyrant Flycatchers',
+  ingested_at: new Date('2026-05-01T13:00:00Z'),
+};
+
+function makeStubBucket() {
+  const saved: Array<{ name: string; bytes: number; md5?: string | undefined }> = [];
+  const copies: Array<{ from: string; to: string }> = [];
+  const deletes: string[] = [];
+  const file = (name: string) => ({
+    save: vi.fn(async (buf: Buffer, opts?: { metadata?: { md5Hash?: string } }) => {
+      saved.push({ name, bytes: buf.length, md5: opts?.metadata?.md5Hash });
+    }),
+    // Mirror what GCS returns from `tmpFile.getMetadata()` so the
+    // post-upload md5 verification passes through the happy path. We
+    // echo back the same md5 that was uploaded — the test isn't
+    // exercising the md5-mismatch branch (that's the third test below).
+    getMetadata: vi.fn(async () => {
+      const last = saved[saved.length - 1];
+      return [{ md5Hash: last?.md5, size: String(last?.bytes ?? 0) }];
+    }),
+    delete: vi.fn(async () => { deletes.push(name); }),
+    copy: vi.fn(async (destFile: { name?: string }) => {
+      copies.push({ from: name, to: destFile?.name ?? '?' });
+    }),
+    name,
+  });
+  return { bucket: { file }, saved, copies, deletes };
+}
+
+describe('archiveAndUpload', () => {
+  it('writes a parquet to a temp key then renames to the partitioned final key', async () => {
+    const stub = makeStubBucket();
+    const result = await archiveAndUpload({
+      bucket: stub.bucket as never,
+      bucketName: 'bird-maps-prod-obs-archive',
+      utcDate: '2026-05-01',
+      rows: [fakeRow],
+    });
+    expect(result.gcsPath).toBe(
+      'gs://bird-maps-prod-obs-archive/observations/year=2026/month=05/day=01.parquet'
+    );
+    // Temp key written before the final partition key
+    expect(stub.saved.map(s => s.name)).toEqual([
+      expect.stringMatching(/^observations\/_tmp\//),
+    ]);
+    // Then the temp key was copied into the final partitioned key
+    expect(stub.copies).toHaveLength(1);
+    expect(stub.copies[0]?.from).toMatch(/^observations\/_tmp\//);
+    expect(stub.copies[0]?.to).toBe('observations/year=2026/month=05/day=01.parquet');
+    // bytes returned matches the saved buffer length
+    expect(result.bytes).toBe(stub.saved[0]?.bytes);
+    expect(result.md5).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  it('does not write the final key if the temp save throws', async () => {
+    const finalCopy = vi.fn(async () => { throw new Error('should not reach final key'); });
+    const bucket = {
+      file: (name: string) => {
+        if (name.startsWith('observations/_tmp/')) {
+          return {
+            save: vi.fn(async () => { throw new Error('GCS down'); }),
+            getMetadata: vi.fn(),
+            delete: vi.fn(),
+            copy: vi.fn(),
+            name,
+          };
+        }
+        return {
+          save: vi.fn(),
+          getMetadata: vi.fn(),
+          delete: vi.fn(),
+          copy: finalCopy,
+          name,
+        };
+      },
+    };
+    await expect(archiveAndUpload({
+      bucket: bucket as never,
+      bucketName: 'bird-maps-prod-obs-archive',
+      utcDate: '2026-05-01',
+      rows: [fakeRow],
+    })).rejects.toThrow('GCS down');
+    expect(finalCopy).not.toHaveBeenCalled();
+  });
+
+  it('throws and does not copy to the final key if md5 verification fails', async () => {
+    const finalCopy = vi.fn(async () => { throw new Error('should not reach final key'); });
+    const tempDelete = vi.fn(async () => {});
+    const bucket = {
+      file: (name: string) => {
+        if (name.startsWith('observations/_tmp/')) {
+          return {
+            save: vi.fn(async () => {}),
+            // Return a different md5 than what was uploaded → triggers
+            // the mismatch branch and the rename is short-circuited.
+            getMetadata: vi.fn(async () => [{ md5Hash: 'deadbeefdeadbeefdeadbeefdeadbeef' }]),
+            delete: tempDelete,
+            copy: vi.fn(),
+            name,
+          };
+        }
+        return {
+          save: vi.fn(),
+          getMetadata: vi.fn(),
+          delete: vi.fn(),
+          copy: finalCopy,
+          name,
+        };
+      },
+    };
+    await expect(archiveAndUpload({
+      bucket: bucket as never,
+      bucketName: 'bird-maps-prod-obs-archive',
+      utcDate: '2026-05-01',
+      rows: [fakeRow],
+    })).rejects.toThrow(/md5 mismatch/);
+    expect(finalCopy).not.toHaveBeenCalled();
+    expect(tempDelete).toHaveBeenCalled();
+  });
+});

--- a/services/ingestor/src/archive/gcs-uploader.ts
+++ b/services/ingestor/src/archive/gcs-uploader.ts
@@ -1,0 +1,99 @@
+import { writeArchiveParquet } from './parquet-writer.js';
+import type { ArchivableRow } from './select-archivable.js';
+import { createHash, randomUUID } from 'node:crypto';
+
+/**
+ * Minimal shape of the @google-cloud/storage Bucket we use — `bucket.file(name)`
+ * returns an object with `save`, `getMetadata`, `copy`, `delete`. Typed here
+ * so tests can stub without depending on the full SDK surface. The real GCS
+ * SDK returns `[FileMetadata, request]` from `getMetadata` (a 2-tuple) but
+ * we only ever read the first element, so the type is widened to
+ * `[meta, ...unknown[]]` to remain assignable from the real SDK shape.
+ */
+export interface BucketLike {
+  file(name: string): {
+    save(buf: Buffer, opts?: { metadata?: { md5Hash?: string }; resumable?: boolean }): Promise<unknown>;
+    getMetadata(): Promise<[{ md5Hash?: string; size?: string | number }, ...unknown[]]>;
+    copy(dest: unknown): Promise<unknown>;
+    delete(): Promise<unknown>;
+  };
+}
+
+export interface ArchiveAndUploadOptions {
+  bucket: BucketLike;
+  /**
+   * Bucket name — used to construct the returned `gs://` URI. Required
+   * because `BucketLike` only exposes `file(name)` and the GCS SDK's
+   * `Bucket.name` is not in our minimal interface (kept narrow so tests
+   * don't have to stub the full SDK shape).
+   */
+  bucketName: string;
+  /** UTC date in ISO YYYY-MM-DD form. */
+  utcDate: string;
+  rows: ArchivableRow[];
+}
+
+export interface ArchiveAndUploadResult {
+  /** Final `gs://bucket/observations/year=.../month=.../day=...parquet` path. */
+  gcsPath: string;
+  /** Compressed Parquet size in bytes. */
+  bytes: number;
+  /** md5 hex digest of the bytes (for tally / verification). */
+  md5: string;
+}
+
+/**
+ * Write Parquet → upload to a temp key → verify md5 matches → copy to the
+ * final partitioned key → delete the temp key. The temp-then-rename pattern
+ * gives us atomic semantics: a partial upload cannot corrupt the final
+ * partition. If anything throws, the final key is never written, runPrune
+ * skips the day's DELETE, and the next nightly run retries cleanly.
+ *
+ * The temp key includes a UUID so two concurrent runs (e.g. an operator
+ * triggered a manual run while the scheduled one is mid-flight) cannot
+ * collide on the temp key. Orphaned `_tmp/<uuid>` objects from a crashed
+ * run are cleaned by a separate lifecycle rule (optional follow-up — the
+ * write volume is low enough that orphans don't materially impact cost).
+ */
+export async function archiveAndUpload(
+  o: ArchiveAndUploadOptions
+): Promise<ArchiveAndUploadResult> {
+  const buf = await writeArchiveParquet(o.rows);
+  const md5 = createHash('md5').update(buf).digest('hex');
+  const md5Base64 = Buffer.from(md5, 'hex').toString('base64');
+
+  const [year, month, day] = o.utcDate.split('-');
+  const finalKey = `observations/year=${year}/month=${month}/day=${day}.parquet`;
+  const tmpKey = `observations/_tmp/${randomUUID()}.parquet`;
+
+  const tmpFile = o.bucket.file(tmpKey);
+  await tmpFile.save(buf, {
+    metadata: { md5Hash: md5Base64 },
+    resumable: false,
+  });
+
+  // Re-fetch md5 from GCS to confirm the write landed intact. GCS auto-
+  // verifies on upload when md5Hash is supplied, but a paranoid second
+  // check costs one HEAD and catches the rare path where a proxy
+  // rewrites the body.
+  const [meta] = await tmpFile.getMetadata();
+  if (meta.md5Hash && meta.md5Hash !== md5Base64) {
+    await tmpFile.delete().catch(() => {});
+    throw new Error(`archive md5 mismatch: expected ${md5Base64}, got ${meta.md5Hash}`);
+  }
+
+  // Atomic rename via copy + delete. GCS does not have a server-side
+  // move; copy is server-side (no bytes traverse the client) and
+  // delete is a single op.
+  await tmpFile.copy(o.bucket.file(finalKey));
+  await tmpFile.delete().catch(() => {
+    // Non-fatal: the final write succeeded; orphan _tmp objects are
+    // cleaned by a separate lifecycle rule (optional follow-up).
+  });
+
+  return {
+    gcsPath: `gs://${o.bucketName}/${finalKey}`,
+    bytes: buf.length,
+    md5,
+  };
+}

--- a/services/ingestor/src/archive/index.ts
+++ b/services/ingestor/src/archive/index.ts
@@ -1,0 +1,1 @@
+export { selectArchivable, type ArchivableRow } from './select-archivable.js';

--- a/services/ingestor/src/archive/index.ts
+++ b/services/ingestor/src/archive/index.ts
@@ -1,1 +1,3 @@
 export { selectArchivable, type ArchivableRow } from './select-archivable.js';
+export { writeArchiveParquet } from './parquet-writer.js';
+export { archiveAndUpload, type BucketLike } from './gcs-uploader.js';

--- a/services/ingestor/src/archive/parquet-writer.test.ts
+++ b/services/ingestor/src/archive/parquet-writer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { writeArchiveParquet, readArchiveParquet } from './parquet-writer.js';
+import type { ArchivableRow } from './select-archivable.js';
+
+const sample: ArchivableRow[] = [
+  {
+    sub_id: 'S1', species_code: 'vermfly',
+    obs_dt: new Date('2026-05-01T12:00:00Z'),
+    lng: -110.88, lat: 31.72,
+    obs_count: 2, is_notable: false,
+    loc_id: 'L1', loc_name: 'A',
+    common_name: 'Vermilion Flycatcher', sci_name: 'Pyrocephalus rubinus',
+    family_code: 'tyrannidae', family_name: 'Tyrant Flycatchers',
+    ingested_at: new Date('2026-05-01T13:00:00Z'),
+  },
+  {
+    sub_id: 'S2', species_code: 'unknownsp',
+    obs_dt: new Date('2026-05-01T18:30:00Z'),
+    lng: -110.89, lat: 31.73,
+    obs_count: null, is_notable: true,
+    loc_id: 'L2', loc_name: null,
+    common_name: null, sci_name: null,
+    family_code: null, family_name: null,
+    ingested_at: new Date('2026-05-01T19:00:00Z'),
+  },
+];
+
+describe('writeArchiveParquet / readArchiveParquet', () => {
+  it('roundtrips a non-empty batch with nullable columns intact', async () => {
+    const bytes = await writeArchiveParquet(sample);
+    const round = await readArchiveParquet(bytes);
+    expect(round).toHaveLength(2);
+    expect(round[0]?.sub_id).toBe('S1');
+    expect(round[0]?.common_name).toBe('Vermilion Flycatcher');
+    expect(round[1]?.common_name).toBeNull();
+    expect(round[1]?.is_notable).toBe(true);
+  });
+
+  it('produces a stable schema: 14 columns', async () => {
+    const bytes = await writeArchiveParquet(sample);
+    const round = await readArchiveParquet(bytes);
+    const keys = Object.keys(round[0] ?? {}).sort();
+    expect(keys).toEqual([
+      'common_name', 'family_code', 'family_name',
+      'ingested_at', 'is_notable', 'lat', 'lng',
+      'loc_id', 'loc_name', 'obs_count', 'obs_dt',
+      'sci_name', 'species_code', 'sub_id',
+    ]);
+  });
+
+  it('writes a non-empty buffer for an empty input (header-only Parquet)', async () => {
+    const bytes = await writeArchiveParquet([]);
+    expect(bytes.length).toBeGreaterThan(0);
+    const round = await readArchiveParquet(bytes);
+    expect(round).toEqual([]);
+  });
+});

--- a/services/ingestor/src/archive/parquet-writer.ts
+++ b/services/ingestor/src/archive/parquet-writer.ts
@@ -1,0 +1,138 @@
+// @ts-expect-error — parquetjs-lite ships without types; the API surface
+// we use (ParquetSchema, ParquetWriter, ParquetReader) is stable.
+import parquet from 'parquetjs-lite';
+// @ts-expect-error — internal types module, untyped but stable; we patch
+// the TIMESTAMP_MILLIS `fromPrimitive` to handle Node 22+ BigInt values.
+import parquetTypes from 'parquetjs-lite/lib/types.js';
+import type { ArchivableRow } from './select-archivable.js';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+
+// parquetjs-lite 0.8.x ships a `fromPrimitive_TIMESTAMP_MILLIS` that does
+// `new Date(+value)`. Under Node 22+ the underlying INT64 column reads as
+// a BigInt and `+bigint` throws TypeError. The library is effectively
+// unmaintained (last release 2021) so we monkey-patch the type table at
+// import time. Production never reads from the archive — this only affects
+// the test roundtrip — but writing through the same code path means the
+// patch is applied uniformly. The fix matches what an upstream PR would
+// do: route through `Number(value)` which coerces BigInt → number.
+//
+// If parquetjs-lite ever ships a fix or we swap to apache-arrow, delete
+// the next four lines.
+const PT = parquetTypes.PARQUET_LOGICAL_TYPES;
+if (PT?.TIMESTAMP_MILLIS) {
+  PT.TIMESTAMP_MILLIS.fromPrimitive = (v: bigint | number | string): Date =>
+    new Date(typeof v === 'bigint' ? Number(v) : +v);
+}
+
+/**
+ * Schema for the observations archive. Column order matches the SELECT
+ * in select-archivable.ts and the table in the plan §2. UTF8 strings,
+ * DOUBLE for lng/lat, INT64 milliseconds for timestamps (TIMESTAMPTZ on
+ * the source side; UTC milliseconds in Parquet). Nullable on every
+ * column the upstream JOIN can leave NULL.
+ *
+ * Compression: gzip. Snappy is also supported but adds an optional
+ * native dep — gzip via Node's zlib is fine for the row counts we ship.
+ *
+ * `statistics: false` on the TIMESTAMP_MILLIS columns: parquetjs-lite's
+ * `decodeStatisticsValue` path calls `+value` on the BigInt min/max it
+ * stored, which throws under Node 22+ (`Cannot convert a BigInt value
+ * to a number`). Disabling per-page stats on the two timestamp columns
+ * sidesteps the library bug without changing the on-disk schema or
+ * downstream reader behavior — BigQuery, DuckDB, and Polars all read
+ * the data column directly and don't depend on Parquet's optional
+ * min/max statistics.
+ */
+const schema = new parquet.ParquetSchema({
+  sub_id:       { type: 'UTF8' },
+  species_code: { type: 'UTF8' },
+  obs_dt:       { type: 'TIMESTAMP_MILLIS', statistics: false },
+  lng:          { type: 'DOUBLE' },
+  lat:          { type: 'DOUBLE' },
+  obs_count:    { type: 'INT32', optional: true },
+  is_notable:   { type: 'BOOLEAN' },
+  loc_id:       { type: 'UTF8' },
+  loc_name:     { type: 'UTF8', optional: true },
+  common_name:  { type: 'UTF8', optional: true },
+  sci_name:     { type: 'UTF8', optional: true },
+  family_code:  { type: 'UTF8', optional: true },
+  family_name:  { type: 'UTF8', optional: true },
+  ingested_at:  { type: 'TIMESTAMP_MILLIS', statistics: false },
+});
+
+/**
+ * Write a batch of ArchivableRow to a Parquet buffer. Returns the gzip-
+ * compressed Parquet bytes ready for GCS upload. Uses a temp file under
+ * the writer because parquetjs-lite's streaming API targets file paths;
+ * we read the bytes back and unlink the temp file before returning.
+ */
+export async function writeArchiveParquet(rows: ArchivableRow[]): Promise<Buffer> {
+  const dir = await mkdtemp(join(tmpdir(), 'birdwatch-archive-'));
+  const path = join(dir, 'archive.parquet');
+  try {
+    const writer = await parquet.ParquetWriter.openFile(schema, path, {
+      compression: 'GZIP',
+    });
+    for (const row of rows) {
+      // Nullable columns: parquetjs-lite's optional fields treat `undefined`
+      // (not `null`) as "absent" — explicit translation here keeps the
+      // ArchivableRow API uniform (null for absent) and matches the
+      // roundtrip test (`expect(round[1]?.common_name).toBeNull()`).
+      await writer.appendRow({
+        ...row,
+        obs_count: row.obs_count ?? undefined,
+        loc_name: row.loc_name ?? undefined,
+        common_name: row.common_name ?? undefined,
+        sci_name: row.sci_name ?? undefined,
+        family_code: row.family_code ?? undefined,
+        family_name: row.family_name ?? undefined,
+      });
+    }
+    await writer.close();
+    return await readFile(path);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Read a Parquet buffer back into ArchivableRow shape. Test helper only —
+ * production never reads from the archive (that path is BigQuery /
+ * DuckDB / Polars in §7).
+ */
+export async function readArchiveParquet(buf: Buffer): Promise<ArchivableRow[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'birdwatch-archive-read-'));
+  const path = join(dir, 'archive.parquet');
+  await writeFile(path, buf);
+  try {
+    const reader = await parquet.ParquetReader.openFile(path);
+    const cursor = reader.getCursor();
+    const out: ArchivableRow[] = [];
+    let r: unknown;
+    while ((r = await cursor.next()) !== null) {
+      const row = r as Record<string, unknown>;
+      out.push({
+        sub_id: row.sub_id as string,
+        species_code: row.species_code as string,
+        obs_dt: new Date(Number(row.obs_dt)),
+        lng: row.lng as number,
+        lat: row.lat as number,
+        obs_count: (row.obs_count ?? null) as number | null,
+        is_notable: row.is_notable as boolean,
+        loc_id: row.loc_id as string,
+        loc_name: (row.loc_name ?? null) as string | null,
+        common_name: (row.common_name ?? null) as string | null,
+        sci_name: (row.sci_name ?? null) as string | null,
+        family_code: (row.family_code ?? null) as string | null,
+        family_name: (row.family_name ?? null) as string | null,
+        ingested_at: new Date(Number(row.ingested_at)),
+      });
+    }
+    await reader.close();
+    return out;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/services/ingestor/src/archive/select-archivable.test.ts
+++ b/services/ingestor/src/archive/select-archivable.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
+import { selectArchivable } from './select-archivable.js';
+
+let db: TestDb;
+
+beforeAll(async () => {
+  db = await startTestDb();
+  await db.pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+     VALUES ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers')`
+  );
+}, 90_000);
+
+beforeEach(async () => {
+  await db.pool.query('TRUNCATE observations');
+});
+
+afterAll(async () => { await db?.stop(); });
+
+describe('selectArchivable', () => {
+  it('returns rows for a single UTC day with species_meta joined', async () => {
+    await db.pool.query(
+      `INSERT INTO observations
+         (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       VALUES
+         ('S1', 'vermfly', 31.72, -110.88, '2026-05-01T12:00:00Z', 'L1', 'A', 2, false),
+         ('S2', 'vermfly', 31.73, -110.89, '2026-05-01T18:00:00Z', 'L2', 'B', 1, true),
+         ('S3', 'vermfly', 31.74, -110.90, '2026-05-02T00:00:01Z', 'L3', null, null, false)`
+    );
+
+    const rows = await selectArchivable({ pool: db.pool, utcDate: '2026-05-01' });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      sub_id: 'S1',
+      species_code: 'vermfly',
+      common_name: 'Vermilion Flycatcher',
+      sci_name: 'Pyrocephalus rubinus',
+      family_code: 'tyrannidae',
+      family_name: 'Tyrant Flycatchers',
+      is_notable: false,
+    });
+    expect(rows.find(r => r.sub_id === 'S2')?.is_notable).toBe(true);
+  });
+
+  it('returns rows for species with no species_meta entry (LEFT JOIN, not INNER)', async () => {
+    await db.pool.query(
+      `INSERT INTO observations
+         (sub_id, species_code, lat, lng, obs_dt, loc_id, how_many, is_notable)
+       VALUES ('S4', 'unknownsp', 31.72, -110.88, '2026-05-01T12:00:00Z', 'L1', 1, false)`
+    );
+
+    const rows = await selectArchivable({ pool: db.pool, utcDate: '2026-05-01' });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.common_name).toBeNull();
+    expect(rows[0]?.family_code).toBeNull();
+  });
+
+  it('returns an empty array when no rows match the day', async () => {
+    const rows = await selectArchivable({ pool: db.pool, utcDate: '2026-05-01' });
+    expect(rows).toEqual([]);
+  });
+});

--- a/services/ingestor/src/archive/select-archivable.ts
+++ b/services/ingestor/src/archive/select-archivable.ts
@@ -1,0 +1,64 @@
+import type { Pool } from '@bird-watch/db-client';
+
+export interface ArchivableRow {
+  sub_id: string;
+  species_code: string;
+  obs_dt: Date;
+  lng: number;
+  lat: number;
+  obs_count: number | null;
+  is_notable: boolean;
+  loc_id: string;
+  loc_name: string | null;
+  common_name: string | null;
+  sci_name: string | null;
+  family_code: string | null;
+  family_name: string | null;
+  ingested_at: Date;
+}
+
+export interface SelectArchivableOptions {
+  pool: Pool;
+  /** UTC date in ISO YYYY-MM-DD form. Selects rows where obs_dt is on this UTC day. */
+  utcDate: string;
+}
+
+/**
+ * Selects the observations rows whose `obs_dt` falls on the given UTC day,
+ * LEFT JOINed to `species_meta` for the denormalized common_name / sci_name /
+ * family_code / family_name. LEFT JOIN (not INNER) so that an observation
+ * for an unmapped species code still archives — with NULL species metadata —
+ * rather than being silently dropped.
+ *
+ * The renamed columns (`how_many` → `obs_count`, `com_name` → `common_name`)
+ * are aliased here so the Parquet writer sees ML-friendly names without
+ * needing a second mapping layer.
+ */
+export async function selectArchivable(
+  o: SelectArchivableOptions
+): Promise<ArchivableRow[]> {
+  const { rows } = await o.pool.query<ArchivableRow>(
+    `SELECT
+       obs.sub_id,
+       obs.species_code,
+       obs.obs_dt,
+       obs.lng,
+       obs.lat,
+       obs.how_many   AS obs_count,
+       obs.is_notable,
+       obs.loc_id,
+       obs.loc_name,
+       sm.com_name    AS common_name,
+       sm.sci_name,
+       sm.family_code,
+       sm.family_name,
+       obs.ingested_at
+     FROM observations obs
+     LEFT JOIN species_meta sm USING (species_code)
+     WHERE obs.obs_dt >= ($1::date)::timestamptz
+       AND obs.obs_dt <  (($1::date) + INTERVAL '1 day')::timestamptz
+     ORDER BY obs.obs_dt`,
+    [o.utcDate]
+  );
+  return rows;
+}

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -370,10 +370,11 @@ describe('runCli', () => {
     await expect(runCli('bogus', deps)).rejects.toThrow(/descriptions/);
   });
 
-  it("'prune' kind dispatches to runPrune with the pool and default retention", async () => {
+  it("'prune' kind dispatches to runPrune with the pool, default retention, and an archiveDay callback", async () => {
     delete process.env.OBSERVATIONS_RETENTION_DAYS;
     const successSummary = {
-      status: 'success' as const, deleted: 0, retentionDays: 14,
+      status: 'success' as const, deleted: 0, archived: 0,
+      archivedDays: 0, gcsPaths: [], retentionDays: 14,
     };
     const runPruneSpy = vi.fn().mockResolvedValue(successSummary);
     const deps = makeDeps({ runPrune: runPruneSpy });
@@ -381,22 +382,30 @@ describe('runCli', () => {
     await runCli('prune', deps);
 
     expect(runPruneSpy).toHaveBeenCalledTimes(1);
-    expect(runPruneSpy).toHaveBeenCalledWith({ pool: POOL_SENTINEL });
+    // After T2/T4 the runPrune call carries an archiveDay callback wired
+    // to archiveAndUpload over @google-cloud/storage. We assert on the
+    // pool + callback presence; the callback's internal wiring is
+    // exercised by archive/gcs-uploader.test.ts.
+    const call = runPruneSpy.mock.calls[0]?.[0];
+    expect(call?.pool).toBe(POOL_SENTINEL);
+    expect(typeof call?.archiveDay).toBe('function');
     expect(deps.closePool).toHaveBeenCalledWith(POOL_SENTINEL);
   });
 
   it("'prune' kind forwards OBSERVATIONS_RETENTION_DAYS as a parsed integer", async () => {
     process.env.OBSERVATIONS_RETENTION_DAYS = '30';
     const runPruneSpy = vi.fn().mockResolvedValue({
-      status: 'success' as const, deleted: 0, retentionDays: 30,
+      status: 'success' as const, deleted: 0, archived: 0,
+      archivedDays: 0, gcsPaths: [], retentionDays: 30,
     });
     const deps = makeDeps({ runPrune: runPruneSpy });
 
     await runCli('prune', deps);
 
-    expect(runPruneSpy).toHaveBeenCalledWith({
-      pool: POOL_SENTINEL, retentionDays: 30,
-    });
+    const call = runPruneSpy.mock.calls[0]?.[0];
+    expect(call?.pool).toBe(POOL_SENTINEL);
+    expect(call?.retentionDays).toBe(30);
+    expect(typeof call?.archiveDay).toBe('function');
   });
 
   it("'prune' rejects a non-positive OBSERVATIONS_RETENTION_DAYS value", async () => {

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -311,9 +311,34 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       if (parsed !== undefined && (!Number.isFinite(parsed) || parsed <= 0)) {
         throw new Error(`OBSERVATIONS_RETENTION_DAYS must be a positive integer; got ${raw}`);
       }
-      summary = await deps.runPrune(
-        parsed === undefined ? { pool } : { pool, retentionDays: parsed }
-      );
+
+      // GCS archive wiring. The bucket name is fixed by infra (T1) — single
+      // tenant, no env override surface needed. ADC inside Cloud Run reaches
+      // GCS via the ingestor SA's bucket bindings (T1 IAM members:
+      // roles/storage.objectCreator + roles/storage.objectViewer).
+      //
+      // Dynamic import: keeps the @google-cloud/storage SDK (heavy ESM init,
+      // ~118 transitive packages) out of the cold path for every non-prune
+      // kind. The prune Cloud Run Job pays the import cost once per run.
+      const ARCHIVE_BUCKET = 'bird-maps-prod-obs-archive';
+      const { Storage } = await import('@google-cloud/storage');
+      const storage = new Storage();
+      const bucket = storage.bucket(ARCHIVE_BUCKET);
+      const { archiveAndUpload } = await import('./archive/index.js');
+
+      summary = await deps.runPrune({
+        pool,
+        ...(parsed === undefined ? {} : { retentionDays: parsed }),
+        archiveDay: async (utcDate, rows) => {
+          const r = await archiveAndUpload({
+            bucket,
+            bucketName: ARCHIVE_BUCKET,
+            utcDate,
+            rows,
+          });
+          return { gcsPath: r.gcsPath, bytes: r.bytes };
+        },
+      });
     } else {
       throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | digest | probe-taxon | probe-wiki`);
     }

--- a/services/ingestor/src/run-prune.test.ts
+++ b/services/ingestor/src/run-prune.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
 import { getRecentIngestRuns } from '@bird-watch/db-client';
 import { runPrune, DEFAULT_RETENTION_DAYS } from './run-prune.js';
+import type { ArchivableRow } from './archive/select-archivable.js';
 
 let db: TestDb;
 
@@ -30,6 +31,24 @@ async function seedAt(subId: string, ageDaysAgo: number): Promise<void> {
   );
 }
 
+/**
+ * Stub archive callback for tests: captures the (utcDate, rowCount) pairs and
+ * returns a fake gs:// path. Production wires `archiveAndUpload` (T4); the
+ * runner contract is the same shape — `{ gcsPath, bytes }` resolved on
+ * success, throw on failure.
+ */
+function makeStubArchive() {
+  const calls: Array<{ utcDate: string; rowCount: number }> = [];
+  const archiveDay = async (utcDate: string, rows: ArchivableRow[]) => {
+    calls.push({ utcDate, rowCount: rows.length });
+    return {
+      gcsPath: `gs://test/observations/year=2026/month=05/day=${utcDate.slice(8)}.parquet`,
+      bytes: 1,
+    };
+  };
+  return { calls, archiveDay };
+}
+
 describe('runPrune', () => {
   it('deletes observations strictly older than the retention window and keeps rows inside it', async () => {
     await seedAt('OLD-30', 30);
@@ -37,7 +56,8 @@ describe('runPrune', () => {
     await seedAt('NEW-13', 13);
     await seedAt('NEW-1', 1);
 
-    const summary = await runPrune({ pool: db.pool, retentionDays: 14 });
+    const stub = makeStubArchive();
+    const summary = await runPrune({ pool: db.pool, retentionDays: 14, archiveDay: stub.archiveDay });
 
     expect(summary.status).toBe('success');
     expect(summary.deleted).toBe(2);
@@ -52,7 +72,8 @@ describe('runPrune', () => {
   it('defaults retention to 14 days when no option is passed', async () => {
     await seedAt('OLD', 20);
     await seedAt('NEW', 7);
-    const summary = await runPrune({ pool: db.pool });
+    const stub = makeStubArchive();
+    const summary = await runPrune({ pool: db.pool, archiveDay: stub.archiveDay });
     expect(summary.retentionDays).toBe(DEFAULT_RETENTION_DAYS);
     expect(summary.deleted).toBe(1);
   });
@@ -62,7 +83,8 @@ describe('runPrune', () => {
     await seedAt('OLD-2', 21);
     await seedAt('NEW-1', 3);
 
-    await runPrune({ pool: db.pool, retentionDays: 14 });
+    const stub = makeStubArchive();
+    await runPrune({ pool: db.pool, retentionDays: 14, archiveDay: stub.archiveDay });
 
     const recent = await getRecentIngestRuns(db.pool, 5);
     expect(recent).toHaveLength(1);
@@ -87,7 +109,8 @@ describe('runPrune', () => {
     // resolution (pg_stat timestamps are at-best millisecond-granular).
     await new Promise(r => setTimeout(r, 50));
     await seedAt('OLD', 30);
-    await runPrune({ pool: db.pool, retentionDays: 14 });
+    const stub = makeStubArchive();
+    await runPrune({ pool: db.pool, retentionDays: 14, archiveDay: stub.archiveDay });
 
     const after = await db.pool.query<{ last_vacuum: Date | null }>(
       `SELECT last_vacuum FROM pg_stat_user_tables WHERE relname = 'observations'`
@@ -97,5 +120,89 @@ describe('runPrune', () => {
     if (beforeTs) {
       expect(afterTs!.getTime()).toBeGreaterThan(beforeTs.getTime());
     }
+  });
+
+  // ── Archive-then-delete contract (T2 §Step 7) ───────────────────────────
+  // The next four tests assert the invariant added by the cold-storage
+  // refactor: every day's rows are archived BEFORE the day is deleted, an
+  // archive failure short-circuits the delete for that day, an empty table
+  // is a clean no-op, and the partial-overlap day at the retention cutoff
+  // is preserved (not wrongly wiped by a day-wide DELETE).
+
+  it('archives the day before deleting it, never the other way', async () => {
+    await seedAt('OLD-1', 30);
+    const order: string[] = [];
+    const archiveDay = async (utcDate: string, _rows: ArchivableRow[]) => {
+      // Confirm the rows still exist in the DB at archive time
+      const { rows: present } = await db.pool.query<{ count: string }>(
+        `SELECT count(*)::text AS count FROM observations
+           WHERE obs_dt >= ($1::date)::timestamptz
+             AND obs_dt <  (($1::date) + INTERVAL '1 day')::timestamptz`,
+        [utcDate]
+      );
+      order.push(`archive:${present[0]?.count}`);
+      return { gcsPath: 'gs://test/x.parquet', bytes: 1 };
+    };
+    await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
+    expect(order[0]).toBe('archive:1'); // row visible at archive time
+    const { rowCount } = await db.pool.query('SELECT 1 FROM observations');
+    expect(rowCount).toBe(0); // and gone after
+  });
+
+  it('does NOT delete the day if archive throws', async () => {
+    await seedAt('OLD-1', 30);
+    const archiveDay = async () => { throw new Error('GCS unreachable'); };
+    const summary = await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
+    expect(summary.status).toBe('failure');
+    expect(summary.deleted).toBe(0);
+    const { rowCount } = await db.pool.query('SELECT 1 FROM observations');
+    expect(rowCount).toBe(1);
+  });
+
+  it('handles an empty table as a clean no-op', async () => {
+    const archiveDay = async () => ({ gcsPath: 'unused', bytes: 0 });
+    const summary = await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
+    expect(summary.status).toBe('success');
+    expect(summary.archived).toBe(0);
+    expect(summary.deleted).toBe(0);
+  });
+
+  it('skips the partial-overlap UTC day at the retention cutoff', async () => {
+    // Bug shape (pre-fix): the day-enumeration query selected any UTC day
+    // with AT LEAST ONE row older than `now() - retention`. The per-day
+    // DELETE then wiped the FULL UTC day [D 00:00Z, D+1 00:00Z), including
+    // rows on D that were still inside the retention window. Net effect:
+    // the partial-overlap day's recent rows were wrongly archived AND
+    // deleted on the same run, shortening effective retention by up to 24h.
+    //
+    // Fix (post): bound by `date_trunc('day', now() - retention)` instead
+    // of `now() - retention`. Only fully-closed UTC days are enumerated.
+    //
+    // To exercise the bug we need two rows on the SAME UTC day: one older
+    // than cutoff (would have triggered the old enumeration), one newer
+    // than cutoff (would have been wrongly deleted by the day-wide DELETE).
+    // We anchor both inserts relative to `date_trunc('day', now() - INTERVAL '14 days')`
+    // (the cutoff day's start in UTC) so we don't depend on CI-time-of-day.
+    await db.pool.query(
+      `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, how_many, is_notable)
+       VALUES
+         ('BOUNDARY-OLD', 'vermfly', 31.7, -110.9,
+           date_trunc('day', now() - INTERVAL '14 days') - INTERVAL '1 hour',
+           'L1', 1, false),
+         ('BOUNDARY-NEW', 'vermfly', 31.7, -110.9,
+           date_trunc('day', now() - INTERVAL '14 days') + INTERVAL '1 hour',
+           'L1', 1, false)`
+    );
+    const archiveDay = async () => ({ gcsPath: 'gs://test/x.parquet', bytes: 1 });
+    const summary = await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
+    // The cutoff day itself is now skipped; the prior day (where the OLD
+    // row lives) IS fully past the cutoff and IS archived+deleted.
+    // BOUNDARY-OLD: on day D-1, fully past cutoff — archived+deleted.
+    // BOUNDARY-NEW: on day D (the partial-overlap day) — preserved.
+    const { rows: remaining } = await db.pool.query<{ sub_id: string }>(
+      `SELECT sub_id FROM observations ORDER BY sub_id`
+    );
+    expect(remaining.map(r => r.sub_id)).toEqual(['BOUNDARY-NEW']);
+    expect(summary.deleted).toBe(1);
   });
 });

--- a/services/ingestor/src/run-prune.test.ts
+++ b/services/ingestor/src/run-prune.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
 import { getRecentIngestRuns } from '@bird-watch/db-client';
 import { runPrune, DEFAULT_RETENTION_DAYS } from './run-prune.js';
@@ -165,6 +165,47 @@ describe('runPrune', () => {
     expect(summary.status).toBe('success');
     expect(summary.archived).toBe(0);
     expect(summary.deleted).toBe(0);
+  });
+
+  it('emits a bird_ingest_archived log line per archived day with the T8-coupled fields', async () => {
+    // T8's archive-vs-delete parity dashboard widget depends on the
+    // shape of this log entry: rowCount and deletedCount MUST appear
+    // in the SAME entry (so a divergent run is one query, not a join),
+    // and gcsPath + bytesUploaded MUST be present (so the bytes-uploaded
+    // and rows-archived widgets extract from the same source). If a
+    // future refactor renames `bird_ingest_archived` or drops a field,
+    // this test fails before the dashboard silently goes blank.
+    await seedAt('OLD-1', 30);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const archiveDay = async () => ({
+        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21.parquet',
+        bytes: 4242,
+      });
+      await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
+
+      const lines = logSpy.mock.calls
+        .map(c => c[0])
+        .filter((s): s is string => typeof s === 'string')
+        .map(s => { try { return JSON.parse(s); } catch { return null; } })
+        .filter((p: unknown): p is Record<string, unknown> => !!p && typeof p === 'object');
+
+      const archived = lines.filter(l => l.message === 'bird_ingest_archived');
+      expect(archived).toHaveLength(1);
+      const entry = archived[0]!;
+      expect(entry).toMatchObject({
+        severity: 'INFO',
+        message: 'bird_ingest_archived',
+        rowCount: 1,
+        deletedCount: 1,
+        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21.parquet',
+        bytesUploaded: 4242,
+      });
+      expect(typeof entry.date).toBe('string');
+      expect(entry.date as string).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('skips the partial-overlap UTC day at the retention cutoff', async () => {

--- a/services/ingestor/src/run-prune.ts
+++ b/services/ingestor/src/run-prune.ts
@@ -2,23 +2,37 @@ import {
   startIngestRun, finishIngestRun,
   type Pool,
 } from '@bird-watch/db-client';
+import { selectArchivable, type ArchivableRow } from './archive/select-archivable.js';
 
 export interface RunPruneOptions {
   pool: Pool;
   /**
    * Rolling-window size in days. Rows with `obs_dt < now() - retentionDays`
-   * are deleted. Default 14 — matches the steady-state Neon Launch tier
-   * runway (~3 GB) discussed in
-   * `docs/analyses/2026-05-14-process-scale-options/phase-4/analysis-report.md`
-   * Finding 8 / Recommendation 2A-lean.
+   * are first archived to GCS, then deleted. Default 14 — matches the
+   * steady-state Cloud SQL runway (see docs/analyses/2026-05-14-process-
+   * scale-options/phase-4/analysis-report.md Finding 8).
    */
   retentionDays?: number;
+  /**
+   * Per-day archive callback. Production wires the Parquet+GCS uploader
+   * (T4); tests pass a stub that captures the rows in memory. The archive
+   * MUST resolve successfully before the day's rows are deleted — any
+   * thrown error short-circuits the delete for that day and the runner
+   * records `status: 'failure'`.
+   */
+  archiveDay: (utcDate: string, rows: ArchivableRow[]) => Promise<{ gcsPath: string; bytes: number }>;
 }
 
 export interface RunPruneSummary {
   status: 'success' | 'failure';
-  /** Number of `observations` rows deleted by the prune DELETE. */
+  /** Number of `observations` rows deleted by the per-day DELETE loop. */
   deleted: number;
+  /** Number of `observations` rows successfully archived to GCS. */
+  archived: number;
+  /** Number of distinct UTC dates that had at least one row archived+deleted. */
+  archivedDays: number;
+  /** gs://… paths of every Parquet object successfully written this run. */
+  gcsPaths: string[];
   /** The retentionDays value actually used (resolved default). */
   retentionDays: number;
   error?: string;
@@ -27,43 +41,100 @@ export interface RunPruneSummary {
 export const DEFAULT_RETENTION_DAYS = 14;
 
 /**
- * Nightly observations-prune job. Deletes rows older than the rolling window,
- * then runs `VACUUM (ANALYZE) observations` to recover GIST-index dead-tuple
- * bloat on the `obs_dt`/geometry indexes. The DELETE+VACUUM pair is the entire
- * contract — no eBird calls, no upserts.
+ * Nightly archive-then-prune job.
  *
- * Records into `ingest_runs` with `kind='prune'` and the deleted row count in
- * `obs_fetched` (column reuse — `obs_fetched` is just an integer slot, and a
- * separate `obs_pruned` column would require a migration for one metric).
+ * For each UTC date that falls fully outside the retention window:
+ *   1. SELECT the day's rows (LEFT JOIN species_meta) via selectArchivable.
+ *   2. archiveDay(utcDate, rows) → writes Parquet to GCS (T4 wiring).
+ *   3. DELETE the day's rows from observations.
+ *
+ * After all days are processed, VACUUM (ANALYZE) observations recovers
+ * GIST/B-tree dead-tuple bloat.
+ *
+ * The archive-then-delete pair is per-day and synchronous: if step 2 throws
+ * for day D, step 3 for day D does NOT run, and the runner returns
+ * status: 'failure' with the count of days that DID succeed in archived/
+ * archivedDays. Prior days that succeeded keep their archive + delete —
+ * partial progress is preserved.
  *
  * VACUUM must run outside any transaction (Postgres rejects VACUUM inside
  * BEGIN/COMMIT). `pool.query('VACUUM ...')` checks out a connection and runs
  * the statement at the connection level — no implicit transaction is opened
  * for non-DML autocommit-safe statements via `pg`. We deliberately invoke
- * VACUUM *after* the DELETE commits so the dead tuples are visible to it.
+ * VACUUM *after* the per-day DELETEs commit so the dead tuples are visible.
  */
 export async function runPrune(o: RunPruneOptions): Promise<RunPruneSummary> {
   const retentionDays = o.retentionDays ?? DEFAULT_RETENTION_DAYS;
   const runId = await startIngestRun(o.pool, 'prune');
+
+  let deleted = 0;
+  let archived = 0;
+  const gcsPaths: string[] = [];
+  const archivedDays = new Set<string>();
+
   try {
-    const cutoffInterval = `${retentionDays} days`;
-    const { rowCount } = await o.pool.query(
-      `DELETE FROM observations WHERE obs_dt < now() - $1::interval`,
-      [cutoffInterval]
+    // Enumerate the UTC dates that need archiving: every UTC day whose
+    // ENTIRE 24-hour range is older than the cutoff. We bound by
+    // `date_trunc('day', now() - retention)` rather than `now() - retention`
+    // so a partial-overlap day (e.g. cutoff = 03:00Z falling inside day D)
+    // is skipped and rolls into tomorrow's run. Invariant: the SELECT/DELETE
+    // below archive a FULL UTC day [D 00:00Z, D+1 00:00Z), so every row
+    // archived must be < the cutoff — only fully-closed days satisfy that.
+    const { rows: dayRows } = await o.pool.query<{ utc_date: string }>(
+      `SELECT DISTINCT (obs_dt AT TIME ZONE 'UTC')::date::text AS utc_date
+         FROM observations
+        WHERE obs_dt < date_trunc('day', now() - ($1 || ' days')::interval)
+        ORDER BY utc_date`,
+      [String(retentionDays)]
     );
-    const deleted = rowCount ?? 0;
-    // VACUUM ANALYZE must be its own statement, outside any explicit
-    // transaction. Reclaims dead-tuple space and refreshes planner stats so
-    // the GIST geometry index + the obs_dt index stay healthy under the
-    // steady-state churn of a 14-day rolling window.
+
+    for (const { utc_date } of dayRows) {
+      const rows = await selectArchivable({ pool: o.pool, utcDate: utc_date });
+      if (rows.length === 0) continue;
+
+      const { gcsPath, bytes } = await o.archiveDay(utc_date, rows);
+      gcsPaths.push(gcsPath);
+      archived += rows.length;
+      archivedDays.add(utc_date);
+
+      const { rowCount } = await o.pool.query(
+        `DELETE FROM observations
+           WHERE obs_dt >= ($1::date)::timestamptz
+             AND obs_dt <  (($1::date) + INTERVAL '1 day')::timestamptz`,
+        [utc_date]
+      );
+      deleted += rowCount ?? 0;
+
+      // Per-day structured log feeding the T8 log-based metrics:
+      // bird-ingest-archived-row-count, bird-ingest-archived-bytes-uploaded,
+      // bird-ingest-archived-deleted-count. The archive-vs-delete parity
+      // widget reads `rowCount` and `deletedCount` from the SAME log entry —
+      // they MUST appear together so a divergent run is one query, not a join.
+      console.log(JSON.stringify({
+        severity: 'INFO',
+        message: 'bird_ingest_archived',
+        date: utc_date,
+        rowCount: rows.length,
+        deletedCount: rowCount ?? 0,
+        gcsPath,
+        bytesUploaded: bytes,
+      }));
+    }
+
     await o.pool.query('VACUUM (ANALYZE) observations');
     await finishIngestRun(o.pool, runId, {
       status: 'success', obsFetched: deleted, obsUpserted: 0,
     });
-    return { status: 'success', deleted, retentionDays };
+    return {
+      status: 'success', deleted, archived,
+      archivedDays: archivedDays.size, gcsPaths, retentionDays,
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     await finishIngestRun(o.pool, runId, { status: 'failure', errorMessage: msg });
-    return { status: 'failure', deleted: 0, retentionDays, error: msg };
+    return {
+      status: 'failure', deleted, archived,
+      archivedDays: archivedDays.size, gcsPaths, retentionDays, error: msg,
+    };
   }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Cron as Cloud Scheduler
    participant Job as bird-ingestor-prune
    participant PG as Cloud SQL
    participant GCS as GCS Nearline<br/>(bird-maps-prod-obs-archive)

    Cron->>Job: nightly trigger (prune)
    Job->>PG: SELECT DISTINCT utc_date<br/>WHERE obs_dt < date_trunc('day', now()-14d)
    loop for each fully-closed UTC day
      Job->>PG: SELECT obs LEFT JOIN species_meta<br/>(selectArchivable)
      Job->>GCS: PUT _tmp/<uuid>.parquet<br/>+ md5Hash metadata
      Job->>GCS: HEAD _tmp/<uuid>.parquet<br/>(verify md5)
      Job->>GCS: COPY _tmp/<uuid> → year=YYYY/month=MM/day=DD.parquet
      Job->>GCS: DELETE _tmp/<uuid>
      Job->>PG: DELETE FROM observations<br/>WHERE obs_dt ∈ [D 00:00Z, D+1 00:00Z)
      Note over Job: emit bird_ingest_archived log<br/>{rowCount, deletedCount, gcsPath, bytesUploaded}
    end
    Job->>PG: VACUUM (ANALYZE) observations
```

```mermaid
flowchart LR
    A[runPrune] --> B[selectArchivable<br/>per UTC day]
    B --> C{rows.length > 0?}
    C -- no --> D[skip day]
    C -- yes --> E[archiveDay callback<br/>injected]
    E --> F[writeArchiveParquet<br/>14-col schema, gzip]
    F --> G[archiveAndUpload<br/>temp → md5 verify → rename]
    G --> H[DELETE day's rows<br/>per-day, not bulk]
    G -. throw .-> X[short-circuit:<br/>day NOT deleted,<br/>summary.status=failure]
    H --> I[next day]
```

## Summary

- Refactors the nightly prune from destructive DELETE into archive-then-delete: per fully-closed UTC day, write the rows (14-col schema, LEFT JOIN species_meta) to a Parquet object in GCS, then DELETE only that day. Archive failure short-circuits the per-day DELETE so partial progress for earlier days is preserved and the next nightly run retries cleanly.
- Adds two ingestor deps (\`parquetjs-lite\` for the writer, \`@google-cloud/storage\` for the uploader) and four new modules under \`services/ingestor/src/archive/\`: \`select-archivable.ts\`, \`parquet-writer.ts\`, \`gcs-uploader.ts\`, and \`index.ts\`. Each lands with a co-located test using the project's testcontainers pattern (no DB mocks) plus vi.fn() stubs for GCS.
- Wires the real \`archiveAndUpload\` into \`cli.ts\`'s \`prune\` branch behind a dynamic \`import('@google-cloud/storage')\` so the heavy SDK stays out of the cold path for every non-prune kind.

## Screenshots

N/A — not UI.

## Test plan

- [x] \`npm run build\` — clean production build (all workspaces)
- [x] \`npm run test --workspaces --if-present\` — green (ingestor 194/194, admin-api 39/39, read-api 133/133, frontend 851/851, db-client + shared-types green)
- [x] New unit + integration tests added: \`select-archivable.test.ts\` (3 tests, real Postgres via testcontainers), \`parquet-writer.test.ts\` (3 roundtrip tests), \`gcs-uploader.test.ts\` (3 tests including md5-mismatch + temp-save-throws), \`run-prune.test.ts\` (4 new tests: archive-before-delete ordering, archive-throw short-circuits delete, empty-table no-op, partial-overlap day at retention cutoff is skipped)
- [x] \`npx tsc --noEmit -p tsconfig.json\` in \`services/ingestor\` — clean
- [x] \`npx knip\` — no new orphans introduced
- [ ] New Playwright e2e spec added — N/A (backend-only change)
- [ ] (UI only) Playwright MCP smoke — N/A (no \`frontend/**\` touches)

## Plan reference

Part of Plan 11 (issue #689), Tasks T2 + T3 + T4. See \`docs/plans/2026-05-20-observations-cold-storage.md\`. T1 (infra) shipped via #694; T5 (apply + runbook), T6/T7 (operational), and T8 (dashboard widgets + log-based metrics) are separate follow-ups.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)