### PR TITLE
chore(frontend): genericize static OG/meta to CONUS national default (closes #785)

### DIFF
--- a/frontend/e2e/static-metadata.spec.ts
+++ b/frontend/e2e/static-metadata.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Static-head / OG metadata regression guard — issue #785.
+ *
+ * The app is a static SPA with no SSR. Every social unfurl (Slack, iMessage,
+ * Twitter/Facebook crawler) and every search-engine snapshot sees only
+ * `index.html`'s static `<head>` — never the React-rendered runtime title.
+ * `SurfaceTitleSync` owns the *runtime* per-scope `document.title`; this spec
+ * guards the *static* metadata attributes that crawlers consume.
+ *
+ * This is a static-head assertion — we do NOT wait for `waitForMapLoad()`.
+ * Per the navigation contract, tests that deliberately skip the map-load wait
+ * assert directly on the static head attributes without `app.waitForMapLoad()`.
+ * No `page.route` stubs, no DB writes.
+ *
+ * Regression tripwire: asserts zero "Arizona" substrings in `<head>` to prevent
+ * the AZ-freeze from silently re-entering. Any future AZ-specific text in the
+ * static head would surface here immediately.
+ */
+
+const NATIONAL_DESCRIPTION =
+  'Recent bird sightings across the United States, updated in real time from eBird.';
+
+test.describe('static OG/meta head — CONUS national fallback (#785)', () => {
+  test('og:title and twitter:title are the bare national title "Bird Maps"', async ({ page }) => {
+    await page.goto('/');
+    const ogTitle = await page.locator('meta[property="og:title"]').getAttribute('content');
+    const twitterTitle = await page.locator('meta[name="twitter:title"]').getAttribute('content');
+    expect(ogTitle).toBe('Bird Maps');
+    expect(twitterTitle).toBe('Bird Maps');
+  });
+
+  test('meta[name=description], og:description, and twitter:description all carry the national description (and are equal)', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    const metaDesc = await page
+      .locator('meta[name="description"]')
+      .getAttribute('content');
+    const ogDesc = await page
+      .locator('meta[property="og:description"]')
+      .getAttribute('content');
+    const twitterDesc = await page
+      .locator('meta[name="twitter:description"]')
+      .getAttribute('content');
+
+    expect(metaDesc).toBe(NATIONAL_DESCRIPTION);
+    expect(ogDesc).toBe(NATIONAL_DESCRIPTION);
+    expect(twitterDesc).toBe(NATIONAL_DESCRIPTION);
+    // All three must be equal — ensures no future drift between them.
+    expect(metaDesc).toBe(ogDesc);
+    expect(metaDesc).toBe(twitterDesc);
+  });
+
+  test('JSON-LD Dataset.spatialCoverage is the CONUS envelope', async ({ page }) => {
+    await page.goto('/');
+    const ldJson = await page.locator('script[type="application/ld+json"]').textContent();
+    const data = JSON.parse(ldJson ?? '{}');
+
+    expect(data.mainEntity.spatialCoverage['@type']).toBe('Place');
+    expect(data.mainEntity.spatialCoverage.name).toBe('Contiguous United States');
+    expect(data.mainEntity.spatialCoverage.geo['@type']).toBe('GeoShape');
+    // CONUS bounding box: minLat minLng maxLat maxLng (same ordering as old AZ value)
+    expect(data.mainEntity.spatialCoverage.geo.box).toBe('24.5 -124.8 49.4 -66.9');
+  });
+
+  test('no static metadata element contains the substring "Arizona" (AZ-freeze regression tripwire)', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    // Check only the static metadata elements — not stylesheets injected at runtime
+    // by Vite, which may contain "Arizona" in CSS comments unrelated to this fix.
+    const metadataStrings = await page.evaluate(() => {
+      const selectors = [
+        'title',
+        'meta[name="description"]',
+        'meta[property="og:title"]',
+        'meta[property="og:description"]',
+        'meta[name="twitter:title"]',
+        'meta[name="twitter:description"]',
+        'script[type="application/ld+json"]',
+      ];
+      return selectors.map((sel) => {
+        const el = document.head.querySelector(sel);
+        if (!el) return '';
+        if (el.tagName === 'TITLE') return el.textContent ?? '';
+        if (el.tagName === 'SCRIPT') return el.textContent ?? '';
+        return el.getAttribute('content') ?? '';
+      });
+    });
+    // None of the static metadata elements should contain "Arizona".
+    for (const text of metadataStrings) {
+      expect(text.toLowerCase()).not.toContain('arizona');
+    }
+  });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,23 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Bird Maps · Arizona</title>
+    <title>Bird Maps</title>
 
     <!-- Description + canonical -->
-    <meta name="description" content="Recent Arizona bird sightings, updated in real time from eBird." />
+    <meta name="description" content="Recent bird sightings across the United States, updated in real time from eBird." />
     <link rel="canonical" href="https://bird-maps.com/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://bird-maps.com/" />
-    <meta property="og:title" content="Bird Maps · Arizona" />
-    <meta property="og:description" content="Recent Arizona bird sightings, updated in real time from eBird." />
+    <meta property="og:title" content="Bird Maps" />
+    <meta property="og:description" content="Recent bird sightings across the United States, updated in real time from eBird." />
     <meta property="og:image" content="https://bird-maps.com/og-image.png" />
 
     <!-- Twitter card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Bird Maps · Arizona" />
-    <meta name="twitter:description" content="Recent Arizona bird sightings, updated in real time from eBird." />
+    <meta name="twitter:title" content="Bird Maps" />
+    <meta name="twitter:description" content="Recent bird sightings across the United States, updated in real time from eBird." />
     <meta name="twitter:image" content="https://bird-maps.com/og-image.png" />
 
     <!-- Theme color (matches --color-surface-base light value from Phase 1 tokens) -->
@@ -57,14 +57,14 @@
     {
       "@context": "https://schema.org",
       "@type": "WebPage",
-      "name": "Bird Maps · Arizona",
-      "description": "Recent Arizona bird sightings, updated in real time from eBird.",
+      "name": "Bird Maps",
+      "description": "Recent bird sightings across the United States, updated in real time from eBird.",
       "url": "https://bird-maps.com/",
       "inLanguage": "en-US",
       "mainEntity": {
         "@type": "Dataset",
-        "name": "Arizona Recent Bird Observations",
-        "description": "Recent bird sightings across Arizona, sourced from eBird (Cornell Lab of Ornithology). Updated in real time.",
+        "name": "Recent Bird Observations Across the United States",
+        "description": "Recent bird sightings across the contiguous United States, sourced from eBird (Cornell Lab of Ornithology). Updated in real time.",
         "url": "https://bird-maps.com/",
         "license": "https://www.birds.cornell.edu/home/ebird-data-access-terms-of-use/",
         "creator": {
@@ -74,10 +74,10 @@
         },
         "spatialCoverage": {
           "@type": "Place",
-          "name": "Arizona, United States",
+          "name": "Contiguous United States",
           "geo": {
             "@type": "GeoShape",
-            "box": "31.332 -114.815 37.004 -109.045"
+            "box": "24.5 -124.8 49.4 -66.9"
           }
         },
         "dateModified": "2026-05-11",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Bird Maps Arizona",
+  "name": "Bird Maps",
   "short_name": "Bird Maps",
-  "description": "Recent Arizona bird sightings, updated in real time from eBird.",
+  "description": "Recent bird sightings across the United States, updated in real time from eBird.",
   "start_url": "/",
   "display": "browser",
   "background_color": "#f4f1ea",


### PR DESCRIPTION
## Diagrams

N/A — static metadata string substitution; no data flows or component structure changed.

## Summary

- The app went national (49 CONUS states) but `frontend/index.html`'s static `<head>` and `frontend/public/manifest.json` were frozen at Arizona-era strings. Crawlers, social unfurlers (Slack/iMessage/OG scrapers), and no-JS views see only the static head — never `SurfaceTitleSync`'s runtime per-scope title.
- Replaces 11 Arizona-bound strings across two static files with the CONUS/national default. `SurfaceTitleSync` continues to own `document.title` at runtime; this PR only fixes the static crawler fallback.
- Adds `frontend/e2e/static-metadata.spec.ts` — 4 assertions guarding the static head against AZ-freeze regression: og/twitter titles = `Bird Maps`, all description attributes = national string and equal each other, JSON-LD `Dataset.spatialCoverage.geo.box` = CONUS envelope `24.5 -124.8 49.4 -66.9`, no "Arizona" in any metadata element.

## Screenshots

N/A — not visible UI (static crawler metadata only; runtime title unchanged by this PR — `SurfaceTitleSync` owns the per-scope `document.title` and is not touched)

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no `className` added
- [x] Multi-viewport design QA — N/A — not UI

## Test plan

- [x] `tsc -b && vite build` — clean production build; `dist/index.html` contains zero "Arizona" occurrences
- [x] `vitest run` — 67 test files, 1062 tests passing (pre-existing WebGL/maplibre-gl jsdom environment failures on `MapCanvas.test.tsx` and `viewport-filter.test.ts` are unrelated to this PR — unchanged from `origin/main`)
- [x] New Playwright e2e spec added: `frontend/e2e/static-metadata.spec.ts` (4 assertions)
- [x] `npx playwright test --workers=1 --project=dev-server` — 249 passed, 14 skipped (coarse-pointer project, expected), 0 failed; `surface-title.spec.ts` passes unmodified (runtime title assertions are independent of static `<title>`)
- [x] `knip` — clean (pre-existing configuration hint only, not caused by this PR)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] `grep -ci arizona frontend/index.html frontend/public/manifest.json` → 0 0
- [x] JSON-LD parses: `node -e "JSON.parse(require('fs').readFileSync('frontend/index.html','utf8').match(/<script type=\"application\/ld\+json\">([\s\S]*?)<\/script>/)[1])"` exits 0

## Plan reference

Out of plan — gap 9 / §10 Phase 5 / V4 from `docs/analyses/2026-05-29-map-first-rearchitecture-761/report.md`; tagged `drift:spec-update` and listed as out-of-epic standalone follow-up in epic #761. See issue #785.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)