### PR TITLE
infra(cloudflare): proxy api.bird-maps.com through CF — closes #707

### DIFF
--- a/infra/terraform/frontend.tf
+++ b/infra/terraform/frontend.tf
@@ -30,14 +30,18 @@ resource "cloudflare_record" "root" {
 # Cloud Run rejects requests whose Host header is not a registered domain
 # mapping, so pointing straight at the run.app URL returns 404. The canonical
 # path is a CNAME to ghs.googlehosted.com plus a google_cloud_run_domain_mapping
-# below; proxied MUST be false so Cloud Run's own Let's Encrypt cert serves
-# (proxying through Cloudflare breaks the SSL handshake).
+# below. `proxied = true` was enabled 2026-05-22 (issue #707) after verifying
+# the zone's SSL mode is `full` (not Full(strict)) — Full skips origin cert
+# chain validation, so Cloud Run's Let's Encrypt cert for api.bird-maps.com
+# is accepted. With proxied=true, CF rate-limit and cache-rule rulesets now
+# apply to /api/* traffic; previously they were no-ops because traffic
+# bypassed CF entirely.
 resource "cloudflare_record" "api" {
   zone_id = var.cloudflare_zone_id
   name    = "api"
   type    = "CNAME"
   content = "ghs.googlehosted.com"
-  proxied = false
+  proxied = true
   ttl     = 1
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Client[Browser] -->|HTTPS| CF[Cloudflare edge]
    CF -->|rate-limit ruleset + cache rule #706| Origin[Cloud Run<br/>read-api]

    classDef wasBypassed fill:#fee,stroke:#900,stroke-dasharray:4
    classDef nowActive fill:#efe,stroke:#090
    class CF nowActive
```

Before: `Client → ghs.googlehosted.com → Cloud Run`. The CF zone's rulesets
(rate-limit, cache-rule from #706) never fired because traffic for
`api.bird-maps.com` bypassed the CF edge entirely.

After: `Client → Cloudflare → Cloud Run`. Same ruleset config — now load-
bearing because requests transit the proxy.

## Summary

- Flips `cloudflare_record.api` from `proxied = false` → `proxied = true` so
  `api.bird-maps.com` traffic transits the Cloudflare edge. This activates
  the existing rate-limit ruleset and the cache rule from #706 — both of
  which are no-ops today because the subdomain bypasses CF.
- Updates the comment block above the resource to record the new state and
  cite the SSL-mode verification (zone is on `full`, not Full(strict); Full
  skips origin cert chain validation, so Cloud Run's Let's Encrypt cert is
  accepted at the CF→origin hop).
- Resource-level diff is one field; no DNS target change (`content` is still
  `ghs.googlehosted.com`), no `cloudflare_record.root` touch, no other CF
  resources touched.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check` — clean on `frontend.tf`
- [x] `terraform validate` — Success! The configuration is valid.
- [x] `terraform plan -target=cloudflare_record.api` — `Plan: 0 to add, 1 to change, 0 to destroy.` The only diff is `proxied: false -> true`; all 12 other attributes unchanged.
- [ ] Post-apply verification (operator follow-up):
  ```sh
  sleep 60  # CF DNS propagation
  dig +short api.bird-maps.com  # should resolve to a Cloudflare IP (104.x or 172.67.x), not ghs.googlehosted.com
  curl -sI "https://api.bird-maps.com/api/observations?since=14d&bbox=-100,30,-90,40&zoom=4" | grep -iE "cf-ray|cf-cache-status"
  # cf-ray header should be present (proves CF is now in the path)
  # cf-cache-status: MISS first time, then HIT on retry (proves PR #706's cache rule applies)
  ```
- CI gate (test/lint/build/e2e + lockfile + tf-drift) handled by Mergify queue.

## Risks & rollback

If proxying breaks the SSL handshake despite the Full mode setting (i.e.
the original `frontend.tf` comment turns out to have been right for a
different reason than stated), revert by setting `proxied = false` via
`terraform apply -target=cloudflare_record.api` from a manual edit, OR by
reverting the merge commit. RTO ~5 min. No data risk; pure routing change.

## Plan reference

Out of plan — Option A from architecture issue #707 (rate-limit + cache
rule from #706 are no-ops until CF is actually in the path). Closes #707
and unblocks the cache-rule activation tracked in #705.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)