### PR TITLE
fix(frontend): rework legend rows + unify detail-surface gutter

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -599,7 +599,25 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   max-width: 760px;
   margin-inline: auto;
 }
-.species-detail-body { margin-top: var(--space-sm); }
+/* Shared by the desktop rail, the desktop modal, and the mobile sheet — they
+   all wrap <SpeciesDetailSurface>, which renders this body. One horizontal
+   gutter (16px) is applied here so EVERY text block (title, sci-name, family,
+   description, map-area banner) shares the same inset; previously only the
+   description carried padding while the title/banner sat flush at the edge. */
+.species-detail-body {
+  padding-inline: var(--space-lg);
+  padding-bottom: var(--space-lg);
+}
+/* The masthead photo (and its silhouette fallback) is a full-bleed hero:
+   cancel the gutter so it spans edge-to-edge. The card's own border-radius +
+   overflow clip rounds the photo's top corners; --photo-radius:0 squares the
+   inner <img>/skeleton so no rounded corners show inside the squared frame. */
+.species-detail-body > .photo {
+  --photo-radius: 0;
+  margin-inline: calc(-1 * var(--space-lg));
+  width: calc(100% + 2 * var(--space-lg));
+  margin-bottom: var(--space-md);
+}
 /* Photo / silhouette visual (#327 task-10). The photo renders at full
    container width capped at 480px so it stays usable on 1440×900 desktop
    without ballooning past the surface's 760px content cap. The silhouette
@@ -866,11 +884,14 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   z-index: var(--z-overlay);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
-  border-radius: 6px;
+  /* Adopt the floating-card geometry contract (spec §2.1, #761 #803): cards
+     round at --card-radius (12px) and the bottom-left legend caps at
+     --card-maxw-legend (280px) — replaces the pre-contract 6px / 240px. */
+  border-radius: var(--card-radius);
   box-shadow: var(--shadow-listbox);
   font-size: var(--type-sm);
   color: var(--color-text-strong);
-  max-width: 240px;
+  max-width: var(--card-maxw-legend);
 }
 .family-legend-toggle {
   display: flex;
@@ -880,12 +901,21 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   appearance: none;
   background: transparent;
   border: none;
-  padding: var(--space-sm) var(--space-md);
+  /* 12px 16px gutter — the title aligns with the entry icons below (which sit
+     at 8px list + 8px entry = 16px from the card edge). */
+  padding: var(--space-md) var(--space-lg);
   font: inherit;
   color: inherit;
   cursor: pointer;
   text-align: left;
-  border-radius: 6px;
+  border-radius: var(--card-radius);
+}
+/* Square the toggle's bottom corners only when an entries list actually
+   follows it, so header + list read as one continuous card. :has() tracks the
+   real presence of entries — correct for expanded-but-empty and
+   force-collapsed states without needing a JS-driven class. */
+.family-legend-toggle:has(+ .family-legend-entries) {
+  border-radius: var(--card-radius) var(--card-radius) 0 0;
 }
 .family-legend-toggle:hover {
   background: var(--color-bg-hover);
@@ -905,13 +935,14 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 .family-legend-entries {
   list-style: none;
   margin: 0;
-  padding: var(--space-xs) var(--space-xs) var(--space-sm) var(--space-xs);
+  padding: var(--space-xs) var(--space-sm) var(--space-sm);
   display: grid;
   grid-template-columns: 1fr;
   gap: 2px;
   max-height: 400px;
   overflow-y: auto;
   border-top: 1px solid var(--color-border-subtle);
+  border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
 .family-legend-entry-item {
   margin: 0;
@@ -920,19 +951,36 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 .family-legend-entry {
   display: flex;
   align-items: center;
-  gap: 6px;
+  /* 12px between the silhouette and the label; 4px block padding around a
+     28px icon yields the even 36px row height. The 8px inline padding adds to
+     the list's 8px to land the icon on the same 16px gutter as the header. */
+  gap: var(--space-md);
   width: 100%;
   appearance: none;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 4px 6px;
+  border-radius: var(--card-radius-inner);
+  padding: var(--space-xs) var(--space-sm);
   font: inherit;
-  font-size: var(--type-xs);
+  font-size: var(--type-sm);
   color: var(--color-text-strong);
   cursor: pointer;
   text-align: left;
-  min-height: 32px;
+  min-height: 36px;
+}
+/* The thumb silhouette renders at 44px in the ds primitive, which dwarfs the
+   13px label and overflows the row. The legend is the only consumer of
+   layout="thumb", so scope it down to a balanced 28px here (covers both the
+   inline-<svg> and the CDN mask-<div> render paths). flex:0 0 auto keeps the
+   glyph from squishing when a long family label fills the row. */
+.family-legend-entry .family-silhouette,
+.family-legend-entry .family-silhouette-img {
+  flex: 0 0 auto;
+}
+.family-legend-entry .family-silhouette--thumb svg,
+.family-legend-entry .family-silhouette-img.family-silhouette--thumb {
+  width: 28px;
+  height: 28px;
 }
 .family-legend-entry:hover {
   background: var(--color-bg-tint);
@@ -1469,7 +1517,10 @@ aside.species-detail-rail .species-detail-rail-close {
    - .species-detail-description-credit: muted small meta paragraph matching
      the freshness/attribution typographic tier throughout the sheet. */
 .species-detail-description {
-  padding: var(--space-md) var(--space-lg);
+  /* Horizontal inset now comes from .species-detail-body's shared gutter;
+     keep only the vertical rhythm so the wiki prose isn't double-indented. */
+  padding-block: var(--space-md);
+  padding-inline: 0;
   font-size: var(--type-sm);
   line-height: 1.6;
   color: var(--color-text-body);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -937,7 +937,16 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   margin: 0;
   padding: var(--space-xs) var(--space-sm) var(--space-sm);
   display: grid;
-  grid-template-columns: 1fr;
+  /* minmax(0, 1fr) — NOT 1fr. A bare 1fr track has an implicit auto
+     minimum, so the row's intrinsic width (icon + gap + nowrap label +
+     count) lets the track exceed the shrink-to-fit card and pushes the
+     flex-shrink:0 count past the card's right edge, where overflow-y:auto
+     clips it. Capping the min to 0 keeps the track within the card so the
+     label ellipsis absorbs the slack and the count keeps its 16px gutter.
+     (overflow-y:auto already shrinks the content box when a classic
+     scrollbar is present, so the count tracks inside it — no extra gutter
+     reservation needed.) */
+  grid-template-columns: minmax(0, 1fr);
   gap: 2px;
   max-height: 400px;
   overflow-y: auto;


### PR DESCRIPTION


## Diagrams

```mermaid
flowchart TB
    rail["desktop Rail (live)"]
    sheet["mobile Sheet (live)"]
    modal["desktop Modal (WIP — CSS held for the migration PR)"]

    subgraph shared["SpeciesDetailSurface → .species-detail-body — NEW: one shared 16px gutter"]
      photo["masthead photo — bleeds full-width as a hero"]
      title["title / sci-name / family — were flush at the edge, now share the gutter"]
      desc["description — previously the ONLY padded block"]
      banner["map-area banner — was edge-to-edge, now an inset card"]
    end

    rail --> shared
    sheet --> shared
    modal -.-> shared

    legend["Family legend (independent):<br/>44px→28px icon · 11px→13px label · 32→36px rows<br/>6px→12px radius · 240→280px · one 16px gutter"]
```

## Summary

- **Why:** the bottom-left family legend rendered a 44px silhouette next to 11px text in 32px-min rows, so the glyph overflowed the row (loose rhythm) and dwarfed the label; separately, the shared detail surface padded only its description block, leaving the title/sci-name/map-area banner flush against the card edge.
- **Legend:** rebalanced to a 28px icon, 13px label, even 36px rows, and a single 16px gutter; brought the card onto the floating-card token contract (`--card-radius` 12px, `--card-maxw-legend` 280px). The 28px override is scoped to `.family-legend-entry` — the legend is the only consumer of `layout="thumb"`.
- **Detail surface:** moved one 16px gutter onto `.species-detail-body` so every text block shares it, and let the masthead photo bleed full-width as a hero. Fixes the live desktop **Rail** and mobile **Sheet** consistently.
- The desktop `SpeciesDetailModal` CSS (the third surface that shares this body) is intentionally **held back** — that component is unwired WIP and would be dead/unreproducible CSS here; it lands with the Rail→Modal migration.

## Screenshots

**Family legend** — map view, legend expanded, 5 canonical viewports × 2 themes:

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![legend 390 light](https://github.com/user-attachments/assets/1456b1ed-01b2-4f26-80f8-2cb1c4341dac) | ![legend 390 dark](https://github.com/user-attachments/assets/1ab37b1f-c00c-49ba-92dd-cb7e79e55d27) |
| 768×1024 (tablet) | ![legend 768 light](https://github.com/user-attachments/assets/0ac385ca-3539-4f43-97c1-d364cc597982) | ![legend 768 dark](https://github.com/user-attachments/assets/02a13e6c-6160-42d8-964a-1f6a184ca816) |
| 1024×768 | ![legend 1024 light](https://github.com/user-attachments/assets/51632157-d997-4832-a754-cc3ec9f68815) | ![legend 1024 dark](https://github.com/user-attachments/assets/2836de79-88f7-4a7a-b077-689aa6728b26) |
| 1440×900 (desktop) | ![legend 1440 light](https://github.com/user-attachments/assets/9df61e3e-d5aa-41b5-9831-24b5e4a94afc) | ![legend 1440 dark](https://github.com/user-attachments/assets/6f1c7514-0b19-4014-a88a-889edee0e50f) |
| 1920×1080 (wide) | ![legend 1920 light](https://github.com/user-attachments/assets/377cdd2d-217f-4ca2-887d-711bce0cf5c6) | ![legend 1920 dark](https://github.com/user-attachments/assets/17f139cd-bca6-4c34-a919-004330e816ee) |

**Detail surface** — the shared `.species-detail-body` gutter + full-bleed hero, on the two live presentations (desktop Rail, mobile Sheet):

| Surface | Light | Dark |
|---|---|---|
| Desktop Rail (1440×900) | ![rail light](https://github.com/user-attachments/assets/47f19e3e-67c3-4ab4-a5e0-85aaa1f04892) | ![rail dark](https://github.com/user-attachments/assets/c8dfb5b3-0381-49a1-ab9e-557773c6fa71) |
| Mobile Sheet (390×844, full snap) | ![sheet light](https://github.com/user-attachments/assets/8dd861ca-049a-4fe6-9b55-695a7130d1ed) | ![sheet dark](https://github.com/user-attachments/assets/a42d6bf8-51f0-4a49-a991-e077a693e074) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule (no new classNames — only restyled existing `.family-legend-*`, `.species-detail-body`, `.species-detail-description`; `scripts/check-orphan-classnames.sh` → PASS).
- [x] Multi-viewport design QA: 14 `user-attachments` URLs (legend 5×2 = 10, plus 4 detail). Legend captures are post-fix (count pills fully inside the card after `minmax(0,1fr)`). The desktop `SpeciesDetailModal` is not reproducible here (CSS held back, component unwired), so it is intentionally not screenshotted.

## Test plan

- [x] `tsc -b` (via `npm run build`) + `npm run test` (legend + 4 detail-surface suites) — **76/76 green**
- [x] No new unit/integration tests — pure CSS, no behavior change
- [x] No new Playwright e2e spec — no user-visible behavior change (existing legend/detail specs unaffected)
- [x] `npm run build` — clean production build
- [x] (UI) Playwright MCP smoke at 390×844, 768×1024, 1024×768, 1440×900, 1920×1080 in light + dark (dev proxied to the prod API for real data): legend + Rail + Sheet driven; computed-style probes confirm 28px icon / 16px gutter / 12px radius / full-bleed photo / banner inset 16px; `browser_console_messages` shows no errors or warnings from these changes (only pre-existing MapLibre basemap noise)

## Plan reference

Out of plan — visual padding/consistency fix flagged from screenshots of the live legend and the in-progress detail modal. Related: floating-card four-corner anchor contract (#761 #803).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
