### PR TITLE
fix(db-client): UNNEST-based upsertObservations to avoid uint16 param overflow (#843)

### DIFF
--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -142,6 +142,111 @@ describe('upsertObservations', () => {
       expect(r.silhouette_id).toBeNull();
     }
   });
+
+  // #843 — Postgres bind-message param overflow regression guard.
+  //
+  // The old single-`INSERT … VALUES ($1..$N)` build emitted one $N placeholder
+  // per field (9 cols/row). The Postgres wire protocol encodes the Bind
+  // parameter count as a uint16 (max 65,535); node-postgres does NOT guard it,
+  // so once total params cross 65,535 the count silently overflows mod 65536
+  // and the bind desyncs ("bind message has N parameter formats but 0
+  // parameters"). 65,535 ÷ 9 = 7,281 rows is a CORRUPTION THRESHOLD, not a safe
+  // ceiling. The #840 per-state fan-out aggregates tens of thousands of rows
+  // into ONE upsert call (the failing prod run had ~13.3k), which is exactly
+  // what this exercises. These tests MUST drive the REAL upsertObservations
+  // path (the per-row JS build + correlated stamp UPDATE), NOT the
+  // generate_series bypass the LIMIT-cap test above uses — that bypass skips the
+  // build site that overflows and would never catch this bug. The path is slow
+  // for 14k rows; that is inherent to exercising the real code.
+  function makeSynthetic(n: number, opts?: { startAt?: number }): ObservationInput[] {
+    const startAt = opts?.startAt ?? 0;
+    const out: ObservationInput[] = [];
+    for (let i = startAt; i < startAt + n; i++) {
+      out.push({
+        subId: `S-bulk-${i}`,
+        speciesCode: 'vermfly',
+        comName: 'Vermilion Flycatcher',
+        lat: 31.72 + (i % 1000) * 0.0001,
+        lng: -110.88 - (i % 1000) * 0.0001,
+        obsDt: '2026-04-15T08:00:00Z',
+        locId: `L-bulk-${i}`,
+        locName: i % 7 === 0 ? null : `Loc ${i}`,
+        howMany: i % 5 === 0 ? null : (i % 4) + 1,
+        isNotable: false,
+      });
+    }
+    return out;
+  }
+
+  it('upserts 14,000 rows in one call without overflowing the uint16 bind-param limit (#843)', async () => {
+    const inputs = makeSynthetic(14_000);
+    const count = await upsertObservations(db.pool, inputs);
+    expect(count).toBe(14_000);
+
+    const { rows } = await db.pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM observations WHERE sub_id LIKE 'S-bulk-%'"
+    );
+    expect(Number(rows[0]!.n)).toBe(14_000);
+
+    // The stamp UPDATE (also previously unbounded, 2 params/row) must have run
+    // across the whole batch — every row gets its silhouette_id.
+    const { rows: stamped } = await db.pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM observations WHERE sub_id LIKE 'S-bulk-%' AND silhouette_id = 'tyrannidae'"
+    );
+    expect(Number(stamped[0]!.n)).toBe(14_000);
+  }, 120_000);
+
+  it('upserts 14,001 distinct rows with no drop or double-count across boundaries (#843)', async () => {
+    const inputs = makeSynthetic(14_001);
+    const count = await upsertObservations(db.pool, inputs);
+    expect(count).toBe(14_001);
+
+    const { rows } = await db.pool.query<{ total: string; distinct: string }>(
+      `SELECT count(*)::text AS total,
+              count(DISTINCT (sub_id, species_code))::text AS distinct
+       FROM observations WHERE sub_id LIKE 'S-bulk-%'`
+    );
+    expect(Number(rows[0]!.total)).toBe(14_001);
+    expect(Number(rows[0]!.distinct)).toBe(14_001);
+  }, 120_000);
+
+  it('OR-coalesces is_notable across large upsert calls at fan-out scale (#843)', async () => {
+    // The `is_notable = observations.is_notable OR EXCLUDED.is_notable`
+    // ON-CONFLICT clause must survive the UNNEST rewrite at >7,281-row scale.
+    // Callers (the #840 fan-out) pass a per-call deduplicated batch — Postgres
+    // rejects two rows sharing the conflict key inside ONE statement ("ON
+    // CONFLICT DO UPDATE command cannot affect row a second time"), exactly as
+    // the old single-INSERT form did, so the in-batch dedup is the caller's job
+    // (run-ingest.ts byKey map). What this guards is the CROSS-CALL coalesce: a
+    // key that arrives non-notable in one big upsert and notable in the next
+    // must end notable, with both calls clearing the uint16 ceiling.
+    const conflictKey = { subId: 'S-notable-x', speciesCode: 'annhum' as const };
+    const notNotable: ObservationInput = {
+      ...conflictKey, comName: "Anna's Hummingbird",
+      lat: 32.3, lng: -110.99, obsDt: '2026-04-15T08:00:00Z',
+      locId: 'L-x', locName: 'X', howMany: 1, isNotable: false,
+    };
+    const notable: ObservationInput = { ...notNotable, isNotable: true, obsDt: '2026-04-16T08:00:00Z' };
+
+    // Call 1: 8,000 filler + the non-notable copy (clears 7,281).
+    await upsertObservations(db.pool, [...makeSynthetic(8_000), notNotable]);
+    // Call 2: a fresh 8,000 filler + the notable copy of the same key.
+    await upsertObservations(db.pool, [...makeSynthetic(8_000, { startAt: 20_000 }), notable]);
+
+    const { rows } = await db.pool.query<{ is_notable: boolean }>(
+      "SELECT is_notable FROM observations WHERE sub_id = 'S-notable-x' AND species_code = 'annhum'"
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.is_notable).toBe(true);
+
+    // And the reverse direction does NOT clobber: a later non-notable upsert of
+    // an already-notable key keeps is_notable = true (OR, not assignment).
+    await upsertObservations(db.pool, [{ ...notable, isNotable: false }]);
+    const { rows: after } = await db.pool.query<{ is_notable: boolean }>(
+      "SELECT is_notable FROM observations WHERE sub_id = 'S-notable-x' AND species_code = 'annhum'"
+    );
+    expect(after[0]!.is_notable).toBe(true);
+  }, 120_000);
 });
 
 describe('getObservations filters', () => {

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -16,31 +16,58 @@ export interface ObservationInput {
   isNotable: boolean;
 }
 
+// UNNEST-based bulk upsert (#843). The previous build emitted one `$N`
+// placeholder per FIELD (9 cols × N rows for the INSERT, 2 × N for the stamp
+// UPDATE). The Postgres wire protocol encodes a Bind message's parameter count
+// as a uint16 (max 65,535) and node-postgres does NOT guard it — past that the
+// count silently overflows mod 65536 and the bind desyncs ("bind message has N
+// parameter formats but 0 parameters"). The #840 per-state `recent` fan-out
+// aggregates tens of thousands of rows into ONE upsert call (~13.3k in the
+// failing prod run), so 7,281 rows (65,535÷9) was a CORRUPTION THRESHOLD, not a
+// safe ceiling. UNNEST passes ONE array param per COLUMN — 9 params for the
+// INSERT, 2 for the stamp — regardless of row count, so the ceiling is
+// structurally unreachable. Both statements run inside a single transaction on
+// one client so a mid-upsert failure rolls back cleanly (a half-written
+// national map is worse than a clean retry next cycle).
 export async function upsertObservations(
   pool: Pool,
   inputs: ObservationInput[]
 ): Promise<number> {
   if (inputs.length === 0) return 0;
 
-  const values: unknown[] = [];
-  const placeholders: string[] = [];
+  // One column-major array per field. Casts match the observations schema:
+  // sub_id/species_code/loc_id/loc_name TEXT, lat/lng DOUBLE PRECISION (float8),
+  // obs_dt TIMESTAMPTZ, how_many INTEGER, is_notable BOOLEAN. loc_name and
+  // how_many are nullable — null elements pass through fine.
+  const subIds: string[] = [];
+  const speciesCodes: string[] = [];
+  const lats: number[] = [];
+  const lngs: number[] = [];
+  const obsDts: string[] = [];
+  const locIds: string[] = [];
+  const locNames: (string | null)[] = [];
+  const howManys: (number | null)[] = [];
+  const isNotables: boolean[] = [];
 
-  inputs.forEach((o, i) => {
-    const off = i * 9;
-    placeholders.push(
-      `($${off + 1}, $${off + 2}, $${off + 3}, $${off + 4}, $${off + 5}, ` +
-      `$${off + 6}, $${off + 7}, $${off + 8}, $${off + 9})`
-    );
-    values.push(
-      o.subId, o.speciesCode, o.lat, o.lng, o.obsDt,
-      o.locId, o.locName, o.howMany, o.isNotable
-    );
-  });
+  for (const o of inputs) {
+    subIds.push(o.subId);
+    speciesCodes.push(o.speciesCode);
+    lats.push(o.lat);
+    lngs.push(o.lng);
+    obsDts.push(o.obsDt);
+    locIds.push(o.locId);
+    locNames.push(o.locName);
+    howManys.push(o.howMany);
+    isNotables.push(o.isNotable);
+  }
 
   const insertSql = `
     INSERT INTO observations
       (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
-    VALUES ${placeholders.join(',')}
+    SELECT * FROM unnest(
+      $1::text[], $2::text[], $3::float8[], $4::float8[], $5::timestamptz[],
+      $6::text[], $7::text[], $8::int[], $9::bool[]
+    )
     ON CONFLICT (sub_id, species_code) DO UPDATE SET
       lat        = EXCLUDED.lat,
       lng        = EXCLUDED.lng,
@@ -52,19 +79,11 @@ export async function upsertObservations(
       ingested_at = now()
   `;
 
-  // Build a (sub_id, species_code) VALUES set that scopes the stamp UPDATE to
-  // just the rows in this batch. Without this scoping the WHERE clause goes
-  // O(table) — every batch re-scans every NULL-stamp residue row in
-  // observations, which is what made the daily backfill loop time out (#505).
+  // Scope the stamp UPDATE to just this batch's (sub_id, species_code) pairs.
+  // Without this scoping the WHERE clause goes O(table) — every batch re-scans
+  // every NULL-stamp residue row in observations, which is what made the daily
+  // backfill loop time out (#505). UNNEST keeps it O(batch) at 2 array params.
   // runReconcileStamping() remains the once-per-run sweeper for NULL residue.
-  const stampValues: unknown[] = [];
-  const stampPlaceholders: string[] = [];
-  inputs.forEach((o, i) => {
-    const off = i * 2;
-    stampPlaceholders.push(`($${off + 1}, $${off + 2})`);
-    stampValues.push(o.subId, o.speciesCode);
-  });
-
   const stampSql = `
     UPDATE observations o
     SET
@@ -75,14 +94,28 @@ export async function upsertObservations(
         WHERE sm.species_code = o.species_code
         LIMIT 1
       )
-    FROM (VALUES ${stampPlaceholders.join(',')}) AS batch(sub_id, species_code)
+    FROM unnest($1::text[], $2::text[]) AS batch(sub_id, species_code)
     WHERE o.sub_id = batch.sub_id
       AND o.species_code = batch.species_code
       AND o.silhouette_id IS NULL
   `;
 
-  await pool.query(insertSql, values);
-  await pool.query(stampSql, stampValues);
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(insertSql, [
+      subIds, speciesCodes, lats, lngs, obsDts,
+      locIds, locNames, howManys, isNotables,
+    ]);
+    await client.query(stampSql, [subIds, speciesCodes]);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+
   return inputs.length;
 }
 

--- a/services/ingestor/src/run-backfill.test.ts
+++ b/services/ingestor/src/run-backfill.test.ts
@@ -263,17 +263,50 @@ describe('runBackfill', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Wrap real pool: pass through startIngestRun/finishIngestRun (which use
-    // INSERT/UPDATE on ingest_runs) but throw on the observations multi-row INSERT.
+    // INSERT/UPDATE on ingest_runs via pool.query) but throw on the observations
+    // multi-row INSERT. As of #843 upsertObservations runs inside a transaction
+    // on a connected client (pool.connect() -> client.query), so the synthetic
+    // failure must be injected on BOTH paths: the direct pool.query path AND the
+    // connected-client path. Intercepting only pool.query (the pre-#843 shape)
+    // would let the real INSERT succeed and the status==='failure' assertion
+    // would never trip.
+    const rejectIfObservationsInsert = (
+      text: string | { text?: string },
+      pass: (t: never, p: never) => Promise<unknown>,
+      params?: unknown[],
+    ) => {
+      const sql = typeof text === 'string' ? text : text.text ?? '';
+      if (sql.includes('observations') && /INSERT/i.test(sql)) {
+        return Promise.reject(new Error('synthetic upsert failure'));
+      }
+      return pass(text as never, params as never);
+    };
     const realQuery = db.pool.query.bind(db.pool);
     const wrappedPool = new Proxy(db.pool, {
       get(target, prop) {
         if (prop === 'query') {
-          return (text: string, params?: unknown[]) => {
-            const sql = typeof text === 'string' ? text : (text as { text?: string }).text ?? '';
-            if (sql.includes('observations') && /INSERT/i.test(sql)) {
-              return Promise.reject(new Error('synthetic upsert failure'));
-            }
-            return realQuery(text as never, params as never);
+          return (text: string, params?: unknown[]) =>
+            rejectIfObservationsInsert(text, realQuery, params);
+        }
+        if (prop === 'connect') {
+          // upsertObservations() acquires a client and runs
+          // BEGIN / INSERT / stamp / COMMIT (or ROLLBACK) on it. Return a Proxy
+          // over the REAL client so BEGIN/ROLLBACK/COMMIT and release() behave
+          // normally, but the observations INSERT rejects with the same
+          // synthetic failure — driving the catch -> ROLLBACK -> rethrow path.
+          return async () => {
+            const client = await db.pool.connect();
+            const realClientQuery = client.query.bind(client);
+            return new Proxy(client, {
+              get(clientTarget, clientProp) {
+                if (clientProp === 'query') {
+                  return (text: string, params?: unknown[]) =>
+                    rejectIfObservationsInsert(text, realClientQuery, params);
+                }
+                const value = (clientTarget as unknown as Record<string | symbol, unknown>)[clientProp as string];
+                return typeof value === 'function' ? value.bind(clientTarget) : value;
+              },
+            });
           };
         }
         return (target as unknown as Record<string | symbol, unknown>)[prop as string];


### PR DESCRIPTION
## Diagrams

The bug and the fix, side by side — the param count that crosses the wire per upsert:

```mermaid
flowchart TB
    subgraph before["BEFORE — single INSERT … VALUES ($1..$N), 9 params/row"]
        A1["#840 fan-out aggregates ~13.3k rows"] --> A2["build 13,359 × 9 = 120,231 bind params"]
        A2 --> A3{"> 65,535 uint16 ceiling?"}
        A3 -->|yes| A4["node-postgres overflows mod 65536<br/>120,231 mod 65,536 = 54,695"]
        A4 --> A5["bind desyncs: 'bind message has 54695<br/>parameter formats but 0 parameters'"]
        A5 --> A6["tx ROLLBACK — no data lands<br/>MO/KS/OK coverage fix stays dark"]
    end
    subgraph after["AFTER — UNNEST, one array param per COLUMN"]
        B1["any row count"] --> B2["INSERT … SELECT * FROM unnest($1::text[] … $9::bool[])<br/>= 9 params total, always"]
        B2 --> B3["stamp UPDATE … FROM unnest($1::text[], $2::text[])<br/>= 2 params, batch-scoped O(batch)"]
        B3 --> B4["BEGIN → insert → stamp → COMMIT on one client<br/>ceiling structurally unreachable"]
    end
```

## Summary

- **Why it broke:** `upsertObservations` built one `INSERT … VALUES` with a `$N` placeholder per field (9 cols/row). Postgres encodes a Bind message's parameter count as a **uint16 (max 65,535)** and node-postgres does not guard it — past 65,535 the count silently overflows `mod 65536` and the bind desyncs. The merged #840 per-state `recent` fan-out aggregates tens of thousands of rows into ONE upsert call (~13.3k in the failing prod run → 120,231 params → `120,231 mod 65,536 = 54,695`), so the post-deploy ingest failed with `bind message has 54695 parameter formats but 0 parameters` and rolled back — the central-states coverage fix never landed. **7,281 rows (65,535÷9) was a corruption threshold, not a safe ceiling.**
- **The fix (UNNEST — preferred):** rewrote the INSERT as `INSERT … SELECT * FROM unnest($1::text[], …, $9::bool[])` and the stamp UPDATE's `(VALUES …)` set as `unnest($1::text[], $2::text[])` — **one array param per column**, so the total stays at 9 (insert) / 2 (stamp) params regardless of row count and the ceiling is structurally unreachable. Casts match the `observations` schema exactly (TEXT / float8 / timestamptz / int / bool; `loc_name` + `how_many` nullable). The **stamp UPDATE was fixed too** (it had the same unbounded 2-params/row build, overflowing at ~32,767 rows) and keeps its batch-scoped O(batch) behavior.
- **Atomicity:** both statements run inside one `BEGIN/COMMIT` on a single pooled client (acquire via `pool.connect()`, `ROLLBACK` + rethrow on error, `release()` in `finally`) so a mid-upsert failure cannot half-write a national map. `ON CONFLICT (sub_id, species_code) DO UPDATE … is_notable = observations.is_notable OR EXCLUDED.is_notable, ingested_at = now()` preserved verbatim.

## Screenshots

N/A — not UI (db-client-only change; no `frontend/**` files touched).

## Test plan

- [x] `npm run build` across shared-types + db-client + ingestor — clean
- [x] `npm run lint` — green (db-client/ingestor have no lint script; `--if-present` skips, matching CI; the lint-job token guard scans only `frontend/src/`, untouched)
- [x] New regression tests in `observations.test.ts` drive the **real** `upsertObservations(pool, inputs)` path (NOT the `generate_series` bypass the existing 6K LIMIT-cap test uses):
  - **14,000 rows** in one call — confirmed failing first (`bind message has 60464 parameter formats but 0 parameters`, = `14,000 × 9 mod 65,536`), green after the fix, returns the correct affected count, and all 14k rows are silhouette-stamped (proves the stamp UPDATE ran across the whole batch).
  - **14,001 rows** — exactly 14,001 distinct upserted, no drop/double-count.
  - **is_notable OR-coalesce at fan-out scale** — same `(sub_id, species_code)` arriving non-notable then notable across two >7,281-row upsert calls ends `is_notable=true`; a later non-notable upsert does NOT clobber it (OR, not assignment). (In-batch dedup of a repeated key remains the caller's job — the #840 `run-ingest.ts` `byKey` map — since a single statement, old or new, rejects two rows sharing the conflict key; UNNEST does not change that contract.)
- [x] Full `@bird-watch/db-client` suite — 14 files, **118 passed (1 todo)**; existing upsert/notable/ON-CONFLICT/stamp-scope tests stay green
- [x] Full `@bird-watch/ingestor` suite — 23 files, **222 passed**. (The connection-path change initially turned the `test` gate **RED**: the pre-existing `run-backfill.test.ts` failure-injection test wrapped only `pool.query` in a Proxy, so the new `pool.connect()` → `client.query` path bypassed the synthetic INSERT failure and `summary.status` stayed `'success'` → `1 failed | 22 passed` test files. **Fixed in this branch** — `test(ingestor): mock pool.connect path in run-backfill failure-injection test`: the Proxy now also intercepts `connect`, returning a Proxy over the real `PoolClient` whose `query` applies the same observations-INSERT reject rule, so the failure fires on the new transaction shape and the `status='failure'` assertion stays meaningful. Verified by falsification against the new db-client build — the pre-fix Proxy reproduces the exact CI error `expected 'success' to be 'failure'`, the new Proxy makes it pass.)
- [ ] New Playwright e2e spec — N/A (no user-visible behavior change)
- [ ] **Post-deploy validation (the real proof, confirmable only after merge+deploy+ingest):** trigger `gcloud run jobs execute bird-ingestor`, confirm `status: success`, then verify `GET /api/observations?state=US-MO&since=7d` distinct species jumps from **15 toward eBird's ~214**. Cannot run in CI.

## Plan reference

Out of plan — production hotfix for #843 (latent un-batched-insert bug, introduced in #9, exposed by the merged #840 / #841 per-state fan-out). Closes #843.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
