### PR TITLE
feat(frontend): de-dock SpeciesDetailRail to floating inset card (#801)

### DIFF
--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -124,6 +124,100 @@ test.describe('species detail surface (#151)', () => {
     // The legacy position:fixed overlay class is still absent.
     await expect(page.locator('.species-panel-overlay')).toHaveCount(0);
   });
+
+  /**
+   * #801 — SpeciesDetailRail de-docked to an inset floating card.
+   *
+   * At ≥1200px the rail must float inset from ALL four sides of the viewport:
+   *   - rect.top > 0     — map pixels visible above the card
+   *   - rect.right < viewportWidth — map pixels visible to the right (inset from right edge)
+   *   - rect.bottom < viewportHeight — map pixels visible below the card
+   *   - rect.left > 0    — map pixels visible to the left (not a full-height dock from left:0)
+   *
+   * Additionally:
+   *   - No border-left divider (the old edge-dock's left border must be gone)
+   *   - border-radius on all four corners (--card-radius ≥ 8px confirms all-corner treatment)
+   *   - --z-rail tier preserved (43 — above chrome 42, below cell/cluster popovers)
+   */
+  test('#801 rail is an inset floating card at 1440×900 — map pixels visible on all four sides', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY);
+    const app = new AppPage(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+    await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
+
+    const rail = page.locator('aside.species-detail-rail');
+    await expect(rail).toBeVisible();
+
+    const m = await rail.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      return {
+        top:            r.top,
+        right:          r.right,
+        bottom:         r.bottom,
+        left:           r.left,
+        viewportWidth:  window.innerWidth,
+        viewportHeight: window.innerHeight,
+        borderLeft:     cs.borderLeftWidth,
+        borderTopLeftRadius:     cs.borderTopLeftRadius,
+        borderTopRightRadius:    cs.borderTopRightRadius,
+        borderBottomLeftRadius:  cs.borderBottomLeftRadius,
+        borderBottomRightRadius: cs.borderBottomRightRadius,
+      };
+    });
+
+    // All four sides must have a gap — the card floats inset, not docked.
+    expect(m.top,    'rail.top > 0: map visible above the card').toBeGreaterThan(0);
+    expect(m.right,  'rail.right < viewportWidth: map visible to the right').toBeLessThan(m.viewportWidth);
+    expect(m.bottom, 'rail.bottom < viewportHeight: map visible below the card').toBeLessThan(m.viewportHeight);
+    expect(m.left,   'rail.left > 0: not full-height docked to left edge').toBeGreaterThan(0);
+
+    // No hard left-border divider — the old edge-dock visual.
+    expect(
+      parseFloat(m.borderLeft),
+      'no border-left divider on the floating card',
+    ).toBeLessThanOrEqual(0);
+
+    // All four corners have border-radius (≥ 8px confirms all-corner floating treatment).
+    const minRadius = 8;
+    expect(parseFloat(m.borderTopLeftRadius),     'top-left radius ≥ 8px').toBeGreaterThanOrEqual(minRadius);
+    expect(parseFloat(m.borderTopRightRadius),    'top-right radius ≥ 8px').toBeGreaterThanOrEqual(minRadius);
+    expect(parseFloat(m.borderBottomLeftRadius),  'bottom-left radius ≥ 8px').toBeGreaterThanOrEqual(minRadius);
+    expect(parseFloat(m.borderBottomRightRadius), 'bottom-right radius ≥ 8px').toBeGreaterThanOrEqual(minRadius);
+  });
+
+  test('#801 rail is an inset floating card at 1920×1080 — map pixels visible on all four sides', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY);
+    const app = new AppPage(page);
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+    await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
+
+    const rail = page.locator('aside.species-detail-rail');
+    await expect(rail).toBeVisible();
+
+    const m = await rail.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return {
+        top:            r.top,
+        right:          r.right,
+        bottom:         r.bottom,
+        left:           r.left,
+        viewportWidth:  window.innerWidth,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(m.top,    'rail.top > 0: map visible above the card at 1920').toBeGreaterThan(0);
+    expect(m.right,  'rail.right < 1920: map visible to the right').toBeLessThan(m.viewportWidth);
+    expect(m.bottom, 'rail.bottom < 1080: map visible below the card at 1920').toBeLessThan(m.viewportHeight);
+    expect(m.left,   'rail.left > 0: not docked to left edge at 1920').toBeGreaterThan(0);
+  });
 });
 
 /**

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -218,6 +218,52 @@ test.describe('species detail surface (#151)', () => {
     expect(m.bottom, 'rail.bottom < 1080: map visible below the card at 1920').toBeLessThan(m.viewportHeight);
     expect(m.left,   'rail.left > 0: not docked to left edge at 1920').toBeGreaterThan(0);
   });
+
+  /**
+   * #801 Tier-2 occlusion regression guard — rail must NOT overlap the controls pill.
+   *
+   * At ≥1440 the rail (z-index --z-rail 43) is stacked ABOVE the controls pill
+   * (z-index --z-chrome 42). If the rail's top edge encroaches into the pill's
+   * vertical band, the Attribution/Filters/theme buttons are painted over and
+   * unclickable. This test asserts disjoint bounding boxes: rail.top ≥ pill.bottom.
+   *
+   * Tested at both canonical wide viewports (1440×900 and 1920×1080).
+   */
+  for (const [vw, vh] of [[1440, 900], [1920, 1080]] as const) {
+    test(`#801 rail does not occlude controls pill at ${vw}×${vh} — rail.top ≥ pill.bottom`, async ({ page, apiStub }) => {
+      await apiStub.stubEmpty();
+      await apiStub.stubSpecies('vermfly', VERMFLY);
+      const app = new AppPage(page);
+      await page.setViewportSize({ width: vw, height: vh });
+      await app.goto('detail=vermfly&view=detail');
+      await app.waitForAppReady();
+      await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
+
+      const rects = await page.evaluate(() => {
+        const rail = document.querySelector('aside.species-detail-rail');
+        const pill = document.querySelector('.app-header-controls-pill');
+        if (!rail || !pill) return null;
+        const railR = rail.getBoundingClientRect();
+        const pillR = pill.getBoundingClientRect();
+        return {
+          railTop:    railR.top,
+          pillBottom: pillR.bottom,
+          pillTop:    pillR.top,
+          pillRight:  pillR.right,
+          railRight:  railR.right,
+        };
+      });
+
+      expect(rects, 'rail and pill elements must be present').not.toBeNull();
+
+      // The rail's top edge must be at or below the pill's bottom edge —
+      // no shared vertical band means no occlusion regardless of z-index.
+      expect(
+        rects!.railTop,
+        `rail.top (${rects!.railTop}px) must be ≥ pill.bottom (${rects!.pillBottom}px) — no vertical overlap`,
+      ).toBeGreaterThanOrEqual(rects!.pillBottom);
+    });
+  }
 });
 
 /**

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -993,7 +993,10 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
    inside <main> — the map stays live and interactive around it.
 
    Geometry:
-     - inset-block: var(--card-inset) — 12px gap top AND bottom
+     - inset-block-start: calc(var(--card-inset) + var(--controls-cluster-h) +
+         var(--card-gap)) — clears the controls pill (54px measured) with an
+         additional 8px gap; rail top sits BELOW the pill bottom at all widths
+     - inset-block-end: var(--card-inset) — 12px gap from the bottom edge
      - inset-inline-end: var(--card-inset) — 12px gap from the right edge
      - inset-inline-start: auto — not docked to the left edge
      - width: clamp(360px, 38vw, var(--card-maxw-rail)) — 360–420px, shrinks
@@ -1005,20 +1008,24 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
        replaces the old directional "-8px 0 32px" edge-dock shadow
      - border-left removed — the old edge-dock visual divider is gone
 
+   At ≥1440px all three inset terms switch to --card-inset-wide (24px) so the
+   rail's right edge aligns with the controls pill's right edge at wide viewports
+   (four-corner anchor contract, spec §3 / CLAUDE.md).
+
    z-index: --z-rail (43) preserved — above map overlays (40/41), above
    identity+controls chrome (42), BELOW cell/cluster popovers (44/45).
    The rank-preserving contract from #778 holds unchanged.
 
-   Collision avoidance (spec §5.3): the card sits in the top-right region
-   *below* the controls cluster (--z-chrome 42 card insets from top by
-   --card-inset; the controls pill is also inset-inline-end from the same
-   edge, so the rail and the controls pill share the same right margin and
-   the rail's top gap keeps it below the pill at typical heights).
+   Collision avoidance (spec §5.3): rail.top ≥ pill.bottom is guaranteed by the
+   inset-block-start formula:
+     <1440  → 12 + 54 + 8 = 74px top; pill bottom = 12 + 54 = 66px → +8px gap
+     ≥1440  → 24 + 54 + 8 = 86px top; pill bottom = 24 + 54 = 78px → +8px gap
    (#801, #761.)
    ========================================================================== */
 aside.species-detail-rail {
   position: fixed;
-  inset-block: var(--card-inset);
+  inset-block-start: calc(var(--card-inset) + var(--controls-cluster-h) + var(--card-gap));
+  inset-block-end: var(--card-inset);
   inset-inline-end: var(--card-inset);
   inset-inline-start: auto;
   width: clamp(360px, 38vw, var(--card-maxw-rail));
@@ -1028,6 +1035,16 @@ aside.species-detail-rail {
   box-shadow: var(--card-elevation-3);
   overflow: auto;
   z-index: var(--z-rail);
+}
+
+/* At ≥1440px switch all three rail insets to --card-inset-wide (24px) so the
+   right edge aligns with the controls pill and both use the same wide gutter. */
+@media (min-width: 1440px) {
+  aside.species-detail-rail {
+    inset-block-start: calc(var(--card-inset-wide) + var(--controls-cluster-h) + var(--card-gap));
+    inset-block-end: var(--card-inset-wide);
+    inset-inline-end: var(--card-inset-wide);
+  }
 }
 
 aside.species-detail-rail .species-detail-rail-close {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -983,33 +983,49 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 }
 
 /* ==========================================================================
-   #663 — in-place species detail rail (≥1200px viewports).
-   Renders as <aside role="complementary"> on the right edge of the
-   viewport, coexisting with a still-mounted Map to the left. Width is
-   capped at 560px (issue #663 Addendum A); the Map keeps the remaining
-   width and stays interactive (no inert backdrop).
+   #663 / #801 — SpeciesDetailRail as an inset floating card (≥1200px).
 
-   z-index: the rail sits at the dedicated rail tier (--z-rail = 43), above the
-   map-assist overlays (--z-overlay/--z-popover = 40/41) and BELOW the
-   cell/cluster popovers (--z-cell-popover/--z-cluster-popover = 44/45 — both
-   popovers still float ABOVE the rail, matching the pre-refactor
-   rail(45) < cell(46) < cluster(47)). This is a rank-preserving rename: the
-   raw value moves 45 → 43 but the rail's order relative to everything that can
-   overlap it is unchanged. The named --z-chrome / --z-modal tiers exist in the
-   scale but are NOT adopted by .app-header / the sheet in this PR (#761 P1 is
-   strict zero-visual-change); the header stays at raw 10 below the overlays
-   until S2 (#775) and the sheet stays at 10/15/20 until O5 (#783). (#761 P1, #778.)
+   #801 de-docks the rail from the right edge (floating-inset chrome principle,
+   spec §4.5). It now insets from ALL four viewport edges so the map is visible
+   above, below, and to the left of it — Google-Maps-style detail card, not a
+   side-panel wall. The #663 interactive-map-beneath guarantee is preserved:
+   the rail is still position:fixed and still a sibling of the map canvas, NOT
+   inside <main> — the map stays live and interactive around it.
+
+   Geometry:
+     - inset-block: var(--card-inset) — 12px gap top AND bottom
+     - inset-inline-end: var(--card-inset) — 12px gap from the right edge
+     - inset-inline-start: auto — not docked to the left edge
+     - width: clamp(360px, 38vw, var(--card-maxw-rail)) — 360–420px, shrinks
+       gracefully on narrow-wide viewports
+     - max-height: none (height is governed by inset-block on both sides)
+     - border-radius: var(--card-radius) on ALL four corners (12px) — no
+       more flush right edge; the card floats with visible corners all around
+     - box-shadow: var(--card-elevation-3) — tier-3 floating shadow (spec §2.3)
+       replaces the old directional "-8px 0 32px" edge-dock shadow
+     - border-left removed — the old edge-dock visual divider is gone
+
+   z-index: --z-rail (43) preserved — above map overlays (40/41), above
+   identity+controls chrome (42), BELOW cell/cluster popovers (44/45).
+   The rank-preserving contract from #778 holds unchanged.
+
+   Collision avoidance (spec §5.3): the card sits in the top-right region
+   *below* the controls cluster (--z-chrome 42 card insets from top by
+   --card-inset; the controls pill is also inset-inline-end from the same
+   edge, so the rail and the controls pill share the same right margin and
+   the rail's top gap keeps it below the pill at typical heights).
+   (#801, #761.)
    ========================================================================== */
 aside.species-detail-rail {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: min(560px, 100vw);
+  inset-block: var(--card-inset);
+  inset-inline-end: var(--card-inset);
+  inset-inline-start: auto;
+  width: clamp(360px, 38vw, var(--card-maxw-rail));
   background: var(--color-bg-surface);
   color: var(--color-text);
-  border-left: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
-  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.12);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-elevation-3);
   overflow: auto;
   z-index: var(--z-rail);
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -102,6 +102,13 @@
   --card-maxw-legend:   280px;  /* bottom-left legend cap                         */
   --card-maxw-rail:     420px;  /* detail card cap (max(420px,38vw) clamp below)  */
   --card-maxw-popover:  300px;  /* transient popover cap                          */
+
+  /* Controls-cluster (top-right pill) height — measured at 54px:
+   *   8px top padding + 36px button min-height + 8px bottom padding + 2px border
+   * Used by the detail rail and filters panel to clear the controls pill's
+   * bottom edge. Named for what it is (the cluster height), NOT --header-height
+   * which is a retired layout-reservation token. Added 2026-05-30 (#801). */
+  --controls-cluster-h: 54px;
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant Rail as SpeciesDetailRail
    participant Map as MapCanvas

    User->>Rail: click species in map
    Note over Rail: position:fixed<br/>inset-block: 12px (top+bottom)<br/>inset-inline-end: 12px (right)<br/>width: clamp(360px, 38vw, 420px)<br/>border-radius: --card-radius (all 4 corners)<br/>box-shadow: --card-elevation-3
    Note over Map: stays live + interactive<br/>visible above, below, left of card
    User->>Map: pan / click elsewhere
    Note over Rail: map pixels visible on all 4 sides
```

## Summary

- **Why:** `aside.species-detail-rail` was a full-height right-edge dock (`top:0; right:0; bottom:0; border-left`) — violating the floating-inset chrome principle established in #800. The map was sliced into "map | panel" instead of wrapping the card on all sides (spec §4.5, #761).
- **What:** De-dock the rail to an inset floating card using `--card-*` tokens from #804. It now insets 12px from all four viewport edges (`inset-block/inset-inline-end: var(--card-inset)`), with `border-radius: var(--card-radius)` on all four corners, `box-shadow: var(--card-elevation-3)`, and the `border-left` divider removed. Width is `clamp(360px, 38vw, var(--card-maxw-rail))`.
- **Preserved:** `#663` interactive-map-beneath behavior (still `position:fixed`, still a sibling of the map canvas, not inside `<main>`); `role="complementary"` landmark; close affordance; `--z-rail` (43) tier.

## Screenshots

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![rail-390x844-light](https://github.com/user-attachments/assets/3a6b318b-59a5-48dc-b7f3-8d32b6dadca7) | ![rail-390x844-dark](https://github.com/user-attachments/assets/7a6fac3f-d2e5-4cf7-a3d0-c2796e646410) |
| 768×1024 (tablet portrait) | ![rail-768x1024-light](https://github.com/user-attachments/assets/976b2329-d06c-4975-8898-d5dc1f1254b2) | ![rail-768x1024-dark](https://github.com/user-attachments/assets/9ba8be9b-7945-4540-8f84-cdd8a4625bab) |
| 1024×768 (tablet landscape) | ![rail-1024x768-light](https://github.com/user-attachments/assets/a1b431c9-e69b-47a9-833d-ff7cb04efa78) | ![rail-1024x768-dark](https://github.com/user-attachments/assets/a08ced47-48a2-4bd6-82eb-3f9c04c44760) |
| 1440×900 (desktop) | ![rail-1440x900-light](https://github.com/user-attachments/assets/612caac3-6122-4967-b2ea-dc9424ebf018) | ![rail-1440x900-dark](https://github.com/user-attachments/assets/d232d523-8cc3-4043-aefb-b5f7a9d0179f) |
| 1920×1080 (wide desktop) | ![rail-1920x1080-light](https://github.com/user-attachments/assets/afd606f6-286b-4f4c-a39a-f519efe86695) | ![rail-1920x1080-dark](https://github.com/user-attachments/assets/aa076481-6596-4244-8a58-a45e79c419c7) |

_Note: the rail's inner content shows "Could not load species details" because the local dev server has no `/api/species/<code>` endpoint (the dev stub covers observations, not detail) — a local-environment artifact, not a regression. #806 only changes the rail's float geometry, which is identical regardless of content; see the measured rail.top ≥ pill.bottom clearance in the Test plan._

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

## Test plan

- [x] `npm run typecheck && npm run test` — green (65 test files, 1008 tests)
- [x] New e2e geometry assertions added in `species-detail.spec.ts` — two tests assert `rect.top > 0`, `rect.right < vw`, `rect.bottom < vh`, `rect.left > 0` at 1440×900 and 1920×1080; plus no `border-left`, plus all-four-corner `border-radius ≥ 8px`
- [x] TDD: assertions written and confirmed red against old dock; CSS implemented; confirmed green
- [x] `npm run build` — clean production build
- [x] `npx playwright test --workers=1` — 233 passed, 15 skipped, 0 failed; full suite
- [x] `npx knip` — exit 0 (pre-existing configuration hint unrelated to this PR)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] (UI only) Playwright MCP smoke — screenshots captured in verification pass before bot review

## Plan reference

Part of epic #761 (map-first rearchitecture). Implements spec §4.5 (`docs/design/2026-05-30-floating-ui-design-spec.md`). Closes #801.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)