### PR TITLE
fix(monitoring): retype 3 archive log-metrics INT64/DELTA so dashboard ALIGN_SUM works

### DIFF
--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -464,6 +464,15 @@ resource "google_project_iam_audit_config" "monitoring_data_read" {
 # in each filter drop malformed entries during a future emit-shape
 # regression rather than landing garbage into the metric stream — matches
 # the pattern in `bird-ingest-run-completed` above.
+#
+# Type choice: DELTA INT64 (not DISTRIBUTION) so the dashboard's per-day
+# ALIGN_SUM aggregation works. Sums of distributions are undefined in GCP
+# Monitoring — DISTRIBUTION-typed metrics under ALIGN_SUM render "0 time
+# series" on xyChart widgets. INT64/DELTA matches `bird-container-crash`
+# and `bird-watch-dashboard-opened` above; the value_extractor pulls the
+# scalar emit field straight onto the time series. The PR-697 bot review
+# flagged this exact concern as a narrow non-blocking risk; this PR
+# realizes the follow-up.
 
 resource "google_logging_metric" "archived_row_count" {
   name = "bird-ingest-archived-row-count"
@@ -475,18 +484,11 @@ resource "google_logging_metric" "archived_row_count" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "DISTRIBUTION"
+    value_type   = "INT64"
     unit         = "1"
     display_name = "Observations archived per day (rowCount)"
   }
   value_extractor = "EXTRACT(jsonPayload.rowCount)"
-  bucket_options {
-    exponential_buckets {
-      num_finite_buckets = 32
-      growth_factor      = 2
-      scale              = 1000 # row counts span 1k (AZ-only) → ~5M (national)
-    }
-  }
 }
 
 resource "google_logging_metric" "archived_bytes_uploaded" {
@@ -499,18 +501,11 @@ resource "google_logging_metric" "archived_bytes_uploaded" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "DISTRIBUTION"
+    value_type   = "INT64"
     unit         = "By"
     display_name = "Parquet bytes uploaded to GCS per day"
   }
   value_extractor = "EXTRACT(jsonPayload.bytesUploaded)"
-  bucket_options {
-    exponential_buckets {
-      num_finite_buckets = 32
-      growth_factor      = 2
-      scale              = 100000 # ~100 KB scale spans 100 KB (AZ tiny day) → ~400 MB (national daily peak)
-    }
-  }
 }
 
 # Parity-check metric. The T2 invariant: archive-then-delete is atomic per
@@ -529,16 +524,9 @@ resource "google_logging_metric" "archived_deleted_count" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "DISTRIBUTION"
+    value_type   = "INT64"
     unit         = "1"
     display_name = "Observations deleted per day post-archive (deletedCount)"
   }
   value_extractor = "EXTRACT(jsonPayload.deletedCount)"
-  bucket_options {
-    exponential_buckets {
-      num_finite_buckets = 32
-      growth_factor      = 2
-      scale              = 1000
-    }
-  }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A["bird_ingest_archived<br/>log emit<br/>(rowCount, bytesUploaded, deletedCount)"]
    B["3 google_logging_metric<br/>DELTA / INT64<br/>(was DISTRIBUTION)"]
    C["dashboard widgets<br/>aggregation { perSeriesAligner = ALIGN_SUM }<br/>(unchanged)"]
    D["xyChart tile<br/>renders daily sum"]

    A --> B
    B --> C
    C --> D

    E["BEFORE: DISTRIBUTION under ALIGN_SUM<br/>= undefined behavior<br/>= '0 time series' on the widget"]
    style E fill:#ffe6e6,stroke:#a00
    B -.was.-> E
```

## Summary

- PR #697 typed 3 archive log-metrics as DELTA DISTRIBUTION but built 4 dashboard widgets that use `perSeriesAligner = ALIGN_SUM`. Sums of distributions are undefined in GCP Monitoring, so the 3 archive widgets render "0 time series" despite valid data sitting in the metric stream.
- Fix: retype the 3 metrics to DELTA INT64 (drop `bucket_options`, flip `value_type`). Pattern matches the existing `bird-container-crash` and `bird-watch-dashboard-opened` metrics in the same file. The `value_extractor` keeps pulling the scalar emit field onto the time series; ALIGN_SUM sums per-day scalar emits into a daily aggregate.
- Dashboard tiles in `infra/terraform/monitoring-dashboard.tf` are intentionally untouched — they were already correct; only the metric type was wrong.

The PR-697 bot review flagged this exact concern as a narrow non-blocking risk: https://github.com/julianken/bird-sight-system/pull/697#pullrequestreview-4333741995. This PR closes that loop.

## Screenshots

N/A — not UI (Terraform / GCP Monitoring config only).

## Test plan

- [x] `terraform fmt -check infra/terraform/monitoring.tf` — clean
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] Scoped `terraform plan -target=google_logging_metric.archived_row_count -target=google_logging_metric.archived_bytes_uploaded -target=google_logging_metric.archived_deleted_count` — `Plan: 0 to add, 3 to change, 0 to destroy`. Each change drops `bucket_options { exponential_buckets { ... } }` and flips `metric_descriptor.value_type` from `DISTRIBUTION` to `INT64`. No other resources touched.
- [x] Read-through of `monitoring-dashboard.tf` Row 5 confirms the 3 archive widgets (Tile 5.1 row count, Tile 5.2 bytes, Tile 5.3 parity) all use `perSeriesAligner = "ALIGN_SUM"` and `crossSeriesReducer = "REDUCE_SUM"` — exactly the aggregation that INT64/DELTA supports cleanly.

### Operator follow-up — scoped `terraform apply`

Plan output shows the change as **in-place** (`3 to change`), but GCP rejects in-place `value_type` mutation on a log-based metric. The likely operator path is delete-then-recreate. Two equivalent routes:

**Route A (recommended) — gcloud delete + terraform apply:**

```sh
gcloud logging metrics delete bird-ingest-archived-row-count       --project=bird-maps-prod --quiet
gcloud logging metrics delete bird-ingest-archived-bytes-uploaded  --project=bird-maps-prod --quiet
gcloud logging metrics delete bird-ingest-archived-deleted-count   --project=bird-maps-prod --quiet

cd infra/terraform
terraform state rm \
  google_logging_metric.archived_row_count \
  google_logging_metric.archived_bytes_uploaded \
  google_logging_metric.archived_deleted_count

terraform apply \
  -target=google_logging_metric.archived_row_count \
  -target=google_logging_metric.archived_bytes_uploaded \
  -target=google_logging_metric.archived_deleted_count
```

**Route B — let terraform try, fall back if rejected:**

```sh
cd infra/terraform
terraform apply \
  -target=google_logging_metric.archived_row_count \
  -target=google_logging_metric.archived_bytes_uploaded \
  -target=google_logging_metric.archived_deleted_count
# If apply fails with "value_type cannot be modified", drop to Route A.
```

**Data loss:** the single existing data point (May 21 03:45 UTC, rowCount 13692, one nightly prune emit) will be discarded. Acceptable — 1 point with no operational value; the next nightly prune emits at the new type and the widgets start filling in immediately.

## Plan reference

Out of plan — follow-up fix to PR #697 (T8 of `docs/plans/2026-05-20-observations-cold-storage.md`). The original T8 work shipped the metrics + widgets together; the type/aggregation mismatch was flagged in the bot review as a narrow non-blocking risk and is now realized.