### PR TITLE
fix(frontend): reassert cameraForBounds longitude on moveend when switching states mid-animation

### DIFF
--- a/frontend/e2e/state-scope-midmotion-longitude.spec.ts
+++ b/frontend/e2e/state-scope-midmotion-longitude.spec.ts
@@ -1,0 +1,308 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * #848 — State framing must land at the CORRECT longitude when switching states
+ * WHILE the camera is mid-animation.
+ *
+ * The bug: a state→state switch made while the camera is still moving (an
+ * in-flight `easeTo`/pan) frames the new state at the wrong `center.lng` — it
+ * sticks near the camera's pre-switch (western) longitude; zoom + latitude land
+ * correctly. `fitBounds` interrupts the in-flight `easeTo`; Mercator
+ * `handleEaseTo` captures its `from`-basis against the frozen mid-flight
+ * transform and — with `renderWorldCopies=false` (state scope) and no `k===1`
+ * target snap — lands on the un-wrapped constrained interpolation endpoint, not
+ * the `cameraForBounds` target. The fix re-asserts the geometry-correct
+ * `cameraForBounds` target on `moveend`.
+ *
+ * Strategy: read the target via `__birdMap.cameraForBounds(envelope, …)` (which
+ * is correct even mid-flight), start a long westward `easeTo`, switch states
+ * WHILE moving via the scope control, then settle and assert
+ * `|getCenter().lng − target.center.lng| < 0.75` (also lat < 0.5, zoom < 0.3 to
+ * isolate the longitude axis). A CONTROL test does the same switch from a
+ * SETTLED camera (correct on old + new code) to prove the test isn't vacuous.
+ *
+ * WebGL-skip via `skipIfMapHookAbsent`. No DB writes (route stubs + camera
+ * reads only).
+ */
+
+/** New York envelope (STATES_FIXTURE [w,s,e,n] = [-79.76, 40.5, -71.86, 45.02]). */
+const NY_BBOX: [[number, number], [number, number]] = [
+  [-79.76, 40.5],
+  [-71.86, 45.02],
+];
+/** Florida envelope (STATES_FIXTURE [-87.63, 24.52, -80.03, 31.0]) — SECONDARY eastward target. */
+const FL_BBOX: [[number, number], [number, number]] = [
+  [-87.63, 24.52],
+  [-80.03, 31.0],
+];
+/** FIT_BOUNDS_PADDING — must match MapCanvas.tsx (single source of truth). */
+const FIT_PADDING = { top: 80, bottom: 48, left: 48, right: 48 } as const;
+
+/**
+ * WebGL skip guard. `window.__birdMap` is exposed only once maplibre fires
+ * `load` on a mounted map. Skip cleanly when the hook is absent (no GPU in
+ * headless). Copied from map-unscoped-no-fetch.spec.ts.
+ */
+async function skipIfMapHookAbsent(
+  page: import('@playwright/test').Page,
+  testRef: typeof test,
+): Promise<boolean> {
+  const present = await page
+    .waitForFunction(
+      () =>
+        typeof (window as { __birdMap?: unknown }).__birdMap !== 'undefined',
+      { timeout: 8_000 },
+    )
+    .then(() => true)
+    .catch(() => false);
+  if (!present) {
+    testRef.skip(
+      true,
+      'window.__birdMap not exposed — maplibre `load` did not fire ' +
+        '(likely WebGL unavailable in headless run).',
+    );
+  }
+  return !present;
+}
+
+test.describe('#848: state framing longitude when switching states mid-animation', () => {
+  // Desktop framing — the controlled experiment in the issue was at 1440×900.
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  /**
+   * Register the always-needed scope stubs (`/api/states`, zip-index, empty
+   * fallbacks) + a non-empty observations body so the scoped map boots. Mirrors
+   * state-scope.spec.ts `setup()`. No DB.
+   */
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('./fixtures.js').ApiStub,
+  ): Promise<{ app: AppPage }> {
+    await apiStub.stubStates();
+    await apiStub.stubZipIndex();
+    // stubEmpty stubs hotspots/observations/silhouettes → [] as a fallback…
+    await apiStub.stubEmpty();
+    // …then a small observations body (LIFO — wins) so the scoped map renders a
+    // non-empty Template-4 lede on both AZ and the switched-to states.
+    await apiStub.stubObservations([
+      {
+        subId: 'S1',
+        speciesCode: 'vermfly',
+        comName: 'Vermilion Flycatcher',
+        lat: 32.22,
+        lng: -110.97,
+        obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        locId: 'L1',
+        locName: 'Tucson',
+        howMany: 1,
+        isNotable: false,
+        silhouetteId: 'tyrannidae',
+        familyCode: 'tyrannidae',
+      },
+    ]);
+    return { app: new AppPage(page) };
+  }
+
+  /**
+   * Read the geometry-correct fit target via __birdMap.cameraForBounds, stash it
+   * on window, then start a long WESTWARD easeTo and return isMoving() — the
+   * mid-flight precondition. Returns the camera-not-available sentinel as null.
+   */
+  async function readTargetAndStartLongMove(
+    page: import('@playwright/test').Page,
+    bbox: [[number, number], [number, number]],
+  ): Promise<{ moving: boolean }> {
+    return page.evaluate(
+      ([bbox, padding]) => {
+        const map = (
+          window as {
+            __birdMap?: {
+              cameraForBounds: (
+                b: [[number, number], [number, number]],
+                o: object,
+              ) => { center: { lng: number; lat: number }; zoom: number } | undefined;
+              easeTo: (o: object) => void;
+              isMoving: () => boolean;
+            };
+          }
+        ).__birdMap!;
+        const target = map.cameraForBounds(bbox, { padding, maxZoom: 12 });
+        (window as { __birdMidmotionTarget?: unknown }).__birdMidmotionTarget =
+          target
+            ? {
+                lng: target.center.lng,
+                lat: target.center.lat,
+                zoom: target.zoom,
+              }
+            : null;
+        // Long animation far west — the camera is interrupted mid-flight by the
+        // scope switch's fitBounds (the #848 trigger).
+        map.easeTo({ center: [-122, 47], zoom: 5, duration: 4000, essential: true });
+        return { moving: map.isMoving() };
+      },
+      [bbox, FIT_PADDING] as [
+        [[number, number], [number, number]],
+        typeof FIT_PADDING,
+      ],
+    );
+  }
+
+  /**
+   * Settle gate. CRITICAL — keep BOTH clauses. `data-scope-fitted` is only a
+   * 1000ms timer (SCOPE_MOVE_SETTLE_MS), NOT a camera-settle signal: it can flip
+   * true while the camera is STILL correcting. The non-negotiable gate is
+   * `!isMoving()` — without it the assertion could read a mid-correction frame
+   * and pass vacuously. Do NOT "simplify" by dropping the waitForFunction clause.
+   */
+  async function waitSettled(
+    page: import('@playwright/test').Page,
+    app: AppPage,
+  ): Promise<void> {
+    await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', {
+      timeout: 5_000,
+    });
+    await page.waitForFunction(
+      () => {
+        const m = (
+          window as { __birdMap?: { loaded: () => boolean; isMoving: () => boolean } }
+        ).__birdMap;
+        return !!m && m.loaded() && !m.isMoving();
+      },
+      undefined,
+      { timeout: 8_000 },
+    );
+  }
+
+  /** Read settled center + zoom and the stashed target; assert axis-isolated. */
+  async function assertFramedToTarget(
+    page: import('@playwright/test').Page,
+  ): Promise<void> {
+    const result = await page.evaluate(() => {
+      const map = (
+        window as {
+          __birdMap?: {
+            getCenter: () => { lng: number; lat: number };
+            getZoom: () => number;
+          };
+          __birdMidmotionTarget?: { lng: number; lat: number; zoom: number } | null;
+        }
+      ).__birdMap!;
+      const target = (
+        window as {
+          __birdMidmotionTarget?: { lng: number; lat: number; zoom: number } | null;
+        }
+      ).__birdMidmotionTarget;
+      const c = map.getCenter();
+      return { lng: c.lng, lat: c.lat, zoom: map.getZoom(), target };
+    });
+    expect(result.target, 'cameraForBounds returned a target').not.toBeNull();
+    const target = result.target!;
+    // Longitude is the bug axis: must land within 0.75° of the cameraForBounds
+    // target (the bug residual was 15–41°).
+    expect(
+      Math.abs(result.lng - target.lng),
+      `settled lng ${result.lng.toFixed(2)} vs target ${target.lng.toFixed(2)}`,
+    ).toBeLessThan(0.75);
+    // Latitude + zoom were correct even with the bug — confirm the fix is
+    // longitude-axis-scoped and did not regress them.
+    expect(Math.abs(result.lat - target.lat)).toBeLessThan(0.5);
+    expect(Math.abs(result.zoom - target.zoom)).toBeLessThan(0.3);
+  }
+
+  test('mid-motion AZ→NY (far east): settles at the cameraForBounds longitude, not the stuck western one', async ({
+    page,
+    apiStub,
+  }) => {
+    test.setTimeout(60_000);
+    const { app } = await setup(page, apiStub);
+
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', {
+      timeout: 5_000,
+    });
+    if (await skipIfMapHookAbsent(page, test)) return;
+
+    // Read the NY target + start a long westward animation; assert it IS moving.
+    const { moving } = await readTargetAndStartLongMove(page, NY_BBOX);
+    expect(moving, 'camera is mid-flight after easeTo(duration:4000)').toBe(true);
+
+    // Switch to NY WHILE the camera is moving. NO resize/drag/reload.
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-NY');
+
+    await waitSettled(page, app);
+    await assertFramedToTarget(page);
+  });
+
+  test('CONTROL: settled AZ→NY frames correctly (proves the test is not vacuous)', async ({
+    page,
+    apiStub,
+  }) => {
+    test.setTimeout(60_000);
+    const { app } = await setup(page, apiStub);
+
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    if (await skipIfMapHookAbsent(page, test)) return;
+
+    // Wait for the AZ frame to fully settle (data-scope-fitted AND !isMoving)
+    // BEFORE switching — the camera is at rest, so the fitBounds does not
+    // interrupt anything. Correct on both old and new code.
+    await waitSettled(page, app);
+
+    // Read the NY target with the camera AT REST (no easeTo) — start no move.
+    await page.evaluate((args) => {
+      const [bbox, padding] = args;
+      const map = (
+        window as {
+          __birdMap?: {
+            cameraForBounds: (
+              b: [[number, number], [number, number]],
+              o: object,
+            ) => { center: { lng: number; lat: number }; zoom: number } | undefined;
+          };
+        }
+      ).__birdMap!;
+      const target = map.cameraForBounds(bbox, { padding, maxZoom: 12 });
+      (window as { __birdMidmotionTarget?: unknown }).__birdMidmotionTarget =
+        target
+          ? { lng: target.center.lng, lat: target.center.lat, zoom: target.zoom }
+          : null;
+    }, [NY_BBOX, FIT_PADDING] as [
+      [[number, number], [number, number]],
+      typeof FIT_PADDING,
+    ]);
+
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-NY');
+
+    await waitSettled(page, app);
+    await assertFramedToTarget(page);
+  });
+
+  test('mid-motion AZ→FL (secondary eastward target): settles at the cameraForBounds longitude', async ({
+    page,
+    apiStub,
+  }) => {
+    test.setTimeout(60_000);
+    const { app } = await setup(page, apiStub);
+
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', {
+      timeout: 5_000,
+    });
+    if (await skipIfMapHookAbsent(page, test)) return;
+
+    const { moving } = await readTargetAndStartLongMove(page, FL_BBOX);
+    expect(moving, 'camera is mid-flight after easeTo(duration:4000)').toBe(true);
+
+    await app.openScopeDisclosure();
+    await app.scopeControlStateSelect.selectOption('US-FL');
+
+    await waitSettled(page, app);
+    await assertFramedToTarget(page);
+  });
+});

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -195,6 +195,30 @@ function makeFakeMap() {
     setRenderWorldCopies: vi.fn((v: boolean) => {
       renderWorldCopiesState = v;
     }),
+    // #848 — mid-motion state→state longitude reassert. The scope-camera
+    // fitBounds branch now reads `cameraForBounds` for the geometry-correct
+    // target, registers a one-shot `once('moveend', …)` corrector, and re-asserts
+    // the target via `jumpTo` if the settled `getCenter()` drifted past EPS.
+    //   - getCenter: overridable per-case via mockReturnValueOnce to simulate a
+    //     stuck-western settle (the bug) vs. a settled-at-target one (no-op).
+    //   - jumpTo: the corrector's reassert spy.
+    //   - cameraForBounds: returns the geometry-correct target (NY here) — the
+    //     value the corrector compares against and jumps to.
+    //   - once: pushes the corrector into `bareHandlersAll['moveend']` (the same
+    //     pool the renderWorldCopies test fires) so a single
+    //     `bareHandlersAll['moveend']?.forEach(cb => cb())` reaches BOTH listeners.
+    //     Production uses `map.once` (self-removing) so jumpTo's own moveend can't
+    //     re-fire the corrector.
+    //   - isMoving: the camera is conceptually mid-flight at switch time.
+    getCenter: vi.fn(() => ({ lng: -110, lat: 34 })),
+    jumpTo: vi.fn(),
+    cameraForBounds: vi.fn(() => ({ center: { lng: -75.8, lat: 42.76 }, zoom: 6 })),
+    once: vi.fn(
+      (event: string, cb: () => void | Promise<void>) => {
+        (bareHandlersAll[event] ??= []).push(cb);
+      },
+    ),
+    isMoving: vi.fn(() => true),
   };
 }
 
@@ -1850,6 +1874,156 @@ describe('MapCanvas controllable camera (#736)', () => {
     const [easeOpts] = fakeMap.easeTo.mock.calls.at(-1);
     expect(easeOpts.center).toEqual([-111, 34]);
     expect(easeOpts.zoom).toBe(12);
+  });
+
+  // ── #848 — mid-motion state→state longitude reassert ──────────────────────
+  //
+  // Switching to a new state WHILE the camera is mid-animation lands center.lng
+  // at the wrong (old-state-edge) longitude. VERIFIED live: the in-flight easeTo
+  // re-`apply`s a CLONE of its start transform every animation frame, clobbering
+  // the new state's `maxBounds`/`lngRange` (which react-map-gl DID apply in its
+  // layout effect) back to the OLD state's — the same #762/#765 clone-replay
+  // class, one axis over. The subsequent `fitBounds` (Mercator `handleEaseTo`,
+  // no `k===1` snap, `renderWorldCopies=false`) then edge-pins center.lng at the
+  // clobbered old-state `lngRange` edge.
+  //
+  // The fix reads the geometry-correct `cameraForBounds` target up front,
+  // registers a one-shot `moveend` corrector BEFORE calling `fitBounds`, and on
+  // the settle moveend (clobbering animation fully ended) RE-ASSERTS the new
+  // scope's `maxBounds` (undoing the clone clobber so the jumpTo is not
+  // re-clamped) then `jumpTo`s the target — iff `getCenter()` drifted past EPS.
+
+  /** New York fit target (far-east of an AZ start) — the bug's worst residual. */
+  const NY_BOUNDS_UNIT: [[number, number], [number, number]] = [
+    [-79.76, 40.5],
+    [-71.86, 45.02],
+  ];
+
+  it('mid-flight state→state: a stuck-western settle reasserts the cameraForBounds target via jumpTo on moveend (#848 CORE)', async () => {
+    stubMatchMedia(null);
+    // cameraForBounds returns the geometry-correct NY target (the value the
+    // corrector compares against and jumps to). Default fakeMap mock already
+    // returns this; pin it explicitly for clarity.
+    fakeMap.cameraForBounds.mockReturnValue({
+      center: { lng: -75.8, lat: 42.76 },
+      zoom: 6,
+    });
+
+    const { rerender } = render(
+      <MapCanvas observations={[]} bounds={AZ_BOUNDS} boundsKey="US-AZ" />,
+    );
+    await waitFor(() => expect(fakeMap.fitBounds).toHaveBeenCalled());
+
+    // The corrector must be registered for the AZ frame too — but the real bug
+    // surfaces on the SWITCH. Re-render to NY (boundsKey change = the in-place
+    // state→state switch; same mask/clampPad shape — none here).
+    rerender(
+      <MapCanvas observations={[]} bounds={NY_BOUNDS_UNIT} boundsKey="US-NY" />,
+    );
+    await waitFor(() =>
+      expect(fakeMap.fitBounds.mock.calls.at(-1)[0]).toEqual(NY_BOUNDS_UNIT),
+    );
+
+    // The corrector for THIS switch was registered via map.once('moveend', …).
+    expect(fakeMap.once).toHaveBeenCalledWith('moveend', expect.any(Function));
+
+    // Simulate the bug: the camera settled at a stuck western longitude (the
+    // un-wrapped interpolation endpoint near the AZ start), zoom/lat ~correct.
+    fakeMap.getCenter.mockReturnValue({ lng: -109.6, lat: 42.76 });
+
+    // Fire moveend (animation finished) → the corrector reasserts the target.
+    act(() => {
+      bareHandlersAll['moveend']?.forEach((cb) => cb());
+    });
+
+    // The corrector first RE-ASSERTS the new scope's clamp (undoing the
+    // in-flight clone's `lngRange` clobber, verified live in the e2e harness —
+    // without it the jumpTo is re-clamped to the old state's edge) — for a plain
+    // state scope (no maskPolygon/clampPad) `clampBounds === bounds`, i.e. the
+    // NY envelope here…
+    expect(fakeMap.setMaxBounds).toHaveBeenCalledWith(NY_BOUNDS_UNIT);
+    // …THEN lands the geometry-correct cameraForBounds target.
+    expect(fakeMap.jumpTo).toHaveBeenCalledWith({
+      center: { lng: -75.8, lat: 42.76 },
+      zoom: 6,
+    });
+  });
+
+  it('settled state→state: getCenter already at the target → jumpTo is NOT called (#848 no-op path)', async () => {
+    stubMatchMedia(null);
+    fakeMap.cameraForBounds.mockReturnValue({
+      center: { lng: -75.8, lat: 42.76 },
+      zoom: 6,
+    });
+
+    const { rerender } = render(
+      <MapCanvas observations={[]} bounds={AZ_BOUNDS} boundsKey="US-AZ" />,
+    );
+    await waitFor(() => expect(fakeMap.fitBounds).toHaveBeenCalled());
+    rerender(
+      <MapCanvas observations={[]} bounds={NY_BOUNDS_UNIT} boundsKey="US-NY" />,
+    );
+    await waitFor(() =>
+      expect(fakeMap.fitBounds.mock.calls.at(-1)[0]).toEqual(NY_BOUNDS_UNIT),
+    );
+
+    // The camera settled exactly at the target (within EPS) — the correct
+    // settled path that is NOT regressed. The corrector must no-op: neither the
+    // maxBounds reassert nor the jumpTo fires when there is no drift.
+    fakeMap.getCenter.mockReturnValue({ lng: -75.8, lat: 42.76 });
+    act(() => {
+      bareHandlersAll['moveend']?.forEach((cb) => cb());
+    });
+
+    expect(fakeMap.jumpTo).not.toHaveBeenCalled();
+    expect(fakeMap.setMaxBounds).not.toHaveBeenCalled();
+  });
+
+  it('ZIP flyTo path attaches NO moveend longitude corrector (untouched branch, #848)', async () => {
+    stubMatchMedia(null);
+    render(
+      <MapCanvas
+        observations={[]}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        flyTo={{ center: [-110.974, 32.222], zoom: 10, key: 'zip:85701' }}
+      />,
+    );
+    await waitFor(() => expect(fakeMap.flyTo).toHaveBeenCalled());
+    // The flyTo (ZIP) branch is byte-for-byte unchanged: it does NOT read
+    // cameraForBounds and registers no longitude corrector via once().
+    expect(fakeMap.fitBounds).not.toHaveBeenCalled();
+    expect(fakeMap.cameraForBounds).not.toHaveBeenCalled();
+    expect(fakeMap.once).not.toHaveBeenCalledWith('moveend', expect.any(Function));
+  });
+
+  it('fitBounds call contract preserved alongside the corrector (padding {top:80,others:48}, maxZoom 12, essential, duration 600) (#848)', async () => {
+    stubMatchMedia(null);
+    render(<MapCanvas observations={[]} bounds={AZ_BOUNDS} boundsKey="US-AZ" />);
+    await waitFor(() => expect(fakeMap.fitBounds).toHaveBeenCalled());
+    const [bounds, opts] = fakeMap.fitBounds.mock.calls.at(-1);
+    expect(bounds).toEqual(AZ_BOUNDS);
+    expect(opts.padding).toEqual({ top: 80, bottom: 48, left: 48, right: 48 });
+    expect(opts.maxZoom).toBe(12);
+    expect(opts.essential).toBe(true);
+    expect(opts.duration).toBe(600);
+  });
+
+  it('reduced-motion state→state still fires fitBounds duration:0 with the corrector in place (#848)', async () => {
+    stubMatchMedia('(prefers-reduced-motion: reduce)');
+    fakeMap.cameraForBounds.mockReturnValue({
+      center: { lng: -75.8, lat: 42.76 },
+      zoom: 6,
+    });
+    render(<MapCanvas observations={[]} bounds={AZ_BOUNDS} boundsKey="US-AZ" />);
+    await waitFor(() => expect(fakeMap.fitBounds).toHaveBeenCalled());
+    const [, opts] = fakeMap.fitBounds.mock.calls.at(-1);
+    expect(opts.duration).toBe(0);
+    expect(opts.essential).toBe(true);
+    // Ordering invariant: once('moveend', …) is registered BEFORE fitBounds, so
+    // under reduced motion (fitBounds runs duration:0 and fires moveend
+    // SYNCHRONOUSLY inside the call) the listener already exists.
+    expect(fakeMap.once).toHaveBeenCalledWith('moveend', expect.any(Function));
   });
 });
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -786,8 +786,97 @@ export function MapCanvas({
         essential: true,
         duration: prefersReducedMotion ? 0 : 800,
       });
+      // The ZIP `flyTo` branch is IMMUNE to the #848 mid-flight longitude bug:
+      // flyTo's easeFunc snaps to the exact targetCenter at `k===1`, so an
+      // interrupted in-flight flyTo still lands the requested center. No
+      // corrector is registered here — the branch is untouched.
       return;
     }
+
+    // #848 — Switching to a new state WHILE the camera is mid-animation frames
+    // the new state at the wrong longitude (zoom + latitude land correctly).
+    // VERIFIED live + traced into maplibre-gl 5.24.0: this is the SAME in-flight
+    // transform-clone replay class as the #762/#765 `renderWorldCopies` clobber
+    // (:864-897) — on the `maxBounds`/`lngRange` axis.
+    //
+    // Sequence (verified frame-by-frame in the e2e harness):
+    //   1. The state switch re-renders; react-map-gl's layout effect runs FIRST
+    //      and `setMaxBounds(newState)` → `transform.lngRange` momentarily holds
+    //      the NEW state envelope ("Not a stale-maxBounds clamp" is true at this
+    //      instant — react-map-gl DID apply the new bounds).
+    //   2. But the still-in-flight `easeTo` from before the switch re-`apply`s a
+    //      CLONE of its start transform (with the OLD state's `lngRange`) on its
+    //      next animation frame — clobbering `lngRange` back to the OLD state
+    //      BEFORE this passive effect even runs (passive effects fire after a
+    //      paint, i.e. after ≥1 animation frame).
+    //   3. So by the time this effect calls `fitBounds`, `transform.lngRange` is
+    //      the OLD (e.g. western) state's. `fitBounds` → Mercator `handleEaseTo`
+    //      captures its `from`-basis against that clobbered transform; with no
+    //      `k===1` target snap (unlike flyTo) and `renderWorldCopies=false` (no
+    //      world-copy wrap), the camera lands edge-pinned at the OLD state's
+    //      eastern `lngRange` edge — the wrong, western-ish longitude.
+    //
+    // `cameraForBounds` returns the geometry-correct target even mid-flight (it
+    // derives from absolute world geometry, independent of the live transform).
+    // So we read the target up front and, on the settle `moveend` (after the
+    // clobbering animation has fully ended so the clone no longer re-applies),
+    // RE-ASSERT the new state's `maxBounds` (undoing the clone clobber of
+    // `lngRange`) and `jumpTo` the target. This mirrors #762/#765's
+    // imperative-reassert-on-moveend exactly, one axis over.
+    //
+    // Why the maxBounds reassert is REQUIRED (not just jumpTo): the clobbered
+    // `lngRange` would clamp the corrective `jumpTo` straight back to the OLD
+    // state's edge — verified live. The reassert is one imperative `setMaxBounds`
+    // INSIDE the moveend corrector, NOT the reactive clamp mechanism: `maxBounds`
+    // remains a reactive `<Map>` prop (finding-(a)); the existing finding-(a)
+    // guard fires no `moveend`, so it stays green. NOT a bare `map.stop()` in the
+    // effect: `easeTo` already self-`_stop`s, freezing the western basis — stop
+    // alone fixes neither the longitude nor the `lngRange` clobber.
+    const target = map.cameraForBounds(activeBounds, {
+      padding: FIT_BOUNDS_PADDING,
+      maxZoom: 12,
+    });
+    let corrector: (() => void) | undefined;
+    // `fitBounds` first `stop()`s the in-flight `easeTo` — which fires a
+    // SYNCHRONOUS cancellation `moveend` (at the frozen western position) DURING
+    // the `fitBounds()` call, before fitBounds starts its own animation. We must
+    // NOT correct on that cancellation moveend: a `jumpTo` there is immediately
+    // clobbered by fitBounds's subsequent animation (verified live). We correct
+    // only on fitBounds's OWN settle moveend, which fires asynchronously AFTER
+    // `fitBounds()` returns. `fitBoundsDispatched` gates that: a moveend that
+    // fires while it is still `false` is the synchronous cancellation (or, under
+    // reduced motion, the instant settle that needs no correction) — re-arm and
+    // skip.
+    let fitBoundsDispatched = false;
+    if (target) {
+      const EPS = 1e-3; // ≈100 m — far below the 15–41° bug magnitude, above float noise.
+      corrector = () => {
+        if (!fitBoundsDispatched) {
+          // Synchronous cancellation moveend (still inside the fitBounds call) —
+          // re-arm for the real settle rather than correcting prematurely.
+          if (corrector) map.once('moveend', corrector);
+          return;
+        }
+        const c = map.getCenter();
+        if (
+          Math.abs(c.lng - target.center.lng) > EPS ||
+          Math.abs(c.lat - target.center.lat) > EPS
+        ) {
+          // Re-assert the new scope's clamp (undo the in-flight clone's
+          // `lngRange` clobber) so the corrective jumpTo is not re-clamped back
+          // to the old state's edge, THEN land the geometry-correct target.
+          map.setMaxBounds(clampBounds);
+          map.jumpTo({ center: target.center, zoom: target.zoom });
+        }
+      };
+      // Register the one-shot corrector BEFORE calling fitBounds — ordering is
+      // load-bearing: under prefers-reduced-motion `fitBounds` runs `duration: 0`
+      // and fires `moveend` SYNCHRONOUSLY inside the call, so the listener must
+      // already exist. `map.once` is self-removing, so `jumpTo`'s own `moveend`
+      // cannot re-fire the corrector (no loop).
+      map.once('moveend', corrector);
+    }
+
     map.fitBounds(activeBounds, {
       // Asymmetric top inset (FIT_BOUNDS_PADDING) clears the floating header +
       // scope-control chrome that stacks over the full-bleed canvas top edge
@@ -797,6 +886,16 @@ export function MapCanvas({
       essential: true,
       duration: prefersReducedMotion ? 0 : 600,
     });
+    // fitBounds has returned: any synchronous cancellation moveend it fired
+    // (while stopping the in-flight easeTo) is now past. From here, the next
+    // moveend is fitBounds's own settle — the corrector may act.
+    fitBoundsDispatched = true;
+
+    // Belt-and-suspenders: detach the corrector on cleanup so a re-fired effect
+    // (next boundsKey change) cannot leave a stale listener (mirrors :894-896).
+    return () => {
+      if (corrector) map.off('moveend', corrector);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- boundsKey +
     // flyTo?.key are the intentional triggers; `activeBounds` identity derives
     // from boundsKey and re-running on its reference churn is undesirable


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant ReactMapGL as react-map-gl (layout effect)
    participant InFlight as in-flight easeTo (clone replay)
    participant Effect as scope-camera effect (passive)
    participant Map as maplibre transform

    Note over Map: camera mid-animation (state=AZ), lngRange=AZ
    User->>ReactMapGL: switch scope → US-NY (re-render)
    ReactMapGL->>Map: setMaxBounds(NY) — lngRange=NY ✓ (momentary)
    InFlight->>Map: next frame re-applies CLONE — lngRange clobbered back to AZ ✗
    Effect->>Map: fitBounds(NY) — captures from-basis vs clobbered AZ lngRange
    Map-->>User: edge-pinned at AZ lngRange edge — WRONG longitude (old bug)

    Note over Effect,Map: FIX — corrector registered before fitBounds
    Map->>Effect: settle moveend (clobbering animation ended)
    Effect->>Map: setMaxBounds(NY) — reassert (undo clone clobber)
    Effect->>Map: jumpTo(cameraForBounds target) — lands correct longitude ✓
```

## Summary

- **Why:** Switching to a new state while the camera was mid-animation framed the new state at the wrong center longitude (zoom + latitude were correct; the target state sat off-screen east). It is the same in-flight transform-clone replay class as the #762/#765 `renderWorldCopies` clobber, one axis over (`maxBounds`/`lngRange`): the still-running `easeTo` re-applies a clone of its start transform every frame, clobbering the new state's `lngRange` back to the old state's *after* react-map-gl applied it but *before* the passive `fitBounds` effect runs. `fitBounds` (Mercator `handleEaseTo`, no `k===1` snap, `renderWorldCopies=false`) then edge-pins `center.lng` at the old state's `lngRange` edge.
- **What:** On the `fitBounds` (state) branch only, read the geometry-correct `cameraForBounds` target up front and register a one-shot `moveend` corrector. On the settle `moveend` (after the clobbering animation fully ends), reassert the new scope's `maxBounds` (undoing the `lngRange` clobber so the corrective jump is not re-clamped) then `jumpTo` the target — iff `getCenter()` drifted past EPS (1e-3°). The corrector skips the synchronous cancellation `moveend` `fitBounds` fires while stopping the in-flight `easeTo` (re-arming once for the real settle). The ZIP `flyTo` branch is byte-for-byte unchanged (immune via its `k===1` snap).
- **Deviation note (for review):** the original issue prescribed `jumpTo`-on-`moveend` *without* `setMaxBounds`. Frame-by-frame e2e investigation in this codebase showed the corrective `jumpTo` is re-clamped to the old state's edge by the clone-clobbered `lngRange` — so a single imperative `setMaxBounds(clampBounds)` reassert *inside the moveend corrector* is required (exactly mirroring the accepted #762/#765 imperative reassert). `maxBounds` remains a reactive `<Map>` prop; the existing finding-(a) "never call setMaxBounds" guard fires no `moveend`, so it stays green.

## Screenshots

Live UI verification driven through chrome-devtools MCP on the PR head (`719c81a`) against real prod data (`api.bird-maps.com`). Captured after a mid-motion AZ→NY state switch (camera in flight at switch time) — the exact #848 repro — confirming the new state lands correctly framed (center lng −75.81, on-screen) rather than shifted west off-screen. Empirical fix check: mid-motion AZ→NY |dLng| = 0.0008° and AZ→FL |dLng| = 0.003° vs the `cameraForBounds` target (PASS; pre-fix this was 15–41° off). 5 canonical viewports × light + dark; console clean at 1440×900.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![390×844 light](https://github.com/user-attachments/assets/ba4b84e9-0eeb-4972-9b50-776b3ef0ce82) | ![390×844 dark](https://github.com/user-attachments/assets/cbae71d7-b6dd-4d15-8f09-ecf8696dc597) |
| 768×1024 (tablet portrait) | ![768×1024 light](https://github.com/user-attachments/assets/229c82dc-c31b-498b-8237-61df1d252cef) | ![768×1024 dark](https://github.com/user-attachments/assets/cd23ffa7-5dce-4e3b-8644-cccb8596f4a8) |
| 1024×768 (tablet landscape) | ![1024×768 light](https://github.com/user-attachments/assets/c82e4037-850f-49c6-97c6-5da98239b4b2) | ![1024×768 dark](https://github.com/user-attachments/assets/4ebf556a-8a25-44a8-9b94-3e6b5a767b0c) |
| 1440×900 (desktop) | ![1440×900 light](https://github.com/user-attachments/assets/1d56ae76-2247-4701-859b-ceaa51ee8dab) | ![1440×900 dark](https://github.com/user-attachments/assets/18cab147-c100-4aed-a3c3-e28680675050) |
| 1920×1080 (wide desktop) | ![1920×1080 light](https://github.com/user-attachments/assets/f936aa64-b8b6-40ba-97c8-f6d726f05a2e) | ![1920×1080 dark](https://github.com/user-attachments/assets/1206a2f6-0c34-4e6a-8d79-37b373d4f231) |

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — clean (tsc -b + vite)
- [x] `npm run test --workspace @bird-watch/frontend` — green (1049 pass; new #848 unit tests RED on origin/main, GREEN after fix; existing `setMaxBounds never` (finding-a) + `renderWorldCopies` moveend reassert stay green)
- [x] New unit tests added — `MapCanvas.test.tsx`: mid-flight state→state reasserts maxBounds + jumpTo to the cameraForBounds target on moveend; settled no-op (no maxBounds/jumpTo); ZIP flyTo attaches no corrector; fitBounds call contract preserved; reduced-motion duration:0 with corrector registered before fitBounds
- [x] New Playwright e2e spec added — `frontend/e2e/state-scope-midmotion-longitude.spec.ts`: mid-motion AZ→NY (far east), CONTROL settled AZ→NY (proves non-vacuous), mid-motion AZ→FL secondary; settle gate is `data-scope-fitted='true'` AND `!isMoving()`; RED on origin/main, GREEN after fix
- [x] `npm run lint` (root) + token-name guard — clean
- [x] knip — exit 0 (new `*.spec.ts` is a playwright entrypoint; no ignore rule needed)
- [x] No-DB-write grep over `frontend/e2e/` — clean
- [ ] (UI only) Playwright MCP smoke — orchestrator owns the live 5-viewport × 2-theme verification (see Screenshots)

## Plan reference

Out of plan — bug fix for #848 (state-scope follow-up).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
