### PR TITLE
test(e2e): V1 — marker-vs-overlay occlusion exclusion-zone + safe-area spec (#788)

### DIFF
--- a/frontend/e2e/marker-overlap.spec.ts
+++ b/frontend/e2e/marker-overlap.spec.ts
@@ -19,6 +19,47 @@ import { AppPage } from './pages/app-page.js';
  * hidden via the `hidden` feature-state (promoteId="subId"). This spec
  * combines DOM marker rects + symbol-layer feature rects (skipping
  * hidden ones) in the pairwise overlap measurement.
+ *
+ * ── Exclusion-zone contract (V1 / issue #788) ────────────────────────────────
+ *
+ * No marker rendered into a region covered by a persistent overlay
+ * (`.family-legend`, `.scope-control`, `.map-context-strip` once O3 makes it
+ * floating, `.observation-popover`) may have non-zero AABB intersection area
+ * with that overlay. Two assertions enforce this:
+ *
+ *   • **390×844 (iphone-14-pro) — full overlay set:**
+ *     `expect(result.marker_overlay_overlap_area).toBe(0)` over the complete
+ *     persistent-overlay set. At 390px the legend is the binding occluder:
+ *     before O5 it widened to ~94% of the viewport via the old uncapped
+ *     `@media (max-width:760px)` rule and sat over the entire bottom-band of
+ *     markers. O5 (#783) capped it to ≤280px at ≤480px; V1 verifies that cap.
+ *     RED-by-construction on pre-O5 `main`; GREEN once O5 is merged.
+ *
+ *   • **1440×900 (desktop-standard) — legend-only set:**
+ *     `expect(result.marker_legend_overlap_area).toBe(0)` over the single
+ *     `.family-legend` rect only. The 1440px control scope is deliberately
+ *     narrower because: (a) `.map-context-strip` is a flow sibling ABOVE
+ *     `.map-surface` on current `main` (no `position` rule, cannot intersect
+ *     a canvas marker rect); (b) `.scope-control` is `fit-content`/top-center,
+ *     narrow on desktop, and any occlusion it causes is governed by O3/O6's
+ *     relocation, NOT by O5. Folding scope-control/strip into the O5-gated
+ *     desktop assertion would falsely couple V1 to O3. The legend's
+ *     width-widening is `@media max-width:760px`-gated (`styles.css:976-979`),
+ *     so the desktop legend is content-sized and never reaches the marker band
+ *     regardless of O5. This control is GREEN on current `main` independently
+ *     of O5 and is pure desktop regression coverage.
+ *
+ * The contract is satisfied physically by O5 (legend mobile-width cap) + O2
+ * (legend hoist to persistent App-root `position:fixed`). Silhouettes always
+ * remain visible — `deconflict.ts:319-326` "silhouettes MUST REMAIN VISIBLE
+ * — no suppression, no hiding" invariant is preserved; the contract is met by
+ * overlay geometry, not by hiding markers.
+ *
+ * Do NOT relax either assertion to `<= residual` — a non-zero value IS the
+ * signal that an overlay geometry change has broken the contract. Treat it as
+ * a Tier-1 finding. Precedent: the strict-zero rationale already in this file
+ * at the `total_overlap_area` assertion below.
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 
 const ZOOM_LEVELS = [5, 6, 8, 10, 12, 14];
@@ -35,10 +76,34 @@ interface OverlapResult {
   marker_count: number;
   total_overlap_area: number;
   worst_overlap_area: number;
+  /** V1 (#788): pairwise AABB intersection, each marker rect × each persistent-overlay rect (full set). */
+  marker_overlay_overlap_area: number;
+  /** V1 (#788): pairwise AABB intersection, each marker rect × the `.family-legend` rect only.
+   *  Kept separate from the full-set measurement so the 1440px desktop control asserts only
+   *  what O5 governs (legend width-widening is @media max-width:760px-gated; at 1440px the
+   *  legend is content-sized regardless of O5 status, giving a clean O5-independent control). */
+  marker_legend_overlap_area: number;
+}
+
+/** Helper: AABB pairwise intersection area between two lists of rects. */
+function pairwiseArea(
+  as: Array<{ x: number; y: number; w: number; h: number }>,
+  bs: Array<{ x: number; y: number; w: number; h: number }>,
+): number {
+  let total = 0;
+  for (const a of as) {
+    for (const b of bs) {
+      const ox = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
+      const oy = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+      if (ox > 0 && oy > 0) total += ox * oy;
+    }
+  }
+  return total;
 }
 
 async function measureOverlap(page: Page): Promise<OverlapResult> {
   return await page.evaluate<OverlapResult>(() => {
+    // ── Marker collection ────────────────────────────────────────────────────
     // DOM-based markers: AdaptiveGridMarker, ClusterPill, displaced silhouettes.
     const grids = Array.from(
       document.querySelectorAll('[data-testid="adaptive-grid-marker"]'),
@@ -93,6 +158,8 @@ async function measureOverlap(page: Page): Promise<OverlapResult> {
     }
 
     const items = [...domItems, ...symBoxes];
+
+    // ── Marker-vs-marker overlap (existing contract — byte-for-byte unchanged) ──
     let total = 0;
     let worst = 0;
     for (let i = 0; i < items.length; i++) {
@@ -114,10 +181,54 @@ async function measureOverlap(page: Page): Promise<OverlapResult> {
         }
       }
     }
+
+    // ── Persistent-overlay collection (V1 / #788) ────────────────────────────
+    // Rects are read live via getBoundingClientRect so they track the
+    // responsive legend width (e.g. ≤280px at ≤480px after O5, content-sized
+    // at 1440px). Overlays absent from the DOM contribute no rect (e.g.
+    // .map-context-strip was removed in #800; .observation-popover only mounts
+    // while a popover is open — both yield empty arrays and contribute zero).
+    // Do NOT fold overlayBoxes into `items` — that would also count
+    // overlay-vs-overlay pairs, which is out of scope.
+    type Rect = { x: number; y: number; w: number; h: number };
+    function elToRect(el: Element): Rect {
+      const r = el.getBoundingClientRect();
+      return { x: r.left, y: r.top, w: r.width, h: r.height };
+    }
+    function queryRects(sel: string): Rect[] {
+      return Array.from(document.querySelectorAll(sel)).map(elToRect);
+    }
+
+    const legendBoxes  = queryRects('.family-legend');
+    const scopeBoxes   = queryRects('.scope-control');
+    const stripBoxes   = queryRects('.map-context-strip'); // absent on current main (#800)
+    const popoverBoxes = queryRects('.observation-popover'); // only when a popover is open
+
+    const overlayBoxes = [...legendBoxes, ...scopeBoxes, ...stripBoxes, ...popoverBoxes];
+
+    // marker_overlay_overlap_area: full overlay set (binding assertion at 390px).
+    function pairArea(as: Rect[], bs: Rect[]): number {
+      let t = 0;
+      for (const a of as) {
+        for (const b of bs) {
+          const ox = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
+          const oy = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+          if (ox > 0 && oy > 0) t += ox * oy;
+        }
+      }
+      return t;
+    }
+
+    const markerOverlayOverlapArea = pairArea(items, overlayBoxes);
+    // marker_legend_overlap_area: legend-only (O5-governed desktop control at 1440px).
+    const markerLegendOverlapArea  = pairArea(items, legendBoxes);
+
     return {
       marker_count: items.length,
       total_overlap_area: total,
       worst_overlap_area: worst,
+      marker_overlay_overlap_area: markerOverlayOverlapArea,
+      marker_legend_overlap_area:  markerLegendOverlapArea,
     };
   });
 }
@@ -145,6 +256,8 @@ for (const viewport of VIEWPORTS) {
       await page.waitForTimeout(500);
 
       const result = await measureOverlap(page);
+
+      // ── Marker-vs-marker assertion (unchanged from V2 baseline) ─────────────
       // INTENTIONALLY strict: total_overlap_area must be exactly zero.
       //
       // The silhouette-displacement layer (deconflict.ts displaceSilhouettes)
@@ -167,6 +280,34 @@ for (const viewport of VIEWPORTS) {
         result.total_overlap_area,
         `marker_count=${result.marker_count}, worst_overlap=${result.worst_overlap_area}px²`,
       ).toBe(0);
+
+      // ── Exclusion-zone assertions (V1 / #788) ────────────────────────────────
+      // See the header doc block above for the full contract rationale.
+      // Do NOT relax to `<= residual` — see strict-zero precedent above.
+
+      if (viewport.name === 'iphone-14-pro') {
+        // 390×844 — full overlay set. O5 (#783) caps the legend ≤280px at ≤480px
+        // so it no longer covers the bottom-band marker region. GREEN post-O5.
+        expect(
+          result.marker_overlay_overlap_area,
+          `[${viewport.name} z${zoom}] marker_overlay_overlap_area must be 0 — ` +
+          `a non-zero value means a persistent overlay (legend/scope-control/strip/popover) ` +
+          `is occluding a marker at 390px (R6 / exclusion-zone contract, V1 #788)`,
+        ).toBe(0);
+      }
+
+      if (viewport.name === 'desktop-standard') {
+        // 1440×900 — legend-only set. The legend width-widening is @media
+        // max-width:760px-gated (styles.css:976-979), so at 1440px the legend
+        // is content-sized and never reaches the marker band regardless of O5.
+        // This is a pure desktop regression / over-constraint guard.
+        expect(
+          result.marker_legend_overlap_area,
+          `[${viewport.name} z${zoom}] marker_legend_overlap_area must be 0 — ` +
+          `the desktop legend must stay content-sized and clear of the marker band ` +
+          `(exclusion-zone contract desktop control, V1 #788)`,
+        ).toBe(0);
+      }
     });
   }
 }

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -78,6 +78,29 @@ export class AppPage {
   /** The Dismiss (×) button inside the error overlay. */
   readonly errorOverlayDismiss: Locator;
 
+  // --- V1 (#788): Persistent-overlay exclusion-zone accessors ---
+  /**
+   * The FamilyLegend overlay (`.family-legend`). After O2 (#770) this is a
+   * `position:fixed` App-root sibling, not a canvas child. O5 (#783) caps it
+   * to ≤280px at ≤480px via `@media max-width:480px` — the physical fix for R6.
+   * This accessor is used by marker-overlap.spec.ts to collect the overlay rect
+   * and by safe-area.spec.ts indirectly (no direct use needed there).
+   */
+  readonly familyLegend: Locator;
+  /**
+   * The `.map-context-strip` in-flow section. After #800/#779 this class is
+   * absent from the DOM on current `main` (strip removed per `styles.css:1313`).
+   * Kept as a forward-compat accessor for O3 (relocation to floating card).
+   * The locator safely returns 0 elements when the strip is not present.
+   */
+  readonly mapContextStrip: Locator;
+  /**
+   * The `SpeciesDetailSheet` element (`data-testid='species-detail-sheet'`).
+   * Used by safe-area.spec.ts to assert bottom-edge flush alignment and the
+   * authored CSS source for `env(safe-area-inset-bottom)`.
+   */
+  readonly speciesDetailSheet: Locator;
+
   constructor(public readonly page: Page) {
     this.filters = new FiltersBar(page);
     // Shared handle for the readiness surface in **Node test context**: every
@@ -123,6 +146,14 @@ export class AppPage {
     this.errorOverlay = page.getByTestId('error-overlay');
     this.errorOverlayRetry = this.errorOverlay.getByRole('button', { name: 'Retry' });
     this.errorOverlayDismiss = this.errorOverlay.getByRole('button', { name: 'Dismiss error' });
+
+    // V1 (#788): persistent-overlay exclusion-zone accessors.
+    // familyLegend: position:fixed App-root sibling after O2 (#770); capped ≤280px at ≤480px by O5 (#783).
+    this.familyLegend = page.locator('.family-legend');
+    // mapContextStrip: removed from DOM in #800/#779 (styles.css:1313); kept for O3 forward-compat.
+    this.mapContextStrip = page.locator('.map-context-strip');
+    // speciesDetailSheet: the bottom-sheet modal (data-testid per SpeciesDetailSheet.tsx:284).
+    this.speciesDetailSheet = page.getByTestId('species-detail-sheet');
   }
 
   /**

--- a/frontend/e2e/safe-area.spec.ts
+++ b/frontend/e2e/safe-area.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Safe-area inset guard — SpeciesDetailSheet (V1 / issue #788).
+ *
+ * Restores the MOB-5 intent that the `mobile-bundle-e.spec.ts` header comment
+ * promised but whose test body no longer exists in that file:
+ *
+ *   "MOB-5 (IMPORTANT) — Sheet safe-area-top: env(safe-area-inset-top) must
+ *    appear in CSS."
+ *
+ * A repo-wide grep confirmed zero runtime/CSS assertions for env(safe-area-inset*)
+ * under frontend/e2e/ outside that dangling comment.
+ *
+ * ── Why this file is named safe-area.spec.ts, NOT *.preview.spec.ts ──────────
+ *
+ * File name is load-bearing. `playwright.config.ts` routes projects by filename:
+ *   • `dev-server` project (baseURL: http://localhost:5173) → testIgnore /.*\.preview\.spec\.ts$/
+ *   • `preview-build` project (baseURL: http://localhost:4173) → testMatch /.*\.preview\.spec\.ts$/
+ *
+ * This spec asserts the **authored CSS source string** (`env(safe-area-inset-bottom`
+ * appearing in a `CSSStyleRule`). The dev-server Vite build injects `styles.css`
+ * as a same-origin `<style>` tag with the **un-minified source preserved**:
+ * `padding-bottom: env(safe-area-inset-bottom, 0)` survives verbatim.
+ *
+ * The preview-build project runs `npm run build` first; the CSS minifier can
+ * shorthand-collapse `padding-top` + `padding-bottom` longhands into a single
+ * `padding` shorthand or reorder declarations — silently breaking the longhand
+ * source-string match even when the production declaration is intact (false RED).
+ * Pinning to dev-server by file-naming convention avoids that hazard.
+ *
+ * This spec is also NOT tagged @coarse (that routes to the coarse-pointer project).
+ *
+ * ── Why getComputedStyle is NOT the falsifiable probe ────────────────────────
+ *
+ * Playwright/Chromium cannot make `env(safe-area-inset-bottom)` resolve to a
+ * nonzero value — there is no API that sets the device inset in headless mode.
+ * `getComputedStyle(sheet).paddingBottom` therefore always yields the `0` fallback
+ * regardless of whether the authored production declaration at `styles.css:1219`
+ * exists or not. It would pass even if the declaration were deleted — a tautology.
+ *
+ * The falsifiable probe is the **authored CSSStyleRule source string**: iterating
+ * `document.styleSheets` and asserting a matched `.species-detail-sheet` rule's
+ * `style.getPropertyValue('padding-bottom')` contains `env(safe-area-inset-bottom`.
+ * This fails on removal of `styles.css:1219` — true regression coverage.
+ */
+
+import { test, expect, VERMFLY_WITH_PHOTO } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+// Pin to 390×844 (iPhone 14 Pro) — the canonical mobile viewport where
+// env(safe-area-inset-bottom) clearance is load-bearing for the home indicator.
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () => {
+  test('padding-bottom authored CSS contains env(safe-area-inset-bottom) and sheet sits flush to viewport bottom', async ({
+    page,
+    apiStub,
+  }) => {
+    // Mirror the stub setup from sheet-snap.spec.ts (lines 8-10).
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+    await apiStub.stubPhotoImage();
+
+    const app = new AppPage(page);
+    // Open the detail sheet via the deep-link URL (mirrors sheet-snap.spec.ts:12-13).
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    // Wait for the sheet to be present in the DOM.
+    const sheet = app.speciesDetailSheet;
+    await sheet.waitFor({ state: 'attached' });
+
+    // ── 1. Authored CSS source-string assertion (falsifiable probe) ───────────
+    //
+    // Iterate ALL document.styleSheets inside a try/catch (cross-origin guard).
+    // The dev-server injects styles.css as a same-origin <style> tag, but
+    // index.html:44 also carries an inline <style> block — match on selectorText,
+    // not on sheet index, so the assertion is robust to multiple sheets.
+    //
+    // Assert that at least one matched `.species-detail-sheet` CSSStyleRule's
+    // padding-bottom source value contains `env(safe-area-inset-bottom`.
+    // This fails if styles.css:1219 is removed (the production declaration).
+    const safeAreaResult = await page.evaluate(() => {
+      const matchedPaddingValues: string[] = [];
+      const matchedPaddingShorthands: string[] = [];
+
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList;
+        try {
+          rules = sheet.cssRules;
+        } catch {
+          // SecurityError: cross-origin sheet — skip (belt-and-suspenders even
+          // in dev-server context where all sheets are same-origin).
+          continue;
+        }
+        for (const rule of Array.from(rules)) {
+          if (!(rule instanceof CSSStyleRule)) continue;
+          // Match the base class — `.species-detail-sheet` exactly (not the
+          // modifier classes like `.species-detail-sheet--full`).
+          if (rule.selectorText !== '.species-detail-sheet') continue;
+
+          const paddingBottom = rule.style.getPropertyValue('padding-bottom');
+          const padding = rule.style.getPropertyValue('padding');
+
+          if (paddingBottom) matchedPaddingValues.push(paddingBottom);
+          if (padding) matchedPaddingShorthands.push(padding);
+        }
+      }
+
+      return { matchedPaddingValues, matchedPaddingShorthands };
+    });
+
+    // The production declaration at styles.css:1219:
+    //   padding-bottom: env(safe-area-inset-bottom, 0);
+    // must appear in at least one matched rule as the longhand, OR (future-proof)
+    // as the padding shorthand if a future change emits the shorthand form.
+    const allValues = [
+      ...safeAreaResult.matchedPaddingValues,
+      ...safeAreaResult.matchedPaddingShorthands,
+    ];
+
+    expect(
+      allValues.some((v) => v.includes('env(safe-area-inset-bottom')),
+      `Expected at least one .species-detail-sheet CSS rule to have ` +
+      `padding-bottom (or padding shorthand) containing env(safe-area-inset-bottom). ` +
+      `Found padding-bottom values: ${JSON.stringify(safeAreaResult.matchedPaddingValues)}; ` +
+      `padding shorthand values: ${JSON.stringify(safeAreaResult.matchedPaddingShorthands)}. ` +
+      `This fails if styles.css:1219 (padding-bottom: env(safe-area-inset-bottom, 0)) is removed.`,
+    ).toBe(true);
+
+    // ── 2. padding-top authored CSS source-string assertion ───────────────────
+    //
+    // The production declaration at styles.css:1218:
+    //   padding-top: max(var(--space-xs, 4px), env(safe-area-inset-top, 0px));
+    // must also appear — this clears the Dynamic Island / status bar at full snap.
+    const safeAreaTopResult = await page.evaluate(() => {
+      const matchedPaddingTopValues: string[] = [];
+
+      for (const sheet of Array.from(document.styleSheets)) {
+        let rules: CSSRuleList;
+        try {
+          rules = sheet.cssRules;
+        } catch {
+          continue;
+        }
+        for (const rule of Array.from(rules)) {
+          if (!(rule instanceof CSSStyleRule)) continue;
+          if (rule.selectorText !== '.species-detail-sheet') continue;
+          const paddingTop = rule.style.getPropertyValue('padding-top');
+          if (paddingTop) matchedPaddingTopValues.push(paddingTop);
+        }
+      }
+
+      return { matchedPaddingTopValues };
+    });
+
+    expect(
+      safeAreaTopResult.matchedPaddingTopValues.some((v) =>
+        v.includes('env(safe-area-inset-top'),
+      ),
+      `Expected at least one .species-detail-sheet CSS rule to have ` +
+      `padding-top containing env(safe-area-inset-top). ` +
+      `Found: ${JSON.stringify(safeAreaTopResult.matchedPaddingTopValues)}. ` +
+      `This fails if styles.css:1218 (padding-top: max(..., env(safe-area-inset-top, 0px))) is removed.`,
+    ).toBe(true);
+
+    // ── 3. Optional computed-style probe (informational, not falsifiable) ─────
+    //
+    // Chromium headless cannot make env(safe-area-inset-bottom) resolve to a
+    // nonzero value (no API sets the inset). Reading getComputedStyle therefore
+    // only confirms the fallback resolves to `0px` — it does NOT prove the
+    // authored env() chain is intact. Assert `0px` here purely as documentation
+    // of the headless constraint; do NOT treat this as proof the guard works.
+    const computedPaddingBottom = await sheet.evaluate(
+      (el) => getComputedStyle(el).paddingBottom,
+    );
+    // Under headless Chromium, env(safe-area-inset-bottom, 0) resolves to `0px`
+    // because there is no API to inject a nonzero safe-area inset.
+    // This is intentionally `0px` — NOT an assertion that the inset is consumed.
+    expect(
+      computedPaddingBottom,
+      'headless fallback: env(safe-area-inset-bottom, 0) must resolve to 0px under headless Chromium ' +
+      '(informational — this does NOT prove the production guard works on real devices)',
+    ).toBe('0px');
+
+    // ── 4. Sheet bottom-edge flush assertion ──────────────────────────────────
+    //
+    // The sheet is `position: fixed; bottom: 0` (styles.css:1197-1200).
+    // Its bottom edge must sit at the viewport bottom edge.
+    const sheetBottom = await sheet.evaluate(
+      (el) => el.getBoundingClientRect().bottom,
+    );
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    expect(
+      sheetBottom,
+      `sheet.getBoundingClientRect().bottom (${sheetBottom}) must equal ` +
+      `window.innerHeight (${viewportHeight}) — sheet is position:fixed;bottom:0 (styles.css:1197-1200)`,
+    ).toBe(viewportHeight);
+  });
+});


### PR DESCRIPTION
## Diagrams

N/A — test/POM/doc-only change; no data flow or component tree changed.

## Summary

- Extends `marker-overlap.spec.ts` with a second measurement dimension (`marker_overlay_overlap_area` and `marker_legend_overlap_area`) that checks pairwise AABB intersection between every marker rect and each persistent-overlay rect (`.family-legend`, `.scope-control`, `.map-context-strip`, `.observation-popover`). The new assertions are strictly zero — no `<= residual` tolerance — consistent with the existing marker-vs-marker strict-zero precedent. The 390×844 full-overlay assertion verifies O5's legend cap clears the bottom-band markers; the 1440×900 legend-only control is an O5-independent desktop regression guard.

- Adds `safe-area.spec.ts` (named to route to the `dev-server` project at `:5173`, NOT `*.preview.spec.ts`) that restores the MOB-5 intent: iterates `document.styleSheets` in a `try/catch`, matches `.species-detail-sheet` `CSSStyleRule` by `selectorText`, and asserts the authored `padding-bottom` source string contains `env(safe-area-inset-bottom` (fails on removal of `styles.css:1219`) and `padding-top` contains `env(safe-area-inset-top` (fails on removal of `styles.css:1218`). Also asserts the sheet bottom edge is flush to the viewport bottom. `getComputedStyle` is used only as an informational headless-fallback probe, explicitly labeled not falsifiable.

- Adds POM accessors `familyLegend`, `mapContextStrip`, `speciesDetailSheet` to `app-page.ts`. Zero production `src/` change.

## Screenshots

N/A — not UI (e2e occlusion + safe-area spec; no DOM/style change)

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A — no new classNames
- [x] Multi-viewport design QA — N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — 1062 unit tests green (no src/ change; unaffected)
- [x] New Playwright e2e spec added: `safe-area.spec.ts` (MOB-5 safe-area authored CSS assert + bottom flush)
- [x] `marker-overlap.spec.ts` extended: 30 tests (5 viewports × 6 zooms) all green, including the new 390×844 `marker_overlay_overlap_area === 0` (full overlay set, GREEN post-O5) and 1440×900 `marker_legend_overlap_area === 0` (legend-only desktop control, GREEN independently of O5)
- [x] `npx playwright test --workers=1` — 247 passed (15 pre-existing skips), no regressions
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — no new findings (existing configuration hint only)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS (no new classNames added)
- [x] No-DB-write grep clean: `grep -rE "request\.(post|patch|delete|put)|fetch\(.*method:|fetch\(.*[\"']POST[\"']" frontend/e2e/` returns nothing
- [x] UI verification — N/A — no DOM/style change; spec asserts against existing live geometry already verified by O2/O5

**`marker_overlay_overlap_area` result at 390×844:** 0 (GREEN) across all 6 zoom levels. O5's `≤280px` cap at `≤480px` media breakpoint keeps the legend clear of the bottom-band markers in the seeded AZ fixture.

**`marker_legend_overlap_area` result at 1440×900:** 0 (GREEN) across all 6 zoom levels. Desktop legend is content-sized (no width rule applies outside `@media max-width:760px`).

**`safe-area.spec.ts` file name:** `safe-area.spec.ts` (NOT `*.preview.spec.ts`) — confirmed runs under `dev-server` project at `:5173` where un-minified CSS source preserves `env(safe-area-inset-bottom, 0)` verbatim.

**Zero production change:** confirmed — only `frontend/e2e/marker-overlap.spec.ts`, `frontend/e2e/safe-area.spec.ts`, and `frontend/e2e/pages/app-page.ts` changed.

## Plan reference

Part of #761 epic, Phase 5 V1 (390px collision pass + safe-area + marker-vs-overlay occlusion exclusion-zone + spec, WS6.5 / gap 7 / report §9 item 7). Closes #788.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)