### PR TITLE
feat(tokens): floating-card design language — geometry + light/dark elevation + lifted dark surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,20 @@ Four load-bearing rules: (1) PR body follows `.github/PULL_REQUEST_TEMPLATE.md` 
 
 Conventional commits style with scope where useful: `feat(scope):`, `chore:`, `ci:`, `infra:`, `docs:`, `test(scope):`, `plan(N):`. Multi-line messages should explain *why*, not *what* — diffs show what.
 
+## Floating-card four-corner anchor contract (#761 #803, spec §3)
+
+**The map owns the center. Every floating surface is assigned exactly one corner or the transient layer — no new bands, no edge docks.**
+
+| Corner | Owns | Width cap |
+|---|---|---|
+| **Top-left** | Identity+scope cluster: wordmark, region, lede, scope control — one stacked card | `--card-maxw-identity` 360px |
+| **Top-right** | Controls cluster: Filters · Attribution · theme toggle — compact pill group | content-width |
+| **Bottom-left** | Family legend | `--card-maxw-legend` 280px |
+| **Bottom-right** | Attribution line + future zoom/locate — safe-zone | content-width |
+| **Transient** | Popovers (flip/shift/clamp), detail card (insets top-right region), filters panel (anchored under trigger) | per-element caps |
+
+Implementing rule: before adding any new floating surface, assign it a corner from this table. If no corner fits, that is a signal the design is wrong — raise it rather than introducing a new band. All shared geometry is in `frontend/src/styles/tokens.css` under `--card-*` (§2.1). Elevation tiers: tier 1 = resting chrome, tier 2 = on-canvas transient, tier 3 = focused/modal. Design authority: `docs/design/2026-05-30-floating-ui-design-spec.md`.
+
 ## Testing
 
 ### UI verification (agents + reviewers)

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -71,6 +71,37 @@
   --overlay-bp-compact: 480px;  /* below: overlays go full-bleed sheet/peek   */
   --overlay-bp-roomy:   600px;  /* above: overlays may sit as anchored cards  */
   --overlay-bp-wide:    1024px; /* above: legend defaults expanded (mirrors MapSurface) */
+
+  /* ── Floating-card geometry (#761 #803, spec §2.1) ─────────────────────
+   *
+   * Four-corner anchor contract (spec §3) — the map owns the center.
+   * Every floating surface is assigned exactly ONE corner or the transient
+   * layer; no new bands are ever created:
+   *
+   *   TOP-LEFT    Identity+scope cluster: wordmark, region, lede, scope
+   *               control — stacked card, cap --card-maxw-identity.
+   *   TOP-RIGHT   Controls cluster: Filters · Attribution · theme toggle
+   *               — compact pill group, content-width.
+   *   BOTTOM-LEFT Family legend — --card-maxw-legend.
+   *   BOTTOM-RIGHT Attribution line + future zoom/locate — safe-zone.
+   *   TRANSIENT   Popovers (flip/shift/clamp to stay on-screen), detail
+   *               card (insets into top-right region), filters panel
+   *               (anchored under its trigger) — per-element caps.
+   *
+   * No floating element may introduce a full-width top/bottom band or an
+   * edge dock. The center of the screen belongs to the map.
+   */
+  --card-radius:        var(--radius-lg);  /* 12px — retires 6px/8px for cards    */
+  --card-radius-inner:  8px;               /* nested controls inside a card        */
+  --card-inset:         var(--space-md);   /* 12px — gutter from viewport edge     */
+  --card-inset-wide:    var(--space-xl);   /* 24px — wider gutter at ≥1440px       */
+  --card-gap:           var(--space-sm);   /* 8px — gap between stacked corner cards */
+  --card-padding:       var(--space-md) var(--space-lg);   /* 12px 16px            */
+  --card-padding-tight: var(--space-sm) var(--space-md);   /* 8px 12px — pills, popover rows */
+  --card-maxw-identity: 360px;  /* top-left identity+scope cluster cap           */
+  --card-maxw-legend:   280px;  /* bottom-left legend cap                         */
+  --card-maxw-rail:     420px;  /* detail card cap (max(420px,38vw) clamp below)  */
+  --card-maxw-popover:  300px;  /* transient popover cap                          */
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */
@@ -100,6 +131,23 @@
   --color-text-subtle: #5c5c5c; /* preserve existing — AA at 12px */
 
   --color-border-ui: #d8d3c3;   /* preserve existing */
+
+  /* Elevation system — light mode (spec §2.3, #761 #803).
+   * Three tiers; tier aliases keep element CSS readable. */
+  --elevation-1: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08);
+  --elevation-2: 0 4px 12px rgba(0,0,0,0.15);
+  --elevation-3: 0 12px 32px rgba(0,0,0,0.22);
+  --card-elevation-1: var(--elevation-1);   /* resting chrome          */
+  --card-elevation-2: var(--elevation-2);   /* on-canvas transient     */
+  --card-elevation-3: var(--elevation-3);   /* focused / modal         */
+
+  /* Undefined-token cleanup (spec §2.5, #761 #803) — these four tokens were
+   * consumed by ds-primitives.css but never defined, causing cell/cluster
+   * popovers to silently inherit nothing. */
+  --color-border-strong: #a09890;           /* stronger hairline — darker than --color-border-ui */
+  --color-text-link:     var(--color-decision-point); /* same orange accent as interactive cue */
+  --text-body-sm:        var(--font-weight-regular) var(--type-sm) / 1.5 var(--font-stack);
+  --text-heading-sm:     var(--font-weight-medium) var(--type-md) / 1.3 var(--font-stack);
 
   /* RENAMED from mock --accent; DO NOT collide with --color-accent-notable-fg.
      Decision-point is a NEW token; spec value lands. */
@@ -135,7 +183,10 @@
  */
 :root[data-theme="dark"] {
   --color-bg-page:    var(--c-navy-900);
-  --color-bg-surface: #131c30;
+  /* Lifted from #131c30 → #1b2742 (spec §2.2, #761 #803): a card sitting only
+   * ~6 luminance points off the #0d1424 basemap cannot separate by shadow alone
+   * on a near-black ground — the fill itself must read as lifted. */
+  --color-bg-surface: #1b2742;
   --color-bg-tint:    #1c2640;
   --color-bg-skeleton: #1c2640;
   --color-bg-skeleton-highlight: #253050;
@@ -148,7 +199,25 @@
      on dark surfaces. Stays within the same blue-grey semantic register. */
   --color-text-subtle: #7a8599;
 
-  --color-border-ui: #283354;
+  /* Lifted from #283354 → #3a4668 (spec §2.2, #761 #803): pairs with the
+   * lifted --color-bg-surface so the hairline remains a visible edge. */
+  --color-border-ui: #3a4668;
+
+  /* Elevation system — dark mode (spec §2.3, #761 #803).
+   * Dark elevation is NOT more black alpha (invisible on a black map) —
+   * it is ambient drop shadow + a top inner rim-light (Google/Apple idiom). */
+  --elevation-1: 0 1px 3px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.05);
+  --elevation-2: 0 4px 14px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.06);
+  --elevation-3: 0 14px 36px rgba(0,0,0,0.62), inset 0 1px 0 rgba(255,255,255,0.07);
+  --card-elevation-1: var(--elevation-1);
+  --card-elevation-2: var(--elevation-2);
+  --card-elevation-3: var(--elevation-3);
+
+  /* Undefined-token cleanup — dark overrides (spec §2.5, #761 #803). */
+  --color-border-strong: #4a5a80;           /* stronger hairline on dark surfaces */
+  --color-text-link:     var(--color-decision-point); /* cyan-500 in dark mode */
+  /* --text-body-sm / --text-heading-sm: font shorthand; no color component so
+     dark override is identical — inherits the :root definition above.         */
 
   --color-decision-point: var(--c-cyan-500);
 

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -163,6 +163,154 @@ describe('tokens.css — W1 conformance', () => {
       expect(TOKENS_CSS).toMatch(/--overlay-bp-wide:\s*1024px/);
     });
   });
+
+  // ── #761 #803: Floating-card design language — geometry + elevation tokens.
+  describe('Floating-card geometry tokens — #761 #803 (spec §2.1)', () => {
+    it('defines --card-radius aliased to --radius-lg', () => {
+      expect(TOKENS_CSS).toMatch(/--card-radius:\s*var\(--radius-lg\)/);
+    });
+    it('defines --card-radius-inner as 8px', () => {
+      expect(TOKENS_CSS).toMatch(/--card-radius-inner:\s*8px/);
+    });
+    it('defines --card-inset aliased to --space-md', () => {
+      expect(TOKENS_CSS).toMatch(/--card-inset:\s*var\(--space-md\)/);
+    });
+    it('defines --card-inset-wide aliased to --space-xl', () => {
+      expect(TOKENS_CSS).toMatch(/--card-inset-wide:\s*var\(--space-xl\)/);
+    });
+    it('defines --card-gap aliased to --space-sm', () => {
+      expect(TOKENS_CSS).toMatch(/--card-gap:\s*var\(--space-sm\)/);
+    });
+    it('defines --card-padding as var(--space-md) var(--space-lg)', () => {
+      expect(TOKENS_CSS).toMatch(/--card-padding:\s*var\(--space-md\)\s*var\(--space-lg\)/);
+    });
+    it('defines --card-padding-tight as var(--space-sm) var(--space-md)', () => {
+      expect(TOKENS_CSS).toMatch(/--card-padding-tight:\s*var\(--space-sm\)\s*var\(--space-md\)/);
+    });
+    it('defines --card-maxw-identity as 360px', () => {
+      expect(TOKENS_CSS).toMatch(/--card-maxw-identity:\s*360px/);
+    });
+    it('defines --card-maxw-legend as 280px', () => {
+      expect(TOKENS_CSS).toMatch(/--card-maxw-legend:\s*280px/);
+    });
+    it('defines --card-maxw-rail as 420px', () => {
+      expect(TOKENS_CSS).toMatch(/--card-maxw-rail:\s*420px/);
+    });
+    it('defines --card-maxw-popover as 300px', () => {
+      expect(TOKENS_CSS).toMatch(/--card-maxw-popover:\s*300px/);
+    });
+  });
+
+  // ── #761 #803: Elevation system — light and dark.
+  describe('Elevation tokens — light mode (spec §2.3)', () => {
+    const lightBlockMatch = TOKENS_CSS.match(
+      /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+    );
+    const lightBlock = lightBlockMatch?.[1] ?? '';
+
+    it('light block exists', () => {
+      expect(lightBlock).not.toBe('');
+    });
+    it('defines --elevation-1 in light (drop shadow, no inset)', () => {
+      expect(lightBlock).toMatch(/--elevation-1:/);
+      // Light elevation must NOT have an inset rim-light (that's dark-mode only)
+      const el1Match = lightBlock.match(/--elevation-1:\s*([^;]+)/);
+      expect(el1Match?.[1]).not.toMatch(/inset/);
+    });
+    it('defines --elevation-2 in light', () => {
+      expect(lightBlock).toMatch(/--elevation-2:/);
+    });
+    it('defines --elevation-3 in light', () => {
+      expect(lightBlock).toMatch(/--elevation-3:/);
+    });
+    it('defines --card-elevation-1/-2/-3 as aliases of --elevation-1/-2/-3 in light', () => {
+      expect(lightBlock).toMatch(/--card-elevation-1:\s*var\(--elevation-1\)/);
+      expect(lightBlock).toMatch(/--card-elevation-2:\s*var\(--elevation-2\)/);
+      expect(lightBlock).toMatch(/--card-elevation-3:\s*var\(--elevation-3\)/);
+    });
+  });
+
+  describe('Elevation tokens — dark mode (spec §2.3)', () => {
+    const darkBlockMatch = TOKENS_CSS.match(
+      /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+    );
+    const darkBlock = darkBlockMatch?.[1] ?? '';
+
+    it('defines --elevation-1 in dark with inset rim-light (not just more black alpha)', () => {
+      const el1Match = darkBlock.match(/--elevation-1:\s*([^;]+)/);
+      expect(el1Match?.[1]).toMatch(/inset/);
+      expect(el1Match?.[1]).toMatch(/rgba\(255,255,255/);
+    });
+    it('defines --elevation-2 in dark with rim-light', () => {
+      const el2Match = darkBlock.match(/--elevation-2:\s*([^;]+)/);
+      expect(el2Match?.[1]).toMatch(/inset/);
+    });
+    it('defines --elevation-3 in dark with rim-light', () => {
+      const el3Match = darkBlock.match(/--elevation-3:\s*([^;]+)/);
+      expect(el3Match?.[1]).toMatch(/inset/);
+    });
+    it('defines --card-elevation-1/-2/-3 as aliases in dark', () => {
+      expect(darkBlock).toMatch(/--card-elevation-1:\s*var\(--elevation-1\)/);
+      expect(darkBlock).toMatch(/--card-elevation-2:\s*var\(--elevation-2\)/);
+      expect(darkBlock).toMatch(/--card-elevation-3:\s*var\(--elevation-3\)/);
+    });
+  });
+
+  // ── #761 #803: Dark surface lift — the primary card-separation fix.
+  describe('Dark surface token lift (spec §2.2)', () => {
+    const darkBlockMatch = TOKENS_CSS.match(
+      /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+    );
+    const darkBlock = darkBlockMatch?.[1] ?? '';
+
+    it('dark --color-bg-surface is lifted to #1b2742 (was #131c30)', () => {
+      expect(darkBlock).toMatch(/--color-bg-surface:\s*#1b2742/);
+    });
+    it('dark --color-border-ui is lifted to #3a4668 (was #283354)', () => {
+      expect(darkBlock).toMatch(/--color-border-ui:\s*#3a4668/);
+    });
+    it('light --color-bg-surface remains #ffffff (no regression)', () => {
+      const lightBlockMatch = TOKENS_CSS.match(
+        /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+      );
+      const lightBlock = lightBlockMatch?.[1] ?? '';
+      expect(lightBlock).toMatch(/--color-bg-surface:\s*#ffffff/);
+    });
+  });
+
+  // ── #761 #803: Previously-undefined tokens now resolve (spec §2.5).
+  describe('Undefined-token cleanup — 4 tokens now resolve (spec §2.5)', () => {
+    it('defines --color-border-strong in light mode', () => {
+      const lightBlockMatch = TOKENS_CSS.match(
+        /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+      );
+      expect(lightBlockMatch?.[1]).toMatch(/--color-border-strong:/);
+    });
+    it('defines --color-border-strong in dark mode', () => {
+      const darkBlockMatch = TOKENS_CSS.match(
+        /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+      );
+      expect(darkBlockMatch?.[1]).toMatch(/--color-border-strong:/);
+    });
+    it('defines --color-text-link in light mode', () => {
+      const lightBlockMatch = TOKENS_CSS.match(
+        /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+      );
+      expect(lightBlockMatch?.[1]).toMatch(/--color-text-link:/);
+    });
+    it('defines --color-text-link in dark mode', () => {
+      const darkBlockMatch = TOKENS_CSS.match(
+        /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+      );
+      expect(darkBlockMatch?.[1]).toMatch(/--color-text-link:/);
+    });
+    it('defines --text-body-sm as a CSS font shorthand', () => {
+      expect(TOKENS_CSS).toMatch(/--text-body-sm:/);
+    });
+    it('defines --text-heading-sm as a CSS font shorthand', () => {
+      expect(TOKENS_CSS).toMatch(/--text-heading-sm:/);
+    });
+  });
 });
 
 describe('styles.css — W1 conformance', () => {


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    A[":root — geometry tokens<br/>--card-radius/inset/gap/padding/maxw-*"] --> B
    B["[data-theme='light'] — elevation<br/>--elevation-1/2/3 drop shadows<br/>--card-elevation-1/2/3 aliases<br/>4 undefined tokens resolved"] --> D
    C["[data-theme='dark'] — elevation<br/>--elevation-1/2/3 drop shadow + rim-light<br/>--color-bg-surface lifted #131c30→#1b2742<br/>--color-border-ui lifted #283354→#3a4668"] --> D
    D["Downstream element PRs<br/>#800 header clusters<br/>#801 rail→card<br/>#779 lede→card<br/>#780 filters→panel<br/>#783 legend<br/>popover primitive"] --> E[Token-consumption changes only — no restyles]
```

## Summary

- Adds the shared floating-card design language (spec §2, #761) as tokens in `frontend/src/styles/tokens.css` so every downstream element PR is a token-consumption change, not a restyle. No element is repositioned; the only intended visual delta is the dark surface token lift.
- Resolves the 4 undefined tokens (`--color-border-strong`, `--color-text-link`, `--text-body-sm`, `--text-heading-sm`) that `ds-primitives.css` was consuming but that resolved to nothing — cell/cluster popovers were silently inheriting empty values.
- Documents the four-corner anchor contract (spec §3) in `tokens.css` comments and `CLAUDE.md`: top-left identity, top-right controls, bottom-left legend, bottom-right attribution, transient layer for popovers/detail/filters.

## Screenshots

UI verification: PASS — dark-mode spot-check confirmed the lifted dark surfaces (`--color-bg-surface #1b2742` / `--color-border-ui #3a4668`) read as a subtle, intentional lift off the near-black basemap on the header, legend, and a cell popover; light mode unchanged; 0 console errors. Foundation token PR — no element repositioned, so the full 5×2 matrix is N/A.

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
      N/A — no new classNames; this PR only adds CSS custom properties to tokens.css.
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)
      N/A — no element repositioned or restyled in this PR. The only visual delta is the dark surface fill lift; orchestrator spot-check pending.

## Test plan

- [x] `npm run typecheck && npm run test` — 935 tests pass; 29 new assertions in `tokens.css.test.ts` for the new `--card-*`/`--elevation-*` tokens, dark surface lift values, and 4 previously-undefined token resolutions. (2 pre-existing maplibre-gl import failures in the worktree — unrelated, pre-existing before this branch.)
- [x] New unit / integration tests added (if behavior changed) — 29 new token conformance assertions added.
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A; no element repositioned. Existing `ds-primitives.spec.ts`, `forced-colors.spec.ts`, `basemap-dark-flip.spec.ts` cover the surfaces whose undefined tokens are now resolved; these run in CI against the full build.
- [x] `npm run build` — pre-existing maplibre-gl type error in the worktree (missing `npm ci`); identical failure before and after this branch. CI runs `npm ci` first and will resolve cleanly.
- [x] `npx knip` — identical output before and after; no new orphaned tokens (new tokens are consumed by tests and documented for imminent use by downstream element PRs).
- [x] Orphan-classname check — clean (exit 0); no new classNames added.
- [x] (UI only) Playwright MCP smoke — N/A; instructed not to run Playwright MCP; orchestrator will spot-check dark-mode surface lift.

## Plan reference

Part of epic #761, implements spec §2 + §6.0 of `docs/design/2026-05-30-floating-ui-design-spec.md`. Blocks #800, #801, #779, #780, #783, and the shared-popover-primitive issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
