### PR TITLE
infra(cloudflare): enable Smart Tiered Cache for cross-colo /api coverage (#713)

### DIFF
--- a/infra/terraform/tiered-cache.tf
+++ b/infra/terraform/tiered-cache.tf
@@ -1,0 +1,28 @@
+# ── Smart Tiered Cache for cross-colo cache-warm propagation ─────────────
+#
+# The cache-warm cron (issue #711) runs from Cloud Run us-west1 and only
+# hydrates the CF colo that serves that egress IP. Live testing 2026-05-22
+# from a PHX-region browser ~3min after a warm cycle returned MISS on
+# CONUS z=3 — proving the warm DID populate some colo (us-west1-routed),
+# just not PHX.
+#
+# Smart Tiered Cache inserts an upper-tier colo between MISS-ing lower-tier
+# colos and origin. One cron warm hydrates the upper tier; subsequent MISS
+# at PHX/JFK/LHR pulls from the upper tier (in-network ~10-30ms) instead
+# of origin (~1-2s). Net effect: globally effective warm without changing
+# the cron, the URL list, or per-region scheduling.
+#
+# Plan tier: available on Free plan (verified at
+# https://developers.cloudflare.com/cache/plans/ availability matrix —
+# Smart Topology is Free+, Generic Global is Enterprise-only).
+#
+# Cloud region hint (gcp:us-west1) is OUT of Terraform scope per repo
+# convention at cloud-sql.tf:96-110 (PostGIS-style operator runbook).
+# See PR body for the runbook.
+#
+# Closes #713.
+
+resource "cloudflare_tiered_cache" "api" {
+  zone_id    = var.cloudflare_zone_id
+  cache_type = "smart"
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser as Browser (PHX/JFK/LHR)
    participant Lower as CF Lower-Tier Colo
    participant Upper as CF Upper-Tier Colo
    participant Origin as Cloud Run origin (us-west1)

    Note over Browser,Origin: WITHOUT Smart Tiered Cache
    Browser->>Lower: GET /api/v1/obs?... (MISS)
    Lower->>Origin: fetch (1–2 s)
    Origin-->>Lower: 200 OK
    Lower-->>Browser: 200 OK (slow)

    Note over Browser,Origin: WITH Smart Tiered Cache (after #711 cron warms upper tier)
    Browser->>Lower: GET /api/v1/obs?... (MISS)
    Lower->>Upper: fetch (10–30 ms in-network)
    Upper-->>Lower: 200 OK (HIT from warm)
    Lower-->>Browser: 200 OK (fast)
```

## Summary

- **Problem**: The cache-warm cron (#711) runs from Cloud Run us-west1 and only hydrates the CF colo that serves that egress IP. Live testing 2026-05-22 from a PHX-region browser ~3 min post-warm returned MISS on CONUS z=3 tiles — the warm worked, just not for non-us-west1-routed users.
- **Fix**: `cloudflare_tiered_cache` with `cache_type = "smart"` inserts an upper-tier colo between any MISS-ing lower-tier colo and origin. The #711 cron warm hydrates the upper tier once; subsequent MISSes from PHX/JFK/LHR hit the upper tier (~10–30 ms) instead of origin (~1–2 s).
- **Cost**: Available on Cloudflare Free plan (verified against https://developers.cloudflare.com/cache/plans/ — Smart Topology is Free+; Generic Global is Enterprise-only). No plan change required.

## Screenshots

N/A — terraform-only change, no UI

- [x] N/A — not UI (no `className` changes)
- [x] N/A — not UI (no viewport screenshots required)

## Test plan

- [x] `npm run typecheck && npm run test` — green (no application code changed)
- [x] `npm run build` — clean (no application code changed)
- [x] `npm run dev` smoke — N/A (no UI)
- [x] New Playwright e2e spec — N/A (no user-visible behavior changed)
- [x] `terraform fmt` — clean (`FMT OK`, no rewrite needed)
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `terraform plan -target='cloudflare_tiered_cache.api'` — scoped to new resource only:

```
Plan: 1 to add, 0 to change, 0 to destroy.
```

CI gates expected green: `test`, `lint`, `build`, `e2e`.

> **Token scope note**: The CF API token currently has `Zone:Cache Rules:Edit` scope (established in PR #708's token-scope cycle). Whether `cloudflare_tiered_cache` requires that scope or `Zone:Cache:Edit` is uncertain — if `terraform apply` 403s on this resource, that is the likely cause. Julian will know.

## Plan reference

Out of plan — follow-up to #711 cache-warm cron, identified during live cross-colo verification on 2026-05-22.

---

## Post-merge operator runbook

After `terraform apply` succeeds, set the Cloud Run region hint so Cloudflare knows the origin is in `gcp:us-west1`. This step is intentionally out of Terraform scope per the repo convention established at `cloud-sql.tf:96-110`.

```sh
# Pull CF zone id + API token from Secret Manager (operator must be authenticated to bird-maps-prod).
ZONE_ID=$(gcloud secrets versions access latest --project=bird-maps-prod --secret=bird-watch-cloudflare-zone-id)
TOKEN=$(gcloud secrets versions access latest --project=bird-maps-prod --secret=bird-watch-cloudflare-api-token)

# Set the region hint. The hostname here is the actual Cloud Run origin behind api.bird-maps.com.
# Verify the payload shape against the live CF API docs at
# https://developers.cloudflare.com/cache/how-to/tiered-cache/#public-cloud-origins
# before running — the 2026-04-17 launch JSON may differ from this draft.
curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/origin_cloud_regions" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  --data '{"hostname":"bird-read-api-5pxlhi7ipa-uw.a.run.app","region":"gcp:us-west1"}'

# Verify
curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/origin_cloud_regions" \
  -H "Authorization: Bearer $TOKEN" | jq
```

## Post-apply verification

Multi-colo HIT verification is the acceptance criterion from #713 and is to be performed by Julian post-apply — not in this PR. The test: from a PHX/JFK/LHR browser session, request a previously warmed `/api/v1/obs?...` tile ~3 min after the #711 cron runs and confirm `CF-Cache-Status: HIT`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)