### PR TITLE
test(map): encode the moveend setMaxBounds reassert exception in the finding-(a) invariant + test (#851)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1798,7 +1798,17 @@ describe('MapCanvas controllable camera (#736)', () => {
     ).toBeNull();
   });
 
-  it('passes maxBounds as a reactive prop and NEVER calls setMaxBounds imperatively (finding a)', async () => {
+  it('passes maxBounds as a reactive prop and calls NO imperative setMaxBounds during reactive reconciliation — mount or maxBounds-prop change with no moveend (finding a)', async () => {
+    // #851: finding-(a) forbids driving `maxBounds` imperatively as the PRIMARY
+    // clamp (during reactive reconciliation). The ONE sanctioned imperative
+    // `setMaxBounds` is the #848 moveend corrector's idempotent reassert of the
+    // SAME declarative value (see MapCanvas.tsx clampBounds invariant + the
+    // moveend corrector). This test guards the forbidden path only: it drives
+    // mount + a maxBounds-prop change and fires NO `moveend`, so the corrector
+    // is registered-but-not-fired and the ONLY way `setMaxBounds` could be hit
+    // is reactive reconciliation — which must never call it. (The allowed
+    // moveend branch is covered by the #848 corrector fire/no-op tests below;
+    // exercising it here would just duplicate them.)
     stubMatchMedia(null);
     const { rerender } = render(
       <MapCanvas observations={[]} bounds={AZ_BOUNDS} boundsKey="US-AZ" />,
@@ -1808,14 +1818,23 @@ describe('MapCanvas controllable camera (#736)', () => {
       const props = JSON.parse(el.getAttribute('data-props') ?? '{}');
       return props.maxBounds;
     };
+    // On mount: maxBounds is a reactive <Map> prop, applied declaratively — no
+    // imperative setMaxBounds during the initial reconciliation.
     expect(readMaxBounds()).toEqual(AZ_BOUNDS);
+    expect(fakeMap.setMaxBounds).not.toHaveBeenCalled();
 
     // Change scope AZ→CA: the rendered maxBounds prop must update with no
-    // imperative setMaxBounds call.
+    // imperative setMaxBounds call during this reactive reconciliation either.
     rerender(
       <MapCanvas observations={[]} bounds={CA_BOUNDS} boundsKey="US-CA" />,
     );
     await waitFor(() => expect(readMaxBounds()).toEqual(CA_BOUNDS));
+
+    // The #848 moveend corrector IS registered (its one sanctioned imperative
+    // setMaxBounds lives behind a moveend), but we deliberately never fire a
+    // moveend here — so the only remaining caller would be reactive
+    // reconciliation, which is forbidden. Registered-but-not-fired ⇒ uncalled.
+    expect(fakeMap.once).toHaveBeenCalledWith('moveend', expect.any(Function));
     expect(fakeMap.setMaxBounds).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -585,8 +585,21 @@ export function MapCanvas({
    * clamp halts the move. For `?scope=us` and legacy callers (no `clampPad`) it
    * stays the raw `bounds ?? CONUS_BOUNDS` — unchanged behavior. Passed straight
    * to `<MapView maxBounds={clampBounds}>`; react-map-gl re-applies a changed
-   * `maxBounds` with no `<Map>` remount. We never call `map.setMaxBounds()`
-   * imperatively (the existing finding-(a) test guards this).
+   * `maxBounds` with no `<Map>` remount.
+   *
+   * Finding-(a) invariant: imperative `setMaxBounds` during REACTIVE
+   * RECONCILIATION — i.e. as the PRIMARY clamp mechanism, driven by a
+   * mount/`maxBounds`-prop change — is FORBIDDEN. `maxBounds` is the reactive
+   * `<Map>` prop above; that is the single authoritative clamp. There is ONE
+   * sanctioned imperative `setMaxBounds` site: the #848 `moveend` corrector
+   * below (~`:868`), a defensive IDEMPOTENT reassert of this same declarative
+   * `clampBounds` value that an in-flight animation's transform-clone clobbered
+   * (mirrors the accepted #762/#765 `renderWorldCopies`-on-`moveend` reassert).
+   * It runs only behind a `moveend`, never during reconciliation, so it does
+   * NOT make `maxBounds` imperative. The finding-(a) test guards the forbidden
+   * path: it fires NO `moveend`, leaving the corrector registered-but-not-fired,
+   * so any `setMaxBounds` it observes would necessarily be a reconciliation-time
+   * primary-clamp call (the thing this invariant forbids).
    */
   const clampBounds =
     bounds && clampPad ? padBounds(bounds, clampPad) : activeBounds;
@@ -826,12 +839,15 @@ export function MapCanvas({
     //
     // Why the maxBounds reassert is REQUIRED (not just jumpTo): the clobbered
     // `lngRange` would clamp the corrective `jumpTo` straight back to the OLD
-    // state's edge — verified live. The reassert is one imperative `setMaxBounds`
-    // INSIDE the moveend corrector, NOT the reactive clamp mechanism: `maxBounds`
-    // remains a reactive `<Map>` prop (finding-(a)); the existing finding-(a)
-    // guard fires no `moveend`, so it stays green. NOT a bare `map.stop()` in the
-    // effect: `easeTo` already self-`_stop`s, freezing the western basis — stop
-    // alone fixes neither the longitude nor the `lngRange` clobber.
+    // state's edge — verified live. The reassert is the ONE sanctioned imperative
+    // `setMaxBounds` site (an idempotent reassert of the same declarative
+    // `clampBounds`), NOT the reactive clamp mechanism: `maxBounds` remains a
+    // reactive `<Map>` prop (finding-(a), invariant documented at the clampBounds
+    // block ~`:580`). It runs only behind this `moveend`, never during reactive
+    // reconciliation; the finding-(a) guard fires no `moveend`, so it stays green.
+    // NOT a bare `map.stop()` in the effect: `easeTo` already self-`_stop`s,
+    // freezing the western basis — stop alone fixes neither the longitude nor
+    // the `lngRange` clobber.
     const target = map.cameraForBounds(activeBounds, {
       padding: FIT_BOUNDS_PADDING,
       maxZoom: 12,


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph reactive["Reactive reconciliation (mount / maxBounds-prop change)"]
        A["clampBounds value"] -->|"declarative &lt;Map maxBounds={clampBounds}&gt;"| B["react-map-gl applies maxBounds<br/>(single authoritative clamp)"]
    end
    subgraph corrector["#848 scope-camera moveend corrector (~:868)"]
        C["in-flight animation clobbers lngRange"] --> D["on settle moveend:<br/>map.setMaxBounds(clampBounds)<br/>(idempotent reassert)"]
    end
    B -.->|"FORBIDDEN: imperative setMaxBounds<br/>during reconciliation / as primary clamp"| X["finding-(a) violation"]
    D -->|"ONE sanctioned imperative site<br/>(only behind a moveend)"| OK["allowed"]

    test["finding-(a) guard test"] -->|"fires NO moveend → corrector registered-but-not-fired"| reactive
    test -->|"asserts setMaxBounds NOT called → catches reconcile-time primary-clamp calls"| X
```

## Summary

- The #848 fix (PR #850) added the **one** sanctioned imperative `setMaxBounds` — an idempotent reassert of the declarative `clampBounds` inside the scope-camera `moveend` corrector — but the finding-(a) invariant comment still read as an absolute "we never call `setMaxBounds` imperatively," and the guard test stayed green only because it fired no `moveend`. A future refactor that drove `maxBounds` imperatively as the **primary** clamp (the thing finding-(a) actually forbids) would NOT have tripped it.
- This PR encodes the now-accepted narrowed boundary: the `clampBounds` invariant comment names the `moveend` corrector (~`:868`) as the sole sanctioned imperative site and restates the primary-clamp prohibition; the corrector's inline comment back-references it; the finding-(a) test now asserts "no imperative `setMaxBounds` during **reactive reconciliation**" (uncalled on mount and on a `maxBounds`-prop change with no `moveend`, corrector registered-but-not-fired).
- Behavior-neutral — comments + one test only. The `MapCanvas.tsx` diff is comment-only; zero runtime change. The test deliberately does NOT exercise the allowed `moveend` branch (covered by the existing #848 corrector fire/no-op tests).

## Screenshots

N/A — not UI (comment + test only)

## Test plan

- [x] `npm run typecheck && npm run test` — green (frontend `tsc -b` clean; 1053 unit tests pass, incl. the tightened finding-(a) test)
- [x] New unit / integration tests added (if behavior changed) — tightened the existing finding-(a) test; red/green confirmed by temporarily injecting a reconcile-time `setMaxBounds` (RED) then reverting (GREEN)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no behavior change; ran the touched specs `state-scope-midmotion-longitude.spec.ts` + `state-scope.spec.ts` (12 passed)
- [x] `npm run build` — clean production build
- [x] (UI only) Playwright MCP smoke — N/A — not UI (comment + test only)

## Plan reference

Out of plan — follow-up #851 (post state-switch-fix RCA).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
