### PR TITLE
feat(frontend): lazy ZIP lookup module + ScopeResolution contract + ZipInput UX

### DIFF
--- a/docs/decisions/zip-delivery.md
+++ b/docs/decisions/zip-delivery.md
@@ -1,0 +1,59 @@
+# Decision: ZIP index delivery — static asset, not a read-api proxy
+
+**Date:** 2026-05-28
+**Plan:** `docs/plans/2026-05-28-state-scope-selector.md`, Stream D (tasks D2–D5)
+**Issue:** #739
+
+## Context
+
+The ZIP scope feature resolves a user-typed 5-digit ZIP to a CONUS state
+(`?state=US-XX`) plus a camera centroid. The state is precomputed offline by
+point-in-polygon against the canonical state polygons (`data/us-state-polygons.geojson`),
+so the frontend never does a runtime ZIP→state lookup. The result is a
+columnar index — `{ v, states, zips: { '85701': [lat, lng, stateIdx] } }` —
+of ~32.5k CONUS ZCTAs, ~1 MB raw.
+
+The question: how does that index reach the browser?
+
+## Options
+
+1. **Static asset in `public/`** (CHOSEN). The ETL writes `frontend/public/zip-index.json`;
+   Vite copies it verbatim into the build; Cloudflare Pages serves it CDN-cached;
+   the frontend fetches it at runtime on first ZIP-input focus.
+2. **Read-api proxy** — a `GET /api/zip/:zip` (or `/api/zip-index`) route backed
+   by Cloud SQL or the bundled file.
+
+## Decision
+
+**Static asset (option 1).**
+
+A read-api proxy would add a route, a Cloud SQL round-trip (or an in-process
+file read replicated per container), and a new rate-limit surface — for zero
+benefit. The index is build-time-stable: it changes ONLY when the offline ETL
+re-runs against a new Census ZCTA vintage, which ships as a normal deploy. A
+flat file on the CDN is the cheapest, most cacheable delivery for
+build-time-stable data, and it keeps the ZIP path entirely client-side (no
+backend dependency for ZIP resolution).
+
+## Consequences / mechanics
+
+- **Lazy load.** The asset is fetched at runtime via `fetch()`, never
+  `import`ed — so Vite never inlines the ~1 MB dataset into the entry chunk.
+  `frontend/src/data/zip-lookup.ts` warms it on the first `ZipInput` focus, and
+  memoizes single-flight (concurrent callers share one fetch; a rejection
+  clears the memo so a later focus retries). A unit test asserts the module
+  contains no static `import` of `zip-index.json`.
+
+- **Cache-busting.** Vite does NOT content-hash files under `public/`, so the
+  edge/browser would serve a stale index after the ETL regenerates it. The
+  fetch URL appends `?v=<datasetVersion>`. The version is **hardcoded to `1`**
+  to match the `v: 1` field the ETL emits into the index (D2 schema).
+  **Increment both in lock-step** (`ZIP_INDEX_VERSION` in `zip-lookup.ts` and
+  the ETL's `v` field) whenever `zip-index.json` is regenerated — otherwise
+  clients keep the old file until their cache naturally expires.
+
+- **ZIP ≠ ZCTA.** ~41k USPS ZIPs vs ~33k Census ZCTAs: PO-box / military /
+  point ZIPs have no ZCTA, so a minority of otherwise-valid ZIPs will MISS the
+  index. That is handled explicitly in `ZipInput` — a well-formed-but-unknown
+  ZIP shows a visible "ZIP not recognized" status (never a silent no-op) and
+  steers the user to the state selector.

--- a/frontend/src/components/ZipInput.test.tsx
+++ b/frontend/src/components/ZipInput.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ZIP_FLYTO_ZOOM } from '../state/scope-types.js';
+
+const { mockLoadZipIndex, mockLookupZip } = vi.hoisted(() => ({
+  mockLoadZipIndex: vi.fn(),
+  mockLookupZip: vi.fn(),
+}));
+
+vi.mock('../data/zip-lookup.js', () => ({
+  loadZipIndex: mockLoadZipIndex,
+  lookupZip: mockLookupZip,
+}));
+
+// Imported AFTER the mock is registered.
+import { ZipInput } from './ZipInput.js';
+
+describe('<ZipInput>', () => {
+  beforeEach(() => {
+    mockLoadZipIndex.mockReset().mockResolvedValue(undefined);
+    mockLookupZip.mockReset();
+  });
+
+  it('renders a native numeric text input labelled "ZIP code"', () => {
+    render(<ZipInput onResolve={vi.fn()} />);
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('inputMode', 'numeric');
+    expect(input).toHaveAttribute('maxLength', '5');
+  });
+
+  it('does NOT call loadZipIndex on mount — only on focus (lazy trigger)', async () => {
+    render(<ZipInput onResolve={vi.fn()} />);
+    expect(mockLoadZipIndex).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('textbox', { name: /ZIP code/i }));
+    expect(mockLoadZipIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolved ZIP → calls onResolve with the ScopeResolution (stateCode + center + zoom=10)', async () => {
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '85701{Enter}');
+
+    expect(mockLookupZip).toHaveBeenCalledWith('85701');
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith({
+      stateCode: 'US-AZ',
+      center: [-110.971, 32.21696],
+      zoom: ZIP_FLYTO_ZOOM,
+    });
+  });
+
+  it('well-formed but unknown ZIP → visible role=status "not recognized", value kept, onResolve NOT called (never silent)', async () => {
+    mockLookupZip.mockResolvedValue(null);
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '99999{Enter}');
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent(/not recognized/i);
+    expect(onResolve).not.toHaveBeenCalled();
+    // Value is kept — never a silent no-op clearing the field.
+    expect(input).toHaveValue('99999');
+  });
+
+  it('malformed input → inline message, no lookup attempted', async () => {
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '123{Enter}');
+
+    expect(screen.getByText(/5-digit ZIP/i)).toBeInTheDocument();
+    expect(mockLookupZip).not.toHaveBeenCalled();
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it('fetch error during lookup → role=alert fallback-to-selector message', async () => {
+    mockLookupZip.mockRejectedValue(new Error('zip-index fetch failed: 503'));
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '85701{Enter}');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/pick a state/i);
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it('a prior "not recognized" status clears once a malformed value is submitted', async () => {
+    mockLookupZip.mockResolvedValueOnce(null);
+    render(<ZipInput onResolve={vi.fn()} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '99999{Enter}');
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '12{Enter}');
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByText(/5-digit ZIP/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ZipInput.test.tsx
+++ b/frontend/src/components/ZipInput.test.tsx
@@ -74,6 +74,24 @@ describe('<ZipInput>', () => {
     expect(input).toHaveValue('99999');
   });
 
+  it("passes the trimmed value straight to lookupZip — ZIP+4 normalization is lookupZip's job, not duplicated here", async () => {
+    // maxLength={5} means a `-####` ZIP+4 suffix can never be typed into the
+    // field, so ZipInput does NOT pre-strip it. lookupZip owns trimming and the
+    // ZIP+4 strip (and is independently tested for both). The component just
+    // hands lookupZip the trimmed input verbatim.
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    render(<ZipInput onResolve={vi.fn()} />);
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '85701{Enter}');
+
+    expect(mockLookupZip).toHaveBeenCalledWith('85701');
+  });
+
   it('malformed input → inline message, no lookup attempted', async () => {
     const onResolve = vi.fn();
     render(<ZipInput onResolve={onResolve} />);

--- a/frontend/src/components/ZipInput.tsx
+++ b/frontend/src/components/ZipInput.tsx
@@ -1,0 +1,107 @@
+import { useId, useState, type FormEvent } from 'react';
+import { loadZipIndex, lookupZip } from '../data/zip-lookup.js';
+import { zipResolutionToScope, type ScopeResolution } from '../state/scope-types.js';
+
+/**
+ * ZIP entry — a native `<input>` (no combobox lib; repo pattern) that resolves
+ * a 5-digit ZIP to a map scope and never fails silently.
+ *
+ * Lazy load: the ~1 MB ZIP index is warmed on the FIRST input FOCUS, not on
+ * mount — that focus is the lazy-load trigger keeping the dataset out of the
+ * entry bundle. `loadZipIndex` is memoized single-flight, so re-focusing is a
+ * no-op after the first warm.
+ *
+ * Four submit outcomes (the "never silent" contract):
+ *   - resolved        → `onResolve(zipResolutionToScope(res))`
+ *   - notRecognized   → well-formed 5-digit ZIP, lookup returned null. A
+ *                       VISIBLE `role=status` message; the input value is KEPT
+ *                       (never a silent no-op).
+ *   - malformed       → not 5 digits. An inline `role=status`-free hint; no
+ *                       fetch is attempted (the regex gate is in `lookupZip`,
+ *                       and we short-circuit here too so the index never warms
+ *                       on a malformed submit).
+ *   - fetchError      → the index download failed. A `role=alert` message
+ *                       steering the user to the state selector instead.
+ */
+
+type Feedback =
+  | { kind: 'none' }
+  | { kind: 'malformed' }
+  | { kind: 'notRecognized' }
+  | { kind: 'fetchError' };
+
+export interface ZipInputProps {
+  /** Called with the resolved scope when a known ZIP is submitted. */
+  onResolve: (scope: ScopeResolution) => void;
+}
+
+export function ZipInput({ onResolve }: ZipInputProps): React.JSX.Element {
+  const [value, setValue] = useState('');
+  const [feedback, setFeedback] = useState<Feedback>({ kind: 'none' });
+  const inputId = useId();
+
+  function handleFocus(): void {
+    // Lazy-load trigger: warm the dataset on first focus. Memoized, so safe
+    // to call on every focus.
+    void loadZipIndex().catch(() => {
+      // A focus-time warm failure is not surfaced here — the submit path
+      // re-attempts the lookup and renders the role=alert fallback if it
+      // still fails. Swallowing keeps focus side-effect-free for the user.
+    });
+  }
+
+  async function handleSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const zip5 = value.trim().replace(/-\d{4}$/, '');
+
+    // Malformed → inline hint, no lookup, no fetch.
+    if (!/^\d{5}$/.test(zip5)) {
+      setFeedback({ kind: 'malformed' });
+      return;
+    }
+
+    try {
+      const res = await lookupZip(zip5);
+      if (res) {
+        setFeedback({ kind: 'none' });
+        onResolve(zipResolutionToScope(res));
+      } else {
+        // Well-formed but unknown: never silent. Keep the value.
+        setFeedback({ kind: 'notRecognized' });
+      }
+    } catch {
+      setFeedback({ kind: 'fetchError' });
+    }
+  }
+
+  return (
+    <form className="zip-input" onSubmit={handleSubmit} role="search">
+      <input
+        id={inputId}
+        className="zip-input__field"
+        type="text"
+        inputMode="numeric"
+        pattern="[0-9]{5}"
+        maxLength={5}
+        aria-label="ZIP code"
+        placeholder="ZIP"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={handleFocus}
+      />
+      {feedback.kind === 'malformed' && (
+        <p className="zip-input__error">Enter a 5-digit ZIP</p>
+      )}
+      {feedback.kind === 'notRecognized' && (
+        <p className="zip-input__status" role="status" aria-live="polite">
+          ZIP not recognized — try a nearby ZIP or pick a state
+        </p>
+      )}
+      {feedback.kind === 'fetchError' && (
+        <p className="zip-input__error" role="alert">
+          Could not load ZIP data — pick a state instead
+        </p>
+      )}
+    </form>
+  );
+}

--- a/frontend/src/components/ZipInput.tsx
+++ b/frontend/src/components/ZipInput.tsx
@@ -52,16 +52,21 @@ export function ZipInput({ onResolve }: ZipInputProps): React.JSX.Element {
 
   async function handleSubmit(e: FormEvent): Promise<void> {
     e.preventDefault();
-    const zip5 = value.trim().replace(/-\d{4}$/, '');
+    // `maxLength={5}` caps the field at 5 chars, so a `-####` ZIP+4 suffix can
+    // never be typed here — and `lookupZip` already trims + strips ZIP+4 + gates
+    // on exactly 5 digits (and is independently tested for it). So we do NOT
+    // re-strip: we gate "malformed → no fetch" on the trimmed value and hand the
+    // normalization to `lookupZip`, keeping a single source of truth.
+    const zip = value.trim();
 
     // Malformed → inline hint, no lookup, no fetch.
-    if (!/^\d{5}$/.test(zip5)) {
+    if (!/^\d{5}$/.test(zip)) {
       setFeedback({ kind: 'malformed' });
       return;
     }
 
     try {
-      const res = await lookupZip(zip5);
+      const res = await lookupZip(zip);
       if (res) {
         setFeedback({ kind: 'none' });
         onResolve(zipResolutionToScope(res));

--- a/frontend/src/data/zip-lookup.test.ts
+++ b/frontend/src/data/zip-lookup.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { loadZipIndex, lookupZip, __resetZipIndexCache, ZIP_INDEX_URL } from './zip-lookup.js';
+
+/**
+ * A minimal columnar index matching the production `zip-index.json` shape
+ * ({ v, states, zips }) with entries encoded `[lat, lng, stateIdx]`.
+ * 85701 (Tucson, AZ) and 10001 (Manhattan, NY) are real centroids.
+ */
+const FIXTURE_INDEX = {
+  v: 1,
+  states: ['US-NY', 'US-AZ'],
+  zips: {
+    '85701': [32.21696, -110.971, 1],
+    '10001': [40.75064, -73.99718, 0],
+  },
+};
+
+function stubFetchOk(body: unknown): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+describe('zip-lookup', () => {
+  beforeEach(() => {
+    __resetZipIndexCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('loadZipIndex — lazy single-flight memo', () => {
+    it('two concurrent callers share a single fetch (single-flight)', async () => {
+      const fetchMock = stubFetchOk(FIXTURE_INDEX);
+
+      const [a, b] = await Promise.all([loadZipIndex(), loadZipIndex()]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(a).toBe(b); // same resolved object
+    });
+
+    it('memoizes across sequential calls — second call does not refetch', async () => {
+      const fetchMock = stubFetchOk(FIXTURE_INDEX);
+
+      await loadZipIndex();
+      await loadZipIndex();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the memo on failure so a later call retries (and can succeed)', async () => {
+      const failing = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(FIXTURE_INDEX) } as Response);
+      vi.stubGlobal('fetch', failing);
+
+      await expect(loadZipIndex()).rejects.toThrow(/network down/);
+      // Memo cleared → retry fires a fresh fetch and resolves.
+      const index = await loadZipIndex();
+      expect(index.v).toBe(1);
+      expect(failing).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats a non-ok HTTP response as a failure and clears the memo', async () => {
+      const failing = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 503, json: () => Promise.resolve({}) } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(FIXTURE_INDEX) } as Response);
+      vi.stubGlobal('fetch', failing);
+
+      await expect(loadZipIndex()).rejects.toThrow();
+      const index = await loadZipIndex();
+      expect(index.v).toBe(1);
+      expect(failing).toHaveBeenCalledTimes(2);
+    });
+
+    it('fetches the public asset with a ?v= cache-bust param (Vite does not hash public/)', async () => {
+      const fetchMock = stubFetchOk(FIXTURE_INDEX);
+
+      await loadZipIndex();
+
+      const url = String(fetchMock.mock.calls[0]?.[0]);
+      expect(url).toBe(ZIP_INDEX_URL);
+      expect(url).toContain('zip-index.json');
+      expect(url).toContain('?v=1');
+    });
+  });
+
+  describe('lookupZip', () => {
+    it('resolves a known 5-digit ZIP to { zip, center:[lng,lat], stateCode }', async () => {
+      stubFetchOk(FIXTURE_INDEX);
+
+      const res = await lookupZip('85701');
+
+      expect(res).not.toBeNull();
+      expect(res?.zip).toBe('85701');
+      expect(res?.stateCode).toBe('US-AZ');
+      // center must be [lng, lat] — the index stores [lat, lng], so indices are swapped.
+      expect(res?.center).toEqual([-110.971, 32.21696]);
+      // Longitude (first) is negative for CONUS — guards against a missing swap.
+      expect(res?.center[0]).toBeLessThan(0);
+    });
+
+    it('strips a ZIP+4 suffix (-####) before lookup', async () => {
+      stubFetchOk(FIXTURE_INDEX);
+
+      const res = await lookupZip('85701-1234');
+
+      expect(res?.zip).toBe('85701');
+      expect(res?.stateCode).toBe('US-AZ');
+    });
+
+    it('trims surrounding whitespace', async () => {
+      stubFetchOk(FIXTURE_INDEX);
+
+      const res = await lookupZip('  10001  ');
+
+      expect(res?.zip).toBe('10001');
+      expect(res?.stateCode).toBe('US-NY');
+    });
+
+    it('returns null for a well-formed but unknown ZIP (after fetching)', async () => {
+      const fetchMock = stubFetchOk(FIXTURE_INDEX);
+
+      const res = await lookupZip('99999');
+
+      expect(res).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1); // it DID consult the index
+    });
+
+    it.each(['abc', '123', '', '1234', '123456', 'az'])(
+      'regex-rejects non-5-digit input %j and returns null WITHOUT fetching',
+      async (raw) => {
+        const fetchMock = stubFetchOk(FIXTURE_INDEX);
+
+        const res = await lookupZip(raw);
+
+        expect(res).toBeNull();
+        expect(fetchMock).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('bundle hygiene', () => {
+    it('loads the index via runtime fetch — never a static import that Vite would inline into the entry chunk', () => {
+      const src = readFileSync(path.resolve(__dirname, 'zip-lookup.ts'), 'utf8');
+      // A static `import ... from '....zip-index.json'` (or a top-level
+      // `import('....zip-index.json')`) would let Vite bundle the ~1 MB
+      // dataset into JS. The asset must stay in public/ and be fetched.
+      // Match only on-line import statements that pull a zip-index.json
+      // module specifier (single- or double-quoted) — not prose comments.
+      expect(src).not.toMatch(/import[^\n]*['"][^'"\n]*zip-index\.json['"]/);
+      expect(src).toMatch(/fetch\(/);
+    });
+  });
+});

--- a/frontend/src/data/zip-lookup.ts
+++ b/frontend/src/data/zip-lookup.ts
@@ -1,0 +1,111 @@
+import type { ZipResolution } from '../state/scope-types.js';
+
+/**
+ * Lazy, memoized loader + lookup for the precomputed CONUS ZIP→state index.
+ *
+ * Why a static asset, not an API proxy: the index is build-time-stable
+ * (~1 MB, regenerated only when the ETL re-runs), so it ships as a flat file
+ * in `public/` and is CDN-cached. A read-api proxy would add a route, a Cloud
+ * SQL round-trip, and a rate-limit surface for zero benefit — rejected. See
+ * `docs/decisions/zip-delivery.md`.
+ *
+ * Delivery mechanics (load-bearing):
+ *   - The asset is fetched at RUNTIME, never `import`ed — so Vite never inlines
+ *     the dataset into the entry chunk (the zip-lookup.test.ts "bundle hygiene"
+ *     case guards this). It stays in `public/` and downloads on demand.
+ *   - Vite does NOT content-hash `public/` files, so the browser/edge cache
+ *     would serve a stale index after the ETL regenerates it. We append a
+ *     `?v=<datasetVersion>` cache-bust param. The version is hardcoded to `1`
+ *     to match the `v: 1` field in the index schema (D2). INCREMENT BOTH IN
+ *     LOCK-STEP whenever the ETL regenerates `frontend/public/zip-index.json`.
+ *   - The memo is single-flight: concurrent callers share one in-flight
+ *     fetch. On rejection the memo is cleared so a later call (e.g. a second
+ *     input focus) retries instead of latching onto the rejected promise.
+ */
+
+/** Columnar on-disk shape of `frontend/public/zip-index.json` (D2). */
+export interface ZipIndex {
+  /** Schema version — kept in lock-step with the ?v= cache-bust param. */
+  v: number;
+  /** State codes; each ZIP entry's third element indexes into this array. */
+  states: string[];
+  /** ZIP5 → [lat, lng, stateIdx]. NOTE: [lat, lng], NOT MapLibre order. */
+  zips: Record<string, [number, number, number]>;
+}
+
+/**
+ * Dataset version. Must equal the `v` field emitted by the ZIP ETL into
+ * `zip-index.json`. Bump on every regeneration to bust the edge/browser cache.
+ */
+const ZIP_INDEX_VERSION = 1;
+
+/**
+ * The cache-busted URL the index is fetched from. `public/zip-index.json` is
+ * served at the site root; the `?v=` param forces a fresh fetch when the
+ * dataset version changes (Vite doesn't hash `public/`).
+ */
+export const ZIP_INDEX_URL = `/zip-index.json?v=${ZIP_INDEX_VERSION}`;
+
+let inflight: Promise<ZipIndex> | null = null;
+
+/**
+ * Test-only: clear the module-level memo so suites don't leak a resolved (or
+ * rejected) index into one another.
+ */
+export function __resetZipIndexCache(): void {
+  inflight = null;
+}
+
+/**
+ * Fetch the ZIP index, memoized single-flight. Concurrent callers share one
+ * fetch; a rejection clears the memo so a later call retries.
+ */
+export function loadZipIndex(): Promise<ZipIndex> {
+  if (inflight) return inflight;
+
+  const promise = fetch(ZIP_INDEX_URL)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`zip-index fetch failed: ${res.status}`);
+      }
+      return res.json() as Promise<ZipIndex>;
+    })
+    .catch((err: unknown) => {
+      // Clear the memo so a later focus retries rather than re-resolving the
+      // rejected promise.
+      if (inflight === promise) inflight = null;
+      throw err;
+    });
+
+  inflight = promise;
+  return promise;
+}
+
+/**
+ * Normalize and resolve a ZIP. Trims, strips a `-####` ZIP+4 suffix, and
+ * requires exactly 5 digits — malformed input returns `null` WITHOUT
+ * fetching (the regex gate runs before `loadZipIndex`). A well-formed but
+ * unknown ZIP returns `null` AFTER consulting the index. Resolved ZIPs return
+ * `center` in `[lng, lat]` (MapLibre) order — the index stores `[lat, lng]`,
+ * so the first two elements are swapped here.
+ */
+export async function lookupZip(raw: string): Promise<ZipResolution | null> {
+  const zip5 = raw.trim().replace(/-\d{4}$/, '');
+  if (!/^\d{5}$/.test(zip5)) return null;
+
+  const index = await loadZipIndex();
+  const entry = index.zips[zip5];
+  if (!entry) return null;
+
+  const [lat, lng, stateIdx] = entry;
+  const stateCode = index.states[stateIdx];
+  if (stateCode === undefined) return null;
+
+  return {
+    zip: zip5,
+    center: [lng, lat],
+    // The ETL only emits CONUS `US-XX` codes into `states`, so this is a
+    // StateCode at runtime; the index is typed `string[]` on disk.
+    stateCode: stateCode as ZipResolution['stateCode'],
+  };
+}

--- a/frontend/src/dev/DsPreview.tsx
+++ b/frontend/src/dev/DsPreview.tsx
@@ -34,6 +34,7 @@ import { ClusterPill } from '../components/ds/ClusterPill.js';
 import { FilterSentence } from '../components/ds/FilterSentence.js';
 import { FeedCard } from '../components/FeedCard.js';
 import { FeedRow } from '../components/FeedRow.js';
+import { ZipInput } from '../components/ZipInput.js';
 import type { NotableObservation, Observation } from '@bird-watch/shared-types';
 import type { FamilyCode } from '../config/family-palette.js';
 import type { UrlState } from '../state/url-state.js';
@@ -262,10 +263,49 @@ export function DsPreview(): ReactNode {
     );
   }
 
+  // ZipInput previews (#739). The component warms the real ~1 MB index on
+  // focus from the dev server's public/zip-index.json; the error key forces a
+  // fetch failure so the role=alert fallback renders deterministically.
+  if (key.startsWith('zip-input')) {
+    return <ZipInputPreview variant={key} />;
+  }
+
   // Unknown key: show a helpful error
   return (
     <div style={{ ...PREVIEW_STYLES, color: 'red' }}>
       <p>Unknown ds-preview key: <code>{key}</code></p>
+    </div>
+  );
+}
+
+/**
+ * ZipInput dev harness. Renders the component in isolation for screenshot
+ * capture across the four submit outcomes. `zip-input` shows the idle field;
+ * the `-error` variant monkeypatches `fetch` to reject so the role=alert
+ * state is reproducible without a flaky network condition. Dev-only — never
+ * ships (DsPreview is gated behind import.meta.env.DEV in main.tsx).
+ */
+function ZipInputPreview({ variant }: { variant: string }): ReactNode {
+  const [resolved, setResolved] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (variant !== 'zip-input-error') return;
+    const original = window.fetch;
+    window.fetch = (() =>
+      Promise.reject(new Error('forced zip-index failure'))) as typeof window.fetch;
+    return () => {
+      window.fetch = original;
+    };
+  }, [variant]);
+
+  return (
+    <div style={{ ...PREVIEW_STYLES, maxWidth: '360px' }}>
+      <ZipInput onResolve={(scope) => setResolved(JSON.stringify(scope))} />
+      {resolved && (
+        <p style={{ marginTop: '12px', fontSize: '14px', color: 'var(--color-text-muted)' }}>
+          Resolved scope: <code>{resolved}</code>
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/state/scope-types.test.ts
+++ b/frontend/src/state/scope-types.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ZIP_FLYTO_ZOOM,
+  zipResolutionToScope,
+  type ScopeResolution,
+  type ZipResolution,
+} from './scope-types.js';
+
+describe('scope-types', () => {
+  it('ZIP_FLYTO_ZOOM is the single shared metro-framing constant (10, inside MAX_BOUNDS, >= 6)', () => {
+    expect(ZIP_FLYTO_ZOOM).toBe(10);
+    expect(ZIP_FLYTO_ZOOM).toBeGreaterThanOrEqual(6);
+  });
+
+  describe('zipResolutionToScope', () => {
+    it('maps a ZipResolution to a ScopeResolution with zoom = ZIP_FLYTO_ZOOM and center/stateCode passthrough', () => {
+      const zip: ZipResolution = {
+        zip: '85701',
+        center: [-110.971, 32.21696],
+        stateCode: 'US-AZ',
+      };
+
+      const scope: ScopeResolution = zipResolutionToScope(zip);
+
+      expect(scope.stateCode).toBe('US-AZ');
+      expect(scope.center).toEqual([-110.971, 32.21696]);
+      expect(scope.zoom).toBe(ZIP_FLYTO_ZOOM);
+    });
+
+    it('center is preserved in [lng, lat] (MapLibre) order — does not swap the tuple', () => {
+      const zip: ZipResolution = {
+        zip: '10001',
+        center: [-73.99718, 40.75064],
+        stateCode: 'US-NY',
+      };
+
+      const scope = zipResolutionToScope(zip);
+
+      // Longitude (first element) is negative for CONUS — a swap would surface it as positive.
+      expect(scope.center[0]).toBeLessThan(0);
+      expect(scope.center[0]).toBe(-73.99718);
+      expect(scope.center[1]).toBe(40.75064);
+    });
+  });
+});

--- a/frontend/src/state/scope-types.ts
+++ b/frontend/src/state/scope-types.ts
@@ -1,28 +1,67 @@
+import type { StateCode } from '@bird-watch/shared-types';
+
 /**
- * The single shared `ZIP_FLYTO_ZOOM` constant.
+ * Pure scope-resolution contracts + the single shared `ZIP_FLYTO_ZOOM`
+ * constant.
  *
  * NO React in this module — it is a pure data handoff (plan seam table: owner
  * D, consumer C). This file is the frozen contract seam between the
- * ZIP-resolution stream (Stream D, #735/#730) and the camera stream
- * (Stream C, #736). Stream C (this task) consumes `ZIP_FLYTO_ZOOM` to drive
- * `MapCanvas`'s ZIP `flyTo`. Stream D's D5 task EXTENDS this file with the
- * `ScopeResolution`/`ZipResolution` shapes and the `zipResolutionToScope`
- * mapper (those have no consumer until D lands, so they live with D to keep
- * knip clean — adding them here now would trip the unused-export gate).
+ * ZIP-resolution stream (Stream D, #735/#730) and the camera + URL-state
+ * stream (Stream C, #736). Stream C consumes `ZIP_FLYTO_ZOOM` to drive
+ * `MapCanvas`'s ZIP `flyTo`; Stream D's D5 task (#739) EXTENDS this same file
+ * with the `ScopeResolution`/`ZipResolution` shapes and the
+ * `zipResolutionToScope` mapper (plan literal #6: "ZIP_FLYTO_ZOOM = 10 as a
+ * single shared constant" — never re-literaled at a call site).
  *
- * Created by #736 (the first consumer that needs `ZIP_FLYTO_ZOOM`) so the
- * camera task is self-contained against `main`; when Stream D's D5 task lands
- * it merges into this same file rather than re-literaling the constant
- * (plan literal #6: "ZIP_FLYTO_ZOOM = 10 as a single shared constant").
+ * `StateCode` is imported from `@bird-watch/shared-types` — the single source
+ * of the 49-code CONUS allowlist (locked decision #6). Re-deriving or
+ * re-listing the codes here would let the clip and the scope contract drift.
  */
+
+/**
+ * A fully-resolved map scope: which state to clip data to (`?state=US-XX`),
+ * and where the camera should sit. `center` is `[lng, lat]` — MapLibre's
+ * coordinate order, NOT the `[lat, lng]` order the columnar ZIP index stores.
+ */
+export interface ScopeResolution {
+  stateCode: StateCode;
+  center: [number, number];
+  zoom: number;
+}
+
+/**
+ * The result of resolving a 5-digit ZIP against the precomputed index: the
+ * ZIP's centroid (`[lng, lat]`) and the CONUS state it falls inside (resolved
+ * offline by point-in-polygon against the canonical state polygons). A
+ * `ZipResolution` carries no zoom — the camera framing is the consumer's
+ * concern, supplied by `zipResolutionToScope`.
+ */
+export interface ZipResolution {
+  zip: string;
+  center: [number, number];
+  stateCode: StateCode;
+}
 
 /**
  * Zoom level the camera flies to when a ZIP centroid is the scope target.
  *
  * 10 = metro framing — close enough to read a city, still inside the
- * whole-state `CONUS_BOUNDS` clamp, and ≥6 (the per-obs API threshold so a ZIP
- * landing never trips the low-zoom aggregation path). Single source of truth:
- * `MapCanvas`'s ZIP `flyTo` imports this; do NOT re-literal `10` at any call
- * site (plan literal #6).
+ * whole-state `CONUS_BOUNDS` clamp, and >= 6 (the per-obs API threshold so a
+ * ZIP landing never trips the low-zoom aggregation path). Single source of
+ * truth: `MapCanvas`'s ZIP `flyTo` imports this; do NOT re-literal `10` at any
+ * call site (plan literal #6).
  */
 export const ZIP_FLYTO_ZOOM = 10;
+
+/**
+ * Lift a `ZipResolution` into a `ScopeResolution` by attaching the standard
+ * metro fly-to zoom. `center` and `stateCode` pass through unchanged — in
+ * particular `center` stays in `[lng, lat]` order (no tuple swap).
+ */
+export function zipResolutionToScope(zip: ZipResolution): ScopeResolution {
+  return {
+    stateCode: zip.stateCode,
+    center: zip.center,
+    zoom: ZIP_FLYTO_ZOOM,
+  };
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1695,3 +1695,48 @@ aside.species-detail-rail .species-detail-rail-close {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
+
+/* ZipInput (#739) — native ZIP entry that resolves to a map scope. A <form
+   role=search> wrapping a single text input plus a feedback line. The input
+   reuses the panel/input visual contract (white surface, --color-border-ui
+   edge, 4px radius); feedback lines use the shared error tokens for the
+   malformed/fetch-error states and muted text for the "not recognized"
+   status. Every className here has a matching rule below (orphan-classname
+   gate). */
+.zip-input {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+.zip-input__field {
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--type-sm);
+  color: var(--color-text-strong);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: 4px;
+  /* A 5-digit ZIP needs little width; cap it so the field doesn't sprawl in
+     the wide on-map control or the landing chooser. */
+  inline-size: 100%;
+  max-inline-size: 8rem;
+}
+.zip-input__field:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.zip-input__status {
+  margin: 0;
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+  line-height: 1.3;
+}
+.zip-input__error {
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--type-sm);
+  color: var(--color-error-text);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: 4px;
+  line-height: 1.3;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Focus["ZipInput focus"] -->|lazy trigger| Load["loadZipIndex()<br/>single-flight memo"]
    Load -->|fetch /zip-index.json?v=1| Pub["public/ asset (CDN, ~1MB)<br/>never in entry chunk"]
    Load -.->|on reject| Clear["clear memo → retry next focus"]

    Submit["Submit (Enter)"] --> Gate{"/^\d{5}$/ ?<br/>(after trim + strip -####)"}
    Gate -->|no| Malformed["inline: Enter a 5-digit ZIP<br/>(no fetch)"]
    Gate -->|yes| Lookup["lookupZip → ZipResolution | null"]
    Lookup -->|resolved| Resolve["onResolve(zipResolutionToScope)<br/>{stateCode, center:[lng,lat], zoom:10}"]
    Lookup -->|null| NotRec["role=status: ZIP not recognized<br/>value KEPT, never silent"]
    Lookup -->|throws| FetchErr["role=alert: pick a state instead"]
```

## Summary

- Stream D tasks D3–D5 of the state/ZIP scope selector plan. The three ship together because `ZipInput` (D5) is the only consumer of both the lazy lookup module (D3) and the pure `ScopeResolution` contract (D4) — splitting them would leave CI-green-but-dead intermediate states. None of this is wired into the app yet; it is consumed by C2a/C4/C6 in later issues.
- The ~1 MB ZIP index is delivered as a CDN-cached `public/` asset, fetched at runtime (never `import`ed → stays out of the entry chunk), warmed lazily on the first input **focus**, memoized single-flight with retry-on-failure, and `?v=1` cache-busted because Vite does not content-hash `public/`. Decision recorded in `docs/decisions/zip-delivery.md`.
- `ZipInput` never fails silently: a resolved ZIP calls `onResolve`; a well-formed-but-unknown ZIP shows a visible `role=status` "ZIP not recognized" message with the value kept; malformed input shows an inline hint with no fetch; a fetch error shows a `role=alert` fallback to the state selector.

## Screenshots

Driven live via Playwright MCP against the dev-only `?ds-preview=zip-input[-error]` harness (gated behind `import.meta.env.DEV`). Zero console errors and zero console warnings at every capture.

**Mobile (390×844) — light theme, all four states + idle**

| Idle | Resolved (85701 → US-AZ) | Not recognized (99999) |
|---|---|---|
| <img alt="zip idle mobile light" src="https://github.com/user-attachments/assets/119a1bc3-b591-4f96-beda-8b06f2635e8c" /> | <img alt="zip resolved mobile light" src="https://github.com/user-attachments/assets/829be00c-9ce7-4355-a7fb-bc1034881708" /> | <img alt="zip not-recognized mobile light" src="https://github.com/user-attachments/assets/d6522933-8150-4d05-9cb9-751b533f614f" /> |

| Malformed (123) | Fetch error |
|---|---|
| <img alt="zip malformed mobile light" src="https://github.com/user-attachments/assets/852a7c39-ca9a-4da0-85ea-51b9ea147796" /> | <img alt="zip fetch-error mobile light" src="https://github.com/user-attachments/assets/a78936d2-8183-4a0e-bff8-4e45d9c90671" /> |

**Mobile (390×844) — dark theme**

| Idle | Not recognized | Malformed | Fetch error |
|---|---|---|---|
| <img alt="zip idle mobile dark" src="https://github.com/user-attachments/assets/6f6247d2-cb37-4abb-9202-a981d33e0584" /> | <img alt="zip not-recognized mobile dark" src="https://github.com/user-attachments/assets/a18ad742-257d-4ba4-b22e-39658cdd039c" /> | <img alt="zip malformed mobile dark" src="https://github.com/user-attachments/assets/cc0c0b2f-f223-473d-9150-86be1d32a90d" /> | <img alt="zip fetch-error mobile dark" src="https://github.com/user-attachments/assets/da21d2fb-b225-4bf3-b6f2-849a3b4acf57" /> |

**Desktop (1440×900)**

| Not recognized — light | Resolved — dark |
|---|---|
| <img alt="zip not-recognized desktop light" src="https://github.com/user-attachments/assets/32a69d59-543d-47aa-8a91-5dcce975756e" /> | <img alt="zip resolved desktop dark" src="https://github.com/user-attachments/assets/144370c5-4cdf-42b6-bd18-ed96b882b87d" /> |

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (886 tests; 26 new across the three files)
- [x] New unit / RTL tests added — `zip-lookup.test.ts` (single-flight, retry, no-fetch-on-malformed, `-####` strip, `[lng,lat]` swap, bundle hygiene), `scope-types.test.ts` (mapper + no-swap guard), `ZipInput.test.tsx` (4 states + load-on-focus-not-mount)
- [ ] New Playwright e2e spec — N/A (e2e ZIP round-trip is task D6, a separate issue; this PR is the unit-tested D3–D5 substrate)
- [x] `npm run build` — clean; `zip-index.json` copied to `dist/` root as a public asset, NOT inlined in any JS chunk
- [x] (UI only) Playwright MCP smoke — drove `ZipInput` via the dev-only `?ds-preview=zip-input[-error]` harness at 390×844 and 1440×900, all four states, light + dark; `browser_console_messages` returned zero errors and zero warnings
- [x] orphan-classname check PASS; knip exit 0

## Plan reference

Part of Plan `state-scope-selector`, Tasks D3 + D4 + D5. See `docs/plans/2026-05-28-state-scope-selector.md`. Part of epic #726. Closes #739.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
