### PR TITLE
infra(cloudflare): cache rule for /api/* — closes #705

### DIFF
--- a/infra/terraform/cache-rule.tf
+++ b/infra/terraform/cache-rule.tf
@@ -1,0 +1,44 @@
+# CDN cache rule for /api/* — addresses the 0.06% baseline hit ratio
+# documented in issue #705 (May 22 2026 prod investigation).
+#
+# Cloudflare's default cache key already includes the full URI with query
+# string, so we only need `ignore_query_strings_order` here. Both ttl modes
+# use `respect_origin` so the origin's `Cache-Control: public, s-maxage=300,
+# stale-while-revalidate=600` is the single source of truth for TTLs.
+#
+# The expression mirrors infra/terraform/rate-limit.tf exactly — same scope,
+# excluding /api/admin/. Phase is http_request_cache_settings; rate-limit
+# is http_ratelimit; the two rulesets do not conflict (different phases).
+#
+# Provider v4.20 uses HCL block syntax (not v5 list-of-objects). See
+# rate-limit.tf for the canonical pattern in this repo.
+
+resource "cloudflare_ruleset" "api_cache" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "api-cache-rule"
+  description = "Cache /api/* responses respecting origin Cache-Control. See issue #705."
+  kind        = "zone"
+  phase       = "http_request_cache_settings"
+
+  rules {
+    description = "Cache /api/* per origin s-maxage"
+    expression  = "(starts_with(http.request.uri.path, \"/api/\") and not starts_with(http.request.uri.path, \"/api/admin/\"))"
+    action      = "set_cache_settings"
+    enabled     = true
+
+    action_parameters {
+      cache = true
+
+      edge_ttl {
+        mode = "respect_origin"
+      }
+      browser_ttl {
+        mode = "respect_origin"
+      }
+
+      cache_key {
+        ignore_query_strings_order = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser
    participant CFEdge as Cloudflare Edge
    participant ReadAPI as Cloud Run (read-api)
    participant DB as Cloud SQL

    Note over Browser,DB: Before this PR (0.06% hit ratio)
    Browser->>CFEdge: GET /api/observations?bbox=...
    CFEdge->>ReadAPI: pass-through (no rule matches /api/*)
    ReadAPI->>DB: SELECT ...
    DB-->>ReadAPI: rows
    ReadAPI-->>CFEdge: 200 + Cache-Control: s-maxage=300
    CFEdge-->>Browser: 200 (cf-cache-status: DYNAMIC)

    Note over Browser,DB: After this PR
    Browser->>CFEdge: GET /api/observations?bbox=... (1st)
    CFEdge->>ReadAPI: MISS — pull origin
    ReadAPI->>DB: SELECT ...
    DB-->>ReadAPI: rows
    ReadAPI-->>CFEdge: 200 + Cache-Control: s-maxage=300
    CFEdge-->>Browser: 200 (cf-cache-status: MISS)

    Browser->>CFEdge: GET /api/observations?bbox=... (2nd, within 5min)
    CFEdge-->>Browser: 200 (cf-cache-status: HIT) — no origin hit
```

## Summary

- Cloudflare's default cache only honors a fixed list of static file extensions; `/api/*` is excluded by omission, so the read-api's `Cache-Control: public, s-maxage=300, stale-while-revalidate=600` is silently ignored at the edge. Over the last 30 days that's **25 of 43,070 requests cached (0.06%)** — every other request hits Cloud Run → Cloud SQL.
- Adds one `cloudflare_ruleset` in phase `http_request_cache_settings` that opts `/api/*` into caching with `respect_origin` for both edge and browser TTL. Origin headers remain the single source of truth — no TTL constants duplicated in Terraform.
- Expression mirrors `infra/terraform/rate-limit.tf` exactly (excludes `/api/admin/`). The two rulesets live in different phases (`http_ratelimit` vs `http_request_cache_settings`) so there's no conflict; both fire independently. Expected lift: 40–60% hit ratio, ~26k fewer Cloud Run invocations/month, net cost change $0.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform plan -target=cloudflare_ruleset.api_cache` — exactly **1 to add, 0 to change, 0 to destroy**
- [ ] **Pre-existing unrelated drift in full plan** (not introduced by this PR): the unscoped plan shows 6 in-place updates to GCP resources (`google_cloud_run_v2_job.ingestor`, `google_cloud_run_v2_job.ingestor_photos`, three `google_logging_metric.*`, and `google_monitoring_dashboard.bird_watch_overview`). These are out of scope for this PR — the operator should apply scoped: `terraform apply -target=cloudflare_ruleset.api_cache`
- [ ] **Post-merge verification** (operator runs after scoped apply):
  ```sh
  # Wait ≥60s after `terraform apply` for the rule to propagate to edge
  sleep 90
  curl -sI "https://api.bird-maps.com/api/observations?since=14d&bbox=-100,30,-90,40&zoom=4" | grep -i cf-cache-status
  # First hit: MISS
  sleep 5
  curl -sI "https://api.bird-maps.com/api/observations?since=14d&bbox=-100,30,-90,40&zoom=4" | grep -i cf-cache-status
  # Second hit: HIT
  ```
- [ ] **Cache-key isolation check** (operator, post-apply):
  ```sh
  # Different bbox = different cache entry
  curl -sI "https://api.bird-maps.com/api/observations?since=14d&bbox=-110,30,-90,40&zoom=4" | grep cf-cache-status  # MISS
  ```
- [ ] **Admin path bypass check** (operator, post-apply):
  ```sh
  curl -sI "https://api.bird-maps.com/api/admin/silhouettes/list" | grep cf-cache-status  # BYPASS / DYNAMIC
  ```

## Plan reference

Out of plan — operational fix from the May 22 2026 prod investigation documented in #705. Closes #705.