### PR TITLE
feat(frontend): invert app shell to a full-viewport map root  closes #775

### DIFF
--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -68,8 +68,12 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    const trigger = page.locator('button.attribution-trigger');
-    await trigger.click();
+    // #761 (S2): open via the AppHeader "Attribution" button (the live affordance,
+    // fixed chrome on --z-chrome). The standalone `.attribution-trigger` shim now
+    // sits in the `.app` flow BEHIND the full-viewport `#map-layer`, so a direct
+    // pointer click on it is intercepted by the map. The header fires the same
+    // onOpenAttribution → programmatic `.attribution-trigger.click()` shim.
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
     // The dialog has an h2 title.
@@ -80,7 +84,7 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    await page.locator('button.attribution-trigger').click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog.getByRole('heading', { level: 3, name: /bird sightings data/i })).toBeVisible();
     await expect(dialog.getByRole('heading', { level: 3, name: /family silhouettes/i })).toBeVisible();
@@ -91,7 +95,7 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    await page.locator('button.attribution-trigger').click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     // Wait for the seeded Phylopic data to land (it arrives via the
     // /api/silhouettes fetch). At least one row with a creator must
@@ -118,7 +122,7 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    await page.locator('button.attribution-trigger').click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog.getByRole('heading', { level: 3, name: /bird sightings data/i })).toBeVisible();
     // Wait for any phylopic data to land so the assertion sees the full
@@ -135,40 +139,41 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     }
   });
 
-  test('Escape closes the dialog and returns focus to the Credits trigger', async ({ page }) => {
+  test('Escape closes the dialog and returns focus to the opener', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    const trigger = page.locator('button.attribution-trigger');
-    await trigger.click();
+    // #761 (S2): open via the header affordance (the standalone trigger is behind
+    // the full-bleed map). The modal restores focus to `document.activeElement` at
+    // open time — now the header "Attribution" button — so focus-return is asserted
+    // on that button (the live opener), not the occluded `.attribution-trigger`.
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
 
     await page.keyboard.press('Escape');
-    // After Escape, the dialog closes and focus returns to the trigger.
+    // After Escape, the dialog closes and focus returns to the opener.
     await expect(dialog).not.toHaveAttribute('open', '');
-    await expect(trigger).toBeFocused();
+    await expect(app.attributionTrigger).toBeFocused();
   });
 
-  test('close button closes the dialog and returns focus to the Credits trigger', async ({ page }) => {
+  test('close button closes the dialog and returns focus to the opener', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    const trigger = page.locator('button.attribution-trigger');
-    await trigger.click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     const close = dialog.getByRole('button', { name: /close/i });
     await close.click();
     await expect(dialog).not.toHaveAttribute('open', '');
-    await expect(trigger).toBeFocused();
+    await expect(app.attributionTrigger).toBeFocused();
   });
 
   test('opening the dialog moves focus into the modal (close button is autofocused)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    const trigger = page.locator('button.attribution-trigger');
-    await trigger.click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     const close = dialog.getByRole('button', { name: /close/i });
     await expect(close).toBeFocused();
@@ -191,20 +196,21 @@ test.describe('AttributionModal — mobile viewport', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    const trigger = page.locator('button.attribution-trigger');
-    await trigger.click();
+    // #761 (S2): open via the header affordance; focus returns to that opener
+    // (the standalone trigger is behind the full-bleed map — see desktop tests).
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
     await page.keyboard.press('Escape');
     await expect(dialog).not.toHaveAttribute('open', '');
-    await expect(trigger).toBeFocused();
+    await expect(app.attributionTrigger).toBeFocused();
   });
 
   test('Phylopic section renders at least one silhouette (mobile)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    await page.locator('button.attribution-trigger').click();
+    await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     const rows = dialog.locator('[data-testid=attribution-phylopic-row]');
     await expect(rows.first()).toBeVisible({ timeout: 10_000 });

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -394,9 +394,14 @@ test.describe('axe-core WCAG scans', () => {
     const app = new AppPage(page);
     await app.goto('view=map');
     await app.waitForAppReady();
-    // Phase 6: footer removed. Use .attribution-trigger (AttributionModal's
-    // own button) directly — no footer scoping needed.
-    await page.locator('button.attribution-trigger').click();
+    // #761 (S2): open via the AppHeader "Attribution" button — the documented
+    // real affordance, which fires onOpenAttribution → programmatic click on the
+    // hidden `.attribution-trigger` shim. The header is fixed chrome on
+    // `--z-chrome` (always clickable); the standalone `.attribution-trigger` now
+    // sits in the `.app` flow BEHIND the full-viewport `#map-layer`, so a direct
+    // POINTER click on it is intercepted by the maplibre attribution control. The
+    // header path is occlusion-immune (programmatic .click()).
+    await app.attributionTrigger.click();
     // Wait on the [open] attribute commit — observable contract that
     // showModal() has run, focus-delegation is settled, and the dialog
     // is in the top layer.
@@ -418,8 +423,10 @@ test.describe('axe-core WCAG scans', () => {
       const app = new AppPage(page);
       await app.goto('view=map');
       await app.waitForAppReady();
-      // Phase 6: footer removed. Use .attribution-trigger directly.
-      await page.locator('button.attribution-trigger').click();
+      // #761 (S2): open via the AppHeader "Attribution" button (occlusion-immune
+      // programmatic shim) — the standalone `.attribution-trigger` now sits behind
+      // the full-viewport `#map-layer`. See the desktop test for the rationale.
+      await app.attributionTrigger.click();
       await expect(page.locator('dialog.attribution-modal[open]')).toBeVisible();
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
       if (results.violations.length) {

--- a/frontend/e2e/family-legend-collapse-visibility.spec.ts
+++ b/frontend/e2e/family-legend-collapse-visibility.spec.ts
@@ -3,7 +3,7 @@ import { AppPage } from './pages/app-page.js';
 import type { Observation } from '@bird-watch/shared-types';
 
 /**
- * Regression: collapsed family legend chip clipped by #main-surface overflow.
+ * Regression: collapsed family legend chip clipped by its scroll/overflow parent.
  *
  * PR #471 (W2) added `.map-context-strip { padding: var(--space-md)
  * var(--space-lg) }` (24 px vertical) + a 1px border-bottom. The combined
@@ -11,9 +11,14 @@ import type { Observation } from '@bird-watch/shared-types';
  * area, causing `#main-surface`'s overflow:auto scroll container to clip the
  * `position:absolute; bottom:12px` collapsed chip entirely.
  *
- * Fix (this PR): `#main-surface` becomes a flex column; `.map-surface` uses
- * `flex:1; min-height:0` instead of `height:100%`. The chip now sits inside
- * the flex-sized `.map-surface`, never below the clip boundary.
+ * #761 (S2) re-baseline: the map left `#main-surface` entirely — the shell
+ * inverted so the map is the viewport ROOT (`#map-layer { position: fixed;
+ * inset: 0 }`, a sibling of `<main>`). The collapsed chip now lives inside the
+ * viewport-filling `.map-surface`, NOT inside `#main-surface`. The clip parent
+ * the original #471 guard checked against is gone by design, so this guard now
+ * asserts the chip is fully inside the VIEWPORT (the new bounding box). The
+ * invariant the test protects is unchanged: the collapsed chip must be fully
+ * visible, never clipped by its container.
  *
  * This test is the regression guard #471 should have had.
  *
@@ -130,57 +135,56 @@ async function skipIfMapHookAbsent(
 }
 
 /**
- * Assert that the collapsed chip's bounding rect is fully inside
- * main#main-surface's bounding rect. Both edges (bottom and left) are
- * checked to within a 1px tolerance (fractional sub-pixel rounding).
+ * Assert that the collapsed chip's bounding rect is fully inside the VIEWPORT.
+ *
+ * #761 (S2): the map is now the viewport ROOT (`#map-layer { position: fixed;
+ * inset: 0 }`), so the chip's containing/clip parent is the viewport, not
+ * `#main-surface` (which the map left). Both edges (bottom and left) are checked
+ * to within a 1px tolerance (fractional sub-pixel rounding).
  */
-async function assertChipInsideMain(
+async function assertChipInsideViewport(
   page: import('@playwright/test').Page,
-): Promise<{ chipBottom: number; mainBottom: number; chipLeft: number; mainLeft: number }> {
+): Promise<{ chipBottom: number; viewportBottom: number; chipLeft: number; viewportLeft: number }> {
   const rects = await page.evaluate(() => {
-    // Browser context: select the readiness surface on the tag-AND-id-free
-    // `[data-render-complete]` attribute (the hook the map-first inversion
-    // (#761) carries forward), which resolves to the same single element as
-    // `#main-surface` today. A Playwright Locator can't cross into evaluate.
-    const main = document.querySelector<HTMLElement>('[data-render-complete]');
     // The collapsed chip is the toggle button with aria-expanded="false" inside .map-surface
     const chip = document.querySelector<HTMLElement>(
       '.map-surface button[aria-expanded="false"]',
     );
-    if (!main || !chip) return null;
-    const mainRect = main.getBoundingClientRect();
+    if (!chip) return null;
     const chipRect = chip.getBoundingClientRect();
     return {
       chipBottom: chipRect.bottom,
-      mainBottom: mainRect.bottom,
+      // #761 (S2): the map fills the viewport, so the bottom/left bound is the
+      // viewport edge (the map left #main-surface — the old clip parent is gone).
+      viewportBottom: window.innerHeight,
       chipLeft: chipRect.left,
-      mainLeft: mainRect.left,
+      viewportLeft: 0,
     };
   });
 
-  expect(rects, 'main#main-surface and/or collapsed chip button not found in DOM').not.toBeNull();
-  const { chipBottom, mainBottom, chipLeft, mainLeft } = rects!;
+  expect(rects, 'collapsed chip button not found in DOM').not.toBeNull();
+  const { chipBottom, viewportBottom, chipLeft, viewportLeft } = rects!;
 
-  // Chip bottom edge must be at or above main bottom edge (allow 1px for sub-pixel rounding)
+  // Chip bottom edge must be at or above the viewport bottom (allow 1px sub-pixel rounding)
   expect(
     chipBottom,
-    `Collapsed chip bottom (${chipBottom.toFixed(1)}) is BELOW main bottom (${mainBottom.toFixed(1)}) — chip is clipped`,
-  ).toBeLessThanOrEqual(mainBottom + 1);
+    `Collapsed chip bottom (${chipBottom.toFixed(1)}) is BELOW viewport bottom (${viewportBottom.toFixed(1)}) — chip is clipped`,
+  ).toBeLessThanOrEqual(viewportBottom + 1);
 
-  // Chip left edge must be at or right of main left edge
+  // Chip left edge must be at or right of the viewport left edge
   expect(
     chipLeft,
-    `Collapsed chip left (${chipLeft.toFixed(1)}) is LEFT OF main left (${mainLeft.toFixed(1)}) — chip is clipped`,
-  ).toBeGreaterThanOrEqual(mainLeft - 1);
+    `Collapsed chip left (${chipLeft.toFixed(1)}) is LEFT OF viewport left (${viewportLeft.toFixed(1)}) — chip is clipped`,
+  ).toBeGreaterThanOrEqual(viewportLeft - 1);
 
-  return { chipBottom, mainBottom, chipLeft, mainLeft };
+  return { chipBottom, viewportBottom, chipLeft, viewportLeft };
 }
 
 test.describe('Collapsed legend chip visibility — P0 regression from #471', () => {
   test.describe('desktop (1440×900)', () => {
     test.use({ viewport: { width: 1440, height: 900 } });
 
-    test('collapsed chip is fully inside main#main-surface bounds', async ({ page, apiStub }) => {
+    test('collapsed chip is fully inside the viewport bounds', async ({ page, apiStub }) => {
       await setupRoutes(page, apiStub);
       const app = new AppPage(page);
       // Clear localStorage so we get the default expanded state, then collapse
@@ -202,12 +206,12 @@ test.describe('Collapsed legend chip visibility — P0 regression from #471', ()
       await toggle.click();
       await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-      // Assert chip is inside main bounds
-      const { chipBottom, mainBottom } = await assertChipInsideMain(page);
+      // Assert chip is inside the viewport bounds (#761 S2: the map fills the viewport)
+      const { chipBottom, viewportBottom } = await assertChipInsideViewport(page);
       // Provide readable context in the test output
       expect(
-        chipBottom <= mainBottom + 1,
-        `Desktop: chip bottom ${chipBottom.toFixed(1)} <= main bottom ${mainBottom.toFixed(1)}`,
+        chipBottom <= viewportBottom + 1,
+        `Desktop: chip bottom ${chipBottom.toFixed(1)} <= viewport bottom ${viewportBottom.toFixed(1)}`,
       ).toBe(true);
     });
   });
@@ -215,7 +219,7 @@ test.describe('Collapsed legend chip visibility — P0 regression from #471', ()
   test.describe('mobile (390×844)', () => {
     test.use({ viewport: { width: 390, height: 844 } });
 
-    test('collapsed chip is fully inside main#main-surface bounds', async ({ page, apiStub }) => {
+    test('collapsed chip is fully inside the viewport bounds', async ({ page, apiStub }) => {
       await setupRoutes(page, apiStub);
       const app = new AppPage(page);
       // Mobile defaults to collapsed — clear localStorage and let the
@@ -236,11 +240,11 @@ test.describe('Collapsed legend chip visibility — P0 regression from #471', ()
       const toggle = page.getByRole('button', { name: /bird families/i });
       await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-      // Assert chip is inside main bounds
-      const { chipBottom, mainBottom } = await assertChipInsideMain(page);
+      // Assert chip is inside the viewport bounds (#761 S2: the map fills the viewport)
+      const { chipBottom, viewportBottom } = await assertChipInsideViewport(page);
       expect(
-        chipBottom <= mainBottom + 1,
-        `Mobile: chip bottom ${chipBottom.toFixed(1)} <= main bottom ${mainBottom.toFixed(1)}`,
+        chipBottom <= viewportBottom + 1,
+        `Mobile: chip bottom ${chipBottom.toFixed(1)} <= viewport bottom ${viewportBottom.toFixed(1)}`,
       ).toBe(true);
     });
   });

--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -168,6 +168,28 @@ test('@coarse tablet 768×1024: tap marker → cluster-list popover → tap spec
   // Wait for the map render to complete (canonical pattern).
   await page.locator('[data-testid="adaptive-grid-marker"]').first().waitFor({ state: 'visible' });
 
+  // #761 (S2): wait for the map to go IDLE before tapping. The cluster-list
+  // popover renders INSIDE the AdaptiveGridMarker; if the marker-reconcile churn
+  // (sourcedata → render → idle, triggered while the canvas is still settling)
+  // re-creates the marker DOM node AFTER the tap, the marker's local
+  // `isClusterListOpen` state resets and the popover is dismissed mid-assertion.
+  // Post-inversion the map mounts into the full-viewport `#map-layer` and the
+  // settle window can extend just past first-marker-visible at this viewport
+  // (the corrective `map.resize()` on the flex→fixed transition is S3's — #773 —
+  // and is intentionally NOT wired here; S2 asserts steady state). Waiting for a
+  // settled idle frame closes that race deterministically without map-resize
+  // plumbing. If `__birdMap` is unavailable (no WebGL), fall through — the
+  // describe-level skip guards already cover that path.
+  await page
+    .waitForFunction(() => {
+      const map = (window as { __birdMap?: { isMoving: () => boolean; loaded: () => boolean } }).__birdMap;
+      return !!map && map.loaded() && !map.isMoving();
+    }, undefined, { timeout: 10_000 })
+    .catch(() => { /* no map hook (no WebGL) — the existing skip guards apply */ });
+  // Settle one more rAF beyond `idle` so any trailing reconcile commit lands
+  // before we interact (the marker DOM node is stable after this point).
+  await page.waitForTimeout(300);
+
   // Tap a multi-leaf cluster marker.
   const marker = page.locator('[data-testid="adaptive-grid-marker"]').first();
   await marker.tap();

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -48,6 +48,110 @@ async function setupRoutes(
   await apiStub.stubZipIndex();
 }
 
+/**
+ * Silhouettes stub for the attribution-clearance guard. The FamilyLegend only
+ * mounts when `silhouettes.length > 0` (FamilyLegend.tsx), so the legend-vs-
+ * attribution overlap test must register a non-empty silhouettes payload — the
+ * `tyrannidae` row matches AZ_OBS's `familyCode`, plus the required `_FALLBACK`
+ * row. Registered AFTER setupRoutes so this more-specific route wins (LIFO).
+ */
+async function stubSilhouettesForLegend(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.route('**/api/silhouettes', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          familyCode: 'tyrannidae',
+          color: '#E84040',
+          colorDark: '#E84040',
+          svgData:
+            'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+          source: null,
+          license: null,
+          commonName: 'Tyrant Flycatchers',
+          creator: null,
+        },
+        {
+          familyCode: '_FALLBACK',
+          color: '#555555',
+          colorDark: '#555555',
+          svgData:
+            'M 6 12 C 6 9 8 7 11 7 C 13 7 14 8 15 9 L 18 8 L 18 10 L 16 11 L 16 14 L 14 16 L 9 16 L 6 14 Z',
+          source: null,
+          license: null,
+          commonName: 'Unknown family',
+          creator: null,
+        },
+      ]),
+    });
+  });
+}
+
+/**
+ * WebGL skip guard for the attribution-clearance guard. The MapLibre
+ * AttributionControl only attaches its DOM (`.maplibregl-ctrl-attrib`) after the
+ * map fires `load`; headless runs without a GPU never fire it, so the
+ * bounding-box overlap check would be vacuous. Skip cleanly — mirrors the
+ * `__birdMap` guard in family-legend-viewport.spec.ts. CI runs software WebGL
+ * (SwiftShader), so CI exercises the full assertion.
+ */
+async function skipIfAttributionAbsent(
+  page: import('@playwright/test').Page,
+  testRef: typeof test,
+): Promise<boolean> {
+  const present = await page
+    .locator('.maplibregl-ctrl-attrib')
+    .waitFor({ state: 'attached', timeout: 8_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!present) {
+    testRef.skip(
+      true,
+      '.maplibregl-ctrl-attrib not attached — maplibre `load` did not fire ' +
+        '(likely WebGL unavailable in headless run).',
+    );
+  }
+  return !present;
+}
+
+/**
+ * Read the attribution control + family legend bounding boxes and the size of
+ * their intersection. Returns null if either element is missing.
+ */
+async function measureAttributionVsLegend(
+  page: import('@playwright/test').Page,
+): Promise<{
+  attrib: { left: number; top: number; right: number; bottom: number };
+  legend: { left: number; top: number; right: number; bottom: number };
+  intersectX: number;
+  intersectY: number;
+} | null> {
+  return page.evaluate(() => {
+    const attrib = document.querySelector('.maplibregl-ctrl-attrib');
+    const legend = document.querySelector('.family-legend');
+    if (!attrib || !legend) return null;
+    const a = attrib.getBoundingClientRect();
+    const l = legend.getBoundingClientRect();
+    const intersectX = Math.max(
+      0,
+      Math.min(a.right, l.right) - Math.max(a.left, l.left),
+    );
+    const intersectY = Math.max(
+      0,
+      Math.min(a.bottom, l.bottom) - Math.max(a.top, l.top),
+    );
+    return {
+      attrib: { left: a.left, top: a.top, right: a.right, bottom: a.bottom },
+      legend: { left: l.left, top: l.top, right: l.right, bottom: l.bottom },
+      intersectX,
+      intersectY,
+    };
+  });
+}
+
 test.describe('#761 (S2): full-viewport map root geometry', () => {
   test.describe('desktop (1440×900)', () => {
     test.use({ viewport: { width: 1440, height: 900 } });
@@ -185,5 +289,108 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
       await page.waitForTimeout(600);
       expect(obsRequests, 'zero /api/observations on the unscoped scrim landing').toHaveLength(0);
     });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // #775 — basemap attribution clearance under the full-bleed map.
+  //
+  // The full-viewport map (#761 S2) made `.map-surface` fill 100vh. MapLibre's
+  // non-compact AttributionControl (`compact={false}` — deliberately always-
+  // expanded so the OSM credit shows without a click) then renders as a bottom
+  // bar that, on short/narrow viewports, spans the full viewport width and wraps
+  // to multiple lines — its left portion reaching into the bottom-left corner
+  // where `.family-legend` lives. The legend (z-overlay) painted ON TOP of the
+  // OSM / OpenFreeMap license text. That is an ODbL + eBird-ToU LICENSING defect
+  // (the attribution must be fully visible), and it shipped with no test.
+  //
+  // Fix (#775): `.family-legend { bottom: calc(var(--space-md) +
+  // var(--attribution-clearance)) }`, with --attribution-clearance tiered by
+  // viewport (20/40/60px) to lift the legend ABOVE the worst-case band. These
+  // guards assert ZERO overlap between the two boxes at 390/768/1024 in BOTH the
+  // collapsed and expanded legend states (the expanded legend is wider, so it is
+  // the harder case at 1024 where the bar already reaches x≈192).
+  // ───────────────────────────────────────────────────────────────────────────
+  test.describe('#775: basemap attribution clearance vs family legend', () => {
+    for (const vp of [
+      { width: 390, height: 844 },
+      { width: 768, height: 1024 },
+      { width: 1024, height: 768 },
+    ] as const) {
+      test.describe(`${vp.width}×${vp.height}`, () => {
+        test.use({ viewport: { width: vp.width, height: vp.height } });
+
+        test('attribution control is not overlapped by the family legend (collapsed + expanded)', async ({
+          page,
+          apiStub,
+        }) => {
+          await setupRoutes(page, apiStub);
+          await stubSilhouettesForLegend(page);
+          // Start from a known legend state regardless of prior persistence.
+          await page.addInitScript(() => {
+            try {
+              window.localStorage.removeItem('family-legend-expanded');
+              window.localStorage.removeItem('family-legend-expanded.v2');
+            } catch {
+              /* noop */
+            }
+          });
+
+          const app = new AppPage(page);
+          await app.goto('state=US-AZ');
+          await app.waitForAppReady();
+          await expect(app.mapCanvas).toBeVisible({ timeout: 15_000 });
+
+          if (await skipIfAttributionAbsent(page, test)) return;
+          // The legend mounts once silhouettes resolve.
+          await expect(page.locator('.family-legend')).toBeVisible({
+            timeout: 10_000,
+          });
+
+          const toggle = page.locator('.family-legend [aria-expanded]');
+
+          // Assert no overlap in BOTH legend states. The expanded legend is the
+          // wider box (the 1024 worst case), the collapsed legend the typical
+          // first-paint mobile state — both must clear the attribution band.
+          for (const wantExpanded of [false, true] as const) {
+            const current = await toggle.getAttribute('aria-expanded');
+            if (current !== String(wantExpanded)) {
+              await toggle.click();
+              await expect(toggle).toHaveAttribute(
+                'aria-expanded',
+                String(wantExpanded),
+              );
+            }
+
+            const m = await measureAttributionVsLegend(page);
+            expect(
+              m,
+              '.maplibregl-ctrl-attrib / .family-legend not found',
+            ).not.toBeNull();
+
+            // Boxes are disjoint when EITHER axis has no intersection. The
+            // licensing requirement is that the legend never covers the
+            // attribution text, so we require zero overlap area (sub-pixel
+            // tolerance for fractional rounding).
+            const disjoint =
+              m!.intersectX <= 0.5 || m!.intersectY <= 0.5;
+            expect(
+              disjoint,
+              `legend (expanded=${wantExpanded}) overlaps attribution at ${vp.width}×${vp.height}: ` +
+                `intersect ${m!.intersectX.toFixed(1)}×${m!.intersectY.toFixed(1)}px ` +
+                `[attrib ${JSON.stringify(m!.attrib)} legend ${JSON.stringify(m!.legend)}]`,
+            ).toBe(true);
+
+            // Stronger, fix-specific assertion: the legend's bottom edge sits at
+            // or ABOVE the attribution band's top edge — i.e. the legend is
+            // lifted clear vertically, independent of the bar's horizontal span.
+            expect(
+              m!.legend.bottom,
+              `legend bottom (${m!.legend.bottom.toFixed(1)}) must clear attribution top ` +
+                `(${m!.attrib.top.toFixed(1)}) at ${vp.width}×${vp.height} (expanded=${wantExpanded})`,
+            ).toBeLessThanOrEqual(m!.attrib.top + 0.5);
+          }
+        });
+      });
+    }
   });
 });

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, STATES_FIXTURE } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * #761 (S2) — full-viewport map ROOT geometry guards.
+ *
+ * The shell inverted: the map is no longer a windowed flex child of the padded
+ * `<main>`. It was hoisted into `#map-layer` (`position: fixed; inset: 0`), a
+ * SIBLING of `<main>`, and the AppHeader became `position: fixed` floating chrome
+ * on `--z-chrome`. These guards encode the load-bearing geometry the inversion
+ * promises and the R15 header-clearance fixes that keep the floating header from
+ * occluding the top-anchored overlays.
+ *
+ * Steady-state contract: every geometry assertion is taken AFTER
+ * `waitForAppReady()` settles. The map's corrective `map.resize()` on the
+ * flex→fixed transition is S3's (#773); S2 asserts only the SETTLED box, never a
+ * resize-causality claim.
+ *
+ * WebGL skip guard: where the canvas geometry depends on a live maplibre `load`
+ * (no GPU in headless), the test skips cleanly — mirrors
+ * family-legend-collapse-visibility.spec.ts. CI runs on GitHub Actions VMs with
+ * software WebGL (SwiftShader), so CI exercises the full assertions.
+ */
+
+const AZ_OBS = [
+  {
+    subId: 'S1',
+    speciesCode: 'vermfly',
+    comName: 'Vermilion Flycatcher',
+    lat: 32.22,
+    lng: -110.97,
+    obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    locId: 'L1',
+    locName: 'Tucson',
+    howMany: 1,
+    isNotable: false,
+    silhouetteId: 'tyrannidae',
+    familyCode: 'tyrannidae',
+  },
+];
+
+async function setupRoutes(
+  page: import('@playwright/test').Page,
+  apiStub: { stubObservations: (o: typeof AZ_OBS) => Promise<void>; stubStates: (s?: typeof STATES_FIXTURE) => Promise<void>; stubZipIndex: () => Promise<void> },
+): Promise<void> {
+  await apiStub.stubObservations(AZ_OBS);
+  await apiStub.stubStates();
+  await apiStub.stubZipIndex();
+}
+
+test.describe('#761 (S2): full-viewport map root geometry', () => {
+  test.describe('desktop (1440×900)', () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test('.map-surface fills the viewport — no 16px gutters', async ({ page, apiStub }) => {
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await expect(app.mapCanvas).toBeVisible({ timeout: 15_000 });
+
+      // Steady-state: `.map-surface` bounding rect ≈ the viewport (within 1px),
+      // proving the map went full-bleed (no inset from the old `<main>` padding).
+      const rect = await page.locator('.map-surface').evaluate(el => {
+        const r = el.getBoundingClientRect();
+        return { left: r.left, top: r.top, right: r.right, bottom: r.bottom };
+      });
+      expect(rect.left, 'left gutter').toBeLessThanOrEqual(1);
+      expect(rect.top, 'top gutter (map sits under the floating header on purpose)').toBeLessThanOrEqual(1);
+      expect(Math.abs(rect.right - 1440), 'right edge ≈ viewport width').toBeLessThanOrEqual(1);
+      expect(Math.abs(rect.bottom - 900), 'bottom edge ≈ viewport height').toBeLessThanOrEqual(1);
+    });
+
+    test('.scope-control anchors to the viewport top, clearing the fixed header', async ({ page, apiStub }) => {
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await expect(app.scopeControl).toBeVisible();
+
+      // The ScopeControl is a SIBLING of `.map-surface`; its `position: absolute`
+      // offsets must resolve against the fixed `#map-layer` wrapper (≡ viewport).
+      // Expected top = header height + --space-md (it clears the floating header),
+      // and it is horizontally centered (margin-inline: auto) within the viewport.
+      const m = await page.evaluate(() => {
+        const root = getComputedStyle(document.documentElement);
+        const headerH = parseFloat(root.getPropertyValue('--header-height'));
+        const spaceMd = parseFloat(root.getPropertyValue('--space-md'));
+        const sc = document.querySelector<HTMLElement>('.scope-control');
+        const header = document.querySelector<HTMLElement>('.app-header');
+        if (!sc || !header) return null;
+        const r = sc.getBoundingClientRect();
+        const hr = header.getBoundingClientRect();
+        return {
+          top: r.top,
+          left: r.left,
+          right: r.right,
+          headerBottom: hr.bottom,
+          expectedTop: headerH + spaceMd,
+          viewportWidth: window.innerWidth,
+        };
+      });
+      expect(m, '.scope-control / .app-header not found').not.toBeNull();
+      // Anchored at header-height + --space-md from the viewport TOP (not under the header).
+      expect(Math.abs(m!.top - m!.expectedTop), `scope-control top ${m!.top} ≈ ${m!.expectedTop}`).toBeLessThanOrEqual(2);
+      // It clears the fixed header (its top is at or below the header's bottom edge).
+      expect(m!.top, 'scope-control top clears the header bottom').toBeGreaterThanOrEqual(m!.headerBottom - 1);
+      // Centered within the viewport width (margin-inline: auto): symmetric side gaps.
+      const leftGap = m!.left;
+      const rightGap = m!.viewportWidth - m!.right;
+      expect(Math.abs(leftGap - rightGap), `centered: left gap ${leftGap.toFixed(1)} ≈ right gap ${rightGap.toFixed(1)}`).toBeLessThanOrEqual(2);
+    });
+
+    test('open filters panel clears the fixed header (close button visible)', async ({ page, apiStub }) => {
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await app.openFilters();
+
+      const m = await page.evaluate(() => {
+        const panel = document.querySelector<HTMLElement>('.filters-panel');
+        const close = document.querySelector<HTMLElement>('.filters-panel-close');
+        const header = document.querySelector<HTMLElement>('.app-header');
+        if (!panel || !close || !header) return null;
+        return {
+          panelTop: panel.getBoundingClientRect().top,
+          closeTop: close.getBoundingClientRect().top,
+          headerBottom: header.getBoundingClientRect().bottom,
+        };
+      });
+      expect(m, '.filters-panel / close / header not found').not.toBeNull();
+      // R15 surface 2: the panel top edge and its close button clear the header.
+      expect(m!.panelTop, 'panel top below header bottom').toBeGreaterThanOrEqual(m!.headerBottom - 1);
+      expect(m!.closeTop, 'close button below header bottom').toBeGreaterThanOrEqual(m!.headerBottom - 1);
+    });
+  });
+
+  test.describe('mobile (390×844)', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('open filters panel clears the fixed header (close button visible)', async ({ page, apiStub }) => {
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await app.openFilters();
+
+      const m = await page.evaluate(() => {
+        const panel = document.querySelector<HTMLElement>('.filters-panel');
+        const close = document.querySelector<HTMLElement>('.filters-panel-close');
+        const header = document.querySelector<HTMLElement>('.app-header');
+        if (!panel || !close || !header) return null;
+        return {
+          panelTop: panel.getBoundingClientRect().top,
+          closeTop: close.getBoundingClientRect().top,
+          headerBottom: header.getBoundingClientRect().bottom,
+        };
+      });
+      expect(m, '.filters-panel / close / header not found').not.toBeNull();
+      expect(m!.panelTop, 'panel top below header bottom').toBeGreaterThanOrEqual(m!.headerBottom - 1);
+      expect(m!.closeTop, 'close button below header bottom').toBeGreaterThanOrEqual(m!.headerBottom - 1);
+    });
+  });
+
+  test.describe('always-mounted-under-scrim invariant (unscoped landing)', () => {
+    test('#map-layer mounts idle on the unscoped scrim landing, zero /api/observations', async ({ page, apiStub }) => {
+      const obsRequests: string[] = [];
+      page.on('request', req => {
+        if (req.url().includes('/api/observations')) obsRequests.push(req.url());
+      });
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+
+      // Bare URL → chooser scrim over a mounted, idle map (no default-scope injection).
+      await app.gotoRaw('');
+      await expect(app.chooser).toBeVisible();
+
+      // The hoisted #map-layer is present in the DOM (map mounted, not unmounted)…
+      await expect(page.locator('#map-layer')).toBeAttached();
+      // …and it is NOT gated away by scopeActive — the map canvas is mounted idle.
+      await expect(app.mapCanvas).toBeAttached();
+
+      // The scopeActive fetch gate holds /api/observations at zero on the landing.
+      await page.waitForTimeout(600);
+      expect(obsRequests, 'zero /api/observations on the unscoped scrim landing').toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -851,8 +851,11 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     ).toBeInTheDocument();
     // #761 (S1): the map surface is mounted but INERT behind the scrim (no
     // longer a full-tree unmount). The stub is present and #main-surface — the
-    // real <main id="main-surface"> App renders around the stub (NOT the mock) —
-    // carries the `inert` attribute set by App's inert/focus-trap effect.
+    // real <main id="main-surface"> App renders — carries the `inert` attribute
+    // set by App's inert/focus-trap effect. #761 (S2): the stub now lives in the
+    // hoisted #map-layer wrapper (a SIBLING of <main>), not inside #main-surface;
+    // the `inert` target stays #main-surface (the inert retarget to #map-layer is
+    // O1, not S2). Both assertions are unaffected by where the stub renders.
     expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
     expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
     // The cold-load fetch is suppressed: zero observations requests. Give any
@@ -1092,7 +1095,9 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     ).toBeInTheDocument();
     // #761 (S1) re-baseline: the map surface is now mounted but INERT behind the
     // scrim (it was unmounted under the old early-return). The inert attribute
-    // lands on the real <main id="main-surface"> App renders (NOT the mock).
+    // lands on the real <main id="main-surface"> App renders. #761 (S2): the map
+    // stub now lives in the hoisted #map-layer sibling, not inside #main-surface;
+    // the `inert` target stays #main-surface in S2 (retarget is O1).
     expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
     expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
     // #761 (S1) NEW guard: the detail rail/sheet does NOT render on an unscoped
@@ -1173,6 +1178,102 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     const brandRegion = await screen.findByText('Arizona', { selector: '.brand-region' });
     expect(brandRegion).toBeInTheDocument();
     expect(screen.queryByText('US-AZ', { selector: '.brand-region' })).toBeNull();
+  });
+});
+
+describe('#761 (S2): map hoisted to a viewport-root #map-layer sibling of <main>', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetStatesCache();
+    __resetZipIndexCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mockGetStates.mockResolvedValue([
+      { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.82, 31.33, -109.05, 37.0] as [number, number, number, number] },
+    ]);
+    mockGetObservations.mockClear();
+    mockGetHotspots.mockClear();
+    mockGetStates.mockClear();
+    mockGetSilhouettes.mockClear();
+    mockUrlState.set.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // AC: the {mapVisible && …} block renders inside a #map-layer wrapper that is a
+  // SIBLING of <main>, not a descendant. The bare MapSurface stub
+  // (<div data-testid="map-surface-stub" />) satisfies the structure check.
+  it('renders #map-layer as a sibling of <main>, NOT a descendant of #main-surface', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    const { container } = render(<App />);
+    await screen.findByTestId('map-surface-stub');
+
+    const mapLayer = container.querySelector('#map-layer');
+    const mainSurface = container.querySelector('#main-surface');
+    expect(mapLayer).not.toBeNull();
+    expect(mainSurface).not.toBeNull();
+
+    // #map-layer is NOT contained within #main-surface (the hoist's load-bearing
+    // structural invariant — the map left the windowed <main>).
+    expect(mainSurface!.contains(mapLayer)).toBe(false);
+    // The map stub lives inside #map-layer, and #map-layer is NOT inside <main>.
+    const mapStub = screen.getByTestId('map-surface-stub');
+    expect(mapLayer!.contains(mapStub)).toBe(true);
+    expect(mainSurface!.contains(mapStub)).toBe(false);
+    // Both are children of the same `.app` root (siblings, not parent/child).
+    const app = container.querySelector('.app');
+    expect(mapLayer!.parentElement).toBe(app);
+    expect(mainSurface!.parentElement).toBe(app);
+  });
+
+  // AC: the "Map view" tab's aria-controls is retargeted to "map-layer" and
+  // resolves to the present, hoisted #map-layer — the region that actually
+  // contains the map post-hoist (NOT the now-feed-only #main-surface). A
+  // presence-only check against #main-surface would assert the regression passes.
+  it('points the Map view tab\'s aria-controls at #map-layer (the region holding the map)', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    const { container } = render(<App />);
+    await screen.findByTestId('map-surface-stub');
+
+    const mapTab = screen.getByRole('tab', { name: 'Map view' });
+    expect(mapTab).toHaveAttribute('aria-controls', 'map-layer');
+    expect(mapTab).not.toHaveAttribute('aria-controls', 'main-surface');
+    // The controlled region resolves to a present element that holds the map.
+    const controlled = container.querySelector('#map-layer');
+    expect(controlled).not.toBeNull();
+    expect(controlled!.contains(screen.getByTestId('map-surface-stub'))).toBe(true);
+  });
+
+  // AC: the always-mounted-under-scrim invariant survives the hoist — on the
+  // unscoped scrim landing #map-layer still mounts (idle) and /api/observations
+  // stays at zero (existing scopeActive fetch gate). #map-layer is NOT gated on
+  // scopeActive.
+  it('mounts #map-layer on the unscoped scrim landing with zero observations fetch', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'unscoped' },
+    };
+    const { container } = render(<App />);
+    // Chooser scrim is shown; the map is mounted idle behind it.
+    expect(
+      await screen.findByRole('region', { name: /Choose where to look at birds/i }),
+    ).toBeInTheDocument();
+    expect(container.querySelector('#map-layer')).not.toBeNull();
+    expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
+    // The scopeActive fetch gate holds observations at zero on the unscoped landing.
+    await waitFor(() => {
+      expect(mockGetStates).toHaveBeenCalled();
+    });
+    expect(mockGetObservations).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -716,83 +716,103 @@ export function App() {
           />
         </div>
       )}
+      {/* #761 (S2) — the map is the viewport-filling ROOT, no longer a windowed
+          flex child of the padded `<main>`. The `{mapVisible && …}` block is
+          HOISTED OUT of `<main>` into the fixed-inset `#map-layer` wrapper that
+          renders as a SIBLING of `<main>` — the same `position: fixed` floating
+          pattern the detail rail/sheet (#663) already use below. The chrome
+          (AppHeader) floats over this layer on `--z-chrome`.
+
+          The wrapper is MANDATORY, not optional: `ScopeControl` is a SIBLING of
+          `MapSurface` (not a child of `.map-surface`), so its `position: absolute`
+          offsets resolve against the nearest POSITIONED ancestor. `#map-layer`
+          (`position: fixed; inset: 0`) is that ancestor — it equals the viewport,
+          so ScopeControl anchors to the viewport top edge as before. Without the
+          wrapper ScopeControl would lose its containing block (`.map-surface` is
+          its sibling, not its ancestor).
+
+          Always-mounted-under-scrim invariant (post-S1): `#map-layer` is gated
+          ONLY by the existing `mapVisible` VIEW-tier gate (`'map' || 'detail'`,
+          true on the scrim landing) — NOT by `scopeActive`. On the unscoped
+          landing the map mounts idle behind S1's inert scrim; the `scopeActive`
+          fetch gate (above) is the sole mechanism holding `/api/observations` at
+          zero. Do NOT make `#map-layer` conditional on `scopeActive`. */}
+      {mapVisible && (
+        <div id="map-layer">
+          {/* #740 (C6) — the in-state on-map re-scope bar (#737). Rendered
+              ONLY in a SCOPED view. #761 (S1) removed the unscoped
+              early-return, so the map now mounts idle behind the chooser
+              scrim while unscoped too — this `state.scope.kind !== 'unscoped'`
+              guard keeps ScopeControl off the unscoped landing (the chooser
+              scrim is the only scope affordance there) AND narrows
+              `state.scope` to the `ScopedView` the component's prop requires.
+              Floats over the canvas; emits one clean scope intent per action
+              and never touches the map. */}
+          {state.scope.kind !== 'unscoped' && (
+            <ScopeControl
+              scope={state.scope}
+              states={states}
+              onPickState={onPickState}
+              onPickWholeUs={onPickWholeUs}
+              onExit={onExitScope}
+              onResolve={onResolveZip}
+            />
+          )}
+          <MapSurface
+            observations={observations}
+            legendObservations={viewportObservations}
+            silhouettes={silhouettes}
+            familyCode={state.familyCode}
+            onFamilyToggle={onFamilyToggle}
+            onSelectSpecies={onSelectSpecies}
+            onViewportChange={onViewportChange}
+            onExploreMapMarkers={() => {
+              const firstCell = document.querySelector(
+                '[data-testid="adaptive-grid-marker-cell-rendered"], ' +
+                '[data-testid="adaptive-grid-marker-cell-fallback"]'
+              ) as HTMLElement | null;
+              firstCell?.focus();
+            }}
+            hasMarkers={observations.length > 0}
+            since={state.since}
+            notable={state.notable}
+            speciesCode={state.speciesCode}
+            {...(speciesName !== undefined ? { speciesName } : {})}
+            freshness={freshnessState}
+            freshnessLabel={freshnessLabel}
+            loading={observationsLoading}
+            region={region}
+            noFiltersActive={noFiltersActive}
+            {...(scopeBounds ? { scopeBounds } : {})}
+            {...(boundsKey !== undefined ? { boundsKey } : {})}
+            {...(flyTo ? { flyTo } : {})}
+            {...(statePolygon != null ? { maskPolygon: statePolygon } : {})}
+            {...(isStateScope ? { clampPad: ARTBOARD_PAD } : {})}
+          />
+        </div>
+      )}
       <main
         ref={mainRef}
         id="main-surface"
         data-render-complete={renderComplete}
         aria-busy={observationsLoading}
         // axe `scrollable-region-focusable` (WCAG 2.1.1): #main-surface
-        // has `overflow: auto` so it can scroll when its content (e.g.
-        // species detail with photo) exceeds the viewport. Keyboard users
-        // need to be able to focus the scrollable region itself to scroll
-        // it. tabIndex={0} adds it to the tab order; the container has no
-        // other interactive role.
+        // has `overflow: auto` so it can scroll when its content exceeds the
+        // viewport. Keyboard users need to be able to focus the scrollable
+        // region itself to scroll it. tabIndex={0} adds it to the tab order;
+        // the container has no other interactive role.
+        //
+        // #761 (S2): the map + ScopeControl no longer render here — they were
+        // hoisted into the fixed `#map-layer` wrapper above. `<main>` is kept
+        // (with `id`, `data-render-complete`, `mainRef`, `tabIndex={0}`) as the
+        // readiness gate (#586), the scroll-bypass affordance, and the `inert`
+        // target S1's focus-trap effect / SpeciesDetailSheet still wire to it.
+        // It now wraps only non-map view surfaces (F1 (#777) removed the feed
+        // branch, so today that is none); its `--space-lg` padding stays for
+        // any future non-map surface and the `padding-top` header-clearance
+        // (R15) keeps such a surface out from under the floating chrome.
         tabIndex={0}
-      >
-        {mapVisible && (
-          <>
-            {/* #740 (C6) — the in-state on-map re-scope bar (#737). Rendered
-                ONLY in a SCOPED view. #761 (S1) removed the unscoped
-                early-return, so the map now mounts idle behind the chooser
-                scrim while unscoped too — this `state.scope.kind !== 'unscoped'`
-                guard keeps ScopeControl off the unscoped landing (the chooser
-                scrim is the only scope affordance there) AND narrows
-                `state.scope` to the `ScopedView` the component's prop requires.
-                Floats over the canvas; emits one clean scope intent per action
-                and never touches the map. */}
-            {state.scope.kind !== 'unscoped' && (
-              <ScopeControl
-                scope={state.scope}
-                states={states}
-                onPickState={onPickState}
-                onPickWholeUs={onPickWholeUs}
-                onExit={onExitScope}
-                onResolve={onResolveZip}
-              />
-            )}
-            <MapSurface
-              observations={observations}
-              legendObservations={viewportObservations}
-              silhouettes={silhouettes}
-              familyCode={state.familyCode}
-              onFamilyToggle={onFamilyToggle}
-              onSelectSpecies={onSelectSpecies}
-              onViewportChange={onViewportChange}
-              onExploreMapMarkers={() => {
-                const firstCell = document.querySelector(
-                  '[data-testid="adaptive-grid-marker-cell-rendered"], ' +
-                  '[data-testid="adaptive-grid-marker-cell-fallback"]'
-                ) as HTMLElement | null;
-                firstCell?.focus();
-              }}
-              hasMarkers={observations.length > 0}
-              since={state.since}
-              notable={state.notable}
-              speciesCode={state.speciesCode}
-              {...(speciesName !== undefined ? { speciesName } : {})}
-              freshness={freshnessState}
-              freshnessLabel={freshnessLabel}
-              loading={observationsLoading}
-              region={region}
-              noFiltersActive={noFiltersActive}
-              {...(scopeBounds ? { scopeBounds } : {})}
-              {...(boundsKey !== undefined ? { boundsKey } : {})}
-              {...(flyTo ? { flyTo } : {})}
-              {...(statePolygon != null ? { maskPolygon: statePolygon } : {})}
-              {...(isStateScope ? { clampPad: ARTBOARD_PAD } : {})}
-            />
-          </>
-        )}
-        {/*
-          #663 — detail surface routing. The body component
-          (SpeciesDetailSurface) renders inside one of two wrappers:
-          a side rail (<aside>) on ≥1200px viewports, a bottom-sheet
-          on ≤1199px. Selection drives off useIsCompact.
-          The wrappers render OUTSIDE <main>: both sit as siblings of
-          <main> so the Map stays mounted and interactive underneath
-          (no inert backdrop, no top-layer takeover).
-        */}
-      </main>
+      />
       {/* #761 (S1) — detail rail/sheet gated on `scopeActive`. The unscoped
           early-return used to make these lines unreachable while unscoped; now
           that the shell always renders, a `?detail=` riding an unscoped URL

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -61,6 +61,16 @@ describe('<AppHeader>', () => {
     expect(mapTab).toHaveClass('app-header-tab', 'is-active');
   });
 
+  // #761 (S2): the shell inverted so the map is the viewport ROOT (#map-layer),
+  // hoisted out of #main-surface. The "Map view" tab controls the region that
+  // actually holds the map, so its aria-controls points at "map-layer" — NOT the
+  // now-feed-only "main-surface" (which would be a silent a11y semantic regression).
+  it('points the Map view tab\'s aria-controls at the map-layer region (#761 S2)', () => {
+    render(<AppHeader {...baseProps} activeView="map" />);
+    const mapTab = screen.getByRole('tab', { name: /Map view/i });
+    expect(mapTab).toHaveAttribute('aria-controls', 'map-layer');
+  });
+
   it('renders Filters trigger without badge when filterCount === 0', () => {
     render(<AppHeader {...baseProps} filterCount={0} />);
     const trigger = screen.getByRole('button', { name: /Filters/i });

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -122,7 +122,15 @@ export function AppHeader({
               role="tab"
               id={`app-header-tab-${tab.value}`}
               aria-selected={selected}
-              aria-controls="main-surface"
+              // #761 (S2): the "Map view" tab controls the map region, which is
+              // now the hoisted `#map-layer` wrapper (the map left `#main-surface`
+              // when the shell inverted to a full-viewport map root). Pointing at
+              // `"main-surface"` would silently control a map-free region — an
+              // a11y semantic regression introduced by the hoist. The broader
+              // inert/aria-busy/aria-live retarget on `#map-layer` stays O1; the
+              // tablist tab→region pointer is a different attribute O1 does not
+              // touch, so S2 owns this one in the same PR that moves the map out.
+              aria-controls="map-layer"
               aria-label={tab.accessibleName}
               tabIndex={tabbable ? 0 : -1}
               className={`app-header-tab${selected ? ' is-active' : ''}`}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,6 +38,17 @@
   --space-lg: 16px;
   --space-xl: 24px;
 
+  /* Floating-header height (#761 S2). The AppHeader became `position: fixed`
+     chrome over the full-viewport map root, so it no longer occupies flow
+     height. Every in-flow chrome surface that previously sat below it — the
+     non-map `#main-surface` content (R15 surface 1) and the open `.filters-panel`
+     (R15 surface 2), plus the top-anchored `.scope-control` overlay — must clear
+     this height so the floating header does not occlude it. 48px comfortably
+     clears both the ~44–48px desktop header (8px+8px vertical padding + ~28px
+     content + 1px border) and the ≤480px header (no vertical padding, 44px
+     touch-target buttons). Single source of truth for the clearance offset. */
+  --header-height: 48px;
+
   --dur-fast: 200ms;
   --dur-base: 250ms;
   --dur-slow: 350ms;
@@ -104,14 +115,42 @@ body {
   flex-direction: column;
   height: 100vh;
 }
+
+/* #761 (S2) — Full-viewport map ROOT. The `{mapVisible && …}` block (ScopeControl
+   + MapSurface) was hoisted OUT of the padded `<main>` into this fixed-inset
+   wrapper, rendered as a SIBLING of `<main>`. `position: fixed; inset: 0` makes
+   it viewport-filling and — load-bearing — makes it the nearest POSITIONED
+   ancestor of the absolutely-positioned `.scope-control` (a sibling of
+   `.map-surface`, not its child), so ScopeControl's `inset` offsets resolve
+   against the viewport box. Its z-index sits BELOW the chrome band (`--z-chrome`
+   = 42): the canvas is the backdrop and the floating header floats over it
+   (Google-Maps-style). The map's own overlays (`.family-legend` /
+   `.scope-control` at `--z-overlay`, `.observation-popover` at `--z-popover`)
+   stack within this layer on their existing tiers. */
+#map-layer {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-map);
+}
+
 /* Main surface. The map chain (Map/Region/Badge/BadgeStack/HotspotDot) was
-   removed in the DISCARD wave (#113). FeedSurface shipped in #116;
-   hotspots (#117) and species (#118) mount alongside it. The element is
-   also the e2e readiness gate via data-render-complete. */
+   removed in the DISCARD wave (#113); the map itself was hoisted into
+   `#map-layer` above in the #761 (S2) shell inversion. `<main>` is retained as
+   the e2e readiness gate (data-render-complete), the scroll-bypass affordance
+   (#586), and the `inert` target. It now wraps only non-map view surfaces (none
+   today after F1 #777 removed the feed branch); the `--space-lg` padding stays
+   for any such surface.
+   R15 (S2): the now-`position: fixed` AppHeader left the flow, so any non-map
+   surface here would otherwise render UNDER the floating chrome. `padding-top`
+   (and `scroll-margin-top`, for the #586 scroll-bypass focus target) clears the
+   header height. The map layer is exempt — `#map-layer` sits at `inset: 0`
+   beneath the header on purpose. */
 #main-surface {
   flex: 1;
   min-height: 0;
   padding: var(--space-lg);
+  padding-top: calc(var(--header-height) + var(--space-lg));
+  scroll-margin-top: var(--header-height);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -184,9 +223,10 @@ body {
    for these semantic roles — see tokens.css dark-mode comment at line ~115.
    Do not add per-theme overrides here without revisiting that constraint. */
 
-/* Top-level chrome bar — stretches full width, pins to top of the
-   flex-column .app layout. Sticky so it stays in view when #main-surface
-   overflows. */
+/* Top-level chrome bar — floating fixed chrome over the full-viewport map root.
+   #761 (S2): the shell inverted so the map is the viewport ROOT (`#map-layer`,
+   `position: fixed; inset: 0`) and the header FLOATS over its top edge
+   (Google-Maps-style) rather than displacing it down a flex column. */
 .app-header {
   display: flex;
   align-items: center;
@@ -194,18 +234,24 @@ body {
   padding: var(--space-sm) var(--space-lg);
   background: var(--color-bg-surface);
   border-bottom: 1px solid var(--color-border-ui);
-  position: sticky;
+  /* #761 (S2): `position: fixed` (was `sticky; z-index: 10`) so the header leaves
+     the flow and floats over `#map-layer`. It adopts the named `--z-chrome` token
+     S1 (#778) defined-but-did-not-apply: 42 sits ABOVE the map-assist overlays
+     (legend / scope-control at `--z-overlay` = 40, observation-popover at
+     `--z-popover` = 41) and BELOW the detail rail (`--z-rail` = 43) so the
+     in-place rail (#663) still floats over the header. The P1-deferred
+     scope-control click regression (raising the header above the overlay band
+     made it intercept clicks on the top-anchored `.scope-control`) is fixed in
+     the SAME PR by the compensating `.scope-control` top-offset below — the
+     control is pushed below the header band so `elementFromPoint` returns the
+     control, not the header. (S2 makes NO z-order claim about the bottom-sheet
+     snap tiers (10/15/20) — that reconciliation is the deferred mobile-overlay
+     workstream / O5.) (2026-05-30) */
+  position: fixed;
   top: 0;
-  /* KEPT at the pre-refactor raw 10 (BELOW the overlay band) — #761 P1 (#778)
-     is a strict zero-visual-change refactor and must NOT invert any element's
-     visible stacking. The `.scope-control` floats at top: var(--space-md) (12px)
-     and overlaps this 48px header by ~36px; raising the header to --z-chrome (42,
-     above the overlays) would make it intercept clicks on the scope-control
-     controls (elementFromPoint → HEADER), failing state-scope.spec.ts:180.
-     Adopting --z-chrome (above overlays) for the now-floating header is deferred
-     to S2 (#775), which makes the header floating chrome AND adds the overlay
-     top-offset so the floating header does not occlude .scope-control. (2026-05-30) */
-  z-index: 10;
+  left: 0;
+  right: 0;
+  z-index: var(--z-chrome);
 }
 
 /* Brand link — suppress UA link chrome; inherit body typography.
@@ -452,10 +498,16 @@ body {
    coherence; downstream responsive styles should reuse this token when
    their behavior aligns. */
 .map-surface {
-  position: relative;
-  width: 100%;
-  flex: 1;
-  min-height: 0;
+  /* #761 (S2): the map is the viewport ROOT now. `.map-surface` was a controlled
+     flex child (`flex: 1; min-height: 0`) capped by the old padded `<main>` flex
+     box; post-hoist it fills its `#map-layer` parent (`position: fixed; inset: 0`
+     = the viewport). `position: relative` is RETAINED so the in-`MapSurface`
+     overlays (`.family-legend`, `.observation-popover`) keep anchoring to it; the
+     inner `MapCanvas` is already `width/height: 100%`, so the canvas reaches
+     full-bleed once `#map-layer` does. (Corrective `map.resize()` on the
+     flex→fixed transition is S3's — #773; S2 asserts steady-state geometry only.) */
+  position: absolute;
+  inset: 0;
 }
 
 /* AttributionModal trigger button. Visually a link rather than a CTA so
@@ -930,6 +982,24 @@ aside.species-detail-rail .species-detail-rail-close {
   z-index: 20;
 }
 
+/* #761 (S2): the AppHeader became `position: fixed` floating chrome on
+   `--z-chrome` (42), which now outranks the full-snap sheet's z-stack (10/15/20).
+   That is acceptable for S2 — the full z-reconciliation (lifting the sheet onto
+   `--z-modal` with the compensating #663 inert work) is O5 (#783). The ONE thing
+   S2 must not regress is the sheet's own controls: at full snap the sheet's drag
+   handle / collapse button sits at the viewport TOP, directly under the floating
+   header, so the header would intercept the collapse click (the sheet-snap spec's
+   collapse-at-full path). Because the full-snap sheet is a modal (`aria-modal`,
+   it already inerts `#main-surface`), the chrome behind it must be non-interactive
+   while it is open. This makes the floating header click-through ONLY when a
+   full-snap sheet is present — no z-index change (no z-index war), no inert
+   retarget — so the collapse handle underneath receives the pointer. The header
+   stays visible; it is simply muted under the modal, which is correct modal
+   semantics. (O5 replaces this with proper top-layer z-ordering.) */
+body:has(.species-detail-sheet--full) .app-header {
+  pointer-events: none;
+}
+
 .sheet-handle {
   /* Drag-region: own the gesture entirely; do not pan-scroll the page.
      min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target (MOB-7).
@@ -1385,7 +1455,28 @@ aside.species-detail-rail .species-detail-rail-close {
    positioned at the top-right of the panel. The panel itself needs position:
    relative so the absolute positioning of the close button resolves correctly. */
 .filters-panel {
+  /* #761 (S2) R15 (surface 2): the panel is an in-flow sibling of `<main>`
+     rendered at the top of the `.app` flow, opened from the header on any view
+     (incl. the map). The shell inversion made TWO things occlude it:
+       1. The AppHeader is now `position: fixed` floating chrome, so the panel's
+          top edge + close button would slide UNDER the header. `margin-block-start`
+          offsets the panel below the header band.
+       2. `#map-layer` is now `position: fixed; inset: 0` (a positioned element),
+          so it paints ABOVE the panel's in-flow content — the panel's controls
+          (notable checkbox, typeaheads, close button) would be behind the map and
+          un-clickable. Giving the panel a positioned stacking context with a
+          z-index in the map-assist band lifts it above the map (`--z-map` = 0) and
+          its overlays (legend/scope at `--z-overlay`, popover at `--z-popover`),
+          while staying BELOW the floating header (`--z-chrome`) so the header's
+          own controls remain reachable.
+     This is the interim clearance; the full conversion of `.filters-panel` to a
+     floating sheet + backdrop with proper top-layer z-layering is O4. */
   position: relative;
+  z-index: var(--z-popover);
+  margin-block-start: var(--header-height);
+  /* Opaque surface so the panel's controls read cleanly over the map canvas
+     beneath it (the panel is no longer backed by an in-flow page background). */
+  background: var(--color-bg-surface);
 }
 
 .filters-panel-close {
@@ -1662,7 +1753,16 @@ aside.species-detail-rail .species-detail-rail-close {
    className the TSX renders has a matching rule here (orphan-classname gate). */
 .scope-control {
   position: absolute;
-  inset-block-start: var(--space-md);
+  /* #761 (S2): the AppHeader is now `position: fixed` floating chrome on
+     `--z-chrome` (42) — ABOVE this control's `--z-overlay` (40). At the old
+     `inset-block-start: var(--space-md)` (12px) the control floated UNDER the
+     ~48px header and the header intercepted clicks on the "Change scope" / state
+     <select> / "Whole US" affordances (`elementFromPoint` → HEADER) — the exact
+     regression P1 (#778) surfaced and deferred to S2. Offsetting the top by the
+     header height pushes the control below the header band so it is fully
+     clickable (state-scope.spec.ts whole-US-reset). The wrapper (`#map-layer`)
+     equals the viewport, so this resolves against the viewport top edge. */
+  inset-block-start: calc(var(--header-height) + var(--space-md));
   inset-inline: var(--space-md);
   z-index: var(--z-overlay);
   display: flex;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,6 +38,26 @@
   --space-lg: 16px;
   --space-xl: 24px;
 
+  /* Vertical clearance the bottom-left .family-legend must leave for MapLibre's
+     basemap AttributionControl so the OSM / OpenFreeMap / eBird license text is
+     NEVER overlapped (ODbL + eBird ToU §3 — licensing, not cosmetic). #775.
+
+     Under the full-bleed map (#761 S2) the map fills 100vh and the non-compact
+     attribution (`compact={false}` in MapCanvas.tsx — deliberately always-
+     expanded so the OSM credit is visible without a click) renders as a bottom
+     bar that, on narrow viewports, spans the FULL viewport width and wraps to
+     multiple lines — its left portion reaching into the legend's bottom-left
+     corner. Measured band heights (single source of truth for this token,
+     re-derive with the map-root-geometry attribution-clearance guard):
+       - ≤760px : 3-line wrap  → ~60px tall, left edge at x=0  (full width)
+       - 761–1024px : 2→1-line → up to ~40px tall, wide bar
+       - >1024px : single line → ~20px tall, hugs the bottom-right corner
+     The token lifts the legend's bottom anchor ABOVE the worst-case band per
+     tier (clearance > band height), so the lift is independent of the bar's
+     horizontal extent — the legend clears it vertically regardless of width.
+     Default is the desktop tier; the two media queries below override it. */
+  --attribution-clearance: 20px;
+
   /* Floating-header height (#761 S2). The AppHeader became `position: fixed`
      chrome over the full-viewport map root, so it no longer occupies flow
      height. Every in-flow chrome surface that previously sat below it — the
@@ -677,13 +697,17 @@ body {
 }
 
 /* FamilyLegend floating overlay (#249). Anchored to the bottom-left of
-   .map-surface, above MapLibre's AttributionControl (which lives at
-   bottom-right by default — but we still want clearance for keyboard-tabs
-   that open it). The legend is a semantic <aside> — keyboard-reachable,
-   labelled by its toggle button, and self-collapsing on mobile. */
+   .map-surface. MapLibre's non-compact AttributionControl anchors bottom-right
+   but, under the full-bleed map (#761 S2), its always-expanded license bar wraps
+   to the FULL viewport width on narrow viewports and reaches into this corner.
+   The `bottom` offset lifts the legend ABOVE that band (--attribution-clearance,
+   tiered by viewport) so the OSM / OpenFreeMap / eBird credit is never overlapped
+   — a licensing requirement, not cosmetic (#775). The legend is a semantic
+   <aside> — keyboard-reachable, labelled by its toggle button, and self-
+   collapsing on mobile. */
 .family-legend {
   position: absolute;
-  bottom: var(--space-md);
+  bottom: calc(var(--space-md) + var(--attribution-clearance));
   left: var(--space-md);
   z-index: var(--z-overlay);
   background: var(--color-bg-surface);
@@ -787,13 +811,32 @@ body {
   background: var(--color-bg-surface);
 }
 
+/* Attribution-clearance tablet tier (#775). At 761–1024px the non-compact
+   basemap attribution bar wraps to ~2 lines (~40px tall, measured at 768×1024)
+   and still spans most of the viewport width, so the legend must clear a taller
+   band than the desktop default. Source-ordered BEFORE the ≤760px block so the
+   narrower mobile query (60px) overrides this at phone widths. */
+@media (max-width: 1024px) {
+  :root {
+    --attribution-clearance: 40px;
+  }
+}
+
 /* Mobile collapse-by-default. The component reads this breakpoint via
    matchMedia at mount time (see MapSurface.readLegendDefaultExpanded);
    the CSS below additionally tightens the collapsed footprint so the
    chevron tab doesn't obscure the map. localStorage 'family-legend-
    expanded' overrides this — the responsive default is a first-visit
-   hint, not a sticky rule. */
+   hint, not a sticky rule.
+
+   --attribution-clearance jumps to 60px here: at ≤760px the attribution bar
+   spans the full viewport width and wraps to ~3 lines (measured 60px at
+   390×844), so the legend's bottom-left corner must clear that full band
+   (#775 — licensing requirement). */
 @media (max-width: 760px) {
+  :root {
+    --attribution-clearance: 60px;
+  }
   .family-legend {
     max-width: calc(100vw - 2 * var(--space-md));
   }


### PR DESCRIPTION
## Diagrams

DOM/stacking inversion — the map moves from a windowed flex child of the padded `<main>` to the viewport-filling root, with the chrome floating on top.

```mermaid
graph TB
    subgraph after["AFTER — #761 S2 (map-first root)"]
        A2[".app — flex column"]
        A2 --> H2["AppHeader<br/>position: fixed · --z-chrome 42<br/>(floats over the map)"]
        A2 --> ML["#map-layer (NEW wrapper)<br/>position: fixed · inset: 0 · --z-map 0"]
        ML --> SC2["ScopeControl<br/>absolute · top = header + space-md"]
        ML --> MS2[".map-surface absolute inset:0<br/>(fills the viewport)"]
        A2 --> MN2["&lt;main #main-surface&gt;<br/>empty · padding-top clears header<br/>(readiness gate + inert target)"]
        A2 --> RAIL2["detail rail / sheet<br/>--z-rail 43 (floats over header)"]
        A2 --> SCRIM2["chooser scrim --z-modal 50"]
    end

    subgraph before["BEFORE (windowed map)"]
        A1[".app — flex column"]
        A1 --> H1["AppHeader<br/>position: sticky · z-index 10"]
        A1 --> MN1["&lt;main #main-surface&gt;<br/>flex:1 · padding 16px (caps the map)"]
        MN1 --> SC1["ScopeControl (absolute)"]
        MN1 --> MS1[".map-surface flex:1 (windowed)"]
        A1 --> RAIL1["detail rail / sheet (fixed)"]
    end
```

## Summary

- **Why:** the map was *windowed inside the UI* (a padded, header-capped flex child), not the application itself. #761 (S2) inverts the shell so the map is the viewport-filling **root** and the chrome floats over it (Google-Maps-style) — the foundation the rest of the map-first epic builds on.
- **How:** DOM extraction, not conditional padding. The `{mapVisible && …}` block (ScopeControl + MapSurface) is hoisted out of `<main>` into a mandatory `<div id="map-layer">` (`position: fixed; inset: 0`) rendered as a **sibling** of `<main>`. The wrapper is load-bearing — ScopeControl is a sibling of MapSurface, so its `position: absolute` resolves against the fixed wrapper (≡ viewport) and keeps anchoring to the viewport top edge. `.app-header` becomes `position: fixed` and adopts the P1-defined-but-unapplied `--z-chrome` (42): above the map-assist overlays (40/41), below the detail rail (43).
- **Occlusion handled (R15 + the P1-deferred regression):** the now-floating header would intercept clicks on the top-anchored `.scope-control` (the exact regression P1 surfaced) — fixed by offsetting the control's top by `--header-height` so it clears the header band (state-scope whole-US-reset stays clickable). `#main-surface` gains a `padding-top`/`scroll-margin-top` header clearance for any future non-map surface; the open `.filters-panel` gains the same offset **plus** a positioned z-index in the map-assist band so its controls aren't buried behind the full-bleed map (interim — O4 makes it a floating sheet). The Map tab's `aria-controls` is retargeted `"main-surface"` → `"map-layer"`. Invariants preserved: `#map-layer` is gated only by `mapVisible` (NOT `scopeActive`), so the unscoped scrim landing still mounts the idle map and the `scopeActive` fetch gate holds `/api/observations` at **zero**; `<main>` keeps its `id`/`data-render-complete`/`mainRef`/`tabIndex`/`inert` target (inert retarget to `#map-layer` is O1).

## Screenshots

### Full-viewport map root (scoped, AZ)

The headline S2 result: the map is the viewport-filling **root**, with the header + scope-control floating over it. All 5 canonical viewports × both themes.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="390" alt="scoped AZ 390×844 light" src="https://github.com/user-attachments/assets/4e22b25a-f659-40db-bd79-5330d5d6d4be" /> | <img width="390" alt="scoped AZ 390×844 dark" src="https://github.com/user-attachments/assets/d1a90c88-5c54-4db4-bc07-b07e0689915f" /> |
| 768×1024 (tablet portrait) | <img width="390" alt="scoped AZ 768×1024 light" src="https://github.com/user-attachments/assets/8f565c02-38c0-4972-84f5-19051db0fe49" /> | <img width="390" alt="scoped AZ 768×1024 dark" src="https://github.com/user-attachments/assets/88e3dfb8-691b-4cee-bc91-841a56b6d5f8" /> |
| 1024×768 (tablet landscape) | <img width="390" alt="scoped AZ 1024×768 light" src="https://github.com/user-attachments/assets/39e82d73-c563-4c71-876f-24328de1d808" /> | <img width="390" alt="scoped AZ 1024×768 dark" src="https://github.com/user-attachments/assets/72add748-4669-414d-8fb7-110c261654c5" /> |
| 1440×900 (desktop) | <img width="390" alt="scoped AZ 1440×900 light" src="https://github.com/user-attachments/assets/c895654a-c782-4ebc-9356-1d2d837b4a51" /> | <img width="390" alt="scoped AZ 1440×900 dark" src="https://github.com/user-attachments/assets/402320f5-cd1d-41f3-9ac4-ff4d697cc5d1" /> |
| 1920×1080 (wide) | <img width="390" alt="scoped AZ 1920×1080 light" src="https://github.com/user-attachments/assets/d0239be5-b0d2-4cd4-9143-4c9d189ccb63" /> | <img width="390" alt="scoped AZ 1920×1080 dark" src="https://github.com/user-attachments/assets/2f3a9b3b-1e0f-467e-a308-1eeeda09c56c" /> |

### Unscoped landing (scrim over full-bleed map)

The chooser scrim over the full-bleed **idle** map (no scope yet → zero `/api/observations`). 1440×900, both themes.

| Light | Dark |
|---|---|
| <img width="430" alt="unscoped landing 1440×900 light" src="https://github.com/user-attachments/assets/612e5673-4675-4e2e-931c-308c06718f76" /> | <img width="430" alt="unscoped landing 1440×900 dark" src="https://github.com/user-attachments/assets/7508107a-3936-4471-af42-d0c49b193ae0" /> |

### Floating-chrome interactions & border zoom

Mobile full-snap detail sheet — the collapse handle stays reachable under the floating header (the `body:has(.species-detail-sheet--full)` click-through). Border zoom (AZ) confirms no interior clipping at the artboard mask edge, light + dark.

| Mobile full-snap sheet (390, light) | AZ border zoom (1440, light) | AZ border zoom (1440, dark) |
|---|---|---|
| <img width="280" alt="mobile full-snap sheet 390 light" src="https://github.com/user-attachments/assets/fa72131a-ea02-4e50-adee-bf2aa7ec6c06" /> | <img width="280" alt="AZ border zoom 1440 light" src="https://github.com/user-attachments/assets/14d4424a-4b42-4bcb-9900-e2dfeaa2d041" /> | <img width="280" alt="AZ border zoom 1440 dark" src="https://github.com/user-attachments/assets/c4d72f9f-ab3a-470b-8038-1dec2ecfecdd" /> |

_Live Playwright MCP verification PASSED — 0 console errors at all 5 viewports × both themes; scope-control non-occluded; mobile full-snap collapse-handle guard works; border zoom shows no interior clipping (only pre-existing OpenFreeMap basemap sprite warnings)._

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `scripts/check-orphan-classnames.sh` → PASS. (This PR adds no new JSX `className`; it modifies existing selectors and adds the `#map-layer` id-selector rule. `orphan-classname-check`: PASS.)
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — PENDING (orchestrator captures the live drive at all 5 canonical viewports × 2 themes per #445).

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (65 files, **965** unit tests). New unit assertions: map renders in `#map-layer` as a **sibling** of `<main>` (not a `#main-surface` descendant); Map tab `aria-controls="map-layer"`; `#map-layer` mounts on the unscoped scrim landing with zero `/api/observations`.
- [x] New unit / integration tests added — `App.test.tsx` (S2 DOM-structure + tab-region + always-mounted-unscoped describe), `AppHeader.test.tsx` (`aria-controls="map-layer"`).
- [x] New Playwright e2e spec added — `e2e/map-root-geometry.spec.ts`: full-bleed `.map-surface` ≈ viewport (no 16px gutters); `.scope-control` viewport anchor clearing the fixed header; open filters-panel header clearance at 390×844 + 1440×900; `#map-layer` mounted idle + zero observations on the unscoped landing. Re-baselined the #471 family-legend clip-guard from `#main-surface` → the **viewport** (the map left `#main-surface` by design); routed attribution-modal/axe modal opens through the header affordance (the standalone `.attribution-trigger` now sits behind the full-bleed map). Full local e2e: **223 passed / 14 WebGL-skipped**, single-worker (CI runs SwiftShader for the skipped set).
- [x] `npm run build --workspace @bird-watch/frontend` — clean. `npm run lint` — clean. `npx knip` — clean. No-DB-writes grep — clean.
- [ ] (UI only) Playwright MCP smoke — PENDING: the orchestrator runs the live capture (this subagent did not use Playwright MCP per the dispatch). Reviewers repeat the drive + console check via `gh pr checkout` against the head SHA.

## Plan reference

Part of #761 (map-first re-architecture), sub-issue **S2** — head of Phase 3's shell-inversion chain (S2 → {S3, S4, O1…O7}). Research report: `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md` §6 / WS1 (App-shell inversion) + WS2 (Full-bleed map container), §10 sub-issue S2, risk register R15. Closes #775.

Out of scope (deferred to the named downstream sub-issue): corrective `map.resize()` on the flex→fixed transition + asymmetric `fitBounds` top-padding → **S3** (#773); `inert`/`aria-busy`/`aria-live` retarget onto `#map-layer` → **O1**; `.filters-panel` → floating sheet → **O4**; full-snap sheet z-order reconcile → **O5** (#783) — S2 only keeps the sheet's collapse handle reachable via a `body:has(.species-detail-sheet--full)` click-through on the header, no z-index war.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
