### PR TITLE
fix(db-client): SET LOCAL statement_timeout=0 in upsert txn + fetchNotable maxResults (#845)

### DIFF
--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import pg from 'pg';
 import { startTestDb, type TestDb } from './test-helpers.js';
 import {
   upsertObservations, getObservations, getObservationsAggregated,
@@ -246,6 +247,104 @@ describe('upsertObservations', () => {
       "SELECT is_notable FROM observations WHERE sub_id = 'S-notable-x' AND species_code = 'annhum'"
     );
     expect(after[0]!.is_notable).toBe(true);
+  }, 120_000);
+});
+
+// #845 — the upsert transaction must exempt itself from the session
+// `statement_timeout`. `pool.ts:35` defaults every ingestor pool connection to
+// 15_000ms (added by #822 to protect the read-api); the ~13.3k-row national
+// fan-out upsert exceeds that on db-g1-small and gets cancelled with SQLSTATE
+// 57014, rolling back so zero rows commit. `SET LOCAL statement_timeout = 0`
+// immediately after BEGIN exempts ONLY the INSERT + stamp UPDATE in this txn
+// and reverts on COMMIT/ROLLBACK — every other query keeps the session cap.
+describe('upsertObservations statement_timeout (#845)', () => {
+  // A dedicated pool on the SAME test DB whose connections carry a deliberately
+  // tiny session `statement_timeout`. `pg.Pool`'s `statement_timeout` option
+  // issues `SET statement_timeout` on every connection, so this stands in for
+  // the prod ingestor pool's 15s cap — just small enough that the real upsert's
+  // INSERT exceeds it without the SET LOCAL override.
+  let tinyPool: pg.Pool;
+
+  // 1ms is well below the wall-clock cost of a real ~14k-row UNNEST INSERT +
+  // correlated stamp UPDATE, so without the SET LOCAL fix the upsert is
+  // cancelled with 57014. Large enough a value that an *empty* pool round-trip
+  // (the no-leak SHOW) still resolves; SHOW is sub-millisecond but tolerant
+  // because statement_timeout's granularity means a 1ms cap rarely trips a
+  // trivial read. We use 50ms to keep the no-leak SHOW robust while still being
+  // far under the multi-second real INSERT.
+  const TINY_TIMEOUT_MS = 50;
+
+  beforeAll(() => {
+    tinyPool = new pg.Pool({
+      connectionString: db.url,
+      max: 4,
+      statement_timeout: TINY_TIMEOUT_MS,
+    });
+  });
+
+  afterAll(async () => {
+    await tinyPool?.end();
+  });
+
+  beforeEach(async () => {
+    await db.pool.query('TRUNCATE observations');
+  });
+
+  function makeBulk(n: number): ObservationInput[] {
+    const out: ObservationInput[] = [];
+    for (let i = 0; i < n; i++) {
+      out.push({
+        subId: `S-timeout-${i}`,
+        speciesCode: 'vermfly',
+        comName: 'Vermilion Flycatcher',
+        lat: 31.72 + (i % 1000) * 0.0001,
+        lng: -110.88 - (i % 1000) * 0.0001,
+        obsDt: '2026-04-15T08:00:00Z',
+        locId: `L-timeout-${i}`,
+        locName: i % 7 === 0 ? null : `Loc ${i}`,
+        howMany: i % 5 === 0 ? null : (i % 4) + 1,
+        isNotable: false,
+      });
+    }
+    return out;
+  }
+
+  it('completes a large upsert despite a tiny session statement_timeout (SET LOCAL 0 overrides the cap)', async () => {
+    // Without `SET LOCAL statement_timeout = 0` after BEGIN, this multi-second
+    // INSERT is cancelled by the 50ms session cap with SQLSTATE 57014 and the
+    // txn rolls back. With the fix the upsert runs to completion and every row
+    // commits.
+    const inputs = makeBulk(14_000);
+    const count = await upsertObservations(tinyPool, inputs);
+    expect(count).toBe(14_000);
+
+    const { rows } = await db.pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM observations WHERE sub_id LIKE 'S-timeout-%'"
+    );
+    expect(Number(rows[0]!.n)).toBe(14_000);
+  }, 120_000);
+
+  it('does NOT leak statement_timeout = 0 — a fresh connection after the txn keeps the session default', async () => {
+    // Run the upsert (which sets statement_timeout = 0 inside its txn), then
+    // acquire a NEW connection from the pool and read its statement_timeout.
+    // `SET LOCAL` is transaction-scoped, so the override must be gone: the fresh
+    // connection sees the session default (50ms), NOT 0. Checking a connection
+    // acquired AFTER the txn closed is the load-bearing part — a same-txn check
+    // would pass even on a leaky implementation.
+    await upsertObservations(tinyPool, makeBulk(14_000));
+
+    const client = await tinyPool.connect();
+    try {
+      const { rows } = await client.query<{ statement_timeout: string }>(
+        'SHOW statement_timeout'
+      );
+      // pg renders the 50ms session cap as '50ms'; the disabled value would be
+      // '0'. Assert it is NOT disabled — the SET LOCAL did not escape the txn.
+      expect(rows[0]!.statement_timeout).not.toBe('0');
+      expect(rows[0]!.statement_timeout).toBe('50ms');
+    } finally {
+      client.release();
+    }
   }, 120_000);
 });
 

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -103,6 +103,19 @@ export async function upsertObservations(
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    // #845 — exempt THIS transaction from the session statement_timeout.
+    // pool.ts defaults every connection to a 15s statement_timeout (#822, to
+    // protect the read-api from runaway queries). The #840 per-state fan-out
+    // funnels the whole nation (~13.3k rows) into one upsert call whose INSERT +
+    // stamp UPDATE exceeds 15s on db-g1-small, so Postgres cancels it (SQLSTATE
+    // 57014), the txn rolls back, and zero rows commit. `SET LOCAL` is
+    // transaction-scoped: it applies ONLY to the two statements below and
+    // auto-reverts on COMMIT/ROLLBACK, so every other ingestor query
+    // (startIngestRun, findMissingSpeciesMeta, finishIngestRun) and the
+    // separate read-api pool keep their 15s guard. This is deliberately
+    // narrower than disabling the timeout pool-wide; the Cloud Run job's 900s
+    // timeout remains the outer kill switch.
+    await client.query('SET LOCAL statement_timeout = 0');
     await client.query(insertSql, [
       subIds, speciesCodes, lats, lngs, obsDts,
       locIds, locNames, howManys, isNotables,

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -240,10 +240,14 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // (one /recent + /recent/notable per state) because eBird's region-recent
       // endpoint dedups to one-observation-per-species region-wide — a single
       // 'US' call starved every non-AZ state. paceMs defaults to 1000ms inside
-      // runIngest (~98 calls × 1s ≈ 98s, well under the 900s job timeout); the
-      // status ladder (success | partial | failure) is keyed on per-state
-      // failure count + 429 circuit-break, and `partial` still pings the
-      // success heartbeat below (only `failure` skips it).
+      // runIngest, applied as ONE inter-round pause per state (recent + notable
+      // fire concurrently per round), so ~48 pauses × 1s ≈ 48s of pacing — well
+      // under the 900s job timeout. (The two endpoints per state make ~98 HTTP
+      // calls total, but they're not serialized 1s apart; the pacing is the ~48
+      // inter-round sleeps, not the call count.) The status ladder (success |
+      // partial | failure) is keyed on per-state failure count + 429
+      // circuit-break, and `partial` still pings the success heartbeat below
+      // (only `failure` skips it).
       summary = await deps.runIngest({ pool, apiKey });
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -45,6 +45,25 @@ describe('EbirdClient.fetchNotable', () => {
     const obs = await client.fetchNotable('US-AZ');
     expect(obs[0]?.speciesCode).toBe('eltrog');
   });
+
+  // #845 — fetchNotable previously set `back` + `detail=simple` but NOT
+  // maxResults, so eBird capped the response at its default of 100. In busy
+  // states at peak migration (200-500 notable sightings/14d) any notable
+  // observation past the top-100 landed with is_notable silently false. Mirror
+  // fetchRecent and request the 10000 ceiling so the notable set is complete.
+  it('requests maxResults=10000 so the notable set is not capped at eBird default 100', async () => {
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('maxResults')).toBe('10000');
+        expect(url.searchParams.get('detail')).toBe('simple');
+        return HttpResponse.json(SAMPLE_OBS);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k' });
+    const obs = await client.fetchNotable('US-AZ');
+    expect(obs).toHaveLength(1);
+  });
 });
 
 describe('EbirdClient.fetchHotspots', () => {

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -45,6 +45,12 @@ export class EbirdClient {
     const url = new URL(`${this.baseUrl}/data/obs/${regionCode}/recent/notable`);
     url.searchParams.set('back', String(o.back ?? 14));
     url.searchParams.set('detail', 'simple');
+    // #845 — without maxResults eBird caps the notable response at its default
+    // of 100. In busy states at peak migration (200-500 notable sightings/14d)
+    // any notable observation past the top-100 would be missing from this set,
+    // so the intersect in run-ingest leaves its is_notable silently false.
+    // Mirror fetchRecent's 10000 ceiling.
+    url.searchParams.set('maxResults', String(o.maxResults ?? 10_000));
     return this.getJson<EbirdObservation[]>(url);
   }
 


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Job as Cloud Run Job (900s cap)
    participant Ingestor
    participant eBird
    participant Postgres

    Job->>Ingestor: execute (recent fan-out)
    loop per state (49) — recent+notable concurrent, ~48 inter-round 1s pauses
        Ingestor->>eBird: GET /data/obs/US-XX/recent (maxResults=10000)
        Ingestor->>eBird: GET /data/obs/US-XX/recent/notable (maxResults=10000 ← #845)
    end
    Ingestor->>Postgres: BEGIN
    Note over Ingestor,Postgres: SET LOCAL statement_timeout = 0  ← #845<br/>(txn-scoped; reverts on COMMIT/ROLLBACK)
    Ingestor->>Postgres: UNNEST INSERT ~13.3k rows + stamp UPDATE (>15s)
    Ingestor->>Postgres: COMMIT (statement_timeout back to session 15s)
```

## Summary

- **Why:** the per-state `recent` fan-out (#840) + UNNEST upsert (#844) still lands zero data in prod (MO 15 species/7d vs eBird ~214). The ~13.3k-row national upsert runs on a pooled client that inherits `pool.ts`'s 15s `statement_timeout` (#822, for the read-api), exceeds it on `db-g1-small`, and Postgres cancels it (SQLSTATE 57014) → whole txn rolls back → nothing commits. This is the **final** scale blocker (the audit ruled out species_meta invariant, OOM, and job timeout).
- **Fix (MUST):** `SET LOCAL statement_timeout = 0` immediately after `BEGIN` in `upsertObservations`. Transaction-scoped, so it exempts only the INSERT + stamp UPDATE and auto-reverts on COMMIT/ROLLBACK — every other ingestor query (`startIngestRun`, `findMissingSpeciesMeta`, `finishIngestRun`) and the separate read-api pool keep their 15s guard. No pool.ts change, no chunking.
- **Also (SHOULD):** `fetchNotable` now requests `maxResults=10000` (it inherited eBird's default-100 cap, silently leaving `is_notable` false past the top-100 in busy states); and the stale `~98 calls × 1s` pacing comment in `cli.ts` is corrected to the actual ~48 inter-round pauses.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — green (db-client 120 passed/1 todo; ingestor 223 passed)
- [x] New unit / integration tests added (if behavior changed) — real testcontainer Postgres, no mocks: (1) a 14k-row upsert on a pool with a deliberately tiny 50ms session `statement_timeout` SUCCEEDS (confirmed RED first with 57014, then green); (2) **no-leak** — a FRESH connection acquired *after* the txn closes shows `SHOW statement_timeout` = `50ms`, NOT `0`; (3) `fetchNotable` request URL asserts `maxResults=10000`
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no frontend change
- [x] `npm run build` — clean production build (db-client + ingestor)
- [ ] (UI only) Playwright MCP smoke — N/A, db-client + ingestor only, no `frontend/**`

## Plan reference

Out of plan — fixes #845, the final scale blocker for the #840 per-state coverage fix. Closes #845.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)