### PR TITLE
fix(frontend): stop the aggregated-mode lede overcounting species (#852)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2383,6 +2383,42 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     expect(lede).not.toHaveTextContent(/in the last/i);
   });
 
+  // #852 — Aggregated (low-zoom / whole-state) mode must NOT report a species
+  // count. At zoom < 6 the API returns coarse-grid buckets with no per-species
+  // code; use-bird-data fabricates synthetic `agg-{bi}-…` codes PREFIXED by the
+  // bucket index, so the SAME species spanning N cells yields N distinct codes
+  // and `new Set(speciesCode).size` counts BUCKETS, not species — the live
+  // "AZ 4257 species" overcount. The fix (option b): in aggregated mode the lede
+  // reports the total SIGHTINGS count (sum of bucket.count = observations.length,
+  // which IS correctly computable) instead of the inflated species count. The
+  // per-observation-mode "{N} species" lede (T4 above) is unchanged.
+  it('Aggregated mode (T4): reports total sightings, never the inflated species count', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    // Three cells, each holding the SAME single species (1 distinct species
+    // total across the region). The synthetic expansion fabricates one code per
+    // bucket (`agg-0-picidae-0`, `agg-1-…`, `agg-2-…`) → Set size 3, even though
+    // the truth is 1 species. Total sightings = 50 + 50 + 50 = 150.
+    mockGetObservations.mockResolvedValue({
+      mode: 'aggregated',
+      buckets: [
+        { lat: 32.2, lng: -110.9, count: 50, speciesCount: 1, families: ['picidae'] },
+        { lat: 33.4, lng: -111.9, count: 50, speciesCount: 1, families: ['picidae'] },
+        { lat: 34.5, lng: -112.4, count: 50, speciesCount: 1, families: ['picidae'] },
+      ],
+      meta: { freshestObservationAt: new Date().toISOString() },
+    });
+    render(<App />);
+    const lede = await screen.findByTestId('map-lede');
+    // The correct, computable count is sightings — not species.
+    expect(lede).toHaveTextContent('150 sightings');
+    // The bug: never report a species count in aggregated mode (3 would be the
+    // bucket-count overcount; any "{N} species" copy is wrong here).
+    expect(lede).not.toHaveTextContent(/species/i);
+  });
+
   it('Family filter (T3): "{N} species of {familyName}" — no region, no window', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: 'picidae',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -333,7 +333,7 @@ export function App() {
   // server clips via ST_Intersects). UNSCOPED and `?scope=us` both leave
   // `stateCode` unset, so the backend stays untouched (data invariant, #735).
   const scopeStateCode = state.scope.kind === 'state' ? state.scope.stateCode : undefined;
-  const { loading, observationsLoading, error, observations, refetch } = useBirdData(
+  const { loading, observationsLoading, error, observations, mode, refetch } = useBirdData(
     apiClient,
     {
       since: state.since,
@@ -927,8 +927,6 @@ export function App() {
     // Cold-load guard (#716/#720): suppress Template 1 while the first fetch is
     // in flight. Same discipline as MapLede's `loading` guard.
     if (observationsLoading && observationCount === 0 && speciesCount === 0) return null;
-    const speciesCommonName =
-      speciesCount === 1 ? (observations[0]?.comName ?? null) : null;
     // #828: the lede is count-only. The region moved into the wordmark headline
     // (no longer repeated in the sentence) and the time-window dropped entirely
     // (it's discoverable via Filters). No period clause, no `${region}` — see the
@@ -937,7 +935,22 @@ export function App() {
       return noFiltersActive
         ? 'No recent sightings'
         : 'No matches for these filters';
-    } else if (speciesCommonName) {
+    }
+    // #852: in aggregated (low-zoom / whole-state) mode the `observations` are
+    // SYNTHETIC rows whose `speciesCode`s are fabricated per-bucket — the same
+    // species across N cells yields N distinct codes, so `speciesCount` counts
+    // buckets, not species (the live "AZ 4257 species" overcount). The total
+    // SIGHTINGS count (observations.length = sum of bucket.count) IS correct in
+    // both modes, so aggregated mode reports sightings instead of a species
+    // count. The per-observation (z >= 6) "{N} species" / "{N} species of
+    // {family}" copy below is unchanged. (Second consumer derived.ts
+    // deriveSpeciesIndex is also synthetic-code-polluted — tracked separately.)
+    if (mode === 'aggregated') {
+      return `${observationCount} sightings`;
+    }
+    const speciesCommonName =
+      speciesCount === 1 ? (observations[0]?.comName ?? null) : null;
+    if (speciesCommonName) {
       return `${observationCount} sightings of ${speciesCommonName}`;
     } else if (familyName) {
       return `${speciesCount} species of ${familyName}`;
@@ -946,6 +959,7 @@ export function App() {
   }, [
     region,
     observations,
+    mode,
     observationsLoading,
     noFiltersActive,
     familyName,

--- a/frontend/src/data/use-bird-data.ts
+++ b/frontend/src/data/use-bird-data.ts
@@ -93,6 +93,21 @@ export interface BirdDataState {
   hotspots: Hotspot[];
   observations: Observation[];
   /**
+   * Render mode of the most recently resolved /api/observations response
+   * (#627). `'aggregated'` at low zoom (z < 6, whole-state/regional view) where
+   * `observations` are SYNTHETIC rows expanded from coarse-grid buckets;
+   * `'observations'` at z >= 6 where they are real per-observation rows.
+   *
+   * #852: consumers that derive a distinct-species count from `observations`
+   * (e.g. the MapLede "{N} species" copy) MUST gate on this — in aggregated
+   * mode the synthetic `agg-{bi}-…` codes are PREFIXED by bucket index, so the
+   * same species across N cells yields N distinct codes and
+   * `new Set(speciesCode).size` counts buckets, not species (the "4257 species"
+   * overcount). The total sightings count (`observations.length`) stays correct
+   * in both modes; the distinct-species count does not in aggregated mode.
+   */
+  mode: 'observations' | 'aggregated';
+  /**
    * ISO string of the most recently ingested observation (MAX(ingested_at)),
    * or null when the table is empty / read-api unavailable. Sourced from
    * meta.freshestObservationAt in the ObservationsResponse envelope (#456 W3-A).
@@ -125,6 +140,10 @@ export function useBirdData(
 ): BirdDataState {
   const [hotspots, setHotspots] = useState<Hotspot[]>([]);
   const [observations, setObservations] = useState<Observation[]>([]);
+  // #852 — mode of the last resolved response. Seeded 'observations' so a
+  // never-resolved/disabled hook reports the per-observation default (no
+  // overcount risk before any aggregated response lands).
+  const [mode, setMode] = useState<'observations' | 'aggregated'>('observations');
   const [freshestObservationAt, setFreshestObservationAt] = useState<string | null>(null);
   // Seed loading from `enabled`: a disabled hook is not loading (nothing is in
   // flight), so the chooser landing never paints a loading shell.
@@ -176,8 +195,10 @@ export function useBirdData(
         if (cancelled) return;
         if (envelope.mode === 'aggregated') {
           setObservations(expandBucketsToSyntheticObservations(envelope.buckets));
+          setMode('aggregated');
         } else {
           setObservations(envelope.data);
+          setMode('observations');
         }
         setFreshestObservationAt(envelope.meta.freshestObservationAt);
       })
@@ -223,6 +244,7 @@ export function useBirdData(
     error,
     hotspots,
     observations,
+    mode,
     freshestObservationAt,
     refetch,
   };


### PR DESCRIPTION











## Diagrams

```mermaid
flowchart TD
    API["/api/observations"] -->|"aggregated (z &lt; 6)"| Buckets["AggregatedBucket array<br/>count, speciesCount, families<br/>NO per-species code"]
    API -->|"observations (z &gt;= 6)"| Rows["Observation array<br/>real species_code"]

    Buckets -->|expandBucketsToSyntheticObservations| Synth["synthetic rows<br/>speciesCode = agg-bi-...<br/>bucket-index PREFIXED"]
    Synth --> Hook["useBirdData returns observations + mode"]
    Rows --> Hook

    Hook --> Lede["App.ledeText"]

    Lede -->|"mode aggregated<br/>was new Set size<br/>counts BUCKETS = '4257 species'"| Fix["NOW: 'N sightings'<br/>sum of bucket.count - correct"]
    Lede -->|"mode observations - unchanged"| Species["'N species' / 'N species of family'<br/>real species_code - correct"]
```

## Summary

- **Why:** At low zoom the Read API returns coarse-grid buckets with no per-species code; `use-bird-data` fabricates synthetic `agg-{bi}-…` codes **prefixed by bucket index**, so the same species across N cells yields N distinct codes and the lede's `new Set(o.speciesCode).size` counts buckets, not species — the live "AZ 4257 species" / "TX 9381 species" overcount (those states have ~550 / ~660 recorded species).
- **What:** Chose **option (b)** (frontend-only): a correct distinct-species count is uncomputable from synthetic codes on the client, and summing per-bucket `speciesCount` would double-count cross-cell species — but the **total sightings count** (`observations.length` = sum of `bucket.count`) is correct in both modes. So aggregated mode now renders `"{N} sightings"`. `useBirdData` surfaces the response `mode` so `App.ledeText` can branch.
- **Why (b) over (a):** Cleaner and self-contained — no producer/consumer lockstep across `shared-types` + `read-api` + `db-client`, no new DB-backed read-api tests. The per-observation (z >= 6) `"{N} species"` lede is byte-for-byte unchanged (the count is correct there: real `species_code`).

## Screenshots

Live-driven through chrome-devtools MCP against the prod data proxy (`api.bird-maps.com`) at the PR head SHA `14eecb3`. Each capture is the **aggregated whole-state view** (`?state=US-AZ`, zoom < 6, response `mode: "aggregated"`) — the lede correctly reads **"4264 sightings"**, not the pre-fix "~4257 species" bucket overcount. Per-observation mode (zoom ≥ 6) still reads "357 species" (real `species_code`), unchanged.

Console at 1440×900: zero app errors/warnings. The only warning is the pre-existing benign OpenFreeMap missing-sprite (`Image "circle-11" could not be loaded`), unrelated to this PR.

| Viewport | Light | Dark |
|---|---|---|
| **390×844** (mobile) | <img width="380" alt="390x844 light" src="https://github.com/user-attachments/assets/cbceee55-7949-4e2f-b4bc-342412214216" /> | <img width="380" alt="390x844 dark" src="https://github.com/user-attachments/assets/15f87de1-1021-4572-a29d-5b93a0e79c8e" /> |
| **768×1024** (tablet) | <img width="380" alt="768x1024 light" src="https://github.com/user-attachments/assets/302e78c8-adf2-46ba-aa22-558c6083ffd2" /> | <img width="380" alt="768x1024 dark" src="https://github.com/user-attachments/assets/e6f69aa2-89cf-43ec-af26-c588c46c1b58" /> |
| **1024×768** (small laptop) | <img width="380" alt="1024x768 light" src="https://github.com/user-attachments/assets/15635b69-1c9d-4a55-9089-489aa0f65148" /> | <img width="380" alt="1024x768 dark" src="https://github.com/user-attachments/assets/6aee4f83-7e9c-4c34-a346-706d91a131d4" /> |
| **1440×900** (desktop) | <img width="380" alt="1440x900 light" src="https://github.com/user-attachments/assets/6d25efcf-53ea-4eb1-a158-1fc4a17f018c" /> | <img width="380" alt="1440x900 dark" src="https://github.com/user-attachments/assets/fa810b3a-e197-4223-b1ee-dfe561cce22a" /> |
| **1920×1080** (wide) | <img width="380" alt="1920x1080 light" src="https://github.com/user-attachments/assets/cd5c1d24-2e1c-42ec-a5fc-a8ee1047acdf" /> | <img width="380" alt="1920x1080 dark" src="https://github.com/user-attachments/assets/86187a97-26c1-42af-9b67-cba2135917ac" /> |

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (1054 tests, 65 files)
- [x] New unit test added (if behavior changed) — `frontend/src/App.test.tsx` "Aggregated mode (T4)": **red** on origin/main (rendered `"3 species"` — the bucket overcount), **green** after fix (`"150 sightings"`)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A; existing stub-based e2e specs (`happy-path`, `filters`, `map-cold-load`, `synthetic-species-code-gate`) stay green and exercise the per-observation-mode lede, which is unchanged. The 16 stub-based specs pass; `map-lede-cls` / `map-adaptive-grid` require a seeded DB (CI provides one).
- [x] `npm run build --workspace @bird-watch/frontend` — clean (`tsc -b` + vite build)
- [x] `npx knip --no-progress` — exit 0, no new findings
- [x] (UI only) Playwright MCP smoke — orchestrator runs the live drive + 5-viewport × 2-theme capture before review (see Screenshots).

## Plan reference

Out of plan — follow-up #852 (post state-switch-fix RCA).

Out of scope (tracked separately): `frontend/src/derived.ts` `deriveSpeciesIndex` is a second consumer also polluted by the synthetic `agg-*` codes.

Closes #852

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
