### PR TITLE
feat(frontend,a11y): O1 — retarget inert to #map-layer + aria-busy re-home + camera data-attrs (#776)

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -62,8 +62,10 @@ test.describe('accessibility', () => {
     await page.goto('/?scope=us');
     // Race: the mount effect kicks off a fetch, and we may miss the `true` state
     // if the network is very fast. Accept either ordering, but we MUST end on 'false'.
+    // O1 (#776): aria-busy re-homed from main#main-surface to #map-layer so
+    // assistive tech announces against the element whose subtree is changing.
     await expect.poll(
-      () => app.mainSurface.getAttribute('aria-busy'),
+      () => app.mapLayer.getAttribute('aria-busy'),
       { timeout: 10_000 }
     ).toBe('false');
   });

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -268,7 +268,8 @@ test.describe('axe-core WCAG scans', () => {
     // Sky Atlas Phase 4 — bottom-sheet at full snap accessibility contract.
     // The sheet is NOT a <dialog> at peek/half (map underneath stays
     // interactive); it flips to role="dialog" aria-modal="true" only at
-    // full snap, with `inert` on #main-surface set BEFORE the role flip.
+    // full snap, with `inert` on #map-layer set BEFORE the role flip
+    // (O1 #776: retargeted from #main-surface to #map-layer).
     test('species detail sheet (mobile) at full snap — role="dialog", map inert', async ({ page, apiStub }) => {
       await apiStub.stubEmpty();
       await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
@@ -294,9 +295,11 @@ test.describe('axe-core WCAG scans', () => {
       await expect(sheet).toHaveAttribute('aria-modal', 'true');
       await expect(sheet).toHaveAttribute('aria-label', /vermilion flycatcher/i);
 
-      // The map landmark is inert — set BEFORE the role flip in JS, but
+      // The map layer is inert — set BEFORE the role flip in JS, but
       // observable as a steady-state attribute once the transition settles.
-      await expect(app.mainSurface).toHaveAttribute('inert', '');
+      // O1 (#776): retargeted from #main-surface to #map-layer so the live
+      // MapLibre canvas is frozen, not the near-empty <main> shell.
+      await expect(app.mapLayer).toHaveAttribute('inert', '');
 
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
       if (results.violations.length) {

--- a/frontend/e2e/error-states.spec.ts
+++ b/frontend/e2e/error-states.spec.ts
@@ -42,11 +42,12 @@ test.describe('error screen', () => {
     const app = new AppPage(page);
     await apiStub.stubApiAbort('observations');
     await page.goto('/?scope=us');
-    // Either the error StatusBlock renders, or main#main-surface stops reporting busy.
+    // Either the error StatusBlock renders, or #map-layer stops reporting busy.
     // Race them with Promise.race — first acceptable resolution wins.
+    // O1 (#776): aria-busy re-homed from main#main-surface to #map-layer.
     await Promise.race([
       expect(page.locator('.status-block--state-error')).toBeVisible({ timeout: 10_000 }),
-      expect(app.mainSurface).toHaveAttribute('aria-busy', 'false', { timeout: 10_000 }),
+      expect(app.mapLayer).toHaveAttribute('aria-busy', 'false', { timeout: 10_000 }),
     ]);
   });
 });

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -4,6 +4,10 @@ import { FiltersBar } from './filters-bar.js';
 export class AppPage {
   readonly filters: FiltersBar;
   readonly mainSurface: Locator;
+  /** O1 (#776): the #map-layer div — receives `inert` at full snap / unscoped
+   *  scrim, carries `aria-busy` (re-homed from <main>), and exposes
+   *  `data-camera-bounds` / `data-scope-fitted` as e2e camera handles. */
+  readonly mapLayer: Locator;
   readonly errorScreen: Locator;
   /**
    * Persistent header banner — transparent wrapper holding identity card +
@@ -64,6 +68,8 @@ export class AppPage {
     // `[data-render-complete]` attribute (the one hook the inversion carries
     // forward onto whatever element becomes the readiness root).
     this.mainSurface = page.locator('main#main-surface');
+    // O1 (#776): map-layer — the inert target, aria-busy node, and camera handle.
+    this.mapLayer = page.locator('#map-layer');
     this.errorScreen = page.locator('.error-screen');
     this.appHeader = page.locator('header.app-header');
     // #800: appHeaderTabs removed — no tablist in the new corner-card header.
@@ -175,13 +181,11 @@ export class AppPage {
   }
 
   /**
-   * #761 (S1): assert the map surface is mounted but INERT behind the chooser
-   * scrim on the unscoped landing. The `inert` attribute on `#main-surface`
-   * (set by App's inert/focus-trap effect) removes the whole map subtree from
-   * the tab order and blocks pointer interaction — the load-bearing half of the
-   * "chooser scrim over a mounted, idle map" model. Specs assert through this
-   * helper rather than inlining the `[inert]` selector so the map-first
-   * inversion (#761 S2, the eventual map hoist) re-points only this one line.
+   * #761 (S1) / O1 (#776): assert the map surface is mounted but INERT behind
+   * the chooser scrim on the unscoped landing. O1 retargeted `inert` from
+   * `#main-surface` to `#map-layer` so the live MapLibre canvas is frozen, not
+   * the near-empty <main> shell. Specs assert through this helper rather than
+   * inlining the `[inert]` selector so future re-targets re-point only here.
    *
    * Returns the inertness assertion as a chainable `expect` so callers can
    * `await app.expectMapInert()`.
@@ -189,8 +193,8 @@ export class AppPage {
   async expectMapInert(): Promise<void> {
     // The map canvas is present (mounted idle behind the scrim)…
     await this.mapCanvas.waitFor({ state: 'attached' });
-    // …and #main-surface carries the `inert` attribute.
-    await this.mainSurface.and(this.page.locator('[inert]')).waitFor({ state: 'attached' });
+    // …and #map-layer carries the `inert` attribute (O1 retarget from #main-surface).
+    await this.mapLayer.and(this.page.locator('[inert]')).waitFor({ state: 'attached' });
   }
 
   /**

--- a/frontend/e2e/prod-smoke.preview.spec.ts
+++ b/frontend/e2e/prod-smoke.preview.spec.ts
@@ -13,7 +13,8 @@ test.describe('production build smoke', () => {
     const app = new AppPage(page);
     await app.goto();
     await app.waitForAppReady(15_000);
-    await expect(app.mainSurface)
+    // O1 (#776): aria-busy re-homed from main#main-surface to #map-layer.
+    await expect(app.mapLayer)
       .toHaveAttribute('aria-busy', 'false', { timeout: 15_000 });
     await expect(page.locator('.error-screen')).toHaveCount(0);
   });

--- a/frontend/e2e/sheet-snap.spec.ts
+++ b/frontend/e2e/sheet-snap.spec.ts
@@ -25,14 +25,21 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     await expect(sheet).toHaveAttribute('data-snap-state', 'full');
     await expect(sheet).toHaveAttribute('role', 'dialog');
     await expect(sheet).toHaveAttribute('aria-modal', 'true');
-    await expect(app.mainSurface).toHaveAttribute('inert', '');
+    // O1 (#776): inert retargeted from #main-surface to #map-layer so the live
+    // MapLibre canvas is frozen at full snap, not the near-empty <main> shell.
+    await expect(app.mapLayer).toHaveAttribute('inert', '');
+    // AC-1: map canvas is non-interactive (inert) at full snap — a marker/cluster
+    // inside #map-layer cannot be focused because the inert attribute removes all
+    // descendants from the tab order and blocks pointer events.
+    await expect(page.locator('#map-layer')).toHaveAttribute('inert', '');
 
     // Collapse path
     const collapse = page.getByRole('button', { name: /collapse/i });
     await collapse.click();
     await expect(sheet).toHaveAttribute('data-snap-state', 'half');
     await expect(sheet).toHaveAttribute('role', 'region');
-    await expect(app.mainSurface).not.toHaveAttribute('inert', '');
+    // O1: inert is removed from #map-layer on collapse (map becomes interactive again).
+    await expect(app.mapLayer).not.toHaveAttribute('inert', '');
   });
 
   test('drag-down past peek dismisses the sheet (URL flips off detail)', async ({ page, apiStub }) => {

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -11,11 +11,13 @@ import { AppPage } from './pages/app-page.js';
  * fires exactly one observations fetch — carrying `state=US-XX` for a state
  * scope, and NO `state=` for `?scope=us` (the data invariant, #735).
  *
- * Camera-assertion handle (AC 4): App.tsx exposes no dedicated camera
- * data-attribute, so the camera move is asserted via the URL round-trip
- * (`?state=` set) + the `/api/observations` request query (`state=US-XX`) — the
- * agreed handle. The map canvas presence (`data-testid='map-canvas'`) confirms
- * the scoped map mounted.
+ * Camera-assertion handle (AC 4 / O1 #776): App.tsx now exposes direct camera
+ * handles on #map-layer: `data-camera-bounds` (the active boundsKey) and
+ * `data-scope-fitted` (false→true after SCOPE_MOVE_SETTLE_MS). These are the
+ * canonical handles. The URL round-trip (`?state=` set) + the
+ * `/api/observations` request query (`state=US-XX`) remain as belt-and-suspenders.
+ * The map canvas presence (`data-testid='map-canvas'`) confirms the scoped map
+ * mounted.
  *
  * Navigation contract (AC 15): the chooser-landing + whole-US-reset cases skip
  * `waitForAppReady()` (no map render is expected); the data cases wait for it.
@@ -179,6 +181,19 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // one chunk request fired on the scoped path (the prefetch on click + the
     // lazy boundary on mount both target the same chunk; ≥1 is the signal).
     expect(mapChunkRequests.length).toBeGreaterThan(0);
+
+    // O1 (#776) camera data-attribute assertions (AC 4 / scoped-path-only):
+    // After a state pick + settle, #map-layer exposes the direct camera handles.
+    // data-camera-bounds carries the active boundsKey ('US-AZ' for a state scope).
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
+    // data-scope-fitted flips true after SCOPE_MOVE_SETTLE_MS (1000ms) — wait
+    // up to 3s for the timer to fire after the scope-pick animation settles.
+    await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', { timeout: 3_000 });
+
+    // O1 (#776) result-settle aria-live region (R9): after data settles the
+    // App-root polite live region carries the scope+result summary. The region
+    // is visually hidden (.sr-only) but present in the a11y tree.
+    await expect(page.locator('[role="status"].sr-only')).toContainText('Arizona', { timeout: 3_000 });
   });
 
   test('?scope=us — CONUS map, region "USA", /api/observations carries NO state=', async ({

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -191,9 +191,10 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', { timeout: 3_000 });
 
     // O1 (#776) result-settle aria-live region (R9): after data settles the
-    // App-root polite live region carries the scope+result summary. The region
-    // is visually hidden (.sr-only) but present in the a11y tree.
-    await expect(page.locator('[role="status"].sr-only')).toContainText('Arizona', { timeout: 3_000 });
+    // App-root polite live region (a <div> at App root, distinct from the
+    // AppHeader scope-change <span>) carries the scope+result summary.
+    // The div is visually hidden (.sr-only) but present in the a11y tree.
+    await expect(page.locator('div[role="status"].sr-only')).toContainText('Arizona', { timeout: 3_000 });
   });
 
   test('?scope=us — CONUS map, region "USA", /api/observations carries NO state=', async ({

--- a/frontend/e2e/zip-scope.spec.ts
+++ b/frontend/e2e/zip-scope.spec.ts
@@ -8,10 +8,12 @@ import { AppPage } from './pages/app-page.js';
  * The ZIP path resolves a 5-digit ZIP to a `?state=US-XX` scope (NO `?zip=`,
  * locked decision #5) + a transient metro `flyTo` at `ZIP_FLYTO_ZOOM` (10). The
  * camera move is asserted via the URL round-trip (`?state=` set, no `?zip=`) +
- * the `/api/observations` request query (`state=US-XX`) — the agreed handle
- * (App exposes no dedicated camera data-attribute); the metro-zoom landing is
- * the prototype's learning (f) (the ZIP `flyTo` wins over the whole-state
- * `fitBounds` on the chooser→map remount).
+ * the `/api/observations` request query (`state=US-XX`). O1 (#776) added direct
+ * camera handles (`data-camera-bounds` / `data-scope-fitted` on #map-layer) —
+ * this spec's assertion re-baseline to those direct handles is deferred to
+ * WS9.3; the URL+observations-proxy assertions remain as belt-and-suspenders.
+ * The metro-zoom landing is the prototype's learning (f) (the ZIP `flyTo` wins
+ * over the whole-state `fitBounds` on the chooser→map remount).
  *
  * Empty-region (AC 11) is the data-availability ≠ filter-narrowing distinction:
  * a valid non-AZ ZIP whose state is empty on the AZ-only seed must read the

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -259,31 +259,36 @@ describe('App aria-busy', () => {
     vi.restoreAllMocks();
   });
 
-  it('sets aria-busy=true on <main> while observations are loading', () => {
-    // #777 removed the `&& state.view === 'feed'` conjunct; aria-busy now
-    // tracks observationsLoading directly on the surviving surface (map).
+  // O1 (#776): aria-busy re-homed from <main> to #map-layer.
+  it('sets aria-busy=true on #map-layer (not <main>) while observations are loading', () => {
+    // O1 re-homes aria-busy from <main id="main-surface"> to #map-layer so
+    // assistive tech announces "busy" against the region that is actually
+    // changing (the map block), not the near-empty <main> shell.
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'map',
       scope: { kind: 'us' as const },
     };
     // getObservations returns a never-resolving promise to keep loading=true
     mockGetObservations.mockReturnValue(new Promise(() => {}));
-    render(<App />);
-    const main = screen.getByRole('main');
-    expect(main.getAttribute('aria-busy')).toBe('true');
+    const { container } = render(<App />);
+    // Map root carries aria-busy=true while loading.
+    expect(container.querySelector('#map-layer')?.getAttribute('aria-busy')).toBe('true');
+    // Single-busy-node invariant: <main id="main-surface"> carries NO aria-busy.
+    expect(screen.getByRole('main').hasAttribute('aria-busy')).toBe(false);
   });
 
-  it('clears aria-busy on <main> once observations have loaded', async () => {
+  it('clears aria-busy on #map-layer once observations have loaded', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'map',
       scope: { kind: 'us' as const },
     };
     mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
-    render(<App />);
+    const { container } = render(<App />);
     await waitFor(() => {
-      const main = screen.getByRole('main');
-      expect(main.getAttribute('aria-busy')).toBe('false');
+      expect(container.querySelector('#map-layer')?.getAttribute('aria-busy')).toBe('false');
     });
+    // Invariant: <main> still has no aria-busy after settle.
+    expect(screen.getByRole('main').hasAttribute('aria-busy')).toBe(false);
   });
 });
 
@@ -962,15 +967,13 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     expect(
       await screen.findByRole('region', { name: /Choose where to look at birds/i }),
     ).toBeInTheDocument();
-    // #761 (S1): the map surface is mounted but INERT behind the scrim (no
-    // longer a full-tree unmount). The stub is present and #main-surface — the
-    // real <main id="main-surface"> App renders — carries the `inert` attribute
-    // set by App's inert/focus-trap effect. #761 (S2): the stub now lives in the
-    // hoisted #map-layer wrapper (a SIBLING of <main>), not inside #main-surface;
-    // the `inert` target stays #main-surface (the inert retarget to #map-layer is
-    // O1, not S2). Both assertions are unaffected by where the stub renders.
+    // #761 (S1) / O1 (#776): the map surface is mounted but INERT behind the
+    // scrim (no longer a full-tree unmount). The stub is present and #map-layer
+    // — the map wrapper — carries the `inert` attribute set by App's
+    // inert/focus-trap effect. O1 retargeted `inert` from #main-surface to
+    // #map-layer so the live MapLibre canvas is frozen, not the near-empty shell.
     expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
-    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
+    expect(container.querySelector('#map-layer')).toHaveAttribute('inert');
     // The cold-load fetch is suppressed: zero observations requests. Give any
     // mistaken effect a tick to fire.
     await waitFor(() => {
@@ -1206,13 +1209,11 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     expect(
       await screen.findByRole('region', { name: /Choose where to look at birds/i }),
     ).toBeInTheDocument();
-    // #761 (S1) re-baseline: the map surface is now mounted but INERT behind the
-    // scrim (it was unmounted under the old early-return). The inert attribute
-    // lands on the real <main id="main-surface"> App renders. #761 (S2): the map
-    // stub now lives in the hoisted #map-layer sibling, not inside #main-surface;
-    // the `inert` target stays #main-surface in S2 (retarget is O1).
+    // #761 (S1) / O1 (#776) re-baseline: the map surface is now mounted but
+    // INERT behind the scrim (it was unmounted under the old early-return).
+    // O1 retargeted `inert` from #main-surface to #map-layer (the map wrapper).
     expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
-    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
+    expect(container.querySelector('#map-layer')).toHaveAttribute('inert');
     // #761 (S1) NEW guard: the detail rail/sheet does NOT render on an unscoped
     // URL even though detail:'vermfly' is set — the `scopeActive` gate (App
     // task #6) stops a `?detail=` from mounting a second top-layer over the
@@ -1242,8 +1243,8 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     expect(container.querySelector('.app')).not.toBeNull();
     // The map stub and the chooser region are BOTH in the DOM simultaneously.
     expect(screen.getByTestId('map-surface-stub')).toBeInTheDocument();
-    // #main-surface is inert.
-    expect(container.querySelector('#main-surface')).toHaveAttribute('inert');
+    // #map-layer is inert (O1 retarget from #main-surface).
+    expect(container.querySelector('#map-layer')).toHaveAttribute('inert');
     // Fetch stays suppressed.
     expect(mockGetObservations).not.toHaveBeenCalled();
     expect(mockGetHotspots).not.toHaveBeenCalled();
@@ -1517,5 +1518,86 @@ describe('O9 (#781): scope-gated MapCanvas prefetch wiring', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+describe('O1 (#776): inert retarget to #map-layer', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetStatesCache();
+    __resetZipIndexCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mockGetStates.mockResolvedValue([]);
+    mapSurfaceRef.renderCount = 0;
+    mapSurfaceRef.boundsKey = undefined;
+    mapSurfaceRef.scopeBounds = undefined;
+    mapSurfaceRef.flyTo = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // S1 unscoped scrim: inert is set on #map-layer (not #main-surface) so the
+  // live MapLibre canvas is frozen while the chooser scrim is active.
+  it('sets inert on #map-layer (not #main-surface) when the unscoped scrim is shown', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'unscoped' },
+    };
+    const { container } = render(<App />);
+    await screen.findByRole('region', { name: /Choose where to look at birds/i });
+
+    // #map-layer carries the inert attribute (the retargeted mute).
+    expect(container.querySelector('#map-layer')).toHaveAttribute('inert');
+    // #main-surface does NOT carry inert (O1 retargets it off main).
+    expect(container.querySelector('#main-surface')).not.toHaveAttribute('inert');
+  });
+
+  // O1 camera data-attributes: data-camera-bounds and data-scope-fitted exist on
+  // the map root on a scoped path. data-scope-fitted starts "false" on a new
+  // boundsKey and flips "true" after SCOPE_MOVE_SETTLE_MS.
+  it('exposes data-camera-bounds on #map-layer for a scoped view', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    const { container } = render(<App />);
+    await screen.findByTestId('map-surface-stub');
+
+    // The camera attribute is present on #map-layer (the map root).
+    const mapLayer = container.querySelector('#map-layer');
+    expect(mapLayer).not.toBeNull();
+    expect(mapLayer?.hasAttribute('data-camera-bounds')).toBe(true);
+  });
+
+  // O1: data-scope-fitted starts 'false' on mount with a boundsKey and flips
+  // 'true' after the SCOPE_MOVE_SETTLE_MS timer fires.
+  it('data-scope-fitted starts false and flips true after SCOPE_MOVE_SETTLE_MS', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    // Install fake timers AFTER setting up state but BEFORE render so the
+    // setTimeout in the boundsKey effect is captured. Use `shouldAdvanceTime:
+    // false` so findByTestId's internal retry (which uses real microtask
+    // scheduling) is not blocked by our clock freeze.
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    let container: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<App />));
+    });
+
+    const mapLayer = container!.querySelector('#map-layer');
+    expect(mapLayer?.getAttribute('data-scope-fitted')).toBe('false');
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000); // SCOPE_MOVE_SETTLE_MS
+    });
+
+    expect(mapLayer?.getAttribute('data-scope-fitted')).toBe('true');
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -349,7 +349,21 @@ export function App() {
   useEffect(() => {
     if (boundsKey !== undefined) {
       scopeMoveUntilRef.current = Date.now() + SCOPE_MOVE_SETTLE_MS;
+      // O1 (#776) — data-scope-fitted: reset to false on each new camera move,
+      // then flip to true after the programmatic animation window expires.
+      // Both this timer and scopeMoveUntilRef share SCOPE_MOVE_SETTLE_MS so
+      // they settle in lockstep. This is an App-local timer — not driven by any
+      // existing settle hook (onViewportChange swallows settle frames in the
+      // window). Scoped-path-only: boundsKey is only defined when scoped.
+      setDataScopeFitted(false);
+      if (scopeFittedTimerRef.current !== null) clearTimeout(scopeFittedTimerRef.current);
+      scopeFittedTimerRef.current = setTimeout(() => {
+        setDataScopeFitted(true);
+      }, SCOPE_MOVE_SETTLE_MS);
     }
+    return () => {
+      if (scopeFittedTimerRef.current !== null) clearTimeout(scopeFittedTimerRef.current);
+    };
   }, [boundsKey, flyTo?.key]);
   const onViewportChange = useCallback((bounds: LngLatBounds, zoom: number) => {
     // S4 (#769) — hard scope-gate. #761 (S1) made the map persistently mounted
@@ -528,6 +542,21 @@ export function App() {
 
   const mainRef = useRef<HTMLElement | null>(null);
 
+  // O1 (#776) — dedicated inert target for the map layer. Both the S1 unscoped
+  // scrim and SpeciesDetailSheet (via the mainRef prop below) operate on this
+  // wrapper so the live MapLibre canvas is frozen whenever a modal/scrim or a
+  // full-snap detail sheet is active. `#main-surface` is kept as the readiness
+  // gate (#586) and scroll-bypass affordance, but no longer receives `inert`.
+  const mapLayerRef = useRef<HTMLDivElement | null>(null);
+
+  // O1 (#776) — camera data-attributes on #map-layer.
+  // data-scope-fitted starts false on each new boundsKey/flyTo change and flips
+  // true after SCOPE_MOVE_SETTLE_MS (the same window that suppresses idle refetch
+  // in scopeMoveUntilRef). Driven by an App-local timer — not by any existing
+  // settle hook (onViewportChange deliberately swallows settle frames).
+  const [dataScopeFitted, setDataScopeFitted] = useState(false);
+  const scopeFittedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // #761 (S1) — the unscoped landing is now an INERT, FOCUS-TRAPPED modal scrim
   // over a mounted-but-idle map (epic OQ1, option (a): modal-over-inert-map),
   // replacing the prior full-tree-unmount early-return. The map mounts behind
@@ -541,34 +570,35 @@ export function App() {
 
   // #761 (S1) — inert + focus-trap handshake for the unscoped scrim. Two
   // mechanisms, BOTH required by the focus-trap AC (they are distinct):
-  //   (4) `inert` on the real <main id="main-surface"> removes the entire map
-  //       subtree (including the map's `.skip-link`) from the tab order while
-  //       the scrim is open. Replicates the attribute-toggle pattern that
-  //       SpeciesDetailSheet.tsx uses on the same `mainRef` (there is no shared
-  //       inert helper — each owner toggles the attribute itself).
+  //   (4) `inert` on #map-layer (O1 retarget from #main-surface) removes the
+  //       live MapLibre canvas from the tab order and blocks pointer interaction
+  //       while the scrim is open. The retarget freezes the map subtree wherever
+  //       it sits (in-<main> pre-S2 or hoisted post-S2) — that's the whole point
+  //       of the wrapper. Replicates the attribute-toggle pattern that
+  //       SpeciesDetailSheet.tsx uses via the mapLayerRef prop (O1 unified target).
   //   (5a) Move initial focus into the scrim on mount — `inert` alone does NOT
   //       move focus, it only removes a subtree from the tab order. The focus
   //       landing target is the scrim wrapper itself (it carries `tabIndex={-1}`
   //       in the JSX below); the focus unit test keys off `scrimRef`/that
   //       wrapper holding focus.
   //   (5b) Trap Tab/Shift+Tab so focus cycles within the chooser and never
-  //       escapes. `inert` on #main-surface covers the map subtree, but the
+  //       escapes. `inert` on #map-layer covers the map subtree, but the
   //       ALWAYS-rendered shell now also mounts the <AppHeader> (wordmark,
-  //       Map tab, Attribution, Filters, ThemeToggle) AND the AttributionModal
-  //       trigger as SIBLINGS of <main> — none of which #main-surface's `inert`
-  //       covers. Rather than mark each of those inert, a keydown wrap handler
-  //       on the scrim keeps focus inside the chooser regardless of what other
-  //       focusable siblings exist (the defensive choice). `Escape` is
-  //       deliberately NOT a dismiss path: there is no "no-scope" state to
-  //       return to — the only exits are picking a scope.
+  //       Attribution, Filters, ThemeToggle) AND the AttributionModal trigger as
+  //       SIBLINGS of #map-layer — none of which #map-layer's `inert` covers.
+  //       Rather than mark each of those inert, a keydown wrap handler on the
+  //       scrim keeps focus inside the chooser regardless of what other focusable
+  //       siblings exist (the defensive choice). `Escape` is deliberately NOT a
+  //       dismiss path: there is no "no-scope" state to return to — the only
+  //       exits are picking a scope.
   useLayoutEffect(() => {
     if (scopeActive) return;
-    const main = mainRef.current;
+    const mapLayer = mapLayerRef.current;
     const scrim = scrimRef.current;
     if (!scrim) return;
 
-    // (4) Remove the map subtree from the tab order.
-    main?.setAttribute('inert', '');
+    // (4) Remove the map subtree from the tab order (O1: target is #map-layer).
+    mapLayer?.setAttribute('inert', '');
 
     // The focusable descendants of the scrim, in DOM order. Recomputed inside
     // the handler so it stays correct if the chooser's controls change (e.g.
@@ -616,7 +646,8 @@ export function App() {
       scrim.removeEventListener('keydown', onKeyDown);
       // Clearing `inert` happens when a scope is picked and the scrim unmounts
       // (this cleanup), or whenever `scopeActive` flips true.
-      main?.removeAttribute('inert');
+      // O1: target is #map-layer, not #main-surface.
+      mapLayer?.removeAttribute('inert');
     };
   }, [scopeActive]);
 
@@ -682,6 +713,30 @@ export function App() {
     noFiltersActive,
     familyName,
   ]);
+
+  // O1 (#776) — App-root polite aria-live result-settle narration (R9).
+  // The AppHeader already announces scope changes ("Showing {region}"). This
+  // region narrates the sightings-count/result settle ONCE per data load,
+  // debounced to SCOPE_MOVE_SETTLE_MS so it fires only after the camera and
+  // fetch both settle — not on every incremental render while loading.
+  // It reuses ledeText (the same copy AppHeader displays) so the SR hears the
+  // same summary a sighted user reads in the identity card, with no duplicate
+  // narration vs the scope-change announcer (which announces the region name
+  // while this announces the result count). Both are polite — they don't
+  // interrupt; the SR hears: "Showing Arizona." → [data loads] → "{N} species …"
+  const [settledLedeText, setSettledLedeText] = useState<string | null>(null);
+  const ledeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    // Only narrate once observations have settled (not while loading, not null).
+    if (observationsLoading || ledeText === null) return;
+    if (ledeDebounceRef.current !== null) clearTimeout(ledeDebounceRef.current);
+    ledeDebounceRef.current = setTimeout(() => {
+      setSettledLedeText(ledeText);
+    }, SCOPE_MOVE_SETTLE_MS);
+    return () => {
+      if (ledeDebounceRef.current !== null) clearTimeout(ledeDebounceRef.current);
+    };
+  }, [ledeText, observationsLoading]);
 
   // #663: clicking a species in a popover opens the detail overlay
   // IN PLACE — the map stays mounted. New click flow writes only
@@ -814,7 +869,15 @@ export function App() {
           fetch gate (above) is the sole mechanism holding `/api/observations` at
           zero. Do NOT make `#map-layer` conditional on `scopeActive`. */}
       {mapVisible && (
-        <div id="map-layer">
+        <div
+          id="map-layer"
+          ref={mapLayerRef}
+          aria-busy={observationsLoading}
+          {...(boundsKey !== undefined ? {
+            'data-camera-bounds': boundsKey,
+            'data-scope-fitted': String(dataScopeFitted),
+          } : {})}
+        >
           {/* #800 (S3): ScopeControl is now folded into the AppHeader identity
               card (spec §4.2) and rendered THERE — no longer a standalone
               floating overlay anchored top-center inside #map-layer. The header-
@@ -849,7 +912,10 @@ export function App() {
         ref={mainRef}
         id="main-surface"
         data-render-complete={renderComplete}
-        aria-busy={observationsLoading}
+        // aria-busy removed from <main> by O1 (#776) — re-homed to #map-layer
+        // above so assistive tech announces "busy" against the region that is
+        // actually changing (the map block), not the near-empty <main> shell.
+        // Single-busy-node invariant: #map-layer is the sole aria-busy node.
         // axe `scrollable-region-focusable` (WCAG 2.1.1): #main-surface
         // has `overflow: auto` so it can scroll when its content exceeds the
         // viewport. Keyboard users need to be able to focus the scrollable
@@ -859,14 +925,22 @@ export function App() {
         // #761 (S2): the map + ScopeControl no longer render here — they were
         // hoisted into the fixed `#map-layer` wrapper above. `<main>` is kept
         // (with `id`, `data-render-complete`, `mainRef`, `tabIndex={0}`) as the
-        // readiness gate (#586), the scroll-bypass affordance, and the `inert`
-        // target S1's focus-trap effect / SpeciesDetailSheet still wire to it.
-        // It now wraps only non-map view surfaces (F1 (#777) removed the feed
-        // branch, so today that is none); its `--space-lg` padding stays for
-        // any future non-map surface and the `padding-top` header-clearance
-        // (R15) keeps such a surface out from under the floating chrome.
+        // readiness gate (#586) and scroll-bypass affordance. O1 (#776) removed
+        // the `inert` toggle from <main> (retargeted to #map-layer) and removed
+        // `aria-busy` (re-homed to #map-layer). It now wraps only non-map view
+        // surfaces; its `--space-lg` padding stays for any future non-map surface.
         tabIndex={0}
       />
+      {/* O1 (#776) — App-root result-settle live region (R9). Announces the
+          sightings-count/result summary once per settle, debounced to
+          SCOPE_MOVE_SETTLE_MS. Complements AppHeader's scope-change announcer
+          ("Showing {region}") — no duplicate: that fires on region change, this
+          fires after data loads. Both are polite; SR hears both in sequence.
+          Composes .sr-only only (no extra class needed — no map-specific
+          positioning override required). */}
+      <div role="status" aria-live="polite" className="sr-only">
+        {settledLedeText ?? ''}
+      </div>
       {/* #761 (S1) — detail rail/sheet gated on `scopeActive`. The unscoped
           early-return used to make these lines unreachable while unscoped; now
           that the shell always renders, a `?detail=` riding an unscoped URL
@@ -890,7 +964,7 @@ export function App() {
           speciesCode={state.detail}
           apiClient={apiClient}
           onClose={onCloseDetail}
-          mainRef={mainRef}
+          mainRef={mapLayerRef}
           bbox={state.bbox}
           onClearBbox={onClearBbox}
         />

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -39,7 +39,8 @@ export interface SpeciesDetailSheetProps {
   bbox?: BBox | null;
   /** Clears the bbox URL param — passed through to SpeciesDetailSurface. */
   onClearBbox?: () => void;
-  /** Ref to <main id="main-surface"> — receives `inert` at full snap. */
+  /** Ref to the inert target element (O1: #map-layer) — receives `inert` at full snap.
+   *  App passes `mapLayerRef` so the live MapLibre canvas is frozen, not <main>. */
   mainRef: RefObject<HTMLElement | null>;
 }
 
@@ -54,8 +55,8 @@ export interface SpeciesDetailSheetProps {
  *   peek/half → role="region", aria-label="Selected sighting"
  *   full      → role="dialog", aria-modal="true", aria-label={species}
  *
- * Sequencing at half→full: `inert` is set on mainRef.current BEFORE
- * the role attribute flips. On full→collapse the order reverses
+ * Sequencing at half→full: `inert` is set on mainRef.current (O1: #map-layer)
+ * BEFORE the role attribute flips. On full→collapse the order reverses
  * (React renders region first, then JS removes inert). The advance
  * side writes `inert` synchronously inside the click/drag handler
  * BEFORE calling setSnap('full'), so the DOM observer order is


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Scrim/Sheet as Scrim or FullSnapSheet
    participant App
    participant MapLayer as #map-layer

    Note over App: O1: mapLayerRef replaces mainRef as the inert target
    Scrim/Sheet->>MapLayer: setAttribute('inert', '')
    Note over MapLayer: MapLibre canvas frozen (pointer+tab blocked)
    Scrim/Sheet->>MapLayer: removeAttribute('inert')
    Note over MapLayer: Map interactive again
```

```mermaid
stateDiagram-v2
    state "data-scope-fitted=false" as Fitting
    state "data-scope-fitted=true" as Fitted
    [*] --> Unscoped: bare URL / scope picks pending
    Unscoped --> Scoped: scope pick (state / ZIP / whole-US)
    Scoped --> CameraMove: boundsKey changes
    CameraMove --> Fitting: SCOPE_MOVE_SETTLE_MS timer starts
    Fitting --> Fitted: setTimeout fires (1000ms)
    Fitted --> CameraMove: new scope pick
```

## Summary

- **Deliverable 1 (inert retarget):** `inert` is now set on `#map-layer` — not `#main-surface` — by both the S1 unscoped scrim (`useLayoutEffect` in App.tsx) and `SpeciesDetailSheet` (via `mapLayerRef` passed as the existing `mainRef` prop). The live MapLibre canvas is actually frozen when a modal/scrim or full-snap sheet is active. `#main-surface` no longer receives `inert`.

- **Deliverable 2 (aria-busy re-home):** `aria-busy={observationsLoading}` moved from `<main id="main-surface">` to `<div id="map-layer">`. Single-busy-node invariant enforced: `<main>` carries no `aria-busy` attribute at all. All six specs that polled `main#main-surface` for `aria-busy` re-pointed to `#map-layer` (`a11y.spec.ts`, `prod-smoke.preview.spec.ts`, `error-states.spec.ts`).

- **Deliverable 3 (aria-live — reconciliation):** AppHeader already provides a scope-change `role="status" aria-live="polite"` announcer (`AppHeader.tsx:165`, rescued from MapLede.tsx by PR #805). That region was REUSED — not duplicated. What was ADDED: a new App-root `<div role="status" aria-live="polite" className="sr-only">` that announces the sightings-count result summary (`ledeText`) once per settle, debounced to `SCOPE_MOVE_SETTLE_MS` (1000ms). SR hears "Showing Arizona." (AppHeader's scope announcer) then "{N} species seen across Arizona…" (new result-settle region) in sequence, with no duplicate.

- **Deliverable 4 (camera data-attrs):** `data-camera-bounds` (carries `boundsKey`) and `data-scope-fitted` (false→true via App-local `setTimeout(SCOPE_MOVE_SETTLE_MS)`) added to `#map-layer` on scoped paths. Driven by a new `dataScopeFitted` state + `scopeFittedTimerRef` — NOT by any existing settle hook (`onViewportChange` deliberately swallows settle frames). Scoped-path-only: attributes are absent on the unscoped landing per spec.

## Screenshots

N/A — not visible UI (a11y: inert/aria-busy/aria-live + e2e camera attrs; no visual change)

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: live region uses `.sr-only` alone (no new class added; `.sr-only` exists at `styles.css:1294`, issue #513)
- [x] Multi-viewport design QA: N/A — not visible UI

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — **1011 tests passed (65 files)**
- [x] New unit tests added (`App.test.tsx`):
  - `sets aria-busy=true on #map-layer (not <main>) while observations are loading`
  - `clears aria-busy on #map-layer once observations have loaded` (+ single-busy-node invariant on `<main>`)
  - `sets inert on #map-layer (not #main-surface) when the unscoped scrim is shown`
  - `exposes data-camera-bounds on #map-layer for a scoped view`
  - `data-scope-fitted starts false and flips true after SCOPE_MOVE_SETTLE_MS`
  - Three C6 "scoped inert" tests re-baselined to `#map-layer`
- [x] E2e specs re-baselined (all now assert against #map-layer):
  - `sheet-snap.spec.ts`: retargeted inert locators + AC-1 "map canvas non-interactive at full snap"
  - `axe.spec.ts`: retargeted the second inert assertion; updated stale comment
  - `a11y.spec.ts`: aria-busy poll re-pointed to `app.mapLayer`
  - `prod-smoke.preview.spec.ts`: aria-busy re-pointed (queue-gating `e2e` job)
  - `error-states.spec.ts`: aria-busy re-pointed (queue-gating `e2e` job)
  - `state-scope.spec.ts`: doc comment updated; `data-camera-bounds`/`data-scope-fitted` assertions + result-settle aria-live assertion added
  - `zip-scope.spec.ts`: stale doc comment corrected (assertion re-baseline deferred to WS9.3 per spec)
  - `pages/app-page.ts`: `mapLayer` Locator accessor added; `expectMapInert()` re-pointed to `#map-layer`
- [x] `npx knip` — clean (1 configuration hint, no real findings)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx playwright test --workers=1` — **235 passed, 15 skipped (pre-existing), 0 failed**
  - Scrim/scope specs confirmed green: `state-scope.spec.ts`, `zip-scope.spec.ts`, chooser specs
  - Inert specs confirmed green: `sheet-snap.spec.ts`, `axe.spec.ts`
  - S1 handshake preserved: `expectMapInert()` now targets `#map-layer` correctly
- [x] No-DB-write grep: `grep -rE "request\.(post|patch|delete|put)|fetch\(.*method:|..." frontend/e2e/` — CLEAN

## Plan reference

Part of epic #761 (map-first rearchitecture), Phase 4 item O1. Resolves risks R7, R8, R9, R14. See `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md` §6 (WS7.2) and §10 (O1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
