### PR TITLE
fix(ingestor): fan out recent ingest per-state (#840)

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -114,6 +114,72 @@ describe('runCli', () => {
     delete process.env.HEALTHCHECKS_URL_RECENT;
   });
 
+  it('"recent" partial run surfaces statesFailed + failed state codes in the run-completed line (#840 review)', async () => {
+    // A degraded-but-green run (some states 500'd, under the failure threshold)
+    // correctly still pings the success heartbeat — but if the aggregate
+    // bird_ingest_run_completed line drops the failed-state count, the dashboard
+    // metrics see a clean INFO line and the silent-degradation is invisible
+    // (the same class of bug that hid the original #840 single-region starve).
+    // The summary line MUST carry statesFailed (and the failed state codes) so a
+    // partial run reads as degraded in Cloud Logging without joining against the
+    // per-state WARNING lines.
+    const partialSummary: RunSummary = {
+      status: 'partial', fetched: 5, upserted: 5,
+      statesSucceeded: 46, statesFailed: 3,
+      failures: [
+        { state: 'US-NM', error: 'boom' },
+        { state: 'US-TX', error: 'timeout' },
+        { state: 'US-NV', error: '500' },
+      ],
+    };
+    const deps = makeDeps({ runIngest: vi.fn().mockResolvedValue(partialSummary) });
+
+    await runCli('recent', deps);
+
+    const emitted = logSpy.mock.calls
+      .map((args: unknown[]): unknown => {
+        try { return JSON.parse(args[0] as string); } catch { return null; }
+      })
+      .filter((o: unknown): o is Record<string, unknown> =>
+        typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'bird_ingest_run_completed'
+      );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({
+      severity: 'INFO',
+      message: 'bird_ingest_run_completed',
+      kind: 'recent',
+      status: 'partial',
+      statesFailed: 3,
+      failedStates: ['US-NM', 'US-TX', 'US-NV'],
+      firstError: 'boom',
+    });
+  });
+
+  it('"recent" success run omits statesFailed/failedStates from the run-completed line', async () => {
+    // A clean run (0 failed) must not clutter the structured line with a
+    // statesFailed:0 / empty failedStates field — those keys appear ONLY when
+    // there is degradation to surface, mirroring the existing conditional
+    // `state` / `firstError` field shape.
+    const successSummary: RunSummary = {
+      status: 'success', fetched: 10, upserted: 10,
+      statesSucceeded: 49, statesFailed: 0,
+    };
+    const deps = makeDeps({ runIngest: vi.fn().mockResolvedValue(successSummary) });
+
+    await runCli('recent', deps);
+
+    const emitted = logSpy.mock.calls
+      .map((args: unknown[]): unknown => {
+        try { return JSON.parse(args[0] as string); } catch { return null; }
+      })
+      .filter((o: unknown): o is Record<string, unknown> =>
+        typeof o === 'object' && o !== null && (o as Record<string, unknown>).message === 'bird_ingest_run_completed'
+      );
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).not.toHaveProperty('statesFailed');
+    expect(emitted[0]).not.toHaveProperty('failedStates');
+  });
+
   it('still closes pool when the runner throws', async () => {
     const deps = makeDeps({
       runTaxonomy: vi.fn().mockRejectedValue(new Error('thrown')),

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -65,13 +65,53 @@ describe('runCli', () => {
   });
 
   it('leaves process.exitCode untouched when summary.status === "success"', async () => {
-    const successSummary: RunSummary = { status: 'success', fetched: 10, upserted: 10 };
+    const successSummary: RunSummary = {
+      status: 'success', fetched: 10, upserted: 10,
+      statesSucceeded: 49, statesFailed: 0,
+    };
     const deps = makeDeps({ runIngest: vi.fn().mockResolvedValue(successSummary) });
 
     await runCli('recent', deps);
 
     expect(process.exitCode).toBeUndefined();
     expect(deps.closePool).toHaveBeenCalledWith(POOL_SENTINEL);
+  });
+
+  it('"recent" kind drives the per-state fan-out — does NOT pass regionCode:"US" (#840)', async () => {
+    // The old single-nationwide-call bug passed `regionCode: 'US'`, which
+    // eBird deduped to one-obs-per-species, starving non-AZ states. runIngest
+    // now loops CONUS_STATE_CODES internally; cli must NOT re-pin a region.
+    const runIngestSpy = vi.fn().mockResolvedValue({
+      status: 'success', fetched: 0, upserted: 0,
+      statesSucceeded: 49, statesFailed: 0,
+    } as RunSummary);
+    const deps = makeDeps({ runIngest: runIngestSpy });
+
+    await runCli('recent', deps);
+
+    expect(runIngestSpy).toHaveBeenCalledTimes(1);
+    const arg = runIngestSpy.mock.calls[0]![0] as { regionCode?: string };
+    expect(arg.regionCode).toBeUndefined();
+  });
+
+  it('"recent" partial status still pings the heartbeat (does not set exitCode)', async () => {
+    process.env.HEALTHCHECKS_URL_RECENT = 'https://hc-ping.com/uuid-recent-partial';
+    const partialSummary: RunSummary = {
+      status: 'partial', fetched: 5, upserted: 5,
+      statesSucceeded: 46, statesFailed: 3,
+      failures: [{ state: 'US-NM', error: 'boom' }],
+    };
+    const pingSpy = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      runIngest: vi.fn().mockResolvedValue(partialSummary),
+      pingHeartbeat: pingSpy,
+    });
+
+    await runCli('recent', deps);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(pingSpy).toHaveBeenCalledWith('https://hc-ping.com/uuid-recent-partial', 'recent');
+    delete process.env.HEALTHCHECKS_URL_RECENT;
   });
 
   it('still closes pool when the runner throws', async () => {
@@ -555,7 +595,10 @@ describe('runCli', () => {
   // payload directly would flap on `duration_seconds` (computed from
   // Date.now()); parse-then-toMatchObject + expect.any(Number) is stable.
   it('emits compact structured JSON with bird_ingest_run_completed message on success', async () => {
-    const successSummary: RunSummary = { status: 'success', fetched: 1, upserted: 1 };
+    const successSummary: RunSummary = {
+      status: 'success', fetched: 1, upserted: 1,
+      statesSucceeded: 49, statesFailed: 0,
+    };
     const deps = makeDeps({ runIngest: vi.fn().mockResolvedValue(successSummary) });
 
     await runCli('recent', deps);

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -384,6 +384,27 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     // log-based metrics extract (see issue #641 + epic #638, PR-2 in #642).
     // Sibling pattern: `services/read-api/src/app.ts:161` (meta_freshness).
     const durationSeconds = Math.round((Date.now() - startedAt) / 1000);
+    // Per-state fan-out degradation (#840 review): a `partial` recent run pings
+    // the SUCCESS heartbeat (correctly — the map made forward progress), so the
+    // ONLY aggregate signal that it was degraded is this line. Without the
+    // failed-state count here, a degraded-but-green run reads as a clean INFO
+    // line and the silent-degradation is invisible — the same class of bug that
+    // hid the original single-region starve. Surface `statesFailed` + the failed
+    // state codes whenever any state failed (covers `partial` AND the per-state
+    // `failure` path; `summary.error` is only set on `failure`, so a `partial`
+    // run otherwise carried no error context at all).
+    const statesFailed =
+      'statesFailed' in summary && typeof summary.statesFailed === 'number'
+        ? summary.statesFailed
+        : 0;
+    const failedStates =
+      'failures' in summary && Array.isArray(summary.failures)
+        ? summary.failures.map(f => f.state)
+        : [];
+    const firstFanoutError =
+      'failures' in summary && Array.isArray(summary.failures)
+        ? summary.failures[0]?.error
+        : undefined;
     console.log(JSON.stringify({
       severity: summary.status === 'failure' ? 'ERROR' : 'INFO',
       message: 'bird_ingest_run_completed',
@@ -394,11 +415,21 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // field so Cloud Logging can filter by `jsonPayload.state="US-CA"`.
       // Omitted for non-backfill kinds to keep the structured shape minimal.
       ...(backfillState !== undefined && { state: backfillState }),
-      // Surface the first per-day error (or fatal pre-loop error) in the
-      // run-completed summary so Cloud Logging triage doesn't require
-      // joining against the per-day bird_ingest_day_failed lines.
-      ...(summary.status !== 'success' && 'error' in summary && typeof summary.error === 'string'
-        && { firstError: summary.error.slice(0, 500) }),
+      // Per-state fan-out: emit the degraded-state count + codes ONLY when there
+      // is degradation to surface (mirrors the conditional `state` shape above).
+      ...(statesFailed > 0 && { statesFailed, failedStates: failedStates.slice(0, 10) }),
+      // Surface the first error in the run-completed summary so Cloud Logging
+      // triage doesn't require joining against the per-state/per-day WARNING
+      // lines. `summary.error` covers fatal pre-loop / >threshold failure; the
+      // per-state `failures[0].error` covers the `partial` path where
+      // `summary.error` is unset.
+      ...((() => {
+        const err =
+          summary.status !== 'success' && 'error' in summary && typeof summary.error === 'string'
+            ? summary.error
+            : firstFanoutError;
+        return err !== undefined ? { firstError: err.slice(0, 500) } : {};
+      })()),
     }));
     if (summary.status === 'failure') {
       // Flag the process as failed without killing the loop mid-pool-close.

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -236,7 +236,15 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     // see scripts/verify-backfill.sh.
     let backfillState: string | undefined;
     if (kind === 'recent') {
-      summary = await deps.runIngest({ pool, apiKey, regionCode: 'US' });
+      // Per-state fan-out (#840): runIngest loops CONUS_STATE_CODES internally
+      // (one /recent + /recent/notable per state) because eBird's region-recent
+      // endpoint dedups to one-observation-per-species region-wide — a single
+      // 'US' call starved every non-AZ state. paceMs defaults to 1000ms inside
+      // runIngest (~98 calls × 1s ≈ 98s, well under the 900s job timeout); the
+      // status ladder (success | partial | failure) is keyed on per-state
+      // failure count + 429 circuit-break, and `partial` still pings the
+      // success heartbeat below (only `failure` skips it).
+      summary = await deps.runIngest({ pool, apiKey });
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (kind === 'backfill') {

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -242,6 +242,41 @@ describe('EbirdClient retries', () => {
     expect(calls).toBe(3); // 1 initial + 2 retries
   });
 
+  it('throws EbirdClientError(429) immediately and surfaces Retry-After (seconds form) as retryAfterMs', async () => {
+    // 429 is a 4xx: not retried at the client layer (the run-ingest fan-out
+    // owns rate-limit backoff/circuit-break, #840). The client's only job is
+    // to surface the eBird-advised cool-down so that layer can honor it.
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => {
+        calls++;
+        return new HttpResponse('rate limited', {
+          status: 429,
+          headers: { 'retry-after': '12' },
+        });
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    const err = await client.fetchRecent('US-AZ').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EbirdClientError);
+    expect((err as EbirdClientError).status).toBe(429);
+    expect((err as EbirdClientError).retryAfterMs).toBe(12_000);
+    expect(calls).toBe(1); // no retry on 4xx
+  });
+
+  it('leaves retryAfterMs undefined when a 429 carries no Retry-After header', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () =>
+        new HttpResponse('rate limited', { status: 429 })
+      )
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    const err = await client.fetchRecent('US-AZ').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EbirdClientError);
+    expect((err as EbirdClientError).status).toBe(429);
+    expect((err as EbirdClientError).retryAfterMs).toBeUndefined();
+  });
+
   it('retries on request timeout then throws EbirdServerError', async () => {
     let calls = 0;
     server.use(

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -101,7 +101,11 @@ export class EbirdClient {
         }
         if (!res.ok) {
           const body = await res.text();
-          throw new EbirdClientError(res.status, body);
+          // 429 is a 4xx — still not retried at this layer (the fan-out in
+          // run-ingest.ts owns rate-limit backoff/circuit-break, issue #840).
+          // Surface the `Retry-After` header (seconds or HTTP-date form) so
+          // that layer can honor eBird's advised cool-down instead of guessing.
+          throw new EbirdClientError(res.status, body, parseRetryAfter(res.headers.get('retry-after')));
         }
         return (await res.json()) as T;
       } catch (err) {
@@ -124,10 +128,34 @@ export class EbirdClient {
 }
 
 export class EbirdClientError extends Error {
-  constructor(public status: number, public body: string) {
+  /**
+   * Parsed `Retry-After` (in ms) when eBird returns 429. `undefined` when the
+   * header was absent or the status wasn't a rate-limit. The per-state recent
+   * fan-out (run-ingest.ts, #840) honors this for its backoff before falling
+   * back to exponential.
+   */
+  constructor(public status: number, public body: string, public retryAfterMs?: number) {
     super(`eBird client error ${status}: ${body}`);
     this.name = 'EbirdClientError';
   }
+}
+
+/**
+ * Parse an HTTP `Retry-After` header into milliseconds. Accepts both the
+ * delta-seconds form (`"120"`) and the HTTP-date form
+ * (`"Wed, 21 Oct 2026 07:28:00 GMT"`). Returns `undefined` for an absent or
+ * unparseable value, or a non-positive delay (already elapsed date).
+ */
+function parseRetryAfter(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1000;
+  }
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return undefined;
+  const delta = dateMs - Date.now();
+  return delta > 0 ? delta : undefined;
 }
 export class EbirdServerError extends Error {
   constructor(public status: number, public body: string) {

--- a/services/ingestor/src/handler.test.ts
+++ b/services/ingestor/src/handler.test.ts
@@ -70,10 +70,10 @@ describe('handleScheduled', () => {
 
     const result = await handleScheduled('recent', ENV);
 
+    // #840: recent fans out per-state inside runIngest — no regionCode pinned.
     expect(runIngestMock).toHaveBeenCalledWith({
       pool: POOL_SENTINEL,
       apiKey: 'test-key',
-      regionCode: 'US',
     });
     expect(result).toBe(summary);
     expect(closePoolMock).toHaveBeenCalledWith(POOL_SENTINEL);

--- a/services/ingestor/src/handler.ts
+++ b/services/ingestor/src/handler.ts
@@ -39,7 +39,11 @@ export async function handleScheduled(
   try {
     switch (kind) {
       case 'recent':
-        return await runIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US' });
+        // Per-state fan-out (#840): runIngest loops CONUS_STATE_CODES internally
+        // rather than making one nationwide 'US' call (which eBird deduped to
+        // one-obs-per-species, starving non-AZ states). Mirrors cli.ts's recent
+        // dispatch — no regionCode pinned.
+        return await runIngest({ pool, apiKey: env.EBIRD_API_KEY });
       case 'hotspots':
         return await runHotspotIngest({ pool, apiKey: env.EBIRD_API_KEY, regionCode: 'US-AZ' });
       case 'backfill':

--- a/services/ingestor/src/run-backfill.test.ts
+++ b/services/ingestor/src/run-backfill.test.ts
@@ -73,7 +73,9 @@ describe('runBackfill', () => {
         HttpResponse.json([TODAY_OBS])   // annhum is notable
       ),
     );
-    await runIngest({ pool: db.pool, apiKey: 'k', regionCode: 'US-AZ' });
+    // runIngest now fans out per-state (#840); scope to US-AZ with no pacing so
+    // this backfill OR-coalesce test still drives a single-state recent ingest.
+    await runIngest({ pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'], paceMs: 0 });
 
     // Confirm it was stamped notable.
     let { data: obs } = await getObservations(db.pool, {});

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import { CONUS_STATE_CODES } from '@bird-watch/shared-types';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
 import { upsertSpeciesMeta, getObservations, getRecentIngestRuns } from '@bird-watch/db-client';
 import { runIngest } from './run-ingest.js';
@@ -21,6 +22,14 @@ const RECENT = [
 const NOTABLE = [
   { ...RECENT[1] },  // mark S101 / annhum as notable
 ];
+
+/** Stub /recent + /recent/notable for a single state. */
+function stateHandlers(state: string, recent: unknown, notable: unknown) {
+  return [
+    http.get(`https://api.ebird.org/v2/data/obs/${state}/recent`, () => HttpResponse.json(recent)),
+    http.get(`https://api.ebird.org/v2/data/obs/${state}/recent/notable`, () => HttpResponse.json(notable)),
+  ];
+}
 
 beforeAll(async () => {
   db = await startTestDb();
@@ -47,23 +56,23 @@ afterAll(async () => {
   await db?.stop();
 });
 
-describe('runIngest', () => {
+describe('runIngest — single-state fan-out semantics', () => {
   it('fetches recent + notable, upserts, and stamps region/silhouette/is_notable', async () => {
-    server.use(
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => HttpResponse.json(RECENT)),
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json(NOTABLE))
-    );
+    server.use(...stateHandlers('US-AZ', RECENT, NOTABLE));
 
     const summary = await runIngest({
       pool: db.pool,
       apiKey: 'test-key',
-      regionCode: 'US-AZ',
+      stateCodes: ['US-AZ'],
+      paceMs: 0,
       back: 14,
     });
 
     expect(summary.fetched).toBe(2);
     expect(summary.upserted).toBe(2);
     expect(summary.status).toBe('success');
+    expect(summary.statesSucceeded).toBe(1);
+    expect(summary.statesFailed).toBe(0);
 
     const { data: obs } = await getObservations(db.pool, {});
     expect(obs).toHaveLength(2);
@@ -83,90 +92,241 @@ describe('runIngest', () => {
   });
 
   it('is idempotent — second run with same data does not duplicate', async () => {
-    server.use(
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => HttpResponse.json(RECENT)),
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json([]))
-    );
-    await runIngest({ pool: db.pool, apiKey: 'k', regionCode: 'US-AZ' });
-    await runIngest({ pool: db.pool, apiKey: 'k', regionCode: 'US-AZ' });
+    server.use(...stateHandlers('US-AZ', RECENT, []));
+    await runIngest({ pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'], paceMs: 0 });
+    await runIngest({ pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'], paceMs: 0 });
     const { data: obs } = await getObservations(db.pool, {});
     expect(obs).toHaveLength(2);
   });
+});
 
-  it('records a failure run when eBird is unreachable', async () => {
+describe('runIngest — per-state fan-out across all CONUS states (#840)', () => {
+  it('calls /recent + /recent/notable for every one of the 49 CONUS states', async () => {
+    const recentHits = new Set<string>();
+    const notableHits = new Set<string>();
     server.use(
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => new HttpResponse('boom', { status: 502 })),
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json([]))
+      http.get('https://api.ebird.org/v2/data/obs/:region/recent', ({ params }) => {
+        recentHits.add(params.region as string);
+        return HttpResponse.json(RECENT);
+      }),
+      http.get('https://api.ebird.org/v2/data/obs/:region/recent/notable', ({ params }) => {
+        notableHits.add(params.region as string);
+        return HttpResponse.json([]);
+      }),
     );
+
     const summary = await runIngest({
-      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
-      retryBaseMs: 1, maxRetries: 1,
+      pool: db.pool,
+      apiKey: 'k',
+      paceMs: 0, // no real waiting in tests
     });
-    expect(summary.status).toBe('failure');
-    expect(summary.error).toBeDefined();
-    const runs = await getRecentIngestRuns(db.pool, 5);
-    expect(runs[0]?.status).toBe('failure');
-    expect(runs[0]?.errorMessage).toContain('502');
+
+    expect(summary.status).toBe('success');
+    expect(summary.statesSucceeded).toBe(CONUS_STATE_CODES.length);
+    expect(summary.statesFailed).toBe(0);
+    // Default fan-out hits every CONUS state for both endpoints.
+    for (const state of CONUS_STATE_CODES) {
+      expect(recentHits.has(state)).toBe(true);
+      expect(notableHits.has(state)).toBe(true);
+    }
+    expect(recentHits.size).toBe(CONUS_STATE_CODES.length);
+    // ...and only CONUS states (no nationwide 'US' call, no AK/HI).
+    expect(recentHits.has('US')).toBe(false);
+    expect(recentHits.has('US-AK')).toBe(false);
+    expect(recentHits.has('US-HI')).toBe(false);
   });
 
-  // Invariant from issue #484: if eBird returns an observation whose
-  // species_code has no matching species_meta row, the ingest must fail
-  // LOUDLY rather than silently inserting an observation that the read-api
-  // cannot resolve to a /api/species/:code response. Future eBird hybrid/spuh
-  // codes that appear in the AZ feed therefore become a CI/cron failure that
-  // a maintainer sees, not a silent prod 404 a user reports.
-  it('fails the ingest when an observation references a missing species_meta row (#484 invariant)', async () => {
-    const RECENT_WITH_LEAK = [
-      ...RECENT,
-      // `xUNKNOWN1` is a synthetic eBird-style spuh code with no
-      // species_meta row — simulates the bug class from #484
-      // (`ixlbun`, `x00059`, etc. before the backfill).
-      { speciesCode: 'xUNKNOWN1', comName: 'Unknown Hybrid',
-        sciName: 'Genus species x other', locId: 'L3', locName: 'Test',
-        obsDt: '2026-04-15 10:00', howMany: 1, lat: 32.30, lng: -110.99,
-        obsValid: true, obsReviewed: false, locationPrivate: false,
-        subId: 'S102' },
+  it('per-state notable intersection is state-local — a notable subId in one state does NOT mark the same code in another', async () => {
+    // US-AZ: S101/annhum is notable. US-NM returns the same speciesCode under a
+    // DIFFERENT subId (S201) and an EMPTY notable list → must NOT be notable.
+    const NM_RECENT = [
+      { ...RECENT[1], subId: 'S201', locId: 'L9', locName: 'Bosque' },
     ];
     server.use(
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent',
-        () => HttpResponse.json(RECENT_WITH_LEAK)),
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
+      ...stateHandlers('US-AZ', RECENT, NOTABLE),
+      ...stateHandlers('US-NM', NM_RECENT, []),
+    );
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ', 'US-NM'], paceMs: 0,
+    });
+    expect(summary.status).toBe('success');
+
+    const { data: obs } = await getObservations(db.pool, {});
+    const azAnna = obs.find(o => o.subId === 'S101')!;
+    const nmAnna = obs.find(o => o.subId === 'S201')!;
+    expect(azAnna.isNotable).toBe(true);  // AZ's S101 is in AZ's notable set
+    expect(nmAnna.isNotable).toBe(false); // NM's S201 is NOT — keyset is per-state
+  });
+});
+
+describe('runIngest — partial-failure isolation + status ladder (#840)', () => {
+  it('isolates one state failure: others still upsert; status=partial under the threshold', async () => {
+    // US-AZ succeeds, US-NM 500s. With the default threshold (5), 1 failure → partial.
+    server.use(
+      ...stateHandlers('US-AZ', RECENT, []),
+      http.get('https://api.ebird.org/v2/data/obs/US-NM/recent',
+        () => new HttpResponse('boom', { status: 500 })),
+      http.get('https://api.ebird.org/v2/data/obs/US-NM/recent/notable',
         () => HttpResponse.json([])),
     );
 
     const summary = await runIngest({
-      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ', 'US-NM'], paceMs: 0,
+      retryBaseMs: 1, maxRetries: 1,
+    });
+
+    expect(summary.status).toBe('partial');
+    expect(summary.statesSucceeded).toBe(1);
+    expect(summary.statesFailed).toBe(1);
+    expect(summary.failures?.[0]?.state).toBe('US-NM');
+    // AZ's two observations still landed despite NM failing.
+    const { data: obs } = await getObservations(db.pool, {});
+    expect(obs).toHaveLength(2);
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.status).toBe('partial');
+  });
+
+  it('status=partial at exactly the threshold; status=failure one over it (boundary)', async () => {
+    // 6-state list, threshold=2. Two failing states → partial; the SAME list
+    // with three failing states → failure. This pins the cli heartbeat
+    // behavior: cli pings the success heartbeat on success AND partial, only
+    // failure skips it, so the cutover is load-bearing.
+    const ok = ['US-AZ', 'US-CA', 'US-CO', 'US-NV'];
+    const okHandlers = ok.flatMap(s => stateHandlers(s, [], []));
+    const fail = (state: string) => [
+      http.get(`https://api.ebird.org/v2/data/obs/${state}/recent`,
+        () => new HttpResponse('boom', { status: 500 })),
+      http.get(`https://api.ebird.org/v2/data/obs/${state}/recent/notable`,
+        () => HttpResponse.json([])),
+    ];
+
+    // 2 failures, threshold 2 → partial
+    server.use(...okHandlers, ...fail('US-NM'), ...fail('US-TX'));
+    const partial = await runIngest({
+      pool: db.pool, apiKey: 'k',
+      stateCodes: [...ok, 'US-NM', 'US-TX'], paceMs: 0,
+      partialFailureThreshold: 2, retryBaseMs: 1, maxRetries: 1,
+    });
+    expect(partial.statesFailed).toBe(2);
+    expect(partial.status).toBe('partial');
+
+    server.resetHandlers();
+    await db.pool.query('TRUNCATE observations');
+    await db.pool.query('TRUNCATE ingest_runs RESTART IDENTITY');
+
+    // 3 failures, threshold 2 → failure
+    server.use(...stateHandlers('US-AZ', [], []), ...stateHandlers('US-CA', [], []),
+      ...stateHandlers('US-CO', [], []),
+      ...fail('US-NM'), ...fail('US-TX'), ...fail('US-NV'));
+    const failure = await runIngest({
+      pool: db.pool, apiKey: 'k',
+      stateCodes: ['US-AZ', 'US-CA', 'US-CO', 'US-NM', 'US-TX', 'US-NV'], paceMs: 0,
+      partialFailureThreshold: 2, retryBaseMs: 1, maxRetries: 1,
+    });
+    expect(failure.statesFailed).toBe(3);
+    expect(failure.status).toBe('failure');
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.status).toBe('failure');
+  });
+});
+
+describe('runIngest — 429 circuit-break (#840)', () => {
+  it('aborts the run as failure after consecutive 429s rather than hammering every state', async () => {
+    // Every state 429s. With max429Streak=3 the fan-out must stop after the
+    // 3rd consecutive 429 and report failure — NOT grind through all states.
+    const hits = new Set<string>();
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/:region/recent', ({ params }) => {
+        hits.add(params.region as string);
+        return new HttpResponse('rate limited', { status: 429, headers: { 'retry-after': '0' } });
+      }),
+      http.get('https://api.ebird.org/v2/data/obs/:region/recent/notable',
+        () => HttpResponse.json([])),
+    );
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k',
+      // a long list so the test proves it STOPS early rather than running to end
+      stateCodes: CONUS_STATE_CODES,
+      paceMs: 0, retryBaseMs: 1, maxRetries: 1,
+      max429Streak: 3,
+    });
+
+    expect(summary.status).toBe('failure');
+    expect(summary.error).toMatch(/429/);
+    // Circuit broke after the 3rd state — did NOT touch all 49.
+    expect(hits.size).toBe(3);
+    const runs = await getRecentIngestRuns(db.pool, 5);
+    expect(runs[0]?.status).toBe('failure');
+    expect(runs[0]?.errorMessage).toMatch(/429/);
+  });
+
+  it('a 429 streak interrupted by a success resets the counter (no false circuit-break)', async () => {
+    // AZ 429s once, CA succeeds (resets streak), NM 429s once. With
+    // max429Streak=2 the streak never reaches 2 consecutively → run is partial,
+    // not failure.
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent',
+        () => new HttpResponse('rl', { status: 429, headers: { 'retry-after': '0' } })),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
+        () => HttpResponse.json([])),
+      ...stateHandlers('US-CA', RECENT, []),
+      http.get('https://api.ebird.org/v2/data/obs/US-NM/recent',
+        () => new HttpResponse('rl', { status: 429, headers: { 'retry-after': '0' } })),
+      http.get('https://api.ebird.org/v2/data/obs/US-NM/recent/notable',
+        () => HttpResponse.json([])),
+    );
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k',
+      stateCodes: ['US-AZ', 'US-CA', 'US-NM'], paceMs: 0,
+      retryBaseMs: 1, maxRetries: 1, max429Streak: 2, partialFailureThreshold: 5,
+    });
+
+    expect(summary.status).toBe('partial');
+    expect(summary.statesSucceeded).toBe(1); // CA
+    expect(summary.statesFailed).toBe(2);    // AZ + NM (429-as-failure)
+    const { data: obs } = await getObservations(db.pool, {});
+    expect(obs).toHaveLength(2); // CA's two observations landed
+  });
+});
+
+describe('runIngest — #484 species-meta invariant (preserved across the fan-out)', () => {
+  it('fails the ingest when an observation references a missing species_meta row', async () => {
+    const RECENT_WITH_LEAK = [
+      ...RECENT,
+      // `xUNKNOWN1` is a synthetic eBird-style spuh code with no species_meta
+      // row — simulates the bug class from #484 (`ixlbun`, `x00059`, etc.).
+      { speciesCode: 'xUNKNOWN1', comName: 'Unknown Hybrid',
+        sciName: 'Genus species x other', locId: 'L3', locName: 'Test',
+        obsDt: '2026-04-15 10:00', howMany: 1, lat: 32.30, lng: -110.99,
+        obsValid: true, obsReviewed: false, locationPrivate: false, subId: 'S102' },
+    ];
+    server.use(...stateHandlers('US-AZ', RECENT_WITH_LEAK, []));
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'], paceMs: 0,
     });
 
     expect(summary.status).toBe('failure');
     expect(summary.error).toBeDefined();
-    // Error message must name the offending code(s) so a triage agent can
-    // jump straight to a `species_meta` backfill PR without re-deriving
-    // which code triggered the failure.
+    // Error message must name the offending code(s) so a triage agent can jump
+    // straight to a `species_meta` backfill PR.
     expect(summary.error).toContain('xUNKNOWN1');
-    // No observations may have been inserted — the invariant runs BEFORE
-    // upsert, so a leak fails the whole batch rather than corrupting the
-    // read path.
+    // No observations may have been inserted — the invariant runs BEFORE upsert,
+    // so a leak fails the whole batch rather than corrupting the read path.
     const { data: obs } = await getObservations(db.pool, {});
     expect(obs).toHaveLength(0);
-    // Failure must be recorded in ingest_runs for the freshness monitor.
     const runs = await getRecentIngestRuns(db.pool, 5);
     expect(runs[0]?.status).toBe('failure');
     expect(runs[0]?.errorMessage).toContain('xUNKNOWN1');
   });
 
   it('succeeds (no false-positive invariant trip) when every observation has a species_meta row', async () => {
-    // Regression guard: the invariant must NOT block legitimate ingests
-    // — only the ones that genuinely reference missing species_meta rows.
-    // RECENT's two codes (vermfly, annhum) are both seeded in beforeAll.
-    server.use(
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent',
-        () => HttpResponse.json(RECENT)),
-      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable',
-        () => HttpResponse.json([])),
-    );
+    server.use(...stateHandlers('US-AZ', RECENT, []));
     const summary = await runIngest({
-      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'], paceMs: 0,
     });
     expect(summary.status).toBe('success');
     expect(summary.upserted).toBe(2);

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -179,7 +179,12 @@ describe('runIngest — partial-failure isolation + status ladder (#840)', () =>
     expect(summary.status).toBe('partial');
     expect(summary.statesSucceeded).toBe(1);
     expect(summary.statesFailed).toBe(1);
+    // The failed-state info rides the summary on `partial` (not only `failure`)
+    // so cli.ts can surface it in the run-completed line — a degraded-but-green
+    // run must read as degraded in the aggregate log, not just the per-state
+    // WARNING lines (#840 review).
     expect(summary.failures?.[0]?.state).toBe('US-NM');
+    expect(summary.failures?.[0]?.error).toBeDefined();
     // AZ's two observations still landed despite NM failing.
     const { data: obs } = await getObservations(db.pool, {});
     expect(obs).toHaveLength(2);

--- a/services/ingestor/src/run-ingest.ts
+++ b/services/ingestor/src/run-ingest.ts
@@ -2,26 +2,100 @@ import {
   upsertObservations, findMissingSpeciesMeta,
   startIngestRun, finishIngestRun, type Pool,
 } from '@bird-watch/db-client';
-import { EbirdClient } from './ebird/client.js';
+import { CONUS_STATE_CODES } from '@bird-watch/shared-types';
+import { EbirdClient, EbirdClientError } from './ebird/client.js';
 import { toObservationInput, notableKeyset } from './transform.js';
 
 export interface RunIngestOptions {
   pool: Pool;
   apiKey: string;
-  regionCode: string;
+  /**
+   * Vestigial single-region knob retained for back-compat. The `recent` ingest
+   * now fans out per-state over `CONUS_STATE_CODES` (issue #840) because eBird's
+   * region-`recent` endpoint dedups to one-observation-per-species region-wide,
+   * starving non-AZ states when called once for `US`. `regionCode` no longer
+   * drives the fan-out; pass `stateCodes` to scope it (tests do this).
+   */
+  regionCode?: string;
   back?: number;
-  /** Test hooks — used by retry tests. */
+  /** Test hooks — used by retry tests on the underlying client. */
   maxRetries?: number;
   retryBaseMs?: number;
   /** Inject a client for tests; if omitted, one is constructed. */
   client?: EbirdClient;
+  /**
+   * The list of eBird region codes to fan out over. Defaults to the 49 CONUS
+   * states (incl. DC, excl. AK/HI) — the single source of truth shared with the
+   * read-api validator and frontend scope selector. Injectable so unit tests can
+   * scope the fan-out to a handful of states against an `onUnhandledRequest:
+   * 'error'` MSW server without standing up 49 handlers.
+   */
+  stateCodes?: readonly string[];
+  /**
+   * Min millis between successive per-state fetch rounds. 49 states × 2 calls
+   * (recent + notable) = ~98 eBird calls/run, every 30 min — without pacing this
+   * bursts one key/IP into eBird's (opaque) rate limit. Default 1000ms (codebase
+   * precedent: cli.ts:323's backfill-extended path); at ~98 calls × 1000ms ≈ 98s
+   * this fits comfortably under the 900s Cloud Run job timeout. Tests pass 0.
+   * First-call-skip pattern mirrors run-backfill.ts:64.
+   */
+  paceMs?: number;
+  /**
+   * Number of states that may fail (non-429 errors: 500/timeout) while the run
+   * still reports `partial` rather than `failure`. `cli.ts` pings the success
+   * heartbeat on both `success` AND `partial`, so this threshold controls when
+   * Healthchecks.io stays green over a degraded national map. Default 5 (#840):
+   * `success` = 0 failed, `partial` = 1..5 failed, `failure` = >5 failed.
+   */
+  partialFailureThreshold?: number;
+  /**
+   * Consecutive eBird 429s that trip the circuit-break and abort the run as
+   * `failure`. A burst of 429s means the key is throttled; grinding through the
+   * remaining states only digs the penalty-box deeper (and the every-30-min
+   * scheduler would re-burst 30 min later). Default 3.
+   */
+  max429Streak?: number;
 }
 
 export interface RunSummary {
-  status: 'success' | 'failure';
+  status: 'success' | 'partial' | 'failure';
   fetched: number;
   upserted: number;
+  /** States that returned data (recent + notable) without error. */
+  statesSucceeded: number;
+  /** States whose fetch failed (non-429) and were skipped. */
+  statesFailed: number;
+  /** Per-state failure reasons, capped, for the run-completed log line. */
+  failures?: { state: string; error: string }[];
   error?: string;
+}
+
+const DEFAULT_PACE_MS = 1_000;
+const DEFAULT_PARTIAL_THRESHOLD = 5;
+const DEFAULT_MAX_429_STREAK = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * One thrown sentinel that aborts the fan-out loop early when eBird rate-limits
+ * us repeatedly. Caught by the outer try so the run is finalized as `failure`
+ * (not `partial`) — a throttled key must NOT ping the success heartbeat.
+ */
+class RateLimitCircuitBreak extends Error {
+  constructor(public streak: number) {
+    super(
+      `eBird returned ${streak} consecutive 429s — aborting the per-state ` +
+      `recent fan-out to avoid deepening the rate-limit penalty box. ` +
+      `The every-30-min scheduler will retry next cycle.`
+    );
+    this.name = 'RateLimitCircuitBreak';
+  }
+}
+
+function is429(err: unknown): err is EbirdClientError {
+  return err instanceof EbirdClientError && err.status === 429;
 }
 
 export async function runIngest(opts: RunIngestOptions): Promise<RunSummary> {
@@ -31,27 +105,112 @@ export async function runIngest(opts: RunIngestOptions): Promise<RunSummary> {
     ...(opts.retryBaseMs !== undefined && { retryBaseMs: opts.retryBaseMs }),
   };
   const client = opts.client ?? new EbirdClient(clientOpts);
+  const states = opts.stateCodes ?? CONUS_STATE_CODES;
+  const back = opts.back ?? 14;
+  const paceMs = opts.paceMs ?? DEFAULT_PACE_MS;
+  const partialThreshold = opts.partialFailureThreshold ?? DEFAULT_PARTIAL_THRESHOLD;
+  const max429Streak = opts.max429Streak ?? DEFAULT_MAX_429_STREAK;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
 
   const runId = await startIngestRun(opts.pool, 'recent');
-  try {
-    const [recent, notable] = await Promise.all([
-      client.fetchRecent(opts.regionCode, { back: opts.back ?? 14 }),
-      client.fetchNotable(opts.regionCode, { back: opts.back ?? 14 }),
-    ]);
-    const notableKeys = notableKeyset(notable);
-    const inputs = recent.map(o => toObservationInput(o, notableKeys));
 
-    // Invariant (issue #484): every observation we insert must have a
-    // matching `species_meta` row, otherwise the read-api 404s on
-    // /api/species/:code for a code the same API also returns from
-    // /api/observations. The check runs BEFORE upsert so a leak aborts the
-    // whole batch — converting future eBird hybrid/spuh additions to the AZ
-    // feed into a loud CI/cron failure instead of a silent prod 404. The
-    // error names every offending code so a triage agent can jump straight
-    // to a `species_meta` backfill PR (see migration
-    // 1700000032000_backfill_species_meta_spuh_hybrid.sql for the 10 codes
-    // this fix unblocked).
-    const speciesCodes = inputs.map(o => o.speciesCode);
+  // Accumulate inputs across states; the #484 invariant + upsert run ONCE on
+  // the aggregate so a single missing species_meta row aborts the whole batch
+  // (preserved from the pre-fan-out implementation).
+  const inputs: ReturnType<typeof toObservationInput>[] = [];
+  let statesSucceeded = 0;
+  const failures: { state: string; error: string }[] = [];
+  let consecutive429 = 0;
+
+  try {
+    let firstRound = true;
+    for (const state of states) {
+      // Pace successive per-state rounds; skip the wait before the first.
+      // Mirrors run-backfill.ts:64 / run-photos.ts.
+      if (!firstRound && paceMs > 0) await sleep(paceMs);
+      firstRound = false;
+
+      try {
+        // Per-state notable intersection: `is_notable` requires BOTH this
+        // state's /recent AND its /recent/notable. Keysets are built per state
+        // and NOT intersected across states (a subId/speciesCode pair is
+        // state-local).
+        const [recent, notable] = await Promise.all([
+          client.fetchRecent(state, { back }),
+          client.fetchNotable(state, { back }),
+        ]);
+        const notableKeys = notableKeyset(notable);
+        for (const o of recent) inputs.push(toObservationInput(o, notableKeys));
+        statesSucceeded++;
+        consecutive429 = 0; // a clean round resets the rate-limit streak
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (is429(err)) {
+          consecutive429++;
+          console.warn(JSON.stringify({
+            severity: 'WARNING',
+            kind: 'recent',
+            message: 'bird_ingest_state_rate_limited',
+            state,
+            consecutive429,
+            error: msg.slice(0, 500),
+          }));
+          if (consecutive429 >= max429Streak) {
+            throw new RateLimitCircuitBreak(consecutive429);
+          }
+          // Back off before the next state: honor eBird's Retry-After when
+          // present, else exponential on the streak length.
+          const backoff = err.retryAfterMs ?? retryBaseMs * Math.pow(2, consecutive429);
+          await sleep(backoff);
+          // This state did not contribute data; count it as failed so the
+          // status ladder reflects the missing coverage.
+          failures.push({ state, error: msg });
+          continue;
+        }
+        // Non-429 (500 / timeout / etc.): isolate — record and continue so one
+        // state's failure does not abort the other 48.
+        consecutive429 = 0;
+        failures.push({ state, error: msg });
+        console.warn(JSON.stringify({
+          severity: 'WARNING',
+          kind: 'recent',
+          message: 'bird_ingest_state_failed',
+          state,
+          error: msg.slice(0, 500),
+        }));
+      }
+    }
+
+    // Dedup the cross-state aggregate by (subId, speciesCode) — the same
+    // conflict target `upsertObservations` uses. eBird checklist subIds are
+    // globally unique, so a state's /recent shouldn't surface a checklist that
+    // also appears in another state's, but a single batch with two rows sharing
+    // the conflict key makes Postgres throw "ON CONFLICT DO UPDATE command
+    // cannot affect row a second time". Coalesce `isNotable` with OR so a
+    // notable stamp from ANY state wins (matches upsertObservations' own
+    // OR-coalesce for repeat runs).
+    const byKey = new Map<string, (typeof inputs)[number]>();
+    for (const input of inputs) {
+      const key = `${input.subId}|${input.speciesCode}`;
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.isNotable = existing.isNotable || input.isNotable;
+      } else {
+        byKey.set(key, input);
+      }
+    }
+    const deduped = [...byKey.values()];
+
+    // Invariant (issue #484): every observation we insert must have a matching
+    // `species_meta` row, otherwise the read-api 404s on /api/species/:code for
+    // a code the same API also returns from /api/observations. The check runs
+    // BEFORE upsert so a leak aborts the whole batch — converting future eBird
+    // hybrid/spuh additions into a loud CI/cron failure instead of a silent
+    // prod 404. The error names every offending code so a triage agent can jump
+    // straight to a `species_meta` backfill PR (see migration
+    // 1700000032000_backfill_species_meta_spuh_hybrid.sql for the 10 codes this
+    // fix unblocked).
+    const speciesCodes = deduped.map(o => o.speciesCode);
     const missing = await findMissingSpeciesMeta(opts.pool, speciesCodes);
     if (missing.length > 0) {
       throw new Error(
@@ -62,21 +221,48 @@ export async function runIngest(opts: RunIngestOptions): Promise<RunSummary> {
       );
     }
 
-    const upserted = await upsertObservations(opts.pool, inputs);
+    const upserted = await upsertObservations(opts.pool, deduped);
+
+    // Status ladder (#840): success = all states ok; partial = 1..threshold
+    // failed; failure = >threshold failed. (429 circuit-break is handled in the
+    // catch below — it throws, so it never reaches this branch as `partial`.)
+    const statesFailed = failures.length;
+    const status: RunSummary['status'] =
+      statesFailed === 0 ? 'success'
+        : statesFailed <= partialThreshold ? 'partial'
+          : 'failure';
+    const firstError = failures[0]?.error;
 
     await finishIngestRun(opts.pool, runId, {
-      status: 'success',
-      obsFetched: recent.length,
+      status,
+      obsFetched: deduped.length,
       obsUpserted: upserted,
+      ...(status !== 'success' && firstError !== undefined && { errorMessage: firstError }),
     });
 
-    return { status: 'success', fetched: recent.length, upserted };
+    return {
+      status,
+      fetched: deduped.length,
+      upserted,
+      statesSucceeded,
+      statesFailed,
+      ...(failures.length > 0 && { failures: failures.slice(0, 10) }),
+      ...(status === 'failure' && firstError !== undefined && { error: firstError }),
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     await finishIngestRun(opts.pool, runId, {
       status: 'failure',
       errorMessage: msg,
     });
-    return { status: 'failure', fetched: 0, upserted: 0, error: msg };
+    return {
+      status: 'failure',
+      fetched: 0,
+      upserted: 0,
+      statesSucceeded,
+      statesFailed: failures.length,
+      ...(failures.length > 0 && { failures: failures.slice(0, 10) }),
+      error: msg,
+    };
   }
 }


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Ingestor
    participant eBird
    participant Postgres

    loop for each of 49 CONUS_STATE_CODES (paced ≥1000ms between rounds)
        Ingestor->>eBird: GET /data/obs/US-XX/recent
        Ingestor->>eBird: GET /data/obs/US-XX/recent/notable
        Note over Ingestor: per-state notable intersection (keyset is state-local)
        alt 429 (rate limited)
            eBird-->>Ingestor: 429 + Retry-After
            Note over Ingestor: "back off (Retry-After else exponential)<br/>3 consecutive 429s ⇒ circuit-break ⇒ abort run as failure"
        else 500 / timeout
            eBird-->>Ingestor: error
            Note over Ingestor: isolate — record + continue (other 48 states unaffected)
        end
    end
    Ingestor->>Ingestor: aggregate + dedup (subId, speciesCode); #484 species-meta invariant
    Ingestor->>Postgres: upsert observations (silhouette + is_notable stamp)
    Note over Ingestor: status ladder — success=0 failed · partial=1..5 failed · failure=>5 failed OR repeated 429
```

## Summary

- **Why:** the daily `recent` ingest made ONE nationwide `/data/obs/US/recent` call, which eBird structurally dedups to one-observation-per-species region-wide (879 records / 879 distinct species for `US`). High-activity regions win every tie, so non-AZ states were starved — Missouri showed 15 species/7d in our API vs 214 in eBird. This fans `recent` out per-state over `CONUS_STATE_CODES` (49 codes, incl. DC, excl. AK/HI) so each state's own `/recent` + `/recent/notable` is requested and the per-state richness reaches the DB.
- **Pacing + cost:** 49 states × 2 calls ≈ 98 eBird calls/run vs 1 today. Injectable `paceMs` defaults to ≥1000ms (precedent `cli.ts:323`) with the first-call-skip pattern (`run-backfill.ts:64`); ~98 calls × 1000ms ≈ 98s sits well under the 900s Cloud Run job timeout, so no infra change is needed (flagged as out-of-scope per the issue). Every-30-min cron ⇒ ~4,700 eBird calls/day from one key — the pacing floor + 429 circuit-break keep that polite.
- **Robustness:** 429s are a circuit-break (honor `Retry-After`, else exponential; 3 consecutive 429s abort the run as `failure` rather than grinding the whole fan-out into a throttled key) — NOT a blind `continue` like backfill. One state's 500/timeout is isolated and the run continues. Status ladder: `success`=all 49 ok, `partial`=1..5 failed, `failure`=>5 failed OR repeated 429 — load-bearing because `cli.ts:395-404` pings the success heartbeat on `success` AND `partial`, only `failure` skips it. Per-state notable intersection and the #484 species-meta invariant are preserved.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build` — clean across `@bird-watch/shared-types`, `@bird-watch/db-client`, `@bird-watch/ingestor` (tsc, no errors)
- [x] `npm run test --workspace @bird-watch/ingestor` — 220 passed / 23 files (real testcontainer Postgres + injected client, no DB mocks)
- [x] New tests added: fan-out hits all 49 CONUS states (and only them — no `US`/AK/HI); per-state notable intersection is state-local; partial-failure isolation; partial/failure boundary (cutover); 429 circuit-break (aborts early + names 429) and streak-reset-on-success; #484 invariant preserved across the aggregate; pacing injectable (`paceMs=0`); client surfaces `Retry-After` (seconds form) as `retryAfterMs` and leaves it undefined when absent
- [x] `npm run lint` — green (ingestor has no lint script; frontend-only token guard N/A)
- [x] knip — no new findings (only a pre-existing unrelated config hint on a prototype dir)
- [ ] (UI only) Playwright MCP smoke — N/A, ingestor-only, no `frontend/**`
- Post-deploy (manual, can't verify in CI): `GET /api/observations?state=US-MO&since=7d` distinct species should jump from ~15 toward eBird's ~214.

## Plan reference

Out of plan — bug fix for issue #840 (national `/recent` dedup starves non-AZ states).

Closes #840

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
