### PR TITLE
fix(infra): grant storage.objects.delete to ingestor SA on obs archive bucket — closes #709

### DIFF
--- a/infra/terraform/observations-archive.tf
+++ b/infra/terraform/observations-archive.tf
@@ -60,22 +60,25 @@ resource "google_storage_bucket" "obs_archive" {
   }
 }
 
-# Ingestor SA writes nightly Parquet exports. Object-level role; no admin
-# or bucket-level binding (the ingestor never lists or deletes archive
-# objects).
-resource "google_storage_bucket_iam_member" "ingestor_archive_writer" {
+# Ingestor SA needs create + get + delete on this bucket's objects.
+# The atomic-rename uploader (services/ingestor/src/archive/gcs-uploader.ts)
+# does four object-level operations:
+#   1. PUT  observations/_tmp/<uuid>.parquet  (storage.objects.create)
+#   2. HEAD temp object for md5 verify        (storage.objects.get)
+#   3. Server-side COPY to final partition    (storage.objects.create)
+#   4. DELETE the temp object                 (storage.objects.delete) ← was
+#      missing from the prior objectCreator + objectViewer split; caused the
+#      2026-05-22 prune-job failure (#709).
+#
+# roles/storage.objectUser covers all four operations (create, get, list,
+# update, delete) at object scope with no bucket-level or IAM-level powers.
+# A narrower IAM condition scoping delete to observations/_tmp/* was
+# considered and rejected as overkill: the lifecycle rule already bounds
+# _tmp/ retention to 1 day, and conditions add operational drag with no
+# real security gain given the bucket's private-only, single-SA access model.
+resource "google_storage_bucket_iam_member" "ingestor_archive_user" {
   bucket = google_storage_bucket.obs_archive.name
-  role   = "roles/storage.objectCreator"
-  member = "serviceAccount:${google_service_account.ingestor.email}"
-}
-
-# Ingestor SA also reads — needed for the temp-object → atomic-rename
-# uploader pattern (T2): we PUT to a temp key, verify the md5, then
-# rewrite to the final partition key. The objectCreator role does not
-# include read.
-resource "google_storage_bucket_iam_member" "ingestor_archive_reader" {
-  bucket = google_storage_bucket.obs_archive.name
-  role   = "roles/storage.objectViewer"
+  role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.ingestor.email}"
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ingestor as bird-ingestor-prune (Cloud Run Job)
    participant GCS as gs://bird-maps-prod-obs-archive

    Ingestor->>GCS: PUT observations/_tmp/<uuid>.parquet (objectCreator ✓)
    Ingestor->>GCS: HEAD temp — md5 verify (objectViewer ✓)
    Ingestor->>GCS: server-side COPY to observations/year=.../data.parquet (objectCreator ✓)
    Ingestor->>GCS: DELETE observations/_tmp/<uuid>.parquet (objectUser ✓ — was ✗)
```

Before this PR: the SA had `objectCreator` + `objectViewer`. Step 4 requires `storage.objects.delete`, which neither role includes. The prune job swallowed the error until PR #701 made it fatal; today's run was the first to fail visibly.

After this PR: `objectUser` is a single binding that covers create + get + list + update + delete at object scope, no bucket/IAM-level powers.

## Summary

- Replaces the two separate `objectCreator` + `objectViewer` IAM bindings on `bird-maps-prod-obs-archive` with a single `objectUser` binding — the minimal role that covers all four object-level operations the atomic-rename uploader performs.
- Fixes the `storage.objects.delete` permission gap that caused the 2026-05-22 `bird-ingestor-prune` execution to fail with exit code 1 on both retry attempts (closes #709).
- Risk is low: blast radius is identical (same SA, same bucket, same object-scope-only boundary); `prevent_destroy = true` on the bucket is unchanged; IAM condition scoping delete to `_tmp/` was considered and rejected as overkill per the issue spec.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform fmt -check observations-archive.tf` — exits 0
- [x] `terraform validate` — reports "Success! The configuration is valid." (providers downloaded via `terraform init -backend=false`)
- [ ] `terraform plan -target=google_storage_bucket_iam_member.ingestor_archive_writer -target=google_storage_bucket_iam_member.ingestor_archive_reader -target=google_storage_bucket_iam_member.ingestor_archive_user` — expected: one create (`ingestor_archive_user`), two destroys (`ingestor_archive_writer`, `ingestor_archive_reader`), no other resources touched. Local run blocked by GCS remote-state backend (no creds in worktree); the `terraform-plan-drift-check` CI workflow will exercise this from the PR.
- [ ] Manual post-merge smoke: `gcloud run jobs execute bird-ingestor-prune --region=us-west1 --project=bird-maps-prod --wait` exits 0; `bird_ingest_archived` INFO logs visible; `gs://bird-maps-prod-obs-archive/observations/_tmp/` empty after the run.
  - Note: two orphan `_tmp/<uuid>.parquet` objects from today's failed attempts (`65295595-...` and `77321236-...`) will still be present until the 1-day lifecycle rule sweeps them (within 24h of 2026-05-22T10:05Z). Their UUIDs will differ from any `_tmp/` objects created by a fresh post-merge run — do not conflate pre-existing orphans with a new failure.
- [ ] 2026-05-23 10:05 UTC scheduled run shows `succeededCount: 1` in the executions list.

## Plan reference

Part of Plan 11 (observations cold storage), hot-fix follow-up. See `docs/plans/2026-05-20-observations-cold-storage.md`. This fix addresses the IAM gap left by cold-storage T2-T4 (PR #696) and surfaced by PR #701 making temp-delete failures fatal.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)