### PR TITLE
fix(ingestor): propagate cold-storage temp-delete failure + TF lifecycle mop-up (#698)

### DIFF
--- a/infra/terraform/observations-archive.tf
+++ b/infra/terraform/observations-archive.tf
@@ -34,6 +34,27 @@ resource "google_storage_bucket" "obs_archive" {
       storage_class = "ARCHIVE"
     }
   }
+
+  # Belt-and-suspenders mop-up for orphaned temp objects (issue #698).
+  # archiveAndUpload writes Parquet to `observations/_tmp/<uuid>.parquet`
+  # then server-side-copies to the final partition key and deletes the
+  # temp. The application-level cleanup now propagates delete failures
+  # (so runPrune skips the source-row DELETE on failure), but a process
+  # crash between copy and delete still strands a temp object. This rule
+  # guarantees those orphans never accumulate: anything under
+  # `observations/_tmp/` older than 1 day is auto-deleted. The 1-day
+  # window is generous — temps live for milliseconds in the happy path —
+  # and avoids racing a long-running run that has already passed the
+  # md5 check but is still mid-copy.
+  lifecycle_rule {
+    condition {
+      age            = 1
+      matches_prefix = ["observations/_tmp/"]
+    }
+    action {
+      type = "Delete"
+    }
+  }
 }
 
 # Ingestor SA writes nightly Parquet exports. Object-level role; no admin

--- a/services/ingestor/src/archive/gcs-uploader.test.ts
+++ b/services/ingestor/src/archive/gcs-uploader.test.ts
@@ -128,4 +128,66 @@ describe('archiveAndUpload', () => {
     expect(finalCopy).not.toHaveBeenCalled();
     expect(tempDelete).toHaveBeenCalled();
   });
+
+  it('logs warn + propagates when temp-delete fails after a successful copy (issue #698)', async () => {
+    // Regression for #698 — `.catch(() => {})` on the post-copy delete
+    // swallowed the error silently, leaving orphan _tmp/<uuid>.parquet
+    // objects in the bucket AND letting runPrune proceed to DELETE the
+    // observation rows even though the cleanup half of the archive
+    // pipeline silently failed. The fix is to log the failure with a
+    // structured `archive_temp_cleanup_failed` entry and re-throw so the
+    // caller (runPrune) marks the run as failed and skips the DB DELETE.
+    const tempDeleteErr = new Error('GCS 503 temp-delete');
+    const tempDelete = vi.fn(async () => { throw tempDeleteErr; });
+    const finalCopy = vi.fn(async () => {});
+    const bucket = {
+      file: (name: string) => {
+        if (name.startsWith('observations/_tmp/')) {
+          return {
+            save: vi.fn(async (buf: Buffer, opts?: { metadata?: { md5Hash?: string } }) => {
+              // Stash the md5 on the closure so getMetadata can echo it
+              // back, mirroring the happy-path stub above.
+              (bucket as unknown as { _md5?: string })._md5 = opts?.metadata?.md5Hash;
+              void buf;
+            }),
+            getMetadata: vi.fn(async () => [
+              { md5Hash: (bucket as unknown as { _md5?: string })._md5, size: '1' },
+            ]),
+            delete: tempDelete,
+            copy: finalCopy,
+            name,
+          };
+        }
+        return {
+          save: vi.fn(),
+          getMetadata: vi.fn(),
+          delete: vi.fn(),
+          copy: vi.fn(),
+          name,
+        };
+      },
+    };
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(archiveAndUpload({
+        bucket: bucket as never,
+        bucketName: 'bird-maps-prod-obs-archive',
+        utcDate: '2026-05-01',
+        rows: [fakeRow],
+      })).rejects.toThrow(/GCS 503 temp-delete/);
+      expect(finalCopy).toHaveBeenCalled();
+      expect(tempDelete).toHaveBeenCalled();
+      // Exactly one structured warn was emitted with the expected fields.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const arg = warnSpy.mock.calls[0]?.[0];
+      expect(typeof arg).toBe('string');
+      const parsed = JSON.parse(arg as string) as Record<string, unknown>;
+      expect(parsed.severity).toBe('WARNING');
+      expect(parsed.message).toBe('archive_temp_cleanup_failed');
+      expect(parsed.tempPath).toMatch(/^observations\/_tmp\//);
+      expect(parsed.error).toBe('GCS 503 temp-delete');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/services/ingestor/src/archive/gcs-uploader.ts
+++ b/services/ingestor/src/archive/gcs-uploader.ts
@@ -52,8 +52,12 @@ export interface ArchiveAndUploadResult {
  * The temp key includes a UUID so two concurrent runs (e.g. an operator
  * triggered a manual run while the scheduled one is mid-flight) cannot
  * collide on the temp key. Orphaned `_tmp/<uuid>` objects from a crashed
- * run are cleaned by a separate lifecycle rule (optional follow-up — the
- * write volume is low enough that orphans don't materially impact cost).
+ * run are mopped up by the `observations/_tmp/`-scoped 1-day lifecycle
+ * rule on the bucket (see `infra/terraform/observations-archive.tf`).
+ * That is belt-and-suspenders defense — the primary cleanup is the
+ * post-copy `delete()` below, whose failure is now propagated (issue
+ * #698) so a silent half-success can't strand orphans AND let the
+ * caller DELETE the source rows.
  */
 export async function archiveAndUpload(
   o: ArchiveAndUploadOptions
@@ -84,11 +88,19 @@ export async function archiveAndUpload(
 
   // Atomic rename via copy + delete. GCS does not have a server-side
   // move; copy is server-side (no bytes traverse the client) and
-  // delete is a single op.
+  // delete is a single op. The delete failure is propagated (issue
+  // #698) so runPrune marks the run as failed and skips the source-
+  // row DELETE; the bucket's `observations/_tmp/` 1-day lifecycle
+  // rule will mop up the orphan on the next sweep.
   await tmpFile.copy(o.bucket.file(finalKey));
-  await tmpFile.delete().catch(() => {
-    // Non-fatal: the final write succeeded; orphan _tmp objects are
-    // cleaned by a separate lifecycle rule (optional follow-up).
+  await tmpFile.delete().catch((err: unknown) => {
+    console.warn(JSON.stringify({
+      severity: 'WARNING',
+      message: 'archive_temp_cleanup_failed',
+      tempPath: tmpKey,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+    throw err;
   });
 
   return {


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant runPrune
    participant archiveAndUpload
    participant GCS

    runPrune->>archiveAndUpload: rows for day=DD
    archiveAndUpload->>GCS: PUT _tmp/<uuid>.parquet
    archiveAndUpload->>GCS: HEAD _tmp/<uuid>.parquet (md5 verify)
    archiveAndUpload->>GCS: COPY _tmp -> year=YYYY/month=MM/day=DD.parquet
    archiveAndUpload->>GCS: DELETE _tmp/<uuid>.parquet
    alt delete throws (transient 5xx, network)
        Note over archiveAndUpload: OLD: .catch(() => {}) swallowed it
        Note over archiveAndUpload: NEW: log archive_temp_cleanup_failed + re-throw
        archiveAndUpload-->>runPrune: reject(err)
        runPrune-->>runPrune: skip DB DELETE for this day
    else delete succeeds
        archiveAndUpload-->>runPrune: { gcsPath, bytes, md5 }
        runPrune->>runPrune: DELETE observations for day=DD
    end

    Note over GCS: belt-and-suspenders<br/>lifecycle: observations/_tmp/<br/>age=1 -> Delete
```

## Summary

- Resolves #698: the post-copy `.catch(() => {})` in `archiveAndUpload` silently absorbed transient GCS errors on the temp-key delete, leaving orphan `_tmp/<uuid>.parquet` objects AND letting `runPrune` proceed to DELETE the source rows because `archiveAndUpload` had resolved successfully.
- App fix: replace the swallowed catch with a structured `archive_temp_cleanup_failed` warn log and re-throw, so `runPrune` marks the run failed and skips the source-row DELETE. The misleading code comment that pointed at a non-existent lifecycle rule now references the new one.
- Infra fix: add a `matches_prefix = ["observations/_tmp/"]` 1-day Delete lifecycle rule to `google_storage_bucket.obs_archive` as belt-and-suspenders defense for the residual case where the process dies between copy and delete (no chance for the catch handler to fire).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — 196/196 pass (4/4 in `gcs-uploader.test.ts` including the new `archive_temp_cleanup_failed` regression)
- [x] New regression test covers temp-upload OK -> server-copy OK -> temp-delete throws path; asserts warn log shape (`severity`, `message`, `tempPath`, `error`) and that `archiveAndUpload` rejects so the caller surfaces the failure
- [x] `npm run build -w @bird-watch/ingestor` — clean tsc
- [x] `terraform fmt -check observations-archive.tf` — clean
- [x] `terraform validate` — Success! The configuration is valid.
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` changes

### Operator post-merge

Scoped apply (no other resources should drift):

```sh
cd infra/terraform
terraform apply -target=google_storage_bucket.obs_archive
```

Expected plan: one in-place update to `google_storage_bucket.obs_archive` adding the second `lifecycle_rule` block (`age=1`, `matches_prefix=["observations/_tmp/"]`, `action.type=Delete`). No replacement, no other resources touched. `prevent_destroy = true` is preserved.

## Plan reference

Part of Plan 11 (`docs/plans/2026-05-20-observations-cold-storage.md`) — post-T8 follow-up surfaced by the bot review on #698. Plan doc unmodified by this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)