### PR TITLE
feat(ingestor): post-ingestion CF cache-warm for popular bboxes

### DIFF
--- a/infra/terraform/ingestor.tf
+++ b/infra/terraform/ingestor.tf
@@ -168,6 +168,21 @@ resource "google_cloud_run_v2_job" "ingestor" {
             }
           }
         }
+        # cache-warm kind (issue #711) — post-ingestion CF cache pre-fetch
+        # runs on this shared `bird-ingestor` Job. The kind opens no DB pool
+        # and makes no eBird API calls, but binding the heartbeat env keeps
+        # the per-kind monitor coverage uniform with the other kinds on this
+        # job. cli.ts derives `HEALTHCHECKS_URL_CACHE_WARM` from the kind name
+        # at runtime, so the env var name must match exactly.
+        env {
+          name = "HEALTHCHECKS_URL_CACHE_WARM"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.healthchecks_url["cache-warm"].secret_id
+              version = "latest"
+            }
+          }
+        }
 
         # Cloud SQL Auth Proxy socket mount — Stage 2 of the Neon→Cloud SQL
         # migration (docs/plans/2026-05-17-cloud-sql-migration.md §3.2).
@@ -260,6 +275,52 @@ resource "google_cloud_scheduler_job" "ingest_recent" {
     oauth_token {
       service_account_email = google_service_account.scheduler.email
     }
+  }
+
+  depends_on = [google_project_service.scheduler]
+}
+
+# ── Post-ingestion Cloudflare cache-warm (issue #711) ────────────────────
+#
+# Fires 2 minutes after each `:00` and `:30` recent-ingest tick so the warm
+# job runs *after* the cache-invalidating ingest completes. Walks ~77 popular
+# bbox URLs sequentially (concurrency=1 + 200ms sleep) and pre-fetches them
+# through Cloudflare's edge cache. Next real user pan into the same area is
+# then a HIT instead of a MISS.
+#
+# Concurrent execution safety: Cloud Run Jobs run independent executions of
+# the same job in parallel — if `recent` exceeds the +2 min offset, the
+# `:02` / `:32` cache-warm execution starts on the same job as a second
+# concurrent execution. This is safe because cache-warm opens no DB pool
+# (pure HTTP, no eBird API calls), so there is zero connection-pool
+# contention with other `bird-ingestor` kinds running concurrently.
+resource "google_cloud_scheduler_job" "cache_warm" {
+  name      = "bird-cache-warm"
+  region    = var.gcp_region
+  schedule  = "2,32 * * * *"
+  time_zone = "Etc/UTC"
+
+  http_target {
+    uri         = local.job_run_url
+    http_method = "POST"
+    headers     = { "Content-Type" = "application/json" }
+    body = base64encode(jsonencode({
+      overrides = {
+        containerOverrides = [{ args = ["cache-warm"] }]
+      }
+    }))
+    oauth_token {
+      service_account_email = google_service_account.scheduler.email
+    }
+  }
+
+  # One retry is enough — the warm job is best-effort. Each cycle is
+  # independent, so a missed run silently falls through to the next 30-min
+  # tick. The retry mainly absorbs transient HTTP 5xx from the Cloud Run
+  # Jobs control plane (matches the per-state backfill retry shape).
+  retry_config {
+    retry_count          = 1
+    min_backoff_duration = "30s"
   }
 
   depends_on = [google_project_service.scheduler]

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -26,7 +26,7 @@ locals {
   # SendGrid 2xx (analysis report §F7); a sender-auth misconfig that lets
   # SendGrid accept but Gmail reject will still trip the heartbeat eventually
   # (no ping = HC alarms), but a tighter delivery-webhook gate is a follow-up.
-  healthchecks_kinds = ["recent", "backfill", "hotspots", "taxonomy", "photos", "descriptions", "prune", "digest"]
+  healthchecks_kinds = ["recent", "backfill", "hotspots", "taxonomy", "photos", "descriptions", "prune", "digest", "cache-warm"]
 }
 
 resource "google_secret_manager_secret" "healthchecks_url" {

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -18,6 +18,7 @@ function makeDeps(overrides: Partial<CliDeps> = {}): CliDeps {
     runPhotos: vi.fn(),
     runDescriptions: vi.fn(),
     runPrune: vi.fn(),
+    runCacheWarm: vi.fn(),
     fetchWikipediaSummary: vi.fn(),
     fetchInatTaxon: vi.fn(),
     ...overrides,
@@ -417,6 +418,85 @@ describe('runCli', () => {
   it("Unknown-kind error string includes 'prune' so operators see the new kind", async () => {
     const deps = makeDeps();
     await expect(runCli('bogus', deps)).rejects.toThrow(/prune/);
+  });
+
+  // ── cache-warm kind (issue #711) ──────────────────────────────────────
+  // The cache-warm kind is pure HTTP — no DB pool, no eBird API. Its early
+  // return must precede the EBIRD_API_KEY / DATABASE_URL guards so a manual
+  // `gcloud run jobs execute bird-ingestor --args=cache-warm` works on a job
+  // execution where those env vars are unset (or being rotated).
+
+  it("'cache-warm' kind dispatches to runCacheWarm without creating a DB pool", async () => {
+    const runCacheWarmSpy = vi.fn().mockResolvedValue({
+      total: 77, miss: 0, hit: 77, expired: 0, dynamic: 0, other: 0, error: 0,
+      p50ms: 50, p95ms: 100,
+    });
+    const deps = makeDeps({ runCacheWarm: runCacheWarmSpy });
+
+    await runCli('cache-warm', deps);
+
+    expect(runCacheWarmSpy).toHaveBeenCalledTimes(1);
+    expect(runCacheWarmSpy).toHaveBeenCalledWith({
+      baseUrl: 'https://api.bird-maps.com',
+    });
+    // Pure HTTP — no createPool / closePool.
+    expect(deps.createPool).not.toHaveBeenCalled();
+    expect(deps.closePool).not.toHaveBeenCalled();
+  });
+
+  it("'cache-warm' kind early-returns ahead of the EBIRD_API_KEY / DATABASE_URL guards", async () => {
+    // Same shape as the probe-* kinds: the operator must be able to invoke
+    // `--args=cache-warm` without standing up eBird/DB secrets in their
+    // shell. Pre-fix the EBIRD_API_KEY guard would have fired first.
+    delete process.env.EBIRD_API_KEY;
+    delete process.env.DATABASE_URL;
+    const runCacheWarmSpy = vi.fn().mockResolvedValue({
+      total: 77, miss: 77, hit: 0, expired: 0, dynamic: 0, other: 0, error: 0,
+      p50ms: 1000, p95ms: 1500,
+    });
+    const deps = makeDeps({ runCacheWarm: runCacheWarmSpy });
+
+    await runCli('cache-warm', deps);
+
+    expect(runCacheWarmSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("'cache-warm' kind pings HEALTHCHECKS_URL_CACHE_WARM on completion", async () => {
+    // Validates the env-var name derivation: kind 'cache-warm' →
+    // HEALTHCHECKS_URL_CACHE_WARM (upper-cased, hyphen → underscore).
+    process.env.HEALTHCHECKS_URL_CACHE_WARM = 'https://hc-ping.com/uuid-cw';
+    const pingSpy = vi.fn().mockResolvedValue(undefined);
+    const runCacheWarmSpy = vi.fn().mockResolvedValue({
+      total: 77, miss: 0, hit: 77, expired: 0, dynamic: 0, other: 0, error: 0,
+      p50ms: 50, p95ms: 100,
+    });
+    const deps = makeDeps({ runCacheWarm: runCacheWarmSpy, pingHeartbeat: pingSpy });
+
+    await runCli('cache-warm', deps);
+
+    expect(pingSpy).toHaveBeenCalledTimes(1);
+    expect(pingSpy).toHaveBeenCalledWith('https://hc-ping.com/uuid-cw', 'cache-warm');
+    delete process.env.HEALTHCHECKS_URL_CACHE_WARM;
+  });
+
+  it("'cache-warm' kind respects CACHE_WARM_BASE_URL env override", async () => {
+    process.env.CACHE_WARM_BASE_URL = 'http://localhost:8080';
+    const runCacheWarmSpy = vi.fn().mockResolvedValue({
+      total: 77, miss: 77, hit: 0, expired: 0, dynamic: 0, other: 0, error: 0,
+      p50ms: 0, p95ms: 0,
+    });
+    const deps = makeDeps({ runCacheWarm: runCacheWarmSpy });
+    try {
+      await runCli('cache-warm', deps);
+      expect(runCacheWarmSpy).toHaveBeenCalledWith({ baseUrl: 'http://localhost:8080' });
+    } finally {
+      delete process.env.CACHE_WARM_BASE_URL;
+    }
+  });
+
+  it("Unknown-kind error string includes 'cache-warm' so operators see the new kind", async () => {
+    const deps = makeDeps();
+    await expect(runCli('bogus', deps)).rejects.toThrow(/cache-warm/);
   });
 
   // ── Heartbeat wiring (S7) ──────────────────────────────────────────────

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -30,6 +30,7 @@ import {
   runPrune as realRunPrune,
   type RunPruneSummary,
 } from './run-prune.js';
+import { runCacheWarm as realRunCacheWarm } from './run-cache-warm.js';
 import { runDigest as realRunDigest, type SendResult } from './digest.js';
 import {
   makeSendGridSender,
@@ -68,6 +69,7 @@ export interface CliDeps {
   runPhotos: typeof realRunPhotos;
   runDescriptions: typeof realRunDescriptions;
   runPrune: typeof realRunPrune;
+  runCacheWarm: typeof realRunCacheWarm;
   runDigest?: typeof realRunDigest;
   fetchWikipediaSummary: typeof realFetchWikipediaSummary;
   fetchInatTaxon: typeof realFetchInatTaxon;
@@ -128,6 +130,30 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     if (!sciName) throw new Error('probe-taxon requires a binomial argument');
     const taxon = await deps.fetchInatTaxon(sciName);
     console.log(JSON.stringify(taxon, null, 2));
+    return;
+  }
+
+  // cache-warm: post-ingestion Cloudflare cache-warm (issue #711). Pure HTTP
+  // — no DB pool, no eBird API. Early-returns ahead of the EBIRD_API_KEY /
+  // DATABASE_URL guards so a `gcloud run jobs execute bird-ingestor
+  // --args=cache-warm` invocation does not require eBird/DB secrets to be
+  // resolvable; the shared job ships both for parity, but skipping the
+  // createPool() call here keeps cold-start fast and avoids holding a Cloud
+  // SQL connection for the duration of the 77-URL walk.
+  //
+  // Heartbeat on completion (no failure path — the runner records per-URL
+  // fetch failures into `summary.error` but does not throw, matching the
+  // Healthchecks-on-success semantics every other kind follows).
+  if (kind === 'cache-warm') {
+    const baseUrl = process.env.CACHE_WARM_BASE_URL ?? 'https://api.bird-maps.com';
+    const summary = await deps.runCacheWarm({ baseUrl });
+    // Reuse the shared HEALTHCHECKS_URL_<KIND> env-var derivation pattern so
+    // Terraform's existing for_each on local.healthchecks_kinds auto-wires
+    // the env binding when "cache-warm" is added to the list.
+    const envKey = `HEALTHCHECKS_URL_${kind.toUpperCase().replace(/-/g, '_')}`;
+    const ping = deps.pingHeartbeat ?? realPingHeartbeat;
+    await ping(process.env[envKey], kind);
+    void summary; // returned for future log-line plumbing; not used here yet
     return;
   }
 
@@ -340,7 +366,7 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
         },
       });
     } else {
-      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | digest | probe-taxon | probe-wiki`);
+      throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | cache-warm | digest | probe-taxon | probe-wiki`);
     }
     // Cloud Run / Cloud Logging splits stdout on newlines and treats each
     // resulting line as its own `textPayload` entry — pretty-printed JSON
@@ -422,6 +448,7 @@ if (isEntrypoint) {
     runPhotos: realRunPhotos,
     runDescriptions: realRunDescriptions,
     runPrune: realRunPrune,
+    runCacheWarm: realRunCacheWarm,
     runDigest: realRunDigest,
     sendDigestEmail,
     fetchMonitoringSignals: makeNullMonitoringSignalsFetcher(),

--- a/services/ingestor/src/run-cache-warm.test.ts
+++ b/services/ingestor/src/run-cache-warm.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { runCacheWarm, buildCacheWarmUrls } from './run-cache-warm.js';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('buildCacheWarmUrls', () => {
+  it('builds exactly 77 URLs: 2 CONUS + 25 metros × 3 zooms', () => {
+    const urls = buildCacheWarmUrls('https://api.bird-maps.com');
+    expect(urls).toHaveLength(77);
+  });
+
+  it('builds the two CONUS aggregated z=3 / z=4 queries first', () => {
+    const urls = buildCacheWarmUrls('https://api.bird-maps.com');
+    expect(urls[0]).toBe(
+      'https://api.bird-maps.com/api/observations?since=14d&bbox=-125,24,-66,50&zoom=3'
+    );
+    expect(urls[1]).toBe(
+      'https://api.bird-maps.com/api/observations?since=14d&bbox=-126,27,-71,51&zoom=4'
+    );
+  });
+
+  it('uses the configured baseUrl verbatim (no trailing slash duplication)', () => {
+    const urls = buildCacheWarmUrls('http://localhost:8080');
+    expect(urls[0]).toMatch(/^http:\/\/localhost:8080\/api\/observations\?/);
+  });
+
+  it('emits z=5, z=6, z=7 URLs for each metro with bboxes derived from ZOOM_HALFW', () => {
+    const urls = buildCacheWarmUrls('https://api.bird-maps.com');
+    // LA at (-118.24, 34.05); z=5 half-widths (11, 6) per spec.
+    // bbox = (lng - 11, lat - 6, lng + 11, lat + 6) = (-129.24, 28.05, -107.24, 40.05)
+    expect(urls).toContain(
+      'https://api.bird-maps.com/api/observations?since=14d&bbox=-129.24,28.05,-107.24,40.05&zoom=5'
+    );
+    // LA z=6: half-widths (5.5, 3) → bbox = (-123.74, 31.05, -112.74, 37.05)
+    expect(urls).toContain(
+      'https://api.bird-maps.com/api/observations?since=14d&bbox=-123.74,31.05,-112.74,37.05&zoom=6'
+    );
+    // LA z=7: half-widths (2.75, 1.5) → bbox = (-120.99, 32.55, -115.49, 35.55)
+    expect(urls).toContain(
+      'https://api.bird-maps.com/api/observations?since=14d&bbox=-120.99,32.55,-115.49,35.55&zoom=7'
+    );
+  });
+});
+
+describe('runCacheWarm', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('counts each cf-cache-status bucket from the response headers', async () => {
+    let callIdx = 0;
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () => {
+        // Rotate through the four buckets + one unknown across the 77 URLs.
+        // Order: miss, hit, expired, dynamic, BYPASS (other) — repeating.
+        const cycle = ['MISS', 'HIT', 'EXPIRED', 'DYNAMIC', 'BYPASS'];
+        const status = cycle[callIdx % cycle.length]!;
+        callIdx++;
+        return new HttpResponse(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { 'cf-cache-status': status, 'content-type': 'application/json' },
+        });
+      })
+    );
+
+    const summary = await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 0 });
+
+    expect(summary.total).toBe(77);
+    // 77 / 5 = 15 full cycles + 2 extras. Distribution: MISS=16, HIT=16, EXPIRED=15, DYNAMIC=15, BYPASS=15.
+    expect(summary.miss).toBe(16);
+    expect(summary.hit).toBe(16);
+    expect(summary.expired).toBe(15);
+    expect(summary.dynamic).toBe(15);
+    expect(summary.other).toBe(15);
+    expect(summary.error).toBe(0);
+  });
+
+  it('counts fetch failures into the error bucket without throwing', async () => {
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () => {
+        return HttpResponse.error();
+      })
+    );
+
+    const summary = await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 0 });
+
+    expect(summary.total).toBe(77);
+    expect(summary.error).toBe(77);
+    expect(summary.miss + summary.hit + summary.expired + summary.dynamic + summary.other).toBe(0);
+  });
+
+  it('emits a single compact bird_ingest_cache_warmed log line with the summary', async () => {
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () =>
+        new HttpResponse(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { 'cf-cache-status': 'MISS', 'content-type': 'application/json' },
+        })
+      )
+    );
+
+    await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 0 });
+
+    const emitted = logSpy.mock.calls
+      .map((args: unknown[]): unknown => {
+        try { return JSON.parse(args[0] as string); } catch { return null; }
+      })
+      .filter((o: unknown): o is Record<string, unknown> =>
+        typeof o === 'object' && o !== null
+          && (o as Record<string, unknown>).message === 'bird_ingest_cache_warmed'
+      );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      severity: 'INFO',
+      message: 'bird_ingest_cache_warmed',
+      kind: 'cache-warm',
+      total: 77,
+      miss: 77,
+      hit: 0,
+      expired: 0,
+      dynamic: 0,
+      other: 0,
+      error: 0,
+      p50ms: expect.any(Number),
+      p95ms: expect.any(Number),
+    });
+    // Single compact line — must not contain a newline (Cloud Logging
+    // splits multi-line stdout into separate textPayload entries, which
+    // would lose the jsonPayload extraction the dashboard depends on).
+    const rawLine = logSpy.mock.calls.find(
+      (args: unknown[]) =>
+        typeof args[0] === 'string' && args[0].includes('bird_ingest_cache_warmed')
+    )?.[0] as string;
+    expect(rawLine).not.toContain('\n');
+  });
+
+  it('sleeps between requests by the configured sleepMs', async () => {
+    // Use sleepMs > 0 with a spied sleep injection so we don't actually wait.
+    // The injectable sleep keeps the test fast (zero wall-clock) while still
+    // proving the runner pauses between every fetch.
+    const sleepSpy = vi.fn().mockResolvedValue(undefined);
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () =>
+        new HttpResponse(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { 'cf-cache-status': 'MISS' },
+        })
+      )
+    );
+
+    await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 200, sleep: sleepSpy });
+
+    // 77 URLs → 77 sleeps (one after each request). Concurrency=1 + 200ms
+    // sleep is load-bearing — it keeps the warm job inside the
+    // Layer-1 ratelimit's 10 req/10s ceiling. See run-cache-warm.ts header.
+    expect(sleepSpy).toHaveBeenCalledTimes(77);
+    expect(sleepSpy).toHaveBeenCalledWith(200);
+  });
+
+  it('treats lowercase / mixed-case cf-cache-status headers as the same bucket', async () => {
+    let callIdx = 0;
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () => {
+        // CF normally returns uppercase, but ANY proxy in front of CF (or a
+        // test fixture) might lowercase it — the runner must not double-count.
+        const variants = ['miss', 'Miss', 'MISS'];
+        const status = variants[callIdx % variants.length]!;
+        callIdx++;
+        return new HttpResponse(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { 'cf-cache-status': status },
+        });
+      })
+    );
+
+    const summary = await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 0 });
+    expect(summary.miss).toBe(77);
+  });
+
+  it('counts responses with no cf-cache-status header into the other bucket', async () => {
+    server.use(
+      http.get('https://api.bird-maps.com/api/observations', () =>
+        new HttpResponse(JSON.stringify({ items: [] }), { status: 200 })
+      )
+    );
+
+    const summary = await runCacheWarm({ baseUrl: 'https://api.bird-maps.com', sleepMs: 0 });
+    expect(summary.other).toBe(77);
+    expect(summary.miss).toBe(0);
+  });
+});

--- a/services/ingestor/src/run-cache-warm.ts
+++ b/services/ingestor/src/run-cache-warm.ts
@@ -1,0 +1,233 @@
+/**
+ * Post-ingestion Cloudflare cache-warm helper (issue #711).
+ *
+ * Two minutes after every `/recent` ingest cycle, this kind walks a curated
+ * list of ~77 popular bbox URLs and issues a `GET` against each so the
+ * Cloudflare edge cache is hydrated before the next real user pans into the
+ * same area. The next user's request then hits CF as a HIT instead of a MISS,
+ * concentrating Cloud SQL CPU on long-tail (rural) bboxes only.
+ *
+ * Pure HTTP — no DB pool, no eBird API calls. The `cache-warm` branch in
+ * `cli.ts` is responsible for skipping `createPool({...})` for this kind.
+ *
+ * ── Rate-limit safety ────────────────────────────────────────────────────
+ * The warm traffic IS subject to the Layer-1 Cloudflare rate-limit ruleset
+ * at `infra/terraform/rate-limit.tf:48` — the bucket key is `[ip.src,
+ * cf.colo.id]` regardless of Cloud Run SA auth. The actual rule allows
+ * 10 requests per 10-second sliding window.
+ *
+ * Concurrency=1 + 200ms sleep is the load-bearing safety margin. In the
+ * pessimistic scenario (every response is a fresh MISS at ~1s wall-clock),
+ * one request + 200ms sleep takes ~1.2s, producing ~8.4 req per 10s window
+ * — comfortably under the 10/10s cap.
+ *
+ * IMPORTANT for future maintainers:
+ *   - If p95 response time drops below ~500ms (e.g. all-HIT steady state),
+ *     the effective rate climbs to ~14 req/10s and the bucket overflows
+ *     → CF starts returning 429s to the warm job itself.
+ *   - Mitigation: bump `sleepMs` to 500ms if you observe sustained sub-500ms
+ *     responses on the warm cycle. Do NOT raise concurrency above 1.
+ *   - At higher concurrency the math breaks immediately (5 req/s sustained
+ *     × 10s = 50 in the bucket vs cap of 10 → guaranteed 429s).
+ */
+
+/**
+ * Static metro center list. The 25 entries below cover the top US metros by
+ * population × birding activity. Manual list — revisit quarterly. A future
+ * enhancement: derive from analytics top-N bboxes.
+ *
+ * Issue #711's spec body prose enumerates 27 candidate metros across the
+ * five regional groups; the spec's URL-count math (25 metros × 3 zooms + 2
+ * CONUS = 77) is the canonical contract that the acceptance test asserts.
+ * To reconcile, the two lowest-priority metros by adjacent-coverage overlap
+ * are dropped here:
+ *   - New Orleans: overlaps Houston z=5 viewport
+ *   - Albuquerque: overlaps Denver / Phoenix z=5 viewports
+ * Restoring either is a one-line edit; the test asserting `total === 77`
+ * will catch any accidental drift between the list and the canonical count.
+ */
+const METROS: ReadonlyArray<{ name: string; lng: number; lat: number }> = [
+  // West
+  { name: 'LA',           lng: -118.24, lat: 34.05 },
+  { name: 'Bay Area',     lng: -122.42, lat: 37.77 },
+  { name: 'San Diego',    lng: -117.16, lat: 32.71 },
+  { name: 'Seattle',      lng: -122.33, lat: 47.61 },
+  { name: 'Portland',     lng: -122.68, lat: 45.52 },
+  { name: 'Vegas',        lng: -115.14, lat: 36.17 },
+  { name: 'Phoenix',      lng: -112.07, lat: 33.45 },
+  // South
+  { name: 'Miami',        lng:  -80.19, lat: 25.76 },
+  { name: 'Atlanta',      lng:  -84.39, lat: 33.75 },
+  { name: 'Houston',      lng:  -95.37, lat: 29.76 },
+  { name: 'Dallas',       lng:  -96.80, lat: 32.78 },
+  { name: 'Austin',       lng:  -97.74, lat: 30.27 },
+  { name: 'Orlando',      lng:  -81.38, lat: 28.54 },
+  { name: 'Tampa',        lng:  -82.46, lat: 27.95 },
+  // East
+  { name: 'NYC',          lng:  -74.01, lat: 40.71 },
+  { name: 'Boston',       lng:  -71.06, lat: 42.36 },
+  { name: 'DC',           lng:  -77.04, lat: 38.91 },
+  { name: 'Philadelphia', lng:  -75.17, lat: 39.95 },
+  { name: 'Charlotte',    lng:  -80.84, lat: 35.23 },
+  // Midwest
+  { name: 'Chicago',      lng:  -87.63, lat: 41.88 },
+  { name: 'Detroit',      lng:  -83.05, lat: 42.33 },
+  { name: 'Minneapolis',  lng:  -93.27, lat: 44.98 },
+  { name: 'St. Louis',    lng:  -90.20, lat: 38.63 },
+  // Mountain
+  { name: 'Denver',       lng: -104.99, lat: 39.74 },
+  { name: 'SLC',          lng: -111.89, lat: 40.76 },
+] as const;
+
+/**
+ * Per-zoom half-widths in degrees. Matches the frontend's tile→bbox mapping
+ * at roughly the standard Web Mercator projection (see issue #711).
+ *
+ * z=5 → ~ ±11° lng, ±6° lat  (continent-scale viewport)
+ * z=6 → ~ ±5.5° lng, ±3° lat (multi-state viewport)
+ * z=7 → ~ ±2.75° lng, ±1.5° lat (single-state metro viewport)
+ */
+const ZOOM_HALFW: Record<number, readonly [number, number]> = {
+  5: [11, 6],
+  6: [5.5, 3],
+  7: [2.75, 1.5],
+};
+
+/**
+ * The two CONUS-wide queries every user hits on initial page load. These two
+ * dominate cold-cache cost so they're warmed first each cycle.
+ */
+const CONUS_BBOXES: ReadonlyArray<{ zoom: number; bbox: string }> = [
+  { zoom: 3, bbox: '-125,24,-66,50' },
+  { zoom: 4, bbox: '-126,27,-71,51' },
+];
+
+/**
+ * Builds the deterministic 77-entry URL list: 2 CONUS aggregated queries plus
+ * 25 metros × 3 zoom levels. Exported for testability — the URL count + shape
+ * are the most error-prone surface area in this helper.
+ */
+export function buildCacheWarmUrls(baseUrl: string): string[] {
+  const urls: string[] = [];
+  for (const c of CONUS_BBOXES) {
+    urls.push(`${baseUrl}/api/observations?since=14d&bbox=${c.bbox}&zoom=${c.zoom}`);
+  }
+  for (const m of METROS) {
+    for (const z of [5, 6, 7]) {
+      const halfW = ZOOM_HALFW[z];
+      if (!halfW) continue;
+      const [hw, hh] = halfW;
+      const bbox =
+        `${(m.lng - hw).toFixed(2)},${(m.lat - hh).toFixed(2)},` +
+        `${(m.lng + hw).toFixed(2)},${(m.lat + hh).toFixed(2)}`;
+      urls.push(`${baseUrl}/api/observations?since=14d&bbox=${bbox}&zoom=${z}`);
+    }
+  }
+  return urls;
+}
+
+export interface RunCacheWarmOptions {
+  baseUrl: string;
+  /**
+   * Sleep between requests, in milliseconds. Default 200ms; lower values
+   * risk tripping the Layer-1 rate-limit (see header comment). Tests pass
+   * 0 to skip wall-clock waits.
+   */
+  sleepMs?: number;
+  /** Injectable sleep — tests pass a spy to assert call count without delay. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable fetcher — tests can override; production uses global fetch. */
+  fetcher?: typeof fetch;
+}
+
+export interface RunCacheWarmSummary {
+  total: number;
+  miss: number;
+  hit: number;
+  expired: number;
+  dynamic: number;
+  other: number;
+  error: number;
+  p50ms: number;
+  p95ms: number;
+}
+
+const DEFAULT_SLEEP_MS = 200;
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Walks the cache-warm URL list sequentially, recording cf-cache-status per
+ * response and emitting a single structured `bird_ingest_cache_warmed` log
+ * line at the end for the dashboard's log-based metric.
+ */
+export async function runCacheWarm(opts: RunCacheWarmOptions): Promise<RunCacheWarmSummary> {
+  const urls = buildCacheWarmUrls(opts.baseUrl);
+  const sleepMs = opts.sleepMs ?? DEFAULT_SLEEP_MS;
+  const fetcher = opts.fetcher ?? fetch;
+  const doSleep = opts.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)));
+
+  const results = {
+    total: urls.length,
+    miss: 0,
+    hit: 0,
+    expired: 0,
+    dynamic: 0,
+    other: 0,
+    error: 0,
+  };
+  const durations: number[] = [];
+
+  for (const url of urls) {
+    const t0 = Date.now();
+    try {
+      const r = await fetcher(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      const raw = r.headers.get('cf-cache-status') ?? 'NONE';
+      const bucket = raw.toLowerCase();
+      // Drain the body so the connection can be reused / closed cleanly.
+      // We don't care about the contents — CF's status header is the signal.
+      // Wrapping in catch keeps a malformed body from inflating the error
+      // bucket (the request itself succeeded).
+      try { await r.text(); } catch { /* drained best-effort */ }
+      if (bucket === 'miss') results.miss++;
+      else if (bucket === 'hit') results.hit++;
+      else if (bucket === 'expired') results.expired++;
+      else if (bucket === 'dynamic') results.dynamic++;
+      else results.other++;
+      durations.push(Date.now() - t0);
+    } catch {
+      results.error++;
+    }
+    if (sleepMs > 0) await doSleep(sleepMs);
+  }
+
+  // Percentile math on the sorted duration list. Empty list (all-error run)
+  // yields p50=p95=0, which the dashboard's downstream log-based metric
+  // handles as "no signal" rather than "fast".
+  durations.sort((a, b) => a - b);
+  const p50 = durations.length > 0
+    ? (durations[Math.floor(durations.length * 0.5)] ?? 0)
+    : 0;
+  const p95 = durations.length > 0
+    ? (durations[Math.floor(durations.length * 0.95)] ?? 0)
+    : 0;
+
+  // Single compact line for Cloud Logging's jsonPayload extraction. Same
+  // shape contract as `bird_ingest_run_completed` (cli.ts) and
+  // `bird_ingest_archived` (run-prune.ts): one stringify, no newlines.
+  console.log(JSON.stringify({
+    severity: 'INFO',
+    message: 'bird_ingest_cache_warmed',
+    kind: 'cache-warm',
+    total: results.total,
+    miss: results.miss,
+    hit: results.hit,
+    expired: results.expired,
+    dynamic: results.dynamic,
+    other: results.other,
+    error: results.error,
+    p50ms: p50,
+    p95ms: p95,
+  }));
+
+  return { ...results, p50ms: p50, p95ms: p95 };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scheduler as Cloud Scheduler<br/>bird-cache-warm
    participant Job as Cloud Run Job<br/>bird-ingestor
    participant CF as Cloudflare<br/>edge cache
    participant API as bird-read-api
    participant DB as Cloud SQL

    Scheduler->>Job: containerOverrides args=["cache-warm"]<br/>(at :02 and :32 each hour)
    loop 77 URLs, concurrency=1, 200ms sleep
        Job->>CF: GET /api/observations?...
        alt cache MISS / EXPIRED
            CF->>API: forward
            API->>DB: SELECT obs
            DB-->>API: rows
            API-->>CF: 200 + s-maxage=300
            CF-->>Job: cf-cache-status: MISS
        else cache HIT
            CF-->>Job: cf-cache-status: HIT
        end
    end
    Job->>Job: emit bird_ingest_cache_warmed log line
```

## Summary

- Adds a `cache-warm` CLI kind on the shared `bird-ingestor` Cloud Run Job that walks 77 popular bbox URLs (2 CONUS aggregated + 25 metros x 3 zoom levels), pre-fetching them through Cloudflare 2 minutes after each `/recent` ingest tick so the next real user pan into the same area is a HIT instead of a cold MISS — turns "popular metros take 6-12s for the first viewer after each ingest cycle" into "<100ms from the first viewer."
- Pure HTTP — no DB pool, no eBird API. cli.ts branches early-return ahead of the EBIRD_API_KEY / DATABASE_URL guards so `gcloud run jobs execute bird-ingestor --args=cache-warm` works without those secrets resolvable.
- Concurrency=1 + 200ms sleep is the load-bearing rate-limit safety margin. In the pessimistic ~1s-MISS case the rate is ~8.4 req/10s, comfortably under the Layer-1 ratelimit's 10/10s ceiling. Module header documents the math and the all-HIT mitigation (bump `sleepMs` to 500ms if sustained sub-500ms responses appear).

## Screenshots

N/A — not UI.

## Test plan

- [x] `npm run build` — clean production build
- [x] `npm test --workspace @bird-watch/ingestor -- cli run-cache-warm heartbeat transform digest` — 64 tests pass
- [x] `terraform -chdir=infra/terraform fmt -check ingestor.tf monitoring.tf` — clean
- [x] `terraform -chdir=infra/terraform validate` — Success
- [x] `npx knip` — clean
- [x] New unit tests added: 10 `runCacheWarm` / `buildCacheWarmUrls` tests + 5 cli kind tests (dispatch, no DB pool, env-bypass, HEALTHCHECKS_URL_CACHE_WARM ping, base-url override, Unknown-kind message)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI.

## Plan reference

Out of plan — operational follow-up to #707 (CF proxy) and #705 (cache rule). Closes the "first-user-per-cycle pays the cold-query cost" gap that the basic cache rule alone doesn't solve.

## Post-merge operator ops

1. Create the Healthchecks.io monitor for the cache-warm cron:
   - Name: `bird-watch cache-warm`
   - Schedule: cron `2,32 * * * *`, timezone Etc/UTC, grace 5 min
   - Copy the resulting `https://hc-ping.com/<uuid>` URL
2. Push the URL into the Secret Manager secret (created by the scoped apply below):
   ```sh
   gcloud secrets versions add bird-watch-healthchecks-cache-warm \
     --project=bird-maps-prod --data-file=- <<< "https://hc-ping.com/<uuid>"
   ```
3. Scoped Terraform apply (provisions the secret, scheduler, env binding):
   ```sh
   cd infra/terraform
   terraform apply \
     -target=google_secret_manager_secret.healthchecks_url \
     -target=google_secret_manager_secret_iam_member.ingestor_healthchecks \
     -target=google_cloud_run_v2_job.ingestor \
     -target=google_cloud_scheduler_job.cache_warm
   ```
4. One-shot smoke run + log inspection:
   ```sh
   gcloud run jobs execute bird-ingestor --args=cache-warm \
     --region=us-west1 --project=bird-maps-prod --wait
   gcloud logging read 'jsonPayload.message="bird_ingest_cache_warmed"' \
     --project=bird-maps-prod --limit=1 --format='value(jsonPayload)'
   ```
   Expected: `{ total: 77, miss: ~varies, hit: ~varies, error: 0 }`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)