### PR TITLE
fix(monitoring): restore DISTRIBUTION+bucket_options on archived_* metrics + dashboard aligner

### DIFF
--- a/infra/terraform/monitoring-dashboard.tf
+++ b/infra/terraform/monitoring-dashboard.tf
@@ -340,7 +340,7 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
                     filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-row-count\" AND resource.type=\"cloud_run_job\""
                     aggregation = {
                       alignmentPeriod    = "86400s" # daily buckets
-                      perSeriesAligner   = "ALIGN_SUM"
+                      perSeriesAligner   = "ALIGN_PERCENTILE_50"
                       crossSeriesReducer = "REDUCE_SUM"
                     }
                   }
@@ -369,7 +369,7 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
                     filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-bytes-uploaded\" AND resource.type=\"cloud_run_job\""
                     aggregation = {
                       alignmentPeriod    = "86400s"
-                      perSeriesAligner   = "ALIGN_SUM"
+                      perSeriesAligner   = "ALIGN_PERCENTILE_50"
                       crossSeriesReducer = "REDUCE_SUM"
                     }
                   }
@@ -403,7 +403,7 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
                       filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-row-count\" AND resource.type=\"cloud_run_job\""
                       aggregation = {
                         alignmentPeriod    = "86400s"
-                        perSeriesAligner   = "ALIGN_SUM"
+                        perSeriesAligner   = "ALIGN_PERCENTILE_50"
                         crossSeriesReducer = "REDUCE_SUM"
                       }
                     }
@@ -417,7 +417,7 @@ resource "google_monitoring_dashboard" "bird_watch_overview" {
                       filter = "metric.type=\"logging.googleapis.com/user/bird-ingest-archived-deleted-count\" AND resource.type=\"cloud_run_job\""
                       aggregation = {
                         alignmentPeriod    = "86400s"
-                        perSeriesAligner   = "ALIGN_SUM"
+                        perSeriesAligner   = "ALIGN_PERCENTILE_50"
                         crossSeriesReducer = "REDUCE_SUM"
                       }
                     }

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -464,15 +464,6 @@ resource "google_project_iam_audit_config" "monitoring_data_read" {
 # in each filter drop malformed entries during a future emit-shape
 # regression rather than landing garbage into the metric stream — matches
 # the pattern in `bird-ingest-run-completed` above.
-#
-# Type choice: DELTA INT64 (not DISTRIBUTION) so the dashboard's per-day
-# ALIGN_SUM aggregation works. Sums of distributions are undefined in GCP
-# Monitoring — DISTRIBUTION-typed metrics under ALIGN_SUM render "0 time
-# series" on xyChart widgets. INT64/DELTA matches `bird-container-crash`
-# and `bird-watch-dashboard-opened` above; the value_extractor pulls the
-# scalar emit field straight onto the time series. The PR-697 bot review
-# flagged this exact concern as a narrow non-blocking risk; this PR
-# realizes the follow-up.
 
 resource "google_logging_metric" "archived_row_count" {
   name = "bird-ingest-archived-row-count"
@@ -484,11 +475,18 @@ resource "google_logging_metric" "archived_row_count" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "INT64"
+    value_type   = "DISTRIBUTION"
     unit         = "1"
     display_name = "Observations archived per day (rowCount)"
   }
   value_extractor = "EXTRACT(jsonPayload.rowCount)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 1000 # row counts span 1k (AZ-only) → ~5M (national)
+    }
+  }
 }
 
 resource "google_logging_metric" "archived_bytes_uploaded" {
@@ -501,11 +499,18 @@ resource "google_logging_metric" "archived_bytes_uploaded" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "INT64"
+    value_type   = "DISTRIBUTION"
     unit         = "By"
     display_name = "Parquet bytes uploaded to GCS per day"
   }
   value_extractor = "EXTRACT(jsonPayload.bytesUploaded)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 100000 # ~100 KB scale spans 100 KB (AZ tiny day) → ~400 MB (national daily peak)
+    }
+  }
 }
 
 # Parity-check metric. The T2 invariant: archive-then-delete is atomic per
@@ -524,9 +529,16 @@ resource "google_logging_metric" "archived_deleted_count" {
   ])
   metric_descriptor {
     metric_kind  = "DELTA"
-    value_type   = "INT64"
+    value_type   = "DISTRIBUTION"
     unit         = "1"
     display_name = "Observations deleted per day post-archive (deletedCount)"
   }
   value_extractor = "EXTRACT(jsonPayload.deletedCount)"
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 32
+      growth_factor      = 2
+      scale              = 1000
+    }
+  }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph Code["infra/terraform (was drifted)"]
      M["archived_* log metrics<br/>value_type = INT64 + value_extractor<br/>(no bucket_options)"]
      D["4 archive dashboard tiles<br/>perSeriesAligner = ALIGN_SUM"]
    end
    subgraph Live["live GCP (bird-maps-prod)"]
      L["archived_* metrics<br/>valueType = DISTRIBUTION"]
    end

    M -- "terraform apply" --> X["GCP 400: INT64 + value_extractor invalid"]
    D -- "ALIGN_SUM on DISTRIBUTION" --> Z["tile renders '0 time series'"]

    M ==>|this PR| M2["value_type = DISTRIBUTION<br/>+ exponential_buckets"]
    D ==>|this PR| D2["perSeriesAligner = ALIGN_PERCENTILE_50"]
    M2 -. "now matches" .-> L
    M2 --> OK["terraform plan = no-op (no recreate, no data loss)"]
    D2 --> OK2["tiles render real series"]
```

## Summary

- The three archive log-based metrics declared `value_type = "INT64"` alongside a `value_extractor` and no `bucket_options` — a combination GCP rejects with a 400 on `terraform apply`, blocking the gated apply (#826). Live GCP already holds these as DISTRIBUTION (verified), so the code had drifted; switching the config to DISTRIBUTION + `exponential_buckets` makes code match reality and the plan a **no-op** (no delete/recreate, no data loss).
- The four archive dashboard tiles aggregated those metrics with `perSeriesAligner = "ALIGN_SUM"`, which is undefined for DISTRIBUTION and renders "0 time series". Switched to `ALIGN_PERCENTILE_50` (at one-sample/day volume, mean/median/sum collapse to the same value). The two legitimate `ALIGN_SUM` tiles on INT64 metrics (`bird-ingest-run-completed`, `bird-container-crash`) are untouched.
- Deletes the stale comment block that justified the broken INT64 choice; no replacement added (matches the verified diff on closed PR #704). This diff is byte-identical to #704's.

## Screenshots

N/A — not UI

## Test plan

- [x] `terraform init -backend=false` — succeeded (google v7.34.0, cloudflare v4.52.7)
- [x] `terraform validate` — "Success! The configuration is valid."
- [x] `terraform fmt -check monitoring.tf monitoring-dashboard.tf` — clean (exit 0)
- [ ] `terraform plan` — NOT run: no GCP credentials in this environment, and must not touch prod. Expected to be a no-op on the three metrics per the live-state verification recorded on #831 (live GCP is already DISTRIBUTION). A creds-holder should confirm a no-op plan before apply.
- [x] Verified the 2 legitimate `ALIGN_SUM` tiles (`bird-ingest-run-completed` L120, `bird-container-crash` L285) remain unchanged; only the 4 archive/DISTRIBUTION tiles flipped to `ALIGN_PERCENTILE_50`.
- [x] Verified no remaining comment in `monitoring.tf` asserts INT64/ALIGN_SUM is the correct choice.

## Plan reference

Out of plan — fixes R2 from the ops-forensics investigation (closes #831). Reuses the verified diff from closed PR #704 (branch `fix/dashboard-aggregation-distribution-compatible`, HEAD cf5ab7e).

Closes #831

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
