### PR TITLE
feat(frontend): bring cell/cluster popovers + hover-preview onto the named z-scale  closes #782

### DIFF
--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -157,6 +157,48 @@ test('desktop 1440×900: keyboard skip-link → cell → Enter → popover → E
   await expect(page).not.toHaveURL(/[?&]detail=/);
 });
 
+// ─── #761 O6 (#782): detail-overlay gate — hovering a cell with a detail
+//     overlay open does NOT surface the passive hover preview ──────────────────
+//
+// The detail rail/sheet stays the topmost interactive surface; the unbidden
+// hover tooltip is suppressed (AdaptiveGridMarker's `detailOpen` gate, threaded
+// App → MapSurface → MapCanvas → AdaptiveGridMarker). WebGL-guarded like the
+// other live-marker scenarios. No @coarse → dev-server, 1440×900.
+
+test('desktop 1440×900: with the detail rail open, hovering a cell does NOT surface the hover preview', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  // Open a detail overlay alongside the live map (rail mounts at ≥1200px).
+  await page.goto('/?scope=us&detail=vermfly&view=detail');
+
+  // Canonical "map settled" gate.
+  const marker = page.locator('[data-testid="adaptive-grid-marker"]').first();
+  const markerVisible = await marker.waitFor({ state: 'visible', timeout: 15_000 }).then(() => true).catch(() => false);
+  if (!markerVisible) {
+    test.skip(true, 'No adaptive-grid markers visible — likely WebGL unavailable in headless run');
+    return;
+  }
+
+  // The detail rail/sheet must be the topmost interactive surface.
+  const detailSurface = page.locator('aside.species-detail-rail, .species-detail-sheet');
+  await expect(detailSurface.first()).toBeVisible({ timeout: 10_000 });
+
+  // Hover a cell — under the gate, the passive preview must NOT mount.
+  const cell = page.locator('[data-testid^="adaptive-grid-marker-cell"]').first();
+  const cellVisible = await cell.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+  if (!cellVisible) {
+    test.skip(true, 'No cell testids visible — Phase 3 cells may not have rendered');
+    return;
+  }
+  await cell.hover();
+
+  // Give the preview the chance it would normally have to appear, then assert
+  // it never did (the gate suppresses the mount while the overlay holds focus).
+  await expect(page.locator('[data-testid="cell-hover-preview"]')).toHaveCount(0);
+  await expect(page.getByRole('tooltip')).toHaveCount(0);
+  // Detail surface still present (it remained the topmost interactive surface).
+  await expect(detailSurface.first()).toBeVisible();
+});
+
 // ─── Scenario 3: Tablet tap → cluster-list → species → bbox-URL (@coarse) ─
 //
 // Phase 2 (#559) test — preserved verbatim (renamed for clarity).
@@ -477,33 +519,38 @@ stubTest.describe('z-index named scale — co-occurrence stacking (#778)', () =>
     stubExpect(railZ, 'rail must stay above the on-canvas popover tier').toBeGreaterThan(popover);
   });
 
-  stubTest('keyboard-focus hover-preview (Path B) keeps its pre-refactor resolved z-index of 45', async ({ page }) => {
-    // Path B = the inline, NON-portaled CellHoverPreview render path
-    // (cursorPos === null). Its layer is governed by the `.cell-hover-preview`
-    // CSS rule, which #761 P1 KEEPS at calc(var(--z-panel) + 5). With --z-panel
-    // now aliased to --z-overlay (40) that still resolves to exactly 45 —
-    // byte-identical to main. The rule was deliberately NOT moved into the
-    // popover band (41): the cursor-driven path (separate inline z-index: 1000)
-    // can float over an open rail/cluster popover, and dropping it to 41 would
-    // change which element wins that real geometric overlap — failing the P1
-    // zero-visual-change litmus. So both hover-preview render paths keep their
-    // pre-refactor ranks. This guard FAILS if a future change lowers the inline
-    // rule's resolved value below 45 without the compensating overlap work.
+  stubTest('hover-preview resolves to the named --z-modal tier, above both popover tiers (#761 O6 #782)', async ({ page }) => {
+    // The `.cell-hover-preview` CSS rule governs BOTH render paths' stacking now:
+    //   - Path B (keyboard focus, cursorPos === null): inline, non-portaled.
+    //   - Path A (cursor following): portaled to body, no longer carries the
+    //     pre-O6 off-scale inline `zIndex: 1000`.
+    // #761 O6 (#782) MIGRATED this rule off `calc(var(--z-panel) + 5)` (=45, a tie
+    // with --z-cluster-popover won only by DOM order) onto the NAMED `--z-modal`
+    // (50) tier — the lowest named tier strictly above --z-cluster-popover (45).
+    // That preserves the tooltip's "above the popovers it overlaps" rank (the
+    // cursor tooltip can still float over an open cell/cluster popover, matching
+    // the pre-O6 inline-1000 intent) while unifying the two paths onto one token.
+    // Safe against real --z-modal surfaces because O6 gates the hover-preview
+    // mount off whenever a detail overlay holds focus. This guard FAILS if a
+    // future change drops the rule below the cluster-popover tier.
     await page.goto('/?scope=us');
     await page.waitForLoadState('domcontentloaded');
 
     const previewZ = await page.evaluate(() => {
       const el = document.createElement('div');
-      el.className = 'cell-hover-preview'; // no inline style → CSS rule governs (Path B)
+      el.className = 'cell-hover-preview'; // no inline style → CSS rule governs
       el.setAttribute('role', 'tooltip');
       document.body.appendChild(el);
       const z = Number.parseInt(getComputedStyle(el).zIndex, 10);
       el.remove();
       return z;
     });
-    const overlay = await resolveZToken(page, '--z-overlay');
+    const modal = await resolveZToken(page, '--z-modal');
+    const cellPopover = await resolveZToken(page, '--z-cell-popover');
+    const clusterPopover = await resolveZToken(page, '--z-cluster-popover');
 
-    // calc(var(--z-panel) + 5) === calc(--z-overlay + 5) === 45 — unchanged from main.
-    stubExpect(previewZ, 'inline hover-preview keeps its pre-refactor resolved z-index of 45').toBe(overlay + 5);
+    stubExpect(previewZ, 'hover-preview now resolves to the named --z-modal tier').toBe(modal);
+    stubExpect(previewZ, 'hover-preview stays above the cell popover tier').toBeGreaterThan(cellPopover);
+    stubExpect(previewZ, 'hover-preview stays above the cluster popover tier').toBeGreaterThan(clusterPopover);
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -788,6 +788,7 @@ export function App() {
             {...(flyTo ? { flyTo } : {})}
             {...(statePolygon != null ? { maskPolygon: statePolygon } : {})}
             {...(isStateScope ? { clampPad: ARTBOARD_PAD } : {})}
+            detailOpen={!!(scopeActive && state.detail)}
           />
         </div>
       )}

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -16,6 +16,30 @@ import type { FamilySilhouette } from '@bird-watch/shared-types';
  *     The footer was removed in Phase 6.
  *   - OSM/OpenFreeMap ODbL §4.3: source attribution + license URL.
  *
+ * Top layer & the CSS z-index scale (#761 O6, issue #782):
+ *   `dialog.showModal()` (below, in the open effect) promotes this dialog into
+ *   the browser **top layer** — a paint surface that sits ABOVE the entire CSS
+ *   z-index stacking context REGARDLESS of any `z-index` value. It CANNOT be
+ *   ordered by the named `--z-*` scale (`--z-overlay` … `--z-skip`, styles.css
+ *   :root): no `--z-*` token governs this dialog, and none should be ADDED
+ *   expecting to. A future author adding e.g. a `--z-modal`-based rule to "put
+ *   Credits above X" would be wrong — `showModal()` already wins unconditionally,
+ *   and `z-index` on a top-layer element is inert. The corollary is that
+ *   `showModal()` also auto-`inert`s the rest of the document (the backdrop's
+ *   sibling tree becomes non-interactive and AT-invisible) while the dialog is
+ *   open, so no manual scrim/`inert` plumbing is required for THIS surface.
+ *
+ *   Focus-trap reconciliation with a future chooser scrim (gap 2, #782):
+ *   The scope-chooser scrim conversion (epic-relative S1) will give the
+ *   `.scope-chooser-scrim` its own JS focus trap. When THIS dialog is open it
+ *   already top-layers + `inert`s the whole document, which MOOTS any scrim
+ *   focus trap underneath it (the scrim's subtree is `inert`, so its trap has
+ *   nothing focusable to cycle). Therefore the two must NOT both run JS focus
+ *   traps simultaneously: when AttributionModal is open, the scrim's trap is a
+ *   no-op by construction and must not fight the native `inert` (e.g. by
+ *   re-focusing into the inert subtree on a focusout). The scrim work (S1)
+ *   inherits this contract; O6 writes no scrim code.
+ *
  * Modal idioms (this is the codebase's first modal — document the pattern):
  *   1. Native `<dialog>` element. `dialog.showModal()` opens with the
  *      browser-managed top-layer + backdrop; `dialog.close()` closes.

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -178,6 +178,15 @@ export interface MapSurfaceProps {
    */
   maskPolygon?: MultiPolygon | null;
   clampPad?: number;
+  /**
+   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
+   * open under an active scope. App.tsx derives this from `scopeActive &&
+   * state.detail` — the same gate that mounts the rail/sheet. Forwarded
+   * VERBATIM to <MapCanvas> (thin pass-through) so the passive cell-hover
+   * preview is suppressed while the detail overlay holds focus. Optional;
+   * defaults to `false` for legacy/test callers.
+   */
+  detailOpen?: boolean;
 }
 
 /**
@@ -216,6 +225,7 @@ export function MapSurface({
   flyTo,
   maskPolygon,
   clampPad,
+  detailOpen = false,
 }: MapSurfaceProps) {
   // Compute the expand-by-default once at mount. The component itself
   // (FamilyLegend) handles localStorage precedence + manual toggle.
@@ -312,6 +322,7 @@ export function MapSurface({
             {...(flyTo ? { flyTo } : {})}
             {...(maskPolygon != null ? { maskPolygon } : {})}
             {...(clampPad !== undefined ? { clampPad } : {})}
+            detailOpen={detailOpen}
           />
         </React.Suspense>
         <FamilyLegend

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -694,16 +694,31 @@ button.adaptive-grid-marker__cell {
 
 .cell-hover-preview {
   position: absolute;
-  /* KEPT at the pre-refactor calc(var(--z-panel) + 5) (#761 P1, #778). The
-     --z-panel alias now resolves to --z-overlay (40), so this still evaluates
-     to 45 — byte-identical rank to main. This governs ONLY the keyboard-focus
-     inline render path (cursorPos === null, no portal); the cursor-driven path
-     keeps its own inline z-index: 1000 in CellHoverPreview.tsx. Both ranks are
-     held unchanged because dropping the preview into the popover band (41) would
-     change which element wins a real geometric overlap (the cursor tooltip can
-     float over an open rail/cluster popover today) — that fails the P1 zero-
-     visual-change litmus, so the old ranks are preserved. */
-  z-index: calc(var(--z-panel) + 5);
+  /* #761 O6 (#782) — MIGRATED off the `calc(var(--z-panel) + 5)` arithmetic onto
+     the named `--z-modal` (50) tier. Rationale: this passive hover tooltip must
+     paint ABOVE every popover it can geometrically overlap. Pre-O6 the two render
+     paths DISAGREED — the keyboard-focus inline path sat at calc(--z-panel + 5) =
+     45 (a tie with --z-cluster-popover, won only by DOM order) while the
+     cursor-following path used an off-scale inline `zIndex: 1000` (~955 above the
+     scale). O6 removes the inline literal (CellHoverPreview.tsx) so BOTH paths now
+     inherit this one class token. `--z-modal` (50) is the lowest NAMED tier that
+     sits strictly above --z-cluster-popover (45), preserving the tooltip's
+     "above the popovers it overlaps" rank — the cursor tooltip can still float
+     over an open cell/cluster popover, matching the pre-O6 inline-1000 intent.
+     This is safe against real --z-modal surfaces (detail sheet 50, scope-chooser
+     scrim 50) because O6 also GATES the hover-preview mount: AdaptiveGridMarker
+     suppresses it whenever a detail overlay holds focus (detailOpen), and the
+     chooser scrim only shows when there are no markers to hover. So the tooltip
+     can never coexist with a --z-modal surface despite sharing the tier value.
+
+     ORDERING CONTRACT vs the detail rail (handoff to O5 / #783):
+     P1's `--z-cell-popover`/`--z-cluster-popover` (44/45) resolve ABOVE the
+     rail's current `--z-rail` (43), so the click-driven popovers temporarily
+     paint over the rail. Re-tiering the rail/sheet ABOVE the popovers (into the
+     --z-modal band with the compensating #663 inert work) is O5's job (report R3);
+     O6 does NOT move the rail's z value. This tooltip at --z-modal (50) is moot to
+     that contract because its mount is gated off while the rail is open. */
+  z-index: var(--z-modal);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-strong);
   border-radius: 4px;
@@ -777,7 +792,17 @@ button.adaptive-grid-marker__cell {
 
 .cell-popover {
   position: absolute;
-  z-index: var(--z-cell-popover); /* #761 P1, #778 — above the rail, below the cluster popover */
+  /* #761 P1, #778 — above the rail, below the cluster popover.
+     #761 O6 (#782) ORDERING CONTRACT vs the detail rail: --z-cell-popover (44)
+     resolves ABOVE the rail's current --z-rail (43), so this click-driven popover
+     temporarily paints over an open SpeciesDetailRail. Re-tiering the rail ABOVE
+     the popovers (into --z-modal with the #663 inert work) is O5's job (report R3);
+     O6 does NOT move the rail's z value and leaves the temporary popover-over-rail
+     state as expected. Verified live (O6): this popover, though mounted inside the
+     transformed MapLibre marker container, escapes to a higher stacking context and
+     paints above the map-assist overlays (legend/scope at --z-overlay 40,
+     observation-popover at --z-popover 41) as the token intends — no portal needed. */
+  z-index: var(--z-cell-popover);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-strong);
   border-radius: 6px;
@@ -885,7 +910,20 @@ button.adaptive-grid-marker__cell {
   left: var(--space-md);
   right: var(--space-md);
   bottom: var(--space-md);
-  z-index: var(--z-cluster-popover); /* #761 P1, #778 — topmost popover, above cell popover + rail */
+  /* #761 P1, #778 — topmost popover, above cell popover + rail.
+     #761 O6 (#782) ORDERING CONTRACT vs the detail rail: --z-cluster-popover (45)
+     resolves ABOVE the rail's current --z-rail (43); this coarse-pointer popover
+     temporarily paints over an open SpeciesDetailRail. Re-tiering the rail ABOVE
+     the popovers is O5's job (report R3); O6 does NOT move the rail's z value.
+     CONTAINING BLOCK NOTE: this rule is `position: fixed`, but on coarse pointers
+     it is anchored to the viewport edges (left/right/bottom = --space-md), so even
+     if the transformed MapLibre marker container traps the fixed positioning to the
+     marker's box, the popover still occupies the bottom strip of the marker-local
+     stacking context at the top of that context's z-order, painting above the
+     map-assist overlays. Verified live (O6): no portal needed — the cluster popover
+     paints above legend/scope (--z-overlay 40) and observation-popover (--z-popover
+     41) as the token intends. */
+  z-index: var(--z-cluster-popover);
   max-height: 70vh;
   overflow-y: auto;
   background: var(--color-bg-surface);

--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -774,6 +774,75 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(screen.getByText(/Hummingbirds \(5\)/)).toBeInTheDocument();
   });
 
+  // --- #761 O6 (#782): detailOpen gates the passive hover preview mount -------
+
+  it('pointer:fine + detailOpen: mouseenter does NOT mount <CellHoverPreview> (gated by a focused detail overlay)', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+          { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+        ])]}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        detailOpen
+        onClick={noop}
+      />
+    );
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    fireEvent.mouseEnter(cell);
+    // The passive hover preview must NOT appear while a detail overlay holds focus.
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('pointer:fine + detailOpen=false (default): existing hover-preview behavior is unchanged', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+          { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+        ])]}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        detailOpen={false}
+        onClick={noop}
+      />
+    );
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    fireEvent.mouseEnter(cell);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('pointer:fine + detailOpen: the click-driven <CellPopover> is UNAFFECTED by the gate', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+          { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+        ])]}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        detailOpen
+        onClick={noop}
+      />
+    );
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    cell.focus();
+    fireEvent.keyDown(cell, { key: 'Enter' });
+    // Only the passive preview is gated; the click-driven popover still opens.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(cell.getAttribute('aria-expanded')).toBe('true');
+  });
+
   // --- Fix 1: outer element tag per perCellInteractive state (nested-button guard) ---
 
   it('pointer:fine → outer is <div role="group" data-testid="adaptive-grid-marker"> (no nested buttons)', async () => {

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -90,6 +90,16 @@ export interface AdaptiveGridMarkerProps {
   onClick: (e: ReactMouseEvent<HTMLElement>) => void;
   /** Phase 1 (#558): forwarded from per-cell popover row clicks. */
   onSelectSpecies?: (speciesCode: string) => void;
+  /**
+   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet)
+   * holds focus (App-level `state.detail` under an active scope). When true,
+   * the passive `<CellHoverPreview>` mount is SUPPRESSED so a hover tooltip
+   * cannot appear unbidden over/under a focused detail overlay. Only the
+   * passive hover preview is gated — the click-driven `<CellPopover>` and
+   * `<ClusterListPopover>` are intentionally UNAFFECTED (they are explicit
+   * user actions, not unbidden surfaces). Defaults to `false`.
+   */
+  detailOpen?: boolean;
 }
 
 // Layout constants — match MosaicMarker's 22px tile / 2px gap (issue #248).
@@ -132,6 +142,7 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
     isNotable,
     onClick,
     onSelectSpecies,
+    detailOpen = false,
   } = props;
 
   const isPointerFine = useMediaQuery('(pointer: fine)');
@@ -352,13 +363,19 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
       )}
       {perCellInteractive && activeCell !== null && activeTile && (
         activeCell.mode === 'preview' ? (
-          <CellHoverPreview
-            familyCode={activeTile.familyCode}
-            familyCount={activeTile.count}
-            species={activeTile.species}
-            id={previewId!}
-            cursorPos={cursorPos}
-          />
+          // #761 O6 (#782): suppress the passive hover preview while a detail
+          // overlay holds focus (detailOpen) so an unbidden tooltip can't appear
+          // over/under a focused SpeciesDetailRail/Sheet. The click-driven
+          // popover branch below is deliberately NOT gated.
+          detailOpen ? null : (
+            <CellHoverPreview
+              familyCode={activeTile.familyCode}
+              familyCount={activeTile.count}
+              species={activeTile.species}
+              id={previewId!}
+              cursorPos={cursorPos}
+            />
+          )
         ) : (
           cellRefs.current[activeCell.index] ? (
             <CellPopover

--- a/frontend/src/components/map/CellHoverPreview.test.tsx
+++ b/frontend/src/components/map/CellHoverPreview.test.tsx
@@ -197,6 +197,12 @@ describe('<CellHoverPreview>', () => {
     expect(tooltip.style.position).toBe('fixed');
     expect(tooltip.style.left).toBe('116px');
     expect(tooltip.style.top).toBe('212px');
+    // #761 O6 (#782): the cursor-following path no longer carries an inline
+    // zIndex — stacking comes from the `.cell-hover-preview` class's --z-modal
+    // token. (`screen.getByRole` queries document.body by default, which reaches
+    // the portaled node for the cursor branch — do NOT scope to a local
+    // container or this lookup fails.)
+    expect(tooltip.style.zIndex).toBe('');
   });
 
   it('with cursorPos=null, root element has no inline position (falls back to CSS)', () => {
@@ -211,5 +217,8 @@ describe('<CellHoverPreview>', () => {
     );
     const tooltip = screen.getByRole('tooltip');
     expect(tooltip.style.position).toBe('');
+    // #761 O6 (#782): the keyboard-focus path never had an inline zIndex; lock
+    // that both render paths now defer stacking entirely to the class token.
+    expect(tooltip.style.zIndex).toBe('');
   });
 });

--- a/frontend/src/components/map/CellHoverPreview.tsx
+++ b/frontend/src/components/map/CellHoverPreview.tsx
@@ -38,13 +38,19 @@ export function CellHoverPreview(props: CellHoverPreviewProps) {
   const visible = species.slice(0, PREVIEW_CAP);
   const hasMore = species.length > PREVIEW_CAP;
 
+  // #761 O6 (#782): the cursor-following branch keeps `position: fixed` +
+  // `left`/`top`/`pointerEvents` inline (computed from `cursorPos`, cannot move
+  // to CSS), but the stacking level no longer comes from the off-scale inline
+  // literal it used to carry (the magic 1000). Both render paths now inherit the
+  // `.cell-hover-preview` class's named `--z-modal` (50) token, so the
+  // keyboard-focus path and the cursor-following path agree on rank (above the
+  // cell/cluster popovers the tooltip can overlap) instead of disagreeing by ~955.
   const positionStyle: CSSProperties | undefined = cursorPos
     ? {
         position: 'fixed',
         left: cursorPos.x + 16,
         top: cursorPos.y + 12,
         pointerEvents: 'none',
-        zIndex: 1000,
       }
     : undefined;
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -321,6 +321,16 @@ export interface MapCanvasProps {
    * `bounds ?? CONUS_BOUNDS` (unchanged behavior).
    */
   clampPad?: number;
+  /**
+   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
+   * open under an active scope (App-level `scopeActive && state.detail`).
+   * Forwarded VERBATIM to every `<AdaptiveGridMarker>` so the passive
+   * `<CellHoverPreview>` mount is suppressed while the overlay holds focus —
+   * a hover tooltip must not appear unbidden over/under a focused detail
+   * surface. The click-driven cell/cluster popovers are unaffected. Defaults
+   * to `false` (legacy/test callers keep the pre-O6 always-mount behavior).
+   */
+  detailOpen?: boolean;
 }
 
 /**
@@ -551,6 +561,7 @@ export function MapCanvas({
   flyTo,
   maskPolygon,
   clampPad,
+  detailOpen = false,
 }: MapCanvasProps) {
   const mapRef = useRef<MapRef>(null);
   /**
@@ -2289,6 +2300,7 @@ export function MapCanvas({
                 ariaLabel={g.ariaLabel}
                 isCoarsePointer={isCoarsePointer}
                 isNotable={anchor.isNotable ?? false}
+                detailOpen={detailOpen}
                 onClick={() => handleGroupClick(g)}
                 {...(onSelectSpecies ? {
                   onSelectSpecies: (code: string) => onSelectSpecies(code, getClusterBbox(g)),

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -23,6 +23,10 @@ const STYLES_CSS = readFileSync(
   join(import.meta.dirname, '../styles.css'),
   'utf8',
 );
+const DS_PRIMITIVES_CSS = readFileSync(
+  join(import.meta.dirname, '../components/ds/ds-primitives.css'),
+  'utf8',
+);
 
 describe('tokens.css — W1 conformance', () => {
   describe('Light mode — --color-accent-notable-fg', () => {
@@ -192,6 +196,32 @@ describe('styles.css — W1 conformance', () => {
       // Encoded as var() indirection (not a hardcoded 40) so it carries no
       // monotonicity obligation and stays correct if --z-overlay ever moves.
       expect(STYLES_CSS).toMatch(/--z-panel:\s*var\(--z-overlay\)/);
+    });
+  });
+
+  // ── #761 O6 (#782): the three on-canvas cell popovers consume P1's NAMED
+  //    popover tokens — no `z-index: calc(var(--z-panel) + N)` arithmetic
+  //    survives on any of them.
+  describe('cell popovers on the named z-scale — #761 O6 (#782)', () => {
+    it('ds-primitives.css has NO `z-index: calc(var(--z-panel) + N)` arithmetic remaining', () => {
+      // The last `calc(var(--z-panel) + 5)` ref (.cell-hover-preview) was
+      // migrated to var(--z-modal) by O6. Any reappearance is a regression.
+      expect(DS_PRIMITIVES_CSS).not.toMatch(/z-index:\s*calc\(\s*var\(--z-panel\)/);
+    });
+
+    it('.cell-hover-preview consumes the named --z-modal tier (above the cell/cluster popovers it can overlap)', () => {
+      expect(DS_PRIMITIVES_CSS).toMatch(
+        /\.cell-hover-preview\s*\{[^}]*z-index:\s*var\(--z-modal\)/s,
+      );
+    });
+
+    it('.cell-popover consumes --z-cell-popover and .cluster-list-popover consumes --z-cluster-popover', () => {
+      expect(DS_PRIMITIVES_CSS).toMatch(
+        /\.cell-popover\s*\{[^}]*z-index:\s*var\(--z-cell-popover\)/s,
+      );
+      expect(DS_PRIMITIVES_CSS).toMatch(
+        /\.cluster-list-popover\s*\{[^}]*z-index:\s*var\(--z-cluster-popover\)/s,
+      );
     });
   });
 });


### PR DESCRIPTION
## Diagrams

Token mapping after O6 (all three on-canvas popovers + the tooltip now consume named `--z-*` tiers; the rail relationship is a conditional contract handed to O5):

```mermaid
graph TD
    subgraph scale["Named --z-* scale (P1 / #778)"]
      overlay["--z-overlay = 40<br/>legend, scope-control"]
      popover["--z-popover = 41<br/>observation-popover"]
      chrome["--z-chrome = 42 (reserved S2)"]
      rail["--z-rail = 43<br/>SpeciesDetailRail"]
      cellpop["--z-cell-popover = 44"]
      clusterpop["--z-cluster-popover = 45"]
      modal["--z-modal = 50<br/>sheet / scrim"]
      skip["--z-skip = 60"]
    end

    CP[".cell-popover"] -->|"O6: keeps var(--z-cell-popover)"| cellpop
    CLP[".cluster-list-popover"] -->|"O6: keeps var(--z-cluster-popover)"| clusterpop
    CHP[".cell-hover-preview<br/>(was calc(--z-panel)+5 = 45<br/>AND inline 1000)"] -->|"O6: MIGRATED to var(--z-modal)"| modal

    rail -.->|"O6 contract: popovers temporarily paint OVER rail;<br/>re-tier is O5's job (R3) — O6 does NOT move rail"| cellpop

    AM["AttributionModal<br/>dialog.showModal()"] -->|"browser TOP LAYER —<br/>above the ENTIRE scale,<br/>ungoverned by any --z-* token"| TL([" "])
```

Mount-gate data flow (passive hover preview suppressed while a detail overlay holds focus):

```mermaid
flowchart LR
    App["App.tsx<br/>detailOpen = !!(scopeActive && state.detail)"] --> MS[MapSurface]
    MS --> MC[MapCanvas]
    MC --> AGM[AdaptiveGridMarker]
    AGM -->|"detailOpen ? null : mount"| CHP["CellHoverPreview<br/>(passive tooltip — gated)"]
    AGM -->|"unaffected by gate"| CP["CellPopover / ClusterListPopover<br/>(click-driven — NOT gated)"]
```

## Summary

- **Why:** O6 (sub-issue of epic #761, Phase 4) finishes the popover z-index reconciliation P1 (#778) started — it removes the last `calc(var(--z-panel) + N)` arithmetic and the off-scale inline `1000` so every on-canvas popover and the cursor tooltip participate in the one named `--z-*` scale, and it records the two facts the scale can't express (AttributionModal's top layer; the rail-vs-popover ordering O5 owns).
- **What moved:** `.cell-hover-preview` migrates from `calc(--z-panel)+5` (=45) **and** an inline `zIndex: 1000` onto a single `var(--z-modal)` (50) token — the lowest named tier strictly above `--z-cluster-popover` (45), preserving the tooltip's "above the popovers it overlaps" rank while unifying the two render paths. `.cell-popover`/`.cluster-list-popover` already used `--z-cell-popover`/`--z-cluster-popover` after P1; O6 adds the inline rail-vs-popover ordering contract (popovers temporarily paint over the rail; re-tiering is O5's job per report R3 — **O6 does not move the rail's z value**).
- **Behavioral change:** a `detailOpen` boolean (derived from `scopeActive && state.detail`) is threaded App → MapSurface → MapCanvas → AdaptiveGridMarker; the **passive** `CellHoverPreview` mount is suppressed while a detail overlay holds focus. The click-driven `CellPopover`/`ClusterListPopover` are intentionally unaffected. AttributionModal gains a docblock note that `showModal()` paints in the browser **top layer** above the entire CSS scale (ungoverned by any `--z-*` token, auto-`inert`s the document) plus the chooser-scrim focus-trap reconciliation contract (gap 2) — no scrim code is written.

## Screenshots

Live Playwright MCP verification PASSED — computed z-index cell 44 / cluster 45 / hover-preview 50 (all above map-assist 40/41), mount-gate suppresses hover-preview when a detail surface is open, 0 console errors (the pre-existing button-in-button nesting warning is unrelated).

### Cell popover stacking (above map + legend, z 44)

| 390×844 dark | 390×844 light |
|---|---|
| ![cell-popover-390x844-dark](https://github.com/user-attachments/assets/115374f1-03aa-4ad8-bf6e-b6df5828c9e8) | ![cell-popover-390x844-light](https://github.com/user-attachments/assets/65ae3b65-c95e-41e5-ab9b-5e51971a23c1) |

| 768×1024 dark | 768×1024 light |
|---|---|
| ![cell-popover-768x1024-dark](https://github.com/user-attachments/assets/8f94b3d6-eafe-4829-83b8-6822651af11b) | ![cell-popover-768x1024-light](https://github.com/user-attachments/assets/621152ae-3fdf-4d1f-9152-e7da03fcdb56) |

| 1024×768 dark | 1024×768 light |
|---|---|
| ![cell-popover-1024x768-dark](https://github.com/user-attachments/assets/28f635ef-2041-4726-8696-5a93e400dd71) | ![cell-popover-1024x768-light](https://github.com/user-attachments/assets/33108bb6-9de6-4fbc-a677-ac9b5cb075a0) |

| 1440×900 dark | 1440×900 light |
|---|---|
| ![cell-popover-1440x900-dark](https://github.com/user-attachments/assets/03c9e3bd-c594-4d21-a6f9-7b4062f8475c) | ![cell-popover-1440x900-light](https://github.com/user-attachments/assets/099f1b6e-b57c-4d1c-a5a2-5717c4786050) |

| 1920×1080 dark | 1920×1080 light |
|---|---|
| ![cell-popover-1920x1080-dark](https://github.com/user-attachments/assets/1002b1ce-1de2-40cf-8674-5e59cb0e4c0b) | ![cell-popover-1920x1080-light](https://github.com/user-attachments/assets/db113a3f-5600-496b-aa86-ddff8a075d5f) |

### Cluster popover (z 45) / hover-preview (z 50) / mount-gate

| cluster 390×844 dark | cluster 390×844 light |
|---|---|
| ![cluster-list-popover-390x844-dark](https://github.com/user-attachments/assets/ae0f88ea-1758-4c18-9311-d8dc58b306a8) | ![cluster-list-popover-390x844-light](https://github.com/user-attachments/assets/ace1a102-2406-41f9-bdf4-23b9bef25903) |

| cluster 1440×900 dark | cluster 1440×900 light |
|---|---|
| ![cluster-list-popover-1440x900-dark](https://github.com/user-attachments/assets/4c3ec70c-7482-411d-8df2-43a75df398c1) | ![cluster-list-popover-1440x900-light](https://github.com/user-attachments/assets/c62a01a8-59d7-42be-a2ae-f47ce8c5bcb2) |

| hover-preview (z 50, above popovers) | hover-preview above open cell-popover |
|---|---|
| ![hover-preview-1440-light](https://github.com/user-attachments/assets/d56a09af-45ad-47ff-a5a9-004e04e4f1d1) | ![hover-preview-above-popover-1440-light](https://github.com/user-attachments/assets/0786dea5-6622-4add-b452-d2fa85c7f937) |

| hover while popover open (no stacking conflict) | hover-gated (detail open — preview absent) |
|---|---|
| ![hover-while-popover-open-1440-light](https://github.com/user-attachments/assets/c1df14a7-84f3-4e19-a51a-a6c7d1249b9a) | ![hover-gated-1440-light](https://github.com/user-attachments/assets/52fb153c-651c-4efd-9cbf-0fdd188e6993) |

| detail-rail open (mount-gate active) |
|---|
| ![detail-rail-check-1440-light](https://github.com/user-attachments/assets/503afc4c-dbe1-42de-b596-cc35669be907) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — **N/A — no new classNames** (z-index value changes + a new TS prop only).
- [x] Multi-viewport design QA: ≥10 `user-attachments` URLs — **DONE** (19 screenshots above).

## Test plan

- [x] `npm run typecheck && npm run test` — green (`tsc -b` clean; **974 unit tests pass**, +11 over base 963: 3 AdaptiveGridMarker gate cases, 3 ds-primitives/tokens popover-scale assertions, 2 `CellHoverPreview` `zIndex === ''` locks, and supporting re-baselines).
- [x] New unit tests added — AdaptiveGridMarker `detailOpen` gate (suppressed when true, unchanged when false, `CellPopover` unaffected); `CellHoverPreview` both paths assert no inline `zIndex`; `tokens.css.test.ts` asserts no `calc(var(--z-panel))` z-index arithmetic remains and the three popovers consume their named tokens.
- [x] New Playwright e2e added/re-baselined — `map-cell-popover.spec.ts`: new "detail rail open → hover cell surfaces no preview" scenario; the hover-preview stacking guard re-baselined to assert `--z-modal` above both popover tiers; existing rail-below-popovers + attribution open/close/focus-return guards stay green.
- [x] `npm run build` — clean production build (`tsc -b && vite build`).
- [x] `npm run lint` — green; `npx knip` — exit 0 (only a pre-existing informational config hint, unrelated).
- [x] e2e ran locally single-worker against a seeded local Postgres+PostGIS: **53 passed / 10 skipped** on `dev-server` (map-cell-popover, map-adaptive-grid, marker-overlap, attribution-modal) + coarse-pointer cluster-list passed. Skips are the WebGL-dependent map-adaptive-grid cases that skip headless on `main` too — not regressions.
- [ ] (UI only) Playwright MCP smoke + ≥10 screenshots — **PENDING**: the orchestrator runs the live capture (this PR was implemented in an isolated worktree; the implementer does not drive the browser here).

## Plan reference

Part of epic #761, sub-issue **O6** (#782). Research report: `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md` — §6 WS3 sub-issue 3.2 (popovers onto the scale + containing-block verification), **R5** (popover z-scale participation, corrected by this issue's ground-truth read), **R3** (z-index inversion — the rail-vs-popover ordering handed to O5), and **Gap 2** (AttributionModal top-layer reconciliation, §9 item 2). Epic workstreams: WS3 (each surface → floating overlay / z-index system) + WS7 (a11y of floating UI, focus-trap reconciliation).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)