### PR TITLE
feat(frontend,map): artboard fidelity — label isolation + clean exterior + float layers (#763)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@bird-watch/shared-types": "*",
     "@microsoft/clarity": "^1.0.2",
+    "@turf/buffer": "^7.3.5",
     "maplibre-gl": "^5.24.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -60,7 +60,44 @@ function makeFakeMap() {
   // stateful pair (maplibre's default is `true`). Lets tests both exercise the
   // effect without throwing AND assert the imperative value it lands on.
   let renderWorldCopiesState = true;
+  // #763 — a representative style.layers list for the artboard-fidelity
+  // imperative work (label isolation, sink, float). Mixes symbol layers (some
+  // matching the place/label heuristic, some NOT — to assert the heuristic is
+  // selective and fails open) with basemap fill/line layers (to assert
+  // sinking) and the #762 mask fill (the z-order anchor). The state-mask-fill
+  // entry is conditionally present so a test can simulate the
+  // reconcile-sequencing window where the mask layer does NOT yet exist (the
+  // moveLayer guard).
+  let styleHasMaskLayer = true;
+  const baseStyleLayers = () => {
+    const layers: Array<{ id: string; type: string; filter?: unknown }> = [
+      { id: 'background', type: 'background' },
+      { id: 'water', type: 'fill' },
+      { id: 'place_country', type: 'symbol', filter: ['==', 'class', 'country'] },
+      { id: 'place_city', type: 'symbol' },
+      { id: 'poi_z14', type: 'symbol' },
+      { id: 'transit_route_ref', type: 'symbol' }, // symbol, no place/label token
+    ];
+    if (styleHasMaskLayer) layers.push({ id: 'state-mask-fill', type: 'fill' });
+    // Stray basemap line/fill layers painted ABOVE the mask (sink targets).
+    layers.push({ id: 'boundary_country', type: 'line' });
+    layers.push({ id: 'landcover_glacier', type: 'fill' });
+    return layers;
+  };
+  let styleLayers = baseStyleLayers();
+  const layersById = () =>
+    Object.fromEntries(styleLayers.map((l) => [l.id, l]));
   return {
+    // #763 test affordances (not part of the maplibre API surface): let a test
+    // simulate the reconcile window where state-mask-fill is absent, and reset
+    // the style layer list between style swaps.
+    __setMaskLayerPresent: (present: boolean) => {
+      styleHasMaskLayer = present;
+      styleLayers = baseStyleLayers();
+    },
+    __resetStyleLayers: () => {
+      styleLayers = baseStyleLayers();
+    },
     on: vi.fn(
       (
         event: string,
@@ -85,7 +122,19 @@ function makeFakeMap() {
     queryRenderedFeatures: vi.fn(),
     querySourceFeatures: vi.fn(() => []),
     getSource: vi.fn(),
-    getLayer: vi.fn(),
+    // #763 — getLayer resolves against the in-memory style layer list so the
+    // moveLayer/float guards and original-filter capture are testable. (The
+    // #762 cluster tests that call getLayer.mockReturnValue still override it.)
+    getLayer: vi.fn((id?: string) => (id ? layersById()[id] : undefined)),
+    // #763 — style introspection + imperative layer ops for artboard fidelity.
+    getStyle: vi.fn(() => ({ layers: styleLayers })),
+    getFilter: vi.fn((id: string) => layersById()[id]?.filter),
+    setFilter: vi.fn((id: string, filter: unknown) => {
+      const layer = layersById()[id];
+      if (layer) layer.filter = filter;
+    }),
+    moveLayer: vi.fn(),
+    triggerRepaint: vi.fn(),
     getCanvas: vi.fn(() => canvas),
     getContainer: vi.fn(() => container),
     easeTo: vi.fn(),
@@ -121,8 +170,17 @@ function makeFakeMap() {
     unproject: vi.fn(() => [-111, 34]),
     addSource: vi.fn(),
     removeSource: vi.fn(),
-    addLayer: vi.fn(),
-    removeLayer: vi.fn(),
+    // #763 — addLayer/removeLayer mutate the in-memory style layer list so the
+    // float-layer lifecycle is realistic: an imperatively-added halo/outline is
+    // then visible to getLayer, and removeFloatLayers can guard-and-remove it.
+    addLayer: vi.fn((layer: { id?: string; type?: string }) => {
+      if (layer?.id && !styleLayers.some((l) => l.id === layer.id)) {
+        styleLayers.push({ id: layer.id, type: layer.type ?? 'line' });
+      }
+    }),
+    removeLayer: vi.fn((id: string) => {
+      styleLayers = styleLayers.filter((l) => l.id !== id);
+    }),
     addImage: vi.fn((id: string) => {
       sprites.add(id);
     }),
@@ -2049,5 +2107,210 @@ describe('MapCanvas state-artboard mask (#762)', () => {
     const [opts] = fakeMap.flyTo.mock.calls.at(-1);
     expect(opts.duration).toBe(0);
     expect(opts.essential).toBe(true);
+  });
+
+  /* ── Artboard FIDELITY wiring (#763) ──────────────────────────────────────
+     These assert the imperative work is WIRED through MapCanvas (the helper's
+     own behavior is unit-tested in artboard-layers.test.ts). The label-bleed
+     regression guard proper lives in the helper test (the within-shape
+     assertion); here we confirm the reconcile-sequencing split, the guard, the
+     teardown, and that the float/sink + isolation fire on an active mask. */
+
+  it('with maskPolygon: label isolation merges ["within", buffered] into matching symbol layers only', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.setFilter).toHaveBeenCalled());
+    const touched = (fakeMap.setFilter.mock.calls as Array<[string, unknown]>).map(
+      (c) => c[0],
+    );
+    // Matching symbol layers isolated…
+    expect(touched).toEqual(
+      expect.arrayContaining(['place_country', 'place_city', 'poi_z14']),
+    );
+    // …non-matching symbol + non-symbol layers untouched.
+    expect(touched).not.toContain('transit_route_ref');
+    expect(touched).not.toContain('water');
+
+    // place_city had no original filter → merged filter is just ['within', geom].
+    const cityCall = (fakeMap.setFilter.mock.calls as Array<[string, unknown[]]>).find(
+      (c) => c[0] === 'place_city',
+    );
+    expect((cityCall?.[1] as unknown[])[0]).toBe('within');
+    // place_country had an original → ['all', original, ['within', geom]].
+    const countryCall = (fakeMap.setFilter.mock.calls as Array<[string, unknown[]]>).find(
+      (c) => c[0] === 'place_country',
+    );
+    expect((countryCall?.[1] as unknown[])[0]).toBe('all');
+
+    // The within geometry is the BUFFERED polygon (bbox strictly larger than the
+    // exact maskPolygon the #762 fill uses) — the near-border-survival contract.
+    const withinGeom = ((cityCall?.[1] as unknown[])[1]) as {
+      coordinates: number[][][][];
+    };
+    const flatX = (g: { coordinates: number[][][][] }) =>
+      g.coordinates.flat(3).filter((_, i) => i % 2 === 0);
+    const exactMinX = Math.min(...flatX(AZ_POLYGON as never));
+    const bufMinX = Math.min(...flatX(withinGeom));
+    expect(bufMinX).toBeLessThan(exactMinX);
+
+    // Defensive idle-map flush fired.
+    expect(fakeMap.triggerRepaint).toHaveBeenCalled();
+  });
+
+  it('absent maskPolygon: NO label isolation, NO float layers (us/chooser untouched)', async () => {
+    render(
+      <MapCanvas observations={[]} bounds={CONUS_PROD_BOUNDS} boundsKey="us" />,
+    );
+    await waitFor(() => expect(fakeMap).not.toBeNull());
+    // No within-merge on the unmasked nationwide view.
+    expect(fakeMap.setFilter).not.toHaveBeenCalled();
+    // No float layers added.
+    const addedFloatIds = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }]>)
+      .map((c) => c[0]?.id)
+      .filter((id): id is string => id === 'state-artboard-halo' || id === 'state-artboard-outline');
+    expect(addedFloatIds).toHaveLength(0);
+  });
+
+  it('with maskPolygon: float layers (halo + crisp outline) add above the mask; stray basemap layers sunk', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => {
+      const ids = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }]>).map(
+        (c) => c[0]?.id,
+      );
+      expect(ids).toContain('state-artboard-halo');
+      expect(ids).toContain('state-artboard-outline');
+    });
+    // Float layers inserted relative to the mask (above the fill).
+    const haloCall = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }, string?]>).find(
+      (c) => c[0]?.id === 'state-artboard-halo',
+    );
+    expect(haloCall?.[1]).toBe('state-mask-fill');
+    // Stray basemap fill/line layers above the mask were sunk beneath it.
+    const moved = (fakeMap.moveLayer.mock.calls as Array<[string, string]>).map(
+      (c) => [c[0], c[1]],
+    );
+    expect(moved).toEqual(
+      expect.arrayContaining([
+        ['boundary_country', 'state-mask-fill'],
+        ['landcover_glacier', 'state-mask-fill'],
+      ]),
+    );
+  });
+
+  it('[blocker guard] moveLayer is NOT called when state-mask-fill is absent at reconcile time', async () => {
+    // Simulate the reconcile-sequencing window: react-map-gl has not re-added
+    // the mask layer yet, so getLayer('state-mask-fill') returns undefined. The
+    // float/sink effect must warn-and-return, NEVER call moveLayer (which would
+    // throw `Cannot move layer before non-existing layer`).
+    fakeMap.__setMaskLayerPresent(false);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.setFilter).toHaveBeenCalled()); // isolation still ran
+    // No moveLayer / float-add against the missing mask anchor.
+    expect(fakeMap.moveLayer).not.toHaveBeenCalled();
+    const addedFloatIds = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }]>)
+      .map((c) => c[0]?.id)
+      .filter((id): id is string => id === 'state-artboard-halo' || id === 'state-artboard-outline');
+    expect(addedFloatIds).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('state-mask-fill not yet reconciled'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('[reconcile split] a style.load reload re-invokes setFilter, NOT moveLayer, in the style.load handler', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.setFilter).toHaveBeenCalled());
+    // Confirm a style.load handler was registered (the once-per-mount listener).
+    expect((bareHandlersAll['style.load'] ?? []).length).toBeGreaterThan(0);
+    // Clear the initial-apply spies so we observe ONLY the style.load re-apply.
+    fakeMap.setFilter.mockClear();
+    fakeMap.moveLayer.mockClear();
+
+    // Fire the style.load handler in ISOLATION (a style reload — e.g. the
+    // setStyle the [data-theme] MutationObserver triggers). This is the exact
+    // moment the AC targets: the style.load HANDLER must re-apply label
+    // isolation only, never the moveLayer stray-sink (which lives in the
+    // maskPolygon effect that runs AFTER react-map-gl re-adds state-mask-fill).
+    await act(async () => {
+      fakeMap.__resetStyleLayers();
+      (bareHandlersAll['style.load'] ?? []).forEach((cb) => cb());
+      await Promise.resolve();
+    });
+
+    // The style.load handler re-applied LABEL isolation only…
+    expect(fakeMap.setFilter).toHaveBeenCalled();
+    // …and did NOT call moveLayer.
+    expect(fakeMap.moveLayer).not.toHaveBeenCalled();
+  });
+
+  it('teardown (state→us): restores captured original filters and removes float layers', async () => {
+    const { rerender } = render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.setFilter).toHaveBeenCalled());
+    fakeMap.setFilter.mockClear();
+    fakeMap.removeLayer.mockClear();
+
+    // state → us: maskPolygon → null. Teardown effect cleanup fires.
+    rerender(
+      <MapCanvas observations={[]} bounds={CONUS_PROD_BOUNDS} boundsKey="us" maskPolygon={null} />,
+    );
+
+    await waitFor(() => {
+      // place_country restored to its ORIGINAL filter (not a within-merge).
+      const restoreCall = (fakeMap.setFilter.mock.calls as Array<[string, unknown[]]>).find(
+        (c) => c[0] === 'place_country',
+      );
+      expect(restoreCall).toBeDefined();
+      expect((restoreCall?.[1] as unknown[])?.[0]).not.toBe('all');
+    });
+    // Float layers removed.
+    const removed = (fakeMap.removeLayer.mock.calls as Array<[string]>).map((c) => c[0]);
+    expect(removed).toEqual(
+      expect.arrayContaining(['state-artboard-halo', 'state-artboard-outline']),
+    );
   });
 });

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -2249,7 +2249,7 @@ describe('MapCanvas state-artboard mask (#762)', () => {
     warnSpy.mockRestore();
   });
 
-  it('[reconcile split] a style.load reload re-invokes setFilter, NOT moveLayer, in the style.load handler', async () => {
+  it('[reconcile split] the style.load HANDLER re-invokes setFilter only — never moveLayer (the stray-sink lives in the post-reconcile maskPolygon effect)', async () => {
     render(
       <MapCanvas
         observations={[]}
@@ -2267,21 +2267,57 @@ describe('MapCanvas state-artboard mask (#762)', () => {
     fakeMap.setFilter.mockClear();
     fakeMap.moveLayer.mockClear();
 
-    // Fire the style.load handler in ISOLATION (a style reload — e.g. the
-    // setStyle the [data-theme] MutationObserver triggers). This is the exact
-    // moment the AC targets: the style.load HANDLER must re-apply label
-    // isolation only, never the moveLayer stray-sink (which lives in the
-    // maskPolygon effect that runs AFTER react-map-gl re-adds state-mask-fill).
+    // Simulate the reconcile WINDOW: react-map-gl has not re-added the mask
+    // layer yet (getLayer('state-mask-fill') → undefined). Now fire style.load.
+    // The handler re-applies LABEL isolation (setFilter); the styleEpoch bump it
+    // emits re-runs the (3b) effect, which — because the mask is still absent —
+    // warn-and-returns WITHOUT moveLayer. So across the whole flush, the ONLY
+    // imperative op is setFilter: the handler never sinks, proving the split.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await act(async () => {
-      fakeMap.__resetStyleLayers();
+      fakeMap.__setMaskLayerPresent(false);
+      (bareHandlersAll['style.load'] ?? []).forEach((cb) => cb());
+      await Promise.resolve();
+    });
+    expect(fakeMap.setFilter).toHaveBeenCalled(); // label isolation re-applied
+    expect(fakeMap.moveLayer).not.toHaveBeenCalled(); // never from the handler
+    warnSpy.mockRestore();
+  });
+
+  it('[theme swap] float layers are RE-ADDED after a style.load (styleEpoch re-fires the float effect once the mask is back)', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => {
+      const ids = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }]>).map((c) => c[0]?.id);
+      expect(ids).toContain('state-artboard-halo');
+    });
+    fakeMap.addLayer.mockClear();
+    fakeMap.moveLayer.mockClear();
+
+    // A style.load reload (the mask layer IS present, mirroring react-map-gl
+    // having reconciled it by the time the styleEpoch effect re-runs).
+    await act(async () => {
+      fakeMap.__resetStyleLayers(); // mask present
       (bareHandlersAll['style.load'] ?? []).forEach((cb) => cb());
       await Promise.resolve();
     });
 
-    // The style.load handler re-applied LABEL isolation only…
-    expect(fakeMap.setFilter).toHaveBeenCalled();
-    // …and did NOT call moveLayer.
-    expect(fakeMap.moveLayer).not.toHaveBeenCalled();
+    // The styleEpoch bump re-ran the float/sink effect: floats re-added + sunk.
+    const reAdded = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }]>)
+      .map((c) => c[0]?.id)
+      .filter((id): id is string => id === 'state-artboard-halo' || id === 'state-artboard-outline');
+    expect(reAdded).toEqual(
+      expect.arrayContaining(['state-artboard-halo', 'state-artboard-outline']),
+    );
+    expect(fakeMap.moveLayer).toHaveBeenCalled();
   });
 
   it('teardown (state→us): restores captured original filters and removes float layers', async () => {

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -70,13 +70,14 @@ function makeFakeMap() {
   // moveLayer guard).
   let styleHasMaskLayer = true;
   const baseStyleLayers = () => {
-    const layers: Array<{ id: string; type: string; filter?: unknown }> = [
+    const layers: Array<{ id: string; type: string; source?: string; filter?: unknown }> = [
       { id: 'background', type: 'background' },
       { id: 'water', type: 'fill' },
-      { id: 'place_country', type: 'symbol', filter: ['==', 'class', 'country'] },
-      { id: 'place_city', type: 'symbol' },
-      { id: 'poi_z14', type: 'symbol' },
-      { id: 'transit_route_ref', type: 'symbol' }, // symbol, no place/label token
+      { id: 'place_country', type: 'symbol', source: 'openmaptiles', filter: ['==', 'class', 'country'] },
+      { id: 'place_city', type: 'symbol', source: 'openmaptiles' },
+      { id: 'poi_z14', type: 'symbol', source: 'openmaptiles' },
+      { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles' }, // _name label
+      { id: 'transit_route_ref', type: 'symbol', source: 'openmaptiles' }, // symbol, no token
     ];
     if (styleHasMaskLayer) layers.push({ id: 'state-mask-fill', type: 'fill' });
     // Stray basemap line/fill layers painted ABOVE the mask (sink targets).
@@ -2197,11 +2198,15 @@ describe('MapCanvas state-artboard mask (#762)', () => {
       expect(ids).toContain('state-artboard-halo');
       expect(ids).toContain('state-artboard-outline');
     });
-    // Float layers inserted relative to the mask (above the fill).
+    // Float layers inserted ABOVE the mask: addLayer(spec, beforeId) inserts
+    // BELOW beforeId, so the anchor is the first layer above state-mask-fill
+    // (here: boundary_country) — NOT the mask id itself (which would put the
+    // floats UNDER the gray).
     const haloCall = (fakeMap.addLayer.mock.calls as Array<[{ id?: string }, string?]>).find(
       (c) => c[0]?.id === 'state-artboard-halo',
     );
-    expect(haloCall?.[1]).toBe('state-mask-fill');
+    expect(haloCall?.[1]).not.toBe('state-mask-fill');
+    expect(haloCall?.[1]).toBe('boundary_country');
     // Stray basemap fill/line layers above the mask were sunk beneath it.
     const moved = (fakeMap.moveLayer.mock.calls as Array<[string, string]>).map(
       (c) => [c[0], c[1]],

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -31,6 +31,14 @@ import {
   MASK_FILL_DARK,
 } from './mask.js';
 import {
+  applyLabelIsolation,
+  restoreLabelIsolation,
+  bufferIsolationPolygon,
+  applyArtboardFidelity,
+  removeFloatLayers,
+  MASK_LAYER_ID,
+} from './artboard-layers.js';
+import {
   observationsToGeoJson,
   buildClusterLayerSpec,
   buildClusterCountLayerSpec,
@@ -645,6 +653,21 @@ export function MapCanvas({
       ? 'dark'
       : 'light',
   );
+
+  // #763 — artboard FIDELITY imperative state.
+  //
+  // `savedFiltersRef` holds the basemap symbol layers' ORIGINAL filters captured
+  // when `applyLabelIsolation` ran, so `restoreLabelIsolation` can undo the
+  // `['within', …]` merge exactly when the mask unmounts (scope → us/chooser).
+  //
+  // `maskPolygonRef` mirrors the current prop so the ONCE-registered
+  // `style.load` handler (which would otherwise close over a stale value) reads
+  // the live polygon at swap time. Updated synchronously on render.
+  const savedFiltersRef = useRef<ReturnType<typeof applyLabelIsolation> | null>(
+    null,
+  );
+  const maskPolygonRef = useRef<MultiPolygon | null>(maskPolygon ?? null);
+  maskPolygonRef.current = maskPolygon ?? null;
   /* Coarse-pointer detection (#247, mobile; also used by auto-spider hit
      targets in #277). matchMedia is the canonical way; we read it on mount
      and listen for changes. */
@@ -767,6 +790,150 @@ export function MapCanvas({
     map.on('moveend', apply);
     return () => {
       map.off('moveend', apply);
+    };
+  }, [mapReady, maskPolygon]);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // #763 — artboard FIDELITY: label isolation + clean exterior + float layers.
+  //
+  // ⚠ RECONCILE-SEQUENCING SPLIT (do NOT collapse this into one effect/handler).
+  //
+  // `map.setStyle()` (fired by the [data-theme] MutationObserver below) clears
+  // and asynchronously reloads ALL layers — dropping both the merged label
+  // filters AND the float layers — so everything must be re-applied after each
+  // swap. But the two halves have DIFFERENT timing requirements:
+  //
+  //   (3a) Label-filter isolation re-applies in `style.load`. Basemap symbol
+  //        layers exist immediately on style load and `applyLabelIsolation`
+  //        needs NO reference to `state-mask-fill`, so it is safe there.
+  //
+  //   (3b) The float `addLayer` + the `moveLayer` stray-sink re-apply from the
+  //        SEPARATE `maskPolygon`-watching effect below — NOT from `style.load`.
+  //        react-map-gl re-adds its managed declarative layers (including
+  //        `state-mask-fill`) on the NEXT React reconcile, which has NOT
+  //        happened yet when `style.load` fires. `moveLayer(x, 'state-mask-fill')`
+  //        or an `addLayer(..., 'state-mask-fill')` inside `style.load` therefore
+  //        throws `Cannot move layer before non-existing layer`. The effect
+  //        below re-fires on the next render (after the reconcile), so the
+  //        reference layer exists — and it still GUARDS on
+  //        `getLayer('state-mask-fill')` (warn-and-return, never call through).
+  //
+  // Collapsing (3b) back into the `style.load` handler reintroduces that throw.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  // (3a-i) Label isolation re-apply on THEME SWAP. Registered ONCE after
+  // `mapReady` as a `style.load` listener (which fires after each
+  // MutationObserver `setStyle`); the handler reads the live `maskPolygon` from
+  // a ref so it needs no re-registration on prop change. Basemap symbol layers
+  // exist immediately on `style.load`, and `applyLabelIsolation` needs no
+  // reference to `state-mask-fill`, so this is safe here (unlike the float/sink
+  // half — see the sequencing comment above).
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    const reapplyIsolation = () => {
+      const poly = maskPolygonRef.current;
+      if (!poly) return; // no state scope → no isolation (us/chooser untouched)
+      try {
+        // The within test uses the OUTWARD-BUFFERED polygon (so near-border
+        // interior labels survive); the #762 mask FILL keeps the EXACT polygon.
+        savedFiltersRef.current = applyLabelIsolation(
+          map,
+          bufferIsolationPolygon(poly),
+        );
+      } catch {
+        /* defensive — style churn after a swap; QA detects un-isolated labels */
+      }
+    };
+
+    map.on('style.load', reapplyIsolation);
+    return () => {
+      map.off('style.load', reapplyIsolation);
+    };
+    // mapReady-only: the handler reads maskPolygon from a ref, so it must NOT
+    // re-register on every prop change (that would leak listeners).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady]);
+
+  // (3a-ii) Label isolation re-apply on MASK CHANGE (initial mount, chooser/us →
+  // state, state → state in-place). Distinct from the `style.load` listener:
+  // those transitions do NOT swap the style, so no `style.load` fires. On a
+  // state → state change the OLD isolation must be restored before the NEW one
+  // is captured+applied (else the new `applyLabelIsolation` would capture the
+  // already-merged `['all', original, within]` filter as the "original").
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    if (!maskPolygon) return; // us/chooser: teardown effect restores originals
+    try {
+      if (savedFiltersRef.current) {
+        restoreLabelIsolation(map, savedFiltersRef.current);
+        savedFiltersRef.current = null;
+      }
+      savedFiltersRef.current = applyLabelIsolation(
+        map,
+        bufferIsolationPolygon(maskPolygon),
+      );
+    } catch {
+      /* defensive — style churn; QA detects un-isolated labels */
+    }
+  }, [mapReady, maskPolygon]);
+
+  // (3b) Float layers + stray-sink — runs from a `maskPolygon`-watching,
+  // `mapReady`-gated effect (also keyed on `maskTheme` so the float re-tints on
+  // a theme swap). It fires AFTER react-map-gl's reconcile has (re-)added
+  // `state-mask-fill`, and `addFloatLayers` is idempotent (removes any prior
+  // instance before re-adding), so re-running it on a theme change re-tints
+  // cleanly without thrashing the LABEL filters (which are owned by the (3a)
+  // `style.load` handler and the separate teardown effect below).
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    if (!maskPolygon) return;
+
+    // Guard: state-mask-fill MUST exist before any moveLayer/insert anchored to
+    // it. If react-map-gl has not re-added it yet, warn and return — the effect
+    // re-fires on the next render once the reconcile lands it. Calling through
+    // is the exact `Cannot move layer before non-existing layer` throw the
+    // 3a/3b split exists to avoid.
+    if (map.getLayer(MASK_LAYER_ID) == null) {
+      console.warn(
+        '[artboard] state-mask-fill not yet reconciled; deferring float/sink',
+      );
+      return;
+    }
+    try {
+      applyArtboardFidelity(map, maskPolygon, maskTheme);
+    } catch {
+      /* defensive — layer/style churn after a swap */
+    }
+  }, [mapReady, maskPolygon, maskTheme]);
+
+  // (3b-teardown) Restore label filters + remove float layers when the mask
+  // unmounts (scope → us/chooser) OR the component unmounts. Keyed ONLY on
+  // `maskPolygon` (NOT `maskTheme`) so a theme swap — which re-applies isolation
+  // via (3a) `style.load` against the NEW style — does not trigger a stale
+  // restore against filters the `setStyle` already cleared. Guarded against a
+  // disposed map / missing layers (the helpers wrap their MapLibre calls).
+  useEffect(() => {
+    if (!mapReady) return;
+    if (!maskPolygon) return; // only arm teardown while a mask is active
+    return () => {
+      const liveMap = mapRef.current?.getMap();
+      if (!liveMap) return;
+      try {
+        if (savedFiltersRef.current) {
+          restoreLabelIsolation(liveMap, savedFiltersRef.current);
+          savedFiltersRef.current = null;
+        }
+        removeFloatLayers(liveMap);
+      } catch {
+        /* defensive — map gone after a swap or unmount */
+      }
     };
   }, [mapReady, maskPolygon]);
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -668,6 +668,13 @@ export function MapCanvas({
   );
   const maskPolygonRef = useRef<MultiPolygon | null>(maskPolygon ?? null);
   maskPolygonRef.current = maskPolygon ?? null;
+  // `styleEpoch` bumps once per `style.load` (i.e. per theme `setStyle` swap).
+  // It is a dep of the float/sink effect so that effect RE-RUNS after the new
+  // style finishes loading — by which time react-map-gl's reconcile has re-added
+  // `state-mask-fill`, so the guard passes and the float layers (which `setStyle`
+  // dropped) are restored. Without this, a theme swap left the artboard with NO
+  // halo/outline until the next unrelated render.
+  const [styleEpoch, setStyleEpoch] = useState(0);
   /* Coarse-pointer detection (#247, mobile; also used by auto-spider hit
      targets in #277). matchMedia is the canonical way; we read it on mount
      and listen for changes. */
@@ -833,8 +840,12 @@ export function MapCanvas({
     const map = mapRef.current?.getMap();
     if (!map) return;
 
-    const reapplyIsolation = () => {
+    const onStyleLoad = () => {
       const poly = maskPolygonRef.current;
+      // Bump the epoch unconditionally so the float/sink effect re-runs after
+      // EVERY style reload (it re-adds the floats `setStyle` dropped, once the
+      // reconcile has re-added `state-mask-fill`).
+      setStyleEpoch((n) => n + 1);
       if (!poly) return; // no state scope → no isolation (us/chooser untouched)
       try {
         // The within test uses the OUTWARD-BUFFERED polygon (so near-border
@@ -848,9 +859,9 @@ export function MapCanvas({
       }
     };
 
-    map.on('style.load', reapplyIsolation);
+    map.on('style.load', onStyleLoad);
     return () => {
-      map.off('style.load', reapplyIsolation);
+      map.off('style.load', onStyleLoad);
     };
     // mapReady-only: the handler reads maskPolygon from a ref, so it must NOT
     // re-register on every prop change (that would leak listeners).
@@ -911,7 +922,9 @@ export function MapCanvas({
     } catch {
       /* defensive — layer/style churn after a swap */
     }
-  }, [mapReady, maskPolygon, maskTheme]);
+    // `styleEpoch` re-runs this AFTER a theme `setStyle`+`style.load` so the
+    // floats `setStyle` dropped are re-added once `state-mask-fill` is back.
+  }, [mapReady, maskPolygon, maskTheme, styleEpoch]);
 
   // (3b-teardown) Restore label filters + remove float layers when the mask
   // unmounts (scope → us/chooser) OR the component unmounts. Keyed ONLY on

--- a/frontend/src/components/map/artboard-layers.test.ts
+++ b/frontend/src/components/map/artboard-layers.test.ts
@@ -11,6 +11,7 @@ import {
   MASK_LAYER_ID,
   ARTBOARD_HALO_ID,
   ARTBOARD_OUTLINE_ID,
+  ARTBOARD_LINE_SOURCE_ID,
   isIsolatableSymbolLayer,
 } from './artboard-layers.js';
 
@@ -73,6 +74,7 @@ function makeStyleLayers() {
 function makeMockMap(layers = makeStyleLayers()) {
   const layersById: Record<string, { id: string; type: string; filter?: unknown }> =
     Object.fromEntries(layers.map((l) => [l.id, l]));
+  const sources: Record<string, unknown> = {};
   return {
     layers,
     layersById,
@@ -82,6 +84,13 @@ function makeMockMap(layers = makeStyleLayers()) {
       if (layersById[id]) layersById[id].filter = filter;
     }),
     getLayer: vi.fn((id: string) => layersById[id]),
+    getSource: vi.fn((id: string) => sources[id]),
+    addSource: vi.fn((id: string, src: unknown) => {
+      sources[id] = src;
+    }),
+    removeSource: vi.fn((id: string) => {
+      delete sources[id];
+    }),
     moveLayer: vi.fn(),
     addLayer: vi.fn(),
     removeLayer: vi.fn(),
@@ -345,6 +354,19 @@ describe('addFloatLayers / removeFloatLayers', () => {
     expect(haloColor(lightMap)).not.toEqual(haloColor(darkMap));
   });
 
+  it('adds ONE explicit named source shared by both layers (no per-layer inline source → no orphan on setStyle)', () => {
+    const map = makeMockMap();
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    expect(map.addSource).toHaveBeenCalledWith(
+      ARTBOARD_LINE_SOURCE_ID,
+      expect.objectContaining({ type: 'geojson' }),
+    );
+    // Both layers reference the named source by id (string), not an inline object.
+    const added = map.addLayer.mock.calls.map((c) => c[0] as { id: string; source: unknown });
+    expect(added.find((l) => l.id === ARTBOARD_HALO_ID)?.source).toBe(ARTBOARD_LINE_SOURCE_ID);
+    expect(added.find((l) => l.id === ARTBOARD_OUTLINE_ID)?.source).toBe(ARTBOARD_LINE_SOURCE_ID);
+  });
+
   it('is idempotent — guarded removal of an already-present layer before re-add', () => {
     const map = makeMockMap();
     // Float layers already present in the style (post theme-swap re-apply).
@@ -354,17 +376,22 @@ describe('addFloatLayers / removeFloatLayers', () => {
     expect(map.removeLayer).toHaveBeenCalledWith(ARTBOARD_OUTLINE_ID);
   });
 
-  it('removeFloatLayers removes both float layers idempotently (guarded, no throw if absent)', () => {
+  it('removeFloatLayers removes both float layers AND the shared source (guarded, no throw if absent)', () => {
     const layers = makeStyleLayers().filter(
       (l) => l.id !== ARTBOARD_HALO_ID && l.id !== ARTBOARD_OUTLINE_ID,
     );
     const map = makeMockMap(layers);
     expect(() => removeFloatLayers(map as never)).not.toThrow();
 
+    // A map where the floats + source ARE present: remove both layers + source.
     const present = makeMockMap();
+    addFloatLayers(present as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    present.removeLayer.mockClear();
+    present.removeSource.mockClear();
     removeFloatLayers(present as never);
     expect(present.removeLayer).toHaveBeenCalledWith(ARTBOARD_HALO_ID);
     expect(present.removeLayer).toHaveBeenCalledWith(ARTBOARD_OUTLINE_ID);
+    expect(present.removeSource).toHaveBeenCalledWith(ARTBOARD_LINE_SOURCE_ID);
   });
 });
 

--- a/frontend/src/components/map/artboard-layers.test.ts
+++ b/frontend/src/components/map/artboard-layers.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { MultiPolygon, Polygon, Position } from 'geojson';
+import {
+  applyLabelIsolation,
+  restoreLabelIsolation,
+  bufferIsolationPolygon,
+  sinkStrayLayersBelowMask,
+  addFloatLayers,
+  removeFloatLayers,
+  applyArtboardFidelity,
+  MASK_LAYER_ID,
+  ARTBOARD_HALO_ID,
+  ARTBOARD_OUTLINE_ID,
+  isIsolatableSymbolLayer,
+} from './artboard-layers.js';
+
+/* ── Fixtures ────────────────────────────────────────────────────────────────
+   A minimal 1-part MultiPolygon standing in for a state's render-only geometry
+   (same shape as MapCanvas.test.tsx's AZ_POLYGON). */
+const AZ_POLYGON: MultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [-114.815, 31.332],
+        [-109.045, 31.332],
+        [-109.045, 37.004],
+        [-114.815, 37.004],
+        [-114.815, 31.332],
+      ],
+    ],
+  ],
+};
+
+/**
+ * A representative style.layers list mixing symbol layers (some matching the
+ * name heuristic, some not), plus basemap fill/line layers (some ABOVE the mask
+ * — to assert sinking — and some BELOW). Order matters for the sink test: the
+ * mask is at index `maskIndex`; layers AFTER it are "above" in paint order.
+ */
+function makeStyleLayers() {
+  return [
+    { id: 'background', type: 'background' },
+    { id: 'water', type: 'fill' },
+    { id: 'water_outline', type: 'line' },
+    { id: 'place_country', type: 'symbol', filter: ['==', 'class', 'country'] },
+    { id: 'place_city', type: 'symbol' },
+    { id: 'poi_z14', type: 'symbol' },
+    // A symbol layer that must NOT match the heuristic (no place/label token).
+    { id: 'transit_route_ref', type: 'symbol' },
+    // The mask fill (the z-order anchor).
+    { id: MASK_LAYER_ID, type: 'fill' },
+    // Stray basemap fill/line layers painted ABOVE the mask — must be sunk.
+    { id: 'boundary_country', type: 'line' },
+    { id: 'landcover_glacier', type: 'fill' },
+    // App-owned float layers (must never be sunk).
+    { id: ARTBOARD_HALO_ID, type: 'line' },
+    { id: ARTBOARD_OUTLINE_ID, type: 'line' },
+  ];
+}
+
+/**
+ * A mock maplibre map backed by an in-memory layer list, with `getStyle`,
+ * `getFilter`, `setFilter`, `getLayer`, `moveLayer`, `addLayer`, `removeLayer`,
+ * and `triggerRepaint` spies. Mirrors the methods MapCanvas.test.tsx's shared
+ * factory exposes, but standalone so the helper is unit-testable without React.
+ */
+function makeMockMap(layers = makeStyleLayers()) {
+  const layersById: Record<string, { id: string; type: string; filter?: unknown }> =
+    Object.fromEntries(layers.map((l) => [l.id, l]));
+  return {
+    layers,
+    layersById,
+    getStyle: vi.fn(() => ({ layers })),
+    getFilter: vi.fn((id: string) => layersById[id]?.filter),
+    setFilter: vi.fn((id: string, filter: unknown) => {
+      if (layersById[id]) layersById[id].filter = filter;
+    }),
+    getLayer: vi.fn((id: string) => layersById[id]),
+    moveLayer: vi.fn(),
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(),
+    triggerRepaint: vi.fn(),
+  };
+}
+
+const turfBbox = (g: Polygon | MultiPolygon): [number, number, number, number] => {
+  let minx = Infinity;
+  let miny = Infinity;
+  let maxx = -Infinity;
+  let maxy = -Infinity;
+  const walk = (c: Position | Position[] | Position[][] | Position[][][]): void => {
+    if (typeof (c as number[])[0] === 'number') {
+      const [x, y] = c as number[];
+      if (x !== undefined && y !== undefined) {
+        minx = Math.min(minx, x);
+        maxx = Math.max(maxx, x);
+        miny = Math.min(miny, y);
+        maxy = Math.max(maxy, y);
+      }
+    } else {
+      for (const sub of c as unknown[]) walk(sub as Position);
+    }
+  };
+  walk(g.coordinates as Position[][][]);
+  return [minx, miny, maxx, maxy];
+};
+
+describe('bufferIsolationPolygon', () => {
+  it('returns an OUTWARD-expanded geometry whose bbox is strictly larger than the input', () => {
+    const buffered = bufferIsolationPolygon(AZ_POLYGON, 8);
+    const [iMinX, iMinY, iMaxX, iMaxY] = turfBbox(AZ_POLYGON);
+    const [bMinX, bMinY, bMaxX, bMaxY] = turfBbox(buffered);
+    // Strictly larger envelope on all four sides — the buffer expands outward,
+    // saving near-border interior label anchors that fall outside the
+    // 5%-simplified edge.
+    expect(bMinX).toBeLessThan(iMinX);
+    expect(bMinY).toBeLessThan(iMinY);
+    expect(bMaxX).toBeGreaterThan(iMaxX);
+    expect(bMaxY).toBeGreaterThan(iMaxY);
+  });
+
+  it('returns a Polygon or MultiPolygon geometry object (not a Feature)', () => {
+    const buffered = bufferIsolationPolygon(AZ_POLYGON, 8);
+    expect(['Polygon', 'MultiPolygon']).toContain(buffered.type);
+    // It is a bare geometry (the shape `within` consumes), NOT a wrapped Feature.
+    expect((buffered as { type: string }).type).not.toBe('Feature');
+  });
+});
+
+describe('isIsolatableSymbolLayer (type + name heuristic, fails OPEN)', () => {
+  it('matches symbol layers whose id contains a place/label token', () => {
+    expect(isIsolatableSymbolLayer({ id: 'place_city', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'place_country', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'poi_z14', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'settlement-major', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'state_label', type: 'symbol' })).toBe(true);
+  });
+
+  it('does NOT match symbol layers with no place/label token (fails open: rendered exterior, not blanked)', () => {
+    expect(isIsolatableSymbolLayer({ id: 'transit_route_ref', type: 'symbol' })).toBe(false);
+  });
+
+  it('does NOT match non-symbol layers even when the id contains a token', () => {
+    expect(isIsolatableSymbolLayer({ id: 'place_fill', type: 'fill' })).toBe(false);
+    expect(isIsolatableSymbolLayer({ id: 'boundary_country', type: 'line' })).toBe(false);
+  });
+});
+
+describe('applyLabelIsolation', () => {
+  it('merges ["within", isolationPolygon] into a layer with NO original filter (single-expr branch)', () => {
+    const map = makeMockMap();
+    const buffered = bufferIsolationPolygon(AZ_POLYGON, 8);
+    applyLabelIsolation(map as never, buffered);
+
+    // place_city has no original filter → merged filter is just ['within', geom].
+    const cityCall = map.setFilter.mock.calls.find((c) => c[0] === 'place_city');
+    expect(cityCall).toBeDefined();
+    const cityFilter = cityCall?.[1] as unknown[];
+    expect(cityFilter[0]).toBe('within');
+    expect(cityFilter[1]).toBe(buffered);
+  });
+
+  it('combines with the captured original via ["all", original, ["within", …]] (all-branch)', () => {
+    const map = makeMockMap();
+    const buffered = bufferIsolationPolygon(AZ_POLYGON, 8);
+    const originalCountryFilter = map.layersById['place_country']?.filter;
+    applyLabelIsolation(map as never, buffered);
+
+    const countryCall = map.setFilter.mock.calls.find((c) => c[0] === 'place_country');
+    expect(countryCall).toBeDefined();
+    const merged = countryCall?.[1] as unknown[];
+    expect(merged[0]).toBe('all');
+    expect(merged[1]).toEqual(originalCountryFilter);
+    expect((merged[2] as unknown[])[0]).toBe('within');
+    expect((merged[2] as unknown[])[1]).toBe(buffered);
+  });
+
+  it('uses the BUFFERED isolationPolygon — distinct (larger bbox) from the exact maskPolygon fill geometry', () => {
+    const map = makeMockMap();
+    const buffered = bufferIsolationPolygon(AZ_POLYGON, 8);
+    applyLabelIsolation(map as never, buffered);
+    const cityCall = map.setFilter.mock.calls.find((c) => c[0] === 'place_city');
+    const withinGeom = (cityCall?.[1] as unknown[])[1] as Polygon | MultiPolygon;
+    const [bMinX] = turfBbox(withinGeom);
+    const [iMinX] = turfBbox(AZ_POLYGON);
+    // The within geometry's envelope is strictly larger than the exact polygon.
+    expect(bMinX).toBeLessThan(iMinX);
+  });
+
+  it('only touches MATCHING symbol layers, leaving non-matching + non-symbol layers untouched', () => {
+    const map = makeMockMap();
+    applyLabelIsolation(map as never, bufferIsolationPolygon(AZ_POLYGON, 8));
+    const touched = map.setFilter.mock.calls.map((c) => c[0]);
+    expect(touched).toEqual(
+      expect.arrayContaining(['place_country', 'place_city', 'poi_z14']),
+    );
+    expect(touched).not.toContain('transit_route_ref'); // symbol but no token
+    expect(touched).not.toContain('water'); // non-symbol
+    expect(touched).not.toContain('boundary_country'); // non-symbol
+  });
+
+  it('captures original filters and calls triggerRepaint (defensive idle-map flush)', () => {
+    const map = makeMockMap();
+    const originalCountryFilter = map.layersById['place_country']?.filter;
+    const saved = applyLabelIsolation(map as never, bufferIsolationPolygon(AZ_POLYGON, 8));
+    // The captured original is the pre-merge filter (so restore is exact).
+    expect(saved['place_country']).toEqual(originalCountryFilter);
+    // place_city had no filter — captured as undefined so restore clears it.
+    expect('place_city' in saved).toBe(true);
+    expect(saved['place_city']).toBeUndefined();
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('restoreLabelIsolation', () => {
+  it('restores each captured original filter and calls triggerRepaint', () => {
+    const map = makeMockMap();
+    const originalCountryFilter = map.layersById['place_country']?.filter;
+    const saved = applyLabelIsolation(map as never, bufferIsolationPolygon(AZ_POLYGON, 8));
+    map.setFilter.mockClear();
+    map.triggerRepaint.mockClear();
+
+    restoreLabelIsolation(map as never, saved);
+
+    const countryRestore = map.setFilter.mock.calls.find((c) => c[0] === 'place_country');
+    expect(countryRestore?.[1]).toEqual(originalCountryFilter);
+    // place_city restores to undefined ("no filter").
+    const cityRestore = map.setFilter.mock.calls.find((c) => c[0] === 'place_city');
+    expect(cityRestore?.[1]).toBeUndefined();
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when a saved layer no longer exists (disposed-map guard)', () => {
+    const map = makeMockMap();
+    map.getLayer = vi.fn(() => undefined);
+    expect(() =>
+      restoreLabelIsolation(map as never, { gone_layer: ['==', 'x', 1] }),
+    ).not.toThrow();
+  });
+});
+
+describe('sinkStrayLayersBelowMask', () => {
+  it('moves basemap fill/line layers ordered ABOVE the mask beneath it via moveLayer(strayId, MASK_LAYER_ID)', () => {
+    const map = makeMockMap();
+    sinkStrayLayersBelowMask(map as never, MASK_LAYER_ID);
+    const moved = map.moveLayer.mock.calls.map((c) => [c[0], c[1]]);
+    // boundary_country (line) + landcover_glacier (fill) are above the mask → sunk.
+    expect(moved).toEqual(
+      expect.arrayContaining([
+        ['boundary_country', MASK_LAYER_ID],
+        ['landcover_glacier', MASK_LAYER_ID],
+      ]),
+    );
+  });
+
+  it('does NOT sink symbol layers, the mask itself, or the app-owned float layers', () => {
+    const map = makeMockMap();
+    sinkStrayLayersBelowMask(map as never, MASK_LAYER_ID);
+    const movedIds = map.moveLayer.mock.calls.map((c) => c[0]);
+    expect(movedIds).not.toContain('place_city'); // symbol stays above
+    expect(movedIds).not.toContain(MASK_LAYER_ID); // never moves itself
+    expect(movedIds).not.toContain(ARTBOARD_HALO_ID);
+    expect(movedIds).not.toContain(ARTBOARD_OUTLINE_ID);
+  });
+
+  it('does not throw when the mask layer is absent from the style', () => {
+    const layers = makeStyleLayers().filter((l) => l.id !== MASK_LAYER_ID);
+    const map = makeMockMap(layers);
+    expect(() => sinkStrayLayersBelowMask(map as never, MASK_LAYER_ID)).not.toThrow();
+  });
+});
+
+describe('addFloatLayers / removeFloatLayers', () => {
+  it('adds the halo (line + line-blur) and crisp outline (line) above the mask, with stable app-owned ids', () => {
+    const map = makeMockMap();
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    const added = map.addLayer.mock.calls.map((c) => c[0] as { id: string; type: string; paint?: Record<string, unknown> });
+    const halo = added.find((l) => l.id === ARTBOARD_HALO_ID);
+    const outline = added.find((l) => l.id === ARTBOARD_OUTLINE_ID);
+    expect(halo).toBeDefined();
+    expect(halo?.type).toBe('line');
+    expect(halo?.paint?.['line-blur']).toBeGreaterThan(0);
+    expect(outline).toBeDefined();
+    expect(outline?.type).toBe('line');
+    // The halo is added first (so the crisp outline paints on top of it).
+    expect(added[0]?.id).toBe(ARTBOARD_HALO_ID);
+    expect(added[1]?.id).toBe(ARTBOARD_OUTLINE_ID);
+  });
+
+  it('theme param drives the halo paint (light drop-shadow vs dark glow differ)', () => {
+    const lightMap = makeMockMap();
+    addFloatLayers(lightMap as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    const darkMap = makeMockMap();
+    addFloatLayers(darkMap as never, AZ_POLYGON, MASK_LAYER_ID, 'dark');
+    const haloColor = (m: ReturnType<typeof makeMockMap>) =>
+      (m.addLayer.mock.calls.find((c) => (c[0] as { id: string }).id === ARTBOARD_HALO_ID)?.[0] as {
+        paint: Record<string, unknown>;
+      }).paint['line-color'];
+    expect(haloColor(lightMap)).not.toEqual(haloColor(darkMap));
+  });
+
+  it('is idempotent — guarded removal of an already-present layer before re-add', () => {
+    const map = makeMockMap();
+    // Float layers already present in the style (post theme-swap re-apply).
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    // getLayer returns the existing halo/outline → addFloatLayers removes first.
+    expect(map.removeLayer).toHaveBeenCalledWith(ARTBOARD_HALO_ID);
+    expect(map.removeLayer).toHaveBeenCalledWith(ARTBOARD_OUTLINE_ID);
+  });
+
+  it('removeFloatLayers removes both float layers idempotently (guarded, no throw if absent)', () => {
+    const layers = makeStyleLayers().filter(
+      (l) => l.id !== ARTBOARD_HALO_ID && l.id !== ARTBOARD_OUTLINE_ID,
+    );
+    const map = makeMockMap(layers);
+    expect(() => removeFloatLayers(map as never)).not.toThrow();
+
+    const present = makeMockMap();
+    removeFloatLayers(present as never);
+    expect(present.removeLayer).toHaveBeenCalledWith(ARTBOARD_HALO_ID);
+    expect(present.removeLayer).toHaveBeenCalledWith(ARTBOARD_OUTLINE_ID);
+  });
+});
+
+describe('applyArtboardFidelity (float/sink composite — item 3b)', () => {
+  it('sinks stray layers then adds the float layers above the mask', () => {
+    const map = makeMockMap();
+    applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
+    // moveLayer (sink) and addLayer (float) both fire.
+    expect(map.moveLayer).toHaveBeenCalled();
+    expect(map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ARTBOARD_HALO_ID }),
+      MASK_LAYER_ID, // float added relative to the mask (above it)
+    );
+    expect(map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ARTBOARD_OUTLINE_ID }),
+      MASK_LAYER_ID, // outline also inserts just above the fill
+    );
+  });
+});

--- a/frontend/src/components/map/artboard-layers.test.ts
+++ b/frontend/src/components/map/artboard-layers.test.ts
@@ -43,11 +43,16 @@ function makeStyleLayers() {
     { id: 'background', type: 'background' },
     { id: 'water', type: 'fill' },
     { id: 'water_outline', type: 'line' },
-    { id: 'place_country', type: 'symbol', filter: ['==', 'class', 'country'] },
-    { id: 'place_city', type: 'symbol' },
-    { id: 'poi_z14', type: 'symbol' },
-    // A symbol layer that must NOT match the heuristic (no place/label token).
-    { id: 'transit_route_ref', type: 'symbol' },
+    { id: 'place_country', type: 'symbol', source: 'openmaptiles', filter: ['==', 'class', 'country'] },
+    { id: 'place_city', type: 'symbol', source: 'openmaptiles' },
+    { id: 'poi_z14', type: 'symbol', source: 'openmaptiles' },
+    // The `<thing>_name` label convention (was bleeding CA/MX freeway names).
+    { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles' },
+    { id: 'water_name', type: 'symbol', source: 'openmaptiles' },
+    // A symbol layer that must NOT match the heuristic (no place/label/_name token).
+    { id: 'transit_route_ref', type: 'symbol', source: 'openmaptiles' },
+    // An app-owned observation symbol layer — must NEVER be isolated.
+    { id: 'unclustered-point', type: 'symbol', source: 'observations' },
     // The mask fill (the z-order anchor).
     { id: MASK_LAYER_ID, type: 'fill' },
     // Stray basemap fill/line layers painted ABOVE the mask — must be sunk.
@@ -137,8 +142,27 @@ describe('isIsolatableSymbolLayer (type + name heuristic, fails OPEN)', () => {
     expect(isIsolatableSymbolLayer({ id: 'state_label', type: 'symbol' })).toBe(true);
   });
 
-  it('does NOT match symbol layers with no place/label token (fails open: rendered exterior, not blanked)', () => {
+  it('matches the openmaptiles <thing>_name text-label layers (the freeway/water-name bleed fix)', () => {
+    expect(isIsolatableSymbolLayer({ id: 'highway_name_motorway', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway_name_other', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'water_name', type: 'symbol' })).toBe(true);
+  });
+
+  it('does NOT match symbol layers with no place/label/_name token (fails open: rendered exterior, not blanked)', () => {
     expect(isIsolatableSymbolLayer({ id: 'transit_route_ref', type: 'symbol' })).toBe(false);
+    // road_oneway is an icon-only arrow layer, not a text label — left untouched.
+    expect(isIsolatableSymbolLayer({ id: 'road_oneway', type: 'symbol' })).toBe(false);
+  });
+
+  it('NEVER matches the app observation/cluster symbol layers (source: observations)', () => {
+    // Guard over the name heuristic: even though the id contains no basemap
+    // token, the source check is the belt — the bird layers are never isolated.
+    expect(
+      isIsolatableSymbolLayer({ id: 'unclustered-point', type: 'symbol', source: 'observations' }),
+    ).toBe(false);
+    expect(
+      isIsolatableSymbolLayer({ id: 'cluster-count', type: 'symbol', source: 'observations' }),
+    ).toBe(false);
   });
 
   it('does NOT match non-symbol layers even when the id contains a token', () => {
@@ -188,14 +212,21 @@ describe('applyLabelIsolation', () => {
     expect(bMinX).toBeLessThan(iMinX);
   });
 
-  it('only touches MATCHING symbol layers, leaving non-matching + non-symbol layers untouched', () => {
+  it('only touches MATCHING basemap symbol layers, leaving non-matching, non-symbol, and observation layers untouched', () => {
     const map = makeMockMap();
     applyLabelIsolation(map as never, bufferIsolationPolygon(AZ_POLYGON, 8));
     const touched = map.setFilter.mock.calls.map((c) => c[0]);
     expect(touched).toEqual(
-      expect.arrayContaining(['place_country', 'place_city', 'poi_z14']),
+      expect.arrayContaining([
+        'place_country',
+        'place_city',
+        'poi_z14',
+        'highway_name_motorway',
+        'water_name',
+      ]),
     );
     expect(touched).not.toContain('transit_route_ref'); // symbol but no token
+    expect(touched).not.toContain('unclustered-point'); // observation layer (source guard)
     expect(touched).not.toContain('water'); // non-symbol
     expect(touched).not.toContain('boundary_country'); // non-symbol
   });
@@ -288,6 +319,20 @@ describe('addFloatLayers / removeFloatLayers', () => {
     expect(added[1]?.id).toBe(ARTBOARD_OUTLINE_ID);
   });
 
+  it('anchors the float adds on the first layer ABOVE the mask (so they paint above the gray, not below it)', () => {
+    const map = makeMockMap();
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    // addLayer(spec, beforeId) inserts BELOW beforeId. The anchor is the first
+    // non-float layer above state-mask-fill (here: boundary_country) → the
+    // floats land just above the mask fill, NOT below it.
+    const haloCall = map.addLayer.mock.calls.find(
+      (c) => (c[0] as { id: string }).id === ARTBOARD_HALO_ID,
+    );
+    expect(haloCall?.[1]).toBe('boundary_country');
+    // Crucially NOT the mask id itself (which would insert BELOW the mask).
+    expect(haloCall?.[1]).not.toBe(MASK_LAYER_ID);
+  });
+
   it('theme param drives the halo paint (light drop-shadow vs dark glow differ)', () => {
     const lightMap = makeMockMap();
     addFloatLayers(lightMap as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
@@ -329,13 +374,15 @@ describe('applyArtboardFidelity (float/sink composite — item 3b)', () => {
     applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
     // moveLayer (sink) and addLayer (float) both fire.
     expect(map.moveLayer).toHaveBeenCalled();
-    expect(map.addLayer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: ARTBOARD_HALO_ID }),
-      MASK_LAYER_ID, // float added relative to the mask (above it)
+    // Float layers are added (anchored above the mask, NOT below it).
+    const haloCall = map.addLayer.mock.calls.find(
+      (c) => (c[0] as { id: string }).id === ARTBOARD_HALO_ID,
     );
-    expect(map.addLayer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: ARTBOARD_OUTLINE_ID }),
-      MASK_LAYER_ID, // outline also inserts just above the fill
+    const outlineCall = map.addLayer.mock.calls.find(
+      (c) => (c[0] as { id: string }).id === ARTBOARD_OUTLINE_ID,
     );
+    expect(haloCall).toBeDefined();
+    expect(outlineCall).toBeDefined();
+    expect(haloCall?.[1]).not.toBe(MASK_LAYER_ID); // never inserted BELOW the mask
   });
 });

--- a/frontend/src/components/map/artboard-layers.ts
+++ b/frontend/src/components/map/artboard-layers.ts
@@ -77,7 +77,9 @@ const HALO_OPACITY = 0.55;
  * The real `map` from `mapRef.current.getMap()` is structurally compatible.
  */
 export interface ArtboardMap {
-  getStyle: () => { layers?: Array<{ id: string; type: string }> } | undefined;
+  getStyle: () =>
+    | { layers?: Array<{ id: string; type: string; source?: string }> }
+    | undefined;
   getFilter: (layerId: string) => unknown;
   setFilter: (layerId: string, filter: unknown) => void;
   getLayer: (layerId: string) => unknown;
@@ -104,20 +106,42 @@ type SavedFilters = Record<string, unknown>;
  * are NOT stable across the two styles, so we match by TYPE + NAME, never by a
  * hardcoded id list.
  *
+ * Tokens cover the openmaptiles label-layer convention observed live in the
+ * positron basemap (verified 2026-05-29 against `?state=US-AZ`):
+ *   - place labels: `place_city`, `place_town`, `place_state`, `place_country*`…
+ *   - the generic `<thing>_name` text-label layers: `water_name`,
+ *     `highway_name_motorway`, `highway_name_other` — these were bleeding CA/MX
+ *     freeway + water names onto the gray until the `_name` token was added.
+ * The `_name` token is what catches the road/water labels WITHOUT also catching
+ * the road ARROW layers (`road_oneway`, source-layer `transportation`): those
+ * are icon-only decorations, not text, and have no `_name`/place/label token, so
+ * they (correctly) do NOT match. A bare `road`/`highway` token would wrongly
+ * match `road_oneway` and pointlessly within-isolate a LineString arrow set
+ * (which a border-crossing `within` test would drop wholesale, in-state arrows
+ * included). A `road_label`/`highway_label` style would still match via `label`.
+ *
  * **Fails OPEN by design:** a new/unmatched symbol layer in a future basemap
  * release simply renders exterior (detectable in QA) rather than throwing or
  * blanking the whole map. We never blanket-isolate every symbol layer.
  */
 const SYMBOL_NAME_PATTERN =
-  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country)([-_]|$)/i;
+  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country)([-_]|$)|_name(_|$)/i;
 
 /**
- * True iff the layer is a `symbol` layer whose id matches the place/label name
- * heuristic. Exported for a deterministic unit test of the selectivity +
- * fail-open contract.
+ * True iff the layer is a basemap text-LABEL `symbol` layer that should be
+ * within-isolated. Matches by the name heuristic but EXCLUDES the app's own
+ * observation/cluster symbol layers (`source: 'observations'`) so the bird data
+ * is never isolated even if a future basemap names a layer collisionally — a
+ * belt over the name heuristic's fail-open default.
  */
-export function isIsolatableSymbolLayer(layer: { id: string; type: string }): boolean {
-  return layer.type === 'symbol' && SYMBOL_NAME_PATTERN.test(layer.id);
+export function isIsolatableSymbolLayer(layer: {
+  id: string;
+  type: string;
+  source?: string;
+}): boolean {
+  if (layer.type !== 'symbol') return false;
+  if (layer.source === 'observations') return false; // never isolate bird layers
+  return SYMBOL_NAME_PATTERN.test(layer.id);
 }
 
 /** Basemap layer types that can bleed onto the gray if painted above the mask. */
@@ -148,9 +172,24 @@ function isStrayBasemapLayer(layer: { id: string; type: string }): boolean {
  *
  * **Units:** `@turf/buffer`'s distance is KILOMETERS by default — NOT degrees.
  * `~0.05–0.1°` would be the wrong unit (and the "bbox strictly larger" check
- * would still pass, so the mistake would be silent). We use ~8 km — wide enough
- * to clear the 5%-simplified edge, narrow enough not to re-admit across-the-
- * border foreign-state labels (verified BOTH directions in the manual review).
+ * would still pass, so the mistake would be silent).
+ *
+ * **Width = 0.2 km (calibrated live, NOT the spec's 8 km starting point).** The
+ * AC requires BOTH directions: near-border INTERIOR labels survive AND
+ * across-the-border FOREIGN labels stay gone. The binding constraint on the AZ
+ * S border is Heroica Nogales (MX): its `place_city` label anchor (−110.945,
+ * 31.329) sits only ~0.4 km south of the surveyed AZ-Sonora line (lat 31.3322).
+ * Live measurement of turf's buffered southern edge:
+ *   - 0.2 km → lat 31.3304  → Nogales (31.329) is SOUTH of it → EXCLUDED ✓
+ *   - 0.5 km → lat 31.3277  → Nogales is NORTH of it → wrongly RE-ADMITTED ✗
+ *   - 8 km   → far south    → re-admits Nogales, El Sásabe, San Luis MX, Blythe
+ * Meanwhile every interior near-border anchor is ≥3.5 km INSIDE the simplified
+ * polygon (Yuma 4.3 km, Sasabe AZ 5.3 km, San Luis AZ 3.5 km) so they survive
+ * `within → true` even un-buffered; the buffer only covers the sub-km
+ * 5%-simplification anchor-drift, NOT a wide margin. 0.2 km is the largest width
+ * below Nogales's ~0.4 km gap, keeping the bbox strictly larger than the exact
+ * fill polygon (the within-vs-fill distinction) while excluding the on-border
+ * Mexican cities. Tunable, but raising it past ~0.35 km re-admits Nogales.
  *
  * Returns a bare geometry object (`Polygon` | `MultiPolygon`) — the shape the
  * `['within', geom]` expression consumes — NOT a wrapped `Feature`. turf may
@@ -159,7 +198,7 @@ function isStrayBasemapLayer(layer: { id: string; type: string }): boolean {
  */
 export function bufferIsolationPolygon(
   maskPolygon: MultiPolygon,
-  distanceKm = 8,
+  distanceKm = 0.2,
 ): Polygon | MultiPolygon {
   const buffered = buffer(
     { type: 'Feature', properties: {}, geometry: maskPolygon } as Feature<MultiPolygon>,
@@ -261,14 +300,21 @@ export function sinkStrayLayersBelowMask(map: ArtboardMap, maskLayerId: string):
 }
 
 /**
- * Add the halo (blurred `line`) + crisp outline (`line`) float layers above the
+ * Add the halo (blurred `line`) + crisp outline (`line`) float layers ABOVE the
  * mask, theme-aware. Both trace the state polygon's exterior. Idempotent:
  * removes any existing instance (post theme-swap re-apply) before re-adding.
  *
  * The float layers source the EXACT state polygon (not the buffered isolation
  * polygon) — they draw the visible artboard edge, which must match the gray
- * fill edge. They get their own line `Source` (the inline `source` on a
- * line-layer spec), so they do not depend on the inverse-mask fill geometry.
+ * fill edge. They get their own inline line `Source`, so they do not depend on
+ * the inverse-mask fill geometry.
+ *
+ * **Z-order:** MapLibre's `addLayer(layer, beforeId)` inserts `layer` BELOW
+ * `beforeId`. To paint the floats ABOVE the mask (so they land on the gray, not
+ * under it) we anchor on the layer that currently sits just ABOVE the mask
+ * (the first observation/cluster layer — e.g. `clusters`). That places the
+ * floats between the mask fill and the bird layers: gray fill → halo → outline
+ * → observations. If no layer sits above the mask yet, we append on top.
  */
 export function addFloatLayers(
   map: ArtboardMap,
@@ -283,6 +329,22 @@ export function addFloatLayers(
   const outlineColor = theme === 'dark' ? OUTLINE_DARK : OUTLINE_LIGHT;
   const haloColor = theme === 'dark' ? HALO_DARK : HALO_LIGHT;
 
+  // Anchor: the first layer ABOVE the mask. addLayer(spec, anchor) inserts the
+  // spec just below `anchor` → just above the mask. Skip our own float ids so a
+  // re-add after a non-removed prior instance still anchors correctly.
+  const layers = map.getStyle()?.layers ?? [];
+  const maskIndex = layers.findIndex((l) => l.id === maskLayerId);
+  let aboveMaskAnchor: string | undefined;
+  if (maskIndex !== -1) {
+    for (let i = maskIndex + 1; i < layers.length; i += 1) {
+      const id = layers[i]?.id;
+      if (id && id !== ARTBOARD_HALO_ID && id !== ARTBOARD_OUTLINE_ID) {
+        aboveMaskAnchor = id;
+        break;
+      }
+    }
+  }
+
   // A line feature tracing every exterior ring of the state. (MapLibre draws a
   // `line` layer from a Polygon/MultiPolygon by stroking each ring.)
   const outlineFeature: Feature<MultiPolygon> = {
@@ -291,8 +353,8 @@ export function addFloatLayers(
     geometry: maskPolygon,
   };
 
-  // Halo first so the crisp outline paints ON TOP of it. Both inserted with the
-  // mask as `beforeId` → just above the fill, beneath the observation layers.
+  // Halo added first, then the crisp outline — so the outline paints ON TOP of
+  // the halo (both below `aboveMaskAnchor`, i.e. just above the mask fill).
   map.addLayer(
     {
       id: ARTBOARD_HALO_ID,
@@ -306,7 +368,7 @@ export function addFloatLayers(
         'line-opacity': HALO_OPACITY,
       },
     },
-    maskLayerId,
+    aboveMaskAnchor,
   );
   map.addLayer(
     {
@@ -319,7 +381,7 @@ export function addFloatLayers(
         'line-width': OUTLINE_WIDTH,
       },
     },
-    maskLayerId,
+    aboveMaskAnchor,
   );
 }
 

--- a/frontend/src/components/map/artboard-layers.ts
+++ b/frontend/src/components/map/artboard-layers.ts
@@ -39,6 +39,16 @@ export const MASK_LAYER_ID = 'state-mask-fill';
 /** Stable, app-owned float-layer ids so re-apply can guard + remove idempotently. */
 export const ARTBOARD_HALO_ID = 'state-artboard-halo';
 export const ARTBOARD_OUTLINE_ID = 'state-artboard-outline';
+/**
+ * Stable, app-owned source id shared by BOTH float layers. Using one EXPLICIT
+ * named source (rather than an inline `source` object per layer) is load-bearing
+ * for theme swaps: an inline source is auto-named and is NOT removed by
+ * `removeLayer`, so each `setStyle` swap orphaned two anonymous sources. The
+ * orphans surfaced as a maplibre render-time `coalesceChanges` TypeError
+ * ("Cannot convert undefined or null to object") under rapid swaps. A named
+ * source we add/remove explicitly avoids the orphan entirely.
+ */
+export const ARTBOARD_LINE_SOURCE_ID = 'state-artboard-line';
 
 /**
  * Float-layer paint tokens.
@@ -83,6 +93,9 @@ export interface ArtboardMap {
   getFilter: (layerId: string) => unknown;
   setFilter: (layerId: string, filter: unknown) => void;
   getLayer: (layerId: string) => unknown;
+  getSource: (sourceId: string) => unknown;
+  addSource: (sourceId: string, source: Record<string, unknown>) => void;
+  removeSource: (sourceId: string) => void;
   moveLayer: (layerId: string, beforeId?: string) => void;
   addLayer: (layer: Record<string, unknown>, beforeId?: string) => void;
   removeLayer: (layerId: string) => void;
@@ -346,12 +359,15 @@ export function addFloatLayers(
   }
 
   // A line feature tracing every exterior ring of the state. (MapLibre draws a
-  // `line` layer from a Polygon/MultiPolygon by stroking each ring.)
+  // `line` layer from a Polygon/MultiPolygon by stroking each ring.) Both float
+  // layers share ONE explicit named source (see ARTBOARD_LINE_SOURCE_ID) so the
+  // source is removable on teardown and never orphans across a setStyle swap.
   const outlineFeature: Feature<MultiPolygon> = {
     type: 'Feature',
     properties: {},
     geometry: maskPolygon,
   };
+  map.addSource(ARTBOARD_LINE_SOURCE_ID, { type: 'geojson', data: outlineFeature });
 
   // Halo added first, then the crisp outline — so the outline paints ON TOP of
   // the halo (both below `aboveMaskAnchor`, i.e. just above the mask fill).
@@ -359,7 +375,7 @@ export function addFloatLayers(
     {
       id: ARTBOARD_HALO_ID,
       type: 'line',
-      source: { type: 'geojson', data: outlineFeature },
+      source: ARTBOARD_LINE_SOURCE_ID,
       layout: { 'line-cap': 'round', 'line-join': 'round' },
       paint: {
         'line-color': haloColor,
@@ -374,7 +390,7 @@ export function addFloatLayers(
     {
       id: ARTBOARD_OUTLINE_ID,
       type: 'line',
-      source: { type: 'geojson', data: outlineFeature },
+      source: ARTBOARD_LINE_SOURCE_ID,
       layout: { 'line-cap': 'round', 'line-join': 'round' },
       paint: {
         'line-color': outlineColor,
@@ -385,7 +401,11 @@ export function addFloatLayers(
   );
 }
 
-/** Idempotent, guarded removal of both float layers (no throw if absent). */
+/**
+ * Idempotent, guarded removal of both float layers AND their shared source (no
+ * throw if absent). The source is removed LAST — maplibre errors if a source is
+ * removed while a layer still references it.
+ */
 export function removeFloatLayers(map: ArtboardMap): void {
   for (const id of [ARTBOARD_OUTLINE_ID, ARTBOARD_HALO_ID]) {
     try {
@@ -393,6 +413,13 @@ export function removeFloatLayers(map: ArtboardMap): void {
     } catch {
       /* defensive — layer/style gone after a swap or disposal */
     }
+  }
+  try {
+    if (map.getSource(ARTBOARD_LINE_SOURCE_ID) != null) {
+      map.removeSource(ARTBOARD_LINE_SOURCE_ID);
+    }
+  } catch {
+    /* defensive — source gone after a swap or disposal */
   }
 }
 

--- a/frontend/src/components/map/artboard-layers.ts
+++ b/frontend/src/components/map/artboard-layers.ts
@@ -1,0 +1,355 @@
+import { buffer } from '@turf/buffer';
+import type { Feature, MultiPolygon, Polygon } from 'geojson';
+
+/**
+ * State-artboard FIDELITY layer manipulation (#760/#763 — SUB2).
+ *
+ * #762 lands the inverse-mask FILL (source `state-mask` / layer `state-mask-fill`):
+ * flat opaque theme-aware gray everywhere except the selected state. With the
+ * fill alone the basemap symbol layers still render across the whole world, so
+ * OTHER-state labels bleed onto the gray and labels straddling the state border
+ * get sliced by the opaque fill. This module makes the artboard look *finished*:
+ *
+ *   1. `applyLabelIsolation` — merge a `['within', isolationPolygon]` test into
+ *      each basemap symbol layer so exterior labels do not render and none are
+ *      sliced; interior labels render whole. Captures + restores originals.
+ *   2. `sinkStrayLayersBelowMask` — move stray basemap fill/line layers (country
+ *      boundaries, coastlines, glaciers) painted ABOVE the mask beneath it so
+ *      nothing bleeds onto the gray.
+ *   3. `addFloatLayers` / `removeFloatLayers` — a blurred halo + a crisp,
+ *      a11y-load-bearing outline above the mask so the artboard "floats".
+ *
+ * All functions take a minimal structural `ArtboardMap` (see below), NOT
+ * react-map-gl's full `MapInstance`, so the helper is unit-testable against a
+ * tiny spy object with no React render and no WebGL.
+ *
+ * GeoJSON structural types are imported from `geojson` (the @types/geojson
+ * module), NOT from `maplibre-gl` — maplibre@5.x does not re-export them (see
+ * the same note in `mask.ts`). `import type`, erased at build.
+ */
+
+/**
+ * The canonical mask FILL layer id from #762 — the z-order anchor. Stray
+ * basemap layers are sunk BELOW it; the float (halo/outline) layers go ABOVE
+ * it (added with this id as the `beforeId` so they insert just above the fill,
+ * beneath the observation/cluster layers).
+ */
+export const MASK_LAYER_ID = 'state-mask-fill';
+
+/** Stable, app-owned float-layer ids so re-apply can guard + remove idempotently. */
+export const ARTBOARD_HALO_ID = 'state-artboard-halo';
+export const ARTBOARD_OUTLINE_ID = 'state-artboard-outline';
+
+/**
+ * Float-layer paint tokens.
+ *
+ * The crisp outline is the WCAG 1.4.11 load-bearing boundary: the mask fill
+ * alone is ≈1.05:1 (dark `#06090e`) / ≈1.26:1 (light `#d8d8d8`) against the
+ * adjacent in-state land, which fails the 3:1 non-text-contrast target. The
+ * outline therefore carries an explicit ≥3:1 target against BOTH (i) the mask
+ * fill and (ii) the adjacent land, in both themes:
+ *
+ *   LIGHT outline `#1a1d24` (near-black):
+ *     vs mask fill `#d8d8d8` (L≈0.690) → contrast ≈ 12.3:1  ✓
+ *     vs positron land (`#f8f4f0`, L≈0.940) → contrast ≈ 16.3:1  ✓
+ *   DARK outline `#e8edf4` (near-white):
+ *     vs mask fill `#06090e` (L≈0.0027) → contrast ≈ 16.4:1  ✓
+ *     vs positron-dark land (`#0e1116`, L≈0.0055) → contrast ≈ 15.6:1  ✓
+ *
+ * (Ratios computed with the WCAG relative-luminance formula; recorded in the
+ * PR body.) The halo is a soft drop-shadow in light / a soft glow in dark — it
+ * reinforces the "float" but is NOT the load-bearing boundary, so its contrast
+ * is not asserted.
+ */
+const OUTLINE_LIGHT = '#1a1d24';
+const OUTLINE_DARK = '#e8edf4';
+const HALO_LIGHT = '#3a3f4a'; // soft dark drop-shadow on the light gray field
+const HALO_DARK = '#7fd0ff'; // soft cyan glow on the near-black dark field
+const OUTLINE_WIDTH = 1.5;
+const HALO_WIDTH = 6;
+const HALO_BLUR = 4;
+const HALO_OPACITY = 0.55;
+
+/**
+ * Minimal structural slice of the maplibre `Map` instance this module needs.
+ * Defined locally (not imported from maplibre-gl) so the helper is trivially
+ * mockable in unit tests and decoupled from react-map-gl's `MapInstance` churn.
+ * The real `map` from `mapRef.current.getMap()` is structurally compatible.
+ */
+export interface ArtboardMap {
+  getStyle: () => { layers?: Array<{ id: string; type: string }> } | undefined;
+  getFilter: (layerId: string) => unknown;
+  setFilter: (layerId: string, filter: unknown) => void;
+  getLayer: (layerId: string) => unknown;
+  moveLayer: (layerId: string, beforeId?: string) => void;
+  addLayer: (layer: Record<string, unknown>, beforeId?: string) => void;
+  removeLayer: (layerId: string) => void;
+  triggerRepaint: () => void;
+}
+
+/**
+ * Captured original filters, keyed by layer id, so isolation can be torn down
+ * exactly (a layer with no original restores to `undefined` = "no filter").
+ *
+ * Kept private (not exported): the `MapCanvas.tsx` call site annotates the
+ * handle with `ReturnType<typeof applyLabelIsolation>`, so this alias needs no
+ * cross-file export. (Per #763: a cross-file-consumed export would be knip-clean
+ * too — this is a readability choice, not a CI requirement.)
+ */
+type SavedFilters = Record<string, unknown>;
+
+/**
+ * The basemap symbol-layer name heuristic. Matched against the layer id with a
+ * conservative place/label token pattern. Positron(light) and dark layer IDs
+ * are NOT stable across the two styles, so we match by TYPE + NAME, never by a
+ * hardcoded id list.
+ *
+ * **Fails OPEN by design:** a new/unmatched symbol layer in a future basemap
+ * release simply renders exterior (detectable in QA) rather than throwing or
+ * blanking the whole map. We never blanket-isolate every symbol layer.
+ */
+const SYMBOL_NAME_PATTERN =
+  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country)([-_]|$)/i;
+
+/**
+ * True iff the layer is a `symbol` layer whose id matches the place/label name
+ * heuristic. Exported for a deterministic unit test of the selectivity +
+ * fail-open contract.
+ */
+export function isIsolatableSymbolLayer(layer: { id: string; type: string }): boolean {
+  return layer.type === 'symbol' && SYMBOL_NAME_PATTERN.test(layer.id);
+}
+
+/** Basemap layer types that can bleed onto the gray if painted above the mask. */
+function isStrayBasemapLayer(layer: { id: string; type: string }): boolean {
+  if (layer.type !== 'fill' && layer.type !== 'line') return false;
+  // Never sink the mask itself or our own float layers.
+  if (
+    layer.id === MASK_LAYER_ID ||
+    layer.id === ARTBOARD_HALO_ID ||
+    layer.id === ARTBOARD_OUTLINE_ID
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Return an OUTWARD-buffered copy of the state polygon for the `within` LABEL
+ * test ONLY. The mask FILL keeps the EXACT unbuffered `maskPolygon` so the gray
+ * edge stays aligned with the server's `ST_Intersects` data-clip (#733).
+ *
+ * Why buffer: the `maskPolygon` is 5%-mapshaper-simplified, so its edge does
+ * NOT coincide with the basemap's native label anchors. `['within', geom]`
+ * returns FALSE for a point ON or OUTSIDE the boundary, so a legitimate INTERIOR
+ * city near the border (e.g. Yuma, AZ) can fall on the wrong side of the
+ * simplified edge and VANISH. An outward buffer pulls the test boundary out past
+ * the simplified edge so near-border interior anchors survive.
+ *
+ * **Units:** `@turf/buffer`'s distance is KILOMETERS by default — NOT degrees.
+ * `~0.05–0.1°` would be the wrong unit (and the "bbox strictly larger" check
+ * would still pass, so the mistake would be silent). We use ~8 km — wide enough
+ * to clear the 5%-simplified edge, narrow enough not to re-admit across-the-
+ * border foreign-state labels (verified BOTH directions in the manual review).
+ *
+ * Returns a bare geometry object (`Polygon` | `MultiPolygon`) — the shape the
+ * `['within', geom]` expression consumes — NOT a wrapped `Feature`. turf may
+ * collapse a `MultiPolygon` whose parts merge after buffering into a single
+ * `Polygon`, so both geometry types are handled.
+ */
+export function bufferIsolationPolygon(
+  maskPolygon: MultiPolygon,
+  distanceKm = 8,
+): Polygon | MultiPolygon {
+  const buffered = buffer(
+    { type: 'Feature', properties: {}, geometry: maskPolygon } as Feature<MultiPolygon>,
+    distanceKm,
+    { units: 'kilometers' },
+  );
+  // Defensive: if turf ever returns undefined (degenerate input), fall back to
+  // the exact polygon so labels still isolate (just without the buffer slack).
+  if (!buffered?.geometry) return maskPolygon;
+  return buffered.geometry as Polygon | MultiPolygon;
+}
+
+/**
+ * Iterate `map.getStyle().layers`, match basemap symbol layers by the type+name
+ * heuristic, capture each ORIGINAL filter, and merge `['within', isolationPolygon]`
+ * into it:
+ *   - no original  → `['within', isolationPolygon]`
+ *   - has original → `['all', original, ['within', isolationPolygon]]`
+ *
+ * `isolationPolygon` MUST be the OUTWARD-BUFFERED polygon from
+ * `bufferIsolationPolygon` (NOT the exact `maskPolygon` the fill uses — see that
+ * function's note on near-border label survival).
+ *
+ * Returns the captured originals so `restoreLabelIsolation` can undo this
+ * exactly when the mask unmounts (scope → us/chooser).
+ *
+ * Defensive idle-map flush: `setFilter` already schedules a render on its own,
+ * so the trailing `triggerRepaint()` is belt-and-suspenders — a force-flush in
+ * case the map is idle when the filter changes. It is NOT load-bearing (the
+ * filter applies without it); it just avoids a 1-frame stale-paint window.
+ */
+export function applyLabelIsolation(
+  map: ArtboardMap,
+  isolationPolygon: Polygon | MultiPolygon,
+): SavedFilters {
+  const saved: SavedFilters = {};
+  const style = map.getStyle();
+  const layers = style?.layers ?? [];
+  const withinExpr = ['within', isolationPolygon] as unknown[];
+
+  for (const layer of layers) {
+    if (!isIsolatableSymbolLayer(layer)) continue;
+    const original = map.getFilter(layer.id);
+    saved[layer.id] = original;
+    const merged =
+      original == null ? withinExpr : ['all', original, withinExpr];
+    map.setFilter(layer.id, merged);
+  }
+
+  // Defensive idle-map flush (see fn doc) — NOT load-bearing.
+  map.triggerRepaint();
+  return saved;
+}
+
+/**
+ * Restore each captured original filter (passing `undefined`/`null` clears the
+ * filter back to "no filter"), then a defensive idle-map flush. Guarded so a
+ * disposed map / removed layer after a style swap does not throw.
+ */
+export function restoreLabelIsolation(map: ArtboardMap, saved: SavedFilters): void {
+  for (const [layerId, original] of Object.entries(saved)) {
+    try {
+      if (map.getLayer(layerId) == null) continue;
+      map.setFilter(layerId, original);
+    } catch {
+      /* layer/style gone after a swap — defensive, matches existing guards */
+    }
+  }
+  // Defensive idle-map flush (see applyLabelIsolation doc) — NOT load-bearing.
+  map.triggerRepaint();
+}
+
+/**
+ * Move every basemap fill/line layer painted ABOVE the mask beneath it via
+ * `moveLayer(strayId, MASK_LAYER_ID)`, so no boundary/coastline/water-outline
+ * bleeds on top of the gray. Layers already below the mask, symbol layers, the
+ * mask itself, and the app-owned float layers are left untouched.
+ *
+ * The CALLER must have already `getLayer`-guarded `state-mask-fill` (see the
+ * reconcile-sequencing blocker in MapCanvas): `moveLayer(x, 'state-mask-fill')`
+ * throws `Cannot move layer before non-existing layer` if the reference layer
+ * is absent. This function additionally no-ops if the mask is missing from the
+ * style as a defensive backstop.
+ */
+export function sinkStrayLayersBelowMask(map: ArtboardMap, maskLayerId: string): void {
+  const layers = map.getStyle()?.layers ?? [];
+  const maskIndex = layers.findIndex((l) => l.id === maskLayerId);
+  if (maskIndex === -1) return; // mask not in style — nothing to anchor against
+  // Layers AFTER the mask in the array are painted ABOVE it.
+  for (let i = maskIndex + 1; i < layers.length; i += 1) {
+    const layer = layers[i];
+    if (!layer || !isStrayBasemapLayer(layer)) continue;
+    try {
+      map.moveLayer(layer.id, maskLayerId);
+    } catch {
+      /* defensive — layer/style churn after a swap */
+    }
+  }
+}
+
+/**
+ * Add the halo (blurred `line`) + crisp outline (`line`) float layers above the
+ * mask, theme-aware. Both trace the state polygon's exterior. Idempotent:
+ * removes any existing instance (post theme-swap re-apply) before re-adding.
+ *
+ * The float layers source the EXACT state polygon (not the buffered isolation
+ * polygon) — they draw the visible artboard edge, which must match the gray
+ * fill edge. They get their own line `Source` (the inline `source` on a
+ * line-layer spec), so they do not depend on the inverse-mask fill geometry.
+ */
+export function addFloatLayers(
+  map: ArtboardMap,
+  maskPolygon: MultiPolygon,
+  maskLayerId: string,
+  theme: 'light' | 'dark',
+): void {
+  // Idempotent guard: a theme-swap re-apply runs against the NEW style where a
+  // prior instance may linger; remove before re-add so ids stay unique.
+  removeFloatLayers(map);
+
+  const outlineColor = theme === 'dark' ? OUTLINE_DARK : OUTLINE_LIGHT;
+  const haloColor = theme === 'dark' ? HALO_DARK : HALO_LIGHT;
+
+  // A line feature tracing every exterior ring of the state. (MapLibre draws a
+  // `line` layer from a Polygon/MultiPolygon by stroking each ring.)
+  const outlineFeature: Feature<MultiPolygon> = {
+    type: 'Feature',
+    properties: {},
+    geometry: maskPolygon,
+  };
+
+  // Halo first so the crisp outline paints ON TOP of it. Both inserted with the
+  // mask as `beforeId` → just above the fill, beneath the observation layers.
+  map.addLayer(
+    {
+      id: ARTBOARD_HALO_ID,
+      type: 'line',
+      source: { type: 'geojson', data: outlineFeature },
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-color': haloColor,
+        'line-width': HALO_WIDTH,
+        'line-blur': HALO_BLUR,
+        'line-opacity': HALO_OPACITY,
+      },
+    },
+    maskLayerId,
+  );
+  map.addLayer(
+    {
+      id: ARTBOARD_OUTLINE_ID,
+      type: 'line',
+      source: { type: 'geojson', data: outlineFeature },
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-color': outlineColor,
+        'line-width': OUTLINE_WIDTH,
+      },
+    },
+    maskLayerId,
+  );
+}
+
+/** Idempotent, guarded removal of both float layers (no throw if absent). */
+export function removeFloatLayers(map: ArtboardMap): void {
+  for (const id of [ARTBOARD_OUTLINE_ID, ARTBOARD_HALO_ID]) {
+    try {
+      if (map.getLayer(id) != null) map.removeLayer(id);
+    } catch {
+      /* defensive — layer/style gone after a swap or disposal */
+    }
+  }
+}
+
+/**
+ * Composite for the FLOAT/SINK half of artboard fidelity (item 3b). This is the
+ * half that MUST run from a `maskPolygon`-watching `mapReady`-gated effect AFTER
+ * react-map-gl re-adds `state-mask-fill` — NOT from `style.load` (where the
+ * reference layer does not yet exist; see the reconcile-sequencing blocker in
+ * MapCanvas). The label-isolation half (`applyLabelIsolation`) runs separately
+ * in `style.load`.
+ *
+ * Order: sink stray basemap layers below the mask, THEN add the float layers
+ * above it.
+ */
+export function applyArtboardFidelity(
+  map: ArtboardMap,
+  maskPolygon: MultiPolygon,
+  theme: 'light' | 'dark',
+): void {
+  sinkStrayLayersBelowMask(map, MASK_LAYER_ID);
+  addFloatLayers(map, maskPolygon, MASK_LAYER_ID, theme);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "dependencies": {
         "@bird-watch/shared-types": "*",
         "@microsoft/clarity": "^1.0.2",
+        "@turf/buffer": "^7.3.5",
         "maplibre-gl": "^5.24.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3952,6 +3953,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/boolean-point-in-polygon": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
@@ -3969,11 +3985,58 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.5.tgz",
+      "integrity": "sha512-TGls3nYtWzviKHT00XVBfHKa7Z2oIZKqiHN7R0xErGwMSAR7YhxVROhxq/iyIsWZjl1SlPwweZZIxWILQuxpZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/center": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.5",
+        "@turf/projection": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.5.tgz",
+      "integrity": "sha512-eub5/Kfdmn89ZqwCONHI7astmTDEtN5M6+JfOkgoSyhKKFhUJYNxUyH1F/vCtIP7j1K369Vs4L9TYiuGapvIKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.5.tgz",
+      "integrity": "sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/helpers": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
       "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.10",
@@ -3991,6 +4054,45 @@
       "license": "MIT",
       "dependencies": {
         "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.5.tgz",
+      "integrity": "sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
       },
@@ -5198,6 +5300,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -6366,6 +6483,15 @@
     "node_modules/json-stringify-pretty-compact": {
       "version": "3.0.0",
       "license": "MIT"
+    },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/just-extend": {
       "version": "6.2.0",


### PR DESCRIPTION

## Diagrams

```mermaid
flowchart TD
    subgraph stateScope["state scope active (maskPolygon set)"]
        SL["map 'style.load'<br/>(fires on each theme setStyle swap)"]
        EFF["maskPolygon-watching<br/>mapReady-gated useEffect<br/>(runs AFTER react-map-gl re-adds state-mask-fill)"]
    end

    SL -->|"3a: label isolation only"| ALI["applyLabelIsolation(map, bufferIsolationPolygon(poly))<br/>merge ['within', isolationPolygon] into each<br/>basemap symbol layer; capture originals"]
    EFF -->|"3b: float + sink<br/>(getLayer-guarded on state-mask-fill)"| AAF["applyArtboardFidelity"]
    AAF --> SINK["sinkStrayLayersBelowMask<br/>moveLayer(stray, 'state-mask-fill')"]
    AAF --> FLOAT["addFloatLayers<br/>halo (line-blur) + crisp outline (line)<br/>via ONE named source state-artboard-line"]

    ALI -.->|"teardown on scope→us/chooser"| REST["restoreLabelIsolation + removeFloatLayers"]

    BUF["maskPolygon (5%-simplified)"] -->|"OUTWARD buffer 0.2 km"| ISO["isolationPolygon<br/>(label 'within' test ONLY)"]
    BUF -->|"EXACT, unbuffered"| FILL["#762 state-mask-fill geometry<br/>(stays aligned with ST_Intersects clip)"]
```

## Summary

- **Why:** #762 lands the inverse-mask fill but the basemap symbol layers still render worldwide, so OTHER-state labels bleed onto the gray and labels straddling the state border get visually SLICED by the opaque fill. On prod this surfaced as labels (Arlington, Alexandria, "Virginia", the river label) clipped at the artboard edge — worst on tiny `US-DC`. SUB2 makes the artboard look *finished*: exterior labels REMOVED (not clipped), interior labels whole, no boundary/coastline bleed, plus a theme-aware halo + crisp outline so the state floats.
- **How:** A new unit-testable helper `artboard-layers.ts` merges `['within', isolationPolygon]` into each basemap symbol layer (matched by a fail-open type+name heuristic, never hardcoded ids), sinks stray fill/line layers below the mask, and adds the float layers. The `within` test uses an **outward-buffered** polygon (calibrated **0.2 km** via `@turf/buffer`) while the fill keeps the **exact** `maskPolygon` — two polygons, two jobs — so near-border interior anchors (Yuma) survive while across-the-border foreign cities (Heroica Nogales, MX) stay gone. The reconcile-sequencing blocker is handled by SPLITTING re-apply: label isolation in `style.load`; float + stray-sink in a separate `maskPolygon`-watching `mapReady`-gated effect guarded by `getLayer('state-mask-fill')`.
- **a11y / robustness:** the crisp outline is the WCAG 1.4.11 load-bearing boundary with an explicit **≥3:1** non-text-contrast target against BOTH the mask fill and the adjacent land, in both themes (light outline `#1a1d24`: ≈12.3:1 vs fill / ≈16.3:1 vs land; dark outline `#e8edf4`: ≈16.4:1 / ≈15.6:1). Both float layers share ONE explicit **named** source (`state-artboard-line`) so rapid theme swaps never orphan an anonymous source — fixing the maplibre `coalesceChanges` "Cannot convert undefined or null to object" render-time throw. **This FIXES the cover-mode label clipping the user reported.**

## Screenshots

**`?state=US-AZ`** — 5 canonical viewports × light + dark (10 captures). Crisp AZ outline + halo float on the gray; interior labels whole (Phoenix/Tucson/Flagstaff/Yuma); zero Mexican-border or coastline bleed.

| Light | Dark |
|---|---|
| <img width="420" alt="az-390-light" src="https://github.com/user-attachments/assets/cb6fed16-d2c4-4d94-9a06-560cb5f3ec60" /> | <img width="420" alt="az-390-dark" src="https://github.com/user-attachments/assets/7dcf85dc-ea9a-434a-bc1f-72961af71d1a" /> |  <!-- 390×844 mobile -->
| <img width="420" alt="az-768-light" src="https://github.com/user-attachments/assets/7f6a06e6-9f91-4e2f-b042-3513742e3e7b" /> | <img width="420" alt="az-768-dark" src="https://github.com/user-attachments/assets/bd52d54a-628a-469e-808b-0a47df12a0c1" /> |  <!-- 768×1024 tablet -->
| <img width="420" alt="az-1024-light" src="https://github.com/user-attachments/assets/500c9d98-d130-4bd3-a5e5-f2555d522403" /> | <img width="420" alt="az-1024-dark" src="https://github.com/user-attachments/assets/d9ca3ef8-27d3-4a2a-b1bd-6edf9184091e" /> |  <!-- 1024×768 small laptop -->
| <img width="420" alt="az-1440-light" src="https://github.com/user-attachments/assets/e871c75f-d495-4385-9d9a-b440e1cebeeb" /> | <img width="420" alt="az-1440-dark" src="https://github.com/user-attachments/assets/01d0fd00-d644-4dd3-984d-5e6431a74078" /> |  <!-- 1440×900 desktop -->
| <img width="420" alt="az-1920-light" src="https://github.com/user-attachments/assets/7094494b-5ecb-4040-9b4c-4fc8615b5a84" /> | <img width="420" alt="az-1920-dark" src="https://github.com/user-attachments/assets/cf6a77a1-c878-4028-8ff4-5ac697c54449" /> |  <!-- 1920×1080 wide -->

**`?state=US-DC`** — the user-flagged worst case (tiny district surrounded by VA/MD). Diamond outline whole; the only labels rendered are DC-interior (Washington + two interior freeways); exterior VA/MD labels (Arlington, Alexandria, "Virginia", the river label) are REMOVED, not clipped. Both themes.

| Light | Dark |
|---|---|
| <img width="420" alt="dc-1440-light" src="https://github.com/user-attachments/assets/54bb8578-1b9f-4f9f-ac48-cc98038647a8" /> | <img width="420" alt="dc-1440-dark" src="https://github.com/user-attachments/assets/9f86a80b-b363-45f2-acb7-fa45daacf6e9" /> |

## Test plan

- [x] `npm run typecheck && npm run test` — green (frontend: 69 files, 1022 tests pass; shared-types built first)
- [x] New unit / integration tests added — `artboard-layers.test.ts` (415 lines) + extended `MapCanvas.test.tsx` mock-map factory (`getStyle`/`getFilter`/`setFilter`/`moveLayer`/`triggerRepaint`)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A here; the formal e2e label-bleed + axe specs are owned by sibling #764 (this is SUB2's implementer pass)
- [x] `npm run build` — clean production build; `npm run lint` 0 errors; `npx knip` no new findings; `npx tsc -p frontend/tsconfig.test.json` 109 (baseline)
- [x] (UI only) Playwright MCP smoke — ran `npm run dev` against a local mock read-api on :8787; drove `?state=US-DC` (flagged worst case), `?state=US-AZ`, `?state=US-RI` at all 5 canonical viewports × light+dark. **DC:** only 3 labels render and ALL are interior (Washington, Anacostia Freeway, Southeast Freeway) — zero foreign labels (Arlington/Alexandria/Virginia REMOVED, not clipped); diamond outline whole; no edge-slice. **AZ:** Yuma (lat 32.72) + Nogales **AZ** (lat 31.34, NORTH of the Sonora line) survive; **zero** place features render south of lat 31.3322 — Heroica Nogales MX (lat 31.329) ABSENT; no coastline bleed. **RI:** Providence/Newport whole; MA/CT cities absent. 5 rapid `data-theme` swaps left all artboard layers intact + recolored with **NO** `coalesceChanges` throw and **NO** `Cannot move layer` throw. Console: 0 errors. The only warnings are missing-positron-sprite warnings (`circle-11` per #764, and `wood-pattern` — the same basemap-sprite class, surfaced by the DC landcover tiles; neither references any artboard layer and neither is introduced by this PR).

## Plan reference

Part of epic **#760** (state-artboard mask), SUB2 of 3 (after #762 core, before #764 verification). See `docs/plans/2026-05-29-state-artboard-mask.md`.

Closes #763

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
