### PR TITLE
feat(ingestor): day-level Hive partition pruning in BigQuery external table (#699)

### DIFF
--- a/docs/plans/2026-05-20-observations-cold-storage.md
+++ b/docs/plans/2026-05-20-observations-cold-storage.md
@@ -52,7 +52,7 @@ The retention window is sized to Cloud SQL's storage tier (see `services/ingesto
 
 - **Format:** Parquet, gzip-compressed (Snappy works too; the writer choice in T3 decides).
 - **Granularity:** one file per UTC date — i.e. one nightly write per partition.
-- **Naming:** `day=DD.parquet` (the file *is* the partition, no further sharding).
+- **Naming:** `day=DD/data.parquet` — `day=DD` is a DIRECTORY segment with a stable `data.parquet` filename, so BigQuery's Hive AUTO partition planner picks up `[year, month, day]` as queryable partition columns (#699). One file per UTC date today; the stable filename leaves room to shard a day across multiple files later.
 
 **Why Parquet, not CSV or JSON or raw SQL?**
 
@@ -74,11 +74,14 @@ gs://bird-maps-prod-obs-archive/
   observations/
     year=2026/
       month=05/
-        day=20.parquet
-        day=21.parquet
+        day=20/
+          data.parquet
+        day=21/
+          data.parquet
         ...
       month=06/
-        day=01.parquet
+        day=01/
+          data.parquet
 ```
 
 **Why Hive-style (`key=value`) partitioning, not flat date prefixes?** Both BigQuery external tables and DuckDB's `read_parquet('gs://...', hive_partitioning=1)` parse `year=YYYY/month=MM/day=DD` automatically and expose them as virtual columns the planner uses to prune at scan time. A query `WHERE year=2026 AND month=5` reads exactly 31 files; a flat layout would force a list-and-filter on every read. The cost difference at BigQuery's per-byte-scanned billing is the difference between $0.005 and $5 for a typical month-of-data query.
@@ -1379,7 +1382,7 @@ Fallback if `parquetjs-lite` rejects in CI (Node compat surprise, WASM build iss
   gcloud storage du gs://bird-maps-prod-obs-archive/
   ```
 
-  Expected: one `day=DD.parquet` per archived day; total size matches `bytesUploaded` summed across log lines.
+  Expected: one `day=DD/data.parquet` per archived day; total size matches `bytesUploaded` summed across log lines. (Layout shipped as `day=DD.parquet` filename in the original plan; #699 restructured to `day=DD/` directory segment so BigQuery's Hive AUTO planner picks up `day` as a partition column.)
 
 - [ ] **Step 4: Smoke-test via BigQuery**
 

--- a/infra/terraform/observations-archive.tf
+++ b/infra/terraform/observations-archive.tf
@@ -1,9 +1,12 @@
 # Observations cold storage — see docs/plans/2026-05-20-observations-cold-storage.md.
 #
 # GCS Nearline bucket holding nightly Parquet exports of pruned observations.
-# Hive-partitioned: observations/year=YYYY/month=MM/day=DD.parquet. BigQuery
-# external table sits over the bucket for ad-hoc SQL; DuckDB and Polars
-# consume the same files locally for ML.
+# Hive-partitioned: observations/year=YYYY/month=MM/day=DD/data.parquet —
+# `day=DD` is a directory segment so BigQuery's Hive AUTO partition planner
+# picks up `[year, month, day]` as queryable partition columns (#699). The
+# stable `data.parquet` filename leaves room for future sharding if a single
+# day ever outgrows one file. BigQuery external table sits over the bucket
+# for ad-hoc SQL; DuckDB and Polars consume the same files locally for ML.
 
 resource "google_storage_bucket" "obs_archive" {
   name                        = "bird-maps-prod-obs-archive"

--- a/services/ingestor/src/archive/gcs-uploader.test.ts
+++ b/services/ingestor/src/archive/gcs-uploader.test.ts
@@ -48,7 +48,7 @@ describe('archiveAndUpload', () => {
       rows: [fakeRow],
     });
     expect(result.gcsPath).toBe(
-      'gs://bird-maps-prod-obs-archive/observations/year=2026/month=05/day=01.parquet'
+      'gs://bird-maps-prod-obs-archive/observations/year=2026/month=05/day=01/data.parquet'
     );
     // Temp key written before the final partition key
     expect(stub.saved.map(s => s.name)).toEqual([
@@ -57,7 +57,15 @@ describe('archiveAndUpload', () => {
     // Then the temp key was copied into the final partitioned key
     expect(stub.copies).toHaveLength(1);
     expect(stub.copies[0]?.from).toMatch(/^observations\/_tmp\//);
-    expect(stub.copies[0]?.to).toBe('observations/year=2026/month=05/day=01.parquet');
+    expect(stub.copies[0]?.to).toBe('observations/year=2026/month=05/day=01/data.parquet');
+    // Regression: the final key MUST have `day=DD` as a directory component
+    // (with a stable `data.parquet` filename), not `day=DD.parquet` as a
+    // filename. BigQuery's Hive AUTO partition detection only treats
+    // `key=value` directory segments as partition columns; encoding `day`
+    // in the filename hides it from the planner and forces every monthly
+    // query to open all ~30 files. See issue #699.
+    expect(stub.copies[0]?.to).toMatch(/\/year=\d{4}\/month=\d{2}\/day=\d{2}\/data\.parquet$/);
+    expect(result.gcsPath).toMatch(/\/year=\d{4}\/month=\d{2}\/day=\d{2}\/data\.parquet$/);
     // bytes returned matches the saved buffer length
     expect(result.bytes).toBe(stub.saved[0]?.bytes);
     expect(result.md5).toMatch(/^[a-f0-9]{32}$/);

--- a/services/ingestor/src/archive/gcs-uploader.ts
+++ b/services/ingestor/src/archive/gcs-uploader.ts
@@ -34,7 +34,7 @@ export interface ArchiveAndUploadOptions {
 }
 
 export interface ArchiveAndUploadResult {
-  /** Final `gs://bucket/observations/year=.../month=.../day=...parquet` path. */
+  /** Final `gs://bucket/observations/year=YYYY/month=MM/day=DD/data.parquet` path. */
   gcsPath: string;
   /** Compressed Parquet size in bytes. */
   bytes: number;
@@ -63,7 +63,13 @@ export async function archiveAndUpload(
   const md5Base64 = Buffer.from(md5, 'hex').toString('base64');
 
   const [year, month, day] = o.utcDate.split('-');
-  const finalKey = `observations/year=${year}/month=${month}/day=${day}.parquet`;
+  // Hive-partitioned layout: `day=DD` is a DIRECTORY segment with a stable
+  // `data.parquet` filename. Encoding `day` in the filename suffix
+  // (`day=DD.parquet`) hides it from BigQuery's Hive AUTO partition
+  // detection — the planner only treats `key=value` directory segments as
+  // partition columns, so every monthly query would open all ~30 files
+  // instead of pruning to one. See issue #699.
+  const finalKey = `observations/year=${year}/month=${month}/day=${day}/data.parquet`;
   const tmpKey = `observations/_tmp/${randomUUID()}.parquet`;
 
   const tmpFile = o.bucket.file(tmpKey);

--- a/services/ingestor/src/run-prune.test.ts
+++ b/services/ingestor/src/run-prune.test.ts
@@ -42,7 +42,7 @@ function makeStubArchive() {
   const archiveDay = async (utcDate: string, rows: ArchivableRow[]) => {
     calls.push({ utcDate, rowCount: rows.length });
     return {
-      gcsPath: `gs://test/observations/year=2026/month=05/day=${utcDate.slice(8)}.parquet`,
+      gcsPath: `gs://test/observations/year=2026/month=05/day=${utcDate.slice(8)}/data.parquet`,
       bytes: 1,
     };
   };
@@ -179,7 +179,7 @@ describe('runPrune', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
       const archiveDay = async () => ({
-        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21.parquet',
+        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21/data.parquet',
         bytes: 4242,
       });
       await runPrune({ pool: db.pool, retentionDays: 14, archiveDay });
@@ -198,7 +198,7 @@ describe('runPrune', () => {
         message: 'bird_ingest_archived',
         rowCount: 1,
         deletedCount: 1,
-        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21.parquet',
+        gcsPath: 'gs://bird-maps-prod-obs-archive/observations/year=2026/month=04/day=21/data.parquet',
         bytesUploaded: 4242,
       });
       expect(typeof entry.date).toBe('string');


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
  subgraph Before["Before #699 — month-grain pruning"]
    A[observations/]
    A --> B[year=2026/]
    B --> C[month=05/]
    C --> D[day=01.parquet]
    C --> E[day=02.parquet]
    C --> F[... ~30 files]
    style D fill:#fcc,stroke:#933
    style E fill:#fcc,stroke:#933
    style F fill:#fcc,stroke:#933
  end
  subgraph After["After #699 — day-grain pruning"]
    A2[observations/]
    A2 --> B2[year=2026/]
    B2 --> C2[month=05/]
    C2 --> D2[day=01/]
    C2 --> E2[day=02/]
    D2 --> G2[data.parquet]
    E2 --> H2[data.parquet]
    style G2 fill:#cfc,stroke:#393
    style H2 fill:#cfc,stroke:#393
  end
```

```mermaid
sequenceDiagram
    participant Q as BQ query<br/>WHERE year=2026 AND month=5 AND day=6
    participant P as Hive AUTO planner
    participant G as GCS scan

    Note over Q,G: Before #699 (day in filename)
    Q->>P: predicate on year,month,day
    P->>P: only year+month are partition cols
    P->>G: scan ALL files in month=05/ (~30 files / ~150 MB)
    G-->>Q: result

    Note over Q,G: After #699 (day as directory)
    Q->>P: predicate on year,month,day
    P->>P: year+month+day are partition cols
    P->>G: scan ONE file (day=06/data.parquet)
    G-->>Q: result
```

## Summary

- Restructures the GCS archive layout from `observations/year=YYYY/month=MM/day=DD.parquet` (day in filename) to `observations/year=YYYY/month=MM/day=DD/data.parquet` (day as directory segment) so BigQuery's Hive AUTO partition planner picks up `[year, month, day]` as queryable partition columns and prunes at the file level for day-grain queries.
- Per the bot audit on #699, Option 2 (add `day` as a Parquet column) is ergonomics-only — the planner still has to open every file in the month to evaluate a predicate. Only Option 1 (this PR) actually prunes; Option 2 is dropped.
- No Terraform resource change needed: `hive_partitioning_options { mode = "AUTO" }` auto-detects the third partition column once the new layout lands. The `source_uris = [".../observations/*.parquet"]` glob recurses under the prefix per BQ docs.

---

## Pre-merge migration REQUIRED — operator action before deploy

**Risk:** BigQuery's Hive AUTO partition detection requires consistent directory depth across all files matched by `source_uris`. If this PR merges and the new ingestor image deploys while the bucket still contains the two legacy 3-level files (`year=YYYY/month=MM/day=DD.parquet`) alongside the new 4-level writes (`year=YYYY/month=MM/day=DD/data.parquet`), the mixed-depth state produces undefined behavior — every query against `observations_archive.observations` could break during the window between deploy and the migration.

**Mitigation:** Operator runs the migration BEFORE the deploy rolls out, so the bucket is uniformly 4-level when the new writer comes online. Volume is tiny (2 files: a placeholder + one real archive).

Run these BEFORE merging PR #700 (the bucket must be 4-level uniform when the new writer goes live):

```sh
gcloud storage mv \
  gs://bird-maps-prod-obs-archive/observations/year=1970/month=01/day=01.parquet \
  gs://bird-maps-prod-obs-archive/observations/year=1970/month=01/day=01/data.parquet \
  --project=bird-maps-prod

gcloud storage mv \
  gs://bird-maps-prod-obs-archive/observations/year=2026/month=05/day=06.parquet \
  gs://bird-maps-prod-obs-archive/observations/year=2026/month=05/day=06/data.parquet \
  --project=bird-maps-prod

# Verify bucket is uniformly 4-level (every leaf should be /day=DD/data.parquet):
gcloud storage ls -r gs://bird-maps-prod-obs-archive/observations/
```

After migration + merge + deploy, BigQuery's `hive_partitioning_options { mode = "AUTO" }` will pick up the new 3-column partition `[year, month, day]` on the first query against the external table. **No Terraform change is needed** — Hive AUTO evaluates the file layout at query time, not at table-create time.

(The 1970 file is a 0-row placeholder; the 2026-05-06 file is the first real archive with 13,692 rows.)

If a schema refresh is needed after the migration (fallback only, should not be required):

```sh
cd infra/terraform
terraform apply -target=google_bigquery_table.observations -replace=google_bigquery_table.observations
```

---

## Screenshots

N/A — not UI

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, no UI
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs
      (5 viewports x 2 themes per #445) — N/A, not UI

## Test plan

- [x] `npm run test --workspace=@bird-watch/ingestor` — 195 tests green (was 196 on baseline; the diff is unrelated baseline state, not this PR)
- [x] New unit test added: regression assertion `/\/year=\d{4}\/month=\d{2}\/day=\d{2}\/data\.parquet$/` on both `gcsPath` (returned URI) and `copies[0].to` (final key passed to GCS), so a future regression that re-introduces filename-encoded `day=DD.parquet` fails fast in CI
- [x] `npm run build --workspace=@bird-watch/ingestor` — clean tsc
- [x] No new Playwright e2e spec (not user-visible behavior)
- [x] Manual `tsc` typecheck via build is clean

## Plan reference

Out of plan — enhancement on top of the shipped cold-storage plan (`docs/plans/2026-05-20-observations-cold-storage.md`). The plan body is updated to note the new layout at section "Naming"; historical code blocks in the plan retain the original `day=DD.parquet` shape for accuracy.

Closes #699.
