### PR TITLE
feat(frontend): scope-gate onViewportChange so a live unscoped map fires zero fetches  closes #769

### DIFF
--- a/frontend/e2e/map-unscoped-no-fetch.spec.ts
+++ b/frontend/e2e/map-unscoped-no-fetch.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * S4 (#769) — scope-gate `onViewportChange` so the persistent unscoped map (S1)
+ * fires ZERO `/api/observations` requests. Closes R1 — the highest-severity risk
+ * in the #761 epic risk register (report §8): a backgrounded-but-mounted unscoped
+ * map scheduling a bbox refetch and breaking the #740/C6
+ * zero-fetch-on-unscoped-landing AC.
+ *
+ * What state-scope.spec.ts already proves: a bare-URL chooser landing fires zero
+ * `/api/observations` (the unmount-independent, fetch-gate-backed assertion).
+ *
+ * What THIS spec adds (the part state-scope.spec.ts does NOT cover): drive a
+ * REAL viewport-idle on the LIVE, MOUNTED unscoped map (via `window.__birdMap` +
+ * `map.once('idle')`) and re-assert net `/api/observations` === 0. That `idle` is
+ * the exact event `onViewportChange` listens to (MapCanvas's handleLoad wires
+ * `map.on('idle', …)`). It is the assertion that would FAIL on the S1 base
+ * WITHOUT the scope-gate and PASSES with it — proving the live map, not the
+ * unmount, is what suppresses the fetch.
+ *
+ * Navigation contract: this is a chooser-landing case, so it skips
+ * `waitForAppReady()` (no `[data-render-complete]` is expected while unscoped).
+ */
+
+/**
+ * Drive the maplibre map to a given center + zoom via the `window.__birdMap`
+ * test hook (set by MapCanvas.tsx's handleLoad callback in non-prod builds).
+ * Installs a one-shot `idle` latch and waits for the post-jump `idle` — the same
+ * event `onViewportChange` listens to. Mirrors `driveMapTo` in
+ * family-legend-viewport.spec.ts. Returns `false` when the hook is missing.
+ */
+async function driveMapTo(
+  page: import('@playwright/test').Page,
+  lng: number,
+  lat: number,
+  zoom: number,
+): Promise<boolean> {
+  const dispatched = await page.evaluate(
+    ([lng, lat, zoom]: [number, number, number]) => {
+      try {
+        const w = window as {
+          __birdMap?: {
+            jumpTo?: (opts: object) => void;
+            flyTo?: (opts: object) => void;
+            once: (ev: string, cb: () => void) => void;
+          };
+          __birdMapIdleSince?: number;
+        };
+        const map = w.__birdMap;
+        if (!map) return false;
+        // One-shot idle latch — wait for the *next* idle after this camera
+        // change rather than racing one that fired before the jump.
+        w.__birdMapIdleSince = 0;
+        map.once('idle', () => {
+          (window as { __birdMapIdleSince?: number }).__birdMapIdleSince =
+            Date.now();
+        });
+        // Prefer jumpTo (synchronous moveend, no animation interpolation) over
+        // flyTo({ duration: 0 }) — the in-tree note: flyTo's duration-0 path can
+        // race the cold-load initial idle under CI load.
+        if (typeof map.jumpTo === 'function') {
+          map.jumpTo({ center: [lng, lat], zoom });
+        } else if (typeof map.flyTo === 'function') {
+          map.flyTo({ center: [lng, lat], zoom, duration: 0 });
+        } else {
+          return false;
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [lng, lat, zoom] as [number, number, number],
+  );
+  if (!dispatched) return false;
+  // Deterministically wait for the post-jump idle (the latch flips non-zero)
+  // instead of racing a fixed timeout — required under `retries: 0`.
+  await page
+    .waitForFunction(
+      () => {
+        const since = (window as { __birdMapIdleSince?: number })
+          .__birdMapIdleSince;
+        return typeof since === 'number' && since > 0;
+      },
+      undefined,
+      { timeout: 5_000 },
+    )
+    .catch(() => undefined);
+  return true;
+}
+
+/**
+ * WebGL skip guard. `window.__birdMap` is exposed only once maplibre fires
+ * `load` on a mounted map. Skip cleanly when the hook is absent (no GPU in
+ * headless). Mirrors `skipIfMapHookAbsent` in family-legend-viewport.spec.ts.
+ */
+async function skipIfMapHookAbsent(
+  page: import('@playwright/test').Page,
+  testRef: typeof test,
+): Promise<boolean> {
+  const present = await page
+    .waitForFunction(
+      () =>
+        typeof (window as { __birdMap?: unknown }).__birdMap !== 'undefined',
+      { timeout: 8_000 },
+    )
+    .then(() => true)
+    .catch(() => false);
+  if (!present) {
+    testRef.skip(
+      true,
+      'window.__birdMap not exposed — maplibre `load` did not fire ' +
+        '(likely WebGL unavailable in headless run).',
+    );
+  }
+  return !present;
+}
+
+test.describe('S4 (#769): live unscoped map fires zero /api/observations', () => {
+  // Desktop framing — the unscoped map mounts behind the chooser scrim at any
+  // viewport; pin a deterministic one.
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  /**
+   * Register the always-needed scope stubs and a `/api/observations` request
+   * counter. Mirrors state-scope.spec.ts `setup()` (stubStates + stubZipIndex +
+   * stubEmpty, and a `page.on('request', …)` matcher on `/api/observations`).
+   */
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('./fixtures.js').ApiStub,
+  ): Promise<{ app: AppPage; obsRequests: string[] }> {
+    await apiStub.stubStates();
+    await apiStub.stubZipIndex();
+    // stubEmpty also stubs /api/observations → [] as a fallback so any leaked
+    // request resolves (and is still counted) rather than 404-ing.
+    await apiStub.stubEmpty();
+
+    const obsRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('/api/observations')) obsRequests.push(req.url());
+    });
+
+    return { app: new AppPage(page), obsRequests };
+  }
+
+  test('a real viewport-idle on the live, mounted unscoped map fires zero /api/observations', async ({
+    page,
+    apiStub,
+  }) => {
+    test.setTimeout(60_000);
+    const { app, obsRequests } = await setup(page, apiStub);
+
+    // gotoRaw('') — NO default-scope injection: the true bare-URL unscoped
+    // landing (goto('') would inject scope=us). Skips waitForAppReady (no map
+    // render-complete is expected while unscoped).
+    await app.gotoRaw('');
+
+    // The chooser scrim is the visible primary surface; the map is mounted but
+    // INERT behind it (S1). This also confirms __birdMap's host is present.
+    await expect(app.chooser).toBeVisible();
+    await app.expectMapInert();
+
+    // Baseline (the state-scope.spec.ts assertion, kept green here too): no
+    // fetch on the static unscoped landing. Hold the window open for any late
+    // fetch.
+    await page.waitForTimeout(800);
+    expect(obsRequests).toHaveLength(0);
+
+    // The S4-specific proof: the map must reach maplibre `load` (so __birdMap is
+    // exposed) THROUGH the scrim — the scrim must overlay, not unmount /
+    // display:none, the map. If WebGL is unavailable in headless, skip cleanly.
+    if (await skipIfMapHookAbsent(page, test)) return;
+
+    // Drive a REAL viewport-idle while still unscoped — the same `idle` event
+    // App's onViewportChange listens to. Without the S4 scope-gate this settle
+    // would stage a bbox/zoom and (once a scope is active) leak a fetch; with
+    // the gate it does ZERO refetch work.
+    const driven = await driveMapTo(page, -111.0, 34.0, 6);
+    expect(driven).toBe(true);
+
+    // Give any (mistaken) 250ms bbox debounce + fetch effect a generous window
+    // to fire before re-asserting.
+    await page.waitForTimeout(800);
+
+    // The load-bearing assertion: STILL zero /api/observations after a live
+    // unscoped idle. This passes only because onViewportChange early-returns
+    // while unscoped (R1 closed) — not because the map is unmounted.
+    expect(obsRequests).toHaveLength(0);
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -794,6 +794,119 @@ describe('Zoom/bbox state-race regression (#690)', () => {
   });
 });
 
+describe('S4 (#769): onViewportChange scope-gate', () => {
+  // A plain object with the four getter methods App.tsx calls on a LngLatBounds
+  // (jsdom can't load maplibre-gl — the same constraint the MapSurface stub and
+  // the #690 block above work around).
+  function makeBounds(
+    west: number, south: number, east: number, north: number,
+  ): LngLatBounds {
+    return {
+      getWest: () => west,
+      getSouth: () => south,
+      getEast: () => east,
+      getNorth: () => north,
+    } as unknown as LngLatBounds;
+  }
+
+  // Two arbitrary, distinct framings — chosen so the second is a clearly
+  // different camera (would force a `setViewportBounds` re-render if the gate
+  // were absent).
+  const FRAME_A = makeBounds(-125, 24, -66, 50);
+  const FRAME_B = makeBounds(-122.5, 37.3, -121.8, 37.9);
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetStatesCache();
+    mockGetStates.mockResolvedValue([]);
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({
+      data: [], meta: { freshestObservationAt: null },
+    });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mockGetObservations.mockClear();
+    mockGetHotspots.mockClear();
+    mapSurfaceRef.onViewportChange = null;
+    mapSurfaceRef.boundsKey = undefined;
+    mapSurfaceRef.scopeBounds = undefined;
+    mapSurfaceRef.flyTo = undefined;
+    mapSurfaceRef.renderCount = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // AC: while unscoped, onViewportChange early-returns — it does NOT call
+  // setViewportBounds, so a settled `idle` causes ZERO additional App renders.
+  // Under S1 the map is persistently mounted behind the scrim, so the real
+  // maplibre `idle` (modelled here by invoking the captured callback) DOES
+  // reach App's onViewportChange even while unscoped — the early-return is the
+  // mechanism that keeps it inert, NOT an unmount. This is the unit-level proof
+  // that the live-map e2e proves at the network layer (net /api/observations
+  // === 0 after a real unscoped idle).
+  it('does NOT update viewportBounds (no re-render) when the map idles while unscoped', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'unscoped' },
+    };
+    render(<App />);
+    // The chooser scrim is up, but the map surface is mounted behind it (S1),
+    // so the stub captures the live onViewportChange even while unscoped.
+    expect(
+      await screen.findByRole('region', { name: /Choose where to look at birds/i }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+    });
+    const onViewportChange = mapSurfaceRef.onViewportChange!;
+
+    const rendersBefore = mapSurfaceRef.renderCount;
+    // Drive a settled viewport idle while unscoped — the gate must swallow it
+    // with ZERO state writes, so no re-render is committed.
+    await act(async () => {
+      onViewportChange(FRAME_A, 4);
+    });
+    await act(async () => {
+      onViewportChange(FRAME_B, 9);
+    });
+    expect(mapSurfaceRef.renderCount).toBe(rendersBefore);
+    // And the enabled=false backstop still holds: no observations fetch fired.
+    expect(mockGetObservations).not.toHaveBeenCalled();
+  });
+
+  // Control case: with a scope active, the SAME callback DOES update
+  // viewportBounds (re-renders) — proving the no-op above is the unscoped gate,
+  // not a dead callback. (`?scope=us` framing arms the scopeMoveUntilRef window,
+  // so we advance past SCOPE_MOVE_SETTLE_MS first; that window suppresses the
+  // bbox *refetch*, NOT the `setViewportBounds` write the legend depends on.)
+  it('DOES update viewportBounds (re-renders) when the map idles while scoped', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'us' as const },
+    };
+    render(<App />);
+    await waitFor(() => {
+      expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+    });
+    const onViewportChange = mapSurfaceRef.onViewportChange!;
+
+    // Clear the scope-framing settle window so the idle is treated as genuine
+    // user pan, not the programmatic scope-frame settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+    });
+    const rendersBefore = mapSurfaceRef.renderCount;
+    await act(async () => {
+      onViewportChange(FRAME_B, 9);
+    });
+    // setViewportBounds committed a new value → at least one re-render.
+    expect(mapSurfaceRef.renderCount).toBeGreaterThan(rendersBefore);
+  });
+});
+
 describe('#740 (C6): scope wiring end-to-end', () => {
   // Two CONUS states for the /api/states table. `bbox` is [w,s,e,n] (the
   // StateSummary order); App converts to [[w,s],[e,n]] for the camera.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -137,6 +137,15 @@ export function App() {
   // but the fetch gate is the load-bearing half: it keeps the network panel
   // empty even though the hooks above this return are always evaluated.
   const scopeActive = state.scope.kind !== 'unscoped';
+  // S4 (#769) — live-readable mirror of `scopeActive` for the empty-deps
+  // `onViewportChange` callback (below). It is read through `.current` so the
+  // callback can hard scope-gate WITHOUT taking `state.scope` as a dep (which
+  // would re-create the `useCallback(…, [])` and risk the #690 bbox/zoom
+  // de-pairing). Same per-render-assignment idiom as MapCanvas's
+  // `onViewportChangeRef` (MapCanvas.tsx:1016-1017): assign on every render so
+  // the ref always holds the current value by the time an `idle` fires.
+  const scopeActiveRef = useRef(scopeActive);
+  scopeActiveRef.current = scopeActive;
   // #740 (C6) — only a `?state=US-XX` scope sends `?state=` to the API (the
   // server clips via ST_Intersects). UNSCOPED and `?scope=us` both leave
   // `stateCode` unset, so the backend stays untouched (data invariant, #735).
@@ -336,7 +345,13 @@ export function App() {
   // is the single fetch trigger (via the `stateCode`/`enabled` deps of
   // useBirdData). After the window, genuine user pan/zoom within the scope
   // refetches normally. Unscoped (`boundsKey === undefined`) needs no
-  // suppression — the map is unmounted and no idle fires.
+  // suppression here — but the reason is NO LONGER "the map is unmounted and no
+  // idle fires." #761 (S1) made the map persistently mounted behind the chooser
+  // scrim, so an unscoped map DOES emit `idle`. The unscoped no-op is now
+  // enforced one level up by the `scopeActiveRef` early-return at the top of
+  // `onViewportChange` below (S4, #769) — it returns before this window is even
+  // read while unscoped, so `scopeMoveUntilRef` is never consulted on the
+  // unscoped landing.
   const SCOPE_MOVE_SETTLE_MS = 1000;
   const scopeMoveUntilRef = useRef(0);
   useEffect(() => {
@@ -345,6 +360,33 @@ export function App() {
     }
   }, [boundsKey, flyTo?.key]);
   const onViewportChange = useCallback((bounds: LngLatBounds, zoom: number) => {
+    // S4 (#769) — hard scope-gate. #761 (S1) made the map persistently mounted
+    // behind the chooser scrim, so a still-UNSCOPED map keeps emitting `idle`.
+    // The `scopeMoveUntilRef` window below only covers the scope-framing settle
+    // and historically assumed the map was UNMOUNTED while unscoped. Under the
+    // always-mounted model an unscoped idle must do ZERO refetch work — not even
+    // `setViewportBounds` or a `scopeMoveUntilRef` read — because
+    // `useBirdData(enabled=false)` is a SINGLE backstop, not the load-bearing
+    // gate (R1, the epic's highest risk). Returning here makes the two gates
+    // independently sufficient: an unscoped idle cannot stage a bbox/zoom even
+    // if a scope is then activated mid-pan.
+    //
+    // Skipping `setViewportBounds(bounds)` while unscoped is safe because of the
+    // EMPTY-OBSERVATIONS invariant, NOT the `mapVisible` view-gate. `mapVisible`
+    // (`state.view === 'map' || 'detail'`) is gated on VIEW, not scope — on the
+    // unscoped landing the view is still `'map'`, so `mapVisible === true` and
+    // it does not discriminate the unscoped case at all. The load-bearing reason
+    // is that while unscoped `useBirdData(enabled=false)` leaves
+    // `observations === []` (use-bird-data.ts:116, the `!enabled` short-circuit
+    // at :148, and `setObservations([])` at :153), so the `viewportObservations`
+    // memo computes `filterObservationsByBounds([], bounds) === []` independent
+    // of `viewportBounds` — a stale/absent `viewportBounds` is therefore inert.
+    // (Secondary, belt-and-suspenders: under S1 the inert scrim also suppresses
+    // map-marker render and the FamilyLegend it feeds; but the primary safety
+    // rests on the empty-observations invariant, not the scrim.)
+    if (!scopeActiveRef.current) {
+      return;
+    }
     setViewportBounds(bounds);
     // Swallow the scope-change settle window: keep the legend's bounds fresh
     // (set above) but skip the bbox/zoom refetch while the programmatic camera


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    idle["maplibre `idle` event<br/>(live, mounted unscoped map — S1)"] --> ovc["onViewportChange(bounds, zoom)"]
    ovc --> gate{"scopeActiveRef.current ?"}
    gate -- "false (UNSCOPED)" --> ret["return — ZERO refetch work:<br/>no setViewportBounds,<br/>no scopeMoveUntilRef read,<br/>no bbox/zoom debounce"]
    gate -- "true (SCOPED)" --> svb["setViewportBounds(bounds)"]
    svb --> win{"within scopeMoveUntilRef<br/>settle window?"}
    win -- "yes" --> legend["legend bounds fresh,<br/>skip refetch"]
    win -- "no" --> debounce["250ms bbox/zoom debounce<br/>→ setDebouncedBbox/Zoom"]
    debounce --> ubd["useBirdData filters change"]

    ret -. "S4 closes R1 here" .- backstop["useBirdData(enabled=scopeActive)<br/>retained backstop — false while unscoped"]

    style gate fill:#fde68a,stroke:#b45309
    style ret fill:#bbf7d0,stroke:#15803d
    style backstop fill:#e0e7ff,stroke:#4338ca
```

```mermaid
sequenceDiagram
    participant E2E as e2e (map-unscoped-no-fetch)
    participant Map as window.__birdMap (live, unscoped)
    participant App as onViewportChange
    participant API as /api/observations

    E2E->>Map: gotoRaw('') — bare URL, scrim over mounted idle map
    Note over API: obsRequests.length === 0 (static landing)
    E2E->>Map: jumpTo({center, zoom}) + once('idle')
    Map->>App: idle → onViewportChange(bounds, zoom)
    App-->>App: scopeActiveRef.current === false → return
    App--xAPI: (no bbox write, no fetch scheduled)
    Note over API: obsRequests.length === 0 (after a REAL live idle)
```

## Summary

- **Why:** S1 (#772) made the map persistently mounted behind the chooser scrim while unscoped, so a live unscoped map now emits maplibre `idle`. `onViewportChange`'s `scopeMoveUntilRef` guard historically relied on the map being UNMOUNTED while unscoped — that premise is now false, leaving `useBirdData(enabled=false)` as the SINGLE backstop against an `/api/observations` fetch on the unscoped landing. This is **R1 — the highest-severity risk in the #761 epic risk register** (report §8).
- **What:** `onViewportChange` hard scope-gates with a `scopeActiveRef.current` early-return as its first statement (before `setViewportBounds`, the `scopeMoveUntilRef` read, and the bbox debounce). The ref mirrors `scopeActive` via a per-render assignment (the MapCanvas `onViewportChangeRef` idiom), so the callback keeps its `useCallback(…, [])` empty deps — `state.scope` is NOT added to the dep array, preserving the #690 bbox/zoom-pairing invariant. `enabled={scopeActive}` is retained unchanged as the documented backstop — the two gates are now independently sufficient.
- **Safety of skipping `setViewportBounds` while unscoped** rests on the EMPTY-OBSERVATIONS invariant (`useBirdData(enabled=false)` leaves `observations === []`, so `viewportObservations === filterObservationsByBounds([], bounds) === []` independent of `viewportBounds`), NOT the `mapVisible` view-gate (which is gated on view — still `'map'` while unscoped — and does not discriminate the unscoped case).

## Screenshots

N/A — non-UI behavioral change (scope-gate on onViewportChange); the zero-/api/observations-on-unscoped-landing guarantee is verified by e2e, not screenshots.

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A — no new classNames (logic-only change)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445) — N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — green (967 frontend unit tests pass, incl. 2 new S4 `onViewportChange scope-gate` cases)
- [x] New unit / integration tests added (if behavior changed) — `App.test.tsx`: unscoped idle → no re-render (early-return); scoped idle → re-renders (control)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — `frontend/e2e/map-unscoped-no-fetch.spec.ts`: drives a REAL viewport-idle on the live, mounted unscoped map via `window.__birdMap` + `map.once('idle')`, asserts net `/api/observations` === 0
- [x] `npm run build` — clean production build (`npm run build --workspace @bird-watch/frontend`)
- [x] Full e2e single-worker — 227 passed, 14 skipped, 0 failed; the new spec ran the live-idle path (WebGL available); existing zero-fetch assertions (state-scope, zip-scope) stayed green
- [x] `npx knip` — clean (exit 0); no-DB-write grep — clean
- [ ] (UI only) Playwright MCP smoke — N/A — not UI (logic-only `frontend/**` change, exempt per CLAUDE.md)

## Plan reference

Part of epic **#761** (map-first re-architecture), sub-issue **S4 (#769)** — WS8 (performance of an always-mounted map). Closes **R1**, the highest-severity risk in the epic risk register: `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md` §8 (R1), §6 (WS8 → 8.2), §7 (cross-cutting map mount lifecycle precondition #2), §10 (Phase 3 → S4). Per the issue, S4's scope-gate co-lands with S1's persistent mount (already on main as #772/#794); this PR delivers the S4 delta + its live-idle e2e against that mounted base. Preserves the #740/C6 zero-`/api/observations`-on-unscoped-landing AC.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)