### PR TITLE
feat(frontend): landing scope chooser (ZIP/state co-primary, whole-US escape hatch) — closes #742

### DIFF
--- a/frontend/src/components/ScopeChooser.test.tsx
+++ b/frontend/src/components/ScopeChooser.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { StateSummary } from '@bird-watch/shared-types';
+import { ZIP_FLYTO_ZOOM } from '../state/scope-types.js';
+
+// ScopeChooser composes the real <ZipInput> (#739). Mock only ZipInput's
+// data layer (`zip-lookup.js`) so the resolution path is deterministic — we
+// assert that the resolved ScopeResolution is FORWARDED through ScopeChooser
+// to its caller. The "ZIP not recognized" / malformed / fetch-error UX is
+// owned and tested by ZipInput.test.tsx; we do NOT duplicate it here.
+const { mockLoadZipIndex, mockLookupZip } = vi.hoisted(() => ({
+  mockLoadZipIndex: vi.fn(),
+  mockLookupZip: vi.fn(),
+}));
+
+vi.mock('../data/zip-lookup.js', () => ({
+  loadZipIndex: mockLoadZipIndex,
+  lookupZip: mockLookupZip,
+}));
+
+// Imported AFTER the mock is registered.
+import { ScopeChooser } from './ScopeChooser.js';
+
+const STATES: StateSummary[] = [
+  { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.8, 31.3, -109.0, 37.0] },
+  { stateCode: 'US-CA', name: 'California', bbox: [-124.4, 32.5, -114.1, 42.0] },
+  { stateCode: 'US-NY', name: 'New York', bbox: [-79.8, 40.5, -71.8, 45.0] },
+];
+
+function renderChooser(overrides: Partial<React.ComponentProps<typeof ScopeChooser>> = {}) {
+  const props = {
+    states: STATES,
+    onPickState: vi.fn(),
+    onPickWholeUs: vi.fn(),
+    onResolve: vi.fn(),
+    ...overrides,
+  };
+  render(<ScopeChooser {...props} />);
+  return props;
+}
+
+describe('<ScopeChooser>', () => {
+  beforeEach(() => {
+    mockLoadZipIndex.mockReset().mockResolvedValue(undefined);
+    mockLookupZip.mockReset();
+  });
+
+  it('renders a labelled region with all three scope paths', () => {
+    renderChooser();
+    const region = screen.getByRole('region', { name: /scope|where|look/i });
+    expect(region).toBeInTheDocument();
+
+    // ZIP path (the real ZipInput).
+    expect(within(region).getByRole('textbox', { name: /ZIP code/i })).toBeInTheDocument();
+    // State path.
+    expect(within(region).getByRole('combobox', { name: /state/i })).toBeInTheDocument();
+    // Whole-US escape hatch.
+    expect(
+      within(region).getByRole('button', { name: /whole us map/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('populates the state <select> options from props.states (value=stateCode, text=name) plus a placeholder', () => {
+    renderChooser();
+    const select = screen.getByRole('combobox', { name: /state/i });
+    const options = within(select).getAllByRole('option');
+    // 3 states + 1 placeholder.
+    expect(options).toHaveLength(STATES.length + 1);
+    // Placeholder is value="" and selected by default.
+    expect(options[0]).toHaveValue('');
+    expect((options[0] as HTMLOptionElement).selected).toBe(true);
+    // Each state maps value=stateCode, text=name.
+    expect(options[1]).toHaveValue('US-AZ');
+    expect(options[1]).toHaveTextContent('Arizona');
+    expect(options[2]).toHaveValue('US-CA');
+    expect(options[3]).toHaveValue('US-NY');
+  });
+
+  it('state "Go" is disabled until a state is selected, then emits onPickState once with the chosen code', async () => {
+    const { onPickState } = renderChooser();
+    const goButton = screen.getByRole('button', { name: /go/i });
+    expect(goButton).toBeDisabled();
+
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: /state/i }),
+      'US-CA',
+    );
+    expect(goButton).toBeEnabled();
+
+    await userEvent.click(goButton);
+    expect(onPickState).toHaveBeenCalledTimes(1);
+    expect(onPickState).toHaveBeenCalledWith('US-CA');
+  });
+
+  it('does not emit onPickState for the empty placeholder selection', async () => {
+    const { onPickState } = renderChooser();
+    const goButton = screen.getByRole('button', { name: /go/i });
+    // Button stays disabled — clicking a disabled button is inert.
+    await userEvent.click(goButton);
+    expect(onPickState).not.toHaveBeenCalled();
+  });
+
+  it('whole-US button emits onPickWholeUs once', async () => {
+    const { onPickWholeUs } = renderChooser();
+    await userEvent.click(screen.getByRole('button', { name: /whole us map/i }));
+    expect(onPickWholeUs).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a resolved ZIP (ScopeResolution) straight up via onResolve', async () => {
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    const { onResolve } = renderChooser();
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '85701{Enter}');
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith({
+      stateCode: 'US-AZ',
+      center: [-110.971, 32.21696],
+      zoom: ZIP_FLYTO_ZOOM,
+    });
+  });
+
+  it('statesLoading → state <select> disabled with a loading placeholder, ZIP path still interactive', async () => {
+    renderChooser({ statesLoading: true });
+    const select = screen.getByRole('combobox', { name: /state/i });
+    expect(select).toBeDisabled();
+    // The placeholder option conveys the loading state (descriptive, not silently inert).
+    const placeholder = within(select).getAllByRole('option')[0];
+    expect(placeholder).toHaveValue('');
+    expect(placeholder).toHaveTextContent(/loading/i);
+    // Go is disabled while loading too.
+    expect(screen.getByRole('button', { name: /go/i })).toBeDisabled();
+
+    // ZIP path stays fully usable: focusing warms the index (independent path).
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    expect(input).toBeEnabled();
+    await userEvent.click(input);
+    expect(mockLoadZipIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('empty states (no statesLoading flag) → state <select> still disabled, ZIP path usable', () => {
+    renderChooser({ states: [] });
+    expect(screen.getByRole('combobox', { name: /state/i })).toBeDisabled();
+    expect(screen.getByRole('textbox', { name: /ZIP code/i })).toBeEnabled();
+  });
+
+  it('a11y: region, ZIP input, and state select are reachable by accessible name', () => {
+    renderChooser();
+    expect(screen.getByRole('region', { name: /scope|where|look/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /ZIP code/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /state/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ScopeChooser.tsx
+++ b/frontend/src/components/ScopeChooser.tsx
@@ -1,0 +1,134 @@
+import { useId, useState, type FormEvent } from 'react';
+import type { StateSummary } from '@bird-watch/shared-types';
+import { ZipInput } from './ZipInput.js';
+import type { ScopeResolution } from '../state/scope-types.js';
+
+/**
+ * Landing scope chooser — the pre-map surface (revised design 2026-05-29).
+ *
+ * Prompts "where do you want to look?" with two CO-PRIMARY paths — a ZIP input
+ * and a state `<select>` — plus a DE-EMPHASIZED "Explore the whole US map"
+ * escape hatch (→ `?scope=us`).
+ *
+ * Ownership boundary (Task C2a, #742): this component is PURELY PRESENTATIONAL
+ * and only EMITS the chosen scope through callback props. It does NOT:
+ *   - render the map,
+ *   - gate the cold-load `/api/observations` fetch,
+ *   - read or write the URL (`?state` / `?zip` / `?scope` are App/#740's job),
+ *   - resolve a ZIP to a state (the lazy `loadZipIndex`/`lookupZip` pipeline
+ *     lives entirely inside `<ZipInput>` / `zip-lookup.ts`, #739),
+ *   - fetch the state list (the caller supplies `props.states` from
+ *     `GET /api/states`, #732).
+ * The render-gating (chooser-vs-map + fetch suppression) lives in App/C6/#740.
+ * If you find yourself importing `url-state.ts`, `api/client.ts`, `fetch`, or a
+ * map module here, you have crossed the boundary.
+ *
+ * The only local state is the transient `<select>` value — no scope/URL/fetch
+ * state. Picking a scope swaps the caller to the map, which UNMOUNTS this
+ * component cleanly (the intentional remount the C0 prototype validated —
+ * camera lifecycle is C3/C6's problem, not C2a's).
+ */
+export interface ScopeChooserProps {
+  /** States for the `<select>`. The caller supplies the result of
+   *  `GET /api/states` (#732) — `StateSummary[]` (`stateCode`, `name`, `bbox`),
+   *  already name-sorted by the endpoint. ScopeChooser does NOT fetch this. */
+  states: StateSummary[];
+  /** State `<select>` path: emits the chosen `US-XX` code. */
+  onPickState: (stateCode: string) => void;
+  /** Whole-US escape hatch: emits the niche `?scope=us` intent. */
+  onPickWholeUs: () => void;
+  /** ZIP path: the resolved `ScopeResolution` from `<ZipInput>`, forwarded
+   *  straight up to the caller (App/C6 turns it into `?state=US-XX` + a camera
+   *  `flyTo` at `ZIP_FLYTO_ZOOM`). ScopeChooser is a pass-through here. */
+  onResolve: (scope: ScopeResolution) => void;
+  /** Loading/empty affordance while the caller's `/api/states` request is in
+   *  flight or returned empty (selector disabled, ZIP still usable). */
+  statesLoading?: boolean;
+}
+
+export function ScopeChooser({
+  states,
+  onPickState,
+  onPickWholeUs,
+  onResolve,
+  statesLoading = false,
+}: ScopeChooserProps): React.JSX.Element {
+  const [stateCode, setStateCode] = useState('');
+  const selectId = useId();
+
+  // The two paths are independent: a slow/empty `/api/states` disables only the
+  // selector — the ZIP path must stay fully usable (C0 contract: ZIP resolves to
+  // a state independent of the selector).
+  const selectorDisabled = statesLoading || states.length === 0;
+
+  function handleStateSubmit(e: FormEvent): void {
+    e.preventDefault();
+    // Only a non-empty selection emits a scope; the placeholder (value "") is
+    // never a valid scope.
+    if (stateCode) onPickState(stateCode);
+  }
+
+  return (
+    <div className="scope-chooser" role="region" aria-label="Choose where to look at birds">
+      <div className="scope-chooser__card">
+        <h1 className="scope-chooser__title">Where do you want to look at birds?</h1>
+        <p className="scope-chooser__subtitle">
+          Enter a ZIP code or pick a state to see recent sightings near you.
+        </p>
+
+        <div className="scope-chooser__field">
+          <span className="scope-chooser__label" id="scope-chooser-zip-label">
+            ZIP code
+          </span>
+          {/* <ZipInput> (#739) owns the ZIP input, lazy index load, lookup, and
+              the "not recognized" / malformed / fetch-error UX. ScopeChooser
+              forwards its onResolve straight up — it never owns ZIP state. */}
+          <ZipInput onResolve={onResolve} />
+        </div>
+
+        <div className="scope-chooser__divider" aria-hidden="true">
+          or
+        </div>
+
+        <form className="scope-chooser__field" onSubmit={handleStateSubmit}>
+          <label className="scope-chooser__label" htmlFor={selectId}>
+            State
+          </label>
+          <div className="scope-chooser__row">
+            <select
+              id={selectId}
+              className="scope-chooser__select"
+              value={stateCode}
+              disabled={selectorDisabled}
+              onChange={(e) => setStateCode(e.target.value)}
+            >
+              <option value="">
+                {selectorDisabled ? 'Loading states…' : 'Choose a state…'}
+              </option>
+              {states.map((s) => (
+                <option key={s.stateCode} value={s.stateCode}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              className="scope-chooser__btn"
+              disabled={selectorDisabled || !stateCode}
+            >
+              Go
+            </button>
+          </div>
+        </form>
+
+        <button
+          type="button"
+          className="scope-chooser__wholeus"
+          onClick={onPickWholeUs}
+        >
+          Explore the whole US map
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/dev/DsPreview.tsx
+++ b/frontend/src/dev/DsPreview.tsx
@@ -35,7 +35,8 @@ import { FilterSentence } from '../components/ds/FilterSentence.js';
 import { FeedCard } from '../components/FeedCard.js';
 import { FeedRow } from '../components/FeedRow.js';
 import { ZipInput } from '../components/ZipInput.js';
-import type { NotableObservation, Observation } from '@bird-watch/shared-types';
+import { ScopeChooser } from '../components/ScopeChooser.js';
+import type { NotableObservation, Observation, StateSummary } from '@bird-watch/shared-types';
 import type { FamilyCode } from '../config/family-palette.js';
 import type { UrlState } from '../state/url-state.js';
 
@@ -79,6 +80,17 @@ const CANNED_FLAT: Observation[] = [
     locId: 'L004', locName: 'Phoenix Zoo', howMany: 2, isNotable: false,
     silhouetteId: null, familyCode: 'trochilidae', taxonOrder: 1600,
   },
+];
+
+// Canned state list for the ScopeChooser preview (#742). A small name-sorted
+// slice — the real list comes from GET /api/states (#732) at runtime.
+const CANNED_STATES: StateSummary[] = [
+  { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.8, 31.3, -109.0, 37.0] },
+  { stateCode: 'US-CA', name: 'California', bbox: [-124.4, 32.5, -114.1, 42.0] },
+  { stateCode: 'US-CO', name: 'Colorado', bbox: [-109.1, 37.0, -102.0, 41.0] },
+  { stateCode: 'US-NM', name: 'New Mexico', bbox: [-109.1, 31.3, -103.0, 37.0] },
+  { stateCode: 'US-NY', name: 'New York', bbox: [-79.8, 40.5, -71.8, 45.0] },
+  { stateCode: 'US-TX', name: 'Texas', bbox: [-106.7, 25.8, -93.5, 36.5] },
 ];
 
 // Minimal placeholder 1×1 transparent PNG data URI used as a stable
@@ -268,6 +280,21 @@ export function DsPreview(): ReactNode {
   // fetch failure so the role=alert fallback renders deterministically.
   if (key.startsWith('zip-input')) {
     return <ZipInputPreview variant={key} />;
+  }
+
+  // ScopeChooser previews (#742). The landing chooser in isolation across its
+  // states: `scope-chooser` = populated selector; `scope-chooser-loading` =
+  // statesLoading (selector disabled, ZIP path still usable).
+  if (key.startsWith('scope-chooser')) {
+    return (
+      <ScopeChooser
+        states={CANNED_STATES}
+        statesLoading={key === 'scope-chooser-loading'}
+        onPickState={() => {}}
+        onPickWholeUs={() => {}}
+        onResolve={() => {}}
+      />
+    );
   }
 
   // Unknown key: show a helpful error

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1740,3 +1740,138 @@ aside.species-detail-rail .species-detail-rail-close {
   border-radius: 4px;
   line-height: 1.3;
 }
+
+/* ── ScopeChooser (#742) ──────────────────────────────────────────────────
+   The pre-map LANDING surface: a centered card prompting "where do you want
+   to look?" with two CO-PRIMARY paths — the <ZipInput> (#739, styled by
+   .zip-input* above; NOT restyled here) and a native state <select> — joined
+   by an "or" divider, plus a DE-EMPHASIZED "Explore the whole US map" escape
+   hatch placed last and lowest. Reuses the existing card/input visual
+   contract (warm cream page, white surface, --color-border-ui edge, shared
+   spacing/type/weight tokens). Every className the TSX introduces has a
+   matching rule below (orphan-classname gate). */
+.scope-chooser {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-block-size: 100%;
+  padding: var(--space-xl) var(--space-lg);
+  background: var(--color-bg-page);
+}
+.scope-chooser__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  inline-size: 100%;
+  max-inline-size: 26rem;
+  padding: var(--space-xl);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: var(--shadow-listbox);
+}
+.scope-chooser__title {
+  margin: 0;
+  font-size: var(--type-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-strong);
+  line-height: 1.2;
+}
+.scope-chooser__subtitle {
+  margin: 0;
+  font-size: var(--type-base);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+.scope-chooser__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+.scope-chooser__label {
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-strong);
+}
+.scope-chooser__divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.scope-chooser__divider::before,
+.scope-chooser__divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--color-border-ui);
+}
+.scope-chooser__row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: stretch;
+}
+.scope-chooser__select {
+  flex: 1;
+  min-inline-size: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--type-base);
+  color: var(--color-text-strong);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: 4px;
+}
+.scope-chooser__select:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.scope-chooser__select:disabled {
+  color: var(--color-text-muted);
+  background: var(--color-bg-tint);
+  cursor: not-allowed;
+}
+.scope-chooser__btn {
+  flex: 0 0 auto;
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--type-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-white);
+  background: var(--color-text-strong);
+  border: 1px solid var(--color-text-strong);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.scope-chooser__btn:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.scope-chooser__btn:disabled {
+  color: var(--color-text-muted);
+  background: var(--color-bg-tint);
+  border-color: var(--color-border-ui);
+  cursor: not-allowed;
+}
+/* De-emphasized escape hatch: visually subordinate (no primary fill, lighter
+   weight, smaller, link-like) but a real, operable, focusable native button. */
+.scope-chooser__wholeus {
+  align-self: center;
+  margin-block-start: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.scope-chooser__wholeus:hover {
+  color: var(--color-text-strong);
+}
+.scope-chooser__wholeus:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}


### PR DESCRIPTION


## Diagrams

```mermaid
flowchart TD
    subgraph ScopeChooser["ScopeChooser (C2a · #742) — presentational, emits only"]
        ZIP["&lt;ZipInput&gt; (#739)<br/>owns lookup + error UX"]
        SEL["state &lt;select&gt;<br/>options from props.states"]
        US["&lt;button&gt; Explore the whole US map<br/>(de-emphasized)"]
    end

    STATES["GET /api/states (#732)<br/>StateSummary[]"] -->|props.states| SEL
    ZIP -->|"onResolve(ScopeResolution)"| CALLER
    SEL -->|"onPickState('US-XX')"| CALLER
    US -->|onPickWholeUs| CALLER

    CALLER["caller (App / C6 · #740)<br/>render-gating + fetch suppression + URL writes"]

    note["ScopeChooser does NOT: render the map · gate the<br/>/api/observations fetch · read/write the URL · resolve ZIPs"]
```

## Summary

- **Why:** the map tab's new LANDING surface (revised design 2026-05-29) — a pre-map scope chooser that asks "where do you want to look?" instead of cold-loading the whole CONUS map. ZIP input and state `<select>` are co-primary; "Explore the whole US map" is a de-emphasized escape hatch (→ `?scope=us`).
- **Ownership boundary (C2a):** this component is purely presentational and only EMITS the chosen scope via callback props (`onPickState` / `onPickWholeUs` / `onResolve`). It renders the real `<ZipInput>` (#739) and forwards its `onResolve` straight up; it consumes `StateSummary[]` from `GET /api/states` (#732) supplied by the caller. The render-gating + fetch-suppression + URL writes live in App/C6 (#740) — no `url-state.ts` / `api/client.ts` / `fetch` / map import crosses into this component.
- **a11y (first interactive surface on landing):** `role="region"` + `aria-label`, labelled ZIP input and state `<select>`, a real focusable native `<button>` for the whole-US hatch, logical tab order, and a disabled + descriptive "Loading states…" placeholder so the selector is never silently inert while the ZIP path stays usable.

## Screenshots

Chooser landing surface (`?ds-preview=scope-chooser`), all 5 canonical viewports × light/dark. Console: 0 errors / 0 warnings on the chooser surface.

| Viewport | Light | Dark |
| --- | --- | --- |
| iPhone 14 Pro (390) | <img width="380" alt="390 light" src="https://github.com/user-attachments/assets/959632c5-85f2-400b-9aae-af833ea3c87a"> | <img width="380" alt="390 dark" src="https://github.com/user-attachments/assets/26e849e0-88cf-4e7a-b4de-5b04cfaad4cc"> |
| iPad portrait (768) | <img width="380" alt="768 light" src="https://github.com/user-attachments/assets/fbb1b7ff-6f0a-4d37-ae08-b3d36668ac69"> | <img width="380" alt="768 dark" src="https://github.com/user-attachments/assets/75e10be9-72ca-4d98-9be8-2e87a9a31a31"> |
| iPad landscape (1024) | <img width="380" alt="1024 light" src="https://github.com/user-attachments/assets/ff39ff8d-731d-4702-a667-d7387a6c7a61"> | <img width="380" alt="1024 dark" src="https://github.com/user-attachments/assets/c61e6ef1-6b2c-4dff-b4bd-829d5eaabaf4"> |
| Desktop (1440) | <img width="380" alt="1440 light" src="https://github.com/user-attachments/assets/0cfc23c7-6b03-4ba5-a47d-149d6d528276"> | <img width="380" alt="1440 dark" src="https://github.com/user-attachments/assets/53b8b575-aa76-43dd-b9f2-4f47cc241b1e"> |
| Wide desktop (1920) | <img width="380" alt="1920 light" src="https://github.com/user-attachments/assets/0d566778-556b-4bff-a09c-bb33b807ac0b"> | <img width="380" alt="1920 dark" src="https://github.com/user-attachments/assets/ce6eb301-7fd3-4edb-984f-7ebf81fa9f96"> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` (orphan-classname-check passes)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (927 tests; 9 new in `ScopeChooser.test.tsx`)
- [x] New unit tests added (`ScopeChooser.test.tsx`: all three paths, options derivation, Go-disabled-until-selected, statesLoading/empty selector, ZIP `onResolve` forwarding, a11y smoke)
- [ ] New Playwright e2e spec — N/A here; the e2e chooser-landing case + design-review gate ride on #741
- [x] `npm run build` — clean production build
- [x] (UI only) Playwright MCP smoke — drove the chooser via `?ds-preview=scope-chooser` (dev-only DsPreview key, zero production bytes) at all 5 canonical viewports × 2 themes; `browser_console_messages` returns 0 errors / 0 warnings on the chooser surface (no basemap → the tolerated MapLibre worker warning does not appear). Screenshots below captured from those runs.

## Plan reference

Part of Plan `2026-05-28-state-scope-selector`, Task C2a. See `docs/plans/2026-05-28-state-scope-selector.md`. Part of epic #726.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
