### PR TITLE
chore(frontend): sweep deferred review nits from the map-first epic (#761)

### DIFF
--- a/frontend/e2e/basemap-dark-flip.spec.ts
+++ b/frontend/e2e/basemap-dark-flip.spec.ts
@@ -41,8 +41,10 @@ import { AppPage } from './pages/app-page.js';
  *   hard-coded point can land on a road, label, or water. Instead, sampleLandPixel()
  *   tries a grid of candidates and picks the first that reads as bright cream
  *   (positron land ≈ #f4f1ea) in light mode — making the choice robust to future
- *   reframes. The AZ-vs-CONUS wording is moot at assert time because the sample
- *   is verified land by construction.
+ *   reframes. When a candidate matches the ±30 cream window it is verified land
+ *   by construction. In the degenerate fallback (all candidates miss), the first
+ *   readable point is used un-verified — AC2's ±20 assertion will catch that
+ *   and report what color was actually sampled.
  *
  * Route stubs: all /api/* endpoints are stubbed to return empty arrays so the
  * test does not depend on a live database or the read-api service being seeded.
@@ -136,8 +138,11 @@ async function readCanvasPixel(
  *
  * V2 (#787): replaces the old single SAMPLE_X/SAMPLE_Y point that was calibrated
  * to the windowed AZ overview but actually sampled the scope=us/CONUS framing.
- * The multi-candidate approach survives reframes: it verifies each point is
- * genuinely land before asserting, so the AZ-vs-CONUS wording is moot.
+ * The multi-candidate approach survives reframes: when a candidate matches the
+ * ±30 cream window it is verified land and the AZ-vs-CONUS wording is moot.
+ * Degenerate fallback: if no candidate matches, returns CANDIDATE_POINTS[0]
+ * un-verified — callers should be aware that AC2's ±20 assertion may then fail
+ * (revealing the unverified sample color rather than silently skipping).
  */
 async function sampleLandPixel(
   page: import('@playwright/test').Page,
@@ -244,8 +249,8 @@ test.describe('Basemap dark-flip pixel assertions (Phase 4, closes G8)', () => {
       // V2 (#787): use sampleLandPixel() — tries CANDIDATE_POINTS to find a
       // pixel that reads as positron cream (≈#f4f1ea ±30) in light mode.
       // This is robust to the full-bleed CONUS reframe (scope=us injected by
-      // the POM) — the point is verified land before it is used for dark-mode
-      // comparison.
+      // the POM). When a candidate matches the ±30 window it is verified land;
+      // in the degenerate fallback, CANDIDATE_POINTS[0] is used un-verified.
       const lightSample = await sampleLandPixel(page);
       // If null the canvas isn't readable (no preserveDrawingBuffer). Skip.
       test.skip(
@@ -309,7 +314,6 @@ test.describe('Basemap dark-flip pixel assertions (Phase 4, closes G8)', () => {
         'Canvas pixel read returned null (likely no preserveDrawingBuffer) — pixel-sample skipped',
       );
 
-      const { x: LAND_X2, y: LAND_Y2, pixel: lightPixel } = lightSample!;
       const { x: landX, y: landY, pixel: [r, g, b] } = lightSample!;
       // Positron land-surface color is #f4f1ea → [244, 241, 234].
       // Tolerance ±20: accounts for sub-pixel rendering, label layers, and tile

--- a/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
+++ b/frontend/e2e/map-skip-link-and-hit-layer.spec.ts
@@ -83,12 +83,11 @@ test.describe('O2 (#770): skip-link DOM-order + focus guard (WCAG 2.4.1)', () =>
       await app.waitForAppReady();
 
       // Wait for the skip-link to be attached (renders when mapVisible && scopeActive).
+      // Hard assertion — with scope=us + observations stubbed, the skip-link MUST
+      // attach. A silent test.skip here would mask the "skip-link never renders"
+      // regression (mapVisible derives from URL state, not WebGL availability).
       const skipLink = page.locator('[data-testid="explore-map-markers-skip-link"]');
-      const attached = await skipLink.waitFor({ state: 'attached', timeout: 8_000 }).then(() => true).catch(() => false);
-      if (!attached) {
-        test.skip(true, 'skip-link not attached — likely unscoped or mapVisible=false in this run');
-        return;
-      }
+      await expect(skipLink, 'skip-link must attach on scoped map view (scope=us)').toBeAttached({ timeout: 8_000 });
 
       // Guard 1: DOM-order assertion (compareDocumentPosition).
       // skip-link must precede #map-layer (the canvas block). If the link were

--- a/frontend/e2e/marker-overlap.spec.ts
+++ b/frontend/e2e/marker-overlap.spec.ts
@@ -85,21 +85,10 @@ interface OverlapResult {
   marker_legend_overlap_area: number;
 }
 
-/** Helper: AABB pairwise intersection area between two lists of rects. */
-function pairwiseArea(
-  as: Array<{ x: number; y: number; w: number; h: number }>,
-  bs: Array<{ x: number; y: number; w: number; h: number }>,
-): number {
-  let total = 0;
-  for (const a of as) {
-    for (const b of bs) {
-      const ox = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
-      const oy = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
-      if (ox > 0 && oy > 0) total += ox * oy;
-    }
-  }
-  return total;
-}
+// NOTE: the top-level `pairwiseArea` helper that used to live here was removed
+// (V1 #814 deferred nit). It was never called — the actual occlusion math runs
+// as the in-page `pairArea` function inside `page.evaluate` in `measureOverlap`
+// below. Keeping both would risk future drift between the two implementations.
 
 async function measureOverlap(page: Page): Promise<OverlapResult> {
   return await page.evaluate<OverlapResult>(() => {

--- a/frontend/e2e/static-metadata.spec.ts
+++ b/frontend/e2e/static-metadata.spec.ts
@@ -94,4 +94,23 @@ test.describe('static OG/meta head — CONUS national fallback (#785)', () => {
       expect(text.toLowerCase()).not.toContain('arizona');
     }
   });
+
+  test('manifest.json carries national name and description (AZ-revert tripwire)', async ({ page }) => {
+    // manifest.json is a static file served by the dev server — fetch it directly
+    // so this assertion fires even before the React app boots. A future AZ-revert
+    // to manifest.json would otherwise pass the <head> guard above and slip through.
+    await page.goto('/');
+    const response = await page.request.get('/manifest.json');
+    expect(response.ok(), 'manifest.json must be reachable').toBe(true);
+    const manifest = await response.json() as { name?: string; description?: string };
+
+    expect(manifest.name, 'manifest.json name must be the national title').toBe('Bird Maps');
+    expect(
+      manifest.description,
+      'manifest.json description must be the national description',
+    ).toBe(NATIONAL_DESCRIPTION);
+    // Belt-and-suspenders: no "Arizona" substring anywhere in either field.
+    expect((manifest.name ?? '').toLowerCase()).not.toContain('arizona');
+    expect((manifest.description ?? '').toLowerCase()).not.toContain('arizona');
+  });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2027,13 +2027,14 @@ describe('O2 (#770): skip-link + FamilyLegend hoisted to App-root siblings', () 
     expect(String(skipLink!.tabIndex)).toBe('-1');
   });
 
-  it('skip-link is NOT inside MapSurface (.map-surface)', () => {
-    const { container } = render(<App />);
-    const skipLink = container.querySelector('[data-testid="explore-map-markers-skip-link"]');
-    const mapSurface = container.querySelector('.map-surface');
-    if (!skipLink || !mapSurface) return; // skip-link absent on unscoped; ok
-    expect(mapSurface.contains(skipLink)).toBe(false);
-  });
+  // NOTE: the vacuous '.map-surface containment' assertion that used to live
+  // here was removed (O2 #809 deferred nit). MapSurface is mocked to
+  // `<div data-testid="map-surface-stub" />` (no .map-surface class) so
+  // `.querySelector('.map-surface')` always returned null and the
+  // early-return guard fired every time — the assertion was never reached.
+  // The real invariant is covered by the DOM-order compareDocumentPosition
+  // test above + the `#map-layer` containment test below + the e2e
+  // compareDocumentPosition guard in `map-skip-link-and-hit-layer.spec.ts`.
 
   it('skip-link is NOT inside #map-layer (it precedes #map-layer in DOM)', () => {
     const { container } = render(<App />);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -168,7 +168,7 @@ export function App() {
   //   Open: set `inert` on #map-layer (same target as S1 scrim / full-snap
   //         detail sheet); move focus into the sheet (close button); add a
   //         Tab/Shift+Tab wrap handler so focus cannot escape to AppHeader
-  //         (mirrors the S1 scrim pattern at App.tsx:652–710).
+  //         (mirrors the S1-scrim inert+focus-trap useLayoutEffect, deps: [scopeActive]).
   //   Close: remove `inert` from #map-layer; restore focus to the trigger
   //         ONLY when transitioning from open→close (not on initial mount).
   // useLayoutEffect so the DOM mutation (inert) lands before the browser
@@ -197,7 +197,8 @@ export function App() {
       // AppHeader siblings (Attribution, theme-toggle, scope-control).
       // `inert` on #map-layer covers only the map subtree; AppHeader sits
       // above the backdrop and stays tabbable without this wrap handler.
-      // Pattern mirrors the S1 scrim focus-wrap at App.tsx:677–700.
+      // Pattern mirrors the S1-scrim onKeyDown wrap handler inside the
+      // S1-scrim inert+focus-trap useLayoutEffect (deps: [scopeActive]).
       const onKeyDown = (e: KeyboardEvent): void => {
         if (e.key !== 'Tab') return;
         const items = focusables();

--- a/frontend/src/lib/use-is-phone.ts
+++ b/frontend/src/lib/use-is-phone.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 /**
  * P1 overlay breakpoint (≤480px). Pin to 480 here; the CSS token is
- * `--overlay-bp` in `frontend/src/styles/tokens.css`. Keep in lockstep:
+ * `--overlay-bp-compact` in `frontend/src/styles/tokens.css`. Keep in lockstep:
  * if P1 changes the token value, update this constant too (O5 #783).
  */
 const OVERLAY_BP_PX = 480;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -103,11 +103,15 @@
   --card-maxw-rail:     420px;  /* detail card cap (max(420px,38vw) clamp below)  */
   --card-maxw-popover:  300px;  /* transient popover cap                          */
 
-  /* Controls-cluster (top-right pill) height — measured at 54px:
-   *   8px top padding + 36px button min-height + 8px bottom padding + 2px border
-   * Used by the detail rail and filters panel to clear the controls pill's
-   * bottom edge. Named for what it is (the cluster height), NOT --header-height
-   * which is a retired layout-reservation token. Added 2026-05-30 (#801). */
+  /* Controls-cluster (top-right pill) height — hand-derived from its inputs:
+   *   8px top padding + 36px button min-height + 8px bottom padding + 2px border = 54px
+   * If any of those inputs changes (e.g. a pill-height redesign), update this
+   * constant to match and verify that the rail-top-offset clearance still holds.
+   * The clearance is e2e-guarded: `map-root-geometry.spec.ts` asserts
+   * `panelTop >= pillBottom` at each canonical viewport — that test must stay
+   * green after any change here (same guard covers `species-detail.spec.ts`).
+   * Named for what it is (the cluster height), NOT --header-height which is a
+   * retired layout-reservation token. Added 2026-05-30 (#801). */
   --controls-cluster-h: 54px;
 }
 


### PR DESCRIPTION
## Diagrams

N/A — comment/dead-code/test-hardening cleanup; no structural change to diagram.

## Summary

- Sweeps 8 SUGGESTION-tier bot findings deferred across map-first epic PRs (#761): token comment cross-reference, rotted line-number refs replaced with symbolic names, vacuous unit-test assertion removed, silent conditional skip promoted to hard assertion, token-name drift fixed, dead variables/helpers deleted, manifest.json AZ-revert tripwire added.
- All changes are comments, dead-code removal, or test hardening — no production runtime behaviour changes (no `.tsx`/`.ts` logic change, no CSS rule change, no assertion added to a previously-passing path).
- Originates from bot review findings on PRs: #797 (item 1–2), #809 (items 3–4), #783 (item 5), #813 (item 6), #814 (item 7), #815 (item 8).

## Screenshots

N/A — not UI (review-nit cleanup: comments, dead-code removal, test hardening; no behavior/style change)

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

## Test plan

- [x] `npm run typecheck && npm run test` — 989 unit tests pass (2 pre-existing failures in MapCanvas.test.tsx / viewport-filter.test.ts unrelated to these changes; confirmed present on main before this branch)
- [x] New unit / integration tests added (if behavior changed) — N/A; App.test.tsx vacuous assertion removed, remaining 3 skip-link tests green
- [x] New Playwright e2e spec added (if user-visible behavior changed) — item 8 adds `manifest.json` AZ-revert tripwire to `static-metadata.spec.ts`; item 4 promotes a silent skip to a hard `expect().toBeAttached` in `map-skip-link-and-hit-layer.spec.ts`
- [x] `npm run build` — pre-existing maplibre-gl type error on this machine (confirmed same on main); vite bundle unaffected (no imports changed)
- [x] (UI only) Playwright MCP smoke — N/A (no UI change)
- [x] `npx knip` — no new findings (dead `pairwiseArea` removal reduced noise; knip findings are pre-existing unlisted binaries)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS

## Plan reference

Out of plan — consolidation of 8 SUGGESTION-tier bot findings deferred from the map-first epic (#761). No plan task.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)