### PR TITLE
fix(frontend): add a submit button to ZipInput (iOS-submittable ZIP) (#827)

### DIFF
--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -28,6 +28,9 @@ export class AppPage {
   readonly chooser: Locator;
   /** ZIP `<input>` inside the chooser (`aria-label='ZIP code'`, owned by ZipInput). */
   readonly chooserZipInput: Locator;
+  /** The chooser ZIP-path "Go" submit button (#827 — scoped to the ZipInput
+   *  `role="search"` form so it doesn't collide with the State row's "Go"). */
+  readonly chooserZipGo: Locator;
   /** State `<select>` inside the chooser (`aria-label='State'` via its `<label>`). */
   readonly chooserStateSelect: Locator;
   /** The chooser state-path "Go" submit button. */
@@ -124,8 +127,18 @@ export class AppPage {
     // Chooser (#742) — region accessible name "Choose where to look at birds".
     this.chooser = page.getByRole('region', { name: 'Choose where to look at birds' });
     this.chooserZipInput = this.chooser.getByLabel('ZIP code', { exact: true });
+    // #827: the ZipInput form is the `role="search"` landmark inside the chooser;
+    // its "Go" submit lives there. Scoping to that form disambiguates it from the
+    // State row's "Go" (both read "Go" after the ZIP submit button was added).
+    const chooserZipForm = this.chooser.getByRole('search');
+    this.chooserZipGo = chooserZipForm.getByRole('button', { name: 'Go', exact: true });
     this.chooserStateSelect = this.chooser.getByLabel('State', { exact: true });
-    this.chooserStateGo = this.chooser.getByRole('button', { name: 'Go', exact: true });
+    // The State "Go" is the chooser's "Go" that is NOT inside the ZIP search form.
+    // Scope it to the State <select>'s ancestor <form> so it never matches the
+    // ZIP "Go" (#827).
+    this.chooserStateGo = this.chooser
+      .locator('form', { has: page.getByLabel('State', { exact: true }) })
+      .getByRole('button', { name: 'Go', exact: true });
     this.chooserWholeUs = this.chooser.getByRole('button', { name: 'Explore the whole US map' });
     this.chooserZipError = this.chooser.getByText('Enter a 5-digit ZIP', { exact: true });
     this.chooserZipStatus = this.chooser.getByRole('status');
@@ -267,12 +280,14 @@ export class AppPage {
   }
 
   /**
-   * Enter a ZIP into the chooser ZIP input and submit (the form submits on
-   * Enter; `role=search` form, no separate Go button for the ZIP path). Used by
-   * the D6 ZIP round-trip / empty-region / unknown / malformed cases.
+   * Enter a ZIP into the chooser ZIP input and submit via the "Go" button
+   * (#827 — the ZipInput form now has a visible submit button, the iOS-safe
+   * pointer path; the keyboard Enter path still works but the button is the
+   * canonical affordance, so the e2e round-trip drives it). Used by the D6
+   * ZIP round-trip / empty-region / unknown / malformed cases.
    */
   async submitChooserZip(zip: string): Promise<void> {
     await this.chooserZipInput.fill(zip);
-    await this.chooserZipInput.press('Enter');
+    await this.chooserZipGo.click();
   }
 }

--- a/frontend/e2e/zip-scope.spec.ts
+++ b/frontend/e2e/zip-scope.spec.ts
@@ -191,18 +191,24 @@ test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', ()
     await app.gotoRaw('');
     await expect(app.chooser).toBeVisible();
 
-    // A non-5-digit value is malformed. The ZIP `<input>` carries
-    // `pattern="[0-9]{5}"`, so the browser's native HTML5 constraint validation
-    // intercepts the Enter-submit on a malformed value — the value is reported
-    // invalid (`patternMismatch`) and the submit is blocked BEFORE
-    // `lookupZip`/`loadZipIndex` is reached. This is the production-faithful
-    // malformed UX in a real browser (the React "Enter a 5-digit ZIP" hint and
-    // the JS `/^\d{5}$/` gate are the jsdom-unit-test path; in-browser the
-    // native gate fires first — either way the load-bearing D3 contract holds:
-    // a malformed submit triggers NO ZIP-index lookup fetch).
+    // A non-5-digit value is malformed. #827 added a submit `<button>` to the
+    // ZipInput form, which would normally let the browser's native HTML5
+    // constraint validation (`pattern="[0-9]{5}"`) block the submit on a
+    // malformed value — but that would make a malformed click a silent no-op
+    // (a native bubble, never our styled hint), breaking the never-silent
+    // contract. So the form carries `noValidate`: native blocking is off, and
+    // the component's own JS gate (`/^\d{5}$/`) owns the malformed path,
+    // rendering the inline ".zip-input__error" hint. This submits via the "Go"
+    // button (submitChooserZip clicks it) — the iOS-safe pointer path.
     await app.submitChooserZip('123');
 
-    // The native validity flags the value as a pattern mismatch (malformed).
+    // The never-silent contract via the button: the inline "Enter a 5-digit
+    // ZIP" hint is VISIBLE (the AC — a malformed submit is never a silent
+    // no-op). This is now the in-browser path too (was jsdom-only before #827).
+    await expect(app.chooserZipError).toBeVisible();
+
+    // `noValidate` suppresses native *blocking*, not validity *computation*:
+    // the input still reports `patternMismatch` via the validity API.
     const validity = await app.chooserZipInput.evaluate(
       (el: HTMLInputElement) => ({ valid: el.validity.valid, patternMismatch: el.validity.patternMismatch }),
     );
@@ -218,9 +224,8 @@ test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', ()
     // D3: the malformed SUBMIT triggers no lookup fetch. `loadZipIndex` warms
     // lazily on FOCUS (an intentional pre-fetch, single-flight memoized), so a
     // focused-then-malformed-submit yields at MOST the one focus warm and never
-    // a per-submit lookup — the regex/native gate short-circuits before
-    // `lookupZip`. (Were the gate after the fetch, a malformed submit would add
-    // a second request.)
+    // a per-submit lookup — the JS regex gate short-circuits before `lookupZip`.
+    // (Were the gate after the fetch, a malformed submit would add a request.)
     await page.waitForTimeout(400);
     expect(zipIndexRequests.length).toBeLessThanOrEqual(1);
     // The input value is retained (never a silent clear).

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1251,7 +1251,14 @@ describe('#740 (C6): scope wiring end-to-end', () => {
       expect(screen.getByRole('option', { name: 'Arizona' })).toBeInTheDocument();
     });
     await userEvent.selectOptions(screen.getByLabelText('State'), 'US-AZ');
-    await userEvent.click(screen.getByRole('button', { name: /^Go$/i }));
+    // #827: the chooser now has TWO "Go" buttons (State + ZIP). Scope to the
+    // State <select>'s own <form> so the click targets the State Go, not the
+    // always-enabled ZIP Go in the sibling role="search" form.
+    {
+      const stateForm = screen.getByLabelText('State').closest('form');
+      if (!stateForm) throw new Error('State <select> is not inside a <form>');
+      await userEvent.click(within(stateForm).getByRole('button', { name: /^Go$/i }));
+    }
     expect(mockUrlState.set).toHaveBeenCalledWith({ scope: { kind: 'state', stateCode: 'US-AZ' } });
   });
 
@@ -1696,7 +1703,14 @@ describe('O9 (#781): scope-gated MapCanvas prefetch wiring', () => {
     });
     expect(mockPrefetchMapCanvas).not.toHaveBeenCalled();
     await userEvent.selectOptions(screen.getByLabelText('State'), 'US-AZ');
-    await userEvent.click(screen.getByRole('button', { name: /^Go$/i }));
+    // #827: the chooser now has TWO "Go" buttons (State + ZIP). Scope to the
+    // State <select>'s own <form> so the click targets the State Go, not the
+    // always-enabled ZIP Go in the sibling role="search" form.
+    {
+      const stateForm = screen.getByLabelText('State').closest('form');
+      if (!stateForm) throw new Error('State <select> is not inside a <form>');
+      await userEvent.click(within(stateForm).getByRole('button', { name: /^Go$/i }));
+    }
     expect(mockPrefetchMapCanvas).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/ScopeChooser.test.tsx
+++ b/frontend/src/components/ScopeChooser.test.tsx
@@ -40,6 +40,20 @@ function renderChooser(overrides: Partial<React.ComponentProps<typeof ScopeChoos
   return props;
 }
 
+/**
+ * The State-path "Go" submit button. #827 added a second "Go" (the ZipInput
+ * submit), so a bare `getByRole('button', { name: /go/i })` is now ambiguous.
+ * The State "Go" is the submit button inside the State `<select>`'s own
+ * `<form>` — scope to that form to select it unambiguously. (The ZIP "Go" lives
+ * in the sibling `role="search"` form and is always enabled.)
+ */
+function getStateGo(): HTMLElement {
+  const stateSelect = screen.getByRole('combobox', { name: /state/i });
+  const stateForm = stateSelect.closest('form');
+  if (!stateForm) throw new Error('State <select> is not inside a <form>');
+  return within(stateForm).getByRole('button', { name: /go/i });
+}
+
 describe('<ScopeChooser>', () => {
   beforeEach(() => {
     mockLoadZipIndex.mockReset().mockResolvedValue(undefined);
@@ -79,7 +93,7 @@ describe('<ScopeChooser>', () => {
 
   it('state "Go" is disabled until a state is selected, then emits onPickState once with the chosen code', async () => {
     const { onPickState } = renderChooser();
-    const goButton = screen.getByRole('button', { name: /go/i });
+    const goButton = getStateGo();
     expect(goButton).toBeDisabled();
 
     await userEvent.selectOptions(
@@ -93,9 +107,42 @@ describe('<ScopeChooser>', () => {
     expect(onPickState).toHaveBeenCalledWith('US-CA');
   });
 
+  it('the ZIP path has its own always-enabled "Go" (#827) — matches the State row, never disabled', () => {
+    renderChooser();
+    // Two distinct "Go" buttons now: the State submit (getStateGo) and the ZIP
+    // submit (inside the role="search" ZipInput form). The ZIP one is always
+    // enabled — submitting a malformed value still surfaces the inline hint.
+    const search = screen.getByRole('search');
+    const zipGo = within(search).getByRole('button', { name: /^go$/i });
+    expect(zipGo).toBeEnabled();
+    expect(zipGo).toHaveAttribute('type', 'submit');
+    // Sanity: it is NOT the State Go (which starts disabled).
+    expect(zipGo).not.toBe(getStateGo());
+  });
+
+  it('forwards a resolved ZIP via the ZIP "Go" button click (#827 — pointer path)', async () => {
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    const { onResolve } = renderChooser();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /ZIP code/i }), '85701');
+    const search = screen.getByRole('search');
+    await userEvent.click(within(search).getByRole('button', { name: /^go$/i }));
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith({
+      stateCode: 'US-AZ',
+      center: [-110.971, 32.21696],
+      zoom: ZIP_FLYTO_ZOOM,
+    });
+  });
+
   it('does not emit onPickState for the empty placeholder selection', async () => {
     const { onPickState } = renderChooser();
-    const goButton = screen.getByRole('button', { name: /go/i });
+    const goButton = getStateGo();
     // Button stays disabled — clicking a disabled button is inert.
     await userEvent.click(goButton);
     expect(onPickState).not.toHaveBeenCalled();
@@ -134,8 +181,8 @@ describe('<ScopeChooser>', () => {
     const placeholder = within(select).getAllByRole('option')[0];
     expect(placeholder).toHaveValue('');
     expect(placeholder).toHaveTextContent(/loading/i);
-    // Go is disabled while loading too.
-    expect(screen.getByRole('button', { name: /go/i })).toBeDisabled();
+    // State Go is disabled while loading too.
+    expect(getStateGo()).toBeDisabled();
 
     // ZIP path stays fully usable: focusing warms the index (independent path).
     const input = screen.getByRole('textbox', { name: /ZIP code/i });

--- a/frontend/src/components/ZipInput.test.tsx
+++ b/frontend/src/components/ZipInput.test.tsx
@@ -30,6 +30,49 @@ describe('<ZipInput>', () => {
     expect(input).toHaveAttribute('maxLength', '5');
   });
 
+  it('renders a visible, always-enabled "Go" submit button (iOS numeric keypad has no Return key)', () => {
+    render(<ZipInput onResolve={vi.fn()} />);
+    const go = screen.getByRole('button', { name: /^Go$/i });
+    expect(go).toBeInTheDocument();
+    expect(go).toHaveAttribute('type', 'submit');
+    // Always-enabled: not gated on a 5-digit value, so a malformed submit still
+    // routes through handleSubmit and surfaces the inline hint (never silent).
+    expect(go).toBeEnabled();
+  });
+
+  it('clicking "Go" submits a resolved ZIP — pointer path, no Enter key (iOS-safe)', async () => {
+    mockLookupZip.mockResolvedValue({
+      zip: '85701',
+      center: [-110.971, 32.21696],
+      stateCode: 'US-AZ',
+    });
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /ZIP code/i }), '85701');
+    await userEvent.click(screen.getByRole('button', { name: /^Go$/i }));
+
+    expect(mockLookupZip).toHaveBeenCalledWith('85701');
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith({
+      stateCode: 'US-AZ',
+      center: [-110.971, 32.21696],
+      zoom: ZIP_FLYTO_ZOOM,
+    });
+  });
+
+  it('clicking "Go" with a malformed value shows the inline hint (never-silent contract via the button)', async () => {
+    const onResolve = vi.fn();
+    render(<ZipInput onResolve={onResolve} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /ZIP code/i }), '123');
+    await userEvent.click(screen.getByRole('button', { name: /^Go$/i }));
+
+    expect(screen.getByText(/5-digit ZIP/i)).toBeInTheDocument();
+    expect(mockLookupZip).not.toHaveBeenCalled();
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
   it('does NOT call loadZipIndex on mount — only on focus (lazy trigger)', async () => {
     render(<ZipInput onResolve={vi.fn()} />);
     expect(mockLoadZipIndex).not.toHaveBeenCalled();

--- a/frontend/src/components/ZipInput.tsx
+++ b/frontend/src/components/ZipInput.tsx
@@ -80,20 +80,42 @@ export function ZipInput({ onResolve }: ZipInputProps): React.JSX.Element {
   }
 
   return (
-    <form className="zip-input" onSubmit={handleSubmit} role="search">
-      <input
-        id={inputId}
-        className="zip-input__field"
-        type="text"
-        inputMode="numeric"
-        pattern="[0-9]{5}"
-        maxLength={5}
-        aria-label="ZIP code"
-        placeholder="ZIP"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onFocus={handleFocus}
-      />
+    // `noValidate`: with a submit `<button>` present, the browser would run
+    // HTML5 constraint validation on submit and BLOCK a malformed value
+    // (`pattern="[0-9]{5}"` → `patternMismatch`) before `handleSubmit` runs —
+    // which would make a malformed click/Enter a silent no-op (only a native
+    // bubble, never our styled inline hint), breaking the never-silent contract.
+    // The component owns its validation in JS (the `/^\d{5}$/` gate below) and
+    // renders its own inline hint, so we opt out of native blocking. `pattern`
+    // is kept for semantics + the `validity` API (asserted in zip-scope.spec).
+    <form className="zip-input" onSubmit={handleSubmit} role="search" noValidate>
+      {/* Field + [Go] share one horizontal row. The submit button gives the ZIP
+          a POINTER affordance and — critically — a way to submit on iOS, whose
+          numeric keypad (inputMode="numeric") has no Return/Go key, so the
+          implicit "Enter submits a one-input form" path is unreachable there.
+          The button is ALWAYS enabled (not gated on 5 digits): a malformed
+          click still routes through handleSubmit and surfaces the inline hint,
+          preserving the never-silent contract. The feedback <p> elements stay
+          OUTSIDE this row as block siblings (below) so the full-width
+          .zip-input__error box keeps its layout. */}
+      <div className="zip-input__row">
+        <input
+          id={inputId}
+          className="zip-input__field"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]{5}"
+          maxLength={5}
+          aria-label="ZIP code"
+          placeholder="ZIP"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onFocus={handleFocus}
+        />
+        <button type="submit" className="zip-input__submit">
+          Go
+        </button>
+      </div>
       {feedback.kind === 'malformed' && (
         <p className="zip-input__error">Enter a 5-digit ZIP</p>
       )}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1768,6 +1768,15 @@ aside.species-detail-rail .species-detail-rail-close {
   flex-direction: column;
   gap: var(--space-xs);
 }
+/* #827: field + [Go] share one horizontal row; the feedback <p> elements stay
+   block siblings of this row (below it, under the column .zip-input flow), so
+   the full-width .zip-input__error box keeps its layout. align-items:stretch
+   makes the button match the field's height. */
+.zip-input__row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: stretch;
+}
 .zip-input__field {
   padding: var(--space-sm) var(--space-md);
   font-size: var(--type-sm);
@@ -1776,11 +1785,33 @@ aside.species-detail-rail .species-detail-rail-close {
   border: 1px solid var(--color-border-ui);
   border-radius: 4px;
   /* A 5-digit ZIP needs little width; cap it so the field doesn't sprawl in
-     the wide on-map control or the landing chooser. */
-  inline-size: 100%;
+     the wide on-map control or the landing chooser. Inside the flex row it
+     grows to the cap then yields the rest to the [Go] button. */
+  flex: 1 1 auto;
+  min-inline-size: 0;
   max-inline-size: 8rem;
 }
 .zip-input__field:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+/* #827: the ZIP [Go] submit button. Mirrors the chooser State row's
+   .scope-chooser__btn (primary dark fill, white text) so the ZIP row matches
+   the State row directly below it. ALWAYS enabled — no :disabled rule — so a
+   malformed click still routes through handleSubmit and shows the inline hint
+   (never-silent contract). */
+.zip-input__submit {
+  flex: 0 0 auto;
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-white);
+  background: var(--color-text-strong);
+  border: 1px solid var(--color-text-strong);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.zip-input__submit:focus-visible {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1815,6 +1815,20 @@ aside.species-detail-rail .species-detail-rail-close {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
+/* #827 / dark-mode fix (PR #834): both Go buttons fill with --color-text-strong,
+   which inverts to near-white (#f5f7fb) in dark mode — so the white label
+   (--color-text-white #fff) would render ~1.07:1 on it (unreadable). The
+   approved Figma dark treatment is a LIGHT button with DARK text; flip the
+   label to --color-bg-surface (#1b2742 → 13.83:1 on the #f5f7fb fill, well past
+   AA). Covering BOTH selectors here is the single place the duplicated-to-match
+   buttons (#827 AC) take the dark fix once, so they can never drift apart in
+   dark mode. :not(:disabled) leaves .scope-chooser__btn:disabled (which sets its
+   own muted color at equal specificity) untouched regardless of source order;
+   .zip-input__submit is always enabled so the guard is a no-op there. */
+[data-theme="dark"] .zip-input__submit,
+[data-theme="dark"] .scope-chooser__btn:not(:disabled) {
+  color: var(--color-bg-surface);
+}
 .zip-input__status {
   margin: 0;
   font-size: var(--type-sm);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph form["form.zip-input (role=search, noValidate)"]
        subgraph row["div.zip-input__row (horizontal)"]
            field["input.zip-input__field<br/>inputMode=numeric"]
            go["button.zip-input__submit<br/>'Go' — ALWAYS enabled"]
        end
        fb["feedback p (block siblings, OUTSIDE the row):<br/>.zip-input__error / .zip-input__status"]
    end

    go -- "click (pointer / iOS-safe)" --> submit
    field -- "Enter (keyboard)" --> submit
    submit["handleSubmit — JS gate (5-digit regex)"]

    submit -->|"not 5 digits"| malformed["malformed: inline 'Enter a 5-digit ZIP'<br/>(no fetch; never silent)"]
    submit -->|"5 digits"| lookup["lookupZip(zip)"]
    lookup -->|"hit"| resolved["resolved: onResolve(scope)"]
    lookup -->|"null"| notrec["notRecognized: role=status (value kept)"]
    lookup -->|"throws"| fetcherr["fetchError: role=alert (pick a state)"]

    malformed -.renders.-> fb
    notrec -.renders.-> fb
    fetcherr -.renders.-> fb
```

The DOM tree is the load-bearing change: a new `div.zip-input__row` wraps the
field and the new always-enabled `[Go]` submit, while the feedback `<p>`
elements stay OUTSIDE that row as block siblings so the full-width
`.zip-input__error` box keeps its layout. Both the pointer (click `[Go]`) and
keyboard (Enter) paths funnel into the same `handleSubmit`, and the existing
four-outcome "never silent" contract is unchanged.

## Summary

- **Why:** `ZipInput` was a one-input `<form>` with no submit button, so
  submission rode on the browser's implicit "Enter submits a one-input form."
  On **iOS** the field is `inputMode="numeric"` — the number pad has **no
  Return/Go key** — so there was *no way to submit a ZIP at all* on the most
  common mobile browser. The landing chooser also looked inconsistent: the
  State row had a `[Go]`, the ZIP row above it did not.
- **Fix:** a visible, **always-enabled** `<button type="submit">Go</button>`
  inside `ZipInput`'s own form, beside the field. One change fixes all three
  call sites (`ScopeControl`, `ScopeChooser`, dev `DsPreview`); the ZIP `[Go]`
  mirrors the chooser State row's `.scope-chooser__btn` so the two rows match.
- **`noValidate`:** once a submit button exists, native HTML5 constraint
  validation (`pattern="[0-9]{5}"`) would *block* a malformed submit before
  `handleSubmit` runs — a silent no-op (native bubble only, never the styled
  hint), breaking the never-silent contract. The component owns its validation
  in JS and renders its own inline hint, so the form opts out of native
  blocking. `pattern` is kept for semantics + the `validity` API.

## Screenshots

ZipInput on the landing chooser, all 5 canonical viewports × light + dark
(`data-theme`). The ZIP `[Go]` matches the State row's `[Go]` directly below
it.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="320" alt="390 light" src="https://github.com/user-attachments/assets/24fef8fa-1149-4b86-bd8a-e95c71151748" /> | <img width="320" alt="390 dark" src="https://github.com/user-attachments/assets/aede1d8d-87b8-4004-a083-67becad2c2cc" /> |
| 768×1024 (tablet) | <img width="320" alt="768 light" src="https://github.com/user-attachments/assets/143faa7b-d79f-4161-8733-dd7bdb71ee49" /> | <img width="320" alt="768 dark" src="https://github.com/user-attachments/assets/dc16b125-e5c2-4f33-b797-abaa7d240201" /> |
| 1024×768 (small laptop) | <img width="320" alt="1024 light" src="https://github.com/user-attachments/assets/899039c1-3090-4b49-b04c-bb565f20e505" /> | <img width="320" alt="1024 dark" src="https://github.com/user-attachments/assets/a1a54641-c17d-405e-bbab-898eb37cf5c9" /> |
| 1440×900 (desktop) | <img width="320" alt="1440 light" src="https://github.com/user-attachments/assets/21e5870e-ce55-43b2-9b43-c7d926465a75" /> | <img width="320" alt="1440 dark" src="https://github.com/user-attachments/assets/569f89b9-fa66-4bf1-9ba0-7599f8d50ee1" /> |
| 1920×1080 (wide) | <img width="320" alt="1920 light" src="https://github.com/user-attachments/assets/97793c5c-dc89-4194-b86f-fe053fe959ad" /> | <img width="320" alt="1920 dark" src="https://github.com/user-attachments/assets/4ad20915-e172-4de5-a712-09968d6386cc" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` (`.zip-input__row`, `.zip-input__submit` — both
      added; `scripts/check-orphan-classnames.sh` passes)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445).

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (67 files, 1039
      tests; +5 new: 3 in `ZipInput.test.tsx`, 2 in `ScopeChooser.test.tsx`)
- [x] New unit tests added: button present & always-enabled; pointer-click
      resolves a ZIP; malformed click shows the inline hint (never-silent)
- [x] e2e updated: `zip-scope.spec.ts` resolves the ZIP via the `[Go]` button
      (POM `submitChooserZip`); the malformed test reframed for `noValidate`
      (inline hint via the JS gate; D3 "no lookup fetch on malformed" holds;
      `patternMismatch` still reported by the validity API). Ran the
      `zip-scope`, `state-scope`, and `state-artboard` specs on `dev-server` —
      22 passed.
- [x] `npm run build --workspace @bird-watch/frontend` — clean (`tsc -b` +
      vite build)
- [x] (UI) Playwright MCP smoke — ran `npm run dev`, drove ZipInput at all 5
      canonical viewports × light + dark; filled `123` + clicked `[Go]` →
      inline "Enter a 5-digit ZIP" hint renders (never-silent via the button).
      Console: only the documented OpenFreeMap basemap-CDN tile-fetch flake
      (`tiles.openfreemap.org` — unrelated to ZipInput); no app errors/warnings
      from the ZipInput surface.

## Plan reference

Out of plan — issue #827; scope-card design spec §6. First, independent PR of
the two-part scope-card redesign (ships ahead of the collapse redesign #828).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
