### PR TITLE
fix(frontend): re-seed bbox/zoom on scope change so a state→state switch repopulates (#847)

### DIFF
--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -142,6 +142,19 @@ export interface ApiStub {
   /** Stubs `/api/observations` to return `200` with the provided list. */
   stubObservations(obs: Observation[]): Promise<void>;
   /**
+   * #847 — state-aware, bbox-intersecting `/api/observations` stub. Models the
+   * server's `stateCode AND bbox` clip (packages/db-client/src/observations.ts:
+   * 184): it parses `state` and `bbox=[w,s,e,n]` off the request URL and returns
+   * a state's `rows` ONLY when the requested bbox intersects that state's
+   * envelope (looked up from `STATES_FIXTURE` by `stateCode`). A request whose
+   * bbox is disjoint from the requested state's envelope — the stale-bbox
+   * de-pairing the #847 bug produces — returns a clean empty 200 (zero rows),
+   * exactly reproducing "No recent sightings" with no thrown error. A request
+   * with no `bbox=` (or no `state=`) returns the state's rows unconditionally
+   * (no clip to apply). Pure `page.route`; no DB writes.
+   */
+  stubStateAwareObservations(rowsByState: Record<string, Observation[]>): Promise<void>;
+  /**
    * Stubs `**\/api/states**` to return `200` with the provided name-sorted
    * `StateSummary[]` (default `STATES_FIXTURE`). Both `<ScopeChooser>` (#742)
    * and the in-state `<ScopeControl>` (#737) fetch this on mount, so every
@@ -216,6 +229,50 @@ export const test = base.extend<{ apiStub: ApiStub }>({
             body: JSON.stringify({
               data: obs,
               meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() },
+            }),
+          });
+        });
+      },
+      async stubStateAwareObservations(rowsByState) {
+        // [w,s,e,n] envelope per state, from STATES_FIXTURE.
+        const envByState = new Map<string, [number, number, number, number]>(
+          STATES_FIXTURE.map(s => [s.stateCode, s.bbox]),
+        );
+        const intersects = (
+          a: [number, number, number, number],
+          b: [number, number, number, number],
+        ): boolean => a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1];
+
+        await page.route('**/api/observations**', async route => {
+          const url = new URL(route.request().url());
+          const state = url.searchParams.get('state');
+          const bboxParam = url.searchParams.get('bbox');
+          const rows = (state && rowsByState[state]) || [];
+
+          // Apply the server's `stateCode AND bbox` clip: a state's rows are
+          // returned only when the requested bbox intersects that state's
+          // envelope. No bbox / no known state → no clip (return the rows).
+          let clipped = rows;
+          if (state && bboxParam) {
+            const parts = bboxParam.split(',').map(Number);
+            const env = envByState.get(state);
+            if (parts.length === 4 && !parts.some(Number.isNaN) && env) {
+              const bbox = parts as [number, number, number, number];
+              clipped = intersects(bbox, env) ? rows : [];
+            }
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              data: clipped,
+              meta: {
+                freshestObservationAt:
+                  clipped.length > 0
+                    ? new Date(Date.now() - 5 * 60 * 1000).toISOString()
+                    : null,
+              },
             }),
           });
         });

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -57,6 +57,107 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
   ];
 
   /**
+   * #847 — per-state observation rows, each LOCATED INSIDE its state's
+   * STATES_FIXTURE envelope (AZ [-114.82,31.33,-109.04,37.0],
+   * FL [-87.63,24.52,-80.03,31.0], NY [-79.76,40.5,-71.86,45.02]). Fed to
+   * `stubStateAwareObservations`, which returns a state's rows ONLY when the
+   * requested bbox intersects that state's envelope — so an in-app state→state
+   * switch that carried the PREVIOUS state's (disjoint) bbox would get an empty
+   * 200 ("No recent sightings"), exactly the bug #847 fixes.
+   */
+  const ROWS_BY_STATE: Record<string, typeof AZ_OBS> = {
+    'US-AZ': AZ_OBS,
+    'US-FL': [
+      {
+        subId: 'FL1', speciesCode: 'rosspo', comName: 'Roseate Spoonbill',
+        lat: 27.8, lng: -82.6,
+        obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        locId: 'LFL1', locName: 'Tampa', howMany: 3, isNotable: false,
+        silhouetteId: 'threskiornithidae', familyCode: 'threskiornithidae',
+      },
+      {
+        subId: 'FL2', speciesCode: 'brnpel', comName: 'Brown Pelican',
+        lat: 25.8, lng: -80.2,
+        obsDt: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+        locId: 'LFL2', locName: 'Miami', howMany: 5, isNotable: false,
+        silhouetteId: 'pelecanidae', familyCode: 'pelecanidae',
+      },
+    ],
+    'US-NY': [
+      {
+        subId: 'NY1', speciesCode: 'amerob', comName: 'American Robin',
+        lat: 42.9, lng: -75.5,
+        obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        locId: 'LNY1', locName: 'Syracuse', howMany: 2, isNotable: false,
+        silhouetteId: 'turdidae', familyCode: 'turdidae',
+      },
+      {
+        subId: 'NY2', speciesCode: 'norcar', comName: 'Northern Cardinal',
+        lat: 43.0, lng: -76.1,
+        obsDt: new Date(Date.now() - 95 * 60 * 1000).toISOString(),
+        locId: 'LNY2', locName: 'Ithaca', howMany: 1, isNotable: false,
+        silhouetteId: 'cardinalidae', familyCode: 'cardinalidae',
+      },
+    ],
+  };
+
+  /** [w,s,e,n] envelopes mirroring STATES_FIXTURE — used to assert the LAST
+   *  /api/observations request carries a bbox intersecting the NEW scope. */
+  const ENV_BY_STATE: Record<string, [number, number, number, number]> = {
+    'US-AZ': [-114.82, 31.33, -109.04, 37.0],
+    'US-FL': [-87.63, 24.52, -80.03, 31.0],
+    'US-NY': [-79.76, 40.5, -71.86, 45.02],
+  };
+
+  /** Axis-aligned overlap of two [w,s,e,n] boxes. */
+  function bboxIntersects(
+    a: [number, number, number, number],
+    b: [number, number, number, number],
+  ): boolean {
+    return a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1];
+  }
+
+  /**
+   * #847 — does `bbox` tightly match the scope `envelope` (each edge within
+   * `tol` degrees)? This is the DETERMINISTIC, WebGL-independent differentiator
+   * between the bug and the fix: in this no-WebGL CI the map never settles a
+   * state-tight viewport into `debouncedBbox`, so on UNPATCHED `main` the
+   * post-switch fetch carries the cold-mount CONUS seed (`-125,24,-66,50`),
+   * which `intersects` (but does NOT tightly match) the new state's envelope.
+   * The render-phase reseed sets `debouncedBbox` to the new scope's exact
+   * envelope, so AFTER the fix the post-switch bbox matches within tol — RED on
+   * main (CONUS seed), GREEN after fix (tight envelope). The bug's live recovery
+   * path (a real map idle refining the bbox) is absent here, so the FETCH
+   * payload — not the eventual lede — is the falsifiable signal.
+   */
+  function bboxMatchesEnvelope(
+    bbox: [number, number, number, number],
+    envelope: [number, number, number, number],
+    tol = 0.5,
+  ): boolean {
+    return bbox.every((v, i) => Math.abs(v - envelope[i]) <= tol);
+  }
+
+  /** Pull the bbox off the LAST /api/observations request carrying `state`. */
+  function lastBboxForState(
+    obsRequests: string[],
+    state: string,
+  ): [number, number, number, number] | null {
+    for (let i = obsRequests.length - 1; i >= 0; i--) {
+      const u = new URL(obsRequests[i]);
+      if (u.searchParams.get('state') !== state) continue;
+      const raw = u.searchParams.get('bbox');
+      if (!raw) return null;
+      const parts = raw.split(',').map(Number);
+      if (parts.length === 4 && !parts.some(Number.isNaN)) {
+        return parts as [number, number, number, number];
+      }
+      return null;
+    }
+    return null;
+  }
+
+  /**
    * Register the always-needed scope stubs (`/api/states`, `/api/silhouettes`,
    * `/api/hotspots`, zip-index) and count `/api/observations` requests. Returns
    * a live `obsRequests` array + the typed `AppPage`. Each spec registers its
@@ -349,5 +450,106 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     const optionTexts = await app.chooserStateSelect.locator('option').allInnerTexts();
     expect(optionTexts[0]).toBe('Choose a state…');
     expect(optionTexts.slice(1)).toEqual(STATES_FIXTURE.map(s => s.name));
+  });
+
+  // #847 — PRIMARY headline guard. An in-app state→state switch (in-card scope
+  // control <select>) must repopulate markers with NO manual move/resize/reload.
+  // Pre-fix, the post-switch fetch carried the stale NY bbox → disjoint from FL
+  // → empty 200 → "No recent sightings". The fix re-seeds the bbox to the FL
+  // envelope at render, so the post-switch fetch intersects FL → rows return.
+  test('#847: in-app NY→FL switch repopulates (no resize/reload); last fetch carries an FL-intersecting bbox', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubStateAwareObservations(ROWS_BY_STATE);
+
+    // Land scoped to NY (a non-empty Template lede).
+    await app.goto('state=US-NY');
+    await app.waitForAppReady();
+    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+
+    // In-app switch to FL via the in-card scope control — NO resize/drag/reload.
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-FL');
+
+    // (a) The camera flips to FL.
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-FL');
+    // (b) The lede repopulates and NEVER sticks on the empty copy.
+    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).not.toHaveText(/No recent sightings/);
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Florida');
+
+    // (c) The LAST /api/observations carrying state=US-FL has a bbox tightly
+    // matching the FL envelope (the render-phase reseed value) — NOT the stale
+    // bbox. On unpatched main this carries the CONUS cold-mount seed, which
+    // intersects FL but does NOT match its envelope → RED; the fix reseeds it to
+    // the FL envelope → GREEN.
+    await expect.poll(() => lastBboxForState(obsRequests, 'US-FL') !== null).toBe(true);
+    const flBbox = lastBboxForState(obsRequests, 'US-FL')!;
+    expect(bboxIntersects(flBbox, ENV_BY_STATE['US-FL'])).toBe(true);
+    expect(
+      bboxMatchesEnvelope(flBbox, ENV_BY_STATE['US-FL']),
+      `last US-FL bbox=${flBbox.join(',')} must match the FL envelope ${ENV_BY_STATE['US-FL'].join(',')} (reseed); got the stale/CONUS bbox`,
+    ).toBe(true);
+  });
+
+  // #847 — reverse-direction companion: FL→NY self-recovers the same way.
+  test('#847: in-app FL→NY switch repopulates; last fetch carries an NY-intersecting bbox', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubStateAwareObservations(ROWS_BY_STATE);
+
+    await app.goto('state=US-FL');
+    await app.waitForAppReady();
+    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-NY');
+
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-NY');
+    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).not.toHaveText(/No recent sightings/);
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('· New York');
+
+    await expect.poll(() => lastBboxForState(obsRequests, 'US-NY') !== null).toBe(true);
+    const nyBbox = lastBboxForState(obsRequests, 'US-NY')!;
+    expect(bboxIntersects(nyBbox, ENV_BY_STATE['US-NY'])).toBe(true);
+    expect(
+      bboxMatchesEnvelope(nyBbox, ENV_BY_STATE['US-NY']),
+      `last US-NY bbox=${nyBbox.join(',')} must match the NY envelope ${ENV_BY_STATE['US-NY'].join(',')} (reseed); got the stale/CONUS bbox`,
+    ).toBe(true);
+  });
+
+  // #847 — whole-US (?scope=us) → state companion: the CONUS-contains-every-state
+  // boundary. From ?scope=us (no state= sent) the in-card switch to AZ must seed
+  // an AZ-intersecting bbox so AZ rows return.
+  test('#847: ?scope=us → AZ switch repopulates; last fetch carries an AZ-intersecting bbox', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app, obsRequests } = await setup(page, apiStub);
+    await apiStub.stubStateAwareObservations(ROWS_BY_STATE);
+
+    await app.goto('scope=us');
+    await app.waitForAppReady();
+
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-AZ');
+
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
+    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).not.toHaveText(/No recent sightings/);
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
+
+    await expect.poll(() => lastBboxForState(obsRequests, 'US-AZ') !== null).toBe(true);
+    const azBbox = lastBboxForState(obsRequests, 'US-AZ')!;
+    expect(bboxIntersects(azBbox, ENV_BY_STATE['US-AZ'])).toBe(true);
+    expect(
+      bboxMatchesEnvelope(azBbox, ENV_BY_STATE['US-AZ']),
+      `last US-AZ bbox=${azBbox.join(',')} must match the AZ envelope ${ENV_BY_STATE['US-AZ'].join(',')} (reseed); got the stale/CONUS bbox`,
+    ).toBe(true);
   });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1495,6 +1495,254 @@ describe('#740 (C6): scope wiring end-to-end', () => {
   });
 });
 
+describe('#847: state→state switch re-seeds debouncedBbox/zoom (render-phase)', () => {
+  // Two DISJOINT CONUS states. The bug: an in-app AZ→CA switch fires
+  // /api/observations with { state: US-CA, bbox: PREVIOUS-settled-AZ viewport }.
+  // The server ANDs stateCode (ST_Intersects) with bbox, so a stale-AZ bbox
+  // never intersects CA → empty 200 → 0 markers, "No recent sightings".
+  // bbox is [w,s,e,n] (the StateSummary order); App converts to [[w,s],[e,n]].
+  const STATES = [
+    { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.82, 31.33, -109.05, 37.0] as [number, number, number, number] },
+    { stateCode: 'US-CA', name: 'California', bbox: [-124.41, 32.53, -114.13, 42.01] as [number, number, number, number] },
+  ];
+
+  // A plain object with the four getter methods App.tsx calls on a LngLatBounds
+  // (jsdom can't load maplibre-gl — same constraint as the #690/#740 blocks).
+  function makeBounds(
+    west: number, south: number, east: number, north: number,
+  ): LngLatBounds {
+    return {
+      getWest: () => west,
+      getSouth: () => south,
+      getEast: () => east,
+      getNorth: () => north,
+    } as unknown as LngLatBounds;
+  }
+
+  // Does bbox [w,s,e,n] intersect the [w,s,e,n] envelope? (axis-aligned overlap)
+  function bboxIntersects(
+    bbox: [number, number, number, number],
+    env: [number, number, number, number],
+  ): boolean {
+    const [w, s, e, n] = bbox;
+    const [ew, es, ee, en] = env;
+    return w <= ee && e >= ew && s <= en && n >= es;
+  }
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetStatesCache();
+    __resetZipIndexCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mockGetStates.mockResolvedValue(STATES);
+    mockGetObservations.mockClear();
+    mockGetHotspots.mockClear();
+    mockGetStates.mockClear();
+    mockGetSilhouettes.mockClear();
+    mockUrlState.set.mockClear();
+    mapSurfaceRef.onViewportChange = null;
+    mapSurfaceRef.boundsKey = undefined;
+    mapSurfaceRef.scopeBounds = undefined;
+    mapSurfaceRef.flyTo = undefined;
+    mapSurfaceRef.renderCount = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // PRIMARY regression: render scoped to AZ, settle an AZ viewport, then switch
+  // to the DISJOINT CA. The LAST/only post-switch fetch must carry stateCode
+  // 'US-CA' with a bbox intersecting CA (NOT the stale AZ viewport), and exactly
+  // one post-switch fetch must fire.
+  it('switching AZ→CA re-seeds the bbox so the post-switch fetch carries a CA-intersecting bbox', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockUrlState.state = {
+        since: '14d', notable: false, speciesCode: null, familyCode: null,
+        view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+      };
+      const { rerender } = render(<App />);
+      await waitFor(() => {
+        expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+      });
+      // The scope itself fires one fetch (the stateCode/enabled trigger).
+      await waitFor(() => {
+        expect(mockGetObservations).toHaveBeenCalledTimes(1);
+      });
+      const onViewportChange = mapSurfaceRef.onViewportChange!;
+
+      // Settle a real INTERIOR-AZ viewport: advance PAST the scope-move window,
+      // fire a genuine AZ idle, then drain the 250ms debounce so debouncedBbox
+      // commits. INTERIOR_AZ is strictly EAST of CA's east edge (-114.13) so it
+      // is genuinely DISJOINT from the CA envelope — this is the stale bbox that,
+      // unreset, de-pairs the post-switch CA fetch (the live-confirmed bug).
+      const INTERIOR_AZ: [number, number, number, number] = [-112.0, 32.0, -110.0, 35.0];
+      await act(async () => { await vi.advanceTimersByTimeAsync(1100); });
+      await act(async () => {
+        onViewportChange(makeBounds(...INTERIOR_AZ), 6);
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(250); });
+
+      // Sanity: the just-committed fetch carried the interior-AZ bbox + AZ state,
+      // and that bbox is disjoint from the CA envelope (the precondition for the bug).
+      const azCall = mockGetObservations.mock.calls.at(-1)![0] as {
+        stateCode?: string; bbox?: [number, number, number, number];
+      };
+      expect(azCall.stateCode).toBe('US-AZ');
+      expect(azCall.bbox).toEqual(INTERIOR_AZ);
+      expect(bboxIntersects(INTERIOR_AZ, STATES[1].bbox)).toBe(false);
+
+      const callsBeforeSwitch = mockGetObservations.mock.calls.length;
+
+      // In-app switch to the DISJOINT CA scope (mutate URL state + rerender —
+      // models the in-card scope-control <select> writing ?state=US-CA).
+      mockUrlState.state = {
+        ...mockUrlState.state,
+        scope: { kind: 'state', stateCode: 'US-CA' },
+      };
+      await act(async () => {
+        rerender(<App />);
+      });
+      // Let any debounce/effect work settle.
+      await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+
+      const postSwitchCalls = mockGetObservations.mock.calls.slice(callsBeforeSwitch);
+      // Exactly ONE post-switch fetch (the scope change itself; no second one).
+      expect(postSwitchCalls).toHaveLength(1);
+
+      // The LAST/only post-switch fetch carries US-CA + a CA-intersecting bbox —
+      // NOT the stale AZ bbox (which is disjoint from CA → the empty-200 bug).
+      const last = mockGetObservations.mock.calls.at(-1)![0] as {
+        stateCode?: string; bbox?: [number, number, number, number];
+      };
+      expect(last.stateCode).toBe('US-CA');
+      expect(last.bbox).toBeDefined();
+      expect(
+        bboxIntersects(last.bbox!, STATES[1].bbox),
+        `post-switch bbox=${last.bbox!.join(',')} must intersect the CA envelope ${STATES[1].bbox.join(',')}`,
+      ).toBe(true);
+      // And it must NOT be the stale AZ viewport (disjoint from CA).
+      expect(
+        bboxIntersects(last.bbox!, STATES[0].bbox) && !bboxIntersects(last.bbox!, STATES[1].bbox),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #690 pairing invariant across the switch: the post-switch fetch satisfies
+  // lngSpan <= 45 || zoom < 6 (no bbox-area-cap violation). The reseeded
+  // zoom = 3 (aggregated) is the documented choice.
+  it('post-switch fetch satisfies the #690 {bbox,zoom} consistency predicate', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockUrlState.state = {
+        since: '14d', notable: false, speciesCode: null, familyCode: null,
+        view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+      };
+      const { rerender } = render(<App />);
+      await waitFor(() => {
+        expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+      });
+      const onViewportChange = mapSurfaceRef.onViewportChange!;
+      await act(async () => { await vi.advanceTimersByTimeAsync(1100); });
+      await act(async () => {
+        onViewportChange(makeBounds(-114.82, 31.33, -109.05, 37.0), 6);
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(250); });
+
+      mockUrlState.state = {
+        ...mockUrlState.state,
+        scope: { kind: 'state', stateCode: 'US-CA' },
+      };
+      await act(async () => { rerender(<App />); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+
+      // Every fetch carrying a bbox/zoom pair must be internally consistent.
+      for (const [filters] of mockGetObservations.mock.calls) {
+        const { bbox, zoom } = filters as {
+          bbox?: [number, number, number, number];
+          zoom?: number;
+        };
+        if (!bbox || zoom === undefined) continue;
+        const lngSpan = bbox[2] - bbox[0];
+        const consistent = lngSpan <= 45 || zoom < 6;
+        expect(
+          consistent,
+          `inconsistent fetch: bbox=${bbox.join(',')} (lngSpan=${lngSpan.toFixed(2)}), zoom=${zoom}`,
+        ).toBe(true);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression-preservation: a mid-animation onViewportChange INSIDE the
+  // scope-move window adds NO extra fetch (the render-phase seed must not
+  // reintroduce the mid-animation double-fetch the window exists to prevent).
+  it('a mid-animation idle inside the scope-move window adds no extra fetch', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockUrlState.state = {
+        since: '14d', notable: false, speciesCode: null, familyCode: null,
+        view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+      };
+      const { rerender } = render(<App />);
+      await waitFor(() => {
+        expect(mapSurfaceRef.onViewportChange).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(mockGetObservations).toHaveBeenCalledTimes(1);
+      });
+      const onViewportChange = mapSurfaceRef.onViewportChange!;
+
+      // Switch to CA — the scope change arms a fresh scope-move window.
+      mockUrlState.state = {
+        ...mockUrlState.state,
+        scope: { kind: 'state', stateCode: 'US-CA' },
+      };
+      await act(async () => { rerender(<App />); });
+      await waitFor(() => {
+        expect(mockGetObservations).toHaveBeenCalledTimes(2);
+      });
+
+      // A mid-animation settle idle INSIDE the freshly-armed window: swallowed,
+      // so the count stays at 2 (no extra fetch).
+      await act(async () => {
+        onViewportChange(makeBounds(-124.41, 32.53, -114.13, 42.01), 6);
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+      expect(mockGetObservations).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression-preservation: the render-phase seed must NOT double-fire on a
+  // cold scoped mount — the FIRST render initializes prevBoundsKeyRef to the
+  // mount boundsKey, so the initial scope is not treated as a change.
+  // Mirrors App.test.tsx AC-5 toHaveBeenCalledTimes(1).
+  it('cold scoped mount still fires exactly one fetch (prevBoundsKeyRef seed guard)', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    render(<App />);
+    await waitFor(() => {
+      expect(mockGetObservations).toHaveBeenCalledTimes(1);
+    });
+    // Give any mistaken second effect/render a tick to fire.
+    await waitFor(() => {
+      expect(mockGetObservations).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetObservations).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('#761 (S2): map hoisted to a viewport-root #map-layer sibling of <main>', () => {
   beforeEach(() => {
     __resetSilhouettesCache();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,22 @@ const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? 
 const CONUS_BOUNDS: [[number, number], [number, number]] = [[-130, 20], [-65, 52]];
 
 /**
+ * #847 — the zoom seeded alongside the scope-envelope bbox on a scope change
+ * (the render-phase reseed below). It forces AGGREGATED mode: the server
+ * aggregates iff `bbox` is present AND `zoom < 6` (services/read-api/src/
+ * app.ts:240). At `zoom >= 6` the per-observation path runs AND applies the
+ * bbox-area cap (services/read-api/src/validate.ts:227-254) — and for
+ * `?scope=us` the seeded CONUS envelope (lng span 65 > the 45° cap) would 400
+ * "bbox too large". `zoom 3` routes to aggregated mode and skips the cap, so
+ * the reseed is safe for the widest possible scope. Mirrors the cold-mount seed
+ * (`debouncedZoom = 3`, below) and #627. Kept near `SCOPE_MOVE_SETTLE_MS` in
+ * spirit (both govern the scope-change camera/data handshake) but declared at
+ * module scope so the render-phase reseed can reference it before the
+ * component-local `SCOPE_MOVE_SETTLE_MS` is evaluated.
+ */
+const AGGREGATED_SEED_ZOOM = 3;
+
+/**
  * O2 (#770): Default-expanded breakpoint for FamilyLegend, moved here from
  * MapSurface so the legend can render as a persistent App-root sibling.
  *
@@ -415,6 +431,61 @@ export function App() {
     return { scopeBounds: undefined, boundsKey: undefined };
   }, [state.scope, states]);
 
+  // #847 — render-phase reseed of the observations fetch inputs on a scope
+  // change. ROOT CAUSE: `debouncedBbox`/`debouncedZoom` (below) feed
+  // `/api/observations` but are ONLY ever rewritten by the `onViewportChange`
+  // idle debounce — nothing resets them on a scope change. So an in-app
+  // state→state switch flips `scopeStateCode` (a fetch dep) and fires the first
+  // fetch with `{ state: NEW, bbox: PREVIOUS scope's settled viewport }`. The
+  // server ANDs `stateCode` (ST_Intersects) with `bbox`
+  // (packages/db-client/src/observations.ts:184), so two disjoint states return
+  // an empty 200 → 0 markers / "No recent sightings" until a manual move/resize/
+  // reload rewrites the bbox (the racy, intermittent recovery #847 documents).
+  //
+  // FIX: when `boundsKey` transitions to a NEW value, re-seed both fetch inputs
+  // to the new scope's envelope (from `scopeBounds`) SYNCHRONOUSLY DURING RENDER
+  // — not in the post-commit scope-framing effect (~below, keyed on boundsKey),
+  // which runs AFTER useBirdData's observations effect and would leave the FIRST
+  // fetch stale (a double-fetch + a broken AC-5 one-fetch count, App.test.tsx
+  // "suppresses scope-change settle idles"). This is React's documented "adjust
+  // state during render" technique: a same-component setState during render
+  // re-renders before committing, so useBirdData reads the consistent
+  // `{state, bbox, zoom}` triple on the FIRST commit of the new scope — one
+  // fetch, correct payload (https://react.dev/reference/react/useState#storing-
+  // information-from-previous-renders).
+  //
+  // `prevBoundsKey` is STATE (not a ref) initialized to the mount `boundsKey`,
+  // for two reasons:
+  //   1. Cold-mount guard: on the FIRST render `prevBoundsKey === boundsKey`, so
+  //      the initial scope is NOT treated as a change — a cold scoped mount stays
+  //      exactly one fetch (App.test.tsx AC-5 `toHaveBeenCalledTimes(1)`).
+  //   2. StrictMode-safety: React 18 StrictMode double-INVOKES the render
+  //      function in dev. A `useRef` mutated during render is NOT idempotent
+  //      under that replay — the first invocation would advance the ref AND queue
+  //      the bbox setState, then the SECOND invocation would see the advanced ref,
+  //      skip the setState, and React keeps the second pass → the reseed is
+  //      silently dropped in dev (the live-verification environment), even though
+  //      it works in the no-StrictMode production build. Storing the guard in
+  //      STATE makes the render-phase update idempotent across the double-invoke
+  //      (queued setStates replay to the same values), so the reseed fires in
+  //      BOTH dev and prod.
+  // The states-table holding→real-envelope transition keeps the SAME boundsKey
+  // (the state code), so it does not re-fire — acceptable, because the CONUS
+  // holding bbox still contains the state. After the scope-move settle window
+  // closes, the genuine post-fit idle refines bbox/zoom to the real viewport
+  // exactly as today; the 1000ms window still swallows the mid-animation settle
+  // idles, so this reseed remains the single fetch trigger per scope change.
+  const [prevBoundsKey, setPrevBoundsKey] = useState<string | undefined>(boundsKey);
+  if (boundsKey !== undefined && boundsKey !== prevBoundsKey) {
+    setPrevBoundsKey(boundsKey);
+    // scopeBounds is `[[w,s],[e,n]]`; it is always defined when boundsKey is.
+    if (scopeBounds) {
+      const [[w, s], [e, n]] = scopeBounds;
+      setDebouncedBbox([w, s, e, n]);
+      setDebouncedZoom(AGGREGATED_SEED_ZOOM);
+    }
+  }
+
   // #760/#762 — state-artboard mask. A `?state=US-XX` scope (and the state a ZIP
   // resolves into, which is also a `state` scope) gets the inverse mask: the
   // exterior is painted flat opaque gray and the camera can zoom out onto that
@@ -498,6 +569,16 @@ export function App() {
   // `fitBounds`/`flyTo` that follows then settles and fires ONE `idle` →
   // `onViewportChange`; without a guard, that settle-frame would write a new
   // bbox/zoom and trigger a SECOND, mid-animation refetch for the same scope.
+  //
+  // #847 INVARIANT: that single scope-change fetch now carries an INTERNALLY
+  // CONSISTENT `{state, bbox, zoom}` triple — the render-phase reseed above
+  // rewrites `debouncedBbox`/`debouncedZoom` to the NEW scope's envelope (at
+  // `AGGREGATED_SEED_ZOOM`) in the SAME render that flips `scopeStateCode`, so
+  // the bbox can never lag a scope behind (the empty-200 de-pairing bug). This
+  // window's role is UNCHANGED: it still swallows the mid-animation settle idles
+  // so they add no second fetch; the post-window idle still refines bbox/zoom to
+  // the real (post-`fitBounds`) viewport. The reseed seeds the consistent triple
+  // at the SOURCE; this window keeps the count at one per scope change.
   //
   // The guard: `scopeMoveUntilRef` holds a timestamp through which idle-driven
   // bbox refetches are suppressed. It is set on every scope-framing change (the


### PR DESCRIPTION
## Diagrams

State→state switch, before vs after. The render-phase reseed makes the first
post-switch fetch carry an internally consistent `{state, bbox, zoom}` triple,
so the server's `stateCode AND bbox` clip returns rows instead of an empty 200.

```mermaid
sequenceDiagram
    participant User
    participant App
    participant useBirdData
    participant ReadAPI as Read API

    Note over App: BEFORE (#847 bug) — switch AZ → CA
    User->>App: pick US-CA
    App->>useBirdData: { state: US-CA, bbox: STALE AZ viewport, zoom }
    useBirdData->>ReadAPI: GET /api/observations?state=US-CA&bbox=<AZ>
    ReadAPI-->>useBirdData: 200 [] (CA ∩ AZ-bbox = ∅)
    Note over App: 0 markers · "No recent sightings" until move/resize/reload

    Note over App: AFTER (#847 fix) — switch AZ → CA
    User->>App: pick US-CA
    App->>App: boundsKey AZ→CA ⇒ reseed bbox=CA envelope, zoom=3 (render-phase)
    App->>useBirdData: { state: US-CA, bbox: CA envelope, zoom: 3 }
    useBirdData->>ReadAPI: GET /api/observations?state=US-CA&bbox=<CA>&zoom=3
    ReadAPI-->>useBirdData: 200 aggregated buckets (CA ∩ CA-bbox ≠ ∅)
    Note over App: markers + lede "N species" — no manual interaction
```

## Summary

- **Why:** an in-app state→state switch (in-card scope select or chooser) could leave the map empty — 0 markers, "No recent sightings", blank legend — until a manual move/resize/reload. Root cause: `debouncedBbox`/`debouncedZoom` feed `GET /api/observations` but were only ever rewritten by the `onViewportChange` idle debounce — nothing reset them on a scope change, so the first fetch after a switch carried `{ state: NEW, bbox: PREVIOUS scope's settled viewport }`. The server ANDs `stateCode` (ST_Intersects) with `bbox`, so two disjoint states return a clean empty 200 (the live-confirmed, intermittent, console-clean failure in #847).
- **Fix:** on a scope change (`boundsKey` transitions to a new value), re-seed `debouncedBbox`/`debouncedZoom` to the new scope's envelope **synchronously during render** (React's "adjust state during render" technique) — not in the post-commit scope-framing effect, which runs after useBirdData's effect and would leave the first fetch stale (a double-fetch that also breaks the AC-5 one-fetch test). One fetch, correct payload, on the first commit of the new scope.
- **Deliberate `zoom = 3` (`AGGREGATED_SEED_ZOOM`):** the server aggregates iff `bbox && zoom < 6` (`app.ts:240`); at `zoom >= 6` it runs per-observation mode and applies the bbox-area cap (`validate.ts:227-254`), which the `?scope=us` CONUS envelope (lng span 65 > the 45° cap) would trip with a 400 "bbox too large". `zoom 3` routes to aggregated mode and skips the cap — safe for the widest scope, and parity with the cold-mount seed (#627). The previous-key guard is stored in **state, not a ref**: a render-phase ref mutation is not idempotent under React 18 StrictMode's double-invoked render (the live-dev verification env) and would silently drop the reseed in dev even though it works in the no-StrictMode production build — a state guard replays consistently. `scopeMoveUntilRef`, the `onViewportChange` swallow guard, the marker reconciler, and all MapCanvas idle/`fitBounds` wiring are untouched.

## Screenshots

Live UI verification of the #847 fix, driven through chrome-devtools MCP against a local Vite dev server proxying the prod API (real data). After an **in-app state switch (AZ → New York)** with **no manual move / resize / reload**, the map repopulates: markers, "297 species" lede, and the family legend all render. Captured at all 5 canonical viewports × light + dark (10 shots). Console at 1440×900: zero app errors/warnings (only the known benign OpenFreeMap missing-sprite warning).

| Viewport | Light | Dark |
|---|---|---|
| **390×844** (mobile) | <img width="390" src="https://github.com/user-attachments/assets/8b7dc68b-da53-4570-9d03-15c86a86ffd1"> | <img width="390" src="https://github.com/user-attachments/assets/eb0e4e99-a8b2-49cb-8d67-b86a098dd7e0"> |
| **768×1024** (tablet portrait) | <img width="390" src="https://github.com/user-attachments/assets/72899d85-b74d-4d8b-ad97-8cea89af7be2"> | <img width="390" src="https://github.com/user-attachments/assets/7303b319-4969-4639-9c65-e582609298ed"> |
| **1024×768** (tablet landscape) | <img width="390" src="https://github.com/user-attachments/assets/16634443-6259-4ad5-81bd-f74097b804c7"> | <img width="390" src="https://github.com/user-attachments/assets/b5c78ad2-b65f-41c9-b96d-c52e63be6cb8"> |
| **1440×900** (desktop) | <img width="390" src="https://github.com/user-attachments/assets/d58602fc-5a49-4c0e-aa10-8c994d6e4741"> | <img width="390" src="https://github.com/user-attachments/assets/04ecf8fb-6a1a-433c-b1d5-8563e9672098"> |
| **1920×1080** (wide desktop) | <img width="390" src="https://github.com/user-attachments/assets/1f10bf94-84e6-471d-a1ed-1fba2d2a658b"> | <img width="390" src="https://github.com/user-attachments/assets/afe09cf6-6b31-4ef0-9ebb-e7f19d1ae750"> |

## Test plan

- [x] `npm run lint` (root) + `npm run build --workspace @bird-watch/frontend` (tsc -b + vite build) — green
- [x] `npm run test --workspace @bird-watch/frontend` — full unit suite green (1048 tests, 65 files); AC-5 one-fetch (`App.test.tsx` "suppresses scope-change settle idles") and #690 still green
- [x] New **unit** tests in `frontend/src/App.test.tsx` (`#847` describe): primary disjoint AZ→CA regression (last/only post-switch fetch carries a CA-intersecting bbox, exactly one fetch) — proven RED on `origin/main`, GREEN after fix — plus #690 consistency, mid-window no-extra-fetch, and cold-mount one-fetch guards
- [x] New **e2e** tests in `frontend/e2e/state-scope.spec.ts` (`#847`: NY→FL, FL→NY, ?scope=us→AZ): in-app switch with NO resize/drag/reload; assert `data-camera-bounds` flips, lede repopulates (never "No recent sightings"), and the last `/api/observations` carries the new scope's envelope (RED on `origin/main` — carries the CONUS cold-mount seed; GREEN after fix — carries the tight scope envelope). Run on the `dev-server` project, all green
- [x] State-aware bbox-intersecting `/api/observations` stub added to `frontend/e2e/fixtures.ts` (pure `page.route`, models the server's `stateCode AND bbox` clip) — no-DB-write grep returns nothing
- [x] `npx knip --no-progress` — exit 0, no new findings; no new files added
- [ ] (UI) Playwright MCP smoke across 5 canonical viewports × light+dark — owned by the orchestrator (deferred to avoid browser-MCP contention)

## Plan reference

Out of plan — bug fix for #847 (state-scope follow-up). See `docs/plans/2026-05-28-state-scope-selector.md`.

Closes #847

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
