### PR TITLE
ci: bump actions/setup-node 4→6 in knip.yml workflow

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: package.json
           cache: npm


### PR DESCRIPTION
## Diagrams

N/A — single-line CI action version bump (`actions/setup-node@v4` → `@v6`), no data flow or behavior to diagram.

## Summary

- Completes the dependency bump abandoned in Dependabot **#346** (`bump actions/setup-node from 4 to 6`), which was closed with its branch deleted, leaving one straggling `actions/setup-node@v4` in `.github/workflows/knip.yml`.
- Brings the last lingering workflow into line — all 9 other workflows already pin `actions/setup-node@v6`; after this PR all 10 are consistent.

## Screenshots

N/A — not UI

## Test plan

- [x] `grep -rn "actions/setup-node@v4" .github/workflows/` returns ZERO matches
- [x] `grep -c "actions/setup-node@v6" .github/workflows/knip.yml` returns 1
- [x] Diff is the single intended line; no other files touched
- [ ] CI `test`, `lint`, `build`, `e2e` green on this PR

## Plan reference

Out of plan — CI maintenance; revives the abandoned Dependabot #346 dependency bump.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)