### PR TITLE
fix(frontend): polish scope-card disclosure — soft focus, even rhythm, legend clearance (#828/#837)

### DIFF
--- a/frontend/e2e/legend-attribution-overlap.spec.ts
+++ b/frontend/e2e/legend-attribution-overlap.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+import type { Observation } from '@bird-watch/shared-types';
+
+/**
+ * #837 fast-follow — the bottom-left family legend must not collide with the
+ * bottom-right `.map-attribution` island at phone width.
+ *
+ * Both surfaces anchor at `bottom: var(--card-inset)` and ride `z-index:
+ * --z-overlay`. The COLLAPSED legend pill (~173px) clears the ~129px attribution
+ * comfortably, but the EXPANDED legend caps at 280px — on a 390px viewport its
+ * bottom-right corner overran the attribution by a ~43×25px band. The fix lifts
+ * the legend above the attribution band ONLY while its entries are showing
+ * (`.family-legend:has(.family-legend-entries)` at ≤480px), so the two never
+ * overlap when expanded and the collapsed pill is untouched.
+ *
+ * This spec expands the legend (the worst case) and asserts the legend and
+ * attribution rectangles do not intersect, at both 390px (mobile, where the fix
+ * applies) and 768px (tablet, where the wider viewport already clears them).
+ *
+ * WebGL skip guard: `.family-legend` + `.map-attribution` render gated on
+ * `mapVisible && scopeActive` (App.tsx), and `mapVisible` requires the maplibre
+ * canvas to paint. Headless Chromium without a GL backend never fires `load`;
+ * skip cleanly there (matches family-legend-viewport.spec.ts).
+ */
+
+// A handful of observations across three families, clustered in southern AZ so
+// the legend renders ≥3 entries (enough to make the expanded card its full
+// 280px width). Families match the silhouette fixture below.
+const OBS: Observation[] = [
+  { subId: 'O1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher', lat: 32.22, lng: -110.97, obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(), locId: 'L1', locName: 'Tucson', howMany: 1, isNotable: false, silhouetteId: 'tyrannidae', familyCode: 'tyrannidae' },
+  { subId: 'O2', speciesCode: 'gilwoo', comName: 'Gila Woodpecker', lat: 32.25, lng: -110.99, obsDt: new Date(Date.now() - 70 * 60 * 1000).toISOString(), locId: 'L2', locName: 'Saguaro', howMany: 2, isNotable: false, silhouetteId: 'picidae', familyCode: 'picidae' },
+  { subId: 'O3', speciesCode: 'cacwre', comName: 'Cactus Wren', lat: 32.28, lng: -111.01, obsDt: new Date(Date.now() - 80 * 60 * 1000).toISOString(), locId: 'L3', locName: 'Desert', howMany: 1, isNotable: false, silhouetteId: 'troglodytidae', familyCode: 'troglodytidae' },
+  { subId: 'O4', speciesCode: 'gambel', comName: "Gambel's Quail", lat: 32.30, lng: -110.95, obsDt: new Date(Date.now() - 90 * 60 * 1000).toISOString(), locId: 'L4', locName: 'Wash', howMany: 4, isNotable: false, silhouetteId: 'odontophoridae', familyCode: 'odontophoridae' },
+];
+
+function silhouetteFixture() {
+  const fams = [
+    { code: 'tyrannidae', color: '#E84040', name: 'Tyrant Flycatchers' },
+    { code: 'picidae', color: '#F5A623', name: 'Woodpeckers' },
+    { code: 'troglodytidae', color: '#5DA832', name: 'Wrens' },
+    { code: 'odontophoridae', color: '#8B5CF6', name: 'New World Quail' },
+  ];
+  const rows = fams.map(({ code, color, name }) => ({
+    familyCode: code,
+    color,
+    svgData: 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+    source: null,
+    license: null,
+    commonName: name,
+    creator: null,
+  }));
+  rows.push({
+    familyCode: '_FALLBACK',
+    color: '#555555',
+    svgData: 'M 6 12 C 6 9 8 7 11 7 C 13 7 14 8 15 9 L 18 8 L 18 10 L 16 11 L 16 14 L 14 16 L 9 16 L 6 14 Z',
+    source: null,
+    license: null,
+    commonName: 'Unknown family',
+    creator: null,
+  });
+  return rows;
+}
+
+async function setupRoutes(
+  page: import('@playwright/test').Page,
+  apiStub: import('./fixtures.js').ApiStub,
+) {
+  await apiStub.stubEmpty();
+  await apiStub.stubObservations(OBS);
+  await page.route('**/api/silhouettes', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(silhouetteFixture()),
+    });
+  });
+}
+
+async function skipIfMapHookAbsent(
+  page: import('@playwright/test').Page,
+  testRef: typeof test,
+): Promise<boolean> {
+  const present = await page
+    .waitForFunction(
+      () => typeof (window as { __birdMap?: unknown }).__birdMap !== 'undefined',
+      { timeout: 8_000 },
+    )
+    .then(() => true)
+    .catch(() => false);
+  if (!present) {
+    testRef.skip(true, 'window.__birdMap not exposed — maplibre `load` did not fire (WebGL unavailable).');
+  }
+  return !present;
+}
+
+/** Intersect two DOMRect-likes; returns the overlap area (0 ⟺ no overlap). */
+function overlapArea(
+  a: { left: number; right: number; top: number; bottom: number },
+  b: { left: number; right: number; top: number; bottom: number },
+): number {
+  const ix = Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left));
+  const iy = Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
+  return ix * iy;
+}
+
+async function assertNoOverlapWhenExpanded(
+  page: import('@playwright/test').Page,
+  app: AppPage,
+) {
+  // Expand the legend (worst case — the 280px card). The mobile legend defaults
+  // collapsed, so click the toggle to reveal the entries.
+  const toggle = page.getByRole('button', { name: /bird families in view/i });
+  await expect(toggle).toBeVisible({ timeout: 15_000 });
+  if ((await toggle.getAttribute('aria-expanded')) === 'false') {
+    await toggle.click();
+  }
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  // The entries list is what widens the card to 280px and what the fix keys on.
+  await expect(page.locator('.family-legend-entries')).toBeVisible();
+
+  const rects = await page.evaluate(() => {
+    const legend = document.querySelector('.family-legend');
+    const attr = document.querySelector('.map-attribution');
+    const pick = (el: Element | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right, top: r.top, bottom: r.bottom };
+    };
+    return { legend: pick(legend), attr: pick(attr) };
+  });
+
+  expect(rects.legend, 'legend must be present').not.toBeNull();
+  expect(rects.attr, 'attribution must be present').not.toBeNull();
+  const area = overlapArea(rects.legend!, rects.attr!);
+  expect(
+    area,
+    `expanded legend (${JSON.stringify(rects.legend)}) must not overlap attribution (${JSON.stringify(rects.attr)})`,
+  ).toBe(0);
+}
+
+test.describe('Legend ↔ attribution clearance (#837)', () => {
+  test.describe('mobile 390px', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('the expanded legend does not overlap the bottom-right attribution', async ({ page, apiStub }) => {
+      test.setTimeout(60_000);
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 15_000 });
+      if (await skipIfMapHookAbsent(page, test)) return;
+      await assertNoOverlapWhenExpanded(page, app);
+    });
+  });
+
+  test.describe('tablet 768px', () => {
+    test.use({ viewport: { width: 768, height: 1024 } });
+
+    test('the expanded legend does not overlap the bottom-right attribution', async ({ page, apiStub }) => {
+      test.setTimeout(60_000);
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 15_000 });
+      if (await skipIfMapHookAbsent(page, test)) return;
+      await assertNoOverlapWhenExpanded(page, app);
+    });
+  });
+});

--- a/frontend/e2e/scope-disclosure.spec.ts
+++ b/frontend/e2e/scope-disclosure.spec.ts
@@ -123,6 +123,35 @@ test.describe('Scope disclosure (#828)', () => {
     ).toBeVisible();
   });
 
+  test('on open, the focused state <select> shows the soft accent ring, not the heavy black box (#837)', async ({ page, apiStub }) => {
+    const app = await setup(page, apiStub);
+
+    await app.scopeDisclosureTrigger.click();
+    await expect(app.scopeControlStateSelect).toBeFocused();
+
+    // #837: the embedded scope fields drop the repo's heavy
+    // `outline: 2px solid var(--color-text-strong); outline-offset: 2px` black
+    // offset box (which looked jarring slammed around the select on open) for a
+    // tight accent box-shadow ring. Assert the softened recipe on the focused
+    // select: a transparent outline (HCM fallback), zero offset, and a
+    // box-shadow ring (the accent token, resolved to a real color).
+    const style = await app.scopeControlStateSelect.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        outlineColor: cs.outlineColor,
+        outlineOffset: cs.outlineOffset,
+        boxShadow: cs.boxShadow,
+      };
+    });
+    // The heavy black outline (rgb(26, 26, 26)) is gone — the outline is now a
+    // forced-colors-only transparent fallback.
+    expect(style.outlineColor).toMatch(/rgba?\(0,\s*0,\s*0,\s*0\)|transparent/);
+    expect(style.outlineOffset).toBe('0px');
+    // A real (non-"none") box-shadow ring conveys the visible focus indicator.
+    expect(style.boxShadow).not.toBe('none');
+    expect(style.boxShadow.length).toBeGreaterThan(0);
+  });
+
   test('Esc collapses the form and restores focus to the trigger', async ({ page, apiStub }) => {
     const app = await setup(page, apiStub);
 

--- a/frontend/e2e/scope-zip-overflow.spec.ts
+++ b/frontend/e2e/scope-zip-overflow.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * #842 — the ZIP row ([ZIP field] + [Go]) inside the EXPANDED scope disclosure
+ * must stay within the top-left identity card at every viewport.
+ *
+ * At ≤480px the identity card is width-capped to `calc(100% - 200px)` (so it
+ * never collides with the top-right controls pill). At 360–404px that leaves the
+ * card's inner column NARROWER than the ZIP row's intrinsic min-content width
+ * (field cap 8rem + gap + [Go] ≈ 188px). The `.scope-control__select` and
+ * `.scope-control__exit-group` already take a full-width line and shrink to the
+ * card, but the ZIP box kept `flex: 0 1 auto` / `min-inline-size: auto`, so it
+ * refused to shrink and [Go] spilled past the card's right edge (≈32px at 390px,
+ * ≈62px at 360px). The fix gives `.scope-control__zip` its own full line and
+ * lets it (and `.zip-input__row`) shrink so the inner field yields width.
+ *
+ * This spec opens the disclosure and asserts the [Go] button's right edge sits
+ * at or within the card's inner (content) right edge, at 390px (mobile, where
+ * the cap bites and the bug lived) and 768px (desktop regression guard — the
+ * ZIP already wrapped clear there, and the fix must not change that).
+ *
+ * Layout-only assertion: it needs the real flex layout, so it runs as e2e (a
+ * jsdom unit test computes no box geometry). It does NOT require the WebGL map —
+ * the identity card and its disclosure render from URL scope alone — so unlike
+ * the legend/attribution spec there is no `__birdMap` skip guard.
+ */
+test.describe('Scope ZIP/Go stays inside the identity card (#842)', () => {
+  const AZ_OBS = [
+    {
+      subId: 'S1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.22,
+      lng: -110.97,
+      obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      locId: 'L1',
+      locName: 'Tucson',
+      howMany: 1,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+  ];
+
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('./fixtures.js').ApiStub,
+  ): Promise<AppPage> {
+    await apiStub.stubStates();
+    await apiStub.stubEmpty();
+    await page.route('**/api/observations**', async route => {
+      const state = new URL(route.request().url()).searchParams.get('state');
+      const data = state === 'US-AZ' ? AZ_OBS : [];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data,
+          meta: {
+            freshestObservationAt:
+              data.length > 0 ? new Date(Date.now() - 5 * 60 * 1000).toISOString() : null,
+          },
+        }),
+      });
+    });
+    const app = new AppPage(page);
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    return app;
+  }
+
+  /**
+   * Open the disclosure, then assert the [Go] submit's right edge ≤ the card's
+   * inner (content) right edge. Returns the measured overflow (px past the inner
+   * edge; ≤0 ⟺ fully inside) for the failure message.
+   */
+  async function assertGoInsideCard(app: AppPage, page: import('@playwright/test').Page) {
+    await app.openScopeDisclosure();
+    await expect(page.locator('.zip-input__submit')).toBeVisible();
+
+    const m = await page.evaluate(() => {
+      const go = document.querySelector('.zip-input__submit');
+      const card = document.querySelector('.app-header-identity-card');
+      if (!go || !card) return null;
+      const cs = getComputedStyle(card);
+      const cb = card.getBoundingClientRect();
+      // The content-box right edge: where the card's children must stay within.
+      const cardInnerRight =
+        cb.right - parseFloat(cs.borderRightWidth) - parseFloat(cs.paddingRight);
+      const goRight = go.getBoundingClientRect().right;
+      return {
+        goRight: Math.round(goRight * 100) / 100,
+        cardInnerRight: Math.round(cardInnerRight * 100) / 100,
+        overflow: Math.round((goRight - cardInnerRight) * 100) / 100,
+      };
+    });
+
+    expect(m, 'Go button and identity card must both be present').not.toBeNull();
+    // ≤ 0.5px tolerance for sub-pixel rounding; the bug was tens of pixels.
+    expect(
+      m!.overflow,
+      `the [Go] button (right=${m!.goRight}) must not spill past the card inner edge (right=${m!.cardInnerRight}); overflow=${m!.overflow}px`,
+    ).toBeLessThanOrEqual(0.5);
+  }
+
+  test.describe('mobile 390px (the cap bites here)', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('the [Go] button stays inside the identity card', async ({ page, apiStub }) => {
+      const app = await setup(page, apiStub);
+      await assertGoInsideCard(app, page);
+    });
+  });
+
+  test.describe('desktop 768px (regression guard)', () => {
+    test.use({ viewport: { width: 768, height: 1024 } });
+
+    test('the [Go] button stays inside the identity card', async ({ page, apiStub }) => {
+      const app = await setup(page, apiStub);
+      await assertGoInsideCard(app, page);
+    });
+  });
+});

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -158,14 +158,17 @@ export function AppHeader({
   const scopeRegionId = useId();
   const scopeTriggerRef = useRef<HTMLButtonElement>(null);
   const scopeRowsRef = useRef<HTMLDivElement>(null);
+  // #837: ref to the FIRST scope field (the state <select>), forwarded into
+  // ScopeControl. The open-effect focuses this directly instead of a fragile
+  // `scopeRowsRef.querySelector('select')` DOM-order query — focus tracks the
+  // declared first field, immune to future field-order changes in ScopeControl.
+  const firstScopeFieldRef = useRef<HTMLSelectElement>(null);
 
-  // Open → move focus to the first field (the state <select>); spec §7. The
-  // ScopeControl owns the <select> internally, so we reach it through the rows
-  // wrapper rather than threading a ref prop. Runs only on the open edge so
-  // re-renders while open don't steal focus.
+  // Open → move focus to the first field (the state <select>); spec §7. Runs
+  // only on the open edge so re-renders while open don't steal focus.
   useEffect(() => {
     if (scopeOpen) {
-      scopeRowsRef.current?.querySelector('select')?.focus();
+      firstScopeFieldRef.current?.focus();
     }
   }, [scopeOpen]);
 
@@ -311,6 +314,7 @@ export function AppHeader({
                 always resolves to a present target.) */}
             {scopeOpen && <hr className="app-header-divider" aria-hidden="true" />}
             <ScopeControl
+              ref={firstScopeFieldRef}
               scope={scope as ScopedView}
               states={states}
               onPickState={onPickState}

--- a/frontend/src/components/ScopeControl.test.tsx
+++ b/frontend/src/components/ScopeControl.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRef } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { StateSummary } from '@bird-watch/shared-types';
@@ -168,5 +169,20 @@ describe('<ScopeControl>', () => {
     expect(select).toHaveFocus();
     await userEvent.tab();
     expect(zip).toHaveFocus();
+  });
+
+  // #837: a forwarded ref attaches to the FIRST field (the state <select>), so
+  // AppHeader's open-the-disclosure effect can focus it directly rather than via
+  // a fragile `querySelector('select')` DOM-order lookup. This is the mechanism
+  // that keeps focus-on-open robust to future field-order changes.
+  it('forwards a ref to the first field (the state <select>) for robust focus-on-open', () => {
+    const ref = createRef<HTMLSelectElement>();
+    renderControl({ ref } as Partial<React.ComponentProps<typeof ScopeControl>>);
+    const select = screen.getByRole('combobox', { name: /switch state/i });
+    // The forwarded ref resolves to the select element itself (not the wrapper,
+    // not the ZIP field) — focusing ref.current focuses the first field.
+    expect(ref.current).toBe(select);
+    ref.current?.focus();
+    expect(select).toHaveFocus();
   });
 });

--- a/frontend/src/components/ScopeControl.tsx
+++ b/frontend/src/components/ScopeControl.tsx
@@ -75,15 +75,22 @@ export interface ScopeControlProps {
   embedded?: boolean;
 }
 
-function ScopeControlImpl({
-  scope,
-  states,
-  onPickState,
-  onPickWholeUs,
-  onExit,
-  onResolve,
-  embedded = false,
-}: ScopeControlProps): React.JSX.Element {
+function ScopeControlImpl(
+  {
+    scope,
+    states,
+    onPickState,
+    onPickWholeUs,
+    onExit,
+    onResolve,
+    embedded = false,
+  }: ScopeControlProps,
+  // #837: forwarded ref to the FIRST field (the state <select>). AppHeader's
+  // open-the-disclosure effect focuses this directly instead of a fragile
+  // `scopeRowsRef.querySelector('select')` DOM-order lookup — focus follows the
+  // declared first field, not whatever tag happens to come first in the tree.
+  firstFieldRef: React.ForwardedRef<HTMLSelectElement>,
+): React.JSX.Element {
   // In a state view the current state is the selected option; in a whole-US
   // view the neutral placeholder ("") is selected (no state is active).
   const selectedState = scope.kind === 'state' ? scope.stateCode : '';
@@ -99,6 +106,7 @@ function ScopeControlImpl({
       aria-label="Change the map scope"
     >
       <select
+        ref={firstFieldRef}
         className="scope-control__select"
         aria-label="Switch state"
         value={selectedState}
@@ -153,6 +161,10 @@ function ScopeControlImpl({
  * reference is stable when no scope-change has occurred (it's the same useState
  * identity from useUrlState). Default shallow comparison short-circuits on a
  * same-minute nowTick bump.
+ *
+ * #837: wrapped in forwardRef so AppHeader can hand a ref to the first field
+ * (the state <select>) for robust focus-on-open. memo(forwardRef(...)) keeps the
+ * O8 re-render boundary while threading the ref through.
  */
-export const ScopeControl = React.memo(ScopeControlImpl);
+export const ScopeControl = React.memo(React.forwardRef(ScopeControlImpl));
 ScopeControl.displayName = 'ScopeControl';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2188,11 +2188,15 @@ aside.species-detail-rail .species-detail-rail-close {
    standard heavy `outline: 2px solid var(--color-text-strong); outline-offset:
    2px` slammed a thick black offset box around it that read as jarring rather
    than deliberate. Inside the disclosure card we instead use a tight accent
-   ring (`--color-decision-point`, the same orange/cyan interactive cue used for
-   links) via box-shadow — no offset gap, so it hugs the control and looks
-   intentional on mouse-open. A transparent `outline` is kept so Windows High
-   Contrast Mode still paints a visible focus ring (forced-colors strips
-   box-shadow). Scoped to `.app-header-scope-rows` so ONLY the in-card scope
+   ring (`--color-focus-ring` — deep amber in light, cyan in dark) via
+   box-shadow — no offset gap, so it hugs the control and looks intentional on
+   mouse-open. The ring color is its OWN mode-paired token, NOT the link/cue
+   `--color-decision-point`: in light mode that orange (#f5853b) only reaches
+   2.53:1 on the white card and 1.69:1 on the field border, both below WCAG
+   2.1 SC 1.4.11's 3:1 floor for focus indicators (#842); the deep amber clears
+   it (6.82:1 / 4.56:1). Dark stays cyan (already 6.68:1). A transparent
+   `outline` is kept so Windows High Contrast Mode still paints a visible focus
+   ring (forced-colors strips box-shadow). Scoped to `.app-header-scope-rows` so ONLY the in-card scope
    form softens — the standalone landing chooser's ZipInput keeps the base
    heavy ring (it is the primary affordance there, not an on-open auto-focus).
    Covers the three focusable inputs (state select, ZIP field, ZIP [Go]); the
@@ -2203,7 +2207,7 @@ aside.species-detail-rail .species-detail-rail-close {
 .app-header-scope-rows .zip-input__submit:focus-visible {
   outline: 2px solid transparent;
   outline-offset: 0;
-  box-shadow: 0 0 0 2px var(--color-decision-point);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .scope-control__select {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1868,6 +1868,15 @@ aside.species-detail-rail .species-detail-rail-close {
   display: flex;
   gap: var(--space-sm);
   align-items: stretch;
+  /* #842: this flex row is the field + [Go]. Its default `min-inline-size: auto`
+     would size it to min-content (≈188px) and refuse to compress, so when the
+     embedded scope form is squeezed into the narrow mobile identity card the row
+     overflowed and [Go] spilled past the card's right edge. `min-inline-size: 0`
+     lets the row shrink (then `.zip-input__field`'s own `min-inline-size: 0`
+     yields the width); `max-inline-size: 100%` clamps it to the available
+     column. No-op in the roomy landing chooser / desktop card. */
+  min-inline-size: 0;
+  max-inline-size: 100%;
 }
 .zip-input__field {
   padding: var(--space-sm) var(--space-md);
@@ -2258,6 +2267,20 @@ aside.species-detail-rail .species-detail-rail-close {
   }
   .scope-control__select {
     flex: 1 1 100%;
+  }
+  /* #842: at the narrow widths the identity card is capped to
+     `calc(100% - 200px)` (line ~594) so it doesn't collide with the controls
+     pill — at 360–404px that leaves the card inner column NARROWER than the ZIP
+     row's intrinsic min-content width (field cap 8rem + gap + [Go] ≈ 188px).
+     The select and exit-group already take their own full-width line here, but
+     the ZIP box kept `flex: 0 1 auto` with the default `min-inline-size: auto`,
+     so it refused to shrink and [Go] spilled ~32px (390px) → ~62px (360px) past
+     the card's right edge. Give the ZIP its own full line and let it shrink so
+     the inner field (already `min-inline-size: 0`) can yield width to stay in
+     the card. */
+  .scope-control__zip {
+    flex: 1 1 100%;
+    min-inline-size: 0;
   }
   .scope-control__exit-group {
     flex: 1 1 100%;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -338,10 +338,16 @@ body {
   box-shadow: var(--card-elevation-1);
   padding: var(--card-padding);
 
-  /* Stacked column layout: each row is a block below the previous. */
+  /* Stacked column layout: each row is a block below the previous. One
+     consistent --space-sm (8px) step governs the whole card rhythm — at rest
+     (wordmark → lede) and expanded (lede → divider → scope rows), matching the
+     8px the embedded scope form already uses between its own fields (#828
+     follow-up). The divider carries NO margin so these flex gaps alone own the
+     vertical spacing (no compounding margin+gap), keeping the step even above
+     and below the hairline. */
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: var(--space-sm);
 }
 
 /* At ≥1440 switch to the wide-gutter corner inset. */
@@ -455,9 +461,13 @@ body {
    below; four-corner contract §4.8). */
 
 /* Hairline divider between the lede content and the revealed scope form.
-   Only present in the DOM when the disclosure is open (#828). */
+   Only present in the DOM when the disclosure is open (#828). margin:0 — the
+   identity-card and scope-rows flex `gap` (both --space-sm) own the spacing, so
+   the hairline gets the SAME 8px breathing room above (card gap, lede → rows)
+   and below (rows gap, divider → select). Adding a margin here would compound
+   with the gap and re-create the cramped/lopsided rhythm this fixes (#837). */
 .app-header-divider {
-  margin: var(--space-xs) 0 0;
+  margin: 0;
   border: none;
   border-top: 1px solid var(--color-border-ui);
 }
@@ -470,7 +480,10 @@ body {
 .app-header-scope-rows {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  /* --space-sm (8px) — one even step with the identity-card gap and the
+     embedded scope form's own field gaps, so divider → select reads the same
+     as every other row in the card (#837). */
+  gap: var(--space-sm);
 }
 /* Defensive: `hidden` already collapses it, but assert display:none on the
    closed state so a stray `display` from a future flex rule can't reveal it. */
@@ -1059,6 +1072,26 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   }
   .family-legend-entries {
     max-height: 240px;
+  }
+
+  /* #837 fast-follow — legend ↔ attribution clearance at phone width.
+     The bottom-left legend and the bottom-right .map-attribution island both
+     anchor at bottom: var(--card-inset). The COLLAPSED chevron pill is only
+     ~173px wide and clears the ~129px attribution comfortably, but the EXPANDED
+     legend caps at 280px — on a 390px viewport its bottom-right corner overran
+     the attribution by a ~43×25px band (both at z-index --z-overlay), the exact
+     overlap #837 flagged. Lift the legend above the attribution band ONLY while
+     its entries are actually showing: `:has(.family-legend-entries)` matches
+     precisely when the list is in the DOM (effectiveExpanded && entries.length
+     > 0 in FamilyLegend.tsx), so a collapsed OR force-collapsed legend is
+     untouched and keeps sitting flush at --card-inset. The 28px literal is the
+     attribution island's box height (≈ 2×--space-xs padding + 1.4×--type-xs
+     line + 1px border, rounded up for headroom); keep it synced if the
+     attribution grows a line. This rule's specificity (0,2,0) is below the
+     peek-sheet lift below (0,2,1), so when a peek sheet is also up the larger
+     120px peek lift correctly wins. */
+  .family-legend:has(.family-legend-entries) {
+    bottom: calc(var(--card-inset) + 28px + var(--space-sm));
   }
 }
 
@@ -2140,6 +2173,30 @@ aside.species-detail-rail .species-detail-rail-close {
   background: none;
   border: none;
 }
+
+/* Softer, intentional focus ring for the EMBEDDED scope form fields (#837).
+   On open, focus auto-moves to the first field (the state <select>); the repo's
+   standard heavy `outline: 2px solid var(--color-text-strong); outline-offset:
+   2px` slammed a thick black offset box around it that read as jarring rather
+   than deliberate. Inside the disclosure card we instead use a tight accent
+   ring (`--color-decision-point`, the same orange/cyan interactive cue used for
+   links) via box-shadow — no offset gap, so it hugs the control and looks
+   intentional on mouse-open. A transparent `outline` is kept so Windows High
+   Contrast Mode still paints a visible focus ring (forced-colors strips
+   box-shadow). Scoped to `.app-header-scope-rows` so ONLY the in-card scope
+   form softens — the standalone landing chooser's ZipInput keeps the base
+   heavy ring (it is the primary affordance there, not an on-open auto-focus).
+   Covers the three focusable inputs (state select, ZIP field, ZIP [Go]); the
+   de-emphasized Whole-US / Change-scope links keep the base text-strong ring
+   (they are link-like, not form fields). */
+.app-header-scope-rows .scope-control__select:focus-visible,
+.app-header-scope-rows .zip-input__field:focus-visible,
+.app-header-scope-rows .zip-input__submit:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 0;
+  box-shadow: 0 0 0 2px var(--color-decision-point);
+}
+
 .scope-control__select {
   flex: 0 1 auto;
   min-inline-size: 0;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -33,6 +33,12 @@
   --c-orange-500: #f5853b;  /* sunrise — light accent */
   --c-cyan-500:   #6db8d4;  /* moon — dark accent */
   --c-deep-ember: #c43a1a;  /* notable — distinct from accent */
+  /* Deep amber — a darkened (L=33%) sibling of --c-orange-500 (same warm ~21°
+     hue, high saturation), used as the LIGHT focus-ring color. The L=60% orange
+     accent only reaches 2.53:1 on #fff / 1.69:1 on the field border #d8d3c3 —
+     below WCAG 2.1 SC 1.4.11's 3:1 floor for focus indicators (#842). This deep
+     amber clears it with headroom: 6.82:1 on #fff, 4.56:1 on #d8d3c3. */
+  --c-amber-700: #984012;
 
   /* Navy / dark scale */
   --c-navy-50:  #f5f7fb;
@@ -167,6 +173,15 @@
      Decision-point is a NEW token; spec value lands. */
   --color-decision-point: var(--c-orange-500);
 
+  /* Focus-ring color — mode-paired, semantic (#842). The embedded scope-form
+     focus ring (.app-header-scope-rows … :focus-visible, a 2px box-shadow with
+     no offset) needs ≥3:1 against BOTH adjacent surfaces — the white card #fff
+     AND the field border #d8d3c3 — per WCAG 2.1 SC 1.4.11. Light mode CANNOT
+     reuse --color-decision-point (orange #f5853b: 2.53:1 / 1.69:1, both fail);
+     it gets the deep amber instead (6.82:1 / 4.56:1). Dark mode's cyan already
+     passes (6.68:1 on the #1b2742 card) so it stays the decision-point cyan. */
+  --color-focus-ring: var(--c-amber-700);
+
   /* NEW cluster-density triad (no existing equivalent) */
   --color-density-low:  var(--c-sky-500);
   --color-density-mid:  var(--c-sand-500);
@@ -234,6 +249,10 @@
      dark override is identical — inherits the :root definition above.         */
 
   --color-decision-point: var(--c-cyan-500);
+
+  /* Dark focus ring keeps the cyan accent — it already clears WCAG 1.4.11
+     (6.68:1 against the #1b2742 card). See the light-block note (#842). */
+  --color-focus-ring: var(--c-cyan-500);
 
   --color-density-low:  #4a8aa8;
   --color-density-mid:  #c49850;

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -89,6 +89,13 @@ describe('tokens.css — W1 conformance', () => {
       expect(darkBlock).toMatch(/--color-decision-point:/);
     });
 
+    // Focus ring (#842) — mode-paired like decision-point. Light uses a deep
+    // amber that meets WCAG 1.4.11's 3:1 floor on both the white card and the
+    // field border; dark keeps the cyan accent (which already passes).
+    it('overrides --color-focus-ring (dark keeps cyan, light is the deep amber)', () => {
+      expect(darkBlock).toMatch(/--color-focus-ring:/);
+    });
+
     // Group 5: density triad (4)
     it('overrides --color-density-low', () => {
       expect(darkBlock).toMatch(/--color-density-low:/);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph TL["Top-left identity card (expanded scope disclosure)"]
        direction TB
        WM["Wordmark / Region"]
        LD["Lede (count only)"]
        DV["hr divider"]
        SEL["state select (first field)"]
        ZIP["ZIP + Go"]
        EXIT["Whole US / Change scope"]
        WM --> LD
        LD --> DV
        DV --> SEL
        SEL --> ZIP
        ZIP --> EXIT
    end
    subgraph BOT["Bottom corners (phone, 480px and below)"]
        direction LR
        LEG["family legend (expanded, 280px)"]
        ATT["map-attribution OpenFreeMap / eBird"]
    end
    F1["Fix 1 soft accent focus ring, not a black box"] -.->|on open| SEL
    F2["Fix 2 even space-sm rhythm, divider margin 0"] -.->|harmonises| DV
    F3["Fix 3 legend lifts while entries show via has-selector"] -.->|clears| LEG
    F4["Fix 4 firstFieldRef forwarded, no querySelector"] -.->|focus target| SEL
    F5["Fix 5 ZIP row gets its own line and can shrink"] -.->|keeps Go in| ZIP
    LEG -.->|"overlap was 43x25, now 0"| ATT
    classDef fix fill:#f5853b,stroke:#9a4d18,color:#1a1a1a
    class F1,F2,F3,F4,F5 fix
```

## Summary

Five review-driven follow-ups to the just-shipped collapsible scope card (#828 / #837). Julian reviewed the live **expanded** card and flagged five things; this fixes all of them. Behaviour + layout changes are unit/e2e-tested; the focus-style + spacing are CSS, verified live across the canonical viewport set in both themes.

- **#1 — soft, intentional focus ring.** On open, focus auto-moves to the state `<select>. The repo's standard heavy `outline: 2px solid var(--color-text-strong); outline-offset: 2px` slammed a thick black offset box around it. Inside `.app-header-scope-rows`, the select / ZIP field / Go button now take a **tight accent `box-shadow` ring** (its own mode-paired `--color-focus-ring` token, zero offset; a transparent `outline` is kept so Windows High Contrast Mode still paints focus). The ring is **deep amber in light, cyan in dark** — deliberately not the link/cue `--color-decision-point` orange, which at 2.53:1 on the white card and 1.69:1 on the field border fails WCAG 2.1 SC 1.4.11's 3:1 floor for focus indicators; the deep amber `#984012` clears it with headroom (**6.82:1** on `#fff`, **4.56:1** on the `#d8d3c3` border), and dark's cyan already passed (6.68:1). Scoped to the disclosure, so the standalone landing chooser's ZipInput keeps the base ring.
- **#2 — even vertical rhythm.** The `<hr>` was lopsided (8px above / 4px below — cramped against the select). The identity-card and scope-rows `gap` are now both `--space-sm` and the divider carries `margin:0`, so the flex gaps alone own the spacing: **every stacked row steps at a consistent 8px** (wordmark → lede → divider → select → ZIP → exit), at rest and expanded, so the card no longer lurches on open.
- **#3 — legend &harr; attribution clearance (fast-follow).** At &le;480px the expanded 280px legend's bottom-right corner overran the bottom-right `.map-attribution` island by a ~43&times;25px band (both `z-index: --z-overlay`). The legend now lifts above the attribution **only while its entries are showing** (`.family-legend:has(.family-legend-entries)`), so a collapsed / force-collapsed pill is untouched and mobile expand is preserved. Specificity sits below the peek-sheet lift, so the larger peek clearance still wins.
- **#4 — focus-on-open hardening (fast-follow).** Replaced the fragile `scopeRowsRef.querySelector('select')` DOM-order lookup with a ref **forwarded from `AppHeader` into `ScopeControl`'s first field** — focus tracks the declared first field, not whatever tag comes first in the tree.
- **#5 — ZIP [Go] spilled past the card's right edge on phones (fast-follow).** Julian's live review caught the `[Go]` button rendering partly **outside** the identity card. Measured live: the `[Go]` right edge sat **+32px** past the card's inner edge at 390px and **+62px** at 360px. Root cause: at &le;480px the card is width-capped to `calc(100% - 200px)` (so it never collides with the controls pill); at 360–404px that leaves the card column narrower than the ZIP row's intrinsic min-content width (field cap 8rem + gap + `[Go]` ≈ 188px). The select and exit-group already take a full-width line and shrink, but `.scope-control__zip` kept `flex: 0 1 auto` / `min-inline-size: auto` and refused to shrink — and the inner `.zip-input__row` (`min-width: auto`) sized to min-content, so the field's existing `min-inline-size: 0` never engaged. Fix: give `.scope-control__zip` its own full line (`flex: 1 1 100%; min-inline-size: 0`) inside the &le;480px block and add `min-inline-size: 0; max-inline-size: 100%` to `.zip-input__row` so the field yields width. Now the `[Go]` right edge measures **0px** past the inner edge at 390px (was +32px); desktop is untouched.

## Screenshots

- [x] Every new/changed `className` has a matching CSS rule in `frontend/src/styles.css` (orphan-classname gate: PASS). No new classNames — every change reuses an existing selector.
- [x] Multi-viewport design QA: 10 canonical captures (5 viewports × 2 themes) of the **expanded scope card on-open**, plus before/after proofs for the focus ring (#1), the legend↔attribution overlap (#3), and the ZIP/[Go] overflow (#5). 20 `user-attachments` URLs total.

### #1 — focus ring on open (before → after)

The state `<select>` is auto-focused when the disclosure opens. Before: the heavy 2px black offset box. After: a tight accent `box-shadow` ring — **deep amber `#984012` in light** (6.82:1 on the white card, 4.56:1 on the field border — both clear WCAG 1.4.11's 3:1 floor), cyan in dark (6.68:1, unchanged).

<table><tr>
<td width="50%"><strong>Before</strong> — heavy black box<br/><img width="380" alt="before-390-scope-open-focus" src="https://github.com/user-attachments/assets/3fbde03e-86fb-4fcc-af61-688a642523ec" /></td>
<td width="50%"><strong>After</strong> — soft accent ring (light)<br/><img width="380" alt="after-390-light" src="https://github.com/user-attachments/assets/0e4bef96-cdc6-4aea-ad3b-a492e2f76550" /></td>
</tr></table>

### #3 — legend ↔ attribution at 390px (before → after)

Expanded legend at phone width. Before: the bottom-right `OpenFreeMap · eBird` island overlapped the legend's bottom rows (~43×25px). After: the legend lifts clear above the attribution.

<table><tr>
<td width="50%"><strong>Before</strong> — overlap<br/><img width="380" alt="before-390-legend-overlap" src="https://github.com/user-attachments/assets/04ce34d2-d5d6-4b9b-9f55-ec95f2da1257" /></td>
<td width="50%"><strong>After</strong> — clears (light)<br/><img width="380" alt="after-390-legend-expanded-light" src="https://github.com/user-attachments/assets/6629365b-746d-4e8a-8da2-24c3f4e8de79" /></td>
</tr></table>

After — clears (dark):<br/><img width="380" alt="after-390-legend-expanded-dark" src="https://github.com/user-attachments/assets/3fd35914-eeef-41f6-93c2-47a843e007c3" />

### #5 — ZIP / [Go] inside the identity card at 390px (before → after)

The `[Go]` submit overflowed the card's right edge on phones (the cap on the card column makes the ZIP row narrower than its intrinsic width). Before: `[Go]` spills ~32px past the card border into the map. After: the ZIP row takes its own full line and shrinks, so the field, `[Go]`, the select and the exit links all sit fully inside the card.

<table>
<tr><th></th><th>Before — [Go] outside the card</th><th>After — [Go] inside the card</th></tr>
<tr><td><strong>Light</strong></td><td><img width="300" alt="before-390-light" src="https://github.com/user-attachments/assets/60d3cb6b-5202-4a1d-9c92-23c1b4a1c54a" /></td><td><img width="300" alt="after-390-light" src="https://github.com/user-attachments/assets/0e4bef96-cdc6-4aea-ad3b-a492e2f76550" /></td></tr>
<tr><td><strong>Dark</strong></td><td><img width="300" alt="before-390-dark" src="https://github.com/user-attachments/assets/807e4a12-e109-4772-8510-ffe731d83d26" /></td><td><img width="300" alt="after-390-dark" src="https://github.com/user-attachments/assets/adf62f75-f5bb-4eaa-9343-1b4f2c5fc120" /></td></tr>
</table>

Desktop (1440×900) is unaffected — the `[Go]` already sat well inside the card; re-captured here to confirm the fix did not regress it:
<table><tr>
<td width="50%"><strong>After (light)</strong><br/><img width="380" alt="after-1440-light" src="https://github.com/user-attachments/assets/8d2c018f-a14d-4bd5-80a7-c2d8306a5550" /></td>
<td width="50%"><strong>After (dark)</strong><br/><img width="380" alt="after-1440-dark" src="https://github.com/user-attachments/assets/82b21b14-1548-43c4-8714-8a578a5abbd8" /></td>
</tr></table>

### Expanded scope card on-open — 5 canonical viewports × light + dark

The 390×844 mobile row uses the **post-#5-fix** captures (ZIP/[Go] inside the card); the tablet/landscape/desktop/wide rows were unaffected by #5.
<table>
<tr><th>Viewport</th><th>Light</th><th>Dark</th></tr>
<tr><td>390×844 mobile</td><td><img width="300" alt="after-390-light" src="https://github.com/user-attachments/assets/0e4bef96-cdc6-4aea-ad3b-a492e2f76550" /></td><td><img width="300" alt="after-390-dark" src="https://github.com/user-attachments/assets/adf62f75-f5bb-4eaa-9343-1b4f2c5fc120" /></td></tr>
<tr><td>768×1024 tablet</td><td><img width="300" alt="after-768-scope-open-light" src="https://github.com/user-attachments/assets/4f01c658-fca0-4ad5-a7fa-2616b66bfe4e" /></td><td><img width="300" alt="after-768-scope-open-dark" src="https://github.com/user-attachments/assets/9384a625-f74e-4e80-b264-7982a4bf90fd" /></td></tr>
<tr><td>1024×768 landscape</td><td><img width="300" alt="after-1024-scope-open-light" src="https://github.com/user-attachments/assets/071edac4-2d54-4f41-965f-81e089487290" /></td><td><img width="300" alt="after-1024-scope-open-dark" src="https://github.com/user-attachments/assets/2fc98fe6-0ed2-4c38-b428-5c13c7668e84" /></td></tr>
<tr><td>1440×900 desktop</td><td><img width="300" alt="after-1440-scope-open-light" src="https://github.com/user-attachments/assets/0ed39752-94c4-43b7-9088-dcd138763501" /></td><td><img width="300" alt="after-1440-scope-open-dark" src="https://github.com/user-attachments/assets/14b60cbb-189e-4507-bd2d-4a6cf16d7a0f" /></td></tr>
<tr><td>1920×1080 wide</td><td><img width="300" alt="after-1920-scope-open-light" src="https://github.com/user-attachments/assets/f940919b-0460-4250-80b2-5b608247fef6" /></td><td><img width="300" alt="after-1920-scope-open-dark" src="https://github.com/user-attachments/assets/670444fc-ae7b-4c16-996f-5b15523a97dc" /></td></tr>
</table>

## Test plan

- [x] `npm run build` (`tsc -b` typecheck + `vite build`) — clean
- [x] `npm run test --workspace @bird-watch/frontend` — 1043 passed
- [x] New unit test: `ScopeControl` forwards a first-field ref (#4)
- [x] New e2e: focused select shows the soft accent ring, not the black box (`scope-disclosure.spec.ts`, #1)
- [x] New e2e: expanded legend does not overlap the attribution at 390 / 768 (`legend-attribution-overlap.spec.ts`, #3)
- [x] New e2e: the ZIP `[Go]` button's right edge stays within the identity card's inner edge at 390px (the bug) and 768px (regression guard) (`scope-zip-overflow.spec.ts`, #5) — the 390px case fails on the pre-fix CSS
- [x] e2e regression sweep: `scope-disclosure`, `zip-scope`, `state-scope`, `family-legend*`, `legend-o5-cap-force-collapse`, `axe` — all green (mobile legend expand preserved; 19 scope specs pass)
- [x] WCAG 2.1 SC 1.4.11 focus-contrast fix (#842): light focus ring `#984012` measured **6.82:1** vs `#fff` and **4.56:1** vs the `#d8d3c3` field border (both ≥ 4.5:1); dark cyan unchanged. New `--color-focus-ring` token added to `tokens.css` (light/dark-paired); `tokens.css.test.ts` covers the dark override.
- [x] `orphan-classname-check` — PASS; `knip` — exit 0
- [x] UI verified live via chrome-devtools MCP at all 5 canonical viewports &times; light+dark; zero console errors (one pre-existing OpenFreeMap basemap sprite warning, unrelated)

## Plan reference

Out of plan — polish follow-up to #828 / #837 (Julian's live review of the expanded scope card; #5 from his second pass on the live PR).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


