### PR TITLE
feat(frontend): AppHeader as thin floating chrome over an edge-to-edge map + remove Map nav

### DIFF
--- a/frontend/e2e/happy-path.spec.ts
+++ b/frontend/e2e/happy-path.spec.ts
@@ -34,10 +34,9 @@ test.describe('Path A happy path', () => {
     await app.goto();
     await app.waitForAppReady();
 
-    // Phase 0: bare '/' now loads the map surface (DEFAULTS.view='map').
-    // The Map tab is the selected AppHeader tab on a cold load.
-    const mapTab = page.getByRole('tab', { name: 'Map view' });
-    await expect(mapTab).toHaveAttribute('aria-selected', 'true');
+    // #800: Map tab removed — map is always-mounted sole surface; assert canvas visible.
+    await expect(page.getByRole('tablist')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
 
     // Map canvas is visible.
     await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 10_000 });
@@ -61,13 +60,10 @@ test.describe('Path A happy path', () => {
     await app.goto('species=vermfly');
     await app.waitForAppReady();
 
-    // Pre-#688: ?species= without ?view= sniffed to view='species'. With the
-    // Species surface removed (#688), bookmarked species URLs cold-load to
-    // the map (DEFAULTS.view) with the species filter active in FiltersBar.
-    const mapTab = page.getByRole('tab', { name: 'Map view' });
-    await expect(mapTab).toHaveAttribute('aria-selected', 'true');
-
-    // No Species tab exists post-#688.
+    // #800: Map tab + tablist removed; the map is the always-mounted sole surface.
+    // Bookmarked species URLs cold-load to the map with the species filter active.
+    await expect(page.getByRole('tablist')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'Species view' })).toHaveCount(0);
 
     // No complementary landmark (SpeciesPanel is deleted; the detail rail
@@ -91,11 +87,10 @@ test.describe('Path A happy path', () => {
     // Phase 4: detail surface renders in a dialog/sheet outside <main>.
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
 
-    // Feed tab removed in #662 and Species tab removed in #688. The Map
-    // tab exists but is NOT selected on view=detail.
-    const mapTab = page.getByRole('tab', { name: 'Map view' });
+    // #800: Map tab + tablist removed entirely (Feed #662, Species #688, Map #800).
+    await expect(page.getByRole('tablist')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'Species view' })).toHaveCount(0);
-    await expect(mapTab).toHaveAttribute('aria-selected', 'false');
   });
 
   test('detail deep link opens the detail surface at mobile and desktop', async ({ page, apiStub }) => {

--- a/frontend/e2e/manual-test.md
+++ b/frontend/e2e/manual-test.md
@@ -56,10 +56,10 @@ content surface.)
    - Script: `document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length`
    - **Pass:** result ≥ 1
 
-4. Verify the Map tab is selected:
+4. Verify no tablist or Map tab exists (#800 Map-nav removal):
    - Tool: `browser_evaluate`
-   - Script: `document.querySelector('[role="tab"][aria-label="Map view"]')?.getAttribute('aria-selected')`
-   - **Pass:** `"true"`
+   - Script: `document.querySelector('[role="tablist"]')`
+   - **Pass:** `null`
 
 5. Take a screenshot at desktop (1440×900) and mobile (390×844).
 

--- a/frontend/e2e/map.spec.ts
+++ b/frontend/e2e/map.spec.ts
@@ -21,9 +21,9 @@ test.describe('Map surface', () => {
     // The MapCanvas component renders a [data-testid=map-canvas] container.
     await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 15_000 });
 
-    // Map tab is selected.
-    const mapTab = page.getByRole('tab', { name: 'Map view' });
-    await expect(mapTab).toHaveAttribute('aria-selected', 'true');
+    // #800: Map tab removed — no tablist/tab in the header; assert map canvas is visible.
+    await expect(page.getByRole('tablist')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
   });
 
   test('?view=hotspots silently redirects to ?view=map', async ({ page }) => {

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -5,10 +5,8 @@ export class AppPage {
   readonly filters: FiltersBar;
   readonly mainSurface: Locator;
   readonly errorScreen: Locator;
-  /** Persistent header chrome — wordmark, tablist, action buttons. */
+  /** Persistent header chrome — wordmark, action buttons. No tab nav (#800). */
   readonly appHeader: Locator;
-  /** Surface tabs inside appHeader (Map). Feed removed in #662; Species in #688. */
-  readonly appHeaderTabs: Locator;
   /** Filters trigger button in appHeader (badge shows active-filter count). */
   readonly filtersTrigger: Locator;
   /** Theme toggle button in appHeader. */
@@ -62,7 +60,6 @@ export class AppPage {
     this.mainSurface = page.locator('main#main-surface');
     this.errorScreen = page.locator('.error-screen');
     this.appHeader = page.locator('header.app-header');
-    this.appHeaderTabs = this.appHeader.getByRole('tab');
     this.filtersTrigger = this.appHeader.getByRole('button', { name: /^Filters/ });
     this.themeToggle = this.appHeader.getByRole('button', { name: /Switch to (light|dark) theme/ });
     this.attributionTrigger = this.appHeader.getByRole('button', { name: /Credits & attribution/ });
@@ -108,15 +105,6 @@ export class AppPage {
       await this.filtersTrigger.click();
       await panel.waitFor({ state: 'visible' });
     }
-  }
-
-  /**
-   * Navigate to a surface by tab name. Only the Map tab remains in the
-   * header post-#688 (Species removed); Feed was removed in #662.
-   */
-  async selectView(view: 'map'): Promise<void> {
-    const labelMap = { map: 'Map view' };
-    await this.appHeader.getByRole('tab', { name: labelMap[view] }).click();
   }
 
   /**

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -68,10 +68,10 @@ test.describe('species detail surface (#151)', () => {
     expect(app.getUrlParams().get('detail')).toBeNull();
     expect(app.getUrlParams().get('view')).toBeNull();
 
-    // #688/#777: Species and Feed tabs are gone. Only the Map tab remains,
-    // and it is the selected tab on the scoped map landing.
+    // #688/#777/#800: Species, Feed, and Map tabs are all removed. No tablist.
+    await expect(page.getByRole('tablist')).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'Species view' })).toHaveCount(0);
-    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
   });
 
   test('network failure shows inline error on detail surface', async ({ page, apiStub }) => {
@@ -102,7 +102,9 @@ test.describe('species detail surface (#151)', () => {
     await expect.poll(() => new URL(page.url()).searchParams.get('detail'), { timeout: 5_000 })
       .toBeNull();
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toHaveCount(0);
-    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveAttribute('aria-selected', 'true');
+    // #800: Map tab removed — no tab role in the header; map canvas is the sole surface.
+    await expect(page.getByRole('tablist')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Map view' })).toHaveCount(0);
   });
 
   test('detail surface renders as <aside role="complementary"> on desktop (#663)', async ({ page, apiStub }) => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1345,11 +1345,10 @@ describe('#761 (S2): map hoisted to a viewport-root #map-layer sibling of <main>
     expect(mainSurface!.parentElement).toBe(app);
   });
 
-  // AC: the "Map view" tab's aria-controls is retargeted to "map-layer" and
-  // resolves to the present, hoisted #map-layer — the region that actually
-  // contains the map post-hoist (NOT the now-feed-only #main-surface). A
-  // presence-only check against #main-surface would assert the regression passes.
-  it('points the Map view tab\'s aria-controls at #map-layer (the region holding the map)', async () => {
+  // AC (#800): no "Map view" tab exists — the Map nav is removed because the
+  // map is the always-mounted sole surface after F1 #777. Assert the tab and
+  // tablist are gone; #map-layer still resolves and holds the map.
+  it('has no Map-view tab or tablist after #800 (Map-nav removal)', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
@@ -1357,13 +1356,14 @@ describe('#761 (S2): map hoisted to a viewport-root #map-layer sibling of <main>
     const { container } = render(<App />);
     await screen.findByTestId('map-surface-stub');
 
-    const mapTab = screen.getByRole('tab', { name: 'Map view' });
-    expect(mapTab).toHaveAttribute('aria-controls', 'map-layer');
-    expect(mapTab).not.toHaveAttribute('aria-controls', 'main-surface');
-    // The controlled region resolves to a present element that holds the map.
-    const controlled = container.querySelector('#map-layer');
-    expect(controlled).not.toBeNull();
-    expect(controlled!.contains(screen.getByTestId('map-surface-stub'))).toBe(true);
+    // The tablist and Map tab are gone.
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Map view' })).toBeNull();
+    expect(container.querySelector('[aria-controls="map-layer"]')).toBeNull();
+    // #map-layer still mounts and holds the map stub.
+    const mapLayer = container.querySelector('#map-layer');
+    expect(mapLayer).not.toBeNull();
+    expect(mapLayer!.contains(screen.getByTestId('map-surface-stub'))).toBe(true);
   });
 
   // AC: the always-mounted-under-scrim invariant survives the hoist — on the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -730,8 +730,6 @@ export function App() {
         region={region}
       />
       <AppHeader
-        activeView={state.view}
-        onSelectView={view => set({ view })}
         region={region}
         filterCount={filterCount}
         onOpenFilters={() => setFiltersOpen(true)}

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -4,8 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { AppHeader } from './AppHeader.js';
 
 const baseProps = {
-  activeView: 'map' as const,
-  onSelectView: vi.fn(),
   region: 'Arizona' as string | null,
   filterCount: 0,
   onOpenFilters: vi.fn(),
@@ -36,39 +34,20 @@ describe('<AppHeader>', () => {
     expect(link.getAttribute('aria-label')).toBe('Bird Maps — home');
   });
 
-  it('renders a single Map tab (Species + Feed removed per #688 / #662)', () => {
+  // #800: Map nav removed (redundant — the map is the always-mounted sole surface
+  // after F1 #777). No tablist/tab role must appear in the header.
+  it('renders no tablist or tab role (#800 Map-nav removal)', () => {
     render(<AppHeader {...baseProps} />);
-    const tablist = screen.getByRole('tablist', { name: /Surface/i });
-    const tabs = within(tablist).getAllByRole('tab');
-    expect(tabs).toHaveLength(1);
-    expect(tabs[0].textContent).toBe('Map');
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryByRole('tab')).toBeNull();
   });
 
-  it('does not render a Feed tab (issue #662)', () => {
-    render(<AppHeader {...baseProps} />);
-    expect(screen.queryByRole('tab', { name: /Feed view/i })).toBeNull();
-  });
-
-  it('does not render a Species tab (issue #688)', () => {
-    render(<AppHeader {...baseProps} />);
-    expect(screen.queryByRole('tab', { name: /Species view/i })).toBeNull();
-  });
-
-  it('marks the Map tab as selected via aria-selected and is-active class', () => {
-    render(<AppHeader {...baseProps} activeView="map" />);
-    const mapTab = screen.getByRole('tab', { name: /Map view/i });
-    expect(mapTab).toHaveAttribute('aria-selected', 'true');
-    expect(mapTab).toHaveClass('app-header-tab', 'is-active');
-  });
-
-  // #761 (S2): the shell inverted so the map is the viewport ROOT (#map-layer),
-  // hoisted out of #main-surface. The "Map view" tab controls the region that
-  // actually holds the map, so its aria-controls points at "map-layer" — NOT the
-  // now-feed-only "main-surface" (which would be a silent a11y semantic regression).
-  it('points the Map view tab\'s aria-controls at the map-layer region (#761 S2)', () => {
-    render(<AppHeader {...baseProps} activeView="map" />);
-    const mapTab = screen.getByRole('tab', { name: /Map view/i });
-    expect(mapTab).toHaveAttribute('aria-controls', 'map-layer');
+  it('renders no "Map" visible label or aria-controls="map-layer" tab (#800)', () => {
+    const { container } = render(<AppHeader {...baseProps} />);
+    // No element with aria-controls="map-layer" (the removed tab attribute).
+    expect(container.querySelector('[aria-controls="map-layer"]')).toBeNull();
+    // No button or element with visible text "Map" alone.
+    expect(screen.queryByRole('tab', { name: /Map view/i })).toBeNull();
   });
 
   it('renders Filters trigger without badge when filterCount === 0', () => {
@@ -104,5 +83,17 @@ describe('<AppHeader>', () => {
     // Fix #459 W4-C: ThemeToggle now uses a static aria-label + aria-pressed.
     // The label no longer changes with theme state.
     expect(screen.getByRole('button', { name: /Toggle color theme/i })).toBeInTheDocument();
+  });
+
+  // #800 AC: floating header — the header element must have top > 0 (inset from
+  // the viewport edge) so map pixels at y=0 are visible above it. We assert
+  // the CSS class is present on the header element (the style rule sets
+  // top: var(--space-md) which JSDOM doesn't compute, but the class association
+  // is sufficient for the unit layer; the live viewport assertion is in the e2e).
+  it('is a <header role="banner"> with class app-header (floating treatment applied via CSS)', () => {
+    const { container } = render(<AppHeader {...baseProps} />);
+    const header = container.querySelector('header.app-header');
+    expect(header).not.toBeNull();
+    expect(header!.getAttribute('role')).toBe('banner');
   });
 });

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,10 +1,6 @@
-import { useRef, type KeyboardEvent } from 'react';
 import { ThemeToggle } from './ThemeToggle.js';
-import type { View } from '../state/url-state.js';
 
 export interface AppHeaderProps {
-  activeView: View;
-  onSelectView: (view: View) => void;
   /**
    * #738/C5: runtime region label for the active scope (from `regionLabelFor`).
    * `null` ⟺ the unscoped/chooser landing — the wordmark renders just "Bird
@@ -20,74 +16,12 @@ export interface AppHeaderProps {
   onOpenAttribution: () => void;
 }
 
-interface TabDef {
-  value: View;
-  label: string;
-  // Accessible name diverges from visible text to avoid colliding with
-  // <FiltersBar>'s "Species" and "Family" input labels. Preserved verbatim
-  // from the pre-#688 two-tab tablist for compatibility with e2e selectors
-  // that target `getByRole('tab', { name: 'Map view' })`.
-  accessibleName: string;
-}
-
-// One-tab tablist post-#688 (Species surface removed). ARIA APG explicitly
-// allows single-tab tablists — the role + aria-selected contract still
-// expresses the surface state and the structure tolerates future additions
-// without churning the markup. The visible "Map" label is suppressed in CSS
-// to avoid a "lone Map word" wordmark-adjacent treatment; the accessible
-// name is preserved so SR users still hear "Map view, selected".
-const TABS: readonly TabDef[] = [
-  { value: 'map', label: 'Map', accessibleName: 'Map view' },
-];
-
 export function AppHeader({
-  activeView,
-  onSelectView,
   region,
   filterCount,
   onOpenFilters,
   onOpenAttribution,
 }: AppHeaderProps) {
-  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
-
-  function activateIndex(index: number) {
-    const next = TABS[index];
-    if (!next) return;
-    tabRefs.current[index]?.focus();
-    if (next.value !== activeView) onSelectView(next.value);
-  }
-
-  function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
-    switch (event.key) {
-      case 'ArrowRight':
-        event.preventDefault();
-        activateIndex((index + 1) % TABS.length);
-        break;
-      case 'ArrowLeft':
-        event.preventDefault();
-        activateIndex((index - 1 + TABS.length) % TABS.length);
-        break;
-      case 'Home':
-        event.preventDefault();
-        activateIndex(0);
-        break;
-      case 'End':
-        event.preventDefault();
-        activateIndex(TABS.length - 1);
-        break;
-      case 'Enter':
-      case ' ': {
-        event.preventDefault();
-        const tab = TABS[index];
-        if (tab && tab.value !== activeView) onSelectView(tab.value);
-        break;
-      }
-      default:
-        break;
-    }
-  }
-
-  const anyTabActive = TABS.some(t => t.value === activeView);
   const filterTriggerLabel =
     filterCount > 0 ? `Filters (${filterCount} active)` : 'Filters';
 
@@ -107,43 +41,6 @@ export function AppHeader({
           </span>
         )}
       </a>
-
-      <div className="app-header-nav" role="tablist" aria-label="Surface">
-        {TABS.map((tab, index) => {
-          const selected = tab.value === activeView;
-          const tabbable = selected || (!anyTabActive && index === 0);
-          return (
-            <button
-              key={tab.value}
-              ref={el => {
-                tabRefs.current[index] = el;
-              }}
-              type="button"
-              role="tab"
-              id={`app-header-tab-${tab.value}`}
-              aria-selected={selected}
-              // #761 (S2): the "Map view" tab controls the map region, which is
-              // now the hoisted `#map-layer` wrapper (the map left `#main-surface`
-              // when the shell inverted to a full-viewport map root). Pointing at
-              // `"main-surface"` would silently control a map-free region — an
-              // a11y semantic regression introduced by the hoist. The broader
-              // inert/aria-busy/aria-live retarget on `#map-layer` stays O1; the
-              // tablist tab→region pointer is a different attribute O1 does not
-              // touch, so S2 owns this one in the same PR that moves the map out.
-              aria-controls="map-layer"
-              aria-label={tab.accessibleName}
-              tabIndex={tabbable ? 0 : -1}
-              className={`app-header-tab${selected ? ' is-active' : ''}`}
-              onClick={() => {
-                if (tab.value !== activeView) onSelectView(tab.value);
-              }}
-              onKeyDown={e => handleKeyDown(e, index)}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
-      </div>
 
       <div className="app-header-right">
         <button

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -404,30 +404,29 @@ const INITIAL_VIEW = {
 
 /**
  * Single source of truth for the scope-framing `fitBounds` padding (#737, S3 of
- * #761). ASYMMETRIC by design: after #761 (S2) the map is the viewport-filling
- * root (`#map-layer` → `position: fixed; inset: 0`) and two stacked overlays now
- * float over its TOP edge — the fixed `.app-header` chrome and the top-anchored
- * `.scope-control` bar below it. A uniform inset would let that chrome occlude
- * the top of the framed region (the northern strip of a state, markers at the
- * top latitude). So `top` is grown to clear BOTH overlays while `bottom`/`left`/
- * `right` keep the historical 48px (the non-chrome edges; bottom also leaves room
- * for the bottom-left `.family-legend` + the MapLibre attribution bar).
+ * #761, revised #800). ASYMMETRIC by design: the map is the viewport-filling
+ * root (`#map-layer` → `position: fixed; inset: 0`) and two stacked overlays
+ * float over its TOP edge — the floating `.app-header` chrome and the
+ * top-anchored `.scope-control` bar below it. A uniform inset would let that
+ * chrome occlude the top of the framed region (the northern strip of a state,
+ * markers at the top latitude). So `top` is grown to clear BOTH overlays while
+ * `bottom`/`left`/`right` keep the historical 48px (the non-chrome edges;
+ * bottom also leaves room for the bottom-left `.family-legend` + the MapLibre
+ * attribution bar).
  *
- * Derivation from the CSS tokens that own this stack (styles.css):
- *   - `--header-height` = 48px (the fixed `.app-header` band).
- *   - `.scope-control` top offset = `--header-height + --space-md` = 48 + 12 = 60px
+ * Derivation from the CSS tokens that own this stack (styles.css), post-#800:
+ *   - `--header-height` = 56px (top-inset `--space-md` = 12px + element ~44px).
+ *   - `.scope-control` top offset = `--header-height + --space-md` = 56 + 12 = 68px
  *     from the viewport top (styles.css `.scope-control { inset-block-start }`).
  *   - `.scope-control` height: `padding: --space-sm` (8px) top + bottom + content.
- *     At ≤480px the bar WRAPS (`flex-wrap: wrap`; the `.scope-control__select` and
- *     `.scope-control__exit-group` each go `flex: 1 1 100%`) to ~2 rows of ~36px
- *     touch targets → ~88px tall worst case. Its bottom edge then sits at
- *     ~60 + 88 ≈ 148px from the viewport top.
- *   `top: 152` clears that wrapped worst case (narrowest 390px viewport) with a
+ *     At ≤480px the bar WRAPS (`flex-wrap: wrap`) to ~2 rows of ~36px touch
+ *     targets → ~88px tall worst case. Its bottom edge then sits at
+ *     ~68 + 88 ≈ 156px from the viewport top.
+ *   `top: 164` clears that wrapped worst case (narrowest 390px viewport) with a
  *   small margin; on wider viewports the single-row bar is ~52px tall (bottom at
- *   ~112px) so the same value clears it comfortably. Verified live against the
- *   measured stack at all 5 canonical viewports (UI verification, #773).
+ *   ~120px) so the same value clears it comfortably.
  */
-const FIT_BOUNDS_PADDING = { top: 152, bottom: 48, left: 48, right: 48 } as const;
+const FIT_BOUNDS_PADDING = { top: 164, bottom: 48, left: 48, right: 48 } as const;
 
 /**
  * Convert a `family_silhouettes` row into a complete SVG document string

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1419,7 +1419,8 @@ body:has(.species-detail-sheet--full) .app-header {
      (incl. the map). The shell inversion made TWO things occlude it:
        1. The AppHeader is now `position: fixed` floating chrome, so the panel's
           top edge + close button would slide UNDER the header. `margin-block-start`
-          offsets the panel below the header band.
+          offsets the panel below the header band (header-height + space-md,
+          matching the `.scope-control` clearance so both clear the header bottom).
        2. `#map-layer` is now `position: fixed; inset: 0` (a positioned element),
           so it paints ABOVE the panel's in-flow content — the panel's controls
           (notable checkbox, typeaheads, close button) would be behind the map and
@@ -1432,7 +1433,7 @@ body:has(.species-detail-sheet--full) .app-header {
      floating sheet + backdrop with proper top-layer z-layering is O4. */
   position: relative;
   z-index: var(--z-popover);
-  margin-block-start: var(--header-height);
+  margin-block-start: calc(var(--header-height) + var(--space-md));
   /* Opaque surface so the panel's controls read cleanly over the map canvas
      beneath it (the panel is no longer backed by an in-flow page background). */
   background: var(--color-bg-surface);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -58,16 +58,14 @@
      Default is the desktop tier; the two media queries below override it. */
   --attribution-clearance: 20px;
 
-  /* Floating-header height (#761 S2). The AppHeader became `position: fixed`
-     chrome over the full-viewport map root, so it no longer occupies flow
-     height. Every in-flow chrome surface that previously sat below it — the
-     non-map `#main-surface` content (R15 surface 1) and the open `.filters-panel`
-     (R15 surface 2), plus the top-anchored `.scope-control` overlay — must clear
-     this height so the floating header does not occlude it. 48px comfortably
-     clears both the ~44–48px desktop header (8px+8px vertical padding + ~28px
-     content + 1px border) and the ≤480px header (no vertical padding, 44px
-     touch-target buttons). Single source of truth for the clearance offset. */
-  --header-height: 48px;
+  /* Floating-header clearance (#761 S2 + #800). The AppHeader is `position:
+     fixed` chrome inset from the viewport edge: `top: --space-md` (12px) +
+     element height ~44px → bottom edge ≈ 56px from the viewport top. Every
+     in-flow chrome surface (non-map `#main-surface`, `.filters-panel`) and the
+     top-anchored `.scope-control` overlay must clear this bottom edge so the
+     header does not occlude them. 56px = top-inset (12px) + element-height
+     (~44px). Single source of truth for the clearance offset. */
+  --header-height: 56px;
 
   --dur-fast: 200ms;
   --dur-base: 250ms;
@@ -243,34 +241,33 @@ body {
    for these semantic roles — see tokens.css dark-mode comment at line ~115.
    Do not add per-theme overrides here without revisiting that constraint. */
 
-/* Top-level chrome bar — floating fixed chrome over the full-viewport map root.
-   #761 (S2): the shell inverted so the map is the viewport ROOT (`#map-layer`,
-   `position: fixed; inset: 0`) and the header FLOATS over its top edge
-   (Google-Maps-style) rather than displacing it down a flex column. */
+/* Top-level chrome bar — thin floating chrome over the full-viewport map root.
+   #761 (#800): Google-Maps-style floating-inset principle. The header is a
+   discrete bar inset from ALL viewport edges: map pixels are visible at y=0
+   (above the header) and to its left/right sides. Rounded corners + shadow
+   match the other floating overlay cards (.scope-control, .family-legend).
+   NO border-bottom — a hard edge would make it read as a cap, not a float.
+   NO left:0/right:0 — full-bleed span kills the "map visible around it" goal.
+
+   z-order: `--z-chrome` (42) sits ABOVE map-assist overlays (legend /
+   scope-control at `--z-overlay` = 40, observation-popover at `--z-popover`
+   = 41) and BELOW the detail rail (`--z-rail` = 43). The scope-control click
+   regression (header intercepting elementFromPoint on the top-anchored
+   .scope-control) is resolved by the compensating `.scope-control`
+   inset-block-start offset below (pushed below the header bottom edge).
+   No z-order claim on the bottom-sheet snap tiers (10/15/20) — deferred to O5. */
 .app-header {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-lg);
+  padding: var(--space-sm) var(--space-md);
   background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-ui);
-  /* #761 (S2): `position: fixed` (was `sticky; z-index: 10`) so the header leaves
-     the flow and floats over `#map-layer`. It adopts the named `--z-chrome` token
-     S1 (#778) defined-but-did-not-apply: 42 sits ABOVE the map-assist overlays
-     (legend / scope-control at `--z-overlay` = 40, observation-popover at
-     `--z-popover` = 41) and BELOW the detail rail (`--z-rail` = 43) so the
-     in-place rail (#663) still floats over the header. The P1-deferred
-     scope-control click regression (raising the header above the overlay band
-     made it intercept clicks on the top-anchored `.scope-control`) is fixed in
-     the SAME PR by the compensating `.scope-control` top-offset below — the
-     control is pushed below the header band so `elementFromPoint` returns the
-     control, not the header. (S2 makes NO z-order claim about the bottom-sheet
-     snap tiers (10/15/20) — that reconciliation is the deferred mobile-overlay
-     workstream / O5.) (2026-05-30) */
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: var(--shadow-listbox);
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: var(--space-md);
+  left: var(--space-md);
+  right: var(--space-md);
   z-index: var(--z-chrome);
 }
 
@@ -293,58 +290,11 @@ body {
   border-radius: 4px;
 }
 
-/* Tablist container — sits between wordmark and action buttons. flex: 1
-   pushes the right cluster to the far edge on wide viewports.
-   justify-content: center aligns the tab cluster to the horizontal
-   midpoint of the available space between the wordmark and right cluster,
-   matching the v4 mock's centred navigation treatment. */
-.app-header-nav {
-  display: flex;
-  gap: var(--space-xs);
-  flex: 1;
-  justify-content: center;
-}
-
-/* Tab buttons — full UA reset, then design-token styling.
-   min-height is applied inside the ≤480px media query (MOB-4) to keep the
-   desktop header height unchanged. */
-.app-header-tab {
-  appearance: none;
-  background: transparent;
-  border: 1px solid transparent;
-  border-bottom-width: 2px;
-  border-radius: 4px;
-  padding: 6px 14px;
-  font: inherit;
-  font-size: var(--type-sm);
-  color: var(--color-text-strong);
-  cursor: pointer;
-  line-height: 1.2;
-}
-.app-header-tab:hover {
-  background: var(--color-bg-tint);
-}
-.app-header-tab:focus-visible {
-  outline: 2px solid var(--color-text-strong);
-  outline-offset: 2px;
-}
-.app-header-tab.is-active {
-  /* Underline-only pattern: mode-safe (works in both light and dark) per
-     v4 mock and #454 W1 cascade-trap fix. The previous filled-chip pattern
-     inverted to white-on-white in dark mode because --color-text-strong
-     flips from #1a1a1a → #f5f7fb in the dark block.
-     border-bottom acts as the visual active indicator; background stays
-     transparent so no dark-mode inversion can occur. */
-  background: transparent;
-  color: var(--color-text-strong);
-  border-color: transparent;
-  border-bottom-color: var(--color-text-strong);
-  border-bottom-width: 2px;
-}
-
 /* Right-side action cluster — Attribution, Filters, ThemeToggle.
    ThemeToggle renders a plain <button> with no class; target all
    buttons in this cluster with the descendant rule below.
+   margin-left: auto pushes the cluster to the far edge of the header now
+   that the nav (flex: 1) is removed (#800 Map-nav removal).
    min-height/min-width 44pt touch targets are applied inside the
    ≤480px media query (MOB-4) to keep the desktop header unchanged. */
 .app-header-right {
@@ -352,6 +302,7 @@ body {
   align-items: center;
   gap: var(--space-xs);
   flex-shrink: 0;
+  margin-left: auto;
 }
 .app-header-right button {
   /* touch targets set in @media (max-width: 480px) block — see MOB-4 */
@@ -413,11 +364,10 @@ body {
   height: 18px;
   padding: 0 4px;
   border-radius: 9px;
-  /* Outline-only pattern — mirrors the active-tab fix in .app-header-tab.is-active.
+  /* Outline-only pattern — mode-safe in both light and dark.
      --color-text-strong flips from #1a1a1a → #f5f7fb in dark mode, so using it as
-     a background would produce white-on-white (1.07:1) in dark mode (the same cascade
-     trap the active-tab had). Outline + transparent background keeps ≥4.5:1 in both
-     themes because the text inherits --color-text-strong against --color-bg-surface. */
+     a background would produce white-on-white (1.07:1). Outline + transparent
+     background keeps ≥4.5:1 in both themes. */
   background: transparent;
   border: 1.5px solid var(--color-text-strong);
   color: var(--color-text-strong);
@@ -1322,7 +1272,6 @@ body:has(.species-detail-sheet--full) .app-header {
      in forced-colors — fall back to a 1px border. */
   button,
   [role="button"],
-  [role="tab"],
   [role="radio"],
   input[type="radio"],
   input[type="checkbox"],
@@ -1337,12 +1286,6 @@ body:has(.species-detail-sheet--full) .app-header {
   :focus-visible {
     outline: 2px solid ButtonText;
     outline-offset: 2px;
-  }
-
-  /* AppHeader tab buttons — selected state is typically communicated via
-     background-color only; add a bottom border so it remains visible. */
-  .app-header-tab.is-active {
-    border-bottom: 3px solid ButtonText;
   }
 
   /* Filter badge — background-only badge is invisible; add a border. */
@@ -1378,38 +1321,23 @@ body:has(.species-detail-sheet--full) .app-header {
    ========================================================================== */
 
 /* ── MOB-1/MOB-4: AppHeader collapse + touch targets at ≤ 480px ─────────────
-   The unconstrained header overflows at 390px (body.scrollWidth≈578px).
-   Strategy: hide the brand region label, compress nav padding, reduce the
-   outer header gap so the three segments (wordmark · tabs · actions) fit
-   inside 390px without wrapping.
+   Strategy: hide the brand region label, reduce the outer header padding/gap
+   so the two segments (wordmark · actions) fit comfortably at 390px.
+   The "Map" nav tab is removed (#800 floating-inset chrome principle) — only
+   the wordmark and right-cluster controls remain.
 
-   We do NOT hide the wordmark entirely — "Bird Maps" is the product name and
-   should remain visible. The " · Arizona" region badge is redundant at mobile
-   (single-region product) and is the largest single contributor to overflow.
+   The right-cluster Attribution + Filters buttons hide their text labels at
+   this breakpoint; icon-only touch targets keep the bar narrow. aria-label
+   attributes remain intact — accessibility preserved via accessible name.
 
-   Space budget at 390px:
-     16px (padding) + 8px (2×4px gaps) = 24px overhead.
-     Available: 366px.
-     Wordmark:       80px (flex-shrink: 0 — guaranteed, no flex contention)
-     Right cluster: 140px (3 × 44px icon-only buttons + 2 × 4px gaps)
-     Nav:           146px remaining for 3 tabs
-
-   The right-cluster Attribution + Filters buttons hide their text labels
-   at this breakpoint (font-size: 0; icon-sized footprint). Their aria-label
-   attributes remain intact — accessibility is preserved via the accessible
-   name, not the visible text. This frees ~120px vs. the previous text-label
-   layout, giving the wordmark guaranteed render space.
-
-   min-height: 44px touch targets (MOB-4) are scoped here rather than
-   globally so the desktop header height is unchanged. */
+   min-height: 44px touch targets (MOB-4) are scoped here so the desktop
+   header height is unchanged. */
 @media (max-width: 480px) {
   .app-header {
     padding: 0 var(--space-sm);
     gap: var(--space-xs);
     /* overflow: hidden prevents the header itself from being wider than the
-       viewport while the body catches up to the new layout. Without this,
-       the header's flex children can still force the layout wider than 390px
-       if any child has a min-width that exceeds available space. */
+       floating bar width (viewport - 2 × --space-md). */
     overflow: hidden;
   }
 
@@ -1418,13 +1346,7 @@ body:has(.species-detail-sheet--full) .app-header {
     display: none;
   }
 
-  /* Guarantee the wordmark renders untruncated.
-     flex-shrink: 0 prevents the nav's flex:1 from squeezing the wordmark
-     below its natural width (~65px for "Bird Maps" at --type-sm / 13px).
-     max-width: 80px gives comfortable headroom above the 65px scrollWidth.
-     Without flex-shrink: 0 here, the flex algorithm allocates space to the
-     nav first (flex-grow: 1) and the wordmark falls below 72px (measured
-     46px at 390px — see design review BLOCKING finding). */
+  /* Guarantee the wordmark renders untruncated at mobile. */
   .app-header-wordmark {
     font-size: var(--type-sm);
     flex-shrink: 0;
@@ -1432,13 +1354,6 @@ body:has(.species-detail-sheet--full) .app-header {
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 80px;
-  }
-
-  /* Compress tab padding while keeping the 44pt min-height touch target. */
-  .app-header-tab {
-    padding: 0 8px;
-    font-size: var(--type-xs);
-    min-height: 44px;
   }
 
   /* Right-cluster buttons: collapse to 44pt icon-only touch targets at mobile.


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph Before["Before (#800)"]
        A["map canvas (y=0 → bottom)"]
        B["AppHeader: full-bleed opaque bar\ntop:0 left:0 right:0\npaintover map top strip\ntablist + Map tab"]
        B --> A
    end
    subgraph After["After (#800) — floating-inset chrome principle"]
        C["map canvas (y=0 → bottom, always visible)"]
        D["AppHeader: inset bar\ntop/left/right: --space-md\nborder-radius + shadow\nno border-bottom, no tablist"]
        D -. "floats over" .-> C
    end
```

```mermaid
graph LR
    H["--header-height: 56px\n(12px inset + ~44px element)"]
    SC[".scope-control\ninset-block-start:\n--header-height + --space-md = 68px"]
    FB["FIT_BOUNDS_PADDING.top: 164\n(scope-control bottom ~156px + margin)"]
    MS["#main-surface padding-top\ncalc(--header-height + --space-lg)"]
    H --> SC
    H --> FB
    H --> MS
```

## Summary

- The AppHeader was a full-bleed opaque bar at `top:0; left:0; right:0` — "map in the UI". This PR corrects that to floating-inset chrome ("UI over the map"): `top/left/right: var(--space-md)` (12px inset), `border-radius: var(--radius-lg)`, `box-shadow: var(--shadow-listbox)`, no `border-bottom`. Map pixels at y=0 are now visible above and around the header, matching the `.scope-control` and `.family-legend` floating-card aesthetic.
- The "Map" navigation tab was redundant — the map is the always-mounted sole surface after F1 #777. Removed the `TABS` array, `role="tablist"` block, roving-tabindex machinery (`tabRefs`/`activateIndex`/`handleKeyDown`), `activeView`/`onSelectView` props, and all dead `.app-header-nav` / `.app-header-tab` CSS (including the forced-colors block). Right cluster pushed to the far edge via `margin-left: auto`.
- Re-derived `--header-height` (48 → 56px), `FIT_BOUNDS_PADDING.top` (152 → 164), and `.scope-control inset-block-start` formula (unchanged formula, new evaluation: 68px). All five test files with Map-tab assertions repointed.

## Screenshots

Live verification PASSED — header is `position:fixed` inset 12px on all edges, border-radius 12 + box-shadow, no border-bottom; map canvas reaches y=0 and is visible above (the 12px strip) + left/right of the inset header at all 5 viewports × both themes; no "Map" nav; filters panel clears the header (top 68 vs header bottom 58); 0 console errors.

### Floating header over edge-to-edge map (scoped, AZ)

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (iPhone 14 Pro) | ![header-390x844-light](https://github.com/user-attachments/assets/478ad24b-2783-4981-868e-a8b849e1b0a1) | ![header-390x844-dark](https://github.com/user-attachments/assets/49a8f692-06d1-4b48-b220-f18f4315ad1e) |
| 768×1024 (iPad portrait) | ![header-768x1024-light](https://github.com/user-attachments/assets/882f26cb-b98e-44e7-818c-c29e1fab893b) | ![header-768x1024-dark](https://github.com/user-attachments/assets/63108d83-4228-4497-a2de-5154c384c1bd) |
| 1024×768 (iPad landscape) | ![header-1024x768-light](https://github.com/user-attachments/assets/6708454f-0f22-4e7f-b723-07d62fec0d23) | ![header-1024x768-dark](https://github.com/user-attachments/assets/2a8fc54b-0997-4a30-bab4-1bcb765137d9) |
| 1440×900 (Desktop) | ![header-1440x900-light](https://github.com/user-attachments/assets/a9cb87cd-30dc-4ab1-97ac-38090eab4e39) | ![header-1440x900-dark](https://github.com/user-attachments/assets/27533f4c-77aa-49b8-b4ad-fd003e75e77c) |
| 1920×1080 (Wide desktop) | ![header-1920x1080-light](https://github.com/user-attachments/assets/14d3c3df-ba9e-4e31-b24f-66d5a42dd8d6) | ![header-1920x1080-dark](https://github.com/user-attachments/assets/7fd86cda-225c-4eb8-a364-0170878e3d80) |

### Controls + unscoped

| | |
|---|---|
| Filters open (1440×900) | Attribution modal (1440×900) |
| ![controls-filters-open-1440x900](https://github.com/user-attachments/assets/6e0c5614-bf19-45a0-be42-c17994a3e1a3) | ![controls-attribution-modal-1440x900](https://github.com/user-attachments/assets/7fc8d2f4-5aa0-40ca-bafd-292f5854caf9) |
| Unscoped landing (light) | |
| ![unscoped-landing-light](https://github.com/user-attachments/assets/68ef2fcf-fcf1-40a3-93d9-72d6202b08fb) | |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

## Test plan

- [x] `npm run test` — 898 tests pass; 2 pre-existing failures (maplibre-gl resolution in test env, unrelated to this PR)
- [x] New unit tests added: `AppHeader.test.tsx` — removed 4 Map-tab assertions, added 2 no-tablist/tab role assertions + floating-header class assertion
- [x] E2E tests repointed: `map.spec.ts:25`, `happy-path.spec.ts:39/67/96`, `species-detail.spec.ts:73/74/105`, `pages/app-page.ts` (removed `appHeaderTabs` + `selectView`); `App.test.tsx:1352-1366` (Map tab aria-controls → no-tab assertion)
- [x] `npm run build` — same pre-existing maplibre-gl TS resolution failures (present on `main` before this PR); no new errors
- [x] `npx knip` — clean (no new unused exports/files)
- [x] `scripts/check-orphan-classnames.sh` — PASS (all removed classNames `.app-header-nav`, `.app-header-tab` had their CSS removed together with the TSX)
- [x] (UI only) Playwright MCP smoke — 5 viewports × 2 themes captured above; 0 console errors at all viewports.

## Plan reference

Part of epic #761 (map-first rearchitecture), sub-issue #800. Revises S2 (#775) — corrects the header treatment (opaque full-bleed → floating inset) while preserving S2's box-model inversion. Coordinates with S3 (#773) `FIT_BOUNDS_PADDING` (updated single-source derivation). Coordinates with O4 (#780) on final header height; current 56px is derived from the floating-inset geometry and may be reconciled in O4 if the panel layout changes. Sibling: detail-rail de-dock (filed separately per issue #800 Audit table).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)