### PR TITLE
feat(frontend): runtime regionLabelFor + sparse/empty-region lede — closes #738

### DIFF
--- a/frontend/e2e/map-cold-load.spec.ts
+++ b/frontend/e2e/map-cold-load.spec.ts
@@ -83,7 +83,11 @@ test.describe('Map cold load — issue #716', () => {
     });
 
     const app = new AppPage(page);
-    await app.goto();
+    // #738 — DEFAULTS.scope is now `unscoped`, so a bare URL renders the
+    // chooser and MapLede returns null (region=null). This suite asserts the
+    // cold-load → lede behaviour, which only exists on a scoped surface, so
+    // land on the whole-US escape hatch (`?scope=us` → region "USA").
+    await app.goto('scope=us');
 
     // <main data-render-complete="false"> is the loading-state marker —
     // App.tsx flips it to "true" only when useBirdData's combined `loading`
@@ -144,7 +148,11 @@ test.describe('Map cold load — issue #716', () => {
     });
 
     const app = new AppPage(page);
-    await app.goto();
+    // #738 — DEFAULTS.scope is now `unscoped`, so a bare URL renders the
+    // chooser and MapLede returns null (region=null). This suite asserts the
+    // cold-load → lede behaviour, which only exists on a scoped surface, so
+    // land on the whole-US escape hatch (`?scope=us` → region "USA").
+    await app.goto('scope=us');
 
     // Wait for the React tree to mount.
     await page.locator('main').waitFor({ state: 'attached', timeout: 5_000 });

--- a/frontend/e2e/map-lede-cls.spec.ts
+++ b/frontend/e2e/map-lede-cls.spec.ts
@@ -81,7 +81,10 @@ test.describe('.map-lede CLS regression — #510', () => {
     await page.setViewportSize(MOBILE);
     await injectLsObserver(page);
 
-    await page.goto('/');
+    // #738 — bare URL now lands unscoped (chooser, no `.map-lede`). The
+    // critical-CSS/CLS contract this spec guards only applies to a scoped
+    // map surface, so navigate to the whole-US escape hatch.
+    await page.goto('/?scope=us');
     await page.waitForLoadState('networkidle');
 
     // .map-lede must be visible and sized correctly
@@ -104,7 +107,8 @@ test.describe('.map-lede CLS regression — #510', () => {
     await page.setViewportSize(DESKTOP);
     await injectLsObserver(page);
 
-    await page.goto('/');
+    // #738 — see mobile case: scope to whole-US so the `.map-lede` renders.
+    await page.goto('/?scope=us');
     await page.waitForLoadState('networkidle');
 
     const lede = page.locator('h1.map-lede');

--- a/frontend/e2e/surface-title.spec.ts
+++ b/frontend/e2e/surface-title.spec.ts
@@ -2,13 +2,18 @@ import { test, expect, VERMFLY } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 test.describe('dynamic <title> per surface', () => {
+  // #738 — DEFAULTS.scope is now `unscoped` (bare URL → chooser, region=null →
+  // SITE_SUFFIX is bare "Bird Maps"). Every navigation here asserts the
+  // *scoped* title contract ("Bird Maps · USA"), so each goto carries the
+  // `?scope=us` whole-US escape hatch that resolves region to "USA". Without
+  // it the unscoped landing would (correctly) render the bare suffix.
   test('map surface shows "Bird Maps · USA"', async ({ page }) => {
-    await page.goto('/?view=map');
+    await page.goto('/?view=map&scope=us');
     await expect(page).toHaveTitle('Bird Maps · USA');
   });
 
   test('feed surface shows "Feed — Bird Maps · USA"', async ({ page }) => {
-    await page.goto('/?view=feed');
+    await page.goto('/?view=feed&scope=us');
     await expect(page).toHaveTitle('Feed — Bird Maps · USA');
   });
 
@@ -17,15 +22,16 @@ test.describe('dynamic <title> per surface', () => {
     // Post-#688: the shim in readUrl redirects to ?view=map; the title is
     // the bare site suffix (no surface prefix). URL constructed via concat
     // so the final-verification grep stays empty without losing coverage.
+    // `scope=us` keeps the region-suffixed title contract under test (#738).
     const legacyView = 'species';
-    await page.goto('/?view=' + legacyView);
+    await page.goto('/?scope=us&view=' + legacyView);
     await expect(page).toHaveTitle('Bird Maps · USA');
   });
 
   test('detail surface with loaded species shows species name in title', async ({ page, apiStub }) => {
     // Stub species endpoint to return Vermilion Flycatcher metadata
     await apiStub.stubSpecies('vermfly', VERMFLY);
-    await page.goto('/?view=detail&detail=vermfly');
+    await page.goto('/?view=detail&detail=vermfly&scope=us');
     // Wait for the detail surface to load species data
     await page.waitForSelector('[data-testid="species-detail-loaded"]', { timeout: 10_000 }).catch(() => {
       // Fallback: wait for detail panel heading to be visible
@@ -39,7 +45,9 @@ test.describe('dynamic <title> per surface', () => {
     // only feed → map remains as a header-driven cross-surface navigation.
     // (Feed itself is reachable only via direct URL post-#662; the Map tab
     // is the only one in AppHeader.)
-    await page.goto('/?view=feed');
+    // `scope=us` persists across the view switch (writeUrl re-emits it), so
+    // both titles keep their "· USA" suffix under the #738 unscoped default.
+    await page.goto('/?view=feed&scope=us');
     await expect(page).toHaveTitle('Feed — Bird Maps · USA');
     const app = new AppPage(page);
     await app.selectView('map');

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -36,6 +36,11 @@ const {
       speciesCode: null as string | null,
       familyCode: null as string | null,
       view: 'feed' as 'feed' | 'map',
+      // #735/#738: scope drives the runtime region label. `us` resolves to
+      // "USA" with no /api/states table needed, so the App→FeedSurface lede
+      // wiring tests assert a deterministic region without inventing a states
+      // fetch (owned by #740). Per-test overrides set scope explicitly.
+      scope: { kind: 'us' as const },
     },
     set: vi.fn(),
   },
@@ -50,10 +55,22 @@ const {
   },
 }));
 
-// Stub url-state before App imports it.
+// Stub url-state before App imports it. #738: App now imports the exported
+// DEFAULTS to compute `noFiltersActive` (`since === DEFAULTS.since`), so the
+// mock must expose it. Only `since` is read by App; mirror the real default.
 vi.mock('./state/url-state.js', () => ({
   useUrlState: () => mockUrlState,
   readMigrationFlag: () => false,
+  DEFAULTS: {
+    speciesCode: null,
+    familyCode: null,
+    since: '14d',
+    notable: false,
+    view: 'map',
+    detail: null,
+    bbox: null,
+    scope: { kind: 'unscoped' },
+  },
 }));
 
 // Stub MapSurface to avoid loading maplibre-gl in jsdom. Since issue #55's
@@ -98,6 +115,7 @@ describe('App error screen', () => {
     __resetSilhouettesCache();
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     mockGetHotspots.mockRejectedValue(new ApiError(503, 'pool exhausted'));
     mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
@@ -179,6 +197,7 @@ describe('App aria-busy', () => {
   it('sets aria-busy=true on <main> when loading on feed view', () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     // getObservations returns a never-resolving promise to keep loading=true
     mockGetObservations.mockReturnValue(new Promise(() => {}));
@@ -190,6 +209,7 @@ describe('App aria-busy', () => {
   it('does NOT set aria-busy=true on map view even while loading', () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'map',
+      scope: { kind: 'us' as const },
     };
     mockGetObservations.mockReturnValue(new Promise(() => {}));
     render(<App />);
@@ -219,6 +239,7 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
     async view => {
       mockUrlState.state = {
         since: '14d', notable: false, speciesCode: null, familyCode: null, view,
+        scope: { kind: 'us' as const },
       };
       const { container } = render(<App />);
       const footer = container.querySelector('footer.app-footer');
@@ -231,6 +252,7 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
     async view => {
       mockUrlState.state = {
         since: '14d', notable: false, speciesCode: null, familyCode: null, view,
+        scope: { kind: 'us' as const },
       };
       render(<App />);
       await screen.findByRole('banner');
@@ -243,6 +265,7 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
   it('AttributionModal Credits button is still present in the DOM (trigger can find it)', () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     const { container } = render(<App />);
     // The modal's own trigger button — className="attribution-trigger"
@@ -267,6 +290,7 @@ describe('Phase 3: AppHeader + Filters panel', () => {
   it('renders <AppHeader> at the top of the app', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     // Wait for initial bird data fetch resolution
@@ -277,6 +301,7 @@ describe('Phase 3: AppHeader + Filters panel', () => {
   it('Filters trigger opens a panel containing <FiltersBar>; closing hides it', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     await screen.findByRole('banner');
@@ -294,6 +319,7 @@ describe('Phase 3: AppHeader + Filters panel', () => {
     // Seed URL with active filters before mount
     mockUrlState.state = {
       since: '14d', notable: true, speciesCode: null, familyCode: 'corvidae', view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     await screen.findByRole('banner');
@@ -331,10 +357,11 @@ describe('Phase 5: FeedSurface lede wiring (App → FeedSurface)', () => {
   it('Priority 1 default lede fires when no species/family filter is set', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     mockGetObservations.mockResolvedValue({ data: [SPECIES_OBS], meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() } });
     render(<App />);
-    await screen.findByText(/species seen across Arizona/i);
+    await screen.findByText(/species seen across USA/i);
     expect(screen.queryByText(/sightings of/i)).toBeNull();
     expect(screen.queryByText(/species of Songbird/i)).toBeNull();
   });
@@ -342,23 +369,25 @@ describe('Phase 5: FeedSurface lede wiring (App → FeedSurface)', () => {
   it('Priority 2 lede fires (species name in lede) when speciesCode filter is active', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: 'vermfly', familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     mockGetObservations.mockResolvedValue({ data: [SPECIES_OBS], meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() } });
     render(<App />);
-    // Priority 2: "{N} sightings of {name} in Arizona in the last {period}."
+    // Priority 2: "{N} sightings of {name} in USA in the last {period}."
     // Regex anchors the period token ("14 days") to catch PERIOD_LABELS
     // regressions that produce "in the last Last 14 days." or similar.
-    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona in the last 14 days\./i);
+    await screen.findByText(/sightings of Vermilion Flycatcher in USA in the last 14 days\./i);
   });
 
   it('Priority 3 lede fires (family name in lede) when familyCode filter is active (no speciesCode)', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: 'songbird', view: 'feed',
+      scope: { kind: 'us' as const },
     };
     mockGetObservations.mockResolvedValue({ data: [SPECIES_OBS], meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() } });
     render(<App />);
-    // Priority 3: "{N} species of {family} seen across Arizona…"
-    await screen.findByText(/species of Songbird seen across Arizona/i);
+    // Priority 3: "{N} species of {family} seen across USA…"
+    await screen.findByText(/species of Songbird seen across USA/i);
   });
 });
 
@@ -394,11 +423,12 @@ describe('Phase 5: FeedSurface cross-surface FilterSentence drift regression', (
   it('with species filter active on feed view, both lede AND FilterSentence mention the species', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: 'vermfly', familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     mockGetObservations.mockResolvedValue({ data: [SPECIES_OBS], meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() } });
     const { container } = render(<App />);
     // Lede must resolve the species name from the speciesIndex and include it.
-    await screen.findByText(/sightings of Vermilion Flycatcher in Arizona in the last 14 days\./i);
+    await screen.findByText(/sightings of Vermilion Flycatcher in USA in the last 14 days\./i);
     // FilterSentence visible sentence must reflect the species — either the
     // resolved common name (when speciesName is threaded from App) or the raw
     // code as a fallback. The key invariant is that the element is rendered
@@ -430,7 +460,9 @@ describe('L2: freshness empty state (null freshestObservationAt)', () => {
 
   beforeEach(() => {
     __resetSilhouettesCache();
-    mockUrlState.state = { since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed' };
+    mockUrlState.state = { since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
+    };
     mockGetHotspots.mockResolvedValue([]);
     mockGetSilhouettes.mockResolvedValue([]);
   });
@@ -442,7 +474,7 @@ describe('L2: freshness empty state (null freshestObservationAt)', () => {
   it('does not render alarming freshness copy when freshestObservationAt is null', async () => {
     mockGetObservations.mockResolvedValue({ data: [OBS], meta: { freshestObservationAt: null } });
     render(<App />);
-    await screen.findByText(/species seen across Arizona/i);
+    await screen.findByText(/species seen across USA/i);
     expect(screen.queryByText(/Source unavailable/i)).toBeNull();
     expect(screen.queryByText(/check back soon/i)).toBeNull();
   });
@@ -472,7 +504,9 @@ describe('L3: nowTick advances on visibilitychange (tab return)', () => {
 
   beforeEach(() => {
     __resetSilhouettesCache();
-    mockUrlState.state = { since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed' };
+    mockUrlState.state = { since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
+    };
     mockGetHotspots.mockResolvedValue([]);
     mockGetSilhouettes.mockResolvedValue([]);
   });
@@ -486,7 +520,7 @@ describe('L3: nowTick advances on visibilitychange (tab return)', () => {
     const removeSpy = vi.spyOn(document, 'removeEventListener');
     mockGetObservations.mockResolvedValue({ data: [OBS], meta: { freshestObservationAt: RECENT_ISO } });
     const { unmount } = render(<App />);
-    await screen.findByText(/species seen across Arizona/i);
+    await screen.findByText(/species seen across USA/i);
 
     expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
 
@@ -497,7 +531,7 @@ describe('L3: nowTick advances on visibilitychange (tab return)', () => {
   it('fires setNowTick when tab becomes visible', async () => {
     mockGetObservations.mockResolvedValue({ data: [OBS], meta: { freshestObservationAt: RECENT_ISO } });
     render(<App />);
-    await screen.findByText(/species seen across Arizona/i);
+    await screen.findByText(/species seen across USA/i);
 
     // Simulate tab returning to foreground — trigger visibilitychange with
     // document.visibilityState === 'visible' (jsdom default).
@@ -509,7 +543,7 @@ describe('L3: nowTick advances on visibilitychange (tab return)', () => {
     // App re-renders without crashing — freshness label is still present
     // (we can't easily assert exact time, but we verify no error is thrown
     // and the lede is still rendered).
-    expect(screen.getByText(/species seen across Arizona/i)).toBeInTheDocument();
+    expect(screen.getByText(/species seen across USA/i)).toBeInTheDocument();
   });
 });
 
@@ -551,6 +585,7 @@ describe('App.tsx onSelectSpecies bbox-clear invariant (#560)', () => {
       speciesCode: null,
       familyCode: null,
       view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     // Wait for feed rows to render
@@ -574,6 +609,7 @@ describe('App.tsx onSelectSpecies bbox-clear invariant (#560)', () => {
       speciesCode: null,
       familyCode: null,
       view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     await screen.findByRole('banner');
@@ -602,6 +638,7 @@ describe('App.tsx onSelectSpecies bbox-clear invariant (#560)', () => {
       speciesCode: null,
       familyCode: null,
       view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     const feedRow = await screen.findByRole('button', { name: /Vermilion Flycatcher/i });
@@ -632,6 +669,7 @@ describe('Clarity view tagging (#657-followup)', () => {
     const setViewSpy = vi.spyOn(analytics, 'setView');
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'feed',
+      scope: { kind: 'us' as const },
     };
     render(<App />);
     expect(setViewSpy).toHaveBeenCalledWith('feed');
@@ -674,6 +712,7 @@ describe('Zoom/bbox state-race regression (#690)', () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map',
+      scope: { kind: 'us' as const },
     };
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
 import { analytics } from './analytics.js';
 import { ApiClient, ApiError } from './api/client.js';
-import { useUrlState } from './state/url-state.js';
+import { useUrlState, DEFAULTS } from './state/url-state.js';
 import type { Since, BBox } from './state/url-state.js';
 import { useBirdData } from './data/use-bird-data.js';
 import { useSilhouettes } from './data/use-silhouettes.js';
@@ -17,7 +17,7 @@ import { useIsCompact } from './lib/use-is-compact.js';
 import { AttributionModal } from './components/AttributionModal.js';
 import { deriveFamilies, deriveSpeciesIndex } from './derived.js';
 import { filterObservationsByBounds } from './lib/viewport-filter.js';
-import { REGION_LABEL } from './config/region.js';
+import { regionLabelFor } from './config/region.js';
 import { SurfaceTitleSync } from './components/SurfaceTitleSync.js';
 import { StatusBlock } from './components/ds/StatusBlock.js';
 import { deriveFreshness } from './lib/freshness.js';
@@ -131,6 +131,25 @@ export function App() {
     '14d': '14 days',
   };
   const period = PERIOD_LABELS[state.since];
+
+  // #738/C5: runtime region label for the active scope (#735). `null` ⟺
+  // unscoped (the chooser landing) — every consumer degrades to no region
+  // claim. The `/api/states` name table (#732) is threaded by #740's wiring;
+  // until then a `?state=US-XX` scope falls back to the bare code (the
+  // documented `?? scope.stateCode` fallback in regionLabelFor).
+  const region = regionLabelFor(state.scope);
+
+  // #738/C7: "no filters active" — the data-availability vs filter-narrowing
+  // split (MapLede) keys off this. A request is unfiltered ONLY when no
+  // species/family/notable filter is set AND `since` is the default. The
+  // `since === DEFAULTS.since` comparison lives here (once, at the call site)
+  // so MapLede stays presentational. DEFAULTS is the exported symbol (#735),
+  // not a re-declared literal.
+  const noFiltersActive =
+    state.speciesCode === null &&
+    state.familyCode === null &&
+    state.notable === false &&
+    state.since === DEFAULTS.since;
 
   // Resolve human-readable species name when a speciesCode filter is active.
   // Derived from speciesIndex — same source the FiltersBar autocomplete uses.
@@ -354,10 +373,12 @@ export function App() {
       <SurfaceTitleSync
         view={state.view}
         speciesCommonName={activeSpeciesMeta?.comName ?? null}
+        region={region}
       />
       <AppHeader
         activeView={state.view}
         onSelectView={view => set({ view })}
+        region={region}
         filterCount={filterCount}
         onOpenFilters={() => setFiltersOpen(true)}
         onOpenAttribution={onOpenAttribution}
@@ -405,7 +426,7 @@ export function App() {
             onSelectSpecies={onSelectSpecies}
             speciesIndex={speciesIndex}
             observationCount={observations.length}
-            regionLabel={REGION_LABEL}
+            regionLabel={region}
             period={period}
             freshness={freshnessState}
             freshnessLabel={freshnessLabel}
@@ -438,6 +459,8 @@ export function App() {
             freshness={freshnessState}
             freshnessLabel={freshnessLabel}
             loading={observationsLoading}
+            region={region}
+            noFiltersActive={noFiltersActive}
           />
         )}
         {/*

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -6,17 +6,34 @@ import { AppHeader } from './AppHeader.js';
 const baseProps = {
   activeView: 'map' as const,
   onSelectView: vi.fn(),
+  region: 'Arizona' as string | null,
   filterCount: 0,
   onOpenFilters: vi.fn(),
   onOpenAttribution: vi.fn(),
 };
 
 describe('<AppHeader>', () => {
-  it('renders the wordmark with REGION_LABEL', () => {
-    render(<AppHeader {...baseProps} />);
+  it('renders the wordmark with the runtime region (#738/C5)', () => {
+    render(<AppHeader {...baseProps} region="Arizona" />);
     const link = screen.getByRole('link', { name: /Bird Maps Arizona — home/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveTextContent(/Bird Maps · Arizona/);
+  });
+
+  it('threads the ?scope=us region "USA" into the wordmark', () => {
+    render(<AppHeader {...baseProps} region="USA" />);
+    const link = screen.getByRole('link', { name: /Bird Maps USA — home/i });
+    expect(link).toHaveTextContent(/Bird Maps · USA/);
+  });
+
+  it('unscoped (region=null): wordmark is "Bird Maps" with no " · " separator', () => {
+    render(<AppHeader {...baseProps} region={null} />);
+    const link = screen.getByRole('link', { name: 'Bird Maps — home' });
+    expect(link).toBeInTheDocument();
+    // No bare separator and no region word in the visible text or aria-label.
+    expect(link.textContent).toBe('Bird Maps');
+    expect(link).not.toHaveTextContent('·');
+    expect(link.getAttribute('aria-label')).toBe('Bird Maps — home');
   });
 
   it('renders a single Map tab (Species + Feed removed per #688 / #662)', () => {

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,11 +1,17 @@
 import { useRef, type KeyboardEvent } from 'react';
-import { REGION_LABEL } from '../config/region.js';
 import { ThemeToggle } from './ThemeToggle.js';
 import type { View } from '../state/url-state.js';
 
 export interface AppHeaderProps {
   activeView: View;
   onSelectView: (view: View) => void;
+  /**
+   * #738/C5: runtime region label for the active scope (from `regionLabelFor`).
+   * `null` ⟺ the unscoped/chooser landing — the wordmark renders just "Bird
+   * Maps" with no ` · {region}` suffix and the aria-label drops the region
+   * word. Non-null appends " · {region}" (e.g. "Bird Maps · Arizona").
+   */
+  region: string | null;
   /** Active filter count — drives the numeric badge on the Filters trigger. */
   filterCount: number;
   /** Open the Filters panel. <App> owns the panel state; this component is presentational. */
@@ -37,6 +43,7 @@ const TABS: readonly TabDef[] = [
 export function AppHeader({
   activeView,
   onSelectView,
+  region,
   filterCount,
   onOpenFilters,
   onOpenAttribution,
@@ -86,8 +93,19 @@ export function AppHeader({
 
   return (
     <header className="app-header" role="banner">
-      <a className="app-header-wordmark" href="/" aria-label={`Bird Maps ${REGION_LABEL} — home`}>
-        Bird Maps<span className="brand-region"><span aria-hidden="true"> ·</span> {REGION_LABEL}</span>
+      <a
+        className="app-header-wordmark"
+        href="/"
+        aria-label={region ? `Bird Maps ${region} — home` : 'Bird Maps — home'}
+      >
+        {/* #738/C5: on the unscoped landing (region=null) the wordmark omits
+            the ` · {region}` suffix entirely — never a bare ` · ` separator. */}
+        Bird Maps
+        {region && (
+          <span className="brand-region">
+            <span aria-hidden="true"> ·</span> {region}
+          </span>
+        )}
       </a>
 
       <div className="app-header-nav" role="tablist" aria-label="Surface">

--- a/frontend/src/components/FeedSurface.tsx
+++ b/frontend/src/components/FeedSurface.tsx
@@ -11,7 +11,6 @@ import { FilterSentence } from './ds/FilterSentence.js';
 import { SortLabel } from './ds/SortLabel.js';
 import type { Freshness } from './MapLede.js';
 import { buildFamilyColorResolver, buildFamilyPathResolver } from '../data/family-color.js';
-import { REGION_LABEL } from '../config/region.js';
 
 export interface FeedSurfaceFilters {
   notable: boolean;
@@ -41,8 +40,13 @@ export interface FeedSurfaceProps {
    * rough fallback (may overcount if multiple obs share a species code).
    */
   observationCount?: number;
-  /** Human-readable region label for the lede ("Arizona"). */
-  regionLabel?: string;
+  /**
+   * Runtime region label for the lede ("Arizona", "USA"), from `regionLabelFor`
+   * (#738/C5). `null`/absent ⟺ the unscoped landing — the feed asserts no
+   * region (the feed surface isn't shown unscoped, but the lede degrades
+   * cleanly rather than printing "null").
+   */
+  regionLabel?: string | null;
   /** Human-readable period for the lede ("14 days"). */
   period?: string;
   /**
@@ -214,7 +218,7 @@ export function FeedSurface(props: FeedSurfaceProps) {
     onSelectSpecies,
     speciesIndex,
     observationCount,
-    regionLabel = REGION_LABEL,
+    regionLabel = null,
     period = '14 days',
     speciesName,
     familyName,
@@ -265,13 +269,23 @@ export function FeedSurface(props: FeedSurfaceProps) {
     if (effectiveCount === 0) {
       return 'No sightings match your current filters.';
     }
+    // #738/C5: region is runtime now. The feed surface only renders under an
+    // active scope (region non-null); when null (unscoped, defensive) the lede
+    // asserts no region — drop the " in/across {region}" phrase rather than
+    // printing "null".
     if (speciesName) {
-      return `${effectiveCount} sightings of ${speciesName} in ${regionLabel}${periodClause}.`;
+      return regionLabel
+        ? `${effectiveCount} sightings of ${speciesName} in ${regionLabel}${periodClause}.`
+        : `${effectiveCount} sightings of ${speciesName}${periodClause}.`;
     }
     if (familyName) {
-      return `${effectiveCount} species of ${familyName} seen across ${regionLabel}${periodClause}.`;
+      return regionLabel
+        ? `${effectiveCount} species of ${familyName} seen across ${regionLabel}${periodClause}.`
+        : `${effectiveCount} species of ${familyName}${periodClause}.`;
     }
-    return `${effectiveCount} species seen across ${regionLabel}${periodClause}.`;
+    return regionLabel
+      ? `${effectiveCount} species seen across ${regionLabel}${periodClause}.`
+      : `${effectiveCount} species${periodClause}.`;
   }, [effectiveCount, speciesName, familyName, regionLabel, periodClause]);
 
   // Build the ActiveFilters shape expected by <FilterSentence>.

--- a/frontend/src/components/MapLede.test.tsx
+++ b/frontend/src/components/MapLede.test.tsx
@@ -2,39 +2,89 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MapLede } from './MapLede.js';
 
+// #738/C7 — MapLede is presentational. It receives the runtime region label
+// (`region: string | null`, from regionLabelFor — `null` ⟺ unscoped) and a
+// caller-computed `noFiltersActive` boolean (App.tsx #740 owns the
+// `since === DEFAULTS.since` comparison). The zero-count branch is split into
+// a data-availability case (sparse/empty region, no filters) and the existing
+// filter-narrowing case.
+const base = {
+  region: 'Arizona' as string | null,
+  noFiltersActive: true,
+  period: '14 days',
+} as const;
+
 describe('<MapLede>', () => {
-  it('Template 1: zero results — returns the no-match string', () => {
-    render(
+  it('unscoped (region=null): renders nothing — the chooser is shown', () => {
+    const { container } = render(
       <MapLede
-        speciesCount={0}
-        observationCount={0}
+        {...base}
+        region={null}
+        speciesCount={344}
+        observationCount={11_412}
         speciesCommonName={null}
         familyName={null}
-        period="14 days"
         freshness="fresh"
         loading={false}
       />,
     );
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-      'No sightings match your current filters.',
-    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
   });
 
-  // Issue #716: during the cold-load window (initial fetch unresolved),
-  // useBirdData seeds observations to [] so MapSurface derives
-  // observationCount=0 + speciesCount=0. Without the loading guard, Template 1
-  // ("No sightings match your current filters.") fires, which is misleading
-  // — the user hasn't applied filters yet. The lede must suppress entirely
-  // during loading so the context strip collapses to nothing (matches
-  // FeedSurface.tsx:353-358 and the always-empty freshness label).
-  it('loading=true with zero counts: renders nothing (issue #716)', () => {
-    const { container } = render(
+  it('zero counts + no filters active: data-availability copy naming the region', () => {
+    render(
       <MapLede
+        {...base}
+        region="New York"
+        noFiltersActive={true}
         speciesCount={0}
         observationCount={0}
         speciesCommonName={null}
         familyName={null}
-        period="14 days"
+        freshness="empty"
+        loading={false}
+      />,
+    );
+    const h = screen.getByRole('heading', { level: 1 });
+    expect(h).toHaveTextContent('No recent sightings in New York yet.');
+    // NOT the filter-narrowing copy.
+    expect(h.textContent).not.toMatch(/match your current filters/);
+  });
+
+  it('zero counts + filters active: keeps the filter-narrowing copy', () => {
+    render(
+      <MapLede
+        {...base}
+        region="Arizona"
+        noFiltersActive={false}
+        speciesCount={0}
+        observationCount={0}
+        speciesCommonName={null}
+        familyName={null}
+        freshness="fresh"
+        loading={false}
+      />,
+    );
+    const h = screen.getByRole('heading', { level: 1 });
+    expect(h).toHaveTextContent('No sightings match your current filters.');
+    expect(h.textContent).not.toMatch(/No recent sightings/);
+  });
+
+  // Issue #716/#720: during the cold-load window the lede must suppress even
+  // when no filters are active — counts are 0 because the fetch hasn't
+  // resolved, not because the region is sparse. The loading guard wins over
+  // the data-availability branch.
+  it('loading=true with zero counts: renders nothing (issue #716)', () => {
+    const { container } = render(
+      <MapLede
+        {...base}
+        region="Arizona"
+        noFiltersActive={true}
+        speciesCount={0}
+        observationCount={0}
+        speciesCommonName={null}
+        familyName={null}
         freshness="empty"
         loading={true}
       />,
@@ -43,37 +93,14 @@ describe('<MapLede>', () => {
     expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
   });
 
-  // Regression guard: once the fetch resolves, a genuinely empty result set
-  // must still surface Template 1 (legitimate empty-state — see the second
-  // screenshot in #716, e.g. ?since=1d&notable=true&familyCode=trogonidae).
-  it('loading=false with zero counts: still renders Template 1', () => {
-    render(
-      <MapLede
-        speciesCount={0}
-        observationCount={0}
-        speciesCommonName={null}
-        familyName={null}
-        period="14 days"
-        freshness="fresh"
-        loading={false}
-      />,
-    );
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-      'No sightings match your current filters.',
-    );
-  });
-
-  // Loading should NOT suppress the lede when counts are non-zero. (Re-fetches
-  // keep stale observations rendered per use-bird-data.ts:87-101, so the lede
-  // should keep narrating the prior result during a refetch.)
   it('loading=true with non-zero counts: still renders the real template', () => {
     render(
       <MapLede
+        {...base}
         speciesCount={344}
         observationCount={11_412}
         speciesCommonName={null}
         familyName={null}
-        period="14 days"
         freshness="fresh"
         loading={true}
       />,
@@ -86,11 +113,11 @@ describe('<MapLede>', () => {
   it('Template 2: single species — count + common name + region + period', () => {
     render(
       <MapLede
+        {...base}
         speciesCount={1}
         observationCount={47}
         speciesCommonName="Vermilion Flycatcher"
         familyName={null}
-        period="14 days"
         freshness="fresh"
         loading={false}
       />,
@@ -103,11 +130,11 @@ describe('<MapLede>', () => {
   it('Template 3: family filter active — N species of family in region in period', () => {
     render(
       <MapLede
+        {...base}
         speciesCount={9}
         observationCount={120}
         speciesCommonName={null}
         familyName="woodpeckers"
-        period="14 days"
         freshness="fresh"
         loading={false}
       />,
@@ -120,11 +147,11 @@ describe('<MapLede>', () => {
   it('Template 4: default — N species across region in period', () => {
     render(
       <MapLede
+        {...base}
         speciesCount={344}
         observationCount={11_412}
         speciesCommonName={null}
         familyName={null}
-        period="14 days"
         freshness="fresh"
         loading={false}
       />,
@@ -134,14 +161,32 @@ describe('<MapLede>', () => {
     );
   });
 
+  it('threads the ?scope=us region "USA" into Template 4', () => {
+    render(
+      <MapLede
+        {...base}
+        region="USA"
+        speciesCount={472}
+        observationCount={20_000}
+        speciesCommonName={null}
+        familyName={null}
+        freshness="fresh"
+        loading={false}
+      />,
+    );
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      '472 species seen across USA in the last 14 days.',
+    );
+  });
+
   it('drops the period clause under freshness="stale"', () => {
     render(
       <MapLede
+        {...base}
         speciesCount={344}
         observationCount={11_412}
         speciesCommonName={null}
         familyName={null}
-        period="14 days"
         freshness="stale"
         loading={false}
       />,
@@ -150,23 +195,5 @@ describe('<MapLede>', () => {
       '344 species seen across Arizona.',
     );
     expect(screen.queryByText(/in the last/)).toBeNull();
-  });
-
-  it('uses REGION_LABEL constant — text contains "Arizona" exactly', () => {
-    render(
-      <MapLede
-        speciesCount={344}
-        observationCount={11_412}
-        speciesCommonName={null}
-        familyName={null}
-        period="14 days"
-        freshness="fresh"
-        loading={false}
-      />,
-    );
-    // Asserts the substitution worked — REGION_LABEL is the source of truth
-    expect(screen.getByRole('heading', { level: 1 }).textContent).toMatch(
-      /across Arizona/,
-    );
   });
 });

--- a/frontend/src/components/MapLede.tsx
+++ b/frontend/src/components/MapLede.tsx
@@ -1,8 +1,20 @@
-import { REGION_LABEL } from '../config/region.js';
-
 export type Freshness = 'fresh' | 'recent' | 'stale' | 'empty' | 'error';
 
 export interface MapLedeProps {
+  /**
+   * Runtime region label for the active scope (from `regionLabelFor`, #738/C5).
+   * `null` ⟺ the unscoped/chooser landing — MapLede renders nothing in that
+   * case (the chooser is shown instead of the map; #740/#742 gate the render).
+   * Non-null is "USA" (`?scope=us`) or the resolved state name (`?state=`).
+   */
+  region: string | null;
+  /**
+   * #738/C7: caller-computed "no filters are active" flag. App.tsx (#740)
+   * owns the `since === DEFAULTS.since` comparison so MapLede stays
+   * presentational. When true AND counts are zero, the lede reads as a
+   * data-availability state (sparse region) rather than a filter mistake.
+   */
+  noFiltersActive: boolean;
   /** Number of distinct species across the active filter scope. */
   speciesCount: number;
   /** Number of observations across the active filter scope. */
@@ -37,8 +49,15 @@ export interface MapLedeProps {
  * Newspaper lede for the map / feed / species surfaces. 4 templates in
  * priority order — see docs/design/01-spec/voice-and-content.md §"Lede
  * contract". Stale data drops the "in the last {period}" clause.
+ *
+ * Zero-count narration (#738/C7) is split into two cases so a scoped-but-thin
+ * region reads as a *data-availability* state, not a *filter-narrowed* one:
+ *   - no filters active → "No recent sightings in {region} yet." (sparse)
+ *   - filters active    → "No sightings match your current filters."
  */
 export function MapLede({
+  region,
+  noFiltersActive,
   speciesCount,
   observationCount,
   speciesCommonName,
@@ -47,12 +66,21 @@ export function MapLede({
   freshness,
   loading,
 }: MapLedeProps) {
+  // #738/C7: unscoped (region=null) → the chooser is shown, not the map, so
+  // there is no region to claim. Return null — same discipline as the
+  // cold-load guard below (#716/#720). Guarding before the loading check is
+  // safe because both branches return null.
+  if (region === null) {
+    return null;
+  }
+
   // Issue #716: suppress the lede during the cold-load window. Without this
-  // guard, the empty seed `observations: []` from useBirdData causes Template 1
-  // ("No sightings match your current filters.") to fire — misleading because
-  // the user hasn't applied any filters yet. Suppressing the lede entirely
-  // (rather than swapping in "Loading sightings…") avoids a transient string
-  // that would flash and get replaced ~1s later.
+  // guard, the empty seed `observations: []` from useBirdData causes the
+  // zero-count Template 1 to fire — misleading because the data simply hasn't
+  // arrived yet. Suppressing the lede entirely (rather than swapping in
+  // "Loading sightings…") avoids a transient string that would flash and get
+  // replaced ~1s later. This wins over the data-availability branch too: a
+  // sparse-region read must not flash before the first fetch resolves.
   if (loading && observationCount === 0 && speciesCount === 0) {
     return null;
   }
@@ -61,17 +89,22 @@ export function MapLede({
 
   let text: string;
   if (observationCount === 0 && speciesCount === 0) {
-    // Template 1
-    text = 'No sightings match your current filters.';
+    // #738/C7 — split the zero-count branch on whether any filter is active.
+    text = noFiltersActive
+      ? // Data-availability: the region itself is sparse; the user didn't
+        // narrow anything. Keep this copy in lockstep with #741's e2e spec.
+        `No recent sightings in ${region} yet.`
+      : // Filter-narrowing: the user's active filters excluded everything.
+        'No sightings match your current filters.';
   } else if (speciesCommonName) {
     // Template 2
-    text = `${observationCount} sightings of ${speciesCommonName} in ${REGION_LABEL}${periodClause}.`;
+    text = `${observationCount} sightings of ${speciesCommonName} in ${region}${periodClause}.`;
   } else if (familyName) {
     // Template 3
-    text = `${speciesCount} species of ${familyName} seen across ${REGION_LABEL}${periodClause}.`;
+    text = `${speciesCount} species of ${familyName} seen across ${region}${periodClause}.`;
   } else {
     // Template 4
-    text = `${speciesCount} species seen across ${REGION_LABEL}${periodClause}.`;
+    text = `${speciesCount} species seen across ${region}${periodClause}.`;
   }
 
   return <h1 className="map-lede">{text}</h1>;

--- a/frontend/src/components/MapSurface.test.tsx
+++ b/frontend/src/components/MapSurface.test.tsx
@@ -78,6 +78,12 @@ const baseProps = {
   // to false so pre-existing tests assert the post-load surface; the
   // loading=true behavior is covered in MapLede.test.tsx.
   loading: false,
+  // #738/C5: runtime region label forwarded to MapLede. Default to the AZ
+  // scope so pre-existing lede assertions ("seen across Arizona") hold.
+  region: 'Arizona' as string | null,
+  // #738/C7: no-filters flag forwarded to MapLede for the data-availability
+  // vs filter-narrowing zero-count split.
+  noFiltersActive: true,
 };
 
 // Issue #662: the "Skip to species list" skip-link + its `onSkipToFeed`
@@ -184,6 +190,8 @@ describe('Phase 3: context strip', () => {
         notable={false}
         freshness="fresh"
         freshnessLabel="Updated 11 min ago · Source: eBird"
+        region="Arizona"
+        noFiltersActive={true}
       />,
     );
     expect(screen.getByRole('heading', { level: 1, name: /3 species seen across Arizona in the last 14 days\./i })).toBeInTheDocument();
@@ -200,6 +208,8 @@ describe('Phase 3: context strip', () => {
         notable={true}
         freshness="fresh"
         freshnessLabel="Updated 11 min ago · Source: eBird"
+        region="Arizona"
+        noFiltersActive={false}
       />,
     );
     // <FilterSentence> renders a span with class .filter-sentence__visible when filters are non-empty
@@ -217,6 +227,8 @@ describe('Phase 3: context strip', () => {
         notable={false}
         freshness="fresh"
         freshnessLabel="Updated 11 min ago · Source: eBird"
+        region="Arizona"
+        noFiltersActive={true}
       />,
     );
     expect(screen.getByText('Updated 11 min ago · Source: eBird')).toHaveClass('map-freshness');
@@ -233,6 +245,8 @@ describe('Phase 3: context strip', () => {
         notable={false}
         freshness="stale"
         freshnessLabel="Last updated 9 h ago · Source: eBird"
+        region="Arizona"
+        noFiltersActive={true}
       />,
     );
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -133,6 +133,19 @@ export interface MapSurfaceProps {
    * resolves before `/api/observations`.
    */
   loading: boolean;
+  /**
+   * #738/C5: runtime region label for the active scope (from `regionLabelFor`).
+   * Forwarded to <MapLede>. `null` ⟺ the unscoped/chooser landing, where
+   * MapLede renders nothing. App.tsx (#740) derives this from `state.scope`.
+   */
+  region: string | null;
+  /**
+   * #738/C7: whether any filter is active (App.tsx owns the
+   * `since === DEFAULTS.since` comparison). Forwarded to <MapLede> so the
+   * zero-count branch reads as data-availability (sparse region) vs
+   * filter-narrowing.
+   */
+  noFiltersActive: boolean;
 }
 
 /**
@@ -165,6 +178,8 @@ export function MapSurface({
   freshness,
   freshnessLabel,
   loading,
+  region,
+  noFiltersActive,
 }: MapSurfaceProps) {
   // Compute the expand-by-default once at mount. The component itself
   // (FamilyLegend) handles localStorage precedence + manual toggle.
@@ -214,6 +229,8 @@ export function MapSurface({
       {/* Phase 3: context strip — lede + filter sentence + freshness meta */}
       <section className="map-context-strip" aria-label="Map context">
         <MapLede
+          region={region}
+          noFiltersActive={noFiltersActive}
           speciesCount={speciesCount}
           observationCount={observationCount}
           speciesCommonName={speciesCommonName}

--- a/frontend/src/components/SurfaceTitleSync.test.tsx
+++ b/frontend/src/components/SurfaceTitleSync.test.tsx
@@ -2,45 +2,67 @@ import { render } from '@testing-library/react';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { SurfaceTitleSync } from './SurfaceTitleSync';
 
-// jsdom allows document.title reads
+// jsdom allows document.title reads. #738/C5: the region is a runtime prop now
+// (from regionLabelFor) — `null` ⟺ the unscoped/chooser landing, where the
+// site suffix falls back to "Bird Maps" (never "Bird Maps · ").
 describe('SurfaceTitleSync', () => {
   beforeEach(() => {
     document.title = '';
   });
 
   it('sets title to "Bird Maps · Arizona" on map surface', () => {
-    render(<SurfaceTitleSync view="map" speciesCommonName={null} />);
+    render(<SurfaceTitleSync view="map" speciesCommonName={null} region="Arizona" />);
     expect(document.title).toBe('Bird Maps · Arizona');
   });
 
   it('sets title to "Feed — Bird Maps · Arizona" on feed surface', () => {
-    render(<SurfaceTitleSync view="feed" speciesCommonName={null} />);
+    render(<SurfaceTitleSync view="feed" speciesCommonName={null} region="Arizona" />);
     expect(document.title).toBe('Feed — Bird Maps · Arizona');
   });
 
   it('sets title to "{commonName} — Bird Maps · Arizona" on detail surface with species', () => {
-    render(<SurfaceTitleSync view="detail" speciesCommonName="Gila Woodpecker" />);
+    render(<SurfaceTitleSync view="detail" speciesCommonName="Gila Woodpecker" region="Arizona" />);
     expect(document.title).toBe('Gila Woodpecker — Bird Maps · Arizona');
   });
 
   it('falls back to "Bird Maps · Arizona" on detail surface with no species', () => {
-    render(<SurfaceTitleSync view="detail" speciesCommonName={null} />);
+    render(<SurfaceTitleSync view="detail" speciesCommonName={null} region="Arizona" />);
     expect(document.title).toBe('Bird Maps · Arizona');
   });
 
+  it('threads the ?scope=us region into the title', () => {
+    render(<SurfaceTitleSync view="map" speciesCommonName={null} region="USA" />);
+    expect(document.title).toBe('Bird Maps · USA');
+  });
+
+  it('unscoped (region=null): title is "Bird Maps" with no trailing " · "', () => {
+    render(<SurfaceTitleSync view="map" speciesCommonName={null} region={null} />);
+    expect(document.title).toBe('Bird Maps');
+    expect(document.title).not.toMatch(/·\s*$/);
+  });
+
+  it('unscoped detail surface with species: "{commonName} — Bird Maps"', () => {
+    render(<SurfaceTitleSync view="detail" speciesCommonName="Gila Woodpecker" region={null} />);
+    expect(document.title).toBe('Gila Woodpecker — Bird Maps');
+  });
+
   it('updates title when view changes', () => {
-    const { rerender } = render(<SurfaceTitleSync view="map" speciesCommonName={null} />);
+    const { rerender } = render(
+      <SurfaceTitleSync view="map" speciesCommonName={null} region="Arizona" />,
+    );
     expect(document.title).toBe('Bird Maps · Arizona');
-    rerender(<SurfaceTitleSync view="feed" speciesCommonName={null} />);
+    rerender(<SurfaceTitleSync view="feed" speciesCommonName={null} region="Arizona" />);
     expect(document.title).toBe('Feed — Bird Maps · Arizona');
   });
 
   it('updates title when species changes on detail surface', () => {
     const { rerender } = render(
-      <SurfaceTitleSync view="detail" speciesCommonName="Gila Woodpecker" />
+      <SurfaceTitleSync view="detail" speciesCommonName="Gila Woodpecker" region="Arizona" />,
     );
     expect(document.title).toBe('Gila Woodpecker — Bird Maps · Arizona');
-    rerender(<SurfaceTitleSync view="detail" speciesCommonName="Vermilion Flycatcher" />);
+    rerender(
+      <SurfaceTitleSync view="detail" speciesCommonName="Vermilion Flycatcher" region="Arizona" />,
+    );
     expect(document.title).toBe('Vermilion Flycatcher — Bird Maps · Arizona');
   });
 });

--- a/frontend/src/components/SurfaceTitleSync.tsx
+++ b/frontend/src/components/SurfaceTitleSync.tsx
@@ -1,23 +1,33 @@
 import { useEffect } from 'react';
 import type { View } from '../state/url-state.js';
-import { REGION_LABEL } from '../config/region.js';
 
 interface SurfaceTitleSyncProps {
   view: View;
   speciesCommonName: string | null;
+  /**
+   * #738/C5: runtime region label for the active scope (from `regionLabelFor`).
+   * `null` ⟺ the unscoped/chooser landing — the site suffix falls back to
+   * "Bird Maps" (no ` · {region}`) so document.title never reads "Bird Maps · ".
+   */
+  region: string | null;
 }
 
-const SITE_SUFFIX = `Bird Maps · ${REGION_LABEL}`;
-
-function buildTitle(view: View, speciesCommonName: string | null): string {
+// #738/C5: SITE_SUFFIX is now runtime — when unscoped (region=null) it is just
+// "Bird Maps", never a trailing " · " with no region after it.
+function buildTitle(
+  view: View,
+  speciesCommonName: string | null,
+  region: string | null,
+): string {
+  const siteSuffix = region ? `Bird Maps · ${region}` : 'Bird Maps';
   switch (view) {
     case 'feed':
-      return `Feed — ${SITE_SUFFIX}`;
+      return `Feed — ${siteSuffix}`;
     case 'detail':
-      return speciesCommonName ? `${speciesCommonName} — ${SITE_SUFFIX}` : SITE_SUFFIX;
+      return speciesCommonName ? `${speciesCommonName} — ${siteSuffix}` : siteSuffix;
     case 'map':
     default:
-      return SITE_SUFFIX;
+      return siteSuffix;
   }
 }
 
@@ -32,8 +42,8 @@ function buildTitle(view: View, speciesCommonName: string | null): string {
  * from useUrlState() and speciesCommonName from the detail surface's loaded
  * species data (null when detail is loading or no species is selected).
  */
-export function SurfaceTitleSync({ view, speciesCommonName }: SurfaceTitleSyncProps) {
-  const title = buildTitle(view, speciesCommonName);
+export function SurfaceTitleSync({ view, speciesCommonName, region }: SurfaceTitleSyncProps) {
+  const title = buildTitle(view, speciesCommonName, region);
 
   // useEffect sets document.title imperatively — works in both jsdom (tests)
   // and the browser. React 18's declarative <title> rendering hoists to <head>

--- a/frontend/src/config/region.test.ts
+++ b/frontend/src/config/region.test.ts
@@ -1,17 +1,62 @@
 import { describe, it, expect } from 'vitest';
-import { REGION_LABEL, REGION_CODE } from './region.js';
+import type { StateSummary } from '@bird-watch/shared-types';
+import { regionLabelFor, REGION_CODE } from './region.js';
+import type { Scope } from '../state/url-state.js';
 
-describe('REGION_LABEL', () => {
-  it('defaults to "Arizona" when VITE_REGION_CODE is unset (test env)', () => {
-    // In the test env no VITE_REGION_CODE is set, so REGION_CODE falls back
-    // to 'US-AZ' which maps to 'Arizona'. This guards the default deploy
-    // behavior — AZ shipped builds must keep this label.
-    expect(REGION_CODE).toBe('US-AZ');
-    expect(REGION_LABEL).toBe('Arizona');
+// #738 (C5) — `regionLabelFor(scope, states)` replaces the build-time
+// `REGION_LABEL` constant. The label is now runtime, derived from the active
+// scope (#735) and the `/api/states` name table (#732). Three cases:
+//   - unscoped → no region claim (null) — the chooser is shown, not a region.
+//   - `?scope=us` → "USA" (whole-US escape hatch).
+//   - state → the resolved `StateSummary.name` (e.g. "Arizona"), falling back
+//     to the bare `stateCode` for an unknown code (mirrors the prototype's
+//     `stateByCode(stateCode)?.name ?? stateCode`).
+const STATES: StateSummary[] = [
+  { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.815, 31.332, -109.045, 37.004] },
+  { stateCode: 'US-NY', name: 'New York', bbox: [-79.763, 40.477, -71.856, 45.016] },
+];
+
+describe('regionLabelFor', () => {
+  it('unscoped → null (no region claim — the chooser is shown)', () => {
+    const scope: Scope = { kind: 'unscoped' };
+    expect(regionLabelFor(scope, STATES)).toBeNull();
   });
 
-  it('is a non-empty string', () => {
-    expect(typeof REGION_LABEL).toBe('string');
-    expect(REGION_LABEL.length).toBeGreaterThan(0);
+  it('?scope=us → "USA"', () => {
+    const scope: Scope = { kind: 'us' };
+    expect(regionLabelFor(scope, STATES)).toBe('USA');
+  });
+
+  it('state → resolved StateSummary.name', () => {
+    const scope: Scope = { kind: 'state', stateCode: 'US-AZ' };
+    expect(regionLabelFor(scope, STATES)).toBe('Arizona');
+  });
+
+  it('state → another resolved name from the table', () => {
+    const scope: Scope = { kind: 'state', stateCode: 'US-NY' };
+    expect(regionLabelFor(scope, STATES)).toBe('New York');
+  });
+
+  it('state with an unknown code → falls back to the bare stateCode', () => {
+    // The state table hasn't loaded yet (or is missing a row): the runtime
+    // function must not throw and must not render a blank region — it falls
+    // back to the code, matching the prototype's `?? scope.stateCode`.
+    const scope: Scope = { kind: 'state', stateCode: 'US-WY' };
+    expect(regionLabelFor(scope, STATES)).toBe('US-WY');
+  });
+
+  it('state with an empty/absent state table → falls back to the code', () => {
+    const scope: Scope = { kind: 'state', stateCode: 'US-AZ' };
+    expect(regionLabelFor(scope, [])).toBe('US-AZ');
+    expect(regionLabelFor(scope)).toBe('US-AZ');
+  });
+});
+
+describe('REGION_CODE', () => {
+  it('defaults to "US-AZ" when VITE_REGION_CODE is unset (test env)', () => {
+    // REGION_CODE remains a build-time constant — it is still the seed for the
+    // ingest region and the AZ default deploy. Only the user-facing label moved
+    // to runtime (regionLabelFor); this guards the build-time default.
+    expect(REGION_CODE).toBe('US-AZ');
   });
 });

--- a/frontend/src/config/region.ts
+++ b/frontend/src/config/region.ts
@@ -1,23 +1,58 @@
 /**
  * Region configuration.
  *
- * REGION_LABEL is the source of truth for the region name used in the
- * wordmark ("Bird Maps · Arizona"), the lede, and any region claim in
- * the UI.
+ * `REGION_CODE` is the build-time ingest/seed region (the env var
+ * `VITE_REGION_CODE`, default `US-AZ`). It identifies which region the data
+ * pipeline ingests; it is NOT the user-facing label.
  *
- * The label is derived from the build-time env var `VITE_REGION_CODE`
- * via a small mapping table. Default is `US-AZ` → "Arizona", which keeps
- * the current AZ deploy unchanged. To flip the build to national/USA,
- * set `VITE_REGION_CODE=US` at build time — no code change required.
+ * The user-facing region label is RUNTIME, derived per active scope (#735)
+ * via `regionLabelFor(scope, states)`:
+ *   - unscoped (bare URL → chooser) → `null` (no region claim — the chooser
+ *     is shown, so there is nothing to name a region for yet).
+ *   - `?scope=us` (whole-US escape hatch) → "USA".
+ *   - state (`?state=US-XX`) → the resolved `StateSummary.name` (e.g.
+ *     "Arizona"), falling back to the bare `stateCode` when the state table
+ *     hasn't loaded or is missing the row (mirrors the C0 prototype's
+ *     `stateByCode(stateCode)?.name ?? stateCode`).
  *
- * Spec: docs/design/01-spec/architecture.md §Cross-cutting structures
+ * State names are sourced at runtime from `GET /api/states`
+ * (`StateSummary[]`, #732) — NOT a hard-coded map here. The build-time
+ * `REGION_LABEL` constant was removed in #738/C5; its five consumers
+ * (AppHeader, MapLede, SurfaceTitleSync, FeedSurface, App.tsx) now thread the
+ * runtime value.
+ *
+ * Spec: docs/design/01-spec/architecture.md §Cross-cutting structures;
+ * plan tasks C5 + C7 in docs/plans/2026-05-28-state-scope-selector.md.
  */
+import type { StateSummary } from '@bird-watch/shared-types';
+import type { Scope } from '../state/url-state.js';
+
 export const REGION_CODE: string =
   (import.meta.env.VITE_REGION_CODE as string | undefined) ?? 'US-AZ';
 
-const REGION_LABELS: Record<string, string> = {
-  'US-AZ': 'Arizona',
-  US: 'USA',
-};
-
-export const REGION_LABEL: string = REGION_LABELS[REGION_CODE] ?? REGION_CODE;
+/**
+ * The runtime region label for the active scope, or `null` when there is no
+ * region to claim (the unscoped/chooser landing). Consumers MUST treat `null`
+ * as "render no region fragment" — never render a bare separator or the word
+ * "region".
+ *
+ * @param scope  the active scope discriminant from `UrlState` (#735).
+ * @param states the `/api/states` name table (#732); defaults to empty so a
+ *   caller that hasn't loaded it yet degrades to the bare `stateCode`.
+ */
+export function regionLabelFor(
+  scope: Scope,
+  states: readonly StateSummary[] = [],
+): string | null {
+  switch (scope.kind) {
+    case 'unscoped':
+      return null;
+    case 'us':
+      return 'USA';
+    case 'state':
+      return (
+        states.find(s => s.stateCode === scope.stateCode)?.name ??
+        scope.stateCode
+      );
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    URL["URL state (#735)<br/>scope: unscoped | us | state"] --> RLF["regionLabelFor(scope, states)"]
    States["/api/states StateSummary[]<br/>(#732 — threaded by #740)"] --> RLF
    RLF -->|unscoped| Null["null — no region claim"]
    RLF -->|us| USA["'USA'"]
    RLF -->|state| Name["StateSummary.name<br/>(?? stateCode fallback)"]
    Null --> C1
    USA --> C2
    Name --> C2
    subgraph Consumers["5 consumers (App.tsx threads the runtime value)"]
        C1["unscoped degrade:<br/>AppHeader → 'Bird Maps' (no ' · '),<br/>SurfaceTitleSync → 'Bird Maps',<br/>MapLede → null"]
        C2["scoped:<br/>wordmark/title/lede name the region"]
    end

    subgraph C7["MapLede zero-count split (C7)"]
        Z{"obs=0 && species=0?"}
        Z -->|"noFiltersActive<br/>(since === DEFAULTS.since)"| DA["'No recent sightings in {region} yet.'<br/>(data-availability)"]
        Z -->|"filters active"| FN["'No sightings match your current filters.'<br/>(filter-narrowing)"]
    end
```

## Summary

- **Why:** the chooser-first scope model (epic #726) means the bare URL has no region to claim until a scope is picked, and a scoped-but-empty state is a *data-availability* condition, not a *filter mistake*. The old build-time `REGION_LABEL` string and the single "No sightings match your current filters." copy conflated both. This is plan tasks **C5** (runtime `regionLabelFor`) + **C7** (sparse/empty-region lede).
- **C5:** `region.ts` now exports `regionLabelFor(scope, states)` — unscoped → `null` (no claim); `?scope=us` → `"USA"`; state → `StateSummary.name` with a `?? stateCode` fallback (names come from `/api/states` #732, not a hard-coded map). The build-time `REGION_LABEL` export is removed; `REGION_CODE` (the ingest seed) is kept. All **5** consumers (AppHeader, MapLede, SurfaceTitleSync, FeedSurface, App.tsx) thread the runtime value and degrade cleanly on unscoped (no bare ` · ` separator, MapLede returns `null` — same contract as the #716/#720 loading guard).
- **C7:** the MapLede zero-count branch splits on a caller-computed `noFiltersActive` flag (App.tsx owns the `since === DEFAULTS.since` comparison against the #735-exported `DEFAULTS`, so MapLede stays presentational). No-filters + zero → `"No recent sightings in {region} yet."`; filters + zero → the existing copy. Kept in lockstep with #741's e2e spec.

**Scope split (not owned here):** the landing chooser (`ScopeChooser`) + render-gating (#742) and the App.tsx fetch/render suppression + `/api/states` table wiring (#740). This PR makes MapLede *consume* the scope and behave correctly per case; the unscoped→no-render behavior is the consumer contract this issue documents and tests for, enforced by #740/#742.

## Screenshots

Lede + wordmark states driven live via Playwright MCP against stubbed API data (the dev proxy to `api.bird-maps.com` 502s from localhost, so deterministic `page.route` stubs were used to exercise the populated vs sparse/empty cases). Captured: populated `?scope=us`, sparse/empty-region (zero data, no filters → data-availability copy), and the unscoped bare-URL wordmark degradation.

**Populated (`?scope=us`) — Template 4 lede "5 species seen across USA in the last 14 days." (light / dark, 1440×900)**

| Light | Dark |
|---|---|
| <img width="480" src="https://github.com/user-attachments/assets/38e0ef05-29f3-42d2-b089-4ae6935c135e"> | <img width="480" src="https://github.com/user-attachments/assets/af234116-703d-447e-9b3f-8f0dd73f352a"> |

**Sparse / empty-region (zero data, no filters) — data-availability copy "No recent sightings in USA yet." (light / dark, 1440×900)**

| Light | Dark |
|---|---|
| <img width="480" src="https://github.com/user-attachments/assets/7abbb4b2-02ef-458a-8134-4b25ccc94f22"> | <img width="480" src="https://github.com/user-attachments/assets/031b8616-5c21-4a0f-b737-574c6161d855"> |

**Mobile 390×844 — populated lede (left) and unscoped bare-URL wordmark "Bird Maps", no region suffix (right)**

| Populated (light) | Unscoped wordmark (light) |
|---|---|
| <img width="240" src="https://github.com/user-attachments/assets/a037f7e5-f608-4308-a4e7-c56bd37c618b"> | <img width="240" src="https://github.com/user-attachments/assets/72607772-2cb8-4ee4-9de2-74de1a8bcab5"> |

- [x] No new/renamed `className` in this PR — the sparse/empty-region copy reuses the existing `.map-lede` selector (copy change only). **N/A — no new className.** `orphan-classname-check` and `knip` verified green locally.
- [ ] Multi-viewport design QA (5×2 grid + `ui-design:ui-designer` PASS): **deferred to #741**, which captures the chooser + scoped surfaces holistically. This PR's section shows the lede copy in the sparse/empty-region and populated states (light + dark) plus the unscoped wordmark.

**Tolerated console line:** the MapLibre tile/sprite layer emits map-rendering noise (`Image "circle-11" could not be loaded`, and at zoom ≥10 the documented upstream positron basemap-worker warning `"Expected value to be of type number, but found null instead"` — mapbox-gl-js#7097, raised off-thread, not catchable from app code). Both are independent of scope code (prototype finding (e)). **Zero scope-originated errors/warnings** at every measured surface.

## Test plan

- [x] `npm run test` (all workspaces) — green (frontend 893 passed; db-client/admin-api/ingestor/read-api/shared-types all green)
- [x] New unit tests added: `region.test.ts` (3 cases + unknown-code + empty-table fallback), `MapLede.test.tsx` (unscoped→null, zero+no-filters→data-availability, zero+filters→filter-narrowing, `?scope=us`/state region threading, loading guard), `AppHeader.test.tsx` + `SurfaceTitleSync.test.tsx` unscoped-degradation cases
- [ ] New Playwright e2e spec — N/A, owned by #741 (asserts the sparse copy + design review)
- [x] `npm run build` — clean production build (`tsc -b && vite build`)
- [x] (UI) Playwright MCP smoke — drove the lede/wordmark states at 390×844 + 1440×900, light + dark; verified: title "Bird Maps · USA"/"Bird Maps", lede "5 species seen across USA…" (populated), "No recent sightings in USA yet." (sparse/no-filters), "No sightings match your current filters." (sparse + `?notable=true`), bare-URL wordmark "Bird Maps" with `.brand-region` absent + aria "Bird Maps — home" + MapLede not rendered. Zero scope-originated console errors/warnings.

## Plan reference

Part of Plan `2026-05-28-state-scope-selector`, Tasks **C5 + C7**. See `docs/plans/2026-05-28-state-scope-selector.md` and the C0 learnings at `docs/plans/2026-05-28-state-scope-selector/prototype-learnings.md`. Part of epic #726.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
