### PR TITLE
feat(frontend): consolidate map attribution into the ⓘ Credits modal + linkified eBird source line (remove the bottom-right bar) (#830)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Conventional commits style with scope where useful: `feat(scope):`, `chore:`, `c
 | **Top-left** | Identity+scope cluster: wordmark, region, lede, scope control — one stacked card | `--card-maxw-identity` 360px |
 | **Top-right** | Controls cluster: Filters · Attribution · theme toggle — compact pill group | content-width |
 | **Bottom-left** | Family legend | `--card-maxw-legend` 280px |
-| **Bottom-right** | Attribution line + future zoom/locate — safe-zone | content-width |
+| **Bottom-right** | Reserved for future zoom/locate — safe-zone. (Attribution consolidated: always-visible eBird source credit in the identity-card freshness line; full credits in the top-right ⓘ Credits modal.) | n/a |
 | **Transient** | Popovers (flip/shift/clamp), detail card (insets top-right region), filters panel (anchored under trigger) | per-element caps |
 
 Implementing rule: before adding any new floating surface, assign it a corner from this table. If no corner fits, that is a signal the design is wrong — raise it rather than introducing a new band. All shared geometry is in `frontend/src/styles/tokens.css` under `--card-*` (§2.1). Elevation tiers: tier 1 = resting chrome, tier 2 = on-canvas transient, tier 3 = focused/modal. Design authority: `docs/design/2026-05-30-floating-ui-design-spec.md`.

--- a/docs/design/2026-05-30-floating-ui-design-spec.md
+++ b/docs/design/2026-05-30-floating-ui-design-spec.md
@@ -102,7 +102,7 @@ The header gains real elevation (it has **none** today) by adopting tier 1. The 
 | **Top-left** | Identity+scope cluster: wordmark `Bird Maps`, region label `Arizona`, the lede (`331 species · updated 20 min ago`), and the scope control (state select / ZIP / Change-scope), as **one stacked card** | `--card-maxw-identity` 360px |
 | **Top-right** | Controls cluster: Filters (labeled at ≥1024), Attribution, theme toggle — a compact pill group | content-width |
 | **Bottom-left** | Family legend | `--card-maxw-legend` 280px |
-| **Bottom-right** | Attribution line + reserved zone for future zoom/locate | content-width |
+| **Bottom-right** | Reserved zone for future zoom/locate — safe-zone. *(Attribution consolidated #830: always-visible eBird source credit in the identity-card freshness line; full credits in the top-right ⓘ Credits modal.)* | n/a |
 | **Transient** | Popovers (flip/shift to stay on-screen), detail card (insets top-right region), filters panel (anchored under its trigger) | per-element caps |
 
 ### Desktop (1440 / 1920)
@@ -120,10 +120,10 @@ The header gains real elevation (it has **none** today) by adopting tier 1. The 
 │ └─────────────────────┘                                                 │
 │                                                                         │
 │ ┌──────────────────┐                                                    │
-│ │ Bird families ▴  │                              ┌────────────────────┐│
-│ │ 🪶 Parrots    5  │                              │ © OpenFreeMap · …  ││  ← bottom-right attribution
-│ │ 🦉 Barn-Owls 12  │                              └────────────────────┘│
-│ └──────────────────┘                                                    │
+│ │ Bird families ▴  │                                                     │
+│ │ 🪶 Parrots    5  │                              (bottom-right reserved │
+│ │ 🦉 Barn-Owls 12  │                               for zoom/locate; attr │
+│ └──────────────────┘                               in ⓘ modal — #830)   │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -154,13 +154,13 @@ One corner stack per region, **at most one expanded surface at a time** (see §5
 │      (map)           │
 │                      │
 │ ┌──────────────────┐ │
-│ │ Bird families ▾  │ │  ← legend, collapsed-by-default below WIDE
-│ └──────────────────┘ │
-│  © OpenFreeMap …     │  ← attribution safe-zone (bottom 60px) the legend pill must clear
+│ │ Bird families ▾  │ │  ← legend, collapsed-by-default below WIDE; at
+│ └──────────────────┘ │     --card-inset (no attribution bar to clear — #830)
+│                      │  ← bottom-right reserved (zoom/locate); full attr in ⓘ modal
 └──────────────────────┘
 ```
 
-When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to its chevron pill and shifts so it never overlaps the sheet or the attribution band.
+When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to its chevron pill and shifts so it never overlaps the sheet. (At half/full it is force-collapsed; at peek it lifts above the peek strip — #830. There is no longer an attribution band to clear.)
 
 ---
 
@@ -192,7 +192,7 @@ When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to 
 ### 4.4 FamilyLegend → keep (the one correct island), formalize
 
 - **Today:** the *only* element already in the right idiom — bottom-left, rounded, shadowed, capped at 240px. Keep the anchor.
-- **Target:** Migrate its hardcoded `--shadow-listbox` 6px to the shared language: `--card-radius` 12px, `--card-elevation-1`, `--card-maxw-legend` 280px, anchored `bottom/left: var(--card-inset)` and clearing the attribution band via the existing `--attribution-clearance` mechanism.
+- **Target:** Migrate its hardcoded `--shadow-listbox` 6px to the shared language: `--card-radius` 12px, `--card-elevation-1`, `--card-maxw-legend` 280px, anchored `bottom/left: var(--card-inset)`. (Post-#830 there is no attribution band to clear; the only bottom-sheet interaction is the peek-snap lift.)
 - **Responsive:** **single expansion authority** — default expanded only above `--overlay-bp-wide` (1024), collapsed below. Delete the divergent dual control (JS-1024 *and* CSS-760) that leaves it expanded over the southwest markers at 768. Below WIDE it's a chevron pill; localStorage override persists user choice.
 
 ### 4.5 SpeciesDetail → inset floating card / bottom sheet *(PRINCIPLE-VIOLATOR #2 — full-height right dock)*
@@ -215,9 +215,9 @@ When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to 
 - **Target:** one shared anchored-popover primitive used by all three. Flip/shift against the viewport, **clamped to the `--card-inset` safe-area** (accounting for the floating header, scope cluster, and legend), with a caret that points to the anchor and survives the flip. All consume `--card-radius`, `--card-elevation-2`, `--card-bg/border`.
 - **Responsive:** anchored popover on fine pointers; bottom sheet on coarse/`--overlay-bp-compact`.
 
-### 4.8 Attribution → bottom-right, and the scope-chooser scrim
+### 4.8 Attribution → consolidated to the ⓘ Credits modal, and the scope-chooser scrim
 
-- **Attribution:** small `--type-xs` line bottom-right; the legend's bottom inset must clear it (existing `--attribution-clearance`). It is a licensing requirement (#775) — it is a *safe-zone*, not a floating card.
+- **Attribution (consolidated, #830):** there is no bottom-right attribution line. The always-visible eBird source credit is a link in the identity-card freshness line (top-left), and the full credits (OSM / OpenMapTiles / OpenFreeMap / eBird / PhyloPic / photos) live in the top-right ⓘ Credits modal. The OSMF Attribution Guidelines explicitly sanction collapsing OSM attribution behind a labeled ⓘ button. The bottom-right corner is a reserved *safe-zone* (future zoom/locate), not a floating card; the legend now sits at `--card-inset` (the retired `--attribution-clearance` lift is gone — the only remaining bottom-sheet interaction is the peek-snap legend lift).
 - **Scope-chooser (landing):** lower the scrim from ~92% opaque toward **~60–70%** (optionally `backdrop-filter: blur(2px)`) so the live map reads clearly behind the chooser card — signaling "pick a place *on this map*." The card stays opaque `--card-bg` so card-text AA is unaffected. Card adopts `--card-radius` / `--card-elevation-3`.
 
 ---
@@ -245,7 +245,7 @@ Today the loudest element is a utility (scope control, top-center) and the quiet
 ### 5.3 Collision avoidance (system rules, not per-element patches)
 
 - **Mobile single-surface discipline:** when detail or filters sheet is at peek/half/full, auto-collapse the legend to its chevron pill and the scope to its `Arizona ▾` pill. Never show expanded legend + full scope + sheet at once.
-- **Bottom-stack manager (≤480):** track sheet height in a CSS var; offset the legend's `bottom` by it (or shift legend bottom-right) so the two never overlap; both clear the 60px attribution safe-zone.
+- **Bottom-stack manager (≤480):** track sheet height in a CSS var; offset the legend's `bottom` by it (or shift legend bottom-right) so the two never overlap. (The 60px attribution safe-zone clause is retired — the attribution bar was removed in #830; the legend lifts above the peek strip via `body:has(.species-detail-sheet--peek) .family-legend`.)
 - **Detail never occludes controls:** the inset detail card sits *below* the top-right cluster (z and offset), never slicing it.
 - **Popover edge-collision:** one shared flip/shift/clamp helper (§4.7).
 - **Clean z-ladder:** `--z-map 0 < --z-overlay 40 (legend, scope, context) < --z-popover 41 < --z-chrome 42 (header clusters) < --z-rail 43 (detail card) < cell 44 < cluster 45 < --z-modal 50 (full sheet / modal)`. The detail card and full-snap sheet move onto this ladder so "what floats over what" is predictable; the `pointer-events:none` header hack is removed.

--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -2,13 +2,13 @@ import { test, expect } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 /**
- * AttributionModal — Phase 6 update: footer removed; Credits trigger
- * is AttributionModal's own .attribution-trigger button, accessible
- * from every view via the AppHeader "Attribution" button which
- * programmatically clicks .attribution-trigger.
+ * AttributionModal — #830 update: the modal is controlled-open. The internal
+ * `.attribution-trigger` button was removed; the only Credits affordance is the
+ * AppHeader ⓘ "Credits & attribution" button (`app.attributionTrigger`), which
+ * sets the modal's `open` prop. Every test opens via that button.
  *
  * Covers:
- *   - Credits trigger reachable from every view (map, detail).
+ *   - Credits trigger (AppHeader ⓘ) reachable from every view (map, detail).
  *   - Modal open / focus management / Escape close / focus return.
  *   - Phylopic per-silhouette section renders creator + license + image-
  *     page link for at least one silhouette using the seeded Phylopic
@@ -29,9 +29,9 @@ const VERMFLY = {
 test.describe('AttributionModal — reachability from AppHeader (desktop)', () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
-  // Phase 6: footer removed. Credits trigger is AttributionModal's own button
-  // (.attribution-trigger). The AppHeader "Attribution" button programmatically
-  // clicks it. Tests assert on the trigger directly — no footer required.
+  // #830: the Credits affordance is the AppHeader ⓘ button (the internal
+  // .attribution-trigger was deleted; aria-expanded is intentionally omitted —
+  // it opens a top-layer showModal() dialog, not an inline disclosure).
   // 'species' removed from iteration in #688 (Species surface deleted); 'feed'
   // removed in #777 (Feed surface deleted).
   for (const view of ['map'] as const) {
@@ -39,10 +39,10 @@ test.describe('AttributionModal — reachability from AppHeader (desktop)', () =
       const app = new AppPage(page);
       await app.goto(`view=${view}`);
       await app.waitForAppReady();
-      // The modal's own trigger button is always in the DOM
-      const trigger = page.locator('button.attribution-trigger');
-      await expect(trigger).toBeAttached();
-      await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      await expect(app.attributionTrigger).toBeVisible();
+      await expect(app.attributionTrigger).toHaveAttribute('aria-haspopup', 'dialog');
+      // The old internal shim is gone from the DOM.
+      await expect(page.locator('button.attribution-trigger')).toHaveCount(0);
     });
   }
 
@@ -54,10 +54,9 @@ test.describe('AttributionModal — reachability from AppHeader (desktop)', () =
     await app.waitForAppReady();
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
       .toBeVisible({ timeout: 10_000 });
-    // Phase 4: the Credits trigger is in the DOM behind the detail dialog.
-    // Reachability = attached in the DOM; click-through is covered separately.
-    const trigger = page.locator('button.attribution-trigger');
-    await expect(trigger).toBeAttached();
+    // The AppHeader ⓘ trigger is the persistent Credits affordance on every view.
+    await expect(app.attributionTrigger).toBeVisible();
+    await expect(page.locator('button.attribution-trigger')).toHaveCount(0);
   });
 });
 
@@ -68,11 +67,8 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    // #761 (S2): open via the AppHeader "Attribution" button (the live affordance,
-    // fixed chrome on --z-chrome). The standalone `.attribution-trigger` shim now
-    // sits in the `.app` flow BEHIND the full-viewport `#map-layer`, so a direct
-    // pointer click on it is intercepted by the map. The header fires the same
-    // onOpenAttribution → programmatic `.attribution-trigger.click()` shim.
+    // #830: open via the AppHeader ⓘ button — it sets the modal's controlled
+    // `open` prop (no internal shim). Fixed chrome on --z-chrome.
     await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
@@ -143,10 +139,9 @@ test.describe('AttributionModal — open / close (desktop)', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    // #761 (S2): open via the header affordance (the standalone trigger is behind
-    // the full-bleed map). The modal restores focus to `document.activeElement` at
-    // open time — now the header "Attribution" button — so focus-return is asserted
-    // on that button (the live opener), not the occluded `.attribution-trigger`.
+    // #830: open via the AppHeader ⓘ button. The modal restores focus to
+    // `document.activeElement` at open time — the ⓘ button — so focus-return is
+    // asserted on that button (the controlled-open opener).
     await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
@@ -187,17 +182,16 @@ test.describe('AttributionModal — mobile viewport', () => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    // Phase 6: footer removed — trigger is AttributionModal's own button.
-    const trigger = page.locator('button.attribution-trigger');
-    await expect(trigger).toBeAttached();
+    // #830: the Credits affordance is the AppHeader ⓘ button.
+    await expect(app.attributionTrigger).toBeVisible();
+    await expect(page.locator('button.attribution-trigger')).toHaveCount(0);
   });
 
   test('open + Escape + focus-return cycle works (mobile)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
-    // #761 (S2): open via the header affordance; focus returns to that opener
-    // (the standalone trigger is behind the full-bleed map — see desktop tests).
+    // #830: open via the AppHeader ⓘ button; focus returns to that opener.
     await app.attributionTrigger.click();
     const dialog = page.locator('dialog.attribution-modal');
     await expect(dialog).toHaveAttribute('open', '');
@@ -259,17 +253,12 @@ test.describe('AttributionModal — iNat photo credit (#327 task-11)', () => {
         await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
           .toBeVisible({ timeout: 10_000 });
 
-        // Phase 4: the detail <dialog> sits in the top layer and intercepts
-        // pointer events, so Playwright's trigger.click() is blocked. Use
-        // page.evaluate to dispatch a synthetic click directly on the DOM
-        // node — this bypasses the top-layer pointer interception while keeping
-        // the page in view=detail so App.activeSpeciesMeta stays populated.
-        // Phase 6: selector updated from 'footer.app-footer button.attribution-trigger'
-        // to 'button.attribution-trigger' (footer removed).
-        await page.evaluate(() => {
-          const btn = document.querySelector('button.attribution-trigger');
-          if (btn instanceof HTMLElement) btn.click();
-        });
+        // #830: open via the AppHeader ⓘ button (controlled-open). It is fixed
+        // chrome on --z-chrome in the top-right pill; the detail rail (desktop)
+        // insets BELOW the controls cluster and the peek sheet (mobile) sits at
+        // the bottom, so the ⓘ stays clickable while view=detail keeps
+        // App.activeSpeciesMeta populated (so the Photos section threads through).
+        await app.attributionTrigger.click();
         const dialog = page.locator('dialog.attribution-modal');
         await expect(dialog).toHaveAttribute('open', '');
 
@@ -304,13 +293,8 @@ test.describe('AttributionModal — iNat photo credit (#327 task-11)', () => {
         await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
           .toBeVisible({ timeout: 10_000 });
 
-        // Phase 4: bypass detail dialog pointer interception via evaluate.
-        // Phase 6: selector updated from 'footer.app-footer button.attribution-trigger'
-        // to 'button.attribution-trigger' (footer removed).
-        await page.evaluate(() => {
-          const btn = document.querySelector('button.attribution-trigger');
-          if (btn instanceof HTMLElement) btn.click();
-        });
+        // #830: open via the AppHeader ⓘ button (controlled-open).
+        await app.attributionTrigger.click();
         const dialog = page.locator('dialog.attribution-modal');
         await expect(dialog).toHaveAttribute('open', '');
         // No Photos heading; no photos section testid.

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -30,10 +30,11 @@ test.describe('axe-core WCAG scans', () => {
   // (bottom-left) and any error overlay. The `#map-layer` canvas wrapper is
   // present in the DOM (position:fixed;inset:0) but MapLibre's WebGL content
   // is not axe-readable without a GPU context. V2 (#787) re-baselined against
-  // the full-bleed shell (#761 S2 + O3). The attribution markup is unit-tested
-  // at the customAttribution-array level, so dropping the canvas contents from
-  // the axe scan does not mask a WCAG regression in the map's own controls
-  // (those are MapLibre-owned and out of our axe jurisdiction anyway).
+  // the full-bleed shell (#761 S2 + O3). #830 removed the MapLibre attribution
+  // bar entirely (attribution consolidated into the ⓘ modal + the freshness-line
+  // eBird link, both unit-tested), so dropping the canvas contents from the axe
+  // scan does not mask a WCAG regression in the map's own controls (the modal
+  // open-state is axe-scanned below).
   test('map view has no WCAG 2/2.1 A/AA violations (desktop)', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('view=map');
@@ -335,12 +336,13 @@ test.describe('axe-core WCAG scans', () => {
     });
   });
 
-  // Issue #243 / #250 — eBird API ToU §3 attribution lives in the app-level
-  // AttributionModal. Phase 6 removed the persistent <footer>; the trigger
-  // is now AttributionModal's own .attribution-trigger button, reachable on
-  // every view via the AppHeader "Attribution" button.
-  test.describe('attribution reachability (issue #250)', () => {
-    test('detail view exposes a Credits trigger in the DOM', async ({ page, apiStub }) => {
+  // Issue #243 / #250 / #830 — eBird API ToU §3 attribution lives in the
+  // app-level AttributionModal, opened by the AppHeader ⓘ "Credits &
+  // attribution" button (the controlled-open trigger, #830 item D). The old
+  // internal .attribution-trigger button was removed; reachability is now the
+  // AppHeader ⓘ button, present on every view.
+  test.describe('attribution reachability (issue #250 / #830)', () => {
+    test('detail view exposes the AppHeader Credits trigger', async ({ page, apiStub }) => {
       await apiStub.stubEmpty();
       await apiStub.stubSpecies('vermfly', VERMFLY);
       const app = new AppPage(page);
@@ -348,16 +350,18 @@ test.describe('axe-core WCAG scans', () => {
       await app.waitForAppReady();
       await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
         .toBeVisible({ timeout: 10_000 });
-      // Phase 4: trigger is in DOM behind the detail dialog; reachability =
-      // attached in DOM (click reachability covered by attribution-modal spec).
-      await expect(page.locator('button.attribution-trigger')).toBeAttached();
+      // The ⓘ Credits trigger is the AppHeader button (reachable on every view).
+      await expect(app.attributionTrigger).toBeVisible();
+      // The old internal shim is gone.
+      await expect(page.locator('button.attribution-trigger')).toHaveCount(0);
     });
 
-    test('map view exposes a Credits trigger in the DOM', async ({ page }) => {
+    test('map view exposes the AppHeader Credits trigger', async ({ page }) => {
       const app = new AppPage(page);
       await app.goto('view=map');
       await app.waitForAppReady();
-      await expect(page.locator('button.attribution-trigger')).toBeAttached();
+      await expect(app.attributionTrigger).toBeVisible();
+      await expect(page.locator('button.attribution-trigger')).toHaveCount(0);
     });
 
     // Phase 6: app-footer removed — assert no app-footer element in DOM.
@@ -402,13 +406,10 @@ test.describe('axe-core WCAG scans', () => {
     const app = new AppPage(page);
     await app.goto('view=map');
     await app.waitForAppReady();
-    // #761 (S2): open via the AppHeader "Attribution" button — the documented
-    // real affordance, which fires onOpenAttribution → programmatic click on the
-    // hidden `.attribution-trigger` shim. The header is fixed chrome on
-    // `--z-chrome` (always clickable); the standalone `.attribution-trigger` now
-    // sits in the `.app` flow BEHIND the full-viewport `#map-layer`, so a direct
-    // POINTER click on it is intercepted by the maplibre attribution control. The
-    // header path is occlusion-immune (programmatic .click()).
+    // #830: open via the AppHeader ⓘ "Credits & attribution" button — the
+    // documented real affordance, which sets the controlled `open` prop on
+    // AttributionModal (item D). The header is fixed chrome on `--z-chrome`
+    // (always clickable). No internal shim is involved any more.
     await app.attributionTrigger.click();
     // Wait on the [open] attribute commit — observable contract that
     // showModal() has run, focus-delegation is settled, and the dialog
@@ -431,9 +432,8 @@ test.describe('axe-core WCAG scans', () => {
       const app = new AppPage(page);
       await app.goto('view=map');
       await app.waitForAppReady();
-      // #761 (S2): open via the AppHeader "Attribution" button (occlusion-immune
-      // programmatic shim) — the standalone `.attribution-trigger` now sits behind
-      // the full-viewport `#map-layer`. See the desktop test for the rationale.
+      // #830: open via the AppHeader ⓘ "Credits & attribution" button (the
+      // controlled-open trigger, item D). See the desktop test for the rationale.
       await app.attributionTrigger.click();
       await expect(page.locator('dialog.attribution-modal[open]')).toBeVisible();
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, STATES_FIXTURE } from './fixtures.js';
+import { test, expect, STATES_FIXTURE, VERMFLY } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 /**
@@ -49,11 +49,11 @@ async function setupRoutes(
 }
 
 /**
- * Silhouettes stub for the attribution-clearance guard. The FamilyLegend only
- * mounts when `silhouettes.length > 0` (FamilyLegend.tsx), so the legend-vs-
- * attribution overlap test must register a non-empty silhouettes payload — the
- * `tyrannidae` row matches AZ_OBS's `familyCode`, plus the required `_FALLBACK`
- * row. Registered AFTER setupRoutes so this more-specific route wins (LIFO).
+ * Silhouettes stub for the peek-clearance guard. The FamilyLegend only mounts
+ * when `silhouettes.length > 0` (FamilyLegend.tsx), so the legend-vs-sheet
+ * overlap test must register a non-empty silhouettes payload — the `tyrannidae`
+ * row matches AZ_OBS's `familyCode`, plus the required `_FALLBACK` row.
+ * Registered AFTER setupRoutes so this more-specific route wins (LIFO).
  */
 async function stubSilhouettesForLegend(
   page: import('@playwright/test').Page,
@@ -91,62 +91,32 @@ async function stubSilhouettesForLegend(
 }
 
 /**
- * WebGL skip guard for the attribution-clearance guard. The MapLibre
- * AttributionControl only attaches its DOM (`.maplibregl-ctrl-attrib`) after the
- * map fires `load`; headless runs without a GPU never fire it, so the
- * bounding-box overlap check would be vacuous. Skip cleanly — mirrors the
- * `__birdMap` guard in family-legend-viewport.spec.ts. CI runs software WebGL
- * (SwiftShader), so CI exercises the full assertion.
+ * Read the family-legend + species-detail-sheet bounding boxes and the size of
+ * their vertical intersection. Returns null if either element is missing.
+ * #830: replaces the old legend-vs-attribution measurement — the attribution
+ * bar was removed, so the only remaining bottom-left collision risk is the
+ * peek-snap detail sheet.
  */
-async function skipIfAttributionAbsent(
-  page: import('@playwright/test').Page,
-  testRef: typeof test,
-): Promise<boolean> {
-  const present = await page
-    .locator('.maplibregl-ctrl-attrib')
-    .waitFor({ state: 'attached', timeout: 8_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!present) {
-    testRef.skip(
-      true,
-      '.maplibregl-ctrl-attrib not attached — maplibre `load` did not fire ' +
-        '(likely WebGL unavailable in headless run).',
-    );
-  }
-  return !present;
-}
-
-/**
- * Read the attribution control + family legend bounding boxes and the size of
- * their intersection. Returns null if either element is missing.
- */
-async function measureAttributionVsLegend(
+async function measureLegendVsSheet(
   page: import('@playwright/test').Page,
 ): Promise<{
-  attrib: { left: number; top: number; right: number; bottom: number };
+  sheet: { left: number; top: number; right: number; bottom: number };
   legend: { left: number; top: number; right: number; bottom: number };
-  intersectX: number;
   intersectY: number;
 } | null> {
   return page.evaluate(() => {
-    const attrib = document.querySelector('.maplibregl-ctrl-attrib');
+    const sheet = document.querySelector('.species-detail-sheet');
     const legend = document.querySelector('.family-legend');
-    if (!attrib || !legend) return null;
-    const a = attrib.getBoundingClientRect();
+    if (!sheet || !legend) return null;
+    const s = sheet.getBoundingClientRect();
     const l = legend.getBoundingClientRect();
-    const intersectX = Math.max(
-      0,
-      Math.min(a.right, l.right) - Math.max(a.left, l.left),
-    );
     const intersectY = Math.max(
       0,
-      Math.min(a.bottom, l.bottom) - Math.max(a.top, l.top),
+      Math.min(s.bottom, l.bottom) - Math.max(s.top, l.top),
     );
     return {
-      attrib: { left: a.left, top: a.top, right: a.right, bottom: a.bottom },
+      sheet: { left: s.left, top: s.top, right: s.right, bottom: s.bottom },
       legend: { left: l.left, top: l.top, right: l.right, bottom: l.bottom },
-      intersectX,
       intersectY,
     };
   });
@@ -339,105 +309,78 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
   });
 
   // ───────────────────────────────────────────────────────────────────────────
-  // #775 — basemap attribution clearance under the full-bleed map.
+  // #830 — peek-snap detail sheet clearance vs the family legend.
   //
-  // The full-viewport map (#761 S2) made `.map-surface` fill 100vh. MapLibre's
-  // non-compact AttributionControl (`compact={false}` — deliberately always-
-  // expanded so the OSM credit shows without a click) then renders as a bottom
-  // bar that, on short/narrow viewports, spans the full viewport width and wraps
-  // to multiple lines — its left portion reaching into the bottom-left corner
-  // where `.family-legend` lives. The legend (z-overlay) painted ON TOP of the
-  // OSM / OpenFreeMap license text. That is an ODbL + eBird-ToU LICENSING defect
-  // (the attribution must be fully visible), and it shipped with no test.
-  //
-  // Fix (#775): `.family-legend { bottom: calc(var(--space-md) +
-  // var(--attribution-clearance)) }`, with --attribution-clearance tiered by
-  // viewport (20/40/60px) to lift the legend ABOVE the worst-case band. These
-  // guards assert ZERO overlap between the two boxes at 390/768/1024 in BOTH the
-  // collapsed and expanded legend states (the expanded legend is wider, so it is
-  // the harder case at 1024 where the bar already reaches x≈192).
+  // The bottom-right MapLibre attribution bar was removed (#830 item A), so the
+  // old legend-vs-attribution guard is gone (it asserted a control that no
+  // longer renders). The only remaining bottom-left collision risk is the
+  // species-detail bottom sheet at its PEEK snap on phones: at half/full the
+  // legend is already force-collapsed (App.tsx legendForceCollapsed), so peek is
+  // the one state where the un-collapsed legend shares the bottom band with the
+  // sheet. The `body:has(.species-detail-sheet--peek) .family-legend` rule lifts
+  // the legend by calc(--card-inset + 120px + --space-md) so the two never
+  // overlap. This guard asserts the legend's bottom edge sits at or ABOVE the
+  // peek sheet's top edge at 390×844 (the AC viewport).
   // ───────────────────────────────────────────────────────────────────────────
-  test.describe('#775: basemap attribution clearance vs family legend', () => {
-    for (const vp of [
-      { width: 390, height: 844 },
-      { width: 768, height: 1024 },
-      { width: 1024, height: 768 },
-    ] as const) {
-      test.describe(`${vp.width}×${vp.height}`, () => {
-        test.use({ viewport: { width: vp.width, height: vp.height } });
+  test.describe('#830: peek-snap detail sheet clearance vs family legend', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
 
-        test('attribution control is not overlapped by the family legend (collapsed + expanded)', async ({
-          page,
-          apiStub,
-        }) => {
-          await setupRoutes(page, apiStub);
-          await stubSilhouettesForLegend(page);
-          // Start from a known legend state regardless of prior persistence.
-          await page.addInitScript(() => {
-            try {
-              window.localStorage.removeItem('family-legend-expanded');
-              window.localStorage.removeItem('family-legend-expanded.v2');
-            } catch {
-              /* noop */
-            }
-          });
-
-          const app = new AppPage(page);
-          await app.goto('state=US-AZ');
-          await app.waitForAppReady();
-          await expect(app.mapCanvas).toBeVisible({ timeout: 15_000 });
-
-          if (await skipIfAttributionAbsent(page, test)) return;
-          // The legend mounts once silhouettes resolve.
-          await expect(page.locator('.family-legend')).toBeVisible({
-            timeout: 10_000,
-          });
-
-          const toggle = page.locator('.family-legend [aria-expanded]');
-
-          // Assert no overlap in BOTH legend states. The expanded legend is the
-          // wider box (the 1024 worst case), the collapsed legend the typical
-          // first-paint mobile state — both must clear the attribution band.
-          for (const wantExpanded of [false, true] as const) {
-            const current = await toggle.getAttribute('aria-expanded');
-            if (current !== String(wantExpanded)) {
-              await toggle.click();
-              await expect(toggle).toHaveAttribute(
-                'aria-expanded',
-                String(wantExpanded),
-              );
-            }
-
-            const m = await measureAttributionVsLegend(page);
-            expect(
-              m,
-              '.maplibregl-ctrl-attrib / .family-legend not found',
-            ).not.toBeNull();
-
-            // Boxes are disjoint when EITHER axis has no intersection. The
-            // licensing requirement is that the legend never covers the
-            // attribution text, so we require zero overlap area (sub-pixel
-            // tolerance for fractional rounding).
-            const disjoint =
-              m!.intersectX <= 0.5 || m!.intersectY <= 0.5;
-            expect(
-              disjoint,
-              `legend (expanded=${wantExpanded}) overlaps attribution at ${vp.width}×${vp.height}: ` +
-                `intersect ${m!.intersectX.toFixed(1)}×${m!.intersectY.toFixed(1)}px ` +
-                `[attrib ${JSON.stringify(m!.attrib)} legend ${JSON.stringify(m!.legend)}]`,
-            ).toBe(true);
-
-            // Stronger, fix-specific assertion: the legend's bottom edge sits at
-            // or ABOVE the attribution band's top edge — i.e. the legend is
-            // lifted clear vertically, independent of the bar's horizontal span.
-            expect(
-              m!.legend.bottom,
-              `legend bottom (${m!.legend.bottom.toFixed(1)}) must clear attribution top ` +
-                `(${m!.attrib.top.toFixed(1)}) at ${vp.width}×${vp.height} (expanded=${wantExpanded})`,
-            ).toBeLessThanOrEqual(m!.attrib.top + 0.5);
-          }
-        });
+    test('family legend clears the peek detail sheet at 390×844 (no overlap)', async ({
+      page,
+      apiStub,
+    }) => {
+      await setupRoutes(page, apiStub);
+      await stubSilhouettesForLegend(page);
+      await apiStub.stubSpecies('vermfly', VERMFLY);
+      // Start from a known (expanded) legend state regardless of prior
+      // persistence — the expanded legend is the taller box and the harder case.
+      await page.addInitScript(() => {
+        try {
+          window.localStorage.removeItem('family-legend-expanded');
+          window.localStorage.removeItem('family-legend-expanded.v2');
+        } catch {
+          /* noop */
+        }
       });
-    }
+
+      const app = new AppPage(page);
+      // Scope to AZ (so the legend mounts with AZ silhouettes) AND deep-link the
+      // detail param so the bottom sheet opens. At 390×844 it lands at peek.
+      await app.goto('state=US-AZ&detail=vermfly&view=detail');
+      await app.waitForAppReady();
+
+      // The sheet mounts at peek (data-snap-state="peek" → the
+      // .species-detail-sheet--peek class that the :has() rule keys on).
+      const sheet = page.locator('[data-testid=species-detail-sheet]');
+      await expect(sheet).toBeVisible({ timeout: 10_000 });
+      await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
+
+      // The legend mounts once silhouettes resolve (App-root sibling — no WebGL
+      // dependency). At peek it is NOT force-collapsed, so it renders normally.
+      await expect(page.locator('.family-legend')).toBeVisible({ timeout: 10_000 });
+      // Ensure the legend is expanded (the taller, harder case).
+      const toggle = page.locator('.family-legend [aria-expanded]');
+      if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      }
+
+      const m = await measureLegendVsSheet(page);
+      expect(m, '.species-detail-sheet / .family-legend not found').not.toBeNull();
+
+      // The legend's bottom edge must sit at or ABOVE the peek sheet's top edge:
+      // the peek-clearance rule lifts it clear so the two never overlap.
+      expect(
+        m!.legend.bottom,
+        `legend bottom (${m!.legend.bottom.toFixed(1)}) must clear peek sheet top ` +
+          `(${m!.sheet.top.toFixed(1)}) at 390×844 ` +
+          `[sheet ${JSON.stringify(m!.sheet)} legend ${JSON.stringify(m!.legend)}]`,
+      ).toBeLessThanOrEqual(m!.sheet.top + 0.5);
+      // And zero vertical overlap area (sub-pixel tolerance for rounding).
+      expect(
+        m!.intersectY,
+        `legend overlaps peek sheet vertically by ${m!.intersectY.toFixed(1)}px at 390×844`,
+      ).toBeLessThanOrEqual(0.5);
+    });
   });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -19,6 +19,32 @@ vi.stubGlobal('matchMedia', (query: string) => ({
   dispatchEvent: vi.fn(),
 }));
 
+// #830 item D: AttributionModal is controlled-open and calls dialog.showModal()
+// / dialog.close(). jsdom predates the top-layer dialog spec, so patch the
+// prototype to mirror open/close (set/remove the `open` attribute, dispatch the
+// native close event) — same polyfill the AttributionModal unit test uses.
+(() => {
+  if (typeof HTMLDialogElement === 'undefined') return;
+  const proto = HTMLDialogElement.prototype as unknown as {
+    showModal?: () => void;
+    close?: () => void;
+    __patched?: boolean;
+  };
+  if ((proto.showModal as unknown as { __patched?: boolean } | undefined)?.__patched) return;
+  const showModal = function (this: HTMLDialogElement) {
+    (this as unknown as { open: boolean }).open = true;
+    this.setAttribute('open', '');
+  };
+  const close = function (this: HTMLDialogElement) {
+    (this as unknown as { open: boolean }).open = false;
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+  Object.defineProperty(showModal, '__patched', { value: true });
+  proto.showModal = showModal as () => void;
+  proto.close = close as () => void;
+})();
+
 // Hoist mock fns so they exist before any module-level code runs.
 const {
   mockGetHotspots,
@@ -521,16 +547,22 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
     },
   );
 
-  it('AttributionModal Credits button is still present in the DOM (trigger can find it)', () => {
+  it('clicking the AppHeader ⓘ button opens the AttributionModal (controlled-open, #830 item D)', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null, view: 'map',
       scope: { kind: 'us' as const },
     };
-    const { container } = render(<App />);
-    // The modal's own trigger button — className="attribution-trigger"
-    // onOpenAttribution's querySelector('.attribution-trigger') must resolve.
-    const credits = container.querySelector('button.attribution-trigger');
-    expect(credits).not.toBeNull();
+    render(<App />);
+    await screen.findByRole('banner');
+    const dialog = document.querySelector('dialog.attribution-modal');
+    expect(dialog).not.toBeNull();
+    // Closed initially (open prop is false).
+    expect(dialog?.hasAttribute('open')).toBe(false);
+    // onOpenAttribution sets attributionOpen → the modal's open prop opens the
+    // native dialog. (No leftover .attribution-trigger shim — it was deleted.)
+    expect(document.querySelector('.attribution-trigger')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: /Credits & attribution/i }));
+    expect(dialog?.hasAttribute('open')).toBe(true);
   });
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -706,15 +706,13 @@ export function App() {
     set({ scope: { kind: 'unscoped' } });
   }, [set]);
 
-  // Phase 3: Attribution modal trigger — AppHeader's "Attribution" button
-  // dispatches a click into the existing AttributionModal trigger inside the
-  // footer (which remains rendered but visually de-emphasized). Phase 6 will
-  // reconcile by removing the footer trigger and wiring a controlled-open API.
-  // TODO(phase-6): replace this querySelector with a proper controlled-open prop.
-  const onOpenAttribution = useCallback(() => {
-    const trigger = document.querySelector<HTMLButtonElement>('.attribution-trigger');
-    trigger?.click();
-  }, []);
+  // Attribution modal — controlled-open (#830 item D). The AppHeader ⓘ button
+  // sets `attributionOpen`; <AttributionModal> mirrors it into the native
+  // <dialog> via its `open` prop, and its native `close` event (Escape /
+  // backdrop / close button) flips the state back through `onOpenChange`. This
+  // replaced the Phase 3 querySelector('.attribution-trigger').click() shim.
+  const [attributionOpen, setAttributionOpen] = useState(false);
+  const onOpenAttribution = useCallback(() => setAttributionOpen(true), []);
 
   const mainRef = useRef<HTMLElement | null>(null);
 
@@ -1289,15 +1287,16 @@ export function App() {
         </div>
       )}
       {/*
-        Phase 6: Footer removed. The Attribution trigger moved to <AppHeader>
-        in Phase 3 — reachable from every view (map|detail), meeting
-        the eBird ToU §3 and CC BY-SA §4(b/c) prominence requirement.
+        The Attribution trigger is the ⓘ button in <AppHeader>, reachable from
+        every view (map|detail), meeting the eBird ToU §3 and CC BY-SA §4(b/c)
+        prominence requirement.
 
-        <AttributionModal> is mounted here (outside any landmark container)
-        so it remains in the DOM on all surfaces. The AppHeader "Attribution"
-        button fires onOpenAttribution → clicks the modal's own trigger button
-        (.attribution-trigger). Phase 6 retains the Phase 3 querySelector
-        shim; a follow-up PR can replace it with a proper controlled-open prop.
+        <AttributionModal> is mounted here (outside any landmark container) so it
+        remains in the DOM on all surfaces. It is controlled-open (#830 item D):
+        onOpenAttribution sets `attributionOpen` → the `open` prop opens the
+        native dialog; the dialog's `close` event flips `attributionOpen` back
+        via onOpenChange. (Replaced the old .attribution-trigger querySelector
+        shim.)
 
         Silhouettes and photo-credit props threaded as before (issue #274,
         issue #327 task-11).
@@ -1306,6 +1305,8 @@ export function App() {
         silhouettes={silhouettes}
         loading={silhouettesLoading}
         error={silhouettesError}
+        open={attributionOpen}
+        onOpenChange={setAttributionOpen}
         photoAttribution={activeSpeciesMeta?.photoAttribution}
         photoLicense={activeSpeciesMeta?.photoLicense}
       />

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -78,6 +78,38 @@ describe('ApiClient', () => {
     if (res.mode === 'observations') expect(res.data).toEqual([]);
   });
 
+  // #830 item B (licensing invariant — Remedy 1): the dead `Array.isArray(raw)`
+  // branch that fabricated `meta.freshestObservationAt: null` for a non-empty
+  // bare array was deleted. The live read-api always emits the discriminated
+  // envelope; the only path that could ever produce non-empty `data` with a
+  // null freshness (breaking "eBird credit visible ⟺ ≥1 marker") was that dead
+  // branch. Assert the envelope's freshestObservationAt is preserved verbatim
+  // (non-null carries through — never silently nulled).
+  it('preserves a non-null meta.freshestObservationAt from the discriminated envelope (#830 B)', async () => {
+    const ts = '2026-05-31T12:00:00.000Z';
+    const envelope = JSON.stringify({
+      mode: 'observations',
+      data: [
+        {
+          subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+          lat: 32.22, lng: -110.97, obsDt: ts, locId: 'L1', locName: 'Tucson',
+          howMany: 1, isNotable: false, silhouetteId: 'tyrannidae', familyCode: 'tyrannidae',
+        },
+      ],
+      meta: { freshestObservationAt: ts },
+    });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    const res = await client.getObservations({});
+    expect(res.mode).toBe('observations');
+    if (res.mode === 'observations') {
+      expect(res.data).toHaveLength(1);
+      // The non-null timestamp survives — the deleted bare-array branch would
+      // have forced this to null on a non-empty payload.
+      expect(res.meta.freshestObservationAt).toBe(ts);
+    }
+  });
+
   it('passes through aggregated envelope unchanged (#627)', async () => {
     const agg = JSON.stringify({
       mode: 'aggregated',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,18 +37,20 @@ export class ApiClient {
     // `stateCode` unset, so the backend stays byte-for-byte untouched (no
     // `?state=` ⇒ unclipped national query, locked decision #4).
     if (f.stateCode) url.searchParams.set('state', f.stateCode);
-    // Defensive: tolerate three legacy shapes during the rollout window —
-    // (a) bare Observation[] (pre-#456), (b) { data, meta } without `mode`
-    // (post-#456, pre-#627), and (c) the discriminated union (#627).
-    // Normalize all three to the discriminated union so callers can switch
-    // on `mode` unconditionally.
+    // Tolerate two shapes — (a) { data, meta } without `mode` (post-#456,
+    // pre-#627) and (b) the discriminated union (#627) — normalizing both to the
+    // discriminated union so callers can switch on `mode` unconditionally.
+    //
+    // The bare-Observation[] branch (pre-#456) was REMOVED in #830 (item B,
+    // Remedy 1): the live read-api never returns a bare array, and that branch
+    // was the only path that could yield non-empty `data` with a fabricated
+    // `freshestObservationAt: null` — which would have broken the licensing
+    // invariant "eBird credit visible ⟺ ≥1 observation marker rendered"
+    // (deriveFreshness(null) → label '' → no eBird credit, despite markers).
     type LegacyEnvelope = { data: Observation[]; meta: { freshestObservationAt: string | null } };
-    const raw = await this.get<ObservationsResponse | LegacyEnvelope | Observation[]>(
+    const raw = await this.get<ObservationsResponse | LegacyEnvelope>(
       url.pathname + url.search,
     );
-    if (Array.isArray(raw)) {
-      return { mode: 'observations', data: raw, meta: { freshestObservationAt: null } };
-    }
     if (!('mode' in raw)) {
       return { mode: 'observations', data: raw.data, meta: raw.meta };
     }

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -89,15 +89,37 @@ describe('<AppHeader>', () => {
     expect(document.querySelector('.app-header-lede-row')).toBeNull();
   });
 
-  it('renders freshnessLabel alongside the lede when both are present', () => {
+  it('renders freshnessLabel + linkified eBird source alongside the lede when both are present', () => {
     render(
       <AppHeader
         {...baseProps}
         ledeText="331 species seen across Arizona in the last 14 days."
-        freshnessLabel="Updated 11 min ago · Source: eBird"
+        freshnessLabel="Updated 11 min ago"
       />,
     );
-    expect(screen.getByText('Updated 11 min ago · Source: eBird')).toBeInTheDocument();
+    // #830 item B: freshnessLabel is the age clause only; AppHeader composes
+    // "· Source: <eBird link>". The eBird credit is now a nested <a>, so the
+    // text splits across nodes — assert the source prefix + the link structurally
+    // (an exact getByText over the whole composed line would no longer match).
+    expect(screen.getByText(/Source:/)).toBeInTheDocument();
+    const ebirdLink = screen.getByRole('link', { name: 'eBird' });
+    expect(ebirdLink).toHaveAttribute('href', 'https://ebird.org');
+    expect(ebirdLink).toHaveAttribute('target', '_blank');
+    expect(ebirdLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does NOT render the freshness/source line when freshnessLabel is empty', () => {
+    render(
+      <AppHeader
+        {...baseProps}
+        ledeText="331 species seen across Arizona in the last 14 days."
+        freshnessLabel=""
+      />,
+    );
+    // #830 item B: the {freshnessLabel && …} guard wraps the WHOLE composed line,
+    // so empty/error states (label: '') render no source credit at all.
+    expect(screen.queryByText(/Source:/)).toBeNull();
+    expect(screen.queryByRole('link', { name: 'eBird' })).toBeNull();
   });
 
   // ── Scope rows ──────────────────────────────────────────────────────────
@@ -150,6 +172,16 @@ describe('<AppHeader>', () => {
     render(<AppHeader {...baseProps} onOpenAttribution={onOpenAttribution} />);
     await userEvent.click(screen.getByRole('button', { name: /Credits & attribution/i }));
     expect(onOpenAttribution).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the Attribution trigger with aria-haspopup="dialog" (and intentionally omits aria-expanded)', () => {
+    // #830 item E: the trigger opens a showModal() dialog (top-layer), not an
+    // inline disclosure — so it carries aria-haspopup but deliberately NOT
+    // aria-expanded (a divergence from the Filters trigger, which is inline).
+    render(<AppHeader {...baseProps} />);
+    const trigger = screen.getByRole('button', { name: /Credits & attribution/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).not.toHaveAttribute('aria-expanded');
   });
 
   // ── ThemeToggle ─────────────────────────────────────────────────────────

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -37,7 +37,8 @@
  * Lede props (O3 #779) — carried from MapSurface into AppHeader so the formerly
  * invisible context-strip content renders in the identity card:
  *   - ledeText: the pre-rendered lede sentence (or null while loading / unscoped).
- *   - freshnessLabel: "331 species · updated 20 min ago · eBird" (or '').
+ *   - freshnessLabel: the age clause only, e.g. "Updated 20 min ago" (or '').
+ *     The "· Source: eBird" credit (a real link) is composed in JSX below (#830).
  *
  * Scope-control props (§4.2) — ScopeControl content is now folded into the
  * bottom rows of this card. When `scope.kind === 'unscoped'` the scope rows
@@ -90,9 +91,11 @@ export interface AppHeaderProps {
    */
   ledeText: string | null;
   /**
-   * Pre-formatted freshness / source string from deriveFreshness (e.g.
-   * "Updated 11 min ago · Source: eBird"). Empty string when not yet resolved.
-   * Rendered in the identity card below the lede at --type-xs --color-text-subtle.
+   * Freshness age clause from deriveFreshness (e.g. "Updated 11 min ago").
+   * Empty string when not yet resolved or for empty/error data states. The
+   * "· Source: eBird" credit (a real ebird.org link) is composed in AppHeader
+   * JSX, not interpolated into this string (#830 item B). Rendered in the
+   * identity card below the lede at --type-xs --color-text-subtle.
    */
   freshnessLabel: string;
   // ── Scope-control props (§4.2) ───────────────────────────────────────────
@@ -194,8 +197,25 @@ export function AppHeader({
         {ledeText && (
           <div className="app-header-lede-row">
             <p className="app-header-lede" data-testid="map-lede">{ledeText}</p>
+            {/* #830 item B: the always-visible eBird credit lives here as a real
+                link (the freshness line is proper top-left chrome, not a floating
+                corner label). `freshnessLabel` is the age clause only; the
+                "· Source: eBird" credit is composed here. The truthiness guard
+                wraps the WHOLE line so empty/error states (label: '') render
+                nothing — eBird credit visible ⟺ observations shown. The link
+                uses rel="noopener noreferrer" (the surviving modal convention;
+                the old MapCanvas noopener-only block was deleted in item A). */}
             {freshnessLabel && (
-              <p className="app-header-freshness">{freshnessLabel}</p>
+              <p className="app-header-freshness">
+                {freshnessLabel} · Source:{' '}
+                <a
+                  href="https://ebird.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  eBird
+                </a>
+              </p>
             )}
           </div>
         )}
@@ -228,6 +248,11 @@ export function AppHeader({
           className="app-header-attribution"
           onClick={onOpenAttribution}
           aria-label="Credits & attribution"
+          // #830 item E: this opens a showModal() dialog rendered in the top
+          // layer, so it carries aria-haspopup="dialog" but INTENTIONALLY omits
+          // aria-expanded — a deliberate divergence from .app-header-filters
+          // (an inline disclosure). Do NOT "fix" to match filters.
+          aria-haspopup="dialog"
         >
           <svg
             className="app-header-btn-icon"

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
+import { useState } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { FamilySilhouette } from '@bird-watch/shared-types';
-import { AttributionModal } from './AttributionModal.js';
+import { AttributionModal, type AttributionModalProps } from './AttributionModal.js';
 
 /**
  * AttributionModal tests (#250).
@@ -42,6 +43,49 @@ function patchDialog() {
 
 patchDialog();
 
+/**
+ * #830 item D: AttributionModal no longer renders its own trigger button — it
+ * is controlled via the `open` prop, opened by the AppHeader ⓘ button. These
+ * tests drive it through a small harness that owns `open` state and exposes a
+ * real "Open credits" opener button, so (a) opening is a genuine click on a
+ * focusable element and (b) focus-return on close has a real restore target
+ * (mirroring the production AppHeader trigger). The harness also threads
+ * `onOpenChange` so the dialog's native close flips `open` back to false.
+ */
+type HarnessProps = Omit<AttributionModalProps, 'open' | 'onOpenChange'> & {
+  onOpenChange?: (open: boolean) => void;
+};
+function ControlledModalHarness({ onOpenChange, ...modalProps }: HarnessProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open credits
+      </button>
+      <AttributionModal
+        {...modalProps}
+        open={open}
+        onOpenChange={next => {
+          setOpen(next);
+          onOpenChange?.(next);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Render the harness and open the dialog via the opener button. Returns the
+ * userEvent instance and the opener element (the focus-return target).
+ */
+async function openModal(props: HarnessProps = { silhouettes: [] }) {
+  const user = userEvent.setup();
+  render(<ControlledModalHarness {...props} />);
+  const opener = screen.getByRole('button', { name: /open credits/i });
+  await user.click(opener);
+  return { user, opener };
+}
+
 const SILHOUETTES: FamilySilhouette[] = [
   {
     familyCode: 'tyrannidae',
@@ -80,38 +124,49 @@ const SILHOUETTES: FamilySilhouette[] = [
 ];
 
 describe('AttributionModal', () => {
-  it('renders a Credits trigger button', () => {
+  it('does NOT render an internal .attribution-trigger button (controlled-open, #830 item D)', () => {
     render(<AttributionModal silhouettes={SILHOUETTES} />);
-    expect(screen.getByRole('button', { name: /credits/i })).toBeInTheDocument();
+    // The modal is controlled via the `open` prop now; its old internal trigger
+    // is gone. The only "Credits" affordance is the AppHeader ⓘ button.
+    expect(document.querySelector('.attribution-trigger')).toBeNull();
+    expect(screen.queryByRole('button', { name: /^credits$/i })).toBeNull();
   });
 
-  it('does not render the dialog content visibly when closed', () => {
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
+  it('does not render the dialog content visibly when open is false', () => {
+    render(<AttributionModal silhouettes={SILHOUETTES} open={false} />);
     // The <dialog> exists in the DOM but reports open=false.
     const dialog = document.querySelector('dialog');
     expect(dialog).not.toBeNull();
     expect(dialog?.hasAttribute('open')).toBe(false);
   });
 
-  it('opens when the trigger is clicked', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+  it('opens the dialog when the open prop is true', () => {
+    render(<AttributionModal silhouettes={SILHOUETTES} open={true} />);
+    const dialog = document.querySelector('dialog');
+    expect(dialog?.hasAttribute('open')).toBe(true);
+  });
+
+  it('closes the dialog when the open prop flips back to false', () => {
+    const { rerender } = render(<AttributionModal silhouettes={SILHOUETTES} open={true} />);
+    const dialog = document.querySelector('dialog');
+    expect(dialog?.hasAttribute('open')).toBe(true);
+    rerender(<AttributionModal silhouettes={SILHOUETTES} open={false} />);
+    expect(dialog?.hasAttribute('open')).toBe(false);
+  });
+
+  it('opens when the opener flips the controlled state', async () => {
+    await openModal({ silhouettes: SILHOUETTES });
     const dialog = document.querySelector('dialog');
     expect(dialog?.hasAttribute('open')).toBe(true);
   });
 
   it('renders the modal title as an <h2>', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     expect(screen.getByRole('heading', { level: 2, name: /credits/i })).toBeInTheDocument();
   });
 
   it('renders five sections (without optional Photos), each with an <h3> heading', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     // eBird, Family Silhouettes (Phylopic), Species descriptions
     // (Wikipedia — #373), Map Tiles (OSM/OpenFreeMap), Privacy
     // (Clarity disclosure — issue #657). Photos is optional and
@@ -129,9 +184,7 @@ describe('AttributionModal', () => {
   // credit on SpeciesDetailSurface satisfies the per-work attribution
   // requirement, so the modal-level credit is the catch-all.
   it('renders a Species descriptions section disclosing Wikipedia + CC BY-SA', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const heading = screen.getByRole('heading', { level: 3, name: /species descriptions/i });
     expect(heading).toBeInTheDocument();
     const section = heading.closest('section');
@@ -146,15 +199,11 @@ describe('AttributionModal', () => {
   });
 
   it('renders the Species descriptions section between Photos and Map Tiles in DOM order', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoAttribution="Jane Photographer"
-        photoLicense="cc-by"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({
+      silhouettes: SILHOUETTES,
+      photoAttribution: 'Jane Photographer',
+      photoLicense: 'cc-by',
+    });
     const headings = screen
       .getAllByRole('heading', { level: 3 })
       .map(h => h.textContent?.toLowerCase() ?? '');
@@ -170,9 +219,7 @@ describe('AttributionModal', () => {
   });
 
   it('renders the Species descriptions section even with Photos absent (sits between Family Silhouettes and Map Tiles)', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const headings = screen
       .getAllByRole('heading', { level: 3 })
       .map(h => h.textContent?.toLowerCase() ?? '');
@@ -190,9 +237,7 @@ describe('AttributionModal', () => {
   });
 
   it('renders a Privacy section disclosing Clarity analytics + default masking', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     // The section follows the existing <h3> idiom (Bird Sightings Data,
     // Family Silhouettes, Photos conditional, Map Tiles).  Privacy is the
     // new final section.
@@ -213,9 +258,7 @@ describe('AttributionModal', () => {
   });
 
   it('renders an eBird credit + link in the Bird Sightings section', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const ebirdLink = screen.getByRole('link', { name: /eBird/i });
     expect(ebirdLink).toHaveAttribute('href', 'https://ebird.org');
     expect(ebirdLink).toHaveAttribute('target', '_blank');
@@ -223,9 +266,7 @@ describe('AttributionModal', () => {
   });
 
   it('renders OSM, OpenMapTiles, and OpenFreeMap credits + links in the Map Tiles section', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const osmLink = screen.getByRole('link', { name: /openstreetmap/i });
     expect(osmLink).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
     expect(osmLink).toHaveAttribute('target', '_blank');
@@ -244,17 +285,13 @@ describe('AttributionModal', () => {
   });
 
   it('renders one Phylopic row per silhouette with a non-null source', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const items = screen.getAllByTestId('attribution-phylopic-row');
     expect(items).toHaveLength(SILHOUETTES.length);
   });
 
   it('renders the creator name and source link for a row with creator + source', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     // The first row in SILHOUETTES is tyrannidae with a creator.
     const rows = screen.getAllByTestId('attribution-phylopic-row');
     const tyr = rows[0]!;
@@ -266,9 +303,7 @@ describe('AttributionModal', () => {
   });
 
   it('omits the "by <creator>" prefix when creator is null but still renders the source link', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const rows = screen.getAllByTestId('attribution-phylopic-row');
     // Cuckoos is the third silhouette, with creator: null.
     const cuckoo = rows[2]!;
@@ -280,9 +315,7 @@ describe('AttributionModal', () => {
   });
 
   it('renders the license short identifier as a link to the matching CC URL', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const rows = screen.getAllByTestId('attribution-phylopic-row');
     // Expected pairs:
     //   tyrannidae   -> CC0-1.0       -> https://creativecommons.org/publicdomain/zero/1.0/
@@ -302,7 +335,6 @@ describe('AttributionModal', () => {
   });
 
   it('skips silhouettes with a null source (no Phylopic data → nothing to attribute)', async () => {
-    const user = userEvent.setup();
     const noPhylopic: FamilySilhouette[] = [
       {
         familyCode: 'fallback',
@@ -317,17 +349,14 @@ describe('AttributionModal', () => {
       },
       ...SILHOUETTES,
     ];
-    render(<AttributionModal silhouettes={noPhylopic} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: noPhylopic });
     // Only the three rows with non-null sources should be rendered.
     const items = screen.getAllByTestId('attribution-phylopic-row');
     expect(items).toHaveLength(3);
   });
 
   it('shows a no-attributions message in the Phylopic section when silhouettes is empty', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={[]} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: [] });
     // eBird + OSM sections render unconditionally; only the Phylopic
     // section degrades to the "no attributions" message. Default props
     // give loading=false, error=null — this is the fetch-succeeded-but-
@@ -338,7 +367,6 @@ describe('AttributionModal', () => {
   });
 
   it('renders the no-attributions message when loading=false, error=null, and phylopicRows=[] (only fallback rows in payload)', async () => {
-    const user = userEvent.setup();
     // The migration-1700000018000 fallback rows have source=null AND
     // creator=null. After phylopicRows filtering they are dropped, so
     // the section renders the empty-attribution message even though the
@@ -367,8 +395,7 @@ describe('AttributionModal', () => {
         creator: null,
       },
     ];
-    render(<AttributionModal silhouettes={fallbackOnly} loading={false} error={null} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: fallbackOnly, loading: false, error: null });
     expect(screen.getByText(/no silhouette attributions available/i)).toBeInTheDocument();
     // Defensive: the loading and error copies must NOT appear in this branch.
     expect(screen.queryByText(/loading silhouette attributions/i)).toBeNull();
@@ -377,49 +404,39 @@ describe('AttributionModal', () => {
     expect(screen.queryAllByTestId('attribution-phylopic-row')).toHaveLength(0);
   });
 
-  it('returns focus to the trigger when the modal closes', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    const trigger = screen.getByRole('button', { name: /credits/i });
-    await user.click(trigger);
-    // Click the close button.
+  it('returns focus to the opener when the modal closes', async () => {
+    // #830 item D: the restore target is the element focused at open time —
+    // here the harness opener (the production equivalent is the AppHeader ⓘ).
+    const { user, opener } = await openModal({ silhouettes: SILHOUETTES });
     const close = screen.getByRole('button', { name: /close/i });
     await user.click(close);
-    // After close, focus returns to the trigger.
-    expect(document.activeElement).toBe(trigger);
+    expect(document.activeElement).toBe(opener);
   });
 
   it('closes when the close button is clicked', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const { user } = await openModal({ silhouettes: SILHOUETTES });
     const dialog = document.querySelector('dialog');
     expect(dialog?.hasAttribute('open')).toBe(true);
     await user.click(screen.getByRole('button', { name: /close/i }));
     expect(dialog?.hasAttribute('open')).toBe(false);
   });
 
-  it('returns focus to the trigger when the dialog dispatches its close event (Escape path)', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    const trigger = screen.getByRole('button', { name: /credits/i });
-    await user.click(trigger);
+  it('returns focus to the opener when the dialog dispatches its close event (Escape path)', async () => {
+    const { opener } = await openModal({ silhouettes: SILHOUETTES });
     const dialog = document.querySelector('dialog')!;
     expect(dialog.hasAttribute('open')).toBe(true);
     // Production contract: native <dialog> closes on Escape and emits a
     // 'close' event. jsdom doesn't synthesise the Escape→close flow, so
     // we dispatch the event directly to verify the close handler returns
-    // focus to the trigger. The component listens for 'close' (the native
+    // focus to the opener. The component listens for 'close' (the native
     // event the browser fires after Escape OR backdrop close OR an
     // explicit close()).
     dialog.dispatchEvent(new Event('close'));
-    expect(document.activeElement).toBe(trigger);
+    expect(document.activeElement).toBe(opener);
   });
 
   it('closes when the user clicks the dialog backdrop', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const dialog = document.querySelector('dialog') as HTMLDialogElement;
     expect(dialog.hasAttribute('open')).toBe(true);
     // The backdrop-click handler matches `event.target === dialog`. jsdom
@@ -432,9 +449,7 @@ describe('AttributionModal', () => {
   });
 
   it('does NOT close when the user clicks inside the dialog content', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     const dialog = document.querySelector('dialog') as HTMLDialogElement;
     // Click an inner element — a heading is convenient and unambiguously
     // not the dialog itself.
@@ -450,7 +465,6 @@ describe('AttributionModal', () => {
   // as plain text rather than a broken link — fail-soft on Phylopic curation
   // adding a new license short identifier the modal hasn't been taught yet.
   it('renders an unknown license short identifier as plain text (no link)', async () => {
-    const user = userEvent.setup();
     const exoticLicense: FamilySilhouette[] = [
       {
         familyCode: 'corvidae',
@@ -464,8 +478,7 @@ describe('AttributionModal', () => {
         creator: 'C. Author',
       },
     ];
-    render(<AttributionModal silhouettes={exoticLicense} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: exoticLicense });
     const rows = screen.getAllByTestId('attribution-phylopic-row');
     // The license string is in the row...
     expect(within(rows[0]!).getByText(/CC-BY-7\.0/)).toBeInTheDocument();
@@ -491,9 +504,7 @@ describe('AttributionModal', () => {
    */
 
   it('renders a user-facing loading message in the Phylopic section when loading=true', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={[]} loading={true} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: [], loading: true });
     // Status (aria-live) text replaces the empty list.
     expect(
       screen.getByText(/loading silhouette attributions/i),
@@ -508,10 +519,8 @@ describe('AttributionModal', () => {
   });
 
   it('renders a user-facing error message in the Phylopic section when error is set (raw message hidden)', async () => {
-    const user = userEvent.setup();
     const err = new Error('pool exhausted');
-    render(<AttributionModal silhouettes={[]} error={err} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: [], error: err });
     // User-facing copy is generic; raw error string MUST NOT leak.
     expect(
       screen.getByText(/couldn't load silhouette attributions/i),
@@ -527,15 +536,7 @@ describe('AttributionModal', () => {
   });
 
   it('error state takes precedence over loading state', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={[]}
-        loading={true}
-        error={new Error('x')}
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: [], loading: true, error: new Error('x') });
     expect(
       screen.getByText(/couldn't load silhouette attributions/i),
     ).toBeInTheDocument();
@@ -545,7 +546,6 @@ describe('AttributionModal', () => {
   });
 
   it('renders a creator-only row (source=null, creator!=null) as plain text — no broken anchor', async () => {
-    const user = userEvent.setup();
     const creatorOnly: FamilySilhouette[] = [
       {
         familyCode: 'foobar',
@@ -559,8 +559,7 @@ describe('AttributionModal', () => {
         creator: 'Jane Doe',
       },
     ];
-    render(<AttributionModal silhouettes={creatorOnly} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: creatorOnly });
     const rows = screen.getAllByTestId('attribution-phylopic-row');
     expect(rows).toHaveLength(1);
     const row = rows[0]!;
@@ -580,14 +579,12 @@ describe('AttributionModal', () => {
     expect(within(row).getByText(/Jane Doe/)).toBeInTheDocument();
   });
 
-  // Smoke test: the trigger calls a controlled onOpenChange callback if
-  // provided (lets App.tsx wire telemetry / focus instrumentation if it
-  // ever wants to without a refactor).
+  // Smoke test: opening (via the controlled `open` prop) and closing both fire
+  // the onOpenChange callback. App.tsx wires this to setAttributionOpen so the
+  // native close (Escape / backdrop / close button) flips the controlled state.
   it('forwards open-state changes to an optional onOpenChange prop', async () => {
     const onOpenChange = vi.fn();
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} onOpenChange={onOpenChange} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    const { user } = await openModal({ silhouettes: SILHOUETTES, onOpenChange });
     expect(onOpenChange).toHaveBeenCalledWith(true);
     await user.click(screen.getByRole('button', { name: /close/i }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -619,15 +616,11 @@ describe('AttributionModal', () => {
    */
 
   it('renders a Photos section when photoAttribution + photoLicense are both present', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoAttribution="Jane Photographer"
-        photoLicense="cc-by"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({
+      silhouettes: SILHOUETTES,
+      photoAttribution: 'Jane Photographer',
+      photoLicense: 'cc-by',
+    });
     // Section heading appears as <h3> (consistent with the other sections).
     expect(
       screen.getByRole('heading', { level: 3, name: /^photos$/i }),
@@ -635,15 +628,11 @@ describe('AttributionModal', () => {
   });
 
   it('renders the photographer name + license link in the Photos section', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoAttribution="Jane Photographer"
-        photoLicense="cc-by"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({
+      silhouettes: SILHOUETTES,
+      photoAttribution: 'Jane Photographer',
+      photoLicense: 'cc-by',
+    });
     const photosHeading = screen.getByRole('heading', { level: 3, name: /^photos$/i });
     const section = photosHeading.closest('section');
     expect(section).not.toBeNull();
@@ -658,9 +647,7 @@ describe('AttributionModal', () => {
   });
 
   it('omits the Photos section when both photoAttribution and photoLicense are absent', async () => {
-    const user = userEvent.setup();
-    render(<AttributionModal silhouettes={SILHOUETTES} />);
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES });
     // No <h3>Photos</h3> in the modal.
     expect(
       screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
@@ -668,43 +655,25 @@ describe('AttributionModal', () => {
   });
 
   it('omits the Photos section when only photoAttribution is present (no license)', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoAttribution="Jane Photographer"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES, photoAttribution: 'Jane Photographer' });
     expect(
       screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
     ).toBeNull();
   });
 
   it('omits the Photos section when only photoLicense is present (no attribution)', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoLicense="cc-by"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({ silhouettes: SILHOUETTES, photoLicense: 'cc-by' });
     expect(
       screen.queryByRole('heading', { level: 3, name: /^photos$/i }),
     ).toBeNull();
   });
 
   it('renders an unknown photo license code as plain text (no link)', async () => {
-    const user = userEvent.setup();
-    render(
-      <AttributionModal
-        silhouettes={SILHOUETTES}
-        photoAttribution="Jane Photographer"
-        photoLicense="cc-mystery-9.9"
-      />,
-    );
-    await user.click(screen.getByRole('button', { name: /credits/i }));
+    await openModal({
+      silhouettes: SILHOUETTES,
+      photoAttribution: 'Jane Photographer',
+      photoLicense: 'cc-mystery-9.9',
+    });
     const photosHeading = screen.getByRole('heading', { level: 3, name: /^photos$/i });
     const section = photosHeading.closest('section');
     expect(section).not.toBeNull();

--- a/frontend/src/components/AttributionModal.test.tsx
+++ b/frontend/src/components/AttributionModal.test.tsx
@@ -222,7 +222,7 @@ describe('AttributionModal', () => {
     expect(ebirdLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('renders OSM and OpenFreeMap credits + links in the Map Tiles section', async () => {
+  it('renders OSM, OpenMapTiles, and OpenFreeMap credits + links in the Map Tiles section', async () => {
     const user = userEvent.setup();
     render(<AttributionModal silhouettes={SILHOUETTES} />);
     await user.click(screen.getByRole('button', { name: /credits/i }));
@@ -230,6 +230,13 @@ describe('AttributionModal', () => {
     expect(osmLink).toHaveAttribute('href', 'https://www.openstreetmap.org/copyright');
     expect(osmLink).toHaveAttribute('target', '_blank');
     expect(osmLink).toHaveAttribute('rel', 'noopener noreferrer');
+    // Item C (#830): OpenFreeMap's required attribution is
+    // "OpenFreeMap © OpenMapTiles Data from OpenStreetMap" — OpenMapTiles is
+    // mandatory and was previously omitted (a compliance gap).
+    const omtLink = screen.getByRole('link', { name: /openmaptiles/i });
+    expect(omtLink).toHaveAttribute('href', 'https://openmaptiles.org');
+    expect(omtLink).toHaveAttribute('target', '_blank');
+    expect(omtLink).toHaveAttribute('rel', 'noopener noreferrer');
     const ofmLink = screen.getByRole('link', { name: /openfreemap/i });
     expect(ofmLink).toHaveAttribute('href', 'https://openfreemap.org');
     expect(ofmLink).toHaveAttribute('target', '_blank');

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -1,20 +1,29 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { FamilySilhouette } from '@bird-watch/shared-types';
 
 /**
- * AttributionModal — credits surface for eBird, Phylopic, and OSM/OpenFreeMap.
+ * AttributionModal — credits surface for eBird, Phylopic, and
+ * OSM/OpenMapTiles/OpenFreeMap. As of #830 this is the SINGLE full-credit
+ * surface for the map: the bottom-right MapLibre AttributionControl bar was
+ * removed, and the always-visible eBird credit now lives (as a link) in the
+ * identity-card freshness line — the modal carries the complete credits.
  *
  * Compliance citations:
  *   - eBird API ToU §3: "You agree to attribute eBird.org as the source of
  *     the data accessed via the API wherever it is used or displayed…
- *     please accompany this with a link back to eBird.org."
+ *     please accompany this with a link back to eBird.org." The always-visible
+ *     anchor is the identity-card freshness-line eBird link (#830); the modal
+ *     carries the full credit.
  *   - CC BY 3.0 / CC BY-SA 3.0 §4(b/c): per-work creator attribution +
  *     license URI; reasonable means of attribution must be prominent enough
  *     to be reachable from every surface that displays the work. The trigger
- *     lives in <AppHeader> (Phase 3) as a persistent header button so the
- *     prominence requirement is met on every view (view=map|detail).
- *     The footer was removed in Phase 6.
- *   - OSM/OpenFreeMap ODbL §4.3: source attribution + license URL.
+ *     is the persistent ⓘ button in <AppHeader> (controlled-open, #830 item D),
+ *     so the prominence requirement is met on every view (view=map|detail).
+ *   - OSM ODbL §4.3 / OSMF Attribution Guidelines: a labeled ⓘ → modal with
+ *     "© OpenStreetMap" + link is explicitly sanctioned ("an '(i)' button in
+ *     the corner of the map"); "any corner of the map is acceptable" (#830).
+ *     OpenFreeMap/OpenMapTiles: required "OpenFreeMap © OpenMapTiles Data from
+ *     OpenStreetMap" — all three linked in the Map Tiles section (#830 item C).
  *
  * Top layer & the CSS z-index scale (#761 O6, issue #782):
  *   `dialog.showModal()` (below, in the open effect) promotes this dialog into
@@ -53,12 +62,15 @@ import type { FamilySilhouette } from '@bird-watch/shared-types';
  *      box hosts the backdrop in the top layer, so a click whose target IS
  *      the dialog element (not a descendant) is a backdrop click.
  *   4. External links use `rel="noopener noreferrer"` and `target="_blank"`.
- *      The codebase's other ebird/OSM credits use `rel="noopener"` (see
- *      MapCanvas customAttribution); the modal intentionally diverges to
- *      `noopener noreferrer` because (a) the modal is the most prominent
- *      attribution surface and (b) the W3C Tag finding on referrer
- *      privacy mandates noreferrer for "credit" links to third parties.
- *      Future modals should match this convention.
+ *      This is the canonical convention for every credit link in the app: the
+ *      W3C Tag finding on referrer privacy mandates noreferrer for "credit"
+ *      links to third parties. The old MapCanvas customAttribution (which used
+ *      `noopener`-only) was removed in #830, so this is the single convention;
+ *      the freshness-line eBird link (#830 item B) also uses noopener noreferrer.
+ *   5. Controlled-open (#830 item D): the dialog has no internal trigger button.
+ *      App.tsx owns `open` state, the AppHeader ⓘ button flips it, and the
+ *      `open`-prop effect runs the shared open/close path. The native `close`
+ *      event still drives onOpenChange(false) + focus-return.
  */
 
 /**
@@ -173,9 +185,19 @@ export interface AttributionModalProps {
    */
   error?: Error | null;
   /**
-   * Optional open-state callback. App.tsx can wire telemetry / focus
-   * instrumentation through this without forcing a refactor. The callback
-   * fires once per state change with the new `open` boolean.
+   * Controlled open state (#830 item D). App.tsx owns this via
+   * `const [attributionOpen, setAttributionOpen] = useState(false)` and the
+   * AppHeader ⓘ trigger drives it. When it flips true the dialog `showModal()`s
+   * (and initial focus + SR state behave identically to the old click-open
+   * path); when it flips false the dialog `close()`s. Defaults to `false` for
+   * callers (e.g. unit tests) that drive the dialog through a wrapper.
+   */
+  open?: boolean;
+  /**
+   * Optional open-state callback. App.tsx wires this to its `setAttributionOpen`
+   * so the native `close` event (Escape / backdrop / close button) flips the
+   * controlled state back to false. The callback fires once per state change
+   * with the new `open` boolean.
    */
   onOpenChange?: (open: boolean) => void;
   /**
@@ -207,20 +229,24 @@ export function AttributionModal({
   silhouettes,
   loading = false,
   error = null,
+  open = false,
   onOpenChange,
   photoAttribution,
   photoLicense,
 }: AttributionModalProps) {
   const dialogRef = useRef<HTMLDialogElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
   // Stash the previously-focused element when the modal opens so we can
-  // return focus on close. Storing on a ref avoids a re-render between
-  // open and close.
+  // return focus on close. With the controlled-open prop (#830 item D) the
+  // restore target is the AppHeader ⓘ button (the element that had focus when
+  // `open` flipped true); we capture document.activeElement at open time.
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
-  const [open, setOpen] = useState<boolean>(false);
 
-  const onOpen = useCallback(() => {
-    previouslyFocusedRef.current = (document.activeElement as HTMLElement) ?? triggerRef.current;
+  // The shared open path (#830 item D): both the controlled `open` effect below
+  // and any future programmatic opener run THIS, so initial focus + SR state are
+  // identical regardless of how the dialog was opened. Extracted from the old
+  // click-handler body verbatim (minus the deleted internal trigger state).
+  const openDialog = useCallback(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
     const dialog = dialogRef.current;
     if (!dialog) return;
     // Some browsers throw if showModal() is called twice without an
@@ -233,16 +259,33 @@ export function AttributionModal({
     // `showModal()` focus-delegation, but headless Chromium under
     // Playwright doesn't always run the delegation step before the
     // test's assertion races in. Setting focus here makes the contract
-    // observable: after onOpen returns, the close button IS the active
+    // observable: after this returns, the close button IS the active
     // element. Wrap in queueMicrotask so React's render commit completes
     // before we touch the DOM ref.
     queueMicrotask(() => {
       const close = dialog.querySelector<HTMLButtonElement>('.attribution-modal-close');
       close?.focus();
     });
-    setOpen(true);
     onOpenChange?.(true);
   }, [onOpenChange]);
+
+  // Controlled-open effect (#830 item D). Mirror the `open` prop into the
+  // native dialog: open via the shared `openDialog` path, close via close().
+  // Deps are [open] ONLY — onOpenChange is intentionally excluded so a parent
+  // passing an unstable callback can't re-fire showModal()/close() on every
+  // render (the open/close guards below also make re-runs idempotent). The
+  // native `close` listener (below) is the single source of truth for
+  // onOpenChange(false); this effect must not also call it on the close path.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      openDialog();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const onClose = useCallback(() => {
     const dialog = dialogRef.current;
@@ -259,11 +302,11 @@ export function AttributionModal({
     const dialog = dialogRef.current;
     if (!dialog) return;
     const handleClose = () => {
-      setOpen(false);
       onOpenChange?.(false);
-      // Restore focus after the React commit cycle so the trigger button
-      // (which may have re-rendered) actually exists in the DOM.
-      const previous = previouslyFocusedRef.current ?? triggerRef.current;
+      // Restore focus after the React commit cycle to the element that had
+      // focus when the dialog opened (the AppHeader ⓘ button under the
+      // controlled-open prop, #830 item D).
+      const previous = previouslyFocusedRef.current;
       if (previous && typeof previous.focus === 'function') {
         previous.focus();
       }
@@ -293,18 +336,10 @@ export function AttributionModal({
   // color only, nothing to attribute, drop.
   const phylopicRows = silhouettes.filter(s => s.source !== null || s.creator !== null);
 
+  // #830 item D: the internal `.attribution-trigger` button is gone — the
+  // dialog is controlled via the `open` prop, opened by the AppHeader ⓘ button.
+  // Only the <dialog> renders here (no fragment wrapper needed).
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="attribution-trigger"
-        onClick={onOpen}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-      >
-        Credits
-      </button>
       <dialog
         ref={dialogRef}
         className="attribution-modal"
@@ -578,6 +613,5 @@ export function AttributionModal({
           </section>
         </div>
       </dialog>
-    </>
   );
 }

--- a/frontend/src/components/AttributionModal.tsx
+++ b/frontend/src/components/AttributionModal.tsx
@@ -525,6 +525,14 @@ export function AttributionModal({
           </section>
           <section className="attribution-modal-section">
             <h3>Map Tiles</h3>
+            {/*
+              OpenFreeMap's required attribution is the full chain
+              "OpenFreeMap © OpenMapTiles Data from OpenStreetMap" — all three
+              of OpenStreetMap, OpenMapTiles, and OpenFreeMap must be credited
+              and linked (#830 item C; previously OpenMapTiles was omitted, a
+              compliance gap). Order/connective words are free; the three
+              linked names are the contractual minimum.
+            */}
             <p>
               Base map data{' '}
               <a
@@ -534,7 +542,15 @@ export function AttributionModal({
               >
                 &copy; OpenStreetMap
               </a>{' '}
-              contributors, tile hosting by{' '}
+              contributors, tiles by{' '}
+              <a
+                href="https://openmaptiles.org"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                OpenMapTiles
+              </a>
+              , hosting by{' '}
               <a
                 href="https://openfreemap.org"
                 target="_blank"

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -19,7 +19,6 @@ import {
    Map is wrapped in forwardRef because MapCanvas passes a ref to it. */
 
 let capturedSourceProps: Record<string, unknown> = {};
-let capturedAttributionProps: Record<string, unknown> = {};
 let capturedLayerFilters: Record<string, unknown> = {};
 // #762: a single OVERWRITTEN capturedSourceProps cannot distinguish the
 // observations <Source> from the state-mask <Source>. Capture sources into an
@@ -247,15 +246,8 @@ vi.mock('react-map-gl/maplibre', () => ({
     }
     return <div data-testid="mock-layer" data-layer-id={props.id} />;
   },
-  AttributionControl: (props: Record<string, unknown>) => {
-    capturedAttributionProps = props;
-    return (
-      <div
-        data-testid="mock-attribution-control"
-        data-props={JSON.stringify(props)}
-      />
-    );
-  },
+  // #830: the standalone <AttributionControl> was removed from MapCanvas — no
+  // mock needed. attributionControl={false} keeps MapLibre auto-attribution off.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Marker: ({ children, longitude, latitude }: any) => (
     <div
@@ -407,7 +399,6 @@ async function fireAllIdleHandlers() {
 describe('MapCanvas', () => {
   beforeEach(() => {
     capturedSourceProps = {};
-    capturedAttributionProps = {};
     capturedLayerFilters = {};
     capturedSourcesById = {};
     capturedLayerPaint = {};
@@ -458,12 +449,12 @@ describe('MapCanvas', () => {
     });
   });
 
-  it('renders the AttributionControl with OSM + OpenFreeMap + eBird (ToU §3)', () => {
+  it('does NOT render a maplibre AttributionControl over the map (#830 — consolidated to the ⓘ modal)', () => {
     render(<MapCanvas observations={[]} />);
-    const attribution = capturedAttributionProps['customAttribution'] as string[];
-    expect(attribution.join(' ')).toMatch(/OpenStreetMap/);
-    expect(attribution.join(' ')).toMatch(/OpenFreeMap/);
-    expect(attribution.join(' ')).toMatch(/eBird/);
+    // Item A: the bottom-right attribution bar is gone. The mock module no
+    // longer exports AttributionControl, and attributionControl={false} on the
+    // <Map> keeps MapLibre's own auto-attribution suppressed.
+    expect(screen.queryByTestId('mock-attribution-control')).toBeNull();
   });
 
   /* ── Sprite registration (issue #246, preserved) ────────────────── */
@@ -1209,7 +1200,6 @@ describe('onSelectSpecies popover wire', () => {
 
   beforeEach(async () => {
     capturedSourceProps = {};
-    capturedAttributionProps = {};
     capturedLayerFilters = {};
     capturedSourcesById = {};
     capturedLayerPaint = {};
@@ -1375,7 +1365,6 @@ describe('onSelectSpecies popover wire', () => {
 describe('ObservationPopover anchoring — displaced silhouette regression (#718)', () => {
   beforeEach(() => {
     capturedSourceProps = {};
-    capturedAttributionProps = {};
     capturedLayerFilters = {};
     capturedSourcesById = {};
     capturedLayerPaint = {};
@@ -1579,7 +1568,6 @@ describe('MapCanvas controllable camera (#736)', () => {
 
   beforeEach(() => {
     capturedSourceProps = {};
-    capturedAttributionProps = {};
     capturedLayerFilters = {};
     capturedSourcesById = {};
     capturedLayerPaint = {};
@@ -1897,7 +1885,6 @@ describe('MapCanvas state-artboard mask (#762)', () => {
 
   beforeEach(() => {
     capturedSourceProps = {};
-    capturedAttributionProps = {};
     capturedLayerFilters = {};
     capturedSourcesById = {};
     capturedLayerPaint = {};

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -14,7 +14,6 @@ import {
   Source,
   Layer,
   Marker,
-  AttributionControl,
 } from 'react-map-gl/maplibre';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -2149,29 +2148,17 @@ export function MapCanvas({
           : {})}
       >
         {/*
-          ODbL compliance: OpenStreetMap data (via OpenFreeMap's positron tiles)
-          is contractually required to be attributed. React-map-gl v7's <Map>
-          prop narrows maplibre's `attributionControl` to `boolean`, so the
-          standalone <AttributionControl> component is the only way to pass
-          `compact: false` alongside custom text. `customAttribution` augments
-          the style's built-in attribution rather than replacing it.
-
-          eBird API ToU §3 (issue #243): observation data displayed on this
-          map originates from the eBird API and must be attributed with a link
-          back to eBird.org. The credit lives here (alongside OSM /
-          OpenFreeMap) on the map view, NOT in a SurfaceFooter, so the map is
-          not double-credited. All three entries use `rel="noopener"` — do
-          NOT introduce a `noopener noreferrer` divergence inside this array;
-          the AttributionModal in #250 inherits this exact convention.
+          Attribution consolidated (#830): the bottom-right MapLibre
+          AttributionControl bar was removed. `attributionControl={false}` (above)
+          keeps MapLibre's own auto-attribution suppressed, so no control renders
+          over the map. License compliance now lives in two places — the
+          always-visible eBird source link in the identity-card freshness line
+          (AppHeader, #830 item B) and the full credits (OSM / OpenMapTiles /
+          OpenFreeMap / eBird / PhyloPic / photos) in the top-right ⓘ
+          AttributionModal. The bottom-right corner is intentionally empty
+          (reserved for future zoom/locate). The OSMF Attribution Guidelines
+          explicitly sanction collapsing attribution behind a labeled ⓘ button.
         */}
-        <AttributionControl
-          compact={false}
-          customAttribution={[
-            '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors',
-            '<a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a>',
-            'Bird data: <a href="https://ebird.org" target="_blank" rel="noopener">eBird</a> (Cornell Lab of Ornithology)',
-          ]}
-        />
         {/*
           State-artboard inverse mask (#760/#762). A single fill of the world
           ring with the selected state punched out as a hole — paints flat opaque

--- a/frontend/src/lib/freshness.test.ts
+++ b/frontend/src/lib/freshness.test.ts
@@ -40,14 +40,16 @@ describe('deriveFreshness — 5-state machine', () => {
       const ts = new Date(NOW.getTime() - 15 * MINUTE_MS).toISOString();
       const result = deriveFreshness(ts, NOW);
       expect(result.state).toBe('fresh');
-      expect(result.label).toBe('Updated 15 min ago · Source: eBird');
+      // #830 item B: the label is the age clause only — the "· Source: eBird"
+      // credit is now composed in AppHeader JSX with a linkified eBird anchor.
+      expect(result.label).toBe('Updated 15 min ago');
     });
 
     it('returns fresh for data 1 minute old', () => {
       const ts = new Date(NOW.getTime() - 1 * MINUTE_MS).toISOString();
       const result = deriveFreshness(ts, NOW);
       expect(result.state).toBe('fresh');
-      expect(result.label).toBe('Updated 1 min ago · Source: eBird');
+      expect(result.label).toBe('Updated 1 min ago');
     });
 
     it('returns fresh for data exactly at the 30-min boundary', () => {
@@ -62,7 +64,7 @@ describe('deriveFreshness — 5-state machine', () => {
       const ts = new Date(NOW.getTime() - 2 * HOUR_MS).toISOString();
       const result = deriveFreshness(ts, NOW);
       expect(result.state).toBe('recent');
-      expect(result.label).toBe('Updated 2h ago · Source: eBird');
+      expect(result.label).toBe('Updated 2h ago');
     });
 
     it('returns recent for data just past the 30-min threshold', () => {
@@ -84,7 +86,7 @@ describe('deriveFreshness — 5-state machine', () => {
       const ts = new Date(NOW.getTime() - 9 * HOUR_MS).toISOString();
       const result = deriveFreshness(ts, NOW);
       expect(result.state).toBe('stale');
-      expect(result.label).toBe('Last updated 9h ago · Source: eBird');
+      expect(result.label).toBe('Last updated 9h ago');
     });
 
     it('returns stale for data just past the 6-h threshold', () => {

--- a/frontend/src/lib/freshness.ts
+++ b/frontend/src/lib/freshness.ts
@@ -5,10 +5,16 @@
  * the freshestObservationAt ISO string from meta.freshestObservationAt to
  * produce a { state, label } pair for display.
  *
+ * The label is the AGE CLAUSE ONLY. The "· Source: eBird" credit is composed in
+ * AppHeader JSX (#830 item B) as `{label} · Source: <a href="https://ebird.org">eBird</a>`
+ * so the eBird credit is a real link, not interpolated text. The credit therefore
+ * appears in fresh/recent/stale (data shown) and is absent in empty/error
+ * (label: '') — preserving "attribute wherever eBird data is displayed."
+ *
  * State machine (spec: docs/design/01-spec/voice-and-content.md §Freshness label state machine):
- *   fresh  — age ≤ FRESHNESS_FRESH_MAX_MS (30 min) → "Updated N min ago · Source: eBird"
- *   recent — age ≤ FRESHNESS_RECENT_MAX_MS (6 h)   → "Updated N h ago · Source: eBird"
- *   stale  — age > FRESHNESS_RECENT_MAX_MS          → "Last updated N h ago · Source: eBird"
+ *   fresh  — age ≤ FRESHNESS_FRESH_MAX_MS (30 min) → "Updated N min ago"
+ *   recent — age ≤ FRESHNESS_RECENT_MAX_MS (6 h)   → "Updated N h ago"
+ *   stale  — age > FRESHNESS_RECENT_MAX_MS          → "Last updated N h ago"
  *   empty  — freshestObservationAt is null AND table is empty (post-migration / fresh deploy)
  *            → label: '' (suppressed — no display noise on a legitimately empty table)
  *   error  — freshestObservationAt is null AND ingestor/API truly failed
@@ -85,20 +91,20 @@ export function deriveFreshness(
   if (ageMs <= FRESHNESS_FRESH_MAX_MS) {
     return {
       state: 'fresh',
-      label: `Updated ${formatAge(ageMs)} · Source: eBird`,
+      label: `Updated ${formatAge(ageMs)}`,
     };
   }
 
   if (ageMs <= FRESHNESS_RECENT_MAX_MS) {
     return {
       state: 'recent',
-      label: `Updated ${formatAge(ageMs)} · Source: eBird`,
+      label: `Updated ${formatAge(ageMs)}`,
     };
   }
 
   // stale: age > FRESHNESS_RECENT_MAX_MS
   return {
     state: 'stale',
-    label: `Last updated ${formatAge(ageMs)} · Source: eBird`,
+    label: `Last updated ${formatAge(ageMs)}`,
   };
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -416,12 +416,27 @@ body {
   line-height: 1.4;
 }
 
-/* Freshness / source meta — "Updated 11 min ago · Source: eBird" */
+/* Freshness / source meta — "Updated 11 min ago · Source: eBird" (the eBird
+   token is a real link; see .app-header-freshness a below). */
 .app-header-freshness {
   margin: 0;
   font-size: var(--type-xs);
   color: var(--color-text-subtle);
   line-height: 1.4;
+}
+/* The always-visible eBird source credit (#830 item B). Uses the modal-link
+   recipe — var(--color-text-strong) (~17:1 light / ~13.8:1 dark on the
+   identity-card surface --color-bg-surface) + underline. Do NOT use the
+   project link token --color-text-link (orange/cyan --color-decision-point):
+   it is only 2.53:1 on the card surface and fails WCAG 1.4.3. */
+.app-header-freshness a {
+  color: var(--color-text-strong);
+  text-decoration: underline;
+}
+.app-header-freshness a:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* Hairline divider between lede content and scope rows. */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,25 +38,12 @@
   --space-lg: 16px;
   --space-xl: 24px;
 
-  /* Vertical clearance the bottom-left .family-legend must leave for MapLibre's
-     basemap AttributionControl so the OSM / OpenFreeMap / eBird license text is
-     NEVER overlapped (ODbL + eBird ToU §3 — licensing, not cosmetic). #775.
-
-     Under the full-bleed map (#761 S2) the map fills 100vh and the non-compact
-     attribution (`compact={false}` in MapCanvas.tsx — deliberately always-
-     expanded so the OSM credit is visible without a click) renders as a bottom
-     bar that, on narrow viewports, spans the FULL viewport width and wraps to
-     multiple lines — its left portion reaching into the legend's bottom-left
-     corner. Measured band heights (single source of truth for this token,
-     re-derive with the map-root-geometry attribution-clearance guard):
-       - ≤760px : 3-line wrap  → ~60px tall, left edge at x=0  (full width)
-       - 761–1024px : 2→1-line → up to ~40px tall, wide bar
-       - >1024px : single line → ~20px tall, hugs the bottom-right corner
-     The token lifts the legend's bottom anchor ABOVE the worst-case band per
-     tier (clearance > band height), so the lift is independent of the bar's
-     horizontal extent — the legend clears it vertically regardless of width.
-     Default is the desktop tier; the two media queries below override it. */
-  --attribution-clearance: 20px;
+  /* The tiered legend-bottom clearance token was retired in #830: the
+     bottom-right MapLibre attribution bar was removed (attribution consolidated
+     into the ⓘ modal + the freshness-line eBird link), so the legend no longer
+     needs a tiered bottom lift to clear it. The legend now sits at --card-inset;
+     the only remaining bottom-sheet interaction is the peek-snap rule below
+     .family-legend. */
 
   --dur-fast: 200ms;
   --dur-base: 250ms;
@@ -866,15 +853,16 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 
 /* FamilyLegend floating overlay (#249). O2 (#770): changed position:absolute
    → position:fixed so the element anchors to the viewport bottom-left corner
-   as an App-root sibling (no longer a child of .map-surface). The bottom
-   offset lifts the legend ABOVE MapLibre's AttributionControl band
-   (--attribution-clearance, tiered by viewport) so the OSM / OpenFreeMap /
-   eBird credit is never overlapped — a licensing requirement, not cosmetic
-   (#775). The legend is a semantic <aside role="complementary"> — keyboard-
-   reachable, labelled by its toggle button, and self-collapsing on mobile. */
+   as an App-root sibling (no longer a child of .map-surface). The legend sits
+   at --card-inset from the bottom-left edge (the four-corner contract's
+   bottom-left anchor). The pre-#830 tiered bottom lift (to clear the removed
+   MapLibre attribution bar) is gone; the only bottom-sheet interaction is the
+   peek-snap rule below. The legend is a semantic <aside
+   role="complementary"> — keyboard-reachable, labelled by its toggle button,
+   and self-collapsing on mobile. */
 .family-legend {
   position: fixed;
-  bottom: calc(var(--space-md) + var(--attribution-clearance));
+  bottom: var(--card-inset);
   left: var(--space-md);
   z-index: var(--z-overlay);
   background: var(--color-bg-surface);
@@ -1017,33 +1005,9 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   background: var(--color-bg-surface);
 }
 
-/* Attribution-clearance tablet tier (#775). At 761–1024px the non-compact
-   basemap attribution bar wraps to ~2 lines (~40px tall, measured at 768×1024)
-   and still spans most of the viewport width, so the legend must clear a taller
-   band than the desktop default. Source-ordered BEFORE the ≤760px block so the
-   narrower mobile query (60px) overrides this at phone widths. */
-@media (max-width: 1024px) {
-  :root {
-    --attribution-clearance: 40px;
-  }
-}
-
-/* Mobile collapse-by-default. The component reads this breakpoint via
-   matchMedia at mount time (see MapSurface.readLegendDefaultExpanded);
-   the CSS below additionally tightens the collapsed footprint so the
-   chevron tab doesn't obscure the map. localStorage 'family-legend-
-   expanded' overrides this — the responsive default is a first-visit
-   hint, not a sticky rule.
-
-   --attribution-clearance jumps to 60px here: at ≤760px the attribution bar
-   spans the full viewport width and wraps to ~3 lines (measured 60px at
-   390×844), so the legend's bottom-left corner must clear that full band
-   (#775 — licensing requirement). */
-@media (max-width: 760px) {
-  :root {
-    --attribution-clearance: 60px;
-  }
-}
+/* #830: the two legend-clearance media overrides (tablet 40px / mobile 60px)
+   were removed along with the token — there is no longer a bottom attribution
+   bar for the legend to clear. */
 
 /* R6 fix (O5 #783): cap the legend at the overlay breakpoint (≤480px, P1's
    --overlay-bp token). The old 760px content-breakpoint rule widened the
@@ -1066,6 +1030,18 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
    bar visible — no localStorage mutation (transient display override only). */
 .family-legend[data-force-collapsed="true"] .family-legend-entries {
   display: none;
+}
+
+/* Peek-snap sheet clearance (#830 item F). At the half/full snaps the legend is
+   already force-collapsed on phones (App.tsx legendForceCollapsed → entries
+   display:none above), so ONLY the peek snap leaves the un-collapsed legend
+   inside the bottom-sheet band. Lift the legend above the peek strip so the two
+   never overlap. This is a Layer-3 (transient-interaction) rule scoped to the
+   peek state — deliberately NOT a :root primitive and NOT applied at --half.
+   The 120px MUST stay synced to PEEK_PX in SpeciesDetailSheet.tsx (the peek
+   strip height); change both together. */
+body:has(.species-detail-sheet--peek) .family-legend {
+  bottom: calc(var(--card-inset) + 120px + var(--space-md));
 }
 
 /* Observation popover (#246, repositioned in #718). Anchored to the

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -718,32 +718,9 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   inset: 0;
 }
 
-/* AttributionModal trigger button. Visually a link rather than a CTA so
-   the footer stays unobtrusive — the credits surface is reference, not
-   action. Underlined + muted color matches the SurfaceFooter idiom the
-   modal subsumes. The 32px min-height satisfies the iOS HIG tap target
-   on mobile (the trigger is the only thing in the footer). */
-.attribution-trigger {
-  appearance: none;
-  background: transparent;
-  border: none;
-  padding: var(--space-xs) var(--space-sm);
-  color: var(--color-text-muted);
-  font: inherit;
-  font-size: var(--type-xs);
-  text-decoration: underline;
-  cursor: pointer;
-  border-radius: 4px;
-  min-height: 32px;
-}
-.attribution-trigger:hover,
-.attribution-trigger:focus-visible {
-  color: var(--color-text-strong);
-}
-.attribution-trigger:focus-visible {
-  outline: 2px solid var(--color-text-strong);
-  outline-offset: 2px;
-}
+/* #830 item D: the internal `.attribution-trigger` button (and its CSS) was
+   removed — the modal is controlled via the `open` prop, opened by the
+   top-right AppHeader ⓘ button. */
 
 /* AttributionModal native <dialog>. Browser-managed top-layer + backdrop
    means we don't need a separate overlay element; ::backdrop styles the
@@ -762,7 +739,10 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
    browser's centering on Safari. */
 .attribution-modal {
   border: 1px solid var(--color-border-ui);
-  border-radius: 8px;
+  /* #830 item G: adopt the floating-card token language (spec §2.3) — cards
+     round at --card-radius (12px, retires the old 8px) and a focused/modal
+     surface uses the tier-3 elevation token (retires the bespoke shadow). */
+  border-radius: var(--card-radius);
   background: var(--color-bg-surface);
   color: var(--color-text-strong);
   padding: 0;
@@ -771,7 +751,7 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   width: calc(100vw - 2 * var(--space-lg));
   inset: 0;
   margin: auto;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, var(--opacity-hover));
+  box-shadow: var(--card-elevation-3);
 }
 .attribution-modal::backdrop {
   background: rgba(0, 0, 0, 0.45);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -83,7 +83,10 @@
    *   TOP-RIGHT   Controls cluster: Filters · Attribution · theme toggle
    *               — compact pill group, content-width.
    *   BOTTOM-LEFT Family legend — --card-maxw-legend.
-   *   BOTTOM-RIGHT Attribution line + future zoom/locate — safe-zone.
+   *   BOTTOM-RIGHT Reserved for future zoom/locate — safe-zone. (Attribution
+   *               consolidated #830: always-visible eBird source credit in the
+   *               identity-card freshness line; full credits in the top-right
+   *               ⓘ Credits modal.)
    *   TRANSIENT   Popovers (flip/shift/clamp to stay on-screen), detail
    *               card (insets into top-right region), filters panel
    *               (anchored under its trigger) — per-element caps.


### PR DESCRIPTION


## Diagrams

Attribution surfaces: two → one. The bottom-right MapLibre bar is removed; the always-visible eBird anchor moves into the identity-card freshness line as a link; the ⓘ modal becomes the single full-credit surface.

```mermaid
flowchart TB
    subgraph before["BEFORE — two surfaces"]
        b1["Bottom-right MapLibre<br/>AttributionControl bar<br/>(OSM · OpenFreeMap · eBird)"]
        b2["Top-right ⓘ modal<br/>(opened via querySelector<br/>.attribution-trigger shim)"]
    end
    subgraph after["AFTER — one surface + a link"]
        a1["Identity-card freshness line:<br/>'Updated N min ago · Source: <b>eBird</b>'<br/>(eBird = real ebird.org link,<br/>--color-text-strong, AA)"]
        a2["Top-right ⓘ modal — controlled-open<br/>(open prop ← App useState)<br/>OSM · <b>OpenMapTiles</b> · OpenFreeMap<br/>· eBird · PhyloPic · photos"]
        a3["Bottom-right: empty<br/>(reserved zoom/locate;<br/>--attribution-clearance retired,<br/>legend at --card-inset)"]
    end
    before -->|"#830"| after
```

```mermaid
sequenceDiagram
    participant U as User
    participant H as AppHeader ⓘ
    participant A as App (attributionOpen)
    participant M as AttributionModal (dialog)
    U->>H: click ⓘ
    H->>A: onOpenAttribution() → setAttributionOpen(true)
    A->>M: open={true}
    M->>M: open-effect → openDialog() → showModal() + focus Close
    U->>M: Esc / backdrop / Close
    M->>A: native close → onOpenChange(false)
    A->>M: open={false} — focus returns to ⓘ
```

## Summary

- **Why:** the always-expanded bottom-right MapLibre attribution bar read as cheap chrome over the edge-to-edge map and duplicated the ⓘ Credits modal. This consolidates to **one** credit surface (the ⓘ modal) plus an always-visible eBird **link** in the identity-card freshness line — without weakening license compliance (the OSMF Attribution Guidelines explicitly sanction collapsing OSM attribution behind a labeled ⓘ button; "any corner of the map is acceptable").
- **What (A–H):** (A) delete the `AttributionControl` bar + its unused import from `MapCanvas`; (B) `freshness.ts` returns the age clause only, `AppHeader` composes `· Source: <eBird link>` (styled `--color-text-strong` + underline, ~17:1 light / ~13.8:1 dark — NOT the orange `--color-text-link` which fails WCAG); Remedy 1 deletes the dead `client.ts` `Array.isArray` branch so the credit⟺markers invariant holds; (C) add the missing **OpenMapTiles** credit to the modal Map Tiles section; (D) replace the `.attribution-trigger` querySelector shim with a controlled `open` prop (App `useState`), delete the internal trigger; (E) `aria-haspopup="dialog"` on the ⓘ trigger (aria-expanded intentionally omitted — top-layer dialog, not inline disclosure); (F) retire `--attribution-clearance`, legend sits at `--card-inset`, add a peek-only sheet-clearance rule synced to `PEEK_PX`=120; (G) modal adopts `--card-radius` + `--card-elevation-3`; (H) amend the four-corner contract in CLAUDE.md, tokens.css, and the design spec.
- **Legal posture:** *eBird ToU §3* — always-visible source credit **+ link** in the freshness line + full credit in the modal, visible whenever eBird data is shown. *OSM ODbL* — collapsing attribution behind a labeled ⓘ is explicitly sanctioned by the OSM Foundation Attribution Guidelines ("an '(i)' button in the corner of the map or an 'About' option in a menu"; "any corner of the map is acceptable") — `osmfoundation.org/wiki/Licence/Attribution_Guidelines`. *OpenFreeMap/OpenMapTiles* — required string "OpenFreeMap © OpenMapTiles Data from OpenStreetMap"; OpenMapTiles + OSM mandatory, fixed by item C. *PhyloPic / photos / Wikipedia* — unchanged.

## Screenshots

**Map surface** — no bottom-right attribution bar; the linkified `· Source: eBird` credit sits in the top-left identity card (legible on the card surface in both themes).

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="map-390-light" src="https://github.com/user-attachments/assets/d6785d32-f3f9-41bf-8e1e-31150e6901d2" /> | <img width="360" alt="map-390-dark" src="https://github.com/user-attachments/assets/910b6a2f-b5cc-42b8-b509-6ab6919754fc" /> |
| **768×1024 (tablet)** | <img width="360" alt="map-768-light" src="https://github.com/user-attachments/assets/7927793d-cfdb-41aa-8bda-75554108e560" /> | <img width="360" alt="map-768-dark" src="https://github.com/user-attachments/assets/9ec2312f-a65b-4d76-a082-865a47a3de91" /> |
| **1024×768 (small laptop)** | <img width="360" alt="map-1024-light" src="https://github.com/user-attachments/assets/9b758dac-bb96-499c-9ce0-336dfba3f5bd" /> | <img width="360" alt="map-1024-dark" src="https://github.com/user-attachments/assets/e808f7de-adf9-463f-8164-2f838fba074e" /> |
| **1440×900 (desktop)** | <img width="360" alt="map-1440-light" src="https://github.com/user-attachments/assets/496331ff-9663-4a80-8758-7526391736a5" /> | <img width="360" alt="map-1440-dark" src="https://github.com/user-attachments/assets/8ef59d1c-1511-4b14-a7b0-faa258fcf5d9" /> |
| **1920×1080 (wide)** | <img width="360" alt="map-1920-light" src="https://github.com/user-attachments/assets/b5ce25d7-a10b-4793-9385-cff960858155" /> | <img width="360" alt="map-1920-dark" src="https://github.com/user-attachments/assets/a5b9330a-cf26-471e-9870-eff82caa5fd6" /> |

**ⓘ Credits modal (open)** — single full-credit surface; Map Tiles section lists OSM · OpenMapTiles · OpenFreeMap; `--card-radius` + tier-3 elevation.

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="modal-390-light" src="https://github.com/user-attachments/assets/3f7d288c-0567-489a-9718-cfa093e287a6" /> | <img width="360" alt="modal-390-dark" src="https://github.com/user-attachments/assets/dd349c5a-cb52-49cc-9709-64b52d7b27e2" /> |
| **768×1024 (tablet)** | <img width="360" alt="modal-768-light" src="https://github.com/user-attachments/assets/d0ba5a4e-ede7-404a-9e6f-dae4513d1755" /> | <img width="360" alt="modal-768-dark" src="https://github.com/user-attachments/assets/772d7c99-4da4-460c-a401-460c08f64e57" /> |
| **1024×768 (small laptop)** | <img width="360" alt="modal-1024-light" src="https://github.com/user-attachments/assets/a1681fe1-452e-4d20-9667-b26ac61cef74" /> | <img width="360" alt="modal-1024-dark" src="https://github.com/user-attachments/assets/dfb0e2d2-c7d5-46d8-9dd9-88c3b338feaa" /> |
| **1440×900 (desktop)** | <img width="360" alt="modal-1440-light" src="https://github.com/user-attachments/assets/dae48f0c-3447-4f8b-9fe7-04641e6d6a0c" /> | <img width="360" alt="modal-1440-dark" src="https://github.com/user-attachments/assets/449194d7-572c-4442-bf2d-bddb3b3dc15d" /> |
| **1920×1080 (wide)** | <img width="360" alt="modal-1920-light" src="https://github.com/user-attachments/assets/943786db-7742-480c-8939-9d47a677e8b5" /> | <img width="360" alt="modal-1920-dark" src="https://github.com/user-attachments/assets/0ad99840-b921-45ed-89c4-c9a7e82dde71" /> |

**Peek-sheet legend clearance (390×844)** — with a species selected at the peek snap, the family legend lifts clear of the sheet (legend.bottom ≤ sheet.top, zero overlap).

| Light | Dark |
|---|---|
| <img width="360" alt="peek-legend-390-light" src="https://github.com/user-attachments/assets/ac0b4123-b892-4265-9dbd-55c13a7abc42" /> | <img width="360" alt="peek-legend-390-dark" src="https://github.com/user-attachments/assets/c815a0ed-10fd-467e-9adf-bf85ed5226ae" /> |

_Captured at all 5 canonical viewports × light + dark, map surface + open ⓘ modal, plus the 390×844 peek-sheet legend-clearance proof. Driven live via Playwright MCP against the worktree build. **Console: 0 errors and 0 new warnings at every viewport.** (One pre-existing `Image "circle-11" could not be loaded` MapLibre dark-basemap sprite warning fires on dark-theme swap; verified identical on unmodified `main`, so it is baseline, not introduced by this PR — this PR touches no sprite/basemap/style code.)_

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` (orphan-classname check PASS; no new classNames introduced — the freshness link is styled via `.app-header-freshness a`, the peek rule targets existing `.species-detail-sheet--peek` / `.family-legend`)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445)

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (`tsc -b && vite build`) — clean (confirms the `AttributionControl` + `useState` import removals)
- [x] `npm test --workspace @bird-watch/frontend` — **1066 passed (67 files)**. Rewrites: all ~35 `AttributionModal.test` open-paths now drive a controlled harness (open via a real opener → focus-return target); `App.test` deletes the stale `.attribution-trigger`-present test and adds controlled-open coverage; `AppHeader.test` asserts the linkified eBird + `aria-haspopup`; `freshness.test` asserts the age-clause-only label; `client.test` pins the freshness-preservation invariant; `MapCanvas.test` drops the `customAttribution`/`AttributionControl` assertions.
- [x] e2e (Playwright) — affected specs run green against the worktree build: `map-root-geometry` (7/7, incl. the new **#830 peek-snap clearance** test replacing the deleted `.maplibregl-ctrl-attrib` guard), `axe` (17/17, incl. rewritten attribution-reachability + modal-open WCAG scans), `state-artboard` (11/11), `sheet-snap` (2/2), `legend-o5-cap-force-collapse` (5/5). `grep -rln "maplibregl-ctrl-attrib" frontend/e2e` → 0.
- [x] `npx knip` — clean; orphan-classname check — PASS; lint forbidden-token guard — clean.
- [x] Playwright MCP live drive at all 5 canonical viewports × light + dark: no bottom-right bar; freshness eBird link legible on the card surface in both themes (`color: rgb(26,26,26)` + underline); modal opens via the ⓘ button (focus → Close), Esc closes + focus returns to ⓘ; all 3 basemap credits (OSM/OpenMapTiles/OpenFreeMap) present; legend clears the peek sheet at 390×844 (legend.bottom 700 ≤ sheet.top 724, 0 overlap); `0` console errors, `0` new warnings.

## Plan reference

Out of plan — implements GitHub issue #830 (an `agent-ready` spec). Closes #830. Builds on the floating-card token language (#803) and the four-corner anchor contract (#761 / spec §3).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

