### PR TITLE
infra(monitoring): T8 cold-storage observability — 4 tiles + 3 log-based metrics

### DIFF
--- a/infra/terraform/monitoring-dashboard.tf
+++ b/infra/terraform/monitoring-dashboard.tf
@@ -318,6 +318,157 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
             }
           }
         },
+        # ── Row 5: Observations archive pipeline (T8 of issue #689) ─────
+        #
+        # Visibility into the nightly prune's archive-then-delete pipeline.
+        # The 14-day live retention window means raw row counts on the
+        # observations table do NOT carry archive throughput — these tiles
+        # are the only way to see the cold-storage data flow without
+        # tailing Cloud Logging by hand.
+        # Tile 5.1 — Rows archived per night
+        {
+          xPos   = 0
+          yPos   = 16
+          width  = 3
+          height = 4
+          widget = {
+            title = "Archive throughput — rows per night (last 30d)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-row-count\" AND resource.type=\"cloud_run_job\""
+                    aggregation = {
+                      alignmentPeriod    = "86400s" # daily buckets
+                      perSeriesAligner   = "ALIGN_SUM"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              yAxis = {
+                label = "rows"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Tile 5.2 — Bytes uploaded per night
+        {
+          xPos   = 3
+          yPos   = 16
+          width  = 3
+          height = 4
+          widget = {
+            title = "GCS bytes uploaded per night (last 30d)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-bytes-uploaded\" AND resource.type=\"cloud_run_job\""
+                    aggregation = {
+                      alignmentPeriod    = "86400s"
+                      perSeriesAligner   = "ALIGN_SUM"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              yAxis = {
+                label = "bytes"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Tile 5.3 — Archive vs Delete parity check
+        # Two lines on one widget. For healthy nights the lines overlay
+        # exactly (rowCount == deletedCount per the T2 atomic-per-day
+        # invariant). Divergence is a visual smell — triage via the
+        # runbook §Failure response.
+        {
+          xPos   = 6
+          yPos   = 16
+          width  = 3
+          height = 4
+          widget = {
+            title = "Archive vs Delete parity (per-day)"
+            xyChart = {
+              dataSets = [
+                {
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-row-count\" AND resource.type=\"cloud_run_job\""
+                      aggregation = {
+                        alignmentPeriod    = "86400s"
+                        perSeriesAligner   = "ALIGN_SUM"
+                        crossSeriesReducer = "REDUCE_SUM"
+                      }
+                    }
+                  }
+                  plotType       = "LINE"
+                  legendTemplate = "archived (rowCount)"
+                },
+                {
+                  timeSeriesQuery = {
+                    timeSeriesFilter = {
+                      filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-deleted-count\" AND resource.type=\"cloud_run_job\""
+                      aggregation = {
+                        alignmentPeriod    = "86400s"
+                        perSeriesAligner   = "ALIGN_SUM"
+                        crossSeriesReducer = "REDUCE_SUM"
+                      }
+                    }
+                  }
+                  plotType       = "LINE"
+                  legendTemplate = "deleted (deletedCount)"
+                },
+              ]
+              yAxis = {
+                label = "rows"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        # Tile 5.4 — GCS bucket size growth (90d, with lifecycle annotation)
+        # GCP-native metric — no log-based metric needed. The 90-day window
+        # is chosen so the Nearline → Archive transition (which fires at
+        # age=90d per T1's lifecycle_rule) is visible: bucket size growth-
+        # rate inflects when old partitions transition out of Nearline
+        # storage class — useful visual sanity check on the lifecycle rule.
+        {
+          xPos   = 9
+          yPos   = 16
+          width  = 3
+          height = 4
+          widget = {
+            title = "GCS archive bucket size — 90d (Nearline → Archive transition visible)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "metric.type=\"storage.googleapis.com/storage/total_bytes\" AND resource.type=\"gcs_bucket\" AND resource.label.bucket_name=\"bird-maps-prod-obs-archive\""
+                    aggregation = {
+                      alignmentPeriod    = "86400s"
+                      perSeriesAligner   = "ALIGN_MEAN"
+                      crossSeriesReducer = "REDUCE_SUM"
+                      groupByFields      = ["resource.label.storage_class"]
+                    }
+                  }
+                }
+                plotType       = "STACKED_AREA"
+                legendTemplate = "$${resource.labels.storage_class}"
+              }]
+              yAxis = {
+                label = "bytes"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
       ]
     }
   })

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -444,3 +444,101 @@ resource "google_project_iam_audit_config" "monitoring_data_read" {
     log_type = "DATA_READ"
   }
 }
+
+# ── T8: Observations archive — log-based metrics ────────────────────────
+#
+# Three metrics extracted from the `bird_ingest_archived` structured-log
+# line emitted by services/ingestor/src/run-prune.ts (T2). One emit per
+# archived day per nightly run, shape:
+#   {
+#     message: "bird_ingest_archived",
+#     date: "YYYY-MM-DD",
+#     rowCount: <int>,         // rows written to Parquet
+#     deletedCount: <int>,     // rows actually DELETEd (parity invariant)
+#     gcsPath: "gs://...",
+#     bytesUploaded: <int>
+#   }
+#
+# These power Row 5 of the bird-watch overview dashboard
+# (infra/terraform/monitoring-dashboard.tf). The two `!=NULL_VALUE` clauses
+# in each filter drop malformed entries during a future emit-shape
+# regression rather than landing garbage into the metric stream — matches
+# the pattern in `bird-ingest-run-completed` above.
+
+resource "google_logging_metric" "archived_row_count" {
+  name = "bird-ingest-archived-row-count"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "resource.labels.job_name=\"bird-ingestor-prune\"",
+    "jsonPayload.message=\"bird_ingest_archived\"",
+    "jsonPayload.rowCount!=NULL_VALUE",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "DISTRIBUTION"
+    unit         = "1"
+    display_name = "Observations archived per day (rowCount)"
+  }
+  value_extractor = "EXTRACT(jsonPayload.rowCount)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 1000 # row counts span 1k (AZ-only) → ~5M (national)
+    }
+  }
+}
+
+resource "google_logging_metric" "archived_bytes_uploaded" {
+  name = "bird-ingest-archived-bytes-uploaded"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "resource.labels.job_name=\"bird-ingestor-prune\"",
+    "jsonPayload.message=\"bird_ingest_archived\"",
+    "jsonPayload.bytesUploaded!=NULL_VALUE",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "DISTRIBUTION"
+    unit         = "By"
+    display_name = "Parquet bytes uploaded to GCS per day"
+  }
+  value_extractor = "EXTRACT(jsonPayload.bytesUploaded)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 100000 # ~100 KB scale spans 100 KB (AZ tiny day) → ~400 MB (national daily peak)
+    }
+  }
+}
+
+# Parity-check metric. The T2 invariant: archive-then-delete is atomic per
+# day — if archive D succeeds, delete D runs against the same row set. The
+# dashboard tile (T8 Tile 5.3 below) renders rowCount and deletedCount as
+# two lines on one widget; for healthy nights the lines are co-incident.
+# Divergence is a visual smell — root-cause via the runbook §Failure
+# response.
+resource "google_logging_metric" "archived_deleted_count" {
+  name = "bird-ingest-archived-deleted-count"
+  filter = join(" AND ", [
+    "resource.type=\"cloud_run_job\"",
+    "resource.labels.job_name=\"bird-ingestor-prune\"",
+    "jsonPayload.message=\"bird_ingest_archived\"",
+    "jsonPayload.deletedCount!=NULL_VALUE",
+  ])
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "DISTRIBUTION"
+    unit         = "1"
+    display_name = "Observations deleted per day post-archive (deletedCount)"
+  }
+  value_extractor = "EXTRACT(jsonPayload.deletedCount)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 1000
+    }
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph CR[Cloud Run Job: bird-ingestor-prune]
      RP[run-prune.ts\narchive-then-delete\nT2 — shipped #696]
    end
    RP -->|console.log JSON| LG[Cloud Logging\nbird_ingest_archived\nrowCount / deletedCount / bytesUploaded / gcsPath]
    LG --> LM1[google_logging_metric\nbird-ingest-archived-row-count]
    LG --> LM2[google_logging_metric\nbird-ingest-archived-bytes-uploaded]
    LG --> LM3[google_logging_metric\nbird-ingest-archived-deleted-count]
    GCS[(GCS bucket\nbird-maps-prod-obs-archive)] -->|storage.googleapis.com\n/storage/total_bytes| NM[GCP-native metric\ngrouped by storage_class]
    LM1 --> T1[Tile 5.1 — rows/night]
    LM2 --> T2[Tile 5.2 — bytes/night]
    LM1 --> T3[Tile 5.3 — parity\nrowCount line]
    LM3 --> T3
    NM --> T4[Tile 5.4 — bucket size 90d\nNearline → Archive transition]
    T1 & T2 & T3 & T4 --> DB[bird-watch overview\nMonitoring dashboard\nRow 5 yPos=16]
```

```mermaid
graph TD
    R1["Row 1 yPos=0 (3 tiles)"]
    R2["Row 2 yPos=4 (3 tiles)"]
    R3["Row 3 yPos=8 (3 tiles)"]
    R4["Row 4 yPos=12 (2 tiles)"]
    R5["Row 5 yPos=16 (4 tiles — NEW)"]
    R1 --> R2 --> R3 --> R4 --> R5
    R5 -.- N["width=3 each (4-wide row)\nprior rows used width=4 (3-wide rows)\nRow 5 is denser because all 4 tiles\nbelong to one pipeline"]
```

## Summary

- T8 of the cold-storage plan (#689). 3 `google_logging_metric` resources extract `rowCount`, `bytesUploaded`, `deletedCount` from the `bird_ingest_archived` structured-log line that the T2 prune job emits per archived day (shipped via #696). 4 new dashboard tiles render the pipeline visually so partial-archive divergence stops being invisible.
- The parity widget (Tile 5.3) renders `rowCount` and `deletedCount` as two lines on one chart — for healthy nights they overlay exactly (T2's atomic per-day invariant); divergence is a single-glance visual smell rather than a manual log audit.
- Tile 5.4 uses the GCP-native `storage.googleapis.com/storage/total_bytes` metric grouped by `storage_class` so the Nearline → Archive lifecycle transition at age=90d (from T1) is visible as a series-color flip. Alerts are explicitly out of scope per plan §T8 (deferred).

## Screenshots

N/A — not UI (Terraform-only; tiles render in GCP console post-apply).

## Test plan

- [x] `terraform fmt -check -diff infra/terraform/monitoring.tf infra/terraform/monitoring-dashboard.tf` — clean
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] Scoped `terraform plan` against the 4 T8 resources — exits **`Plan: 3 to add, 1 to change, 0 to destroy`** (matches the TDD anchor in plan §T8 Step 1):
  ```
  + google_logging_metric.archived_row_count
  + google_logging_metric.archived_bytes_uploaded
  + google_logging_metric.archived_deleted_count
  ~ google_monitoring_dashboard.bird_watch_overview  (in-place: appends Row 5)
  ```
- [x] Log-line shape verified against `services/ingestor/src/run-prune.ts` lines 113–121 — `message`, `date`, `rowCount`, `deletedCount`, `gcsPath`, `bytesUploaded` all match each metric's `EXTRACT(...)` and filter clauses. T2's test suite (#696) regression-guards the emit shape.
- [x] Tile yPos math: 4 existing rows × height 4 = bottom at 16; Row 5 starts at yPos=16. No tile-removal so the L1 dashboard_json diff-suppression landmine does not apply (additive only).

### Out-of-scope deferrals (deliberate)

- **No alerts.** Plan §T8 names this explicitly — widgets only; alerts deferred.
- **No `terraform apply`.** Per plan §T8 Step 6, the operator runs the scoped apply (see below) as a manual follow-up because the local terraform state shows unrelated drift (50 backfill scheduler jobs + 4 other deltas) that should not land via this PR. The scoped command isolates T8 from that drift.
- **No runbook cross-link (plan §T8 Step 10).** `docs/runbooks/observations-archive.md` is created in T5 (which runs after the operator applies T1 + this T8 PR), so there's no §Daily verification query section to append to yet. T5 will fold the cross-link in when it creates the file.

### Operator: scoped apply command (post-merge)

```bash
cd infra/terraform
terraform plan -out=t8-observability.plan \
  -target=google_logging_metric.archived_row_count \
  -target=google_logging_metric.archived_bytes_uploaded \
  -target=google_logging_metric.archived_deleted_count \
  -target=google_monitoring_dashboard.bird_watch_overview
# verify: Plan: 3 to add, 1 to change, 0 to destroy
terraform apply t8-observability.plan
# then verify metric descriptors exist:
for m in row-count bytes-uploaded deleted-count; do
  gcloud monitoring metrics-descriptors describe \
    "logging.googleapis.com/user/bird-ingest-archived-${m}" \
    --project=bird-maps-prod
done
```

## Plan reference

Part of [Plan 11 — observations cold storage](../blob/main/docs/plans/2026-05-20-observations-cold-storage.md), Task T8 (plan lines 1443–1880). Issue: #689. T1 (infra) shipped via #694; T2–T4 (code) shipped via #696. T5/T6/T7 are operator-only post-merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)