### PR TITLE
docs: realign README + per-workspace docs to current architecture; add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,51 @@
 # bird-sight-system
 
-Visualize Arizona bird sightings on a real-geographic map.
+Visualize recent US bird sightings on a real-geographic map, scoped by state or ZIP.
 
 Status: **live at [bird-maps.com](https://bird-maps.com)** — shipped 2026-04-19.
 
 ## What it is
 
-A web app that renders recent eBird observations across Arizona on a MapLibre GL JS map (OpenFreeMap Positron tiles). Observations are displayed as clustered points color-keyed by bird family; clusters expand on click to reveal individual sightings with bird-silhouette markers sourced from Phylopic. A FamilyLegend panel and FiltersBar let users narrow by time window, notable-only, species, or family. URL state makes any filtered view shareable.
+A map-first web app that renders recent eBird observations across the continental US (CONUS — the 48 contiguous states plus DC) on a full-viewport MapLibre GL JS map (OpenFreeMap tiles, light/dark). The map is always mounted; floating cards anchor to the four corners over an edge-to-edge canvas (top-left identity + scope, top-right controls pill, bottom-left FamilyLegend, bottom-right attribution). There is no nav bar and no separate feed or species surface — the app is scope-driven, not tab-driven.
+
+Observations are keyed to bird family by color and silhouette (silhouettes sourced from Phylopic). At low zoom the Read API returns server-side aggregated buckets; below max zoom, observations render as MapLibre supercluster pills; at max zoom, markers de-cluster into an adaptive 4×4 cell grid (clicking a cell opens a species popover). Filters (time window, notable-only, species, family) live in a floating sheet opened from the controls pill, and FamilyLegend is a floating corner card. URL state (`?state=`, `?scope=us`, filters, `?detail=`) makes any view shareable.
+
+The system covers the whole CONUS by default but opens on a scope chooser; see **Scope model** below.
+
+## Scope model
+
+Scope is a discriminated union with three landing states, encoded in the URL (`frontend/src/state/url-state.ts`):
+
+- **Unscoped** (bare URL) — the default landing. The map mounts behind an inert, focus-trapped scope-chooser modal and fires zero `/api/observations` requests until a scope is picked.
+- **State** (`?state=US-XX`) — the only shareable scope unit. The server applies a hard PostGIS `ST_Intersects` clip against a `state_boundaries` table (49 seeded CONUS polygons). A Sketch-style "artboard mask" paints everything outside the selected state a flat theme-aware gray, and `maxBounds` is padded so small states can zoom out onto the gray field.
+- **Whole-US** (`?scope=us`) — the de-emphasized CONUS escape hatch.
+
+ZIP entry is transient (never persisted): a ZIP resolves to a state plus a `flyTo` camera via a vendored Census ZCTA index. State codes are validated against the 49-code CONUS allowlist (`CONUS_STATE_CODES` in `@bird-watch/shared-types`). No Alaska, Hawaii, or territories.
+
+Scope-selector and artboard-mask design: `docs/plans/2026-05-28-state-scope-selector.md`, `docs/plans/2026-05-29-state-artboard-mask.md`. Map-first floating-card layout: `docs/design/2026-05-30-floating-ui-design-spec.md` and the "Floating-card four-corner anchor contract" section of `CLAUDE.md`.
 
 ## Architecture
 
-Two external dependencies + four internal services. Monorepo. Everything provisioned by Terraform.
+Monorepo, everything provisioned by Terraform. Three deployable Node services (`ingestor`, `read-api`, `admin-api`) and two Cloudflare Workers, fed by four external enrichment sources.
 
-- **eBird API** → polled every 30 min by the Ingestor
-- **Phylopic** → one-time seed of family silhouettes
-- **Ingestor** (GCP Cloud Run Job, Cloud Scheduler-triggered) → upserts to Postgres, stamps `silhouette_id` via family-code lookup
-- **Read API** (GCP Cloud Run Service, scale-to-zero) → serves typed JSON with per-endpoint cache TTLs
-- **Postgres + PostGIS** (Neon, serverless, scale-to-zero) → persistent rolling store, analytics-ready
-- **Frontend** (React + Vite, Cloudflare Pages) → MapLibre GL JS real-geographic map, StackedSilhouetteMarker clustering, FamilyLegend, FiltersBar
+External sources:
 
-Compute and DB are both true serverless — scale to zero, $0/month at hobbyist usage. Everything ships as Docker containers, so the same images move to AWS Fargate / Azure Container Apps / Fly Machines / Kubernetes with config-only changes.
+- **eBird API** — recent + notable observations (intersected for the `is_notable` flag) and the monthly taxonomy ref.
+- **Phylopic** — family silhouettes.
+- **iNaturalist** — species photos and Wikipedia-title resolution.
+- **Wikipedia REST** — species descriptions and lead-image photos.
 
-See `docs/specs/2026-04-16-bird-watch-design.md` for the full spec.
+Internal services:
+
+- **Ingestor** (GCP Cloud Run Jobs, Cloud Scheduler-triggered) — CLI dispatched on a `kind` argument (`recent`, `hotspots`, `backfill`, `backfill-extended`, `taxonomy`, `photos`, `descriptions`, `prune`, `cache-warm`, `digest`, plus probe kinds). The `recent` lane is **national** (`regionCode 'US'`, every 30 min); hotspots and the default backfill remain US-AZ, with national coverage achieved via a per-state backfill fan-out (`--state=US-XX`). Entry point: `services/ingestor/src/cli.ts`. Upserts to Postgres, stamps `silhouette_id` via family-code lookup, archives pruned rows to GCS Parquet, warms the Cloudflare cache, and sends a daily SendGrid health digest. Pings Healthchecks.io as a liveness heartbeat.
+- **Read API** (GCP Cloud Run Service `bird-read-api`, scale-to-zero, behind Cloudflare CDN at `api.bird-maps.com`) — platform-agnostic Hono app (`createApp({ pool })` exported from `services/read-api/src/app.ts`). Serves typed JSON: `GET /health`, `/api/hotspots`, `/api/observations`, `/api/silhouettes`, `/api/states`, `/api/species/:code`, `/api/species/:code/phenology`. `/api/observations` supports `bbox` filtering, zoom-aware aggregated-bucket mode (below zoom 6), the `?state=` `ST_Intersects` clip, strict allowlist param validation, and a row-cap brake surfaced as `meta.truncated`. National-scale guards: a Hono in-memory token-bucket rate limiter behind the Cloudflare rate-limit ruleset, plus per-endpoint `Cache-Control` (`s-maxage` + `stale-while-revalidate`) respected by the Cloudflare `/api/*` cache rule and Smart Tiered Cache.
+- **Admin API** (GCP Cloud Run Service `bird-admin-api`, operator-only, bearer-auth) — Hono app for silhouette overrides: `PUT`/`DELETE /admin/silhouettes/family/:code` validate and upload an SVG to a Cloudflare R2 bucket, update the `family_silhouettes` table, and purge the Cloudflare cache. Operator reference: [`docs/runbooks/silhouette-override.md`](docs/runbooks/silhouette-override.md).
+- **Postgres + PostGIS** — GCP Cloud SQL for Postgres 16 (`birdwatch-pg16`, `db-g1-small`, `us-west1`, zonal), reached over the Cloud SQL Auth Proxy. Persistent rolling store; 14-day retention with Parquet cold-storage on GCS (queryable via a BigQuery external table).
+- **Frontend** (React + Vite, Cloudflare Pages) — map-first always-mounted MapLibre GL JS (5.x) canvas: supercluster pills + adaptive 4×4 grid de-clustering, server-side aggregation at low zoom, floating FamilyLegend, floating Filters sheet, and four-corner floating chrome. Analytics via Microsoft Clarity (prod-only, env-gated).
+
+Cloudflare Workers (source in `infra/workers/`, not npm workspaces): `birdwatch-silhouette-server` and `birdwatch-photo-server` serve the R2 silhouette/photo buckets at `silhouettes.bird-maps.com` and `photos.bird-maps.com`.
+
+> The service topology has moved past `docs/specs/2026-04-16-bird-watch-design.md` (which predates the national flip, the admin-api, the Cloud SQL migration, and the map-first re-architecture). Treat the spec as historical design rationale; `CLAUDE.md` ("Repo state" + the floating-card contract) is the current high-trust prose.
 
 ## Local development
 
@@ -47,49 +71,16 @@ Set `DATABASE_URL` in a `.env` file at the repo root (not committed):
 DATABASE_URL=postgres://birdwatch:birdwatch@localhost:5432/birdwatch
 ```
 
-## Repo layout
-
-```
-bird-sight-system/
-  docs/
-    specs/   ← design docs
-    plans/   ← implementation plans (9 sub-projects)
-  packages/  ← shared libs (created during Plan 1)
-  services/  ← ingestor, read-api (created during Plans 2, 3)
-  frontend/  ← React app (created during Plan 4)
-  infra/     ← Terraform (created during Plan 5)
-  migrations/ ← plain SQL Postgres migrations
-```
-
-## Plans
-
-| # | Plan | Tasks |
-|---|---|---|
-| 1 | DB foundation — monorepo + Postgres + PostGIS + db-client | 22 |
-| 2 | Ingestor service — eBird client + scheduled handler | 11 |
-| 3 | Read API — Hono routes + cache headers | 9 |
-| 4 | Frontend — React + Vite + Playwright E2E (SVG renderer, replaced by Plan 7) | 13 |
-| 5 | Infra — Terraform + GCP Cloud Run + Neon + Cloudflare Pages | 12 |
-| 6 | Path-A reimagine — post-SVG architecture assessment + redesign | — |
-| 7 | Map v1 — MapLibre GL JS real-geographic map (replaces Plan 4 renderer) | — |
-| epic-251 | Phylopic silhouettes — StackedSilhouetteMarker, FamilyLegend, AttributionModal | — |
-| spider-v2 | Spider layout v2 — fan-layout auto-spider for dense clusters | — |
-
-Plans 1–5 are the original build sequence; Plans 6–7 and the epics shipped post-launch.
-
-## Stack at a glance
-
-TypeScript · React 18 · Vite · Hono · `pg` · PostGIS · MapLibre GL JS · Vitest · Playwright · Docker · GCP Cloud Run · Cloud Scheduler · Cloudflare Pages · Neon · Terraform. Live at [bird-maps.com](https://bird-maps.com) since 2026-04-19.
+For the frontend dev server and the live UI-verification protocol (5 canonical viewports × 2 themes, Playwright MCP), see the **Testing** section of `CLAUDE.md`.
 
 ## Deployment
 
-This project deploys to **GCP Cloud Run + Neon Postgres + Cloudflare Pages** — true serverless, scale-to-zero, hobbyist free tier.
+This project deploys to **GCP Cloud Run + Cloud SQL Postgres 16 + Cloudflare (Pages, R2, Workers)**. Cloud Run services scale to zero; the Cloud SQL instance is an always-on `db-g1-small` (not serverless), guarded by a $100/mo GCP billing budget. Everything compute-side ships as Docker containers, so the same images move to AWS Fargate / Azure Container Apps / Fly Machines / Kubernetes with config-only changes.
 
 ### Prerequisites
 
-- GCP account with a project, `gcloud` CLI authenticated, billing enabled (free tier covers our usage)
-- Neon account (Neon dashboard → Settings → API keys)
-- Cloudflare account with a zone you control (used for Pages + DNS only)
+- GCP account with a project, `gcloud` CLI authenticated, billing enabled
+- Cloudflare account with a zone you control (Pages + DNS + R2 + Workers)
 - eBird API key (free at ebird.org/api/keygen)
 - Terraform >= 1.6
 - Docker + `docker buildx` for multi-arch builds
@@ -97,19 +88,19 @@ This project deploys to **GCP Cloud Run + Neon Postgres + Cloudflare Pages** —
 
 ### One-time setup
 
-1. `cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars` and fill in:
-   - `gcp_project_id`, `gcp_region`
-   - `neon_api_key`
+1. `cp infra/terraform/terraform.tfvars.example infra/terraform/terraform.tfvars` and fill in (reconcile against `infra/terraform/variables.tf`):
+   - `gcp_project_id`, `gcp_region`, `gcp_billing_account_id`
    - `cloudflare_account_id`, `cloudflare_api_token`, `cloudflare_zone_id`, `domain`
    - `ebird_api_key`
+   - `alert_email`
 2. `gcloud auth login && gcloud auth application-default login`
-3. `cd infra/terraform && terraform init`
-4. `./scripts/deploy.sh` — provisions infra, builds + pushes images, deploys frontend
+3. `cd infra/terraform && terraform init` — the database is Cloud SQL Postgres 16, provisioned through the `google` provider (no separate DB-vendor account or API key required).
+4. `./scripts/deploy.sh` — runs `terraform apply -auto-approve` to provision infra. The migrations, read-api, ingestor, and frontend deploys are not done by this script; they run in CI (the `.github/workflows/deploy-*.yml` workflows) on push to `main`. The script just echoes which workflow owns each.
 5. `./scripts/smoke-test.sh`
 
 ### Subsequent deploys
 
-After code changes: `./scripts/deploy.sh` rebuilds and rolls Cloud Run to the new image. Terraform sees no diff and skips infra.
+After code changes, the per-service GitHub Actions workflows (`deploy-migrations.yml`, `deploy-read-api.yml`, `deploy-ingestor.yml`, `deploy-frontend.yml`) build the images and roll Cloud Run / Pages to the new revisions on push to `main`. `./scripts/deploy.sh` only applies Terraform (infra changes); it does not build, push, or deploy images itself. Terraform uses `ignore_changes` on the container image, so `terraform apply` does not roll back a CD deploy.
 
 ### Portability
 
@@ -117,10 +108,51 @@ The compute is plain Docker. To migrate to AWS / Azure / Fly:
 
 | Move | What changes | What stays |
 |---|---|---|
-| **GCP → AWS** | Push Dockerfiles to ECR; deploy to App Runner or Fargate; replace Cloud Scheduler with EventBridge Rules; replace Secret Manager with AWS Secrets Manager | Application code, Neon DB, frontend |
-| **GCP → Azure** | Push Dockerfiles to ACR; deploy to Azure Container Apps; replace Cloud Scheduler with Azure Logic Apps or Functions Timer; replace Secret Manager with Key Vault | Application code, Neon DB, frontend |
-| **GCP → Fly.io** | Push Dockerfiles to Fly registry; `fly deploy` for the API service; use Fly's Cron Manager (JSON schedules) for arbitrary crons — `fly machines run --schedule` only accepts `hourly`/`daily`/`weekly`/`monthly` literals, which covers the backfill + hotspots jobs but not the 30-minute recent cron | Application code, frontend (could move to Fly too) |
-| **Neon → another Postgres** | `pg_dump` from Neon → restore to RDS / Cloud SQL / Azure DB / self-hosted; update `DATABASE_URL` secret | Compute layer, all application code |
+| **GCP → AWS** | Push Dockerfiles to ECR; deploy to App Runner or Fargate; replace Cloud Scheduler with EventBridge Rules; replace Secret Manager with AWS Secrets Manager; repoint the DB at RDS for Postgres | Application code, frontend, the Postgres schema |
+| **GCP → Azure** | Push Dockerfiles to ACR; deploy to Azure Container Apps; replace Cloud Scheduler with Azure Logic Apps or Functions Timer; replace Secret Manager with Key Vault; repoint the DB at Azure Database for PostgreSQL | Application code, frontend, the Postgres schema |
+| **GCP → Fly.io** | Push Dockerfiles to Fly registry; `fly deploy` for the API services; replace Cloud Scheduler with a Fly-side scheduler for the ingestor lanes | Application code, frontend |
+
+The data layer is portable too: `pg_dump` from Cloud SQL → restore to any Postgres 16 + PostGIS host, then update the `DATABASE_URL` secret. The R2 buckets and Cloudflare Workers are Cloudflare-specific and would need an equivalent object store + edge function on a non-Cloudflare target.
+
+## Repo layout
+
+```
+bird-sight-system/
+  docs/
+    specs/   ← design docs (2026-04-16 spec is historical)
+    plans/   ← implementation plans (39 entries)
+    design/  ← floating-UI design spec
+    runbooks/ ← operator references
+  packages/  ← shared libs (db-client, shared-types)
+  services/  ← ingestor, read-api, admin-api
+  frontend/  ← React app
+  infra/     ← Terraform + Cloudflare Workers (not an npm workspace)
+  migrations/ ← plain SQL Postgres migrations
+  scripts/   ← deploy.sh, smoke-test.sh, zip-etl/, …
+```
+
+npm workspaces are `packages/*`, `services/*`, and `frontend`. (`packages/family-mapping` is a stale orphan directory with no `package.json` or source — its family-code→color logic now lives in `frontend/src/data/family-color.ts` and the `family_silhouettes` table.)
+
+## Plans
+
+Implementation plans live under `docs/plans/` (39 entries). Plans 1–5 are the original build sequence (DB foundation → ingestor → read-api → frontend → infra); Plans 6–7 and a long tail of post-launch epics shipped after the 2026-04-19 launch.
+
+Notable post-launch plans on disk:
+
+- `2026-05-14-adaptive-cluster-grid` — adaptive 4×4 cell grid (retired the prior mosaic + auto-spider clustering)
+- `2026-05-15`/`16-cell-species-popover-phase-0..3`, `2026-05-15-marker-overlap-deconflict`, `2026-05-16-adaptive-grid-tile-contrast`
+- `2026-05-13-silhouette-admin-api`, `2026-05-12-backfill-38-family-silhouettes`
+- `2026-05-17-cloud-sql-migration` (Neon → Cloud SQL Postgres 16)
+- `2026-05-17-going-national` (US-AZ → CONUS recent lane), `2026-05-17-monitoring-and-alerts`
+- `2026-05-20-observations-cold-storage` (GCS Parquet + BigQuery), `2026-05-18-pmtiles-observation-tiles` (planned/deferred — not the live render path)
+- `2026-05-28-state-scope-selector`, `2026-05-29-state-artboard-mask`
+- the map-first re-architecture epic (#761) — full-viewport always-mounted canvas, feed surface removed, floating-card chrome
+
+The `spider-v2` auto-spider plan is retired (the auto-spider + mosaic code was deleted when the adaptive cluster grid cut over).
+
+## Stack at a glance
+
+TypeScript · React 18 · Vite · Hono · `pg` · PostGIS · MapLibre GL JS (5.x) · Vitest · Playwright · Docker · GCP Cloud Run · Cloud Scheduler · Cloud SQL Postgres 16 · Cloud Monitoring · GCS · BigQuery · Cloudflare (Pages, R2, Workers) · Microsoft Clarity · iNaturalist · Wikipedia · SendGrid · Terraform. Live at [bird-maps.com](https://bird-maps.com) since 2026-04-19.
 
 ## Operator runbooks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+`bird-sight-system` powers the public site [bird-maps.com](https://bird-maps.com).
+We take security reports seriously and appreciate responsible disclosure.
+
+## Reporting a vulnerability
+
+**Please report privately — do not open a public issue for a security problem.**
+
+Use GitHub's private vulnerability reporting: open the repository's **Security** tab and
+choose **Report a vulnerability**
+([how it works](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)).
+
+We aim to acknowledge a report within 3 business days and to share a remediation
+timeline after triage.
+
+## Scope
+
+In scope:
+
+- The public read API (`api.bird-maps.com`) and the site (`bird-maps.com`).
+- The operator **admin API** (`bird-admin-api`) — authentication/authorization handling,
+  input validation, and the storage / cache-purge path.
+- Secret or credential exposure in this repository or its build/deploy artifacts.
+
+Out of scope:
+
+- Volumetric denial-of-service. The read API is rate-limited by design
+  (see [`services/read-api/README.md`](services/read-api/README.md)).
+- Findings that require an already-compromised operator bearer token, absent a
+  vulnerability in how that token is issued, stored, or validated.
+- Vulnerabilities in third-party data sources (eBird, Phylopic, iNaturalist, Wikipedia)
+  or infrastructure providers (GCP, Cloudflare).
+
+## No bounty
+
+This is a personal, non-commercial project. We can't offer monetary rewards, but we're
+grateful for every report and will credit reporters who wish to be named.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,73 @@
+# `@bird-watch/frontend` — bird-maps.com web client
+
+Map-first React + Vite + MapLibre GL app for visualizing recent eBird
+observations across the continental US (CONUS). Deployed as a static bundle to
+Cloudflare Pages and served at [bird-maps.com](https://bird-maps.com); it reads
+from the Read API at `api.bird-maps.com`.
+
+This is the `frontend` npm workspace of the `bird-watch` monorepo. It is the
+only workspace that ships browser code; the others (`packages/*`,
+`services/*`) are the data layer and backend services.
+
+## What it is
+
+The UI is a single always-mounted, full-viewport MapLibre canvas (`#map-layer`)
+with floating chrome anchored to the four corners — there is no top bar, no
+nav tabs, and no feed/list surface. The map is the application. Geographic
+scope is URL-driven, not tab-driven:
+
+- `?state=US-XX` — a single state (48 contiguous states + DC; no AK/HI/territories)
+- `?scope=us` — the whole-CONUS escape hatch
+- bare URL — a scope chooser landing (the default), shown over the idle map
+
+Observations render through MapLibre's built-in GeoJSON clustering, with
+server-side aggregation at low zoom for the national-scale payload. The full
+layout law (corner anchors, elevation tiers, transient layer) lives in the
+design spec linked below, not here.
+
+## Develop
+
+From the repo root:
+
+```sh
+npm install                                   # installs the whole workspace
+npm run dev --workspace @bird-watch/frontend  # vite dev server on :5173
+```
+
+Other workspace scripts (run with `--workspace @bird-watch/frontend`):
+
+| Script | Command | Purpose |
+| --- | --- | --- |
+| `dev` | `vite` | dev server |
+| `build` | `tsc -b && vite build` | typecheck + production bundle to `dist/` |
+| `preview` | `vite preview` | serve the built `dist/` on :4173 |
+| `test` | `vitest run` | unit/component tests |
+| `test:e2e` | `playwright test` | end-to-end specs (`e2e/*.spec.ts`) |
+
+### Build-time environment
+
+Vite reads `VITE_*` variables at build time:
+
+- `VITE_API_BASE_URL` — Read API origin (production: `https://api.bird-maps.com`)
+- `VITE_REGION_CODE` — eBird region code (production: `US`)
+- `VITE_CLARITY_PROJECT_ID` — Microsoft Clarity project; analytics initialize
+  only when this is set **and** `import.meta.env.PROD` is true. Never import
+  `@microsoft/clarity` directly — go through the `safeClarity` wrapper in
+  `src/clarity.ts`.
+
+## Reference
+
+Do not duplicate the canonical references below — they are the higher-trust
+anchors and this README is deliberately thin to avoid drifting against them.
+
+- **`../CLAUDE.md`** — the repo's source of truth for the floating-card
+  four-corner anchor contract, the canonical 5-viewport set, the Playwright
+  MCP UI-verification protocol, the E2E spec-authoring conventions, and the
+  PR workflow. Read this before touching visible UI.
+- **`../docs/design/2026-05-30-floating-ui-design-spec.md`** — the design
+  authority for the map-first floating-UI system (anchors, tokens, elevation,
+  popover/detail/filters behavior).
+- **`../docs/specs/2026-04-16-bird-watch-design.md`** — the original system
+  design. Note: it predates the map-first re-architecture and the national
+  flip and is materially stale on UX and service topology; treat `CLAUDE.md`
+  as current ground truth where they conflict.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,8 +1,12 @@
 # Infrastructure
 
-Terraform configuration for the bird-watch system, managing GCP (Cloud Run,
-Artifact Registry, Secret Manager, Cloud Scheduler), Neon (Postgres), and
-Cloudflare (Pages, DNS).
+Terraform configuration for the bird-watch system, managing GCP (Cloud Run
+services + scheduled jobs, Cloud SQL for Postgres 16, Artifact Registry,
+Secret Manager, Cloud Scheduler, Cloud Monitoring, GCS observations-archive,
+BigQuery, Billing Budget) and Cloudflare (Pages, DNS, R2, Workers, cache &
+rate-limit rulesets, Smart Tiered Cache). The Cloud Run footprint is two
+services (`bird-read-api`, `bird-admin-api`) plus the ingestor and digest
+jobs; Neon is decommissioned (no Neon provider in `versions.tf`).
 
 ## Remote state
 

--- a/packages/db-client/README.md
+++ b/packages/db-client/README.md
@@ -1,0 +1,90 @@
+# `@bird-watch/db-client`
+
+The typed [`pg`](https://node-postgres.com/) query layer shared by all three
+Node services — `services/read-api`, `services/ingestor`, and
+`services/admin-api`. It owns pool lifecycle and every Postgres + PostGIS query
+the services issue; row shapes are the wire/domain types from
+[`@bird-watch/shared-types`](../shared-types). It is a workspace-internal
+package (not published to npm) — consumed via the root `workspaces` glob
+`packages/*`.
+
+Runtime dependencies: `pg` and `@bird-watch/shared-types`. Integration tests run
+against a real Postgres + PostGIS via `@testcontainers/postgresql` (no DB mocks
+— see the repo `CLAUDE.md` "Conventions" section).
+
+## Exports
+
+Re-exported from `src/index.ts`.
+
+### Pool lifecycle (`pool.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `createPool(opts: PoolOptions)` | fn | Returns a `pg.Pool`. Memoized by `opts.key` when set. Defaults: `max: 5`, `idleTimeoutMillis: 30_000`. |
+| `closePool(pool)` | fn | Ends the pool and clears any memoization entry. |
+| `Pool` | type | Alias for `pg.Pool`. |
+| `PoolOptions` | type | `{ databaseUrl, key?, max?, idleTimeoutMillis? }`. |
+
+### Hotspots (`hotspots.ts`)
+
+| Export | Kind |
+| --- | --- |
+| `getHotspots` | query |
+| `upsertHotspots` | write |
+| `HotspotInput` | type |
+
+### Observations (`observations.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `getObservations` | query | Per-observation read; row-capped with a cap+1 truncation probe. |
+| `getObservationsAggregated` | query | Coarse-grid bucket aggregation for low-zoom reads. |
+| `upsertObservations` | write | Stamps `silhouette_id` per batch on upsert. |
+| `runReconcileStamping` | write | Sweeps NULL `silhouette_id` residue. |
+| `getFreshestObservationAt` | query | Freshness timestamp. |
+| `ObservationInput` | type | |
+
+Both read paths support a `?state=US-XX` clip (PostGIS `ST_Intersects`) and a
+bbox filter (`geom && ST_MakeEnvelope`).
+
+### Species: meta, photos, phenology, descriptions (`species.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `getSpeciesMeta` | query | |
+| `upsertSpeciesMeta` | write | Taxonomy ingest target. |
+| `findMissingSpeciesMeta` | query | Returns species codes with no `species_meta` row (FK invariant guard). |
+| `insertSpeciesPhoto` | write | |
+| `getSpeciesPhotos` | query | |
+| `getSpeciesPhenology` | query | On-read monthly aggregation of observations (UTC). |
+| `insertSpeciesDescription` | write | |
+| `SpeciesPhoto`, `SpeciesPhotoInput`, `SpeciesDescriptionInput` | type | |
+
+### Silhouettes (`silhouettes.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `getSilhouettes` | query | Reads `family_silhouettes` (family → color + SDF/SVG). |
+
+### State boundaries (`state-boundaries.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `resolveStateForPoint` | query | Point-in-polygon `US-XX` lookup (`ST_Intersects`). |
+| `listStatesWithBbox` | query | State list + bbox for camera framing; deliberately omits the polygon `geom`. |
+
+### Ingest-run ledger (`ingest-runs.ts`)
+
+| Export | Kind | Notes |
+| --- | --- | --- |
+| `startIngestRun` | write | Opens a row in `ingest_runs`. |
+| `finishIngestRun` | write | Closes it with status + counts. |
+| `getRecentIngestRuns` | query | |
+| `IngestKind`, `IngestStatus`, `FinishOptions` | type | |
+
+## Build / test
+
+```sh
+npm run build --workspace @bird-watch/db-client
+npm run test  --workspace @bird-watch/db-client   # vitest, testcontainers Postgres
+```

--- a/services/admin-api/README.md
+++ b/services/admin-api/README.md
@@ -1,0 +1,191 @@
+# `@bird-watch/admin-api`
+
+Operator-only HTTP service for overriding the family **silhouette** that
+bird-maps.com renders for any bird family. A `PUT` uploads a hand-sourced SVG to
+the silhouettes R2 bucket, points the `family_silhouettes` DB row at it, and
+purges the `/api/silhouettes` JSON cache on Cloudflare so the change is live
+within ~30s; a `DELETE` reverts the family to its `_FALLBACK` shape. This is a
+write path distinct from the public, read-only [`read-api`](../read-api): every
+`/admin/*` route is behind a bearer token and the service runs scale-to-zero
+with no CDN in front. Added for issue #502; not part of the original
+`docs/specs/2026-04-16-bird-watch-design.md` service inventory.
+
+## How it fits
+
+```
+operator → scripts/silhouette.mjs (npm run silhouette)
+              │  PUT/DELETE /admin/silhouettes/family/:code  (Bearer)
+              ▼
+         bird-admin-api (Cloud Run)
+              ├── R2 PUT/DELETE        → bird-maps-silhouettes bucket
+              │                          (served at silhouettes.bird-maps.com)
+              ├── UPDATE family_silhouettes (svg_url, svg_data)
+              └── Cloudflare purge_cache → https://api.bird-maps.com/api/silhouettes
+```
+
+The silhouettes bucket is served to the browser by the
+`birdwatch-silhouette-server` Cloudflare Worker; the admin-api only writes to it.
+
+## Quickstart (local)
+
+The service is a [Hono](https://hono.dev) app. `createApp({ pool, storage, token })`
+is exported from `src/app.ts`; `src/local.ts` is the Node entry point
+(`@hono/node-server`), and `src/index.ts` re-exports `createApp` for tests.
+
+```sh
+# from the repo root
+npm run dev --workspace @bird-watch/admin-api
+# → "Admin API listening on http://localhost:8788"  (PORT overridable)
+```
+
+Required env for local dev (`src/local.ts`, `src/storage.ts`):
+
+```sh
+export DATABASE_URL="postgres://<USER>:<PASSWORD>@localhost:5432/birdwatch"
+export ADMIN_API_TOKEN="<ANY_NON_EMPTY_STRING>"   # boot fails if empty
+export R2_ENDPOINT="https://<ACCOUNT_ID>.r2.cloudflarestorage.com"
+export R2_ACCESS_KEY_ID="<YOUR_R2_KEY_ID>"
+export R2_SECRET_ACCESS_KEY="<YOUR_R2_SECRET>"
+```
+
+Then exercise it (the `/admin/*` routes require the bearer header; `/health`
+does not):
+
+```sh
+curl -s localhost:8788/health
+# {"ok":true}
+
+curl -s -X PUT localhost:8788/admin/silhouettes/family/cuculidae \
+  -H "Authorization: Bearer $ADMIN_API_TOKEN" \
+  -F "file=@./cuckoo.svg"
+# {"url":"https://silhouettes.bird-maps.com/family/cuculidae.<sha>.svg","key":"...","pathD":"..."}
+```
+
+If `R2_*` / Cloudflare env is unset, the upload itself fails (R2) or the cache
+purge is skipped with an `X-Purge-Status: failed` response header — the DB write
+still succeeds.
+
+### Prefer the CLI in practice
+
+Day-to-day operators use the root-level wrapper rather than raw `curl`:
+
+```sh
+npm run silhouette set <family-code> <path-to-svg>
+npm run silhouette unset <family-code>
+```
+
+It reads `ADMIN_API_URL` and `ADMIN_API_TOKEN` from the env and posts the
+multipart `file` field for you (`scripts/silhouette.mjs`). The end-to-end
+operator procedure — minting/rotating the token, the Phylopic-SVG flattening
+caveat, and post-deploy smoke steps — lives in the runbook:
+[`docs/runbooks/silhouette-override.md`](../../docs/runbooks/silhouette-override.md).
+For sourcing the SVG art itself, see the `curating-fallback-silhouettes` skill
+(`.claude/skills/curating-fallback-silhouettes/SKILL.md`).
+
+## Reference
+
+### Endpoints
+
+| Method | Path | Auth | Behavior |
+| --- | --- | --- | --- |
+| `GET` | `/health` | none | `{"ok":true}` |
+| `PUT` | `/admin/silhouettes/family/:code` | Bearer | Multipart `file` (SVG) → validate → R2 `PUT` → `UPDATE family_silhouettes SET svg_url, svg_data` → Cloudflare purge. Returns `{ url, key, pathD }`. |
+| `DELETE` | `/admin/silhouettes/family/:code` | Bearer | R2 `DELETE` of the prior object → `UPDATE family_silhouettes SET svg_url = NULL, svg_data = NULL` → Cloudflare purge. Returns `{ ok:true }`. |
+
+`:code` must match `^[a-z]+$` (lowercase letters only) — otherwise `400`.
+The family row must already exist in `family_silhouettes` or the request `404`s
+(the admin-api overrides existing rows, it does not create families).
+
+### Auth model (`src/auth.ts`)
+
+`bearerAuth(token)` middleware guards `/admin/*`. The request's
+`Authorization: Bearer <token>` value is compared to `ADMIN_API_TOKEN` with a
+constant-time compare (`node:crypto` `timingSafeEqual`, length-guarded). A
+missing/malformed header or any mismatch returns `401`. The middleware throws at
+construction if `ADMIN_API_TOKEN` is empty, so a misconfigured deploy fails to
+boot rather than serving an open endpoint. Cloud Run IAM allows public invoke —
+the bearer token is the auth boundary, not network ACLs — so **rotate the token
+on any leak** (runbook).
+
+### SVG validation contract (`src/validate.ts`)
+
+Uploads are checked against an allow-list before any side effect; a failure
+returns `400` naming the rule:
+
+- body non-empty and ≤ 64 KB
+- contains an `<svg>` element
+- exactly one `<path>` element; no `<g>`, `<style>`, `<script>`, `<defs>`, `<use>`
+- no `on*` event-handler attribute; no `xlink:*` attribute
+- `viewBox`, if present, equals `0 0 24 24`
+- `<path>` has a `d` attribute whose value matches the path-data charset
+  (digits, the SVG command letters, space, `-`, `.`, `,`) — the same check the
+  frontend's silhouette fallback uses (issue #271)
+
+On success the verbatim source bytes go to R2 and the extracted `d` string is
+written to `family_silhouettes.svg_data`.
+
+### Storage & purge flow
+
+- **R2** (`src/storage.ts`, `@aws-sdk/client-s3` against the R2 S3-compatible
+  endpoint): objects are content-addressed — key `family/<code>.<sha8>.svg`,
+  uploaded with `Content-Type: image/svg+xml` and
+  `Cache-Control: public, max-age=31536000, immutable`. The public URL is
+  `<SILHOUETTES_PUBLIC_PREFIX>/<key>` (default
+  `https://silhouettes.bird-maps.com`). On `PUT`, R2 is written **first**; the
+  DB pointer is updated only after a successful upload (a DB row pointing at a
+  missing key would render broken images). Any prior object is deleted
+  **between** the new upload and the DB update — i.e. before the swap, not
+  after; R2 cleanup failures are non-fatal (logged), the DB write is the
+  load-bearing step.
+- **Cloudflare purge** (`src/purge.ts`): a single-file `purge_cache` POST for
+  `https://<API_HOST>/api/silhouettes` (default host `api.bird-maps.com`), so
+  the next read returns the new silhouette. A failed/timed-out purge (5s) sets
+  the `X-Purge-Status: failed` response header but does not fail the request —
+  recover with `scripts/purge-silhouettes-cache.sh` (runbook).
+
+### Environment variables
+
+| Var | Required | Default | Used by |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | yes | — | `family_silhouettes` reads/writes |
+| `ADMIN_API_TOKEN` | yes | — | bearer auth; empty → boot fails |
+| `R2_ENDPOINT` | yes | — | R2 S3 client |
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | yes (prod) | — | R2 credentials |
+| `R2_BUCKET_NAME` | no | `bird-maps-silhouettes` | R2 target bucket |
+| `SILHOUETTES_PUBLIC_PREFIX` | no | `https://silhouettes.bird-maps.com` | public URL prefix written to DB |
+| `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN` | for purge | — | `purge_cache` call |
+| `API_HOST` | no | `api.bird-maps.com` | purge target host |
+| `PORT` | no | `8788` (local) / `8080` (container) | listen port |
+
+### Deploy target
+
+Deployed as the GCP **Cloud Run v2 service `bird-admin-api`** (us-west1),
+scale-to-zero (`min_instance_count = 0`, `max_instance_count = 2`), with all
+secret-bound env wired from Secret Manager and a Cloud SQL Auth Proxy socket
+mount for the database (`infra/terraform/admin-api.tf`). The container is built
+from this directory's `Dockerfile` (multi-stage, monorepo-root context, runs
+`node services/admin-api/dist/local.js`). The image tag is rolled forward by
+`.github/workflows/deploy-admin-api.yml`; Terraform `ignore_changes` on the
+container image keeps `terraform apply` from reverting CD deploys.
+
+There is **no** `admin.bird-maps.com` custom-domain mapping in committed
+Terraform — access the service via its `*.run.app` URL (`terraform output
+admin_api_url`, or `gcloud run services describe bird-admin-api`). See the
+runbook for the exact commands.
+
+## Dependencies
+
+`@bird-watch/db-client` (typed `pg` pool, `family_silhouettes` access),
+`@bird-watch/shared-types`, `hono` + `@hono/node-server`, and
+`@aws-sdk/client-s3` (R2). See `package.json`.
+
+## Tests
+
+```sh
+npm run test --workspace @bird-watch/admin-api   # vitest
+```
+
+`app.test.ts` runs against a real Postgres + PostGIS via
+`@testcontainers/postgresql` (no DB mocks — repo convention); R2 is stubbed with
+`aws-sdk-client-mock` and the Cloudflare purge is faked. `auth.ts`, `storage.ts`,
+`purge.ts`, and `validate.ts` have unit coverage.

--- a/services/ingestor/README.md
+++ b/services/ingestor/README.md
@@ -1,0 +1,197 @@
+# Ingestor — scheduled ingest + enrichment
+
+`@bird-watch/ingestor` is the batch service behind bird-maps.com. It is a CLI
+(not an HTTP service): a single entry point dispatches on `argv[2]` to one of
+twelve *kinds*. In production each kind runs as a Cloud Run v2 **Job** triggered
+by Cloud Scheduler; locally it runs under `tsx`.
+
+Two responsibilities:
+
+- **Ingest** — pull bird observations, hotspots, and taxonomy from eBird into
+  Postgres (PostGIS). The recent-observations lane is national (`regionCode
+  'US'`); hotspots and the default backfill remain `US-AZ`.
+- **Enrichment** — fill out species metadata from external sources: iNaturalist
+  (photos + taxon resolution), Wikipedia (descriptions), and Phylopic family
+  silhouettes (seeded via DB migrations, written by the separate admin-api).
+
+There are also operational kinds: retention prune with cold-storage archival,
+a daily health digest email, a Cloudflare cache-warm pass, and two operator
+probe tools.
+
+The platform-agnostic ingest core lives in the `run-*.ts` runners. The Cloud
+Run Job entry point is `src/cli.ts`. A second file, `src/handler.ts`, exports a
+`handleScheduled` covering only a six-kind subset and is **not** the production
+entry point — treat `cli.ts` as authoritative for the kind list.
+
+## Run a kind locally
+
+The CLI is `src/cli.ts` (shebang `#!/usr/bin/env tsx`). The package script
+`ingest:local` wraps it:
+
+```sh
+# Default kind is `recent` when argv[2] is omitted.
+EBIRD_API_KEY=<YOUR_EBIRD_KEY> DATABASE_URL=<YOUR_DATABASE_URL> \
+  npm run ingest:local --workspace @bird-watch/ingestor
+
+# An explicit kind:
+EBIRD_API_KEY=<YOUR_EBIRD_KEY> DATABASE_URL=<YOUR_DATABASE_URL> \
+  npm run ingest:local --workspace @bird-watch/ingestor -- hotspots
+```
+
+### Backfill flags
+
+`backfill` accepts two optional flags (`src/cli.ts:255-300`):
+
+```sh
+# Per-state, 14-day window. --state accepts US-XX or an eBird county code US-XX-NNN.
+... -- backfill --state=US-CA --back=14
+```
+
+- `--state=US-XX` (default `US-AZ`) — validated against `/^US-[A-Z]{2}(-[A-Z0-9]+)?$/`.
+  County codes (`US-XX-NNN`) exist because a single per-day full-state historic
+  call can exceed eBird's response-size limit on large states; the fix is to fan
+  out per county.
+- `--back=N` (default `19`) — integer 1–30 (eBird's `recent` window cap).
+
+`backfill-extended` is a one-shot 365-day backfill at 1 rps
+(`src/cli.ts:301-324`). It is **not** scheduled — it runs on the shared
+`bird-ingestor` Cloud Run Job, whose `timeout` is `900s`
+(`infra/terraform/ingestor.tf:101`). Its wall time is ~364s (365 calls at 1
+rps), comfortably under that ceiling, so no per-execution timeout override is
+needed. (The inline comment at `src/cli.ts:308-309` still claims `timeout =
+"300s"` and cites `ingestor.tf:91`; that is stale — line 91 is now the
+bump-comment and the live value at line 101 is `900s`.)
+
+### Probe tools (no DB / no eBird auth)
+
+`probe-wiki <title>` and `probe-taxon <binomial>` early-return ahead of the
+`EBIRD_API_KEY` / `DATABASE_URL` guards (`src/cli.ts:116-134`), so they run from
+a laptop with no secrets:
+
+```sh
+npx tsx services/ingestor/src/cli.ts probe-taxon "Cardinalis cardinalis"
+npx tsx services/ingestor/src/cli.ts probe-wiki "Northern cardinal"
+```
+
+## Reference
+
+### Kinds
+
+All kinds dispatch from `src/cli.ts`. `regionCode` applies only to eBird ingest
+kinds. Schedules are the production Cloud Scheduler cadences (UTC); kinds with
+no schedule are operator-triggered.
+
+| Kind | What it does | regionCode | Schedule (cron) |
+| --- | --- | --- | --- |
+| `recent` | eBird recent + notable intersect → observations (default kind) | `US` | `*/30 * * * *` |
+| `hotspots` | eBird hotspots → hotspots table | `US-AZ` | `0 5 * * 0` (weekly Sun) |
+| `backfill` | eBird historic backfill; `--state`/`--back` flags | `US-AZ` (or `--state`) | `0 4 * * *`; per-state fan-out staggered |
+| `backfill-extended` | one-shot 365-day backfill at 1 rps | `US-AZ` | — (operator only) |
+| `taxonomy` | eBird taxonomy (7 categories) → species_meta | n/a | `0 6 1 * *` (monthly) |
+| `photos` | iNaturalist (Tier 1) → Wikipedia lead-image fallback → species_photos | n/a | `0 7 1 * *` (monthly) |
+| `descriptions` | Wikipedia REST summary → iNat summary fallback → species_descriptions | n/a | `0 8 * * *` (daily) |
+| `prune` | 14-day retention; archive-then-delete to GCS Parquet, then VACUUM | n/a | `5 10 * * *` (daily) |
+| `cache-warm` | prime the Cloudflare cache for popular `/api` URLs | n/a | `2,32 * * * *` |
+| `digest` | daily health-digest email via SendGrid | n/a | `0 9 * * *` (daily) |
+| `probe-taxon` | operator triage: hit iNat `/v1/taxa` for one binomial | n/a | — |
+| `probe-wiki` | operator triage: fetch one Wikipedia summary by title | n/a | — |
+
+The per-state backfill fan-out is a Cloud Scheduler `for_each` that invokes the
+shared `bird-ingestor` job with `--args=backfill --state=US-XX --back=14` at
+staggered times (`infra/terraform/ingestor.tf`).
+
+### eBird ingest details
+
+- **`is_notable` requires two calls.** `recent` fetches `/data/obs/{region}/recent`
+  and `/data/obs/{region}/recent/notable` in parallel, builds a key set from the
+  notable response, and stamps `is_notable` per observation by membership
+  (`src/run-ingest.ts:37-42`, `src/transform.ts`). Without both calls the notable
+  filter does not work. The notable call passes `detail=simple`; both default to
+  `back=14` days (`src/ebird/client.ts:36-48`).
+- **species_meta invariant.** Before upserting observations, `findMissingSpeciesMeta`
+  checks every `species_code` against `species_meta`; a single missing row aborts
+  the whole batch loudly (issue #484, `src/run-ingest.ts:54-63`). The monthly
+  `taxonomy` cron keeps all 7 eBird categories so hybrid/spuh/slash codes get
+  rows.
+- **Taxonomy** fetches `cat=species,issf,hybrid,spuh,slash,domestic,form` with no
+  `version` param (eBird then defaults to the latest taxonomy;
+  `src/ebird/client.ts:83-89`).
+
+### Enrichment lanes
+
+- **Photos** (`src/run-photos.ts`, `src/inat/`) — iNaturalist is the Tier-1
+  source with a region → US → global cascade; Wikipedia lead-image is the next
+  fallback. There is no further photo source — the family silhouette is the final
+  fallback. Only species that appear in `observations` are iterated (an `EXISTS`
+  filter).
+- **Descriptions** (`src/run-descriptions.ts`, `src/wikipedia/`, `src/inat/`) —
+  resolves a Wikipedia title via the cached `inat_taxon_id` (warm) or iNat
+  `/v1/taxa` (cold), conditional-GETs the Wikipedia REST summary (304
+  short-circuit), sanitizes the HTML, and persists to `species_descriptions`. On
+  a cold-cache Wikipedia 404 it falls back to the iNat summary plaintext
+  (`source='inat'`). Wikipedia text is stored CC-BY-SA-4.0.
+- **Silhouettes** — the ingestor does **not** write silhouettes at runtime. Family
+  silhouettes (`family_silhouettes` table: family → color and SDF shape) are
+  seeded and backfilled via DB migrations (Phylopic crawl) and overridden by the
+  separate `services/admin-api`. See that service's source for the upload path.
+
+iNaturalist and Wikipedia run with a `User-Agent` of
+`bird-maps.com/1.0 (https://bird-maps.com)` and pace at roughly 1 rps.
+
+### Prune + cold storage
+
+`prune` runs `runPrune` (`src/run-prune.ts`): 14-day rolling retention
+(`DEFAULT_RETENTION_DAYS=14`, override via `OBSERVATIONS_RETENTION_DAYS`). For
+each UTC day outside the window it archives the day's rows to gzip Parquet on
+the GCS bucket `bird-maps-prod-obs-archive`, then deletes them, then
+`VACUUM (ANALYZE)` the table. Archive-then-delete is per-day and synchronous: if
+the archive throws for a day, that day's delete is skipped and the run reports
+`failure` while preserving prior days' progress.
+
+Parquet is Hive-partitioned (`observations/year=YYYY/month=MM/day=DD/data.parquet`)
+for BigQuery partition pruning, written with a temp-key + md5-verify + copy +
+delete atomic rename (`src/archive/`). A BigQuery external table reads the
+archive; production never reads it back through this service.
+
+### Digest
+
+`digest` composes a daily health-summary email from Postgres + Cloud Monitoring
+signals and sends it via SendGrid (`src/digest.ts`, `src/digest-providers.ts`).
+It branches before the `EBIRD_API_KEY` guard (no eBird call) but still requires
+`DATABASE_URL`. The Healthchecks.io heartbeat fires only on
+`status === 'delivered'`, not on `queued` (`src/cli.ts:160-213`).
+
+### Environment
+
+| Var | Used by | Notes |
+| --- | --- | --- |
+| `EBIRD_API_KEY` | all ingest kinds | enforced uniformly across the shared image; not strictly needed by DB-only kinds |
+| `DATABASE_URL` | all DB kinds | Cloud SQL Postgres 16 (Auth Proxy) in production |
+| `OBSERVATIONS_RETENTION_DAYS` | `prune` | positive integer; overrides the 14-day default |
+| `CACHE_WARM_BASE_URL` | `cache-warm` | defaults to `https://api.bird-maps.com` |
+| `SENDGRID_API_KEY`, `DIGEST_EMAIL_RECIPIENT`, `DIGEST_FROM_ADDRESS` | `digest` | from address defaults to `digest@bird-maps.com` |
+| `HEALTHCHECKS_URL_<KIND>` | per-kind heartbeat | e.g. `HEALTHCHECKS_URL_RECENT`. Ingest kinds ping on success/partial, never on failure (`src/cli.ts:399-405`). Two kinds deviate: `digest` pings only on `status === 'delivered'`, not on `queued` (`src/cli.ts:205-208`); `cache-warm` always pings on completion, with no failure path (`src/cli.ts:147-157`). |
+
+### Deployment
+
+Built into the shared Docker image and run as five Cloud Run v2 Jobs
+(`bird-ingestor`, `bird-ingestor-photos`, `bird-ingestor-descriptions`,
+`bird-ingestor-prune`, `bird-digest-daily`), each triggered by Cloud Scheduler.
+The default `bird-ingestor` job (`args=["recent"]`) also serves `backfill`,
+`backfill-extended`, `hotspots`, `taxonomy`, and `cache-warm` via per-scheduler
+arg overrides. The per-state backfill fan-out adds **no** extra Cloud Run Jobs:
+it is a single `google_cloud_scheduler_job` with `for_each`
+(`backfill_per_state`, `infra/terraform/ingestor.tf:383-416`) whose members are
+named `bird-ingestor-backfill-<state>` and invoke the shared `bird-ingestor`
+job with `args=["backfill","--state=US-XX","--back=14"]`; these schedulers ship
+paused (`paused = true`). See `infra/terraform/ingestor.tf` and
+`infra/terraform/digest.tf`. Run exit codes: a runner `failure` sets
+`process.exitCode = 1` (Cloud Run marks the execution failed) without killing
+the pool-close; `partial` backfill is treated as success.
+
+### Related
+
+- Workspace dependency layer: `@bird-watch/db-client` (typed `pg` query layer),
+  `@bird-watch/shared-types` (wire/domain types, `CONUS_STATE_CODES`).
+- Repo conventions, context7 libraries, and the architecture spec: see the repo
+  root `CLAUDE.md`.

--- a/services/read-api/README.md
+++ b/services/read-api/README.md
@@ -1,17 +1,23 @@
 # read-api
 
 Hono-based HTTP service exposing read-only endpoints for the bird-maps.com
-frontend. Platform-agnostic by design — the app is exported from `src/app.ts`
-and adapted by `src/index.ts` (Cloud Run / node) and `src/local.ts` (local
-dev). Cloud-specific code must stay out of `app.ts`.
+frontend. Platform-agnostic by design — `createApp(deps)` is exported from
+`src/app.ts`. `src/local.ts` is the platform entry point: it wires
+`@hono/node-server` (`serve({ fetch: app.fetch, port })`) and is both the
+local-dev command (`npm run dev` → `tsx src/local.ts`) and the production
+Cloud Run command (Dockerfile `CMD ["node", "services/read-api/dist/local.js"]`).
+`src/index.ts` is the package entry that re-exports `createApp` and
+`cacheControlFor` for consumers — it is not an adapter. Cloud-specific code
+must stay out of `app.ts`.
 
 ## Audience-protection rate limit (issue #596)
 
-National expansion is committed at Hacker News scale (~200x audience
-multiplier). Without rate limiting, a single viral burst clips Cloud Run
-autoscale into the Neon connection-pool ceiling and produces both 503s and a
-surprise GCP bill. The rate limit caps cost at a known, configurable rate
-instead of whatever Reddit decides today.
+National expansion (live since #669) runs at Hacker-News-scale spike risk
+(~200x audience multiplier). Without rate limiting, a single viral burst clips
+Cloud Run autoscale into the Cloud SQL connection-pool ceiling (Postgres 16 via
+the Auth Proxy) and produces both 503s and a surprise GCP bill. The rate limit
+caps cost at a known, configurable rate instead of whatever Reddit decides
+today.
 
 Three composing layers:
 
@@ -21,8 +27,8 @@ Three composing layers:
 | 2 | Cloudflare WAF managed challenge (manual — see `rate-limit.tf` MANUAL note) | Broad scraper/bot signature defense via free-tier Bot Fight Mode + medium security level. |
 | 3 | Hono token-bucket middleware (`src/rate-limit.ts`) | Defense in depth: catches direct `*.a.run.app` hits that bypass Cloudflare. |
 
-Layer 3 is **in-memory per Cloud Run instance** — no Redis, no extra Neon
-pressure. Across N instances an attacker gets up to N × `burst` tokens; that
+Layer 3 is **in-memory per Cloud Run instance** — no Redis, no extra Cloud SQL
+DB-pool pressure. Across N instances an attacker gets up to N × `burst` tokens; that
 surplus is bounded and known, and Layer 1 is the global ceiling. The
 middleware exists to prevent a single instance from exhausting its DB pool
 when Cloudflare is bypassed.


### PR DESCRIPTION
## Diagrams

The system topology the docs now describe (the shape the root README, infra, and the
new service READMEs were realigned to):

```mermaid
graph TD
  subgraph ext[External sources]
    eBird; Phylopic; iNat[iNaturalist]; Wiki[Wikipedia]
  end
  subgraph gcp[GCP]
    Ing[Ingestor<br/>Cloud Run Jobs + Scheduler]
    RA[read-api<br/>Cloud Run Service]
    AA[admin-api<br/>Cloud Run Service · bearer-auth]
    SQL[(Cloud SQL<br/>Postgres 16 + PostGIS)]
    GCS[(GCS Parquet archive)]
  end
  subgraph cf[Cloudflare]
    Pages[Pages · React/MapLibre frontend]
    R2[(R2 · silhouettes + photos)]
    WK[silhouette + photo Workers]
  end
  eBird --> Ing
  iNat --> Ing
  Wiki --> Ing
  Phylopic --> Ing
  Ing --> SQL
  Ing --> GCS
  RA --> SQL
  Pages --> RA
  AA --> R2
  AA --> SQL
  R2 --> WK
```

## Summary

- The root `README.md` was **153 commits stale** (last touched 2026-05-14) and predated the going-national flip, the **Neon → Cloud SQL Postgres 16** migration, the **admin-api** service, and the **map-first re-architecture (#761)** — every section actively misdescribed the live system (one section's setup steps told a new contributor to create a Neon account that no longer exists).
- This realigns the public-facing docs to **verified** reality: a near-total root README rewrite, surgical patches to `infra/` and `read-api`, and **new READMEs for the two services that shipped undocumented** (`admin-api`, `ingestor`) plus thin `frontend`/`db-client` pointers.
- Adds a `SECURITY.md` (GitHub private vulnerability reporting, now enabled on the repo) — surfaced by a public-repo security review, since the `admin-api` write path is now publicly documented.

## Screenshots

N/A — not UI. Documentation only; no visible UI, components, or `className`s changed (`frontend/README.md` is a doc file).

- [x] N/A — no new/renamed `className` in this PR
- [x] N/A — not UI (no viewport QA applicable)

## Test plan

- [x] **Doc accuracy** — every factual claim is `file:line`-grounded against the live code, reconstructed reality-first (not paraphrased from the stale doc), and **adversarially verified** (27 candidate drifts → 25 confirmed; 2 false positives dropped). The authoring pass's 7 hallucinated facts were caught by a fact-check stage and repaired against source.
- [x] **Public-repo security review** — per-doc + holistic audit: `clear-to-review`, 0 critical blockers, no secret or internal-identifier leakage; the one connection string is a localhost dev value. GitHub private vulnerability reporting enabled so the `SECURITY.md` channel is live.
- [ ] N/A — `npm run typecheck && npm run test`: documentation only, no source or tests changed (the required `test`/`lint`/`build`/`e2e` checks will confirm green).
- [ ] N/A — new unit/integration/e2e tests: no behavior changed.
- [ ] N/A — `npm run build`: no source changed.
- [ ] N/A — Playwright MCP smoke: not UI.

## Plan reference

Out of plan — documentation-drift sweep: README + per-workspace docs realigned to post-launch reality (national/CONUS, Cloud SQL, admin-api, map-first #761), plus a public-repo `SECURITY.md` surfaced by the accompanying security review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
