### PR TITLE
fix(frontend,map): move state-mask below the first basemap label — fixes interior-label clipping

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -2219,6 +2219,33 @@ describe('MapCanvas state-artboard mask (#762)', () => {
     );
   });
 
+  it('with maskPolygon: state-mask-fill is moved BELOW the first basemap label layer (interior-label un-clip)', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        silhouettes={SILHOUETTES}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.moveLayer).toHaveBeenCalled());
+    // The fidelity composite lowers state-mask-fill below the FIRST basemap
+    // label (symbol) layer (here `place_country`, the first isolatable symbol),
+    // so within-filtered INTERIOR labels paint ON TOP of the gray and a
+    // near-border label is no longer sliced by the opaque mask.
+    const moved = (fakeMap.moveLayer.mock.calls as Array<[string, string?]>);
+    expect(moved).toEqual(
+      expect.arrayContaining([['state-mask-fill', 'place_country']]),
+    );
+    // The mask is NEVER lowered below the app observation symbol layer or a
+    // float layer (it anchors on the first ISOLATABLE basemap label only).
+    expect(moved).not.toEqual(
+      expect.arrayContaining([['state-mask-fill', 'transit_route_ref']]),
+    );
+  });
+
   it('[blocker guard] moveLayer is NOT called when state-mask-fill is absent at reconcile time', async () => {
     // Simulate the reconcile-sequencing window: react-map-gl has not re-added
     // the mask layer yet, so getLayer('state-mask-fill') returns undefined. The

--- a/frontend/src/components/map/artboard-layers.test.ts
+++ b/frontend/src/components/map/artboard-layers.test.ts
@@ -5,6 +5,7 @@ import {
   restoreLabelIsolation,
   bufferIsolationPolygon,
   sinkStrayLayersBelowMask,
+  moveMaskBelowFirstLabel,
   addFloatLayers,
   removeFloatLayers,
   applyArtboardFidelity,
@@ -91,7 +92,27 @@ function makeMockMap(layers = makeStyleLayers()) {
     removeSource: vi.fn((id: string) => {
       delete sources[id];
     }),
-    moveLayer: vi.fn(),
+    // moveLayer mutates the in-memory `layers` array so order-sensitive tests
+    // (the mask-below-first-label move) can assert final z-order, not just the
+    // spy call args. `moveLayer(id)` (no beforeId) moves to the top; with
+    // `beforeId` it re-inserts `id` immediately BEFORE `beforeId` (MapLibre
+    // semantics: the moved layer is painted UNDER `beforeId`).
+    moveLayer: vi.fn((id: string, beforeId?: string) => {
+      const from = layers.findIndex((l) => l.id === id);
+      if (from === -1) return;
+      const [moved] = layers.splice(from, 1);
+      if (!moved) return;
+      if (beforeId == null) {
+        layers.push(moved);
+        return;
+      }
+      const to = layers.findIndex((l) => l.id === beforeId);
+      if (to === -1) {
+        layers.push(moved);
+        return;
+      }
+      layers.splice(to, 0, moved);
+    }),
     addLayer: vi.fn(),
     removeLayer: vi.fn(),
     triggerRepaint: vi.fn(),
@@ -157,9 +178,29 @@ describe('isIsolatableSymbolLayer (type + name heuristic, fails OPEN)', () => {
     expect(isIsolatableSymbolLayer({ id: 'water_name', type: 'symbol' })).toBe(true);
   });
 
-  it('does NOT match symbol layers with no place/label/_name token (fails open: rendered exterior, not blanked)', () => {
+  it('matches the LIGHT (positron) basemap label/road/shield/airport layers (hyphenated + new tokens)', () => {
+    // positron uses `label_*` instead of `place_*`.
+    expect(isIsolatableSymbolLayer({ id: 'label_other', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'label_city', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'label_country_1', type: 'symbol' })).toBe(true);
+    // HYPHENATED road-name labels — the `_name`-only pattern silently missed
+    // these, so VA-side freeway names bled onto the gray once the mask dropped
+    // below the labels. `[-_]name([-_]|$)` now catches them.
+    expect(isIsolatableSymbolLayer({ id: 'highway-name-major', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-name-minor', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-name-path', type: 'symbol' })).toBe(true);
+    // Shields + airport labels (own symbol layers, no place/label/name token).
+    expect(isIsolatableSymbolLayer({ id: 'road_shield_us', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-shield-us-interstate', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-shield-non-us', type: 'symbol' })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'airport', type: 'symbol' })).toBe(true);
+  });
+
+  it('does NOT match symbol layers with no place/label/name/shield/airport token (fails open: rendered exterior, not blanked)', () => {
     expect(isIsolatableSymbolLayer({ id: 'transit_route_ref', type: 'symbol' })).toBe(false);
-    // road_oneway is an icon-only arrow layer, not a text label — left untouched.
+    // road_oneway is an icon-only arrow layer, not a text label — left untouched
+    // (no label-bearing token; a bare `road`/`highway` token is deliberately not
+    // used so this LineString arrow set is never within-dropped).
     expect(isIsolatableSymbolLayer({ id: 'road_oneway', type: 'symbol' })).toBe(false);
   });
 
@@ -280,6 +321,73 @@ describe('restoreLabelIsolation', () => {
   });
 });
 
+describe('moveMaskBelowFirstLabel (isolate mode — interior labels render ON TOP of the gray)', () => {
+  // The fixture style places state-mask-fill AFTER all the symbol/label layers
+  // (the pre-fix BUG state from #762: the mask <Layer> has no beforeId so
+  // react-map-gl appends it above the basemap labels). The first basemap label
+  // layer is `place_country` (the first isolatable symbol). The mask must move
+  // to sit immediately BELOW it.
+  const firstLabelId = 'place_country';
+
+  it('moves state-mask-fill BELOW the first basemap label (symbol) layer', () => {
+    const map = makeMockMap();
+    // Precondition: the mask starts ABOVE the first label (the bug).
+    const before = map.layers.map((l) => l.id);
+    expect(before.indexOf(MASK_LAYER_ID)).toBeGreaterThan(before.indexOf(firstLabelId));
+
+    moveMaskBelowFirstLabel(map as never, MASK_LAYER_ID);
+
+    expect(map.moveLayer).toHaveBeenCalledWith(MASK_LAYER_ID, firstLabelId);
+    // Final z-order: the mask now sits immediately below the first label layer.
+    const after = map.layers.map((l) => l.id);
+    expect(after.indexOf(MASK_LAYER_ID)).toBeLessThan(after.indexOf(firstLabelId));
+    // …specifically directly beneath it.
+    expect(after.indexOf(MASK_LAYER_ID)).toBe(after.indexOf(firstLabelId) - 1);
+  });
+
+  it('lands EVERY interior basemap label layer ABOVE the mask (the un-clip invariant)', () => {
+    const map = makeMockMap();
+    moveMaskBelowFirstLabel(map as never, MASK_LAYER_ID);
+    const after = map.layers.map((l) => l.id);
+    const maskIdx = after.indexOf(MASK_LAYER_ID);
+    // All basemap label symbol layers now paint ABOVE the mask → interior labels
+    // (within-filtered) render whole on top of the gray instead of being sliced.
+    for (const labelId of ['place_country', 'place_city', 'poi_z14', 'highway_name_motorway', 'water_name']) {
+      expect(after.indexOf(labelId)).toBeGreaterThan(maskIdx);
+    }
+  });
+
+  it('anchors on the first ISOLATABLE symbol layer (never an app observation / float layer)', () => {
+    const map = makeMockMap();
+    moveMaskBelowFirstLabel(map as never, MASK_LAYER_ID);
+    // The anchor is place_country (first isolatable basemap label), NOT the
+    // app-owned observation symbol (`unclustered-point`, source: observations)
+    // nor a float line layer — so the mask is never lowered below the bird data.
+    expect(map.moveLayer).toHaveBeenCalledTimes(1);
+    expect(map.moveLayer).toHaveBeenCalledWith(MASK_LAYER_ID, 'place_country');
+    expect(map.moveLayer).not.toHaveBeenCalledWith(MASK_LAYER_ID, 'unclustered-point');
+    expect(map.moveLayer).not.toHaveBeenCalledWith(MASK_LAYER_ID, ARTBOARD_HALO_ID);
+  });
+
+  it('warns and does NOT move when the mask layer is absent (reconcile-sequencing guard, fail open)', () => {
+    const layers = makeStyleLayers().filter((l) => l.id !== MASK_LAYER_ID);
+    const map = makeMockMap(layers);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    moveMaskBelowFirstLabel(map as never, MASK_LAYER_ID);
+    expect(map.moveLayer).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('leaves the mask where it is when NO basemap label layer exists (fail open, no throw)', () => {
+    // A style with the mask but zero isolatable symbol layers.
+    const layers = makeStyleLayers().filter((l) => l.type !== 'symbol');
+    const map = makeMockMap(layers);
+    expect(() => moveMaskBelowFirstLabel(map as never, MASK_LAYER_ID)).not.toThrow();
+    expect(map.moveLayer).not.toHaveBeenCalled();
+  });
+});
+
 describe('sinkStrayLayersBelowMask', () => {
   it('moves basemap fill/line layers ordered ABOVE the mask beneath it via moveLayer(strayId, MASK_LAYER_ID)', () => {
     const map = makeMockMap();
@@ -395,11 +503,13 @@ describe('addFloatLayers / removeFloatLayers', () => {
   });
 });
 
-describe('applyArtboardFidelity (float/sink composite — item 3b)', () => {
-  it('sinks stray layers then adds the float layers above the mask', () => {
+describe('applyArtboardFidelity (mask-move + float/sink composite — item 3b)', () => {
+  it('moves the mask below the first label, sinks stray layers, then adds the float layers above the mask', () => {
     const map = makeMockMap();
     applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
-    // moveLayer (sink) and addLayer (float) both fire.
+    // Step 1: the mask moved below the first basemap label layer (place_country).
+    expect(map.moveLayer).toHaveBeenCalledWith(MASK_LAYER_ID, 'place_country');
+    // moveLayer (mask-move + sink) and addLayer (float) both fire.
     expect(map.moveLayer).toHaveBeenCalled();
     // Float layers are added (anchored above the mask, NOT below it).
     const haloCall = map.addLayer.mock.calls.find(
@@ -411,5 +521,17 @@ describe('applyArtboardFidelity (float/sink composite — item 3b)', () => {
     expect(haloCall).toBeDefined();
     expect(outlineCall).toBeDefined();
     expect(haloCall?.[1]).not.toBe(MASK_LAYER_ID); // never inserted BELOW the mask
+  });
+
+  it('runs the mask-move BEFORE the float/sink (interior labels end up above the mask)', () => {
+    const map = makeMockMap();
+    applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
+    // After the composite, every basemap label layer paints ABOVE the lowered
+    // mask — the interior-label un-clip invariant.
+    const after = map.layers.map((l) => l.id);
+    const maskIdx = after.indexOf(MASK_LAYER_ID);
+    for (const labelId of ['place_country', 'place_city', 'poi_z14']) {
+      expect(after.indexOf(labelId)).toBeGreaterThan(maskIdx);
+    }
   });
 });

--- a/frontend/src/components/map/artboard-layers.ts
+++ b/frontend/src/components/map/artboard-layers.ts
@@ -5,18 +5,26 @@ import type { Feature, MultiPolygon, Polygon } from 'geojson';
  * State-artboard FIDELITY layer manipulation (#760/#763 — SUB2).
  *
  * #762 lands the inverse-mask FILL (source `state-mask` / layer `state-mask-fill`):
- * flat opaque theme-aware gray everywhere except the selected state. With the
- * fill alone the basemap symbol layers still render across the whole world, so
- * OTHER-state labels bleed onto the gray and labels straddling the state border
- * get sliced by the opaque fill. This module makes the artboard look *finished*:
+ * flat opaque theme-aware gray everywhere except the selected state. #762 renders
+ * that fill as a react-map-gl `<Layer>` with NO `beforeId`, so it lands ON TOP of
+ * the WHOLE basemap — including the basemap symbol (label) layers. With the fill
+ * alone OTHER-state labels bleed onto the gray, and an INTERIOR label straddling
+ * the (server-clipped) border gets SLICED by the opaque fill above it. This
+ * module makes the artboard look *finished*:
  *
- *   1. `applyLabelIsolation` — merge a `['within', isolationPolygon]` test into
- *      each basemap symbol layer so exterior labels do not render and none are
- *      sliced; interior labels render whole. Captures + restores originals.
- *   2. `sinkStrayLayersBelowMask` — move stray basemap fill/line layers (country
+ *   1. `moveMaskBelowFirstLabel` — move `state-mask-fill` BELOW the first basemap
+ *      label (`symbol`) layer so `within`-passing INTERIOR labels render ON TOP
+ *      of the gray (whole, overhang onto the gray included). This is the
+ *      "isolate mode" of the v3 mockup and the fix for the interior-label
+ *      clipping regression — without it the mask sits above the labels and any
+ *      near-border interior label is sliced by the gray.
+ *   2. `applyLabelIsolation` — merge a `['within', isolationPolygon]` test into
+ *      each basemap symbol layer so exterior labels do not render; interior
+ *      labels render whole. Captures + restores originals.
+ *   3. `sinkStrayLayersBelowMask` — move stray basemap fill/line layers (country
  *      boundaries, coastlines, glaciers) painted ABOVE the mask beneath it so
  *      nothing bleeds onto the gray.
- *   3. `addFloatLayers` / `removeFloatLayers` — a blurred halo + a crisp,
+ *   4. `addFloatLayers` / `removeFloatLayers` — a blurred halo + a crisp,
  *      a11y-load-bearing outline above the mask so the artboard "floats".
  *
  * All functions take a minimal structural `ArtboardMap` (see below), NOT
@@ -115,30 +123,41 @@ type SavedFilters = Record<string, unknown>;
 
 /**
  * The basemap symbol-layer name heuristic. Matched against the layer id with a
- * conservative place/label token pattern. Positron(light) and dark layer IDs
- * are NOT stable across the two styles, so we match by TYPE + NAME, never by a
- * hardcoded id list.
+ * conservative place/label token pattern. The two basemaps use DIFFERENT layer
+ * id conventions, so we match by TYPE + NAME, never by a hardcoded id list:
+ *   - DARK (`.../styles/dark`): underscore ids — `place_city`, `place_country*`,
+ *     `water_name`, `highway_name_motorway`, `highway_name_other`.
+ *   - LIGHT (`.../styles/positron`): a mix of `label_*` (`label_other`,
+ *     `label_city`, `label_country_1`…) AND HYPHENATED road labels
+ *     (`highway-name-major`, `highway-name-minor`, `highway-name-path`),
+ *     shields (`road_shield_us`, `highway-shield-us-interstate`,
+ *     `highway-shield-non-us`), and `airport`.
  *
- * Tokens cover the openmaptiles label-layer convention observed live in the
- * positron basemap (verified 2026-05-29 against `?state=US-AZ`):
- *   - place labels: `place_city`, `place_town`, `place_state`, `place_country*`…
- *   - the generic `<thing>_name` text-label layers: `water_name`,
- *     `highway_name_motorway`, `highway_name_other` — these were bleeding CA/MX
- *     freeway + water names onto the gray until the `_name` token was added.
- * The `_name` token is what catches the road/water labels WITHOUT also catching
- * the road ARROW layers (`road_oneway`, source-layer `transportation`): those
- * are icon-only decorations, not text, and have no `_name`/place/label token, so
- * they (correctly) do NOT match. A bare `road`/`highway` token would wrongly
- * match `road_oneway` and pointlessly within-isolate a LineString arrow set
- * (which a border-crossing `within` test would drop wholesale, in-state arrows
- * included). A `road_label`/`highway_label` style would still match via `label`.
+ * Tokens:
+ *   - place/label tokens: `place|settlement|poi|label|town|city|village|state|
+ *     country` (catches both `place_city` AND `label_city`).
+ *   - `name` with EITHER an underscore OR a hyphen separator
+ *     (`[-_]name([-_]|$)`) — catches the dark `water_name`/`highway_name_*` AND
+ *     the light `highway-name-*`. The earlier `_name(_|$)`-only form silently
+ *     missed the light basemap's hyphenated road labels, so VA-side freeway
+ *     names bled onto the gray once the mask dropped below the labels (#762/#763
+ *     interior-label-clipping fix). The separator class is what now catches them.
+ *   - `shield` / `airport` — the light basemap renders road shields and the
+ *     airport label as their own symbol layers with no place/label/name token;
+ *     both are decorations tied to a road/place and must isolate with the rest.
+ *
+ * **`road_oneway` is still EXCLUDED** (the original calibration constraint): it
+ * is an icon-only arrow layer with no place/label/`name`/`shield`/`airport`
+ * token, so it does NOT match — a bare `road`/`highway` token (deliberately not
+ * used) would have wrongly within-isolated that LineString arrow set, dropping
+ * in-state arrows along with foreign ones. We require a label-bearing token.
  *
  * **Fails OPEN by design:** a new/unmatched symbol layer in a future basemap
  * release simply renders exterior (detectable in QA) rather than throwing or
  * blanking the whole map. We never blanket-isolate every symbol layer.
  */
 const SYMBOL_NAME_PATTERN =
-  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country)([-_]|$)|_name(_|$)/i;
+  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country|shield|airport)([-_]|$)|[-_]name([-_]|$)/i;
 
 /**
  * True iff the layer is a basemap text-LABEL `symbol` layer that should be
@@ -155,6 +174,75 @@ export function isIsolatableSymbolLayer(layer: {
   if (layer.type !== 'symbol') return false;
   if (layer.source === 'observations') return false; // never isolate bird layers
   return SYMBOL_NAME_PATTERN.test(layer.id);
+}
+
+/**
+ * True iff the layer is a basemap text-LABEL `symbol` layer that the mask FILL
+ * should be moved BELOW (the "isolate mode" of the v3 mockup). Reuses the same
+ * type+name heuristic as `isIsolatableSymbolLayer` so the mask anchors on the
+ * SAME class of layer the `within` isolation operates on — but additionally
+ * EXCLUDES the app-owned float layers (`state-artboard-*`). Those are `line`
+ * layers (so the symbol check already drops them), but the exclusion is an
+ * explicit belt in case a future float layer is ever a symbol.
+ *
+ * `isIsolatableSymbolLayer` already excludes `source: 'observations'` (the
+ * cluster-count / unclustered-point app symbol layers), so anchoring the mask
+ * here can never land it below the bird data.
+ */
+function isFirstLabelAnchorLayer(layer: {
+  id: string;
+  type: string;
+  source?: string;
+}): boolean {
+  if (layer.id === ARTBOARD_HALO_ID || layer.id === ARTBOARD_OUTLINE_ID) {
+    return false;
+  }
+  return isIsolatableSymbolLayer(layer);
+}
+
+/**
+ * Move `state-mask-fill` BELOW the FIRST basemap label (`symbol`) layer so the
+ * `within`-filtered INTERIOR labels render ON TOP of the gray — i.e. a label
+ * that overhangs the (server-clipped) state boundary into the gray is drawn
+ * WHOLE rather than sliced by the opaque mask fill (#762/#763 interior-label
+ * clipping regression).
+ *
+ * Root cause this repairs: #762 renders the mask as a react-map-gl `<Layer
+ * id="state-mask-fill">` with NO `beforeId`, so react-map-gl appends it ON TOP
+ * of the entire basemap — including the basemap symbol/label layers. #763's
+ * `sinkStrayLayersBelowMask` only moves `fill`/`line` strays below the mask
+ * (never `symbol`), so the label layers stayed UNDER the mask and any interior
+ * label straddling the border got clipped by the gray. Lowering the mask below
+ * the first label layer puts every basemap label back on top of the gray; the
+ * `within` filter (unchanged) keeps EXTERIOR labels removed, so only whole
+ * interior labels — overhang onto the gray included — remain.
+ *
+ * **Fails OPEN.** Guards on `getLayer(maskLayerId)` (warn-and-return if the
+ * mask is absent — the reconcile-sequencing window). If NO basemap symbol/label
+ * layer is found, the mask is left exactly where it is (no throw, no move) —
+ * the worst case is the pre-fix clipping, never a blanked map.
+ *
+ * Idempotent: re-running after the mask is already beneath the first label is a
+ * no-op `moveLayer(maskLayerId, sameAnchor)` (MapLibre tolerates moving a layer
+ * to its current relative position). The CALLER re-applies this wherever
+ * fidelity runs (the `maskPolygon` effect AND the `style.load` re-apply path),
+ * so the imperative move survives react-map-gl reconciles and theme swaps.
+ */
+export function moveMaskBelowFirstLabel(map: ArtboardMap, maskLayerId: string): void {
+  if (map.getLayer(maskLayerId) == null) {
+    console.warn(
+      `[artboard] ${maskLayerId} absent; cannot move below labels (deferring)`,
+    );
+    return;
+  }
+  const layers = map.getStyle()?.layers ?? [];
+  const firstLabel = layers.find((l) => isFirstLabelAnchorLayer(l));
+  if (!firstLabel) return; // no basemap label layer found — fail open, leave as-is
+  try {
+    map.moveLayer(maskLayerId, firstLabel.id);
+  } catch {
+    /* defensive — layer/style churn after a swap */
+  }
 }
 
 /** Basemap layer types that can bleed onto the gray if painted above the mask. */
@@ -431,14 +519,28 @@ export function removeFloatLayers(map: ArtboardMap): void {
  * MapCanvas). The label-isolation half (`applyLabelIsolation`) runs separately
  * in `style.load`.
  *
- * Order: sink stray basemap layers below the mask, THEN add the float layers
- * above it.
+ * Order of operations (load-bearing):
+ *   1. `moveMaskBelowFirstLabel` — lower `state-mask-fill` BENEATH the first
+ *      basemap label (`symbol`) layer so `within`-filtered INTERIOR labels
+ *      render ON TOP of the gray (whole, overhang onto the gray included) — the
+ *      "isolate mode" of the v3 mockup; repairs the interior-label-clipping
+ *      regression where a near-border label was sliced by the opaque mask.
+ *   2. `sinkStrayLayersBelowMask` — move stray basemap fill/line layers painted
+ *      ABOVE the mask beneath it (coastlines, boundaries) so nothing bleeds.
+ *   3. `addFloatLayers` — halo + crisp outline ABOVE the mask. The crisp outline
+ *      remains a clear top edge regardless of where the mask now sits.
+ *
+ * Step 1 runs FIRST: the float/sink anchors derive from the mask's NEW position
+ * in the layer array, and the stray-sink only needs to act on fill/line layers
+ * that end up above the lowered mask. Moving the mask first means the
+ * subsequent `getStyle().layers` reads reflect the final mask index.
  */
 export function applyArtboardFidelity(
   map: ArtboardMap,
   maskPolygon: MultiPolygon,
   theme: 'light' | 'dark',
 ): void {
+  moveMaskBelowFirstLabel(map, MASK_LAYER_ID);
   sinkStrayLayersBelowMask(map, MASK_LAYER_ID);
   addFloatLayers(map, maskPolygon, MASK_LAYER_ID, theme);
 }


### PR DESCRIPTION


## Diagrams

Layer z-order at `?state=US-DC`, before vs. after this fix. The mask `<Layer id="state-mask-fill">` (#762) has no `beforeId`, so react-map-gl appends it above the whole basemap. #763 sank `fill`/`line` strays below it but never `symbol`, leaving the basemap label layers BENEATH the mask — so an interior label overhanging the (server-clipped) border was sliced by the opaque gray. The fix lowers the mask below the first basemap label layer.

```mermaid
graph TB
    subgraph BEFORE["BEFORE (bug): mask above labels"]
        b_obs["observation / cluster layers"]
        b_mask["state-mask-fill (opaque gray)"]
        b_label["basemap label/symbol layers ← SLICED by gray"]
        b_base["basemap fill/line"]
        b_obs --> b_mask --> b_label --> b_base
    end
    subgraph AFTER["AFTER (fix): mask below first label"]
        a_obs["observation / cluster layers"]
        a_float["state-artboard-halo + crisp outline"]
        a_label["basemap label/symbol layers ← render WHOLE on the gray"]
        a_mask["state-mask-fill (opaque gray)"]
        a_base["basemap fill/line (sunk strays)"]
        a_obs --> a_float --> a_label --> a_mask --> a_base
    end
```

## Summary

- **Why:** post-#763 regression, maintainer-confirmed live on prod — when zoomed in near a state border (e.g. `?state=US-DC` at the Potomac: "Theodore Roosevelt Island", "Columbia Island"; `?state=US-AZ` near Nogales), an INTERIOR-anchored basemap label that overhangs the boundary into the gray was CLIPPED by the opaque inverse-mask fill. Root cause: #762's `state-mask-fill` `<Layer>` has no `beforeId` so it sits above the basemap label layers; #763's `sinkStrayLayersBelowMask` only sinks `fill`/`line`, never `symbol`, so the labels stayed under the mask.
- **Fix (the v3 mockup's "isolate mode"):** new `moveMaskBelowFirstLabel()` lowers `state-mask-fill` BELOW the first basemap label (`symbol`) layer (found via the existing `isIsolatableSymbolLayer` heuristic, which already excludes `source:'observations'` app layers and the `state-artboard-*` floats). Order in `applyArtboardFidelity`: (1) move mask below first label → (2) sink stray fill/line → (3) add halo + crisp outline. Re-applied from the `maskPolygon` effect AND, via the `styleEpoch` bump, the `style.load` path, so it survives theme swaps with no "Cannot move layer" throw. The `within` isolation is unchanged; exterior labels stay removed.
- **Also widened `SYMBOL_NAME_PATTERN`** so the `within`-isolation covers the LIGHT (positron) basemap ids the `_name`-only form silently missed — hyphenated `-name-` road labels (`highway-name-*`), plus `shield`/`airport` tokens (`road_shield_us`, `highway-shield-*`, `airport`). Without this, once the mask dropped below the labels, VA-side freeway/shield names bled onto the gray. `road_oneway` arrow layers stay excluded (no label-bearing token).

## Screenshots

**Before / after — `?state=US-DC`, zoomed in at the Potomac/VA border (z 15.5, light), same framing.** In BEFORE the mask sits above the labels, so the "COLUMBIA ISLAND" + "Mount Vernon Trail" labels that overhang the boundary are sliced/covered by the gray. In AFTER the mask sits below the first basemap label layer, so those interior labels render WHOLE on the gray; the crisp outline still traces the edge and exterior labels stay removed.

| BEFORE (bug — mask above labels, interior labels clipped) | AFTER (fix — mask below labels, interior labels whole) |
| --- | --- |
| <img width="500" src="https://github.com/user-attachments/assets/d6b4535a-773f-4b0a-8801-49834becd4b4"> | <img width="500" src="https://github.com/user-attachments/assets/4057d3e2-d055-4003-be91-7f103ece7edc"> |

**AZ border (Nogales) — exterior MX labels stay off the gray, interior AZ labels + shields render whole.**

<img width="700" src="https://github.com/user-attachments/assets/b80b5315-a571-4a28-9b6b-26c320d19d11">

**Canonical 5 viewports × 2 themes (`?state=US-DC`, zoomed in at the border).** Interior labels render whole at every size; exterior labels gone; theme-swap re-applies the move with a clean console.

| Viewport | Light | Dark |
| --- | --- | --- |
| 390×844 | <img width="360" src="https://github.com/user-attachments/assets/0085f22b-9d6a-4e1a-8ddf-85b6b63c6bd7"> | <img width="360" src="https://github.com/user-attachments/assets/eac14365-776a-4aa6-8b6f-0527b407e41c"> |
| 768×1024 | <img width="360" src="https://github.com/user-attachments/assets/a16c08cb-cb5b-4241-90cf-d334b7ff5053"> | <img width="360" src="https://github.com/user-attachments/assets/10977c3a-d286-4d54-8c07-97b669baea9d"> |
| 1024×768 | <img width="360" src="https://github.com/user-attachments/assets/6f7a8298-55f1-46a1-8b31-aa2f79b5aa95"> | <img width="360" src="https://github.com/user-attachments/assets/cf922285-f38b-495b-a7af-77424c45091d"> |
| 1440×900 | <img width="360" src="https://github.com/user-attachments/assets/ac69126f-bfc8-41dc-b90b-9b032c8cd5d5"> | <img width="360" src="https://github.com/user-attachments/assets/309a2bd7-1987-49fa-be75-7445f3321fc8"> |
| 1920×1080 | <img width="360" src="https://github.com/user-attachments/assets/440c86f6-1f56-4854-892d-4289fb413789"> | <img width="360" src="https://github.com/user-attachments/assets/b8c64295-4f17-4c62-89a7-32fe5c0991f1"> |

## Test plan

- [x] `npm run typecheck && npm run test` — green (frontend 1029, read-api 165, ingestor 211, + db-client integration; `artboard-layers.test.ts` 31 + `MapCanvas.test.tsx` 59)
- [x] New unit / integration tests added — `moveMaskBelowFirstLabel` (mask lands below first symbol; interior labels above mask; fail-open guards), `applyArtboardFidelity` move-runs-first, MapCanvas wiring assertion, and light-basemap heuristic cases
- [x] No new Playwright e2e spec — z-order fix is unit-covered; the existing artboard e2e suite (#764) still passes
- [x] `npm run build` — clean production build
- [x] (UI only) Playwright MCP smoke — drove `?state=US-DC` (Potomac) and `?state=US-AZ` (Nogales) at all 5 canonical viewports × light + dark; `window.__birdMap` confirms `state-mask-fill` now sits BELOW all basemap label layers; interior labels render whole, exterior labels gone, theme-swap throws nothing, console clean (only the accepted `wood-pattern` basemap warning)
- [x] `npx knip` — no new findings · `npx tsc -p frontend/tsconfig.test.json` — 109 (baseline, no net-new)

## Plan reference

Out of plan — hotfix for a post-#763 interior-label-clipping regression in the state-artboard feature (epic #760; #762 mask render, #763 fidelity).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
