### PR TITLE
chore(frontend): wire onError on the map to silence benign tile-abort console errors

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -337,7 +337,12 @@ if (typeof URL.createObjectURL === 'undefined') {
 }
 
 /* ── Import after mocks ───────────────────────────────────────────────── */
-const { MapCanvas, __resetAdaptiveGridCacheForTesting } = await import('./MapCanvas.js');
+const {
+  MapCanvas,
+  __resetAdaptiveGridCacheForTesting,
+  handleMapError,
+  BASEMAP_SOURCE_ID,
+} = await import('./MapCanvas.js');
 
 /* ── Helpers ──────────────────────────────────────────────────────────── */
 
@@ -2637,5 +2642,87 @@ describe('MapCanvas state-artboard mask (#762)', () => {
     expect(removed).toEqual(
       expect.arrayContaining(['state-artboard-halo', 'state-artboard-outline']),
     );
+  });
+});
+
+/* ── onError console hygiene (#854) ──────────────────────────────────────────
+   `<MapView onError={handleMapError}>` diverts maplibre `error` events away from
+   react-map-gl's built-in `_onEvent` fallback. That fallback (in
+   @vis.gl/react-maplibre 8.1.1 `maplibre.js` `_onEvent` :93-102) does
+   `const cb = this.props['onError']; if (cb) cb(e); else if (e.type === 'error')
+   console.error(e.error)` — so once `onError` is wired, the library NO LONGER
+   logs anything itself; `handleMapError` is solely responsible for re-surfacing
+   genuinely-unexpected errors via `console.error`. These tests pin the narrow
+   swallow predicate (AbortError + basemap-source-keyed tile/network errors only)
+   and prove an unknown error still reaches `console.error`. */
+describe('handleMapError (#854 console hygiene)', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function errEvent(error: Error, sourceId?: string): any {
+    return { type: 'error', target: fakeMap, error, sourceId };
+  }
+
+  it('swallows an AbortError (in-flight tile fetch cancelled mid-camera-move) via console.debug, not console.error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    const abort = new Error('The user aborted a request.');
+    abort.name = 'AbortError';
+    handleMapError(errEvent(abort));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('swallows a basemap-source tile/network error (keyed on the basemap sourceId) via console.debug, not console.error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    // Generic network Error (no AbortError name) but carrying the basemap
+    // source id — the OpenFreeMap CDN hiccup the issue describes.
+    const tileErr = new Error('Failed to fetch');
+    handleMapError(errEvent(tileErr, BASEMAP_SOURCE_ID));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('re-logs a genuinely-unexpected error (non-Abort, non-basemap-source) via console.error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    // A style-load / parse error with no sourceId — exactly the kind of real
+    // error the issue insists must NOT be swallowed.
+    const styleErr = new Error('Style is not done loading');
+    handleMapError(errEvent(styleErr));
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(styleErr);
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it('does NOT swallow a 404/error on one of the app\'s own sources (observations) — re-logs it', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    // A non-Abort error keyed on the `observations` source (NOT the basemap)
+    // is a real app-data failure — it must surface, not be swallowed.
+    const appErr = new Error('observations source failed');
+    handleMapError(errEvent(appErr, 'observations'));
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(appErr);
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 });

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -147,6 +147,73 @@ export function __resetAdaptiveGridCacheForTesting(): void {
 }
 
 /**
+ * The vector-tile source id used by the OpenFreeMap basemap styles
+ * (`positron` / `dark`, BASEMAP_LIGHT / BASEMAP_DARK). Both styles key their
+ * tiles on `openmaptiles` — see the representative `style.layers` fixture in
+ * MapCanvas.test.tsx (`source: 'openmaptiles'`). Used by `handleMapError` to
+ * scope the benign tile/network swallow to the basemap ONLY, so a real 404 /
+ * style-load error on one of the app's own sources (`observations`,
+ * `state-mask`) is never silenced.
+ */
+export const BASEMAP_SOURCE_ID = 'openmaptiles';
+
+/**
+ * The maplibre `error` event payload as react-map-gl surfaces it
+ * (@vis.gl/react-maplibre 8.1.1 `ErrorEvent = MapEvent<Map> & { error: Error }`).
+ * `sourceId` is NOT in that exported type, but maplibre-gl 5.x attaches it to
+ * source-data `error` events at runtime — so we widen the shape with an optional
+ * `sourceId` rather than reach for `any`.
+ */
+type MapErrorEvent = { type: string; error?: Error; sourceId?: string };
+
+/**
+ * Narrow, explicit predicate for transient/benign map errors that are safe to
+ * downgrade to `console.debug` during camera moves (#854). Two — and only two —
+ * structured signals qualify; everything else is treated as genuine:
+ *
+ *   (i)  `error.name === 'AbortError'` — an in-flight basemap-tile fetch that was
+ *        cancelled when a `fitBounds` fly (e.g. a scope/state switch) superseded
+ *        it. This is the dominant noise source and the only one with a stable,
+ *        structured discriminator.
+ *   (ii) a tile/network error keyed on the basemap vector source
+ *        (`sourceId === BASEMAP_SOURCE_ID`) — the occasionally-flaky OpenFreeMap
+ *        CDN hiccup the issue describes.
+ *
+ * Deliberately NOT a loose message-substring match: a broad predicate would eat
+ * a real basemap 404 or a style-load failure, which is exactly the "masks real
+ * errors" failure mode #854 (and the bot review) warns against. An error on the
+ * app's own sources (`observations`, `state-mask`) never matches clause (ii).
+ */
+export function isBenignMapError(e: MapErrorEvent): boolean {
+  if (e.error?.name === 'AbortError') return true;
+  if (e.sourceId === BASEMAP_SOURCE_ID) return true;
+  return false;
+}
+
+/**
+ * `onError` handler for `<MapView>` (#854). Passing `onError` fully diverts the
+ * maplibre `error` event away from react-map-gl's built-in `_onEvent` fallback
+ * (@vis.gl/react-maplibre 8.1.1 `maplibre.js` `_onEvent` :93-102 —
+ * `const cb = this.props['onError']; if (cb) cb(e); else if (e.type === 'error')
+ * console.error(e.error)`). Because the `cb` branch is taken, the library no
+ * longer logs anything itself — so this handler MUST re-surface genuinely
+ * unexpected errors via `console.error`, or they would be silently dropped.
+ *
+ * Benign transient errors (see `isBenignMapError`) are downgraded to
+ * `console.debug` so the console stays clean during camera moves without hiding
+ * real failures. No behavior change to the map.
+ */
+export function handleMapError(e: MapErrorEvent): void {
+  if (isBenignMapError(e)) {
+    // Downgraded, not dropped — still visible at the debug log level for anyone
+    // who opts in, but out of the default error/warning console surface.
+    console.debug('[map] benign transient error swallowed (#854)', e.error);
+    return;
+  }
+  console.error(e.error);
+}
+
+/**
  * Stable string hash for observation subIds (issue #554 silhouette
  * deconflict). Used to derive a NEGATIVE pseudo-cluster_id so silhouette
  * inputs can be carried through `buildGroups` alongside real clusters
@@ -2234,6 +2301,15 @@ export function MapCanvas({
             : BASEMAP_LIGHT
         }
         onLoad={handleLoad}
+        // #854: swallow benign transient map errors (AbortErrors from tile
+        // fetches cancelled mid-camera-move; OpenFreeMap CDN hiccups keyed on
+        // the basemap source) and re-log everything else. Without an `onError`
+        // prop, react-map-gl's `_onEvent` falls back to `console.error(e.error)`
+        // for every maplibre `error` event — dirtying the console during a
+        // scope `fitBounds` fly. Passing this handler diverts that fallback, so
+        // `handleMapError` re-surfaces genuine errors itself. See the handler's
+        // doc comment + isBenignMapError for the narrow swallow predicate.
+        onError={handleMapError}
         attributionControl={false}
         // Fix 3b (PR #582 bot review): preserve the WebGL backbuffer when running
         // e2e tests so `readCanvasPixel` in basemap-dark-flip.spec.ts can sample


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["maplibre error event"] --> B["MapView onError = handleMapError"]
    B --> C{isBenignMapError?}
    C -->|"error.name is AbortError"| D["console.debug — swallowed"]
    C -->|"sourceId is openmaptiles basemap"| D
    C -->|"anything else: style-load err, app-source 404"| E["console.error — re-surfaced"]
    N["Before this PR: no onError, so react-map-gl _onEvent falls back to console.error for EVERY error, dirtying the console during a fitBounds fly"] -.-> B
```

## Summary

- During a scope `fitBounds` fly (notably a state switch), MapLibre emits `error` events for in-flight basemap-tile fetches cancelled mid-animation (`AbortError`) plus the occasionally-flaky OpenFreeMap CDN. With no `onError` on `<MapView>`, react-map-gl's `_onEvent` fell back to `console.error(e.error)` for each — a Tier-1 dirty-console finding that also masks genuine errors at review time.
- Wires an `onError` handler with a deliberately **narrow, structured** swallow predicate — only `error.name === 'AbortError'` and tile/network errors keyed on the basemap source (`sourceId === 'openmaptiles'`) are downgraded to `console.debug`. A loose message-substring match was rejected: it would eat a real basemap 404 / style-load error or an `observations`/`state-mask` source failure, which is exactly the "masks real errors" failure mode #854 guards against.
- Because passing `onError` **fully diverts** the event from react-map-gl's built-in fallback (the library no longer logs alongside the handler), `handleMapError` re-surfaces everything non-benign via `console.error` itself. No behavior change to the map.

## Screenshots

N/A — not UI (error-handling + test only; console hygiene verified separately by the orchestrator)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (65 files, 1057 tests; the 4 new `handleMapError` unit tests included)
- [x] New unit tests added: `handleMapError` swallows an `AbortError` and a basemap-source tile error via `console.debug`, and re-logs a non-Abort/non-basemap error (and an `observations`-source error) via `console.error` — see `frontend/src/components/map/MapCanvas.test.tsx`. Red→green confirmed (RED on origin/main: `handleMapError is not a function`).
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npm run lint` — green (root no-op across workspaces + forbidden-token guard clean on touched files)
- [x] `npx knip --no-progress` — exit 0, no new findings (new exports are all referenced)
- [x] e2e (`--project=dev-server`): `state-scope`, `state-scope-midmotion-longitude`, `basemap-dark-flip`, `map-cold-load`, `state-artboard`, `map` — 32 passed. (Two camera-settle assertions flaked once on the live OpenFreeMap CDN, then passed clean on re-run — documented basemap-CDN flakiness, not caused by this change, which adds only an `onError` handler.)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — follow-up #854 (post state-switch-fix RCA).

Closes #854

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
