### PR TITLE
feat(frontend): in-state on-map ScopeControl (StateSelector + ZipInput + whole-US niche affordance) + CSS — closes #737

### DIFF
--- a/frontend/src/components/ScopeControl.test.tsx
+++ b/frontend/src/components/ScopeControl.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { StateSummary } from '@bird-watch/shared-types';
+import { ZIP_FLYTO_ZOOM } from '../state/scope-types.js';
+
+// ScopeControl composes the real <ZipInput> (#739). Mock only ZipInput's data
+// layer (`zip-lookup.js`) so the resolution path is deterministic — we assert
+// that the resolved ScopeResolution is FORWARDED through ScopeControl to its
+// caller. The "ZIP not recognized" / malformed / fetch-error UX is owned and
+// tested by ZipInput.test.tsx; we do NOT duplicate it here.
+const { mockLoadZipIndex, mockLookupZip } = vi.hoisted(() => ({
+  mockLoadZipIndex: vi.fn(),
+  mockLookupZip: vi.fn(),
+}));
+
+vi.mock('../data/zip-lookup.js', () => ({
+  loadZipIndex: mockLoadZipIndex,
+  lookupZip: mockLookupZip,
+}));
+
+// Imported AFTER the mock is registered.
+import { ScopeControl } from './ScopeControl.js';
+
+const STATES: StateSummary[] = [
+  { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.8, 31.3, -109.0, 37.0] },
+  { stateCode: 'US-CA', name: 'California', bbox: [-124.4, 32.5, -114.1, 42.0] },
+  { stateCode: 'US-NY', name: 'New York', bbox: [-79.8, 40.5, -71.8, 45.0] },
+];
+
+function renderControl(
+  overrides: Partial<React.ComponentProps<typeof ScopeControl>> = {},
+) {
+  const props = {
+    states: STATES,
+    scope: { kind: 'state' as const, stateCode: 'US-AZ' },
+    onPickState: vi.fn(),
+    onPickWholeUs: vi.fn(),
+    onExit: vi.fn(),
+    onResolve: vi.fn(),
+    ...overrides,
+  };
+  render(<ScopeControl {...props} />);
+  return props;
+}
+
+describe('<ScopeControl>', () => {
+  beforeEach(() => {
+    mockLoadZipIndex.mockReset().mockResolvedValue(undefined);
+    mockLookupZip.mockReset();
+  });
+
+  it('renders a labelled region exposing the state select, ZIP input, and exit affordances', () => {
+    renderControl();
+    // The control is a labelled landmark so screen-reader users can jump to it.
+    const region = screen.getByRole('region', { name: /scope|change.*where|map scope/i });
+    expect(region).toBeInTheDocument();
+    // State <select>.
+    expect(within(region).getByRole('combobox', { name: /switch state/i })).toBeInTheDocument();
+    // ZIP path (the real ZipInput).
+    expect(within(region).getByRole('textbox', { name: /ZIP code/i })).toBeInTheDocument();
+    // Exit affordance.
+    expect(within(region).getByRole('button', { name: /change scope/i })).toBeInTheDocument();
+  });
+
+  it('populates the state <select> from props.states (value=stateCode, text=name) plus a placeholder', () => {
+    renderControl();
+    const select = screen.getByRole('combobox', { name: /switch state/i });
+    const options = within(select).getAllByRole('option');
+    // 3 states + 1 placeholder.
+    expect(options).toHaveLength(STATES.length + 1);
+    expect(options[0]).toHaveValue('');
+    expect(options[0]).toHaveTextContent(/switch state/i);
+    expect(options[1]).toHaveValue('US-AZ');
+    expect(options[1]).toHaveTextContent('Arizona');
+    expect(options[2]).toHaveValue('US-CA');
+    expect(options[3]).toHaveValue('US-NY');
+  });
+
+  it('in a state view, the current scope state is the selected option', () => {
+    renderControl({ scope: { kind: 'state', stateCode: 'US-CA' } });
+    const select = screen.getByRole('combobox', {
+      name: /switch state/i,
+    }) as HTMLSelectElement;
+    expect(select.value).toBe('US-CA');
+  });
+
+  it('selecting a state emits onPickState once with the chosen US-XX code', async () => {
+    const { onPickState } = renderControl();
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: /switch state/i }),
+      'US-NY',
+    );
+    expect(onPickState).toHaveBeenCalledTimes(1);
+    expect(onPickState).toHaveBeenCalledWith('US-NY');
+  });
+
+  it('in a ?scope=us view the select shows the neutral placeholder, and a state pick still calls onPickState', async () => {
+    const { onPickState } = renderControl({ scope: { kind: 'us' } });
+    const select = screen.getByRole('combobox', {
+      name: /switch state/i,
+    }) as HTMLSelectElement;
+    // Neutral placeholder selected (no state is active in whole-US).
+    expect(select.value).toBe('');
+    expect(within(select).getAllByRole('option')[0]).toHaveTextContent(/switch state/i);
+
+    await userEvent.selectOptions(select, 'US-AZ');
+    expect(onPickState).toHaveBeenCalledTimes(1);
+    expect(onPickState).toHaveBeenCalledWith('US-AZ');
+  });
+
+  it('the exit affordance ("Change scope") calls onExit once', async () => {
+    const { onExit } = renderControl();
+    await userEvent.click(screen.getByRole('button', { name: /change scope/i }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('in a state view, the de-emphasized "Whole US" affordance calls onPickWholeUs once', async () => {
+    const { onPickWholeUs } = renderControl({ scope: { kind: 'state', stateCode: 'US-AZ' } });
+    await userEvent.click(screen.getByRole('button', { name: /whole us/i }));
+    expect(onPickWholeUs).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render the "Whole US" affordance when already in a ?scope=us view (no-op self-link)', () => {
+    renderControl({ scope: { kind: 'us' } });
+    expect(screen.queryByRole('button', { name: /whole us/i })).not.toBeInTheDocument();
+    // Exit is always present.
+    expect(screen.getByRole('button', { name: /change scope/i })).toBeInTheDocument();
+  });
+
+  it('a ZIP resolution from the embedded ZipInput bubbles up via props.onResolve with the ScopeResolution payload', async () => {
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    const { onResolve } = renderControl();
+
+    const input = screen.getByRole('textbox', { name: /ZIP code/i });
+    await userEvent.type(input, '85701{Enter}');
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith({
+      stateCode: 'US-AZ',
+      center: [-110.971, 32.21696],
+      zoom: ZIP_FLYTO_ZOOM,
+    });
+  });
+
+  it('ScopeControl triggers no data fetch and no ZIP-index warm on mount (C6 owns refetch; ZipInput warms on focus)', () => {
+    renderControl();
+    // Lazy ZIP index is only warmed on input focus, never on mount.
+    expect(mockLoadZipIndex).not.toHaveBeenCalled();
+  });
+
+  it('a11y: select + buttons are reachable by accessible name and keyboard-operable in order', async () => {
+    renderControl();
+    const select = screen.getByRole('combobox', { name: /switch state/i });
+    const zip = screen.getByRole('textbox', { name: /ZIP code/i });
+    const exit = screen.getByRole('button', { name: /change scope/i });
+    expect(select).toBeInTheDocument();
+    expect(zip).toBeInTheDocument();
+    expect(exit).toBeInTheDocument();
+
+    // Tab order: state select → ZIP input → (whole-US) → exit. No trap — the
+    // exit button is reachable from the select via tabbing.
+    select.focus();
+    expect(select).toHaveFocus();
+    await userEvent.tab();
+    expect(zip).toHaveFocus();
+  });
+});

--- a/frontend/src/components/ScopeControl.tsx
+++ b/frontend/src/components/ScopeControl.tsx
@@ -1,0 +1,129 @@
+import type { StateSummary } from '@bird-watch/shared-types';
+import type { Scope } from '../state/url-state.js';
+import { ZipInput } from './ZipInput.js';
+import type { ScopeResolution } from '../state/scope-types.js';
+
+/**
+ * In-state on-map scope control (Task C4, #737).
+ *
+ * The FLOATING re-scope bar — rendered ONLY after a scope is chosen, i.e. in a
+ * `?state=US-XX` state view or a `?scope=us` whole-US view. It is NEVER the
+ * pre-map landing chooser (that is `<ScopeChooser>`, #742). It floats over the
+ * map canvas (absolutely positioned overlay anchored top, above the basemap via
+ * the `--z-panel` token layer the other map overlays use) and lets a user
+ * re-scope without going back to the chooser:
+ *   - a native `<select>` StateSelector (no combobox lib — repo pattern),
+ *   - the existing `<ZipInput>` (#739), reused not re-implemented,
+ *   - a small, DE-EMPHASIZED exit affordance ("Change scope" → chooser) and,
+ *     in a state view, a niche "Whole US" escape hatch (→ `?scope=us`).
+ *
+ * Ownership boundary (contract note, #737): ScopeControl is PURELY
+ * PRESENTATIONAL. It does NOT own scope state, does NOT read/write the URL, and
+ * — critically — NEVER touches the map. In particular it does NOT call
+ * `map.setMaxBounds()`: per the C0 prototype's finding (a) + the C1 maplibre-5.x
+ * notes §1, `maxBounds` is a REACTIVE camera prop owned by #736/C3. ScopeControl
+ * only EMITS the new state code via `onPickState`; the parent (#740/C6) turns
+ * that into URL writes + a `bounds`/`maxBounds` prop change, which flows to the
+ * `<Map>` WITHOUT A REMOUNT. That no-remount-on-state-switch behaviour is the
+ * whole point of this in-state control (prototype finding (a)).
+ *
+ * It also triggers NO data fetch: #740/C6 owns the "one refetch per scope
+ * change" invariant (finding (d)). ScopeControl just emits one clean intent per
+ * user action (`onPickState` / `onResolve` / `onPickWholeUs` / `onExit`).
+ *
+ * Camera hand-off (AC 5): because this control FLOATS over the canvas, #736/C3's
+ * `fitBounds` top-padding must be ASYMMETRIC — top padding ≈ this bar's height —
+ * so the framed state isn't occluded by the control. Flagged in the PR.
+ */
+
+/** The scopes in which ScopeControl is mounted — never `unscoped` (that view
+ *  renders the chooser, not this control). A narrowing of `Scope` (#735). */
+export type ScopedView = Exclude<Scope, { kind: 'unscoped' }>;
+
+export interface ScopeControlProps {
+  /** Current resolved scope — either a `?state=US-XX` view or the `?scope=us`
+   *  whole-US view. Drives the selected `<select>` option and whether the
+   *  niche "Whole US" affordance is shown. */
+  scope: ScopedView;
+  /** States for the `<select>`. The caller supplies the result of
+   *  `GET /api/states` (#732) — `StateSummary[]`, already name-sorted by the
+   *  endpoint. ScopeControl does NOT fetch this. */
+  states: StateSummary[];
+  /** State `<select>` path: emits the chosen `US-XX` code. The parent
+   *  (#740/C6) turns it into a `?state=` write + a reactive camera change. */
+  onPickState: (stateCode: string) => void;
+  /** Niche whole-US escape hatch: emits the `?scope=us` intent. Only shown in
+   *  a state view (in a whole-US view it would be a no-op self-link). */
+  onPickWholeUs: () => void;
+  /** Exit affordance: clears the scope, returning to the chooser (`unscoped`). */
+  onExit: () => void;
+  /** ZIP path: the resolved `ScopeResolution` from the embedded `<ZipInput>`,
+   *  forwarded straight up (#740 turns it into `?state=US-XX` + a `flyTo` at
+   *  `ZIP_FLYTO_ZOOM`). ScopeControl is a pass-through here. */
+  onResolve: (scope: ScopeResolution) => void;
+}
+
+export function ScopeControl({
+  scope,
+  states,
+  onPickState,
+  onPickWholeUs,
+  onExit,
+  onResolve,
+}: ScopeControlProps): React.JSX.Element {
+  // In a state view the current state is the selected option; in a whole-US
+  // view the neutral placeholder ("") is selected (no state is active).
+  const selectedState = scope.kind === 'state' ? scope.stateCode : '';
+
+  return (
+    <section
+      className="scope-control"
+      role="region"
+      aria-label="Change the map scope"
+    >
+      <select
+        className="scope-control__select"
+        aria-label="Switch state"
+        value={selectedState}
+        // Only a non-empty selection emits a scope; the placeholder is inert.
+        onChange={(e) => e.target.value && onPickState(e.target.value)}
+      >
+        <option value="">Switch state…</option>
+        {states.map((s) => (
+          <option key={s.stateCode} value={s.stateCode}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+
+      {/* <ZipInput> (#739) owns the ZIP input, lazy index load, lookup, and the
+          "not recognized" / malformed / fetch-error UX. ScopeControl forwards
+          its onResolve straight up — it never owns ZIP state or duplicates the
+          ZIP copy. */}
+      <div className="scope-control__zip">
+        <ZipInput onResolve={onResolve} />
+      </div>
+
+      {/* De-emphasized exit affordances, visually subordinate to the state/ZIP
+          inputs (link-like, lower weight — not filled buttons). */}
+      <div className="scope-control__exit-group">
+        {scope.kind === 'state' && (
+          <button
+            type="button"
+            className="scope-control__wholeus"
+            onClick={onPickWholeUs}
+          >
+            Whole US
+          </button>
+        )}
+        <button
+          type="button"
+          className="scope-control__exit"
+          onClick={onExit}
+        >
+          Change scope
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/dev/DsPreview.tsx
+++ b/frontend/src/dev/DsPreview.tsx
@@ -24,6 +24,8 @@
  *   filter-notable        → <FilterSentence> with notable=true
  *   filter-notable-family → <FilterSentence> with notable=true + familyCode
  *   feed-card             → <FeedCard> elevated card with canned notable observation
+ *   scope-control         → <ScopeControl> in a state view (US-AZ), floated over a map-ish backdrop
+ *   scope-control-us      → <ScopeControl> in the whole-US view (no "Whole US" self-link)
  */
 import { useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
@@ -36,6 +38,7 @@ import { FeedCard } from '../components/FeedCard.js';
 import { FeedRow } from '../components/FeedRow.js';
 import { ZipInput } from '../components/ZipInput.js';
 import { ScopeChooser } from '../components/ScopeChooser.js';
+import { ScopeControl } from '../components/ScopeControl.js';
 import type { NotableObservation, Observation, StateSummary } from '@bird-watch/shared-types';
 import type { FamilyCode } from '../config/family-palette.js';
 import type { UrlState } from '../state/url-state.js';
@@ -297,10 +300,54 @@ export function DsPreview(): ReactNode {
     );
   }
 
+  // ScopeControl previews (#737). The in-state on-map re-scope bar, floated
+  // over a representative map-tinted backdrop so the overlay treatment reads
+  // correctly: `scope-control` = a state view (US-AZ selected, "Whole US" +
+  // "Change scope" exits visible); `scope-control-us` = the whole-US view
+  // (neutral placeholder, no "Whole US" self-link).
+  if (key.startsWith('scope-control')) {
+    return (
+      <ScopeControlPreview variant={key} />
+    );
+  }
+
   // Unknown key: show a helpful error
   return (
     <div style={{ ...PREVIEW_STYLES, color: 'red' }}>
       <p>Unknown ds-preview key: <code>{key}</code></p>
+    </div>
+  );
+}
+
+/**
+ * ScopeControl dev harness (#737). The control FLOATS over the map canvas via
+ * `position:absolute` + `--z-panel`, so isolating it requires a
+ * `position:relative` backdrop that stands in for `.map-surface`. A muted
+ * map-ish fill makes the overlay chrome (surface, border, shadow) legible at
+ * screenshot time without mounting the real MapLibre canvas. Dev-only — never
+ * ships (DsPreview is gated behind import.meta.env.DEV in main.tsx).
+ */
+function ScopeControlPreview({ variant }: { variant: string }): ReactNode {
+  const isUs = variant === 'scope-control-us';
+  return (
+    <div
+      style={{
+        position: 'relative',
+        minHeight: '100vh',
+        // A neutral map-ish backdrop (token-derived tint) so the floating
+        // overlay's surface/border/shadow are visible in both themes.
+        background:
+          'repeating-linear-gradient(45deg, var(--color-bg-tint) 0 16px, var(--color-bg-page) 16px 32px)',
+      }}
+    >
+      <ScopeControl
+        scope={isUs ? { kind: 'us' } : { kind: 'state', stateCode: 'US-AZ' }}
+        states={CANNED_STATES}
+        onPickState={() => {}}
+        onPickWholeUs={() => {}}
+        onExit={() => {}}
+        onResolve={() => {}}
+      />
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1875,3 +1875,115 @@ aside.species-detail-rail .species-detail-rail-close {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
+
+/* ── ScopeControl (#737) — in-state on-map re-scope bar (C4) ────────────────
+   Rendered ONLY in a scoped view (`?state=US-XX` or `?scope=us`), NEVER on the
+   chooser landing (that is .scope-chooser above). Unlike the C0 prototype's
+   .scope-app__bar — a non-overlapping flex row that sat ABOVE the map — the
+   production control FLOATS over the canvas: absolutely positioned, anchored
+   top-center, layered above the basemap via the same `--z-panel` token the
+   other map overlays (.family-legend, .observation-popover) use. Because it
+   floats, #736/C3's `fitBounds` top-padding is ASYMMETRIC (top ≈ this bar's
+   height) so the framed state isn't occluded.
+
+   Surface visual contract mirrors the other map overlays (white surface,
+   --color-border-ui edge, --shadow-listbox). All color/spacing/type/weight
+   comes from semantic tokens (no raw hex — ds-primitives.css convention); the
+   semantic tokens swap under [data-theme="dark"], and the float gets an
+   explicit dark surface override below (mirroring the prototype's
+   .scope-app__bar dark block) for contrast against the dark basemap. Every
+   className the TSX renders has a matching rule here (orphan-classname gate). */
+.scope-control {
+  position: absolute;
+  inset-block-start: var(--space-md);
+  inset-inline: var(--space-md);
+  z-index: var(--z-panel);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-md);
+  margin-inline: auto;
+  inline-size: fit-content;
+  max-inline-size: calc(100% - 2 * var(--space-md));
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: var(--shadow-listbox);
+}
+[data-theme="dark"] .scope-control {
+  /* Explicit dark surface for contrast against the dark basemap — mirrors the
+     prototype's [data-theme] .scope-app__bar treatment. The semantic
+     --color-bg-surface / --color-border-ui already swap, so this block only
+     re-asserts them as the documented dark surface anchor. */
+  background: var(--color-bg-surface);
+  border-color: var(--color-border-ui);
+}
+.scope-control__select {
+  flex: 0 1 auto;
+  min-inline-size: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--type-sm);
+  color: var(--color-text-strong);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: 4px;
+}
+.scope-control__select:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.scope-control__zip {
+  flex: 0 1 auto;
+}
+/* Exit/whole-US affordances are grouped and pushed to the trailing edge so the
+   state + ZIP inputs read as the primary actions and the exit controls as
+   subordinate. */
+.scope-control__exit-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-inline-start: auto;
+}
+/* De-emphasized affordances: visually subordinate (no primary fill, lighter
+   weight, smaller, link-like) but real, operable, focusable native buttons. */
+.scope-control__wholeus,
+.scope-control__exit {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.scope-control__wholeus:hover,
+.scope-control__exit:hover {
+  color: var(--color-text-strong);
+}
+.scope-control__wholeus:focus-visible,
+.scope-control__exit:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+
+/* Mobile (≤ 480px): the float spans the canvas width and the exit group wraps
+   below the inputs rather than crowding them on one short row. Matches the
+   codebase responsive convention (the ≤480px MOB breakpoint at styles.css). */
+@media (max-width: 480px) {
+  .scope-control {
+    inline-size: auto;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+  }
+  .scope-control__select {
+    flex: 1 1 100%;
+  }
+  .scope-control__exit-group {
+    flex: 1 1 100%;
+    margin-inline-start: 0;
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION


## Diagrams

```mermaid
sequenceDiagram
    actor User
    participant SC as ScopeControl (this PR)
    participant ZI as ZipInput (#739)
    participant App as App / C6 (#740)
    participant Map as MapCanvas / C3 (#736)

    Note over SC: Rendered ONLY in a scoped view<br/>(?state=US-XX or ?scope=us), never on the chooser

    User->>SC: pick state in <select>
    SC->>App: onPickState("US-CA")
    App->>App: write ?state=US-CA
    App-->>Map: bounds / maxBounds prop change
    Note over Map: reactive maxBounds — NO <Map> remount<br/>(C0 finding (a))

    User->>ZI: type ZIP + Enter
    ZI->>SC: onResolve(ScopeResolution)
    SC->>App: onResolve(ScopeResolution)
    App-->>Map: flyTo({center, zoom: ZIP_FLYTO_ZOOM})

    User->>SC: "Whole US"  →  onPickWholeUs()  → ?scope=us
    User->>SC: "Change scope" → onExit() → unscoped (chooser)
```

## Summary

- **Why:** the in-state on-map re-scope bar (Task **C4**) lets a user switch state / enter a ZIP / leave the scope **without bouncing back to the landing chooser** (#742). It is purely presentational — it owns no scope state, never touches the map, and triggers no fetch; it emits one clean intent per action (`onPickState` / `onResolve` / `onPickWholeUs` / `onExit`) that #740/C6 turns into URL writes + reactive camera changes.
- **No-remount guarantee:** switching state flows as a `maxBounds` **prop** change (not an imperative `map.setMaxBounds()`), so the `<Map>` stays mounted — the direct validation of C0 prototype finding (a). ScopeControl only emits the new state code.
- **Reuse, not fork:** the ZIP field is the existing `<ZipInput>` (#739) — the "ZIP not recognized" / malformed / fetch-error UX stays in one place. The whole-US / exit affordances are de-emphasized (link-style, muted, lower weight) per the revised "whole-US is niche" design.
- **C8 CSS sweep:** every `scope-control*` className has a token-driven rule in `styles.css` (orphan-classname + knip green), including the `--z-panel` float layer and a `[data-theme="dark"]` surface override. C8 ran AFTER #742 (ScopeChooser classNames) and #738 (MapLede/FilterSentence scope narration) merged, so the orphan sweep is not a false-clean.

> **⚠️ C3 hand-off (#736):** because this control **floats over the canvas** (AC 5 — `position:absolute` + `--z-panel`), C3's `fitBounds` top-padding must be **asymmetric** (top padding ≈ the ScopeControl bar height) so the framed state isn't occluded by the bar. The prototype's uniform `padding:48` only worked because its header was a non-overlapping flex row (finding (c)). `MapCanvas.tsx` already carries a `TODO(#737)` at the fitBounds call site — wire the matching top-padding there.

## Screenshots

ScopeControl in the **state view** (US-AZ selected, "Whole US" + "Change scope" exits), floated over a representative map-tinted backdrop via the dev-only `?ds-preview=scope-control` harness. 5 canonical viewports × 2 themes (10 captures).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img src="https://github.com/user-attachments/assets/9af7646e-d749-41c3-9c69-0be9b7f0e562" width="380"> | <img src="https://github.com/user-attachments/assets/ba0c34ef-dba2-4618-a807-e6c89bebf4fa" width="380"> |
| 768×1024 (tablet) | <img src="https://github.com/user-attachments/assets/6acc8ab7-c2a0-4696-844c-64955ef901b6" width="380"> | <img src="https://github.com/user-attachments/assets/6171050c-032e-43b1-9731-c420c0d51ce0" width="380"> |
| 1024×768 (small laptop) | <img src="https://github.com/user-attachments/assets/2432709b-d988-403c-9703-d95fd6c151f6" width="380"> | <img src="https://github.com/user-attachments/assets/225571e5-ab9c-43b0-b242-4a602f7b07a5" width="380"> |
| 1440×900 (desktop) | <img src="https://github.com/user-attachments/assets/d0e0d9c7-5fb9-446a-9302-fcc3a9da9f97" width="380"> | <img src="https://github.com/user-attachments/assets/10381e11-3506-46f0-a39a-db8b66b4164a" width="380"> |
| 1920×1080 (wide) | <img src="https://github.com/user-attachments/assets/73d8a409-11f5-441d-9ed4-0c4fc992c6d6" width="380"> | <img src="https://github.com/user-attachments/assets/848de64a-7402-46d3-a186-dcaff74a45ed" width="380"> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` (orphan-classname-check + knip green)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes)

**UI-verification note (AC 11 / AC 12):** drove the control live through `?ds-preview=scope-control` (state view) and `?ds-preview=scope-control-us` (whole-US view) at all 5 canonical viewports × 2 themes. State-switch, ZIP entry, whole-US, and exit affordances were exercised; tab order is select → ZIP → exit (no trap). **Scope-originated console: zero errors, zero warnings.** Per AC 12 the known non-suppressible upstream MapLibre 5.x basemap worker warning — `"Expected value to be of type number, but found null instead"` (raised inside the tile-parsing web worker, uncatchable from the main thread) — is the documented exclusion and is NOT scope code; the isolated preview harness mounts no map, so even that line does not originate here.

## Test plan

- [x] `npx tsc --noEmit && npm run test --workspace @bird-watch/frontend` — green (949 tests, 66 files; 11 new in `ScopeControl.test.tsx`)
- [x] New unit tests added — `ScopeControl.test.tsx` (RTL): state pick → `onPickState`, current state is the selected option, `?scope=us` placeholder + still-picks, `onExit` / `onPickWholeUs`, ZIP resolution bubbles to `onResolve`, whole-US hidden in `us` view, no mount-time fetch / no ZIP-index warm, accessible-name + tab-order assertions
- [ ] New Playwright e2e spec — N/A (the e2e wiring is the epic's #741/C9; this component is unmounted until #740/C6 wires it into `App.tsx`)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] (UI only) Playwright MCP smoke — ran `npm run dev`, drove the feature at all 5 viewports × 2 themes via `browser_*`, `browser_console_messages` returns zero scope-originated errors/warnings, screenshots captured from those runs
- [x] `bash scripts/check-orphan-classnames.sh` — PASS; `npx knip` — clean

## Plan reference

Part of epic #726, Plan **State / ZIP Map Scope Selector**, Tasks **C4** (in-state on-map ScopeControl) + **C8** (CSS sweep). See `docs/plans/2026-05-28-state-scope-selector.md`. Closes #737.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
