### PR TITLE
test(e2e): scope chooser/state/ZIP/whole-US/empty-region specs + 5×2 screenshots (C9+D6) — closes #741

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,8 +1,13 @@
 import { test as base } from '@playwright/test';
-import type { Observation, SpeciesMeta } from '@bird-watch/shared-types';
+import type { Observation, SpeciesMeta, StateSummary } from '@bird-watch/shared-types';
 
-/** Read API endpoints that can be stubbed. Keep in sync with services/read-api/src/app.ts. */
-export type StubbableEndpoint = 'hotspots' | 'observations' | 'species' | 'silhouettes';
+/**
+ * Read API endpoints that can be stubbed. Keep in sync with
+ * services/read-api/src/app.ts. `'states'` is the A4/#732 endpoint
+ * (`GET /api/states`) — adding it here makes `stubApiFailure('states', …)` /
+ * `stubApiAbort('states')` typecheck for the #741 fetch-error case.
+ */
+export type StubbableEndpoint = 'hotspots' | 'observations' | 'species' | 'silhouettes' | 'states';
 
 /**
  * Canonical Vermilion Flycatcher SpeciesMeta fixture (NO photoUrl) — exercises
@@ -65,6 +70,53 @@ export const VERMFLY_OBS: Observation[] = [
 ];
 
 /**
+ * Minimal name-sorted `StateSummary[]` for the scope chooser/control `<select>`
+ * (#741). Three CONUS states with real `bbox:[w,s,e,n]` envelopes so the
+ * `?state=US-XX` camera `fitBounds`/`maxBounds` derivation in App.tsx has a
+ * non-degenerate envelope to frame. Both `<ScopeChooser>` (#742) and the
+ * in-state `<ScopeControl>` (#737) fetch `GET /api/states` on mount, so EVERY
+ * scope spec must register `stubStates()` — an unstubbed route (the local
+ * read-api has no seed in e2e) renders a perpetually-loading / disabled
+ * selector. Name-sorted (Arizona < Florida < New York) to mirror the endpoint
+ * contract (#732 returns rows name-sorted).
+ */
+export const STATES_FIXTURE: StateSummary[] = [
+  { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.82, 31.33, -109.04, 37.0] },
+  { stateCode: 'US-FL', name: 'Florida', bbox: [-87.63, 24.52, -80.03, 31.0] },
+  { stateCode: 'US-NY', name: 'New York', bbox: [-79.76, 40.5, -71.86, 45.02] },
+];
+
+/** Columnar on-disk shape of `public/zip-index.json` (D2), mirrored from
+ *  `frontend/src/data/zip-lookup.ts::ZipIndex`. */
+export interface ZipIndexFixture {
+  v: number;
+  states: string[];
+  zips: Record<string, [number, number, number]>;
+}
+
+/**
+ * Small canned columnar ZIP index matching the production on-disk shape
+ * (`{ v, states, zips }`, D2) consumed by `frontend/src/data/zip-lookup.ts`.
+ * `zips` maps ZIP5 → `[lat, lng, stateIdx]` ([lat, lng], NOT MapLibre order —
+ * `lookupZip` swaps to `[lng, lat]` on decode). Two entries:
+ *   - `85701` → US-AZ (Tucson). After columnar decode → center `[-110.974,
+ *     32.222]` ([lng, lat]) inside the Arizona envelope.
+ *   - `10001` → US-NY (Manhattan). Lands inside New York — used by the
+ *     empty-region case (NY is empty on the AZ-only observation seed).
+ * `10002` is deliberately ABSENT so a well-formed-but-unknown ZIP exercises the
+ * "ZIP not recognized" path. Never serve the real ~1 MB asset in e2e.
+ */
+export const ZIP_INDEX_FIXTURE: ZipIndexFixture = {
+  v: 1,
+  states: ['US-AZ', 'US-NY'],
+  zips: {
+    // [lat, lng, stateIdx] — lookupZip decodes to center [lng, lat].
+    '85701': [32.222, -110.974, 0], // Tucson, AZ
+    '10001': [40.7506, -73.9971, 1], // Manhattan, NY
+  },
+};
+
+/**
  * 1×1 transparent PNG (67 bytes, base64) used by `stubPhotoImage` to satisfy
  * the browser's `<img>` request for `photoUrl`. Returning a real binary keeps
  * the network stack happy: we never load a real photo across the wire from the
@@ -89,6 +141,21 @@ export interface ApiStub {
   stubEmpty(): Promise<void>;
   /** Stubs `/api/observations` to return `200` with the provided list. */
   stubObservations(obs: Observation[]): Promise<void>;
+  /**
+   * Stubs `**\/api/states**` to return `200` with the provided name-sorted
+   * `StateSummary[]` (default `STATES_FIXTURE`). Both `<ScopeChooser>` (#742)
+   * and the in-state `<ScopeControl>` (#737) fetch this on mount, so every
+   * scope spec must register it — without it the local read-api (unseeded in
+   * e2e) yields an empty/flaky selector.
+   */
+  stubStates(states?: StateSummary[]): Promise<void>;
+  /**
+   * Stubs `**\/zip-index.json*` (the trailing `*` matches the
+   * `?v=<datasetVersion>` cache-bust suffix `zip-lookup.ts` appends) to return
+   * `200` with a small canned columnar index (default `ZIP_INDEX_FIXTURE`).
+   * Never serves the real ~1 MB `public/zip-index.json`.
+   */
+  stubZipIndex(index?: ZipIndexFixture): Promise<void>;
   /**
    * Stubs `**\/api/species/{code}` to return `200` with the provided
    * SpeciesMeta. The glob captures the exact code as a path suffix so
@@ -150,6 +217,24 @@ export const test = base.extend<{ apiStub: ApiStub }>({
               data: obs,
               meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() },
             }),
+          });
+        });
+      },
+      async stubStates(states = STATES_FIXTURE) {
+        await page.route('**/api/states**', async route => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(states),
+          });
+        });
+      },
+      async stubZipIndex(index = ZIP_INDEX_FIXTURE) {
+        await page.route('**/zip-index.json*', async route => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(index),
           });
         });
       },

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -16,6 +16,39 @@ export class AppPage {
   /** Credits & attribution trigger in appHeader. */
   readonly attributionTrigger: Locator;
 
+  // --- Scope chooser (landing surface, #742) accessors (C9/D6, #741) ---
+  /** The `<ScopeChooser>` landing region (visible only on the unscoped/bare URL).
+   *  Accessible name is the component's `aria-label`. */
+  readonly chooser: Locator;
+  /** ZIP `<input>` inside the chooser (`aria-label='ZIP code'`, owned by ZipInput). */
+  readonly chooserZipInput: Locator;
+  /** State `<select>` inside the chooser (`aria-label='State'` via its `<label>`). */
+  readonly chooserStateSelect: Locator;
+  /** The chooser state-path "Go" submit button. */
+  readonly chooserStateGo: Locator;
+  /** The de-emphasized "Explore the whole US map" escape-hatch button. */
+  readonly chooserWholeUs: Locator;
+  /** ZIP malformed inline hint inside the chooser ("Enter a 5-digit ZIP"). */
+  readonly chooserZipError: Locator;
+  /** ZIP `role=status` region inside the chooser ("ZIP not recognized — …"). */
+  readonly chooserZipStatus: Locator;
+
+  // --- In-state ScopeControl (on-map re-scope bar, #737) accessors ---
+  /** The floating in-state `<ScopeControl>` region (visible only in a scoped view). */
+  readonly scopeControl: Locator;
+  /** The in-state state-switch `<select>` (`aria-label='Switch state'`). */
+  readonly scopeControlStateSelect: Locator;
+  /** The in-state niche "Whole US" escape hatch (state view only). */
+  readonly scopeControlWholeUs: Locator;
+  /** The "Change scope" exit affordance → returns to the chooser. */
+  readonly scopeControlExit: Locator;
+
+  // --- Shared narration / region surfaces ---
+  /** The map's runtime region lede (`<h1 class="map-lede">`, MapLede #738/C7). */
+  readonly mapLede: Locator;
+  /** The map canvas root (`data-testid='map-canvas'`). */
+  readonly mapCanvas: Locator;
+
   constructor(public readonly page: Page) {
     this.filters = new FiltersBar(page);
     this.mainSurface = page.locator('main#main-surface');
@@ -25,6 +58,24 @@ export class AppPage {
     this.filtersTrigger = this.appHeader.getByRole('button', { name: /^Filters/ });
     this.themeToggle = this.appHeader.getByRole('button', { name: /Switch to (light|dark) theme/ });
     this.attributionTrigger = this.appHeader.getByRole('button', { name: /Credits & attribution/ });
+
+    // Chooser (#742) — region accessible name "Choose where to look at birds".
+    this.chooser = page.getByRole('region', { name: 'Choose where to look at birds' });
+    this.chooserZipInput = this.chooser.getByLabel('ZIP code', { exact: true });
+    this.chooserStateSelect = this.chooser.getByLabel('State', { exact: true });
+    this.chooserStateGo = this.chooser.getByRole('button', { name: 'Go', exact: true });
+    this.chooserWholeUs = this.chooser.getByRole('button', { name: 'Explore the whole US map' });
+    this.chooserZipError = this.chooser.getByText('Enter a 5-digit ZIP', { exact: true });
+    this.chooserZipStatus = this.chooser.getByRole('status');
+
+    // In-state ScopeControl (#737) — region accessible name "Change the map scope".
+    this.scopeControl = page.getByRole('region', { name: 'Change the map scope' });
+    this.scopeControlStateSelect = this.scopeControl.getByLabel('Switch state', { exact: true });
+    this.scopeControlWholeUs = this.scopeControl.getByRole('button', { name: 'Whole US', exact: true });
+    this.scopeControlExit = this.scopeControl.getByRole('button', { name: 'Change scope' });
+
+    this.mapLede = page.locator('.map-lede');
+    this.mapCanvas = page.locator('[data-testid="map-canvas"]');
   }
 
   /**
@@ -102,5 +153,25 @@ export class AppPage {
 
   getUrlParams(): URLSearchParams {
     return new URL(this.page.url()).searchParams;
+  }
+
+  /**
+   * Pick a state from the chooser `<select>` + click Go (C9 state-select
+   * round-trip). The select is the chooser's own (`aria-label='State'`); Go is
+   * disabled until a non-empty option is chosen, so this selects first.
+   */
+  async pickStateInChooser(stateCode: string): Promise<void> {
+    await this.chooserStateSelect.selectOption(stateCode);
+    await this.chooserStateGo.click();
+  }
+
+  /**
+   * Enter a ZIP into the chooser ZIP input and submit (the form submits on
+   * Enter; `role=search` form, no separate Go button for the ZIP path). Used by
+   * the D6 ZIP round-trip / empty-region / unknown / malformed cases.
+   */
+  async submitChooserZip(zip: string): Promise<void> {
+    await this.chooserZipInput.fill(zip);
+    await this.chooserZipInput.press('Enter');
   }
 }

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -1,0 +1,247 @@
+import { test, expect, STATES_FIXTURE } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * C9 (#741) — chooser-first scope IA: chooser landing, state-select, `?scope=us`
+ * CONUS, whole-US-reset → chooser, and `?state=` deep-link precedence.
+ *
+ * The headline assertion (AC 5 / prototype learning (f)) is the cold-load fetch
+ * suppression: a bare URL lands on `<ScopeChooser>` with the map render AND the
+ * `/api/observations` fetch SUPPRESSED. Picking a scope mounts the map fresh and
+ * fires exactly one observations fetch — carrying `state=US-XX` for a state
+ * scope, and NO `state=` for `?scope=us` (the data invariant, #735).
+ *
+ * Camera-assertion handle (AC 4): App.tsx exposes no dedicated camera
+ * data-attribute, so the camera move is asserted via the URL round-trip
+ * (`?state=` set) + the `/api/observations` request query (`state=US-XX`) — the
+ * agreed handle. The map canvas presence (`data-testid='map-canvas'`) confirms
+ * the scoped map mounted.
+ *
+ * Navigation contract (AC 15): the chooser-landing + whole-US-reset cases skip
+ * `waitForAppReady()` (no map render is expected); the data cases wait for it.
+ * Every test begins with its own `goto`/`gotoRaw` — no reliance on prior state.
+ */
+test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
+  /** Two-species AZ payload so a state scope yields a non-empty Template-4 lede. */
+  const AZ_OBS = [
+    {
+      subId: 'S1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.22,
+      lng: -110.97,
+      obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      locId: 'L1',
+      locName: 'Tucson',
+      howMany: 1,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+    {
+      subId: 'S2',
+      speciesCode: 'gilwoo',
+      comName: 'Gila Woodpecker',
+      lat: 32.3,
+      lng: -111.0,
+      obsDt: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+      locId: 'L2',
+      locName: 'Saguaro NP',
+      howMany: 2,
+      isNotable: false,
+      silhouetteId: 'picidae',
+      familyCode: 'picidae',
+    },
+  ];
+
+  /**
+   * Register the always-needed scope stubs (`/api/states`, `/api/silhouettes`,
+   * `/api/hotspots`, zip-index) and count `/api/observations` requests. Returns
+   * a live `obsRequests` array + the typed `AppPage`. Each spec registers its
+   * own `/api/observations` body on top (LIFO — last registration wins).
+   */
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('./fixtures.js').ApiStub,
+  ): Promise<{ app: AppPage; obsRequests: string[] }> {
+    await apiStub.stubStates();
+    await apiStub.stubZipIndex();
+    // hotspots + silhouettes resolve immediately so the rest of the app boots
+    // (stubEmpty also stubs /api/observations → [] as a fallback; specs that
+    // need a body re-register it afterwards, LIFO).
+    await apiStub.stubEmpty();
+
+    const obsRequests: string[] = [];
+    page.on('request', req => {
+      const url = req.url();
+      if (url.includes('/api/observations')) obsRequests.push(url);
+    });
+
+    return { app: new AppPage(page), obsRequests };
+  }
+
+  test('chooser landing (bare URL) — map + cold-load /api/observations fetch suppressed', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+
+    // gotoRaw — NO default-scope injection, so this is the true bare-URL
+    // unscoped landing (the C9 chooser case). Navigation contract: chooser case
+    // skips waitForAppReady (no map render expected).
+    await app.gotoRaw('');
+
+    // The chooser is the visible primary surface.
+    await expect(app.chooser).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Where do you want to look at birds?' }),
+    ).toBeVisible();
+    // Both co-primary paths are present; the whole-US escape hatch is present
+    // but de-emphasized (it is still a button — visibility, not prominence).
+    await expect(app.chooserZipInput).toBeVisible();
+    await expect(app.chooserStateSelect).toBeVisible();
+    await expect(app.chooserWholeUs).toBeVisible();
+
+    // The map canvas is NOT rendered (the unscoped early-return shows the
+    // chooser in place of the map surface).
+    await expect(app.mapCanvas).toHaveCount(0);
+    await expect(app.mainSurface).toHaveCount(0);
+
+    // Headline assertion (learning (f)): ZERO /api/observations requests fire on
+    // the chooser landing. Hold the window open to be sure no late fetch slips
+    // through (the scope gate is in App, not just the unmount).
+    await page.waitForTimeout(800);
+    expect(obsRequests).toHaveLength(0);
+  });
+
+  test('state select round-trip — ?state=US-AZ, map fetches once with state=US-AZ, region "Arizona"', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubObservations(AZ_OBS);
+
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // Pick Arizona from the chooser <select> + Go.
+    await app.pickStateInChooser('US-AZ');
+
+    // URL gains ?state=US-AZ.
+    await expect(page).toHaveURL(/[?&]state=US-AZ\b/);
+    expect(app.getUrlParams().get('state')).toBe('US-AZ');
+
+    // The map mounts; data resolves.
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+
+    // The chooser is gone (replaced by the scoped map).
+    await expect(app.chooser).toHaveCount(0);
+
+    // /api/observations was requested AT LEAST once, and every request carries
+    // state=US-AZ (the server clips via ST_Intersects). There must be no
+    // unscoped observations request before the scope was chosen.
+    expect(obsRequests.length).toBeGreaterThan(0);
+    for (const url of obsRequests) {
+      expect(new URL(url).searchParams.get('state')).toBe('US-AZ');
+    }
+
+    // Region label reads "Arizona" (resolved from the /api/states name table).
+    await expect(app.mapLede).toContainText('Arizona');
+  });
+
+  test('?scope=us — CONUS map, region "USA", /api/observations carries NO state=', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubObservations(AZ_OBS);
+
+    // ?scope=us is the explicit whole-US escape hatch (a real scope), so the
+    // map renders directly — wait for the data case.
+    await app.goto('scope=us');
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+
+    // Region label is "USA".
+    await expect(app.mapLede).toContainText('USA');
+
+    // Data invariant (#735): ?scope=us sends NO state= — byte-for-byte the
+    // unscoped national query. Every observations request must omit state=.
+    expect(obsRequests.length).toBeGreaterThan(0);
+    for (const url of obsRequests) {
+      expect(new URL(url).searchParams.has('state')).toBe(false);
+    }
+    // URL carries scope=us, not state=.
+    expect(app.getUrlParams().get('scope')).toBe('us');
+    expect(app.getUrlParams().has('state')).toBe(false);
+  });
+
+  test('whole-US reset → CHOOSER (not a CONUS home); observations fetch stops', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubObservations(AZ_OBS);
+
+    // Start in a scoped state view.
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    await expect(app.scopeControl).toBeVisible();
+    expect(obsRequests.length).toBeGreaterThan(0);
+
+    // Activate the "Change scope" exit affordance.
+    const countBeforeExit = obsRequests.length;
+    await app.scopeControlExit.click();
+
+    // We return to the CHOOSER, NOT a CONUS map.
+    await expect(app.chooser).toBeVisible();
+    await expect(app.mapCanvas).toHaveCount(0);
+    await expect(app.mainSurface).toHaveCount(0);
+    // URL is bare again (no state=, no scope=).
+    expect(app.getUrlParams().has('state')).toBe(false);
+    expect(app.getUrlParams().has('scope')).toBe(false);
+
+    // The observations fetch is suppressed again — no NEW request after exit.
+    await page.waitForTimeout(800);
+    expect(obsRequests.length).toBe(countBeforeExit);
+  });
+
+  test('?state= deep-link precedence — ?state wins over ?zip; AZ renders', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubObservations(AZ_OBS);
+
+    // goto() leaves ?state= present (it injects scope=us only when neither
+    // scope nor state is present) — so this is the literal deep-link. ?zip= is
+    // never read by url-state; ?state wins and AZ renders.
+    await app.goto('state=US-AZ&zip=10001');
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+
+    // ?state wins; the ?zip is not a scope and is dropped from the resolution.
+    expect(app.getUrlParams().get('state')).toBe('US-AZ');
+    await expect(app.mapLede).toContainText('Arizona');
+    expect(obsRequests.length).toBeGreaterThan(0);
+    for (const url of obsRequests) {
+      expect(new URL(url).searchParams.get('state')).toBe('US-AZ');
+    }
+  });
+
+  test('chooser state <select> lists the name-sorted states from /api/states', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // The placeholder + each fixture state name, in the fixture (name-sorted)
+    // order. Confirms the chooser consumed the /api/states stub on mount.
+    const optionTexts = await app.chooserStateSelect.locator('option').allInnerTexts();
+    expect(optionTexts[0]).toBe('Choose a state…');
+    expect(optionTexts.slice(1)).toEqual(STATES_FIXTURE.map(s => s.name));
+  });
+});

--- a/frontend/e2e/zip-scope.spec.ts
+++ b/frontend/e2e/zip-scope.spec.ts
@@ -1,0 +1,279 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * D6 (#741) — ZIP round-trip, empty-region narration, and the ZIP / `/api/states`
+ * error paths. Asserts the C7 sparse/empty-region copy wired by #740.
+ *
+ * The ZIP path resolves a 5-digit ZIP to a `?state=US-XX` scope (NO `?zip=`,
+ * locked decision #5) + a transient metro `flyTo` at `ZIP_FLYTO_ZOOM` (10). The
+ * camera move is asserted via the URL round-trip (`?state=` set, no `?zip=`) +
+ * the `/api/observations` request query (`state=US-XX`) — the agreed handle
+ * (App exposes no dedicated camera data-attribute); the metro-zoom landing is
+ * the prototype's learning (f) (the ZIP `flyTo` wins over the whole-state
+ * `fitBounds` on the chooser→map remount).
+ *
+ * Empty-region (AC 11) is the data-availability ≠ filter-narrowing distinction:
+ * a valid non-AZ ZIP whose state is empty on the AZ-only seed must read the
+ * sparse copy "No recent sightings in {region} yet.", NOT "No sightings match
+ * your current filters."
+ */
+test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', () => {
+  const AZ_OBS = [
+    {
+      subId: 'S1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.22,
+      lng: -110.97,
+      obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      locId: 'L1',
+      locName: 'Tucson',
+      howMany: 1,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+    {
+      subId: 'S2',
+      speciesCode: 'gilwoo',
+      comName: 'Gila Woodpecker',
+      lat: 32.3,
+      lng: -111.0,
+      obsDt: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+      locId: 'L2',
+      locName: 'Saguaro NP',
+      howMany: 2,
+      isNotable: false,
+      silhouetteId: 'picidae',
+      familyCode: 'picidae',
+    },
+  ];
+
+  /**
+   * Register the always-needed stubs and count `/api/observations` +
+   * `zip-index.json` requests. A STATE-AWARE `/api/observations` handler returns
+   * the AZ seed for `state=US-AZ` and an empty envelope for any other state —
+   * so the AZ scope is populated while NY (and any other) reads as a sparse,
+   * data-available-but-empty region.
+   */
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('./fixtures.js').ApiStub,
+  ): Promise<{ app: AppPage; obsRequests: string[]; zipIndexRequests: string[] }> {
+    await apiStub.stubStates();
+    await apiStub.stubZipIndex();
+    await apiStub.stubEmpty();
+
+    const obsRequests: string[] = [];
+    const zipIndexRequests: string[] = [];
+    page.on('request', req => {
+      const url = req.url();
+      if (url.includes('/api/observations')) obsRequests.push(url);
+      if (url.includes('/zip-index.json')) zipIndexRequests.push(url);
+    });
+
+    // State-aware observations (LIFO — wins over stubEmpty's handler).
+    await page.route('**/api/observations**', async route => {
+      const state = new URL(route.request().url()).searchParams.get('state');
+      const data = state === 'US-AZ' ? AZ_OBS : [];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data,
+          meta: {
+            freshestObservationAt:
+              data.length > 0 ? new Date(Date.now() - 5 * 60 * 1000).toISOString() : null,
+          },
+        }),
+      });
+    });
+
+    return { app: new AppPage(page), obsRequests, zipIndexRequests };
+  }
+
+  test('ZIP 85701 → state-zoom: ?state=US-AZ (no ?zip=), data clips to AZ', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // Tucson ZIP → resolves to US-AZ + a metro flyTo (zoom 10). The lazy ZIP
+    // index warms on focus; submitChooserZip focuses (fill) then submits.
+    await app.submitChooserZip('85701');
+
+    // URL gains ?state=US-AZ and NEVER ?zip= (locked decision #5).
+    await expect(page).toHaveURL(/[?&]state=US-AZ\b/);
+    expect(app.getUrlParams().get('state')).toBe('US-AZ');
+    expect(app.getUrlParams().has('zip')).toBe(false);
+
+    // The map mounts and clips to AZ (camera handle: state= round-trip + the
+    // observations query carries state=US-AZ; the metro-zoom landing is the
+    // App flyTo, asserted indirectly via the AZ scope + populated data).
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+    expect(obsRequests.length).toBeGreaterThan(0);
+    for (const url of obsRequests) {
+      expect(new URL(url).searchParams.get('state')).toBe('US-AZ');
+    }
+    // AZ has data → the lede reads a populated region (NOT the empty copy).
+    await expect(app.mapLede).toContainText('Arizona');
+    await expect(app.mapLede).not.toContainText('No recent sightings');
+  });
+
+  test('valid non-AZ ZIP (10001 → US-NY, empty) → distinct sparse/empty-region copy', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // Manhattan ZIP → resolves to US-NY, which is empty on the AZ-only seed.
+    await app.submitChooserZip('10001');
+
+    await expect(page).toHaveURL(/[?&]state=US-NY\b/);
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+
+    // Data-availability copy (C7): the region itself is sparse — NOT the
+    // filter-narrowing copy. Region label resolves to "New York".
+    await expect(app.mapLede).toHaveText('No recent sightings in New York yet.');
+    // The filter-narrowing copy MUST be absent (the load-bearing distinction).
+    await expect(
+      page.getByText('No sightings match your current filters.'),
+    ).toHaveCount(0);
+  });
+
+  test('unknown well-formed ZIP → role=status "ZIP not recognized"; scope unchanged; value retained', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // 10002 is a well-formed 5-digit ZIP absent from the canned index.
+    await app.submitChooserZip('10002');
+
+    // Never a silent no-op: a role=status message is visible.
+    await expect(app.chooserZipStatus).toBeVisible();
+    await expect(app.chooserZipStatus).toHaveText(
+      'ZIP not recognized — try a nearby ZIP or pick a state',
+    );
+
+    // Scope/URL unchanged — still on the chooser, no state= written.
+    await expect(app.chooser).toBeVisible();
+    await expect(app.mapCanvas).toHaveCount(0);
+    expect(app.getUrlParams().has('state')).toBe(false);
+    // The input value is retained (not cleared).
+    await expect(app.chooserZipInput).toHaveValue('10002');
+    // No scope was activated → no observations fetch.
+    await page.waitForTimeout(400);
+    expect(obsRequests).toHaveLength(0);
+  });
+
+  test('malformed ZIP → rejected, no scope, no lookup fetch (gate before fetch, D3)', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, zipIndexRequests } = await setup(page, apiStub);
+
+    await app.gotoRaw('');
+    await expect(app.chooser).toBeVisible();
+
+    // A non-5-digit value is malformed. The ZIP `<input>` carries
+    // `pattern="[0-9]{5}"`, so the browser's native HTML5 constraint validation
+    // intercepts the Enter-submit on a malformed value — the value is reported
+    // invalid (`patternMismatch`) and the submit is blocked BEFORE
+    // `lookupZip`/`loadZipIndex` is reached. This is the production-faithful
+    // malformed UX in a real browser (the React "Enter a 5-digit ZIP" hint and
+    // the JS `/^\d{5}$/` gate are the jsdom-unit-test path; in-browser the
+    // native gate fires first — either way the load-bearing D3 contract holds:
+    // a malformed submit triggers NO ZIP-index lookup fetch).
+    await app.submitChooserZip('123');
+
+    // The native validity flags the value as a pattern mismatch (malformed).
+    const validity = await app.chooserZipInput.evaluate(
+      (el: HTMLInputElement) => ({ valid: el.validity.valid, patternMismatch: el.validity.patternMismatch }),
+    );
+    expect(validity.valid).toBe(false);
+    expect(validity.patternMismatch).toBe(true);
+
+    // Scope unchanged — still on the chooser, no state= written, no map.
+    await expect(app.chooser).toBeVisible();
+    expect(app.getUrlParams().has('state')).toBe(false);
+    await expect(app.mapCanvas).toHaveCount(0);
+
+    // D3: the malformed SUBMIT triggers no lookup fetch. `loadZipIndex` warms
+    // lazily on FOCUS (an intentional pre-fetch, single-flight memoized), so a
+    // focused-then-malformed-submit yields at MOST the one focus warm and never
+    // a per-submit lookup — the regex/native gate short-circuits before
+    // `lookupZip`. (Were the gate after the fetch, a malformed submit would add
+    // a second request.)
+    await page.waitForTimeout(400);
+    expect(zipIndexRequests.length).toBeLessThanOrEqual(1);
+    // The input value is retained (never a silent clear).
+    await expect(app.chooserZipInput).toHaveValue('123');
+  });
+
+  test('/api/states fetch-error → chooser degrades gracefully; ZIP path still resolves a scope', async ({
+    page,
+    apiStub,
+  }) => {
+    // Register the failure FIRST so the LIFO stubStates in setup would override
+    // it — instead we DON'T call stubStates here; we fail /api/states.
+    await apiStub.stubZipIndex();
+    await apiStub.stubEmpty();
+    await apiStub.stubApiFailure('states', 500);
+
+    const obsRequests: string[] = [];
+    page.on('request', req => {
+      if (req.url().includes('/api/observations')) obsRequests.push(req.url());
+    });
+    // State-aware observations so the ZIP-resolved AZ scope is populated.
+    await page.route('**/api/observations**', async route => {
+      const state = new URL(route.request().url()).searchParams.get('state');
+      const data = state === 'US-AZ' ? AZ_OBS : [];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data,
+          meta: {
+            freshestObservationAt:
+              data.length > 0 ? new Date(Date.now() - 5 * 60 * 1000).toISOString() : null,
+          },
+        }),
+      });
+    });
+
+    const app = new AppPage(page);
+
+    // No uncaught error: capture page errors over the whole test.
+    const pageErrors: string[] = [];
+    page.on('pageerror', err => pageErrors.push(String(err)));
+
+    await app.gotoRaw('');
+
+    // The chooser still renders (does NOT throw to the error screen). The
+    // selector degrades to an honest placeholder; the ZIP path stays usable.
+    await expect(app.chooser).toBeVisible();
+    await expect(app.errorScreen).toHaveCount(0);
+
+    // The user can STILL pick a scope via the ZIP path.
+    await app.submitChooserZip('85701');
+    await expect(page).toHaveURL(/[?&]state=US-AZ\b/);
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toBeVisible();
+
+    // No uncaught page error surfaced from the /api/states failure.
+    expect(pageErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    bare["bare URL — gotoRaw('')"] -->|scope unscoped| chooser["ScopeChooser landing<br/>map + /api/observations SUPPRESSED"]
    chooser -->|pick state + Go| stateView
    chooser -->|"ZIP 85701 resolve"| stateView["?state=US-XX view<br/>fitBounds + clip + flyTo zoom 10"]
    chooser -->|Explore whole US| usView["?scope=us → CONUS<br/>region USA, NO state= on fetch"]
    usq["goto('scope=us')"] --> usView
    stateView -->|Change scope exit| chooser
    stateView -->|/api/observations| obsAZ["state=US-AZ → AZ rows clip"]
    stateNY["?state=US-NY empty seed"] --> empty["lede: No recent sightings in<br/>New York yet. — C7 sparse,<br/>NOT the filter-narrowing copy"]
```

```mermaid
sequenceDiagram
    participant Spec as e2e spec
    participant Page as App
    participant API as api stubs

    Spec->>Page: gotoRaw('') bare URL
    Page->>API: GET /api/states
    Note over Page,API: ZERO /api/observations<br/>cold-load fetch SUPPRESSED — learning (f)
    Spec->>Page: pick state US-AZ / submit ZIP 85701
    Page->>API: GET /api/observations?state=US-AZ
    API-->>Page: AZ rows → region Arizona
    Spec->>Page: Change scope exit
    Note over Page,API: back to CHOOSER (not a CONUS home)<br/>observations fetch stops
```

## Summary

- **Why:** locks the chooser-first scope IA (#727–#742) behind `@playwright/test` so the load-bearing behaviors — cold-load fetch suppression on the chooser landing (prototype learning (f)), the `?scope=us` "no `state=`" data invariant (#735), and the data-availability ≠ filter-narrowing copy split (#738/C7) — can't silently regress.
- **C9 (`state-scope.spec.ts`):** chooser landing (bare URL → chooser, map + `/api/observations` fetch suppressed), state-select round-trip (`?state=US-AZ`, fetch carries `state=US-AZ`, region "Arizona"), `?scope=us` → CONUS (region "USA", no `state=`), whole-US reset → CHOOSER (not a CONUS home; fetch stops), `?state=` deep-link precedence.
- **D6 (`zip-scope.spec.ts`):** ZIP `85701` → state-zoom (`?state=US-AZ`, no `?zip=`, clips AZ), valid non-AZ ZIP `10001` → distinct sparse/empty-region copy, unknown well-formed ZIP → `role=status` + value retained, malformed ZIP → rejected before any lookup fetch (D3 gate), `/api/states` fetch-error → chooser degrades gracefully (ZIP path still resolves a scope).
- **Fixtures/POM:** `StubbableEndpoint` gains `'states'`; new `STATES_FIXTURE` + `ZIP_INDEX_FIXTURE` (columnar `{v,states,zips}` per D2) + `stubStates()`/`stubZipIndex()` helpers; POM accessors for the chooser, in-state `ScopeControl`, map lede/canvas, and ZIP status/error regions. No `frontend/src/**` change (e2e + fixtures + POM only).

## Screenshots

Live-driven through Playwright MCP. Chooser landing captured at all 5 canonical viewports × 2 themes (the primary new surface); the scoped state view and the sparse/empty-region view captured at desktop × 2 themes.

### Chooser landing — 5 viewports × 2 themes

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img src="https://github.com/user-attachments/assets/10ba2d8d-cb94-40c5-b31e-630fd85cf637" width="380"> | <img src="https://github.com/user-attachments/assets/cd2ba805-feab-49e1-b2c0-13bac379bcda" width="380"> |
| 768×1024 (tablet) | <img src="https://github.com/user-attachments/assets/9c93f25d-8da4-4606-afa2-24023ad6924c" width="380"> | <img src="https://github.com/user-attachments/assets/aa3135b8-a9cb-4570-b577-7603a885882e" width="380"> |
| 1024×768 (small laptop) | <img src="https://github.com/user-attachments/assets/6b5cedd6-ed0f-4c67-9768-a7132bcb7b3b" width="380"> | <img src="https://github.com/user-attachments/assets/30707370-7340-41fa-a046-06e50d277685" width="380"> |
| 1440×900 (desktop) | <img src="https://github.com/user-attachments/assets/0945579f-ea12-4278-8437-b695f5f0f10e" width="380"> | <img src="https://github.com/user-attachments/assets/f0379833-b906-4be7-a301-2824005830a4" width="380"> |
| 1920×1080 (wide) | <img src="https://github.com/user-attachments/assets/b79624e0-1755-43d2-b967-30e0ce2fa858" width="380"> | <img src="https://github.com/user-attachments/assets/8f69d672-69b3-4d08-b7ca-d985c92f552d" width="380"> |

### Scoped state view (`?state=US-AZ`) — populated lede + in-state ScopeControl

| Light | Dark |
|---|---|
| <img src="https://github.com/user-attachments/assets/d83d43e5-805a-4611-be73-766907edc3e1" width="380"> | <img src="https://github.com/user-attachments/assets/66bc5621-9801-4c86-931e-b6b0275dcb0d" width="380"> |

### Sparse/empty-region view (`?state=US-NY`) — C7 "No recent sightings in New York yet."

| Light | Dark |
|---|---|
| <img src="https://github.com/user-attachments/assets/124d07a4-a400-4325-971f-d1361c7e6737" width="380"> | <img src="https://github.com/user-attachments/assets/8d940038-56d3-40d2-acc6-c20db0c4a70b" width="380"> |

> Console: **zero scope-originated errors/warnings** at every viewport/theme. The single tolerated warning is the documented, non-suppressible upstream positron-vector-basemap MapLibre 5.x line — `"Expected value to be of type number, but found null instead"` — emitted from the tile-parsing web worker at zoom ≥ 10 (prototype learning (e)), per AC 19.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A — no `frontend/src/**` change; e2e + fixtures + POM only
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445) — 14 URLs

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] New Playwright e2e specs added (`state-scope.spec.ts` C9 + `zip-scope.spec.ts` D6) — 11 tests green locally (`--project=dev-server`)
- [x] No-DB-write grep clean; `knip` clean; orphan-classname check PASS
- [x] (UI verification) Playwright MCP smoke — drove the chooser landing, state view, ZIP→state, `?scope=us`, whole-US reset, and empty-region at all 5 canonical viewports × 2 themes; `browser_console_messages` returns zero scope-originated errors/warnings (only the tolerated upstream basemap line above).

## Plan reference

Part of epic #726, Plan `2026-05-28-state-scope-selector`, Tasks **C9 + D6**. Closes #741. Depends on #737/#740/#742 (all on `main`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
