### PR TITLE
feat(shared-types): CONUS allowlist + stateCode filter + meta.truncated + StateSummary

### DIFF
--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -1,4 +1,12 @@
-import type { SpeciesMeta, ObservationsResponse, Observation } from './index.js';
+import type {
+  SpeciesMeta,
+  ObservationsResponse,
+  Observation,
+  StateCode,
+  ObservationFilters,
+  StateSummary,
+} from './index.js';
+import { CONUS_STATE_CODES } from './index.js';
 
 // Compile-time-only tests for the optional photo projection fields added
 // to SpeciesMeta in issue #327, task-3. These fields are derived at read
@@ -124,3 +132,119 @@ if (_aggregated.mode === 'aggregated') {
   // @ts-expect-error — `data` does not exist on the aggregated branch
   void _aggregated.data;
 }
+
+// ── State scope type-level tests (#727 / plan tasks B1 + A3) ───────────────
+
+// Case 11: CONUS_STATE_CODES is the single-source 49-code allowlist (48
+// contiguous states + DC, excluding US-AK and US-HI). It must be a runtime
+// value (imported above as a value, not a type) so parseState/the ZIP
+// contract/the selector can build a Set from it.
+const _codeCount: number = CONUS_STATE_CODES.length;
+if (_codeCount !== 49) {
+  throw new Error(`CONUS_STATE_CODES must have 49 entries, got ${_codeCount}`);
+}
+// Alaska + Hawaii are deliberately absent (out of the CONUS scope).
+if (
+  (CONUS_STATE_CODES as readonly string[]).includes('US-AK') ||
+  (CONUS_STATE_CODES as readonly string[]).includes('US-HI')
+) {
+  throw new Error('CONUS_STATE_CODES must exclude US-AK and US-HI');
+}
+// DC and a representative state are present.
+if (
+  !(CONUS_STATE_CODES as readonly string[]).includes('US-DC') ||
+  !(CONUS_STATE_CODES as readonly string[]).includes('US-AZ')
+) {
+  throw new Error('CONUS_STATE_CODES must include US-DC and US-AZ');
+}
+
+// Case 12: StateCode is the union of the literal members of CONUS_STATE_CODES.
+// A member literal assigns; an off-list literal does not.
+const _okState: StateCode = 'US-AZ';
+void _okState;
+const _dc: StateCode = 'US-DC';
+void _dc;
+// @ts-expect-error — US-AK is not a CONUS code
+const _ak: StateCode = 'US-AK';
+void _ak;
+// @ts-expect-error — bare 'AZ' is not a StateCode (codes are eBird 'US-XX')
+const _bare: StateCode = 'AZ';
+void _bare;
+
+// Case 13: StateCode flows back through the const-array element type.
+const _firstCode: StateCode = CONUS_STATE_CODES[0];
+void _firstCode;
+
+// Case 14: ObservationFilters.stateCode is an optional string — a hard
+// server-side data boundary that ANDs with bbox. Omitting it = whole-US.
+const _noScope: ObservationFilters = { since: '7d' };
+void _noScope;
+const _scoped: ObservationFilters = { stateCode: 'US-AZ', bbox: [-111, 31.5, -110.85, 31.9] };
+void _scoped;
+const _scopeAccess: string | undefined = _scoped.stateCode;
+void _scopeAccess;
+const _badScope: ObservationFilters = {
+  // @ts-expect-error — stateCode must be a string when set
+  stateCode: 123,
+};
+void _badScope;
+
+// Case 15: meta.truncated is OPTIONAL on the per-observation branch (stale
+// CDN bodies predating the field deserialize cleanly). Both present and
+// omitted are well-formed.
+const _truncated: ObservationsResponse = {
+  mode: 'observations',
+  data: [_obs],
+  meta: { freshestObservationAt: '2026-05-28T00:00:00.000Z', truncated: true },
+};
+void _truncated;
+const _notTruncated: ObservationsResponse = {
+  mode: 'observations',
+  data: [_obs],
+  // truncated omitted — must still compile
+  meta: { freshestObservationAt: '2026-05-28T00:00:00.000Z' },
+};
+void _notTruncated;
+if (_truncated.mode === 'observations') {
+  const _t: boolean | undefined = _truncated.meta.truncated;
+  void _t;
+}
+const _badTruncated: ObservationsResponse = {
+  mode: 'observations',
+  data: [],
+  // @ts-expect-error — truncated must be a boolean when set
+  meta: { freshestObservationAt: null, truncated: 'yes' },
+};
+void _badTruncated;
+
+// Case 16: meta.truncated is OPTIONAL on the aggregated branch too (the
+// aggregated path omits it; the field must still be accepted for parity).
+const _aggTruncated: ObservationsResponse = {
+  mode: 'aggregated',
+  buckets: [],
+  meta: { freshestObservationAt: null, truncated: true },
+};
+void _aggTruncated;
+if (_aggTruncated.mode === 'aggregated') {
+  const _t: boolean | undefined = _aggTruncated.meta.truncated;
+  void _t;
+}
+
+// Case 17: StateSummary — { stateCode; name; bbox:[w,s,e,n] }. The bbox is a
+// 4-number tuple in the same [west,south,east,north] order as
+// ObservationFilters.bbox. `geom` never appears (it stays server-side).
+const _summary: StateSummary = {
+  stateCode: 'US-AZ',
+  name: 'Arizona',
+  bbox: [-114.82, 31.33, -109.05, 37.0],
+};
+void _summary;
+const _summaryBbox: [number, number, number, number] = _summary.bbox;
+void _summaryBbox;
+const _badSummary: StateSummary = {
+  stateCode: 'US-AZ',
+  name: 'Arizona',
+  // @ts-expect-error — bbox must be a 4-tuple of numbers
+  bbox: [-114.82, 31.33, -109.05],
+};
+void _badSummary;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,3 +1,51 @@
+/**
+ * The 49 CONUS eBird region codes — the 48 contiguous states plus the
+ * District of Columbia, in eBird's `US-XX` form. Alaska (`US-AK`) and Hawaii
+ * (`US-HI`) are deliberately excluded: the state-scope selector (epic #726)
+ * frames the lower-48 + DC, and the `state_boundaries` polygon table is seeded
+ * to match this exact set.
+ *
+ * This is the SINGLE source of truth for the allowlist. The read-api validator
+ * (`parseState`), the frontend ZIP→state contract, and the scope selector all
+ * import this array (and derive `StateCode` from it) rather than re-listing the
+ * codes — keeping the allowlist in one place avoids the three-way drift a
+ * duplicated list would invite (locked decision #6, plan task B1).
+ *
+ * `as const` makes every element a string literal, which `StateCode` lifts into
+ * a union; `Object.freeze` blocks accidental runtime mutation of the shared
+ * array by any importer.
+ */
+export const CONUS_STATE_CODES = Object.freeze([
+  'US-AL', 'US-AZ', 'US-AR', 'US-CA', 'US-CO', 'US-CT', 'US-DE', 'US-DC',
+  'US-FL', 'US-GA', 'US-ID', 'US-IL', 'US-IN', 'US-IA', 'US-KS', 'US-KY',
+  'US-LA', 'US-ME', 'US-MD', 'US-MA', 'US-MI', 'US-MN', 'US-MS', 'US-MO',
+  'US-MT', 'US-NE', 'US-NV', 'US-NH', 'US-NJ', 'US-NM', 'US-NY', 'US-NC',
+  'US-ND', 'US-OH', 'US-OK', 'US-OR', 'US-PA', 'US-RI', 'US-SC', 'US-SD',
+  'US-TN', 'US-TX', 'US-UT', 'US-VT', 'US-VA', 'US-WA', 'US-WV', 'US-WI',
+  'US-WY',
+] as const);
+
+/**
+ * A member of the CONUS allowlist — the eBird `US-XX` code union derived
+ * directly from `CONUS_STATE_CODES`. Bare codes (`'AZ'`) are NOT `StateCode`s;
+ * `parseState` normalizes input to this form. Derive, never re-list.
+ */
+export type StateCode = (typeof CONUS_STATE_CODES)[number];
+
+/**
+ * A single CONUS state's display name + bounding envelope, returned by
+ * `GET /api/states` (one row per `CONUS_STATE_CODES` entry, name-sorted). The
+ * `bbox` tuple is `[west, south, east, north]` — the SAME lng/lat ordering as
+ * `ObservationFilters.bbox` — and drives the frontend's camera `fitBounds` and
+ * `MAX_BOUNDS` when a state is chosen. The underlying polygon (`geom`) is
+ * NEVER projected into this shape; it stays server-side (plan tasks A3 + A4).
+ */
+export interface StateSummary {
+  stateCode: string;
+  name: string;
+  bbox: [number, number, number, number];
+}
+
 export interface Hotspot {
   locId: string;
   locName: string;
@@ -159,6 +207,18 @@ export type ObservationFilters = {
    * to keep the CONUS-view payload below the Phase 2 <2 MB gate. Issue #627.
    */
   zoom?: number;
+  /**
+   * Hard server-side data boundary: a CONUS `US-XX` code (`StateCode`) that
+   * clips the observation query to that state's polygon via PostGIS
+   * `ST_Intersects` against `state_boundaries`. ANDs with `bbox` and every
+   * other filter — `bbox`/`zoom` keep their viewport / level-of-detail roles
+   * *within* the clip. ABSENCE means whole-US (the unclipped national query);
+   * the explicit Whole-US escape hatch sends no `?state=` at all. Serialized
+   * as `?state=US-XX`. Typed as `string` (not `StateCode`) because the value
+   * arrives unvalidated off the wire — `parseState` validates it against
+   * `CONUS_STATE_CODES` before it reaches the data layer (plan task B1).
+   */
+  stateCode?: string;
 };
 
 /**
@@ -187,15 +247,25 @@ export interface AggregatedBucket {
  *
  * `meta.freshestObservationAt` carries the same MAX(ingested_at) signal in
  * both modes so the frontend's freshness state machine stays consumer-agnostic.
+ *
+ * `meta.truncated` (issue #727, plan task B6) signals that the per-observation
+ * query hit its row brake (`LIMIT 10000`, or `5000` for a species-filtered
+ * query) and the body is a partial set. It is OPTIONAL on BOTH branches:
+ * - stale CDN bodies predating the field deserialize cleanly (consumers treat
+ *   `undefined` as "not truncated" — no Cache-Control bump required);
+ * - the aggregated path never paginates, so it omits the field entirely (it is
+ *   declared on the aggregated branch only for shape parity, never set there).
+ * The per-observation path sets `truncated: true` only when the brake fired;
+ * it omits the field otherwise rather than emitting `truncated: false`.
  */
 export type ObservationsResponse =
   | {
       mode: 'observations';
       data: Observation[];
-      meta: { freshestObservationAt: string | null };
+      meta: { freshestObservationAt: string | null; truncated?: boolean };
     }
   | {
       mode: 'aggregated';
       buckets: AggregatedBucket[];
-      meta: { freshestObservationAt: string | null };
+      meta: { freshestObservationAt: string | null; truncated?: boolean };
     };


### PR DESCRIPTION
## Diagrams

The shared type surface every state-scope stream codes against — a single allowlist plus three optional fields/types that downstream tasks import (epic #726):

```mermaid
graph TD
    SRC["packages/shared-types/src/index.ts"]
    A["CONUS_STATE_CODES (frozen 49 = 48 states + DC)"] --> SRC
    B["StateCode = typeof CONUS_STATE_CODES[number]"] --> SRC
    C["ObservationFilters.stateCode? : string"] --> SRC
    D["meta.truncated? : boolean (both union members)"] --> SRC
    E["StateSummary { stateCode; name; bbox:[w,s,e,n] }"] --> SRC

    SRC -->|imports allowlist + StateCode| P["parseState validator (B2)"]
    SRC -->|imports allowlist + StateCode| Z["ZIP→state contract (D4)"]
    SRC -->|imports allowlist + StateCode| SEL["scope selector (C)"]
    SRC -->|meta.truncated| BRAKE["LIMIT 10000 brake (B6)"]
    SRC -->|StateSummary| STATES["GET /api/states (A3/A4)"]
```

## Summary

- **Why a single allowlist:** `CONUS_STATE_CODES` is the one source `parseState`, the ZIP contract, and the selector all import (locked decision #6). Re-listing the codes in three places invites three-way drift; `StateCode` is *derived* from the array so the union can never disagree with the runtime value. The set is the 48 contiguous states + DC — Alaska and Hawaii are deliberately excluded because the selector frames CONUS and `state_boundaries` is seeded to match.
- **Why everything else is optional:** `ObservationFilters.stateCode?`, `meta.truncated?` (on **both** `ObservationsResponse` members), and `StateSummary` are additive. `stateCode` absence preserves the unclipped-national-query invariant; `meta.truncated` is optional so stale CDN bodies deserialize cleanly and the aggregated path can omit it. All new fields optional ⇒ zero consumer breaks.
- **Type-only, no DB / no runtime behavior change.** The proof is `tsc` + `build` + `test` green across all six workspaces.

## Screenshots

N/A — not UI (type-only change under `packages/shared-types/**`).

## Test plan

- [x] `npm test` — green across all workspaces (shared-types `tsc -p tsconfig.test.json`; db-client, admin-api, ingestor, read-api, frontend vitest all pass)
- [x] New type-level tests added: `packages/shared-types/src/index.test.ts` cases 11–17 — 49-count invariant, AK/HI exclusion, DC/AZ inclusion, `StateCode` union membership, `stateCode?` optionality, `meta.truncated?` optionality on both branches, `StateSummary` 4-tuple bbox, plus load-bearing `@ts-expect-error` rejections of off-spec values (followed RED→GREEN: confirmed the additions failed compilation before implementing)
- [ ] New Playwright e2e spec added — N/A (no user-visible behavior)
- [x] `npm run build` — clean production build across all five built workspaces
- [x] `npx knip` — exit 0 (only a pre-existing config hint unrelated to this change)
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Part of epic #726, Plan tasks **B1** (allowlist + `stateCode?` + `meta.truncated?`) + **A3** (`StateSummary`). See `docs/plans/2026-05-28-state-scope-selector.md` (on `plan/state-scope-selector`, not yet merged to `main`). Closes #727.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)