### PR TITLE
fix(frontend): bound family legend on the 481-1023px band so a stored-expanded legend does not occlude the framed state (#853)

### DIFF
--- a/frontend/e2e/legend-roomy-band-cap.spec.ts
+++ b/frontend/e2e/legend-roomy-band-cap.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+import type { Observation } from '@bird-watch/shared-types';
+
+/**
+ * #853 — family legend occludes the framed state on the 481–1023px 'roomy' band.
+ *
+ * What already ships (do NOT re-implement here):
+ *   - #809: collapse-by-default below 1024px (App.tsx LEGEND_EXPAND_MIN_WIDTH).
+ *   - #810: ≤480px width/height cap (styles.css @media max-width:480px).
+ *
+ * The surviving bug this spec guards: on the 481–1023px band a user with a
+ * stored `family-legend-expanded.v2=true` preference (e.g. expanded on a prior
+ * desktop session) sees the legend render expanded — and because the ≤480px cap
+ * media query does NOT apply above 480px, `.family-legend-entries` falls back to
+ * the desktop `max-height: 400px`. The resulting ~440px-tall panel anchored at
+ * the bottom-left occludes the lower-left of the framed state.
+ *
+ * The fix bounds the entries panel on the 481–1023px band to a shorter,
+ * scrollable max-height so a stored-expanded legend does not reach into the
+ * framed state's central content. ≥1024px desktop and ≤480px behaviour are
+ * unchanged (covered by family-legend-viewport.spec.ts and
+ * legend-o5-cap-force-collapse.spec.ts respectively).
+ *
+ * Repo e2e conventions: page.goto() via the POM; data cases wait for
+ * [data-render-complete]; no DB writes; no per-spec retries.
+ */
+
+/** Minimal silhouette fixture — one real family + the required _FALLBACK row. */
+function stubSilhouettesFixture() {
+  return [
+    {
+      familyCode: 'tyrannidae',
+      color: '#E84040',
+      colorDark: '#E84040',
+      svgData:
+        'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+      svgUrl: null,
+      source: null,
+      license: null,
+      commonName: 'Tyrant Flycatchers',
+      creator: null,
+    },
+    {
+      familyCode: '_FALLBACK',
+      color: '#555555',
+      colorDark: '#555555',
+      svgData:
+        'M 6 12 C 6 9 8 7 11 7 C 13 7 14 8 15 9 L 18 8 L 18 10 L 16 11 L 16 14 L 14 16 L 9 16 L 6 14 Z',
+      svgUrl: null,
+      source: null,
+      license: null,
+      commonName: 'Unknown family',
+      creator: null,
+    },
+  ];
+}
+
+/** One observation matching the stubbed family so FamilyLegend renders non-null. */
+function stubObservationsFixture(): Observation[] {
+  return [
+    {
+      subId: 'S-853-TEST-1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      familyCode: 'tyrannidae',
+      lat: 32.2217,
+      lng: -110.9265,
+      locId: 'L999853',
+      locName: 'Tucson, AZ',
+      obsDt: '2026-05-30T12:00:00Z',
+      howMany: 1,
+      isNotable: false,
+      silhouetteId: null,
+    },
+  ];
+}
+
+async function setupRoutes(
+  page: import('@playwright/test').Page,
+  apiStub: import('./fixtures.js').ApiStub,
+): Promise<void> {
+  // LIFO route order: catch-all first, then the specific handlers win.
+  await apiStub.stubEmpty();
+  await apiStub.stubObservations(stubObservationsFixture());
+  await page.route('**/api/silhouettes', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(stubSilhouettesFixture()),
+    });
+  });
+}
+
+// ─── 500×844 — the issue's primary repro viewport ────────────────────────────
+test.describe('#853 — legend cap on the roomy band (500×844, stored-expanded)', () => {
+  test.use({ viewport: { width: 500, height: 844 } });
+
+  test('stored-expanded legend entries are capped well below the desktop 400px', async ({
+    page,
+    apiStub,
+  }) => {
+    await setupRoutes(page, apiStub);
+    // Simulate the bug-reporting user: expanded on a prior (desktop) session, so
+    // the stored .v2 preference overrides the <1024px collapse-default (#809).
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+      } catch {
+        /* noop */
+      }
+    });
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const toggle = page.getByRole('button', { name: /bird families in view/i });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    // The stored preference still wins on the roomy band (we do NOT collapse it).
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const entries = page.locator('.family-legend-entries');
+    await expect(entries).toBeVisible();
+
+    // The entries panel must be capped on the 481–1023px band. The desktop
+    // fallback is 400px; the fix bounds it to a shorter scrollable height so the
+    // stored-expanded legend does not occlude the framed state's centre.
+    const maxHeightPx = await entries.evaluate(
+      (el) => parseFloat(getComputedStyle(el).maxHeight),
+    );
+    expect(
+      maxHeightPx,
+      `.family-legend-entries max-height ${maxHeightPx}px must be < the desktop 400px fallback on the 481–1023px band`,
+    ).toBeLessThan(400);
+
+    // The bounded legend's top edge must clear the vertical centre of the
+    // viewport so the framed state's central content is not occluded.
+    const legendEl = page.locator('.family-legend');
+    const box = await legendEl.boundingBox();
+    expect(box, 'legend element not found in DOM').not.toBeNull();
+    const viewportCentreY = 844 / 2;
+    expect(
+      box!.y,
+      `legend top edge ${box!.y.toFixed(1)}px must sit below the viewport centre (${viewportCentreY}px) so the framed state is not occluded`,
+    ).toBeGreaterThan(viewportCentreY);
+
+    // Sanity: the cap is a CSS display bound only — the stored preference is
+    // not mutated (#809/#810 invariant carried forward).
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem('family-legend-expanded.v2'),
+    );
+    expect(stored).toBe('true');
+  });
+
+  test('the legend toggle still collapses/expands on the roomy band', async ({
+    page,
+    apiStub,
+  }) => {
+    await setupRoutes(page, apiStub);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+      } catch {
+        /* noop */
+      }
+    });
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const toggle = page.getByRole('button', { name: /bird families in view/i });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('.family-legend-entries')).not.toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.locator('.family-legend-entries')).toBeVisible();
+  });
+});
+
+// ─── 768×1024 — tablet portrait, the issue's second repro viewport ───────────
+test.describe('#853 — legend cap on the roomy band (768×1024, stored-expanded)', () => {
+  test.use({ viewport: { width: 768, height: 1024 } });
+
+  test('stored-expanded legend entries are capped below 400px at tablet portrait', async ({
+    page,
+    apiStub,
+  }) => {
+    await setupRoutes(page, apiStub);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+      } catch {
+        /* noop */
+      }
+    });
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const toggle = page.getByRole('button', { name: /bird families in view/i });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const entries = page.locator('.family-legend-entries');
+    await expect(entries).toBeVisible();
+    const maxHeightPx = await entries.evaluate(
+      (el) => parseFloat(getComputedStyle(el).maxHeight),
+    );
+    expect(
+      maxHeightPx,
+      `.family-legend-entries max-height ${maxHeightPx}px must be < 400px on the 481–1023px band`,
+    ).toBeLessThan(400);
+  });
+});
+
+// ─── ≥1024px desktop counter-case: the cap must NOT apply ────────────────────
+test.describe('#853 counter-case — desktop ≥1024px keeps the 400px fallback', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('expanded legend at 1440×900 retains the desktop 400px entries max-height', async ({
+    page,
+    apiStub,
+  }) => {
+    await setupRoutes(page, apiStub);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+      } catch {
+        /* noop */
+      }
+    });
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const toggle = page.getByRole('button', { name: /bird families in view/i });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    const entries = page.locator('.family-legend-entries');
+    await expect(entries).toBeVisible();
+    const maxHeightPx = await entries.evaluate(
+      (el) => parseFloat(getComputedStyle(el).maxHeight),
+    );
+    // Desktop is unchanged: the 400px fallback still applies above the band.
+    expect(
+      maxHeightPx,
+      `desktop .family-legend-entries max-height ${maxHeightPx}px must stay at the 400px fallback`,
+    ).toBe(400);
+  });
+});

--- a/frontend/src/components/FamilyLegend.test.tsx
+++ b/frontend/src/components/FamilyLegend.test.tsx
@@ -395,6 +395,35 @@ describe('Phase 3: mobile-collapsed default', () => {
       'true',
     );
   });
+
+  // #853: on the 481–1023px 'roomy' band, App passes defaultExpanded=false
+  // (the <1024px collapse-default, #809). A stored .v2='true' preference still
+  // overrides that default and renders the entries expanded — this behaviour is
+  // intentional and must be preserved; the occlusion is bounded in CSS (a
+  // shorter scrollable entries max-height on the band, NOT a forced collapse).
+  // jsdom does not evaluate media queries, so the height cap itself is asserted
+  // by legend-roomy-band-cap.spec.ts; this case guards the component contract
+  // that the stored-expanded path keeps rendering entries on the band.
+  it('#853: stored .v2=true keeps entries expanded on the roomy band (defaultExpanded=false)', () => {
+    window.localStorage.setItem('family-legend-expanded.v2', 'true');
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    // The stored preference wins over the roomy-band collapse-default: entries
+    // render, and the toggle reports expanded. The bounding cap is CSS-only and
+    // does NOT collapse the legend or mutate the stored preference.
+    expect(screen.getAllByTestId('family-legend-entry')).toHaveLength(3);
+    expect(
+      screen.getByRole('button', { name: /Bird families in view/i }),
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(window.localStorage.getItem('family-legend-expanded.v2')).toBe('true');
+  });
 });
 
 describe('Phase 3: shape-paired swatches', () => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1095,6 +1095,36 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   }
 }
 
+/* #853: bound the legend on the 481–1023px 'roomy' band (useBreakpoint's
+   `'roomy'` tier; --overlay-bp-compact 480px → --overlay-bp-wide 1024px). On
+   this band a user with a stored `family-legend-expanded.v2=true` preference
+   (e.g. expanded on a prior desktop session) sees the legend render expanded —
+   the <1024px collapse-default (#809) is correctly overridden by the stored
+   preference — but the ≤480px height cap above (#810) does NOT apply here, so
+   `.family-legend-entries` fell back to the desktop `max-height: 400px`
+   (~:985). The resulting ~440px-tall panel anchored bottom-left occluded the
+   lower-left of the framed state (reproduced live at ~500×844).
+
+   Cap the entries panel to a shorter, scrollable height so a stored-expanded
+   legend's top edge clears the framed state's central content. `min(280px,
+   40vh)` keeps the panel comfortably below the viewport centre on a short
+   tablet-portrait viewport (40vh of 844px ⇒ 280px; total card ≈ toggle + 280px
+   still leaves the upper half clear) and shrinks further on shorter heights.
+   The 280px ceiling mirrors the --card-maxw-legend width contract so the
+   bounded card reads as a balanced square. overflow-y:auto (from the base
+   .family-legend-entries rule, ~:986) makes the surplus rows scrollable — the
+   stored preference is NOT mutated; this is a CSS display cap only, exactly as
+   the ≤480px cap is.
+
+   Scoped strictly to 481–1023px: ≥1024px desktop keeps the 400px fallback
+   (counter-case asserted at 1440×900) and ≤480px keeps its own 240px cap
+   (#810) — both unchanged. Behaviour guarded by legend-roomy-band-cap.spec.ts. */
+@media (min-width: 481px) and (max-width: 1023px) {
+  .family-legend-entries {
+    max-height: min(280px, 40vh);
+  }
+}
+
 /* Force-collapsed treatment (O5 #783): when another overlay holds focus on
    mobile and forceCollapsed=true, FamilyLegend sets data-force-collapsed="true"
    on the <aside>. This suppresses the entries list while keeping the toggle


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["Stored family-legend-expanded.v2 = true<br/>(expanded on a prior desktop session)"] --> B{Viewport width band}
    B -->|"&le; 480px (#810)"| C["@media max-width:480px<br/>.family-legend-entries max-height: 240px<br/>(capped — OK)"]
    B -->|"481&ndash;1023px 'roomy'"| D0{Before this PR}
    B -->|"&ge; 1024px desktop"| E["base rule<br/>max-height: 400px<br/>(intended — OK)"]
    D0 -->|"BUG: &le;480 cap doesn't apply,<br/>falls back to desktop rule"| D1["max-height: 400px<br/>~440px-tall card occludes<br/>the framed state &#10007;"]
    D0 -->|"AFTER: new band media query"| D2["@media (min-width:481px) and (max-width:1023px)<br/>.family-legend-entries max-height: min(280px, 40vh)<br/>(scrollable — top edge clears viewport centre &#10003;)"]
```

## Summary

- On the 481–1023px `'roomy'` band a stored `family-legend-expanded.v2=true` preference rendered the legend expanded (correctly overriding the <1024px collapse-default #809), but the ≤480px height cap (#810) does not apply above 480px — so `.family-legend-entries` fell back to the desktop `max-height: 400px`, producing a ~440px-tall bottom-left card that occluded the lower-left of the framed state (reproduced live at ~500×844).
- Fix: add a `@media (min-width: 481px) and (max-width: 1023px)` rule capping the entries panel to `min(280px, 40vh)` (scrollable via the base rule's `overflow-y:auto`), so the bounded card's top edge clears the viewport centre on a short tablet-portrait viewport. The 280px ceiling mirrors the `--card-maxw-legend` width contract. CSS display bound only — the stored preference is not mutated.
- Scoped strictly to the band: ≥1024px desktop keeps the 400px fallback and ≤480px keeps its own 240px cap — both unchanged. **No re-implementation of #809/#810.**

## Screenshots

Live design-review drive on the PR head (`7501f2f`) against real production data via the `api.bird-maps.com` proxy. The 481–1023px 'roomy' band was driven with a stored `family-legend-expanded.v2=true` preference so the legend renders **expanded**; at 500×844 and 768×1024 the expanded entries panel is height-capped to `min(280px, 40vh)`, scrollable, and its top edge sits below the viewport centre — the framed state's central content is **not occluded**. ≥1024px desktop retains the 400px fallback; ≤480px (390px capture) retains its own 240px cap. Console clean at 1440×900 (only the pre-existing benign OpenFreeMap `circle-11` missing-sprite warning; zero errors).

| Viewport | Light | Dark |
|---|---|---|
| **390×844** (mobile, ≤480px regime — 240px cap unchanged) | <img width="300" alt="01-390x844-light" src="https://github.com/user-attachments/assets/e5bb1e42-64c0-4263-9688-d0f6ceffd1f8" /> | <img width="300" alt="02-390x844-dark" src="https://github.com/user-attachments/assets/dfc3ebe3-4d53-439d-9e28-05f74f0d7567" /> |
| **768×1024** (tablet portrait, in-band — capped 280px, scrollable, clears centre) | <img width="300" alt="03-768x1024-light" src="https://github.com/user-attachments/assets/37c22424-19bf-488b-9004-2f0e0ffe8e6f" /> | <img width="300" alt="04-768x1024-dark" src="https://github.com/user-attachments/assets/bdcf8d92-f478-458a-9efb-043d4857b70f" /> |
| **1024×768** (landscape, ≥1024px — 400px fallback unchanged) | <img width="300" alt="05-1024x768-light" src="https://github.com/user-attachments/assets/8effa59f-833c-4858-b3d0-01af5e745ab7" /> | <img width="300" alt="06-1024x768-dark" src="https://github.com/user-attachments/assets/a4d44267-6eea-4c73-af22-66e1578bde2b" /> |
| **1440×900** (desktop — 400px fallback unchanged) | <img width="300" alt="07-1440x900-light" src="https://github.com/user-attachments/assets/46d41549-4af2-4059-bf4e-fd19b1026b39" /> | <img width="300" alt="08-1440x900-dark" src="https://github.com/user-attachments/assets/af4d349c-6b2b-4557-bb5a-3949f9dd3a84" /> |
| **1920×1080** (wide desktop — 400px fallback unchanged) | <img width="300" alt="09-1920x1080-light" src="https://github.com/user-attachments/assets/fa62ae9e-7307-45b5-be5f-42c50e4dee26" /> | <img width="300" alt="10-1920x1080-dark" src="https://github.com/user-attachments/assets/6f3915f7-ff2e-4fc3-aa0f-ec0407276f6f" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
      — N/A, this PR adds no new className; it only adds a media-query rule for the existing `.family-legend-entries` class. `scripts/check-orphan-classnames.sh` passes.
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)
      — orchestrator captures these before review (see Screenshots note above).

## Test plan

- [x] `npm run typecheck && npm run test` — green (`npm run build` = `tsc -b && vite build` typecheck clean; 1054 unit tests pass, 65 files)
- [x] New unit / integration tests added (if behavior changed) — `FamilyLegend.test.tsx`: `#853: stored .v2=true keeps entries expanded on the roomy band (defaultExpanded=false)`
- [x] New Playwright e2e spec added (if user-visible behavior changed) — `frontend/e2e/legend-roomy-band-cap.spec.ts`: 500×844 + 768×1024 stored-expanded cap assertions, a roomy-band toggle round-trip, and a 1440×900 desktop counter-case asserting the 400px fallback is retained. Red on `origin/main` (entries fell back to 400px), green after the fix.
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — orchestrator runs the live multi-viewport drive + console check for this visual PR (per repo convention, implementer ran the e2e CLI suite; orchestrator owns the live verification). The CLI e2e suite (legend specs: 20 passed including the 4 new ones) and the no-DB-write grep (clean) were run locally.

## Plan reference

Out of plan — follow-up #853 (post state-switch-fix RCA).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
