### PR TITLE
chore(frontend): make .sheet-scroll hero containment explicit (overflow-x: clip)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1335,6 +1335,10 @@ aside.species-detail-rail .species-detail-rail-close {
   touch-action: pan-y;
   flex: 1;
   overflow-y: auto;
+  /* The detail body's full-bleed hero photo bleeds ±16px; contain it
+     explicitly rather than relying on overflow-y:auto implicitly promoting
+     overflow-x. (julianken-bot suggestion, PR #820.) */
+  overflow-x: clip;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
## Diagrams

N/A — single-line CSS hardening, not diagrammable.

## Summary

- The mobile detail-sheet's `.sheet-scroll` container relied on `overflow-y: auto` *implicitly* promoting the computed `overflow-x` to `auto`, which is what was containing the detail body's full-bleed hero photo (±16px negative-margin bleed). That horizontal containment was incidental, not declared.
- This adds an explicit `overflow-x: clip;` so the intent is legible and robust to future `overflow-y` changes. Zero visual change — it formalizes behavior that already happens.
- Follow-up hardening from the `julianken-bot` review on PR #820.

## Screenshots

N/A — CSS robustness only; no visual change (overflow-x: clip formalizes the existing implicit overflow-x:auto containment of the hero photo, renders identically). Existing detail-sheet e2e specs cover the surface.

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, no new classNames; this is a single declaration added to an existing rule.
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). — N/A — not UI (no visual change).

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — clean production build (`✓ built in 213ms`; only the pre-existing chunk-size advisory warning, no errors).
- [x] Single-declaration CSS hardening with zero visual change — no new unit/integration tests needed; existing detail-sheet e2e specs cover the surface.
- [ ] New unit / integration tests added (if behavior changed) — N/A, no behavior change.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible change.
- [ ] (UI only) Playwright MCP smoke — N/A, no visual change; `overflow-x: clip` renders identically to the existing implicit `overflow-x: auto` containment.

## Plan reference

Out of plan — follow-up hardening from the PR #820 bot review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)