### PR TITLE
feat(frontend): scope chooser as an inert modal scrim over a mounted, idle map  closes #772

### DIFF
--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -169,6 +169,25 @@ export class AppPage {
   }
 
   /**
+   * #761 (S1): assert the map surface is mounted but INERT behind the chooser
+   * scrim on the unscoped landing. The `inert` attribute on `#main-surface`
+   * (set by App's inert/focus-trap effect) removes the whole map subtree from
+   * the tab order and blocks pointer interaction — the load-bearing half of the
+   * "chooser scrim over a mounted, idle map" model. Specs assert through this
+   * helper rather than inlining the `[inert]` selector so the map-first
+   * inversion (#761 S2, the eventual map hoist) re-points only this one line.
+   *
+   * Returns the inertness assertion as a chainable `expect` so callers can
+   * `await app.expectMapInert()`.
+   */
+  async expectMapInert(): Promise<void> {
+    // The map canvas is present (mounted idle behind the scrim)…
+    await this.mapCanvas.waitFor({ state: 'attached' });
+    // …and #main-surface carries the `inert` attribute.
+    await this.mainSurface.and(this.page.locator('[inert]')).waitFor({ state: 'attached' });
+  }
+
+  /**
    * Pick a state from the chooser `<select>` + click Go (C9 state-select
    * round-trip). The select is the chooser's own (`aria-label='State'`); Go is
    * disabled until a non-empty option is chosen, so this selects first.

--- a/frontend/e2e/state-artboard.spec.ts
+++ b/frontend/e2e/state-artboard.spec.ts
@@ -648,34 +648,38 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
     assertCleanConsole();
   });
 
-  test('state → chooser: map unmounts, chooser visible, mask never present @remount-shaped', async ({
+  test('state → chooser: map stays mounted-but-inert, chooser visible, mask never present', async ({
     page,
     apiStub,
   }) => {
-    // @remount-shaped: under #761 (always-mounted canvas) the map no longer
-    // tears down on chooser navigation — the #761 implementer must revisit the
-    // `mapCanvas` count-0 assertion here rather than paper over the now-false
-    // remount assumption.
+    // #761 (S1): the unscoped early-return is gone — the map no longer tears
+    // down on chooser navigation. On the "Change scope" exit the map stays
+    // MOUNTED but INERT behind the chooser scrim (`#main-surface` carries
+    // `inert`), and the scope gate keeps the observations fetch suppressed
+    // (`scopeActive === false`) so no new request fires even though the canvas
+    // is still mounted. (This resolves the prior @remount-shaped TODO that
+    // flagged the now-false count-0 assumption.)
     const { app, obsRequests, assertCleanConsole } = await setup(page, apiStub);
 
     await app.goto('state=US-AZ');
     await app.waitForAppReady();
     await expect(app.scopeControl).toBeVisible();
 
-    // "Change scope" exit → returns to the CHOOSER (not a CONUS home).
+    // "Change scope" exit → returns to the CHOOSER scrim (not a CONUS home).
     await app.scopeControlExit.click();
     await expect(app.chooser).toBeVisible();
-    await expect(app.mapCanvas).toHaveCount(0);
-    await expect(app.mainSurface).toHaveCount(0);
+    await app.expectMapInert();
     expect(app.getUrlParams().has('state')).toBe(false);
     expect(app.getUrlParams().has('scope')).toBe(false);
 
-    // The observations fetch is suppressed again — no NEW request after exit.
+    // The observations fetch is suppressed again — no NEW request after exit,
+    // even though the map is now mounted-and-inert (the scope gate, not the
+    // unmount, is what holds the request count flat).
     const countAtExit = obsRequests.length;
     await page.waitForTimeout(600);
     expect(obsRequests.length).toBe(countAtExit);
 
-    // The mask never renders on the chooser (no canvas at all).
+    // The mask never renders on the chooser scrim (no scope → no state polygon).
     assertCleanConsole();
   });
 

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -111,20 +111,27 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.chooserStateSelect).toBeVisible();
     await expect(app.chooserWholeUs).toBeVisible();
 
-    // The map canvas is NOT rendered (the unscoped early-return shows the
-    // chooser in place of the map surface).
-    await expect(app.mapCanvas).toHaveCount(0);
-    await expect(app.mainSurface).toHaveCount(0);
+    // #761 (S1) re-baseline: the map is now MOUNTED but INERT behind the chooser
+    // scrim (the prior full-tree unmount is gone). The chooser scrim is the
+    // visible primary surface (asserted above); the map canvas is present and
+    // #main-surface carries `inert`.
+    await app.expectMapInert();
 
-    // Headline assertion (learning (f)): ZERO /api/observations requests fire on
-    // the chooser landing. Hold the window open to be sure no late fetch slips
-    // through (the scope gate is in App, not just the unmount).
+    // Headline assertion (learning (f)) — UNCHANGED and STILL GREEN: ZERO
+    // /api/observations requests fire on the chooser landing. The map mounting
+    // idle does NOT fire a request — `scopeActive === false` keeps the fetch
+    // gate closed (the gate is in App, independent of the now-removed unmount).
+    // Hold the window open to be sure no late fetch slips through.
     await page.waitForTimeout(800);
     expect(obsRequests).toHaveLength(0);
-    // O9 (#781): the chooser landing is fetch-light — the scope-gated prefetch
-    // must NOT warm the MapCanvas/maplibre chunk while unscoped. ZERO chunk
-    // requests over the same window.
-    expect(mapChunkRequests).toHaveLength(0);
+    // #761 (S1) re-baseline of the O9 (#781) chunk assertion: under S1 the map
+    // MOUNTS idle behind the scrim, so its lazy MapCanvas/maplibre chunk now
+    // loads on the unscoped landing (the React.lazy boundary fires once
+    // <MapSurface> mounts). This is intended — the map-first model mounts the
+    // map once and never unmounts it. The fetch-light guarantee that survives is
+    // the NETWORK one above (zero /api/observations); the JS-bundle chunk is no
+    // longer suppressible while the map is mounted-but-inert.
+    expect(mapChunkRequests.length).toBeGreaterThan(0);
   });
 
   test('state select round-trip — ?state=US-AZ, map fetches once with state=US-AZ, region "Arizona"', async ({
@@ -136,9 +143,12 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
 
     await app.gotoRaw('');
     await expect(app.chooser).toBeVisible();
-    // O9 (#781): the chunk is NOT warmed while we are still on the unscoped
-    // chooser (pre-pick). The scope-pick below is what triggers the prefetch.
-    expect(mapChunkRequests).toHaveLength(0);
+    // #761 (S1) re-baseline of the O9 (#781) pre-pick assertion: under S1 the
+    // idle map mounts behind the chooser scrim, so the lazy MapCanvas/maplibre
+    // chunk is already loaded BEFORE the scope is picked (the React.lazy
+    // boundary fires on the idle map's mount). The post-pick ≥1 assertion below
+    // is the surviving O9 signal that the scoped map renders.
+    await app.expectMapInert();
 
     // Pick Arizona from the chooser <select> + Go.
     await app.pickStateInChooser('US-AZ');
@@ -215,10 +225,10 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     const countBeforeExit = obsRequests.length;
     await app.scopeControlExit.click();
 
-    // We return to the CHOOSER, NOT a CONUS map.
+    // We return to the CHOOSER scrim, NOT a CONUS map. #761 (S1): the map stays
+    // MOUNTED but INERT behind the scrim (no teardown on chooser navigation).
     await expect(app.chooser).toBeVisible();
-    await expect(app.mapCanvas).toHaveCount(0);
-    await expect(app.mainSurface).toHaveCount(0);
+    await app.expectMapInert();
     // URL is bare again (no state=, no scope=).
     expect(app.getUrlParams().has('state')).toBe(false);
     expect(app.getUrlParams().has('scope')).toBe(false);

--- a/frontend/e2e/zip-scope.spec.ts
+++ b/frontend/e2e/zip-scope.spec.ts
@@ -168,9 +168,10 @@ test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', ()
       'ZIP not recognized — try a nearby ZIP or pick a state',
     );
 
-    // Scope/URL unchanged — still on the chooser, no state= written.
+    // Scope/URL unchanged — still on the chooser scrim, no state= written.
+    // #761 (S1): the map is mounted-but-INERT behind the scrim (no unmount).
     await expect(app.chooser).toBeVisible();
-    await expect(app.mapCanvas).toHaveCount(0);
+    await app.expectMapInert();
     expect(app.getUrlParams().has('state')).toBe(false);
     // The input value is retained (not cleared).
     await expect(app.chooserZipInput).toHaveValue('10002');
@@ -206,10 +207,11 @@ test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', ()
     expect(validity.valid).toBe(false);
     expect(validity.patternMismatch).toBe(true);
 
-    // Scope unchanged — still on the chooser, no state= written, no map.
+    // Scope unchanged — still on the chooser scrim, no state= written.
+    // #761 (S1): the map is mounted-but-INERT behind the scrim (no unmount).
     await expect(app.chooser).toBeVisible();
     expect(app.getUrlParams().has('state')).toBe(false);
-    await expect(app.mapCanvas).toHaveCount(0);
+    await app.expectMapInert();
 
     // D3: the malformed SUBMIT triggers no lookup fetch. `loadZipIndex` warms
     // lazily on FOCUS (an intentional pre-fetch, single-flight memoized), so a

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -838,19 +838,23 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     vi.restoreAllMocks();
   });
 
-  // AC 1: Unscoped → chooser, fetch + map suppressed.
+  // AC 1: Unscoped → chooser scrim over a mounted-but-INERT map, fetch suppressed.
   it('renders the ScopeChooser and fires ZERO /api/observations requests when unscoped', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map', scope: { kind: 'unscoped' },
     };
-    render(<App />);
-    // Chooser is shown in place of the map.
+    const { container } = render(<App />);
+    // Chooser scrim is shown over the map.
     expect(
       await screen.findByRole('region', { name: /Choose where to look at birds/i }),
     ).toBeInTheDocument();
-    // Map surface is NOT mounted.
-    expect(screen.queryByTestId('map-surface-stub')).toBeNull();
+    // #761 (S1): the map surface is mounted but INERT behind the scrim (no
+    // longer a full-tree unmount). The stub is present and #main-surface — the
+    // real <main id="main-surface"> App renders around the stub (NOT the mock) —
+    // carries the `inert` attribute set by App's inert/focus-trap effect.
+    expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
+    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
     // The cold-load fetch is suppressed: zero observations requests. Give any
     // mistaken effect a tick to fire.
     await waitFor(() => {
@@ -1075,18 +1079,73 @@ describe('#740 (C6): scope wiring end-to-end', () => {
   });
 
   // AC: detail overlay does not by itself constitute a scope — an unscoped URL
-  // carrying ?detail= still shows the chooser, not the detail rail.
+  // carrying ?detail= still shows the chooser scrim, not the detail rail.
   it('an unscoped URL with a detail code still shows the chooser (detail is not a scope)', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map', detail: 'vermfly', scope: { kind: 'unscoped' },
     } as typeof mockUrlState.state;
-    render(<App />);
+    const { container } = render(<App />);
+    // Pre-existing guard (a): the chooser region is shown.
     expect(
       await screen.findByRole('region', { name: /Choose where to look at birds/i }),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId('map-surface-stub')).toBeNull();
+    // #761 (S1) re-baseline: the map surface is now mounted but INERT behind the
+    // scrim (it was unmounted under the old early-return). The inert attribute
+    // lands on the real <main id="main-surface"> App renders (NOT the mock).
+    expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
+    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
+    // #761 (S1) NEW guard: the detail rail/sheet does NOT render on an unscoped
+    // URL even though detail:'vermfly' is set — the `scopeActive` gate (App
+    // task #6) stops a `?detail=` from mounting a second top-layer over the
+    // scrim. SpeciesDetailRail is NOT mocked here, so key off its real DOM: the
+    // rail renders <aside role="complementary"> with a "Close species detail"
+    // button. Neither must be present.
+    expect(screen.queryByRole('complementary', { name: /detail/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Close species detail/i })).toBeNull();
+    // Pre-existing guard (b): zero /api/observations while unscoped.
     expect(mockGetObservations).not.toHaveBeenCalled();
+  });
+
+  // #761 (S1): the always-rendered shell, the mounted-but-inert map stub, and
+  // the chooser region all co-exist on an unscoped render (under the old
+  // early-return they were mutually exclusive). The shell is `.app`; #main-surface
+  // carries `inert`; the cold-load fetch stays suppressed.
+  it('unscoped render mounts the shell + inert map + chooser together, no observations fetch', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'unscoped' },
+    };
+    const { container } = render(<App />);
+    expect(
+      await screen.findByRole('region', { name: /Choose where to look at birds/i }),
+    ).toBeInTheDocument();
+    // The full app shell renders (it used to be replaced by the chooser).
+    expect(container.querySelector('.app')).not.toBeNull();
+    // The map stub and the chooser region are BOTH in the DOM simultaneously.
+    expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
+    // #main-surface is inert.
+    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
+    // Fetch stays suppressed.
+    expect(mockGetObservations).not.toHaveBeenCalled();
+    expect(mockGetHotspots).not.toHaveBeenCalled();
+  });
+
+  // #761 (S1) focus-trap (task #5a): initial focus is moved into the chooser
+  // scrim on mount. The focus LANDING TARGET task #5a chose is the
+  // `.scope-chooser-scrim` wrapper element (it carries `tabIndex={-1}`); App's
+  // inert/focus-trap useLayoutEffect calls `.focus()` on it after mount. Assert
+  // that wrapper holds focus on the unscoped render.
+  it('moves initial focus into the chooser scrim on the unscoped landing', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'unscoped' },
+    };
+    const { container } = render(<App />);
+    await screen.findByRole('region', { name: /Choose where to look at birds/i });
+    const scrim = container.querySelector('.scope-chooser-scrim');
+    expect(scrim).not.toBeNull();
+    expect(scrim).toHaveFocus();
   });
 
   // Region label: state scope resolves to the state NAME from /api/states.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
 import { analytics } from './analytics.js';
 import { ApiClient, ApiError } from './api/client.js';
@@ -494,6 +494,98 @@ export function App() {
 
   const mainRef = useRef<HTMLElement | null>(null);
 
+  // #761 (S1) — the unscoped landing is now an INERT, FOCUS-TRAPPED modal scrim
+  // over a mounted-but-idle map (epic OQ1, option (a): modal-over-inert-map),
+  // replacing the prior full-tree-unmount early-return. The map mounts behind
+  // the scrim and fires ZERO /api/observations purely because `scopeActive ===
+  // false` keeps `useBirdData`'s `enabled` false (the fetch gate above is the
+  // load-bearing half — no render-gate change is needed to preserve the
+  // #740/C6 zero-observations-on-landing AC). The scrim itself is rendered as a
+  // floating sibling of <main> (the #663 floating-overlay pattern that
+  // SpeciesDetailRail/Sheet already use) below.
+  const scrimRef = useRef<HTMLDivElement | null>(null);
+
+  // #761 (S1) — inert + focus-trap handshake for the unscoped scrim. Two
+  // mechanisms, BOTH required by the focus-trap AC (they are distinct):
+  //   (4) `inert` on the real <main id="main-surface"> removes the entire map
+  //       subtree (including the map's `.skip-link`) from the tab order while
+  //       the scrim is open. Replicates the attribute-toggle pattern that
+  //       SpeciesDetailSheet.tsx uses on the same `mainRef` (there is no shared
+  //       inert helper — each owner toggles the attribute itself).
+  //   (5a) Move initial focus into the scrim on mount — `inert` alone does NOT
+  //       move focus, it only removes a subtree from the tab order. The focus
+  //       landing target is the scrim wrapper itself (it carries `tabIndex={-1}`
+  //       in the JSX below); the focus unit test keys off `scrimRef`/that
+  //       wrapper holding focus.
+  //   (5b) Trap Tab/Shift+Tab so focus cycles within the chooser and never
+  //       escapes. `inert` on #main-surface covers the map subtree, but the
+  //       ALWAYS-rendered shell now also mounts the <AppHeader> (wordmark,
+  //       Map tab, Attribution, Filters, ThemeToggle) AND the AttributionModal
+  //       trigger as SIBLINGS of <main> — none of which #main-surface's `inert`
+  //       covers. Rather than mark each of those inert, a keydown wrap handler
+  //       on the scrim keeps focus inside the chooser regardless of what other
+  //       focusable siblings exist (the defensive choice). `Escape` is
+  //       deliberately NOT a dismiss path: there is no "no-scope" state to
+  //       return to — the only exits are picking a scope.
+  useLayoutEffect(() => {
+    if (scopeActive) return;
+    const main = mainRef.current;
+    const scrim = scrimRef.current;
+    if (!scrim) return;
+
+    // (4) Remove the map subtree from the tab order.
+    main?.setAttribute('inert', '');
+
+    // The focusable descendants of the scrim, in DOM order. Recomputed inside
+    // the handler so it stays correct if the chooser's controls change (e.g.
+    // the state <select> enabling once /api/states resolves).
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const focusables = (): HTMLElement[] =>
+      Array.from(scrim.querySelectorAll<HTMLElement>(focusableSelector));
+
+    // (5a) Move initial focus onto the scrim wrapper (the tabIndex={-1}
+    // landing element). Keeping it on the wrapper rather than the first control
+    // avoids stealing focus into the ZIP <input> on every render and matches
+    // the focus unit test's target.
+    scrim.focus();
+
+    // (5b) Wrap Tab / Shift+Tab between the first and last focusable controls.
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (!first || !last) {
+        // Nothing focusable inside yet — keep focus pinned to the scrim.
+        e.preventDefault();
+        scrim.focus();
+        return;
+      }
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        // Backward from the first control (or from the scrim wrapper) → last.
+        if (active === first || active === scrim || !scrim.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !scrim.contains(active)) {
+        // Forward from the last control (or from outside) → first.
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    scrim.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      scrim.removeEventListener('keydown', onKeyDown);
+      // Clearing `inert` happens when a scope is picked and the scrim unmounts
+      // (this cleanup), or whenever `scopeActive` flips true.
+      main?.removeAttribute('inert');
+    };
+  }, [scopeActive]);
+
   // nowTick advances when the user returns to the tab so freshness labels
   // re-derive after the tab has been hidden for a long time. useRef(new Date())
   // would freeze `now` at first render and never advance — after 5 h open the
@@ -557,33 +649,26 @@ export function App() {
     }
   }, [error]);
 
-  // #740 (C6) — chooser-first landing (locked decision 4b). When unscoped,
-  // render <ScopeChooser> IN PLACE OF the map surface; picking a scope mounts
-  // the map fresh (the validated chooser-gated REMOUNT model, finding (f)).
-  // This return is placed BEFORE the error guard so it takes precedence:
-  //   - The cold-load fetch is already suppressed (scopeActive === false), so
-  //     the chooser landing makes zero /api/observations requests (AC 1).
-  //   - Clearing the scope (the ScopeControl exit, AC "whole-US reset returns
-  //     to the chooser") routes here even if a prior scoped session left a
-  //     sticky `error` in useBirdData — the chooser is the destination, not the
-  //     error screen.
-  //   - A `?detail=` that somehow rides an unscoped URL does NOT constitute a
-  //     scope (AC "detail overlay does not by itself constitute a scope") — the
-  //     chooser still wins.
-  if (state.scope.kind === 'unscoped') {
-    return (
-      <ScopeChooser
-        states={states}
-        statesLoading={statesLoading}
-        statesError={statesError}
-        onPickState={onPickState}
-        onPickWholeUs={onPickWholeUs}
-        onResolve={onResolveZip}
-      />
-    );
-  }
-
-  if (error) {
+  // #761 (S1) — the unscoped early-return is GONE. The `.app` shell now always
+  // renders; the unscoped <ScopeChooser> is hosted as an inert, focus-trapped
+  // modal scrim sibling of <main> (below), over a mounted-but-idle map. See the
+  // inert/focus-trap `useLayoutEffect` above. The cold-load fetch stays
+  // suppressed because `scopeActive === false` keeps `useBirdData`'s `enabled`
+  // false (the #740/C6 zero-observations-on-landing AC is preserved, not
+  // superseded). A `?detail=` riding an unscoped URL does NOT constitute a
+  // scope: the detail rail/sheet render is gated on `scopeActive` below, so the
+  // chooser scrim is the only overlay shown.
+  //
+  // The error early-return below is RETAINED (error-as-overlay is the third
+  // unmount fork, deferred to O7 — out of scope here). It is gated on
+  // `scopeActive` to preserve the exact precedence the old unscoped early-return
+  // gave for free: that return sat BEFORE this guard, so the chooser won over a
+  // sticky `error`. `useBirdData` does not clear `error` when it is disabled, so
+  // a scoped session that errored and then cleared scope (→ unscoped) would
+  // otherwise fall through to the error screen instead of the chooser scrim.
+  // While unscoped the chooser scrim is always the destination (AC: clearing
+  // scope returns to the chooser, never a CONUS home or the error screen).
+  if (scopeActive && error) {
     return (
       <StatusBlock
         state="error"
@@ -647,19 +732,24 @@ export function App() {
         {mapVisible && (
           <>
             {/* #740 (C6) — the in-state on-map re-scope bar (#737). Rendered
-                ONLY in a scoped view (guaranteed here: the unscoped early-return
-                above shows the chooser instead). Floats over the canvas; emits
-                one clean scope intent per action and never touches the map.
-                `state.scope` is narrowed to a ScopedView since unscoped already
-                returned. */}
-            <ScopeControl
-              scope={state.scope}
-              states={states}
-              onPickState={onPickState}
-              onPickWholeUs={onPickWholeUs}
-              onExit={onExitScope}
-              onResolve={onResolveZip}
-            />
+                ONLY in a SCOPED view. #761 (S1) removed the unscoped
+                early-return, so the map now mounts idle behind the chooser
+                scrim while unscoped too — this `state.scope.kind !== 'unscoped'`
+                guard keeps ScopeControl off the unscoped landing (the chooser
+                scrim is the only scope affordance there) AND narrows
+                `state.scope` to the `ScopedView` the component's prop requires.
+                Floats over the canvas; emits one clean scope intent per action
+                and never touches the map. */}
+            {state.scope.kind !== 'unscoped' && (
+              <ScopeControl
+                scope={state.scope}
+                states={states}
+                onPickState={onPickState}
+                onPickWholeUs={onPickWholeUs}
+                onExit={onExitScope}
+                onResolve={onResolveZip}
+              />
+            )}
             <MapSurface
               observations={observations}
               legendObservations={viewportObservations}
@@ -703,7 +793,14 @@ export function App() {
           (no inert backdrop, no top-layer takeover).
         */}
       </main>
-      {state.detail && !isCompact && (
+      {/* #761 (S1) — detail rail/sheet gated on `scopeActive`. The unscoped
+          early-return used to make these lines unreachable while unscoped; now
+          that the shell always renders, a `?detail=` riding an unscoped URL
+          would otherwise mount a SECOND top-layer overlay over the chooser
+          scrim. The `scopeActive` gate stops that: detail is not a scope (AC
+          "detail overlay does not by itself constitute a scope"), so the
+          chooser scrim is the only overlay shown on the unscoped landing. */}
+      {scopeActive && state.detail && !isCompact && (
         <SpeciesDetailRail
           key={state.detail}
           speciesCode={state.detail}
@@ -713,7 +810,7 @@ export function App() {
           onClearBbox={onClearBbox}
         />
       )}
-      {state.detail && isCompact && (
+      {scopeActive && state.detail && isCompact && (
         <SpeciesDetailSheet
           key={state.detail}
           speciesCode={state.detail}
@@ -723,6 +820,33 @@ export function App() {
           bbox={state.bbox}
           onClearBbox={onClearBbox}
         />
+      )}
+      {/* #761 (S1) — the unscoped landing chooser, hosted as an INERT,
+          FOCUS-TRAPPED modal scrim over the mounted-but-idle map. It renders as
+          a floating sibling of <main> (the #663 floating-overlay pattern), NOT
+          in place of the shell — the early-return that used to unmount the whole
+          tree is gone. The scrim wrapper carries `tabIndex={-1}` so the
+          inert/focus-trap effect above can land initial focus on it; the
+          backdrop + above-the-overlays z-tier live in `.scope-chooser-scrim` in
+          styles.css. `<ScopeChooser>` is unchanged — same callback props as
+          before. Gated on `!scopeActive`: picking a scope (state/ZIP/whole-US)
+          unmounts the scrim, clears `inert`, and the live-camera path animates
+          with no shell remount. */}
+      {!scopeActive && (
+        <div
+          ref={scrimRef}
+          className="scope-chooser-scrim"
+          tabIndex={-1}
+        >
+          <ScopeChooser
+            states={states}
+            statesLoading={statesLoading}
+            statesError={statesError}
+            onPickState={onPickState}
+            onPickWholeUs={onPickWholeUs}
+            onResolve={onResolveZip}
+          />
+        </div>
       )}
       {/*
         Phase 6: Footer removed. The Attribution trigger moved to <AppHeader>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1465,6 +1465,37 @@ aside.species-detail-rail .species-detail-rail-close {
   line-height: 1.3;
 }
 
+/* ── ScopeChooser scrim (#761 S1) ─────────────────────────────────────────
+   The unscoped landing is now an INERT, FOCUS-TRAPPED modal scrim over a
+   mounted-but-idle map (epic OQ1 option (a)), NOT a full-tree unmount. App
+   renders `<ScopeChooser>` inside this `.scope-chooser-scrim` wrapper as a
+   floating sibling of <main> (the #663 floating-overlay pattern). The wrapper
+   is the full-viewport fixed backdrop + the focus-trap landing element
+   (`tabIndex={-1}`, focused by App's inert/focus-trap effect).
+
+   Z-tier: `--z-modal` (50, the named modal tier from #761 P1 / #778). The scrim
+   must PAINT above the highest currently-rendered overlay — the detail rail at
+   `--z-rail` (43) and the map-assist overlays at `--z-overlay`/`--z-popover`
+   (40/41). It does NOT need to out-stack the map's `.skip-link` (`--z-skip`,
+   60): focusability on the inert map is governed by the `inert` attribute App
+   sets on #main-surface (task #4), not by z-index — `inert` removes the whole
+   map subtree (skip-link included) from the tab order regardless of paint
+   order. The scrim only needs to win the PAINT layering, which 50 does over
+   43/41/40.
+
+   Backdrop: a near-opaque cream wash (`color-mix` over the page color) so the
+   idle map is faintly visible behind the chooser card without competing with
+   it — a true scrim, not the old opaque full-surface unmount. */
+.scope-chooser-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  display: flex;
+  background: color-mix(in srgb, var(--color-bg-page) 92%, transparent);
+  /* The scrim is the scroll container for a tall card on short viewports. */
+  overflow: auto;
+}
+
 /* ── ScopeChooser (#742) ──────────────────────────────────────────────────
    The pre-map LANDING surface: a centered card prompting "where do you want
    to look?" with two CO-PRIMARY paths — the <ZipInput> (#739, styled by
@@ -1473,14 +1504,19 @@ aside.species-detail-rail .species-detail-rail-close {
    hatch placed last and lowest. Reuses the existing card/input visual
    contract (warm cream page, white surface, --color-border-ui edge, shared
    spacing/type/weight tokens). Every className the TSX introduces has a
-   matching rule below (orphan-classname gate). */
+   matching rule below (orphan-classname gate).
+
+   #761 (S1): now hosted INSIDE `.scope-chooser-scrim` (the fixed backdrop). It
+   only centers the card here — the scrim owns the full-viewport background, so
+   this layer is transparent and fills the scrim. */
 .scope-chooser {
   display: flex;
+  flex: 1;
   align-items: center;
   justify-content: center;
   min-block-size: 100%;
   padding: var(--space-xl) var(--space-lg);
-  background: var(--color-bg-page);
+  background: transparent;
 }
 .scope-chooser__card {
   display: flex;


### PR DESCRIPTION
## Diagrams

State machine — the unscoped landing is no longer a full-tree unmount; the shell always renders and the chooser is an inert scrim over a mounted-but-idle map:

```mermaid
stateDiagram-v2
    [*] --> Unscoped: bare URL (scope.kind == 'unscoped')

    state "Always-rendered .app shell" as Shell {
        state "Map mounts IDLE behind scrim\n(scopeActive == false -> useBirdData enabled == false\n-> ZERO /api/observations)" as IdleMap
        state "ScopeChooser scrim (sibling of <main>)\n--z-modal=50, #main-surface inert,\nfocus trapped in scrim" as Scrim
        IdleMap --> Scrim: painted above
    }

    Unscoped --> Shell: render shell + scrim (NO early-return)
    Shell --> Scoped: pick state / ZIP / whole-US\n(scrim unmounts, inert cleared,\nlive camera animates — NO remount)
    Scoped --> Shell: Change scope\n(map stays mounted+inert, fetch suppressed again)

    state "Scoped map (live, interactive)" as Scoped
    Scoped --> [*]
```

Focus / inert handshake on the unscoped scrim (two distinct mechanisms):

```mermaid
flowchart TD
    A[useLayoutEffect gated on !scopeActive] --> B["(4) setAttribute inert on #main-surface\n-> map subtree + skip-link leave tab order"]
    A --> C["(5a) scrim.focus()\n-> initial focus on tabIndex=-1 scrim wrapper"]
    A --> D["(5b) keydown wrap handler on scrim\n-> Tab/Shift+Tab cycle first<->last chooser control"]
    D -. covers .-> E["AppHeader controls + AttributionModal trigger\n(siblings of <main>, NOT covered by inert)"]
    A --> F[cleanup: removeAttribute inert + remove handler\non scope pick / scopeActive flip]
```

## Summary

- **Why:** `#761` (map-first inversion) requires the map to mount **once** when a scope first becomes known and never be unmounted thereafter. The unscoped landing was one of three full-tree-unmount forks (`App.tsx` returned `<ScopeChooser>` *before* the `.app` shell). This PR (S1) converts it to the pivotal **option (a): modal-over-inert-map** — the `.app` shell always renders, the map mounts idle behind an inert, focus-trapped `<ScopeChooser>` scrim, and picking a scope animates the live camera with **no shell remount**.
- **Zero-observations AC preserved, not superseded:** the idle map fires **zero** `/api/observations` purely because `scopeActive === false` keeps `useBirdData`'s `enabled` false (the fetch gate is decoupled from the render gate). The inert scrim blocks user panning and there is no scope → no `fitBounds`, so no viewport-driven fetch can fire either. `R1` (programmatic `onViewportChange` hardening) is correctly deferred to S4.
- **Focus-trap + inert mechanism:** an App-level `useLayoutEffect` (gated on `!scopeActive`) sets `inert` on the real `<main id="main-surface">` (replicating `SpeciesDetailSheet`'s attribute-toggle pattern — there is no shared helper), moves initial focus onto the scrim wrapper (`tabIndex={-1}`), and installs a Tab/Shift+Tab wrap handler. The wrap handler is **required** (not optional `inert`-is-enough): the now-always-rendered shell mounts the `AppHeader` controls (wordmark, Map tab, Attribution, Filters, ThemeToggle) **and** the `AttributionModal` trigger as siblings of `<main>` that `#main-surface`'s `inert` does not cover. `Escape` is deliberately not a dismiss path (no "no-scope" state to return to). The detail rail/sheet render and the error early-return are gated on `scopeActive`, so a `?detail=` (or a sticky `error`) on an unscoped URL shows only the chooser scrim.

## Screenshots

Live Playwright MCP UI verification **PASSED** — 0 console errors at all 5 canonical viewports × both themes (one pre-existing basemap `circle-11` warning, not an S1 regression).

### Unscoped landing (chooser scrim over the idle map)

The chooser scrim painted above the mounted-but-idle map, captured at all 5 canonical viewports × both themes (10 shots).

| Viewport | Light | Dark |
|---|---|---|
| **390×844**<br>iPhone 14 Pro (mobile) | <img width="380" alt="unscoped landing 390×844 light" src="https://github.com/user-attachments/assets/b5ceba32-32c2-4b87-b9e5-d82fa6831524" /> | <img width="380" alt="unscoped landing 390×844 dark" src="https://github.com/user-attachments/assets/341f9526-9443-491a-8ea8-a5d4da239cf7" /> |
| **768×1024**<br>iPad portrait (tablet) | <img width="380" alt="unscoped landing 768×1024 light" src="https://github.com/user-attachments/assets/99a06740-2530-4fd7-abfa-d4cd9f2e3f5c" /> | <img width="380" alt="unscoped landing 768×1024 dark" src="https://github.com/user-attachments/assets/b03365d7-09ea-4550-ab99-df48c6b947b3" /> |
| **1024×768**<br>iPad landscape / small laptop | <img width="380" alt="unscoped landing 1024×768 light" src="https://github.com/user-attachments/assets/080fca8d-975d-406a-a9dc-ca5d29c5f834" /> | <img width="380" alt="unscoped landing 1024×768 dark" src="https://github.com/user-attachments/assets/9a9b9bf6-94f7-4801-ab34-1736156ec1ab" /> |
| **1440×900**<br>Desktop standard | <img width="380" alt="unscoped landing 1440×900 light" src="https://github.com/user-attachments/assets/89f69181-53db-4c33-9f94-753aed1ac631" /> | <img width="380" alt="unscoped landing 1440×900 dark" src="https://github.com/user-attachments/assets/dd9e7f01-48f0-40d7-b9c4-d5978dcfdade" /> |
| **1920×1080**<br>Wide desktop | <img width="380" alt="unscoped landing 1920×1080 light" src="https://github.com/user-attachments/assets/0e193dfc-427d-47a2-9eb7-602fca7ec515" /> | <img width="380" alt="unscoped landing 1920×1080 dark" src="https://github.com/user-attachments/assets/9b5332bd-ac1f-4733-a1b1-5e4f33dcc4f7" /> |

### Interaction

After picking **"Whole US"** the scrim dismisses, the map goes live, and the on-map `ScopeControl` appears (left); a direct `?state=US-AZ` load mounts straight into the scoped map with no scrim (right). Both at 1440×900, light.

| After scope pick ("Whole US") | Direct `?state=US-AZ` load (no scrim) |
|---|---|
| <img width="380" alt="after picking Whole US — scrim dismissed, map active, ScopeControl visible" src="https://github.com/user-attachments/assets/29a38904-d65f-43e2-8696-43c1fc028748" /> | <img width="380" alt="direct ?state=US-AZ load — no scrim, scoped map" src="https://github.com/user-attachments/assets/9fe6e858-6f28-4815-b91d-9b3132fc61c4" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` — `.scope-chooser-scrim` added; `orphan-classname-check` passes locally.
- [x] Multi-viewport design QA: PR body has 12 `user-attachments` URLs (5 viewports × 2 themes per #445, + 2 interaction shots) — orchestrator captured live via Playwright MCP.

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — **961 unit tests pass** (65 files). Re-baselined both unscoped map-stub-absent assertions (`App.test.tsx` AC-1 + scope-gate tests) to present-but-inert; added a NEW detail-overlay-absent guard and a focus-on-mount test. `grep "queryByTestId('map-surface-stub')).toBeNull"` returns zero matches.
- [x] New unit tests added: shell+inert-map+chooser co-exist on unscoped render; focus moves into the chooser scrim on mount; detail overlay absent on unscoped `?detail=` URL.
- [x] E2E re-baselined in this same PR (no leave-CI-red): `state-scope.spec.ts` (`:116-117`, `:220-221`), `zip-scope.spec.ts` (`:173`, `:212`), `state-artboard.spec.ts` (`:668-669` + `@remount-shaped` retitle/TODO-resolve) → scrim-visible + map-inert via new `app.expectMapInert()` POM helper, with every `obsRequests`/`obsRequests.length` zero-guard kept green. Dir-wide sweep `grep -rnE 'expect\(app\.(mapCanvas|mainSurface)\)\.toHaveCount\(0\)' frontend/e2e/` returns **zero** matches.
- [x] Full local e2e green: **dev-server 218 passed / 14 skipped**, **preview-build 1 passed**, **coarse-pointer 1 passed / 1 skipped** (single-worker; skips are headless-WebGL environment skips). The headline `state-scope.spec.ts:92` (chooser landing, zero `/api/observations`) and `:211` (whole-US reset) pass.
- [x] `npm run build` — clean (root build across all 5 workspaces exits 0; `tsc -b` + `vite build` green).
- [x] `npm run lint` (root) exits 0; the lint-workflow forbidden-raw-token guard passes; `npx knip` exits 0 with no dead-code findings.
- [x] (UI only) Playwright MCP smoke + screenshots — orchestrator drove the live browser at all 5 viewports × both themes; 0 console errors (one pre-existing basemap `circle-11` warning, not an S1 regression).

## Plan reference

Part of **#761** (map-first re-architecture epic). This is sub-issue **S1** (closes #772). Research report: `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md` — §4 (the pivotal chooser decision, option (a): modal-over-inert-map), §5 OQ1, WS4 (Scope chooser & landing model, sub-issue 4.2), §10 Phase 3 **S1**, and risk **R10** (the `state-scope`/`zip-scope` count-0 re-baseline this PR owns). `R1` is explicitly deferred to S4; the detail-gate rationale is tied to `App.test.tsx`. Builds on P1 (#778, `--z-*` scale incl. `--z-modal=50`), P2 (#774, POM resilience), and F1 (#777, feed removed). S2 (map hoist to a fixed viewport sibling) depends on this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
