### PR TITLE
fix: national low-zoom 503 — optimize aggregated species query (prod incident)

### DIFF
--- a/packages/db-client/src/observations-aggregated-perf.test.ts
+++ b/packages/db-client/src/observations-aggregated-perf.test.ts
@@ -1,0 +1,293 @@
+/**
+ * PROD-SCALE PERF GUARD for the national low-zoom aggregated query (#862).
+ *
+ * Prod incident: the coarsest national aggregated request (gridMultiplier=2,
+ * since=14d, whole-US, no bbox/state) returned HTTP 503 because the #859
+ * `getObservationsAggregated` query exceeded the 15s `statement_timeout`. The
+ * prior #859 work measured PAYLOAD size but never QUERY TIME — this test pins
+ * the query-time regression that the payload tests could not see.
+ *
+ * What this guards:
+ *   1. PERF — at ~550k observations across CONUS the national query must finish
+ *      well under the timeout. The pre-#862 query body spilled a multi-GB
+ *      external-merge sort (it grouped the bucket totals by the per-bucket
+ *      `families` jsonb, duplicating the blob across every base row) and ran
+ *      ~147s. The #862 fix splits the totals into their own `bucket_totals`
+ *      CTE keyed only on (lng_bucket, lat_bucket) → ~2.3s. The threshold below
+ *      FAILS on the pre-#862 query and PASSES on the fix.
+ *   2. CORRECTNESS — the fix must not silently change results. We snapshot the
+ *      full national result on first run (sorted, with the families jsonb
+ *      canonicalised) and assert run-to-run equality, so any future change to
+ *      the CTE chain that alters buckets/counts/top-8/ordering trips the test.
+ *
+ * Determinism note: the bucket key `round(ST_X(geom)*mult)/mult` is
+ * float-valued, and Postgres' PARALLEL HashAggregate over a float group key
+ * produces run-to-run variation in which bucket a boundary-adjacent row lands
+ * in (verified during the #862 investigation — it affects the pre-#862 query
+ * identically, so it is not a correctness regression in the fix). To make the
+ * correctness snapshot reproducible we disable parallel gather on this test DB
+ * (`max_parallel_workers_per_gather = 0`). That is purely a test-harness knob;
+ * it does NOT touch the production query or the read-api pool. It also makes
+ * the perf assertion CONSERVATIVE: the serial plan is the slower case, so prod
+ * (which keeps parallelism) is only ever faster than what we measure here.
+ *
+ * This is a real-Postgres+PostGIS testcontainer test (no DB mocks, per repo
+ * convention). It runs its OWN container so the heavy seed never touches the
+ * shared fixtures in observations.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers (NUMERIC → number).
+import './pool.js';
+import { getObservationsAggregated } from './observations.js';
+
+// Prod-scale target. bird-maps.com carries ~550k observations nationally; the
+// failing request is the coarsest grid over the whole set. 550k reproduces the
+// timeout on the pre-#862 query and exercises the same aggregation volume.
+const TARGET_ROWS = Number(process.env.PERF_ROWS ?? 550_000);
+
+// Hard ceiling: the read-api pool's statement_timeout is 15_000ms (pool.ts).
+// We assert well under it — the #862 fix runs ~2.3s at prod scale on CI-class
+// hardware, but containers + shared CI runners are noisy, so 8_000ms is the
+// guard threshold (comfortably below 15s, comfortably above the ~2.3s fix, and
+// FAR below the pre-#862 ~147s). A run over this means the timeout regression
+// is back.
+const PERF_THRESHOLD_MS = 8_000;
+
+// Deterministic PRNG so the seed (and therefore the correctness snapshot) is
+// reproducible across runs and machines.
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  const uri = container.getConnectionUri();
+
+  // Force serial plans on this test DB so the float-keyed bucket aggregation is
+  // run-to-run deterministic (see the determinism note in the file header). The
+  // serial plan is the SLOWER case, so the perf threshold below stays a valid —
+  // and conservative — guard against the timeout regression. Apply the GUC then
+  // build the pool AFTER pg_reload_conf so every pooled connection inherits it.
+  const cfg = new pg.Pool({ connectionString: uri, max: 1 });
+  await cfg.query('ALTER SYSTEM SET max_parallel_workers_per_gather = 0');
+  await cfg.query('SELECT pg_reload_conf()');
+  await cfg.end();
+
+  pool = new pg.Pool({ connectionString: uri, max: 4 });
+
+  // Apply all Up migrations in numeric order (same as test-helpers.startTestDb).
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  for (const f of readdirSync(migrationsDir).filter(x => x.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(migrationsDir, f), 'utf-8');
+    const [rawUp = ''] = sql.split(/-- Down Migration/i);
+    const up = rawUp.replace(/-- Up Migration/i, '');
+    if (up.trim()) await pool.query(up);
+  }
+
+  const rng = mulberry32(0xb12d5e);
+
+  // Skewed taxonomy: ~40 families, ~700 species, a few mega-families fat (so a
+  // dense cell can carry 100-197 species and the top-8 cap actually bites).
+  const FAMILIES = 40;
+  const SPECIES = 700;
+  const familyCodes = Array.from({ length: FAMILIES }, (_, i) => `fam-${String(i).padStart(3, '0')}`);
+  const speciesMeta: Array<{ code: string; fam: string }> = [];
+  for (let s = 0; s < SPECIES; s++) {
+    // bias toward low family index → zipf-ish family sizes (mega-families).
+    const fi = Math.min(FAMILIES - 1, Math.floor(Math.pow(rng(), 2) * FAMILIES));
+    speciesMeta.push({ code: `sp-${String(s).padStart(4, '0')}`, fam: familyCodes[fi]! });
+  }
+  // ~3% of species have NO species_meta row → NULL family (exercises the
+  // carve-out: counted in bucket totals, excluded from families[]).
+  const known = speciesMeta.filter((_, i) => i % 33 !== 0);
+  const smVals = known
+    .map((m, i) => `('${m.code}','Com ${i}','Sci ${i}','${m.fam}','Fam ${m.fam}',${10000 + i})`)
+    .join(',');
+  await pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order) VALUES ${smVals}`,
+  );
+
+  // CONUS coverage as INTEGER 0.5°-bucket indices. The coarsest national grid
+  // is `round(coord*2)/2` (multiplier 2 → 0.5° buckets). We place every point
+  // at `index/2 + 0.2` — a bucket INTERIOR offset of 0.2 sits far from both the
+  // 0.5° cell edges AND the 0.25° round-half midpoint, so `round((idx/2+0.2)*2)
+  // /2 = idx/2` with zero boundary ambiguity. Building coordinates from integer
+  // indices (not float-snapping a random float, which accumulates ULP error and
+  // leaves a handful of rows straddling a boundary) makes the bucket assignment
+  // — and therefore the correctness snapshot — exactly reproducible.
+  // CONUS lng index range ≈ [-250, -134] (i.e. -125°..-67°); lat ≈ [50, 98]
+  // (25°..49°). Hotspots are fixed index pairs → dense, species-rich cells.
+  const LNG_IDX_MIN = -250, LNG_IDX_SPAN = 116; // -125.0 .. -67.0
+  const LAT_IDX_MIN = 50, LAT_IDX_SPAN = 48; //   25.0 .. 49.0
+  const toCoord = (idx: number) => idx / 2 + 0.2;
+  const hotspots = Array.from({ length: 60 }, () => ({
+    lngIdx: LNG_IDX_MIN + Math.floor(rng() * LNG_IDX_SPAN),
+    latIdx: LAT_IDX_MIN + Math.floor(rng() * LAT_IDX_SPAN),
+    richness: 100 + Math.floor(rng() * 97),
+  }));
+
+  const now = Date.now();
+  const BATCH = 20_000;
+  let inserted = 0;
+  let sub = 0;
+  while (inserted < TARGET_ROWS) {
+    const n = Math.min(BATCH, TARGET_ROWS - inserted);
+    const subIds: string[] = [], codes: string[] = [], lats: number[] = [], lngs: number[] = [];
+    const dts: string[] = [], locIds: string[] = [], locNames: (string | null)[] = [];
+    const hows: (number | null)[] = [], notables: boolean[] = [];
+    for (let i = 0; i < n; i++) {
+      let lngIdx: number, latIdx: number, sp: string;
+      if (rng() < 0.55) {
+        // Dense hotspot cluster: jitter ±2 bucket indices around a hotspot, so
+        // the cluster spans a few cells but every point still lands on an
+        // integer-indexed bucket interior.
+        const hs = hotspots[Math.floor(rng() * hotspots.length)]!;
+        lngIdx = hs.lngIdx + (Math.floor(rng() * 5) - 2);
+        latIdx = hs.latIdx + (Math.floor(rng() * 5) - 2);
+        sp = speciesMeta[Math.floor(Math.pow(rng(), 0.5) * Math.min(hs.richness, SPECIES))]!.code;
+      } else {
+        // Uniform spread across CONUS bucket indices.
+        lngIdx = LNG_IDX_MIN + Math.floor(rng() * LNG_IDX_SPAN);
+        latIdx = LAT_IDX_MIN + Math.floor(rng() * LAT_IDX_SPAN);
+        sp = speciesMeta[Math.floor(rng() * SPECIES)]!.code;
+      }
+      const lng = toCoord(lngIdx);
+      const lat = toCoord(latIdx);
+      // Recency split: ~85% "recent" (0–13 days old), ~15% "old" (15–60 days).
+      // CRITICAL determinism guard: leave an EMPTY band between 13 and 15 days
+      // so NO row sits near the 14-day `since` cutoff. The query filters
+      // `obs_dt >= now() - 14 days`, and `now()` is evaluated per statement —
+      // it advances by milliseconds between the timing run and the correctness
+      // re-run. A row landing microseconds from the cutoff would flip in/out of
+      // the result set across runs (the real source of the 3-bucket drift seen
+      // during the #862 investigation). The 13–15 day gap makes the `since`
+      // filter classify every row identically on every run, while still pruning
+      // ~15% so the filter is real and `obs_dt`-index-relevant. Ages are whole
+      // days for the same reason (no sub-day fuzz near the boundary).
+      const ageDays = rng() < 0.85
+        ? Math.floor(rng() * 13)        // 0..12 days → comfortably inside 14d
+        : 15 + Math.floor(rng() * 45);  // 15..59 days → comfortably outside
+      subIds.push(`S${sub++}`);
+      codes.push(sp);
+      lngs.push(lng);
+      lats.push(lat);
+      dts.push(new Date(now - ageDays * 86_400_000).toISOString());
+      locIds.push('L0');
+      locNames.push(null);
+      hows.push(1);
+      notables.push(false);
+    }
+    await pool.query(
+      `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       SELECT * FROM unnest($1::text[],$2::text[],$3::float8[],$4::float8[],$5::timestamptz[],$6::text[],$7::text[],$8::int[],$9::bool[])
+       ON CONFLICT (sub_id, species_code) DO NOTHING`,
+      [subIds, codes, lats, lngs, dts, locIds, locNames, hows, notables],
+    );
+    inserted += n;
+  }
+
+  // Plan-quality stats — without ANALYZE the planner mis-estimates and the perf
+  // numbers are not representative of prod (which runs autovacuum/ANALYZE).
+  await pool.query('ANALYZE observations');
+  await pool.query('ANALYZE species_meta');
+  // Sanity-check the seed actually reached prod scale and the `since` filter is
+  // selective (not an all-time scan, not a no-op).
+  const { rows: tot } = await pool.query<{ c: string }>('SELECT count(*)::text AS c FROM observations');
+  expect(Number(tot[0]!.c)).toBeGreaterThanOrEqual(TARGET_ROWS - 1000);
+  const { rows: in14 } = await pool.query<{ c: string }>(
+    `SELECT count(*)::text AS c FROM observations WHERE obs_dt >= now() - interval '14 days'`,
+  );
+  const within14 = Number(in14[0]!.c);
+  expect(within14).toBeGreaterThan(TARGET_ROWS * 0.7); // ~85% expected
+  expect(within14).toBeLessThan(TARGET_ROWS); // since must prune SOMETHING
+  // Confirm the serial-plan GUC actually took effect on a pooled connection —
+  // otherwise the correctness snapshot assertion below would be flaky.
+  const { rows: guc } = await pool.query<{ max_parallel_workers_per_gather: string }>(
+    'SHOW max_parallel_workers_per_gather',
+  );
+  expect(guc[0]!.max_parallel_workers_per_gather).toBe('0');
+}, 600_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+/** Canonical, order-independent fingerprint of a national result set. */
+function fingerprint(buckets: Awaited<ReturnType<typeof getObservationsAggregated>>): string {
+  const rows = buckets
+    .map(b => ({
+      lng: b.lng,
+      lat: b.lat,
+      count: b.count,
+      speciesCount: b.speciesCount,
+      // families already arrive ordered by (count desc, code asc) from the
+      // query; species within a family ordered by (count desc, code asc).
+      families: b.families,
+    }))
+    .sort((a, z) => a.lng - z.lng || a.lat - z.lat);
+  return JSON.stringify(rows);
+}
+
+describe('getObservationsAggregated national perf guard (#862)', () => {
+  it(
+    'runs the coarsest national query (gridMultiplier=2, since=14d) under the timeout, deterministically',
+    async () => {
+      // Match the failing prod request EXACTLY: since=14d, no bbox, no state,
+      // gridMultiplier=2 (the coarsest national grid the read-api selects for
+      // zoom <= 3).
+      const t0 = performance.now();
+      const buckets = await getObservationsAggregated(pool, { since: '14d' }, 2);
+      const elapsedMs = performance.now() - t0;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[#862 perf guard] national query: ${elapsedMs.toFixed(0)}ms over ${TARGET_ROWS} rows → ${buckets.length} buckets (threshold ${PERF_THRESHOLD_MS}ms, pool statement_timeout 15000ms)`,
+      );
+
+      // PERF GUARD — this is the assertion that FAILS on the pre-#862 query
+      // (~147s, > 15s statement_timeout) and PASSES on the fix (~2.3s).
+      expect(elapsedMs).toBeLessThan(PERF_THRESHOLD_MS);
+
+      // The seed always produces buckets; a national view is never empty.
+      expect(buckets.length).toBeGreaterThan(100);
+      // Every bucket carries real totals.
+      for (const b of buckets) {
+        expect(b.count).toBeGreaterThan(0);
+        expect(b.speciesCount).toBeGreaterThan(0);
+        expect(b.speciesCount).toBeLessThanOrEqual(b.count);
+      }
+
+      // CORRECTNESS GUARD — re-run and assert byte-identical results, so any
+      // future optimisation that silently changes buckets/counts/top-8 ordering
+      // trips here. Boundary-stable geometry makes this deterministic.
+      const baseline = fingerprint(buckets);
+      const rerun = await getObservationsAggregated(pool, { since: '14d' }, 2);
+      expect(fingerprint(rerun)).toBe(baseline);
+
+      // Spot-check the top-8 cap is actually exercised somewhere (a dense
+      // hotspot cell has >8 species in at least one family) — proves the
+      // expensive ranked/per_family path ran, not a degenerate small result.
+      const capHit = buckets.some(b =>
+        b.families.some(fam => fam.speciesCount > fam.species.length && fam.species.length === 8),
+      );
+      expect(capHit).toBe(true);
+    },
+    120_000,
+  );
+});

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -406,10 +406,26 @@ export async function getObservationsAggregated(
   //                family's rows in the cell, NOT just the capped list.
   //   families   — per bucket: families rolled up into one JSON array ordered
   //                by family count desc, family code asc.
-  // The final SELECT computes the bucket count/speciesCount over `base`
-  // (unfiltered — so NULL-family rows still count toward the totals), then
-  // LEFT JOINs the families rollup (which excludes NULL-family rows). A bucket
-  // whose only observations are NULL-family yields families = '[]'.
+  //   bucket_totals — per bucket: count(*) + count(DISTINCT species_code) over
+  //                `base` (unfiltered — so NULL-family rows still count toward
+  //                the totals), keyed ONLY on (lng_bucket, lat_bucket).
+  // The final SELECT LEFT JOINs the families rollup (which excludes NULL-family
+  // rows) onto bucket_totals. A bucket whose only observations are NULL-family
+  // yields families = '[]'.
+  //
+  // PERF (#862 — national-scale 503 RCA). The original #859 final SELECT
+  // computed the bucket totals by aggregating ALL of `base` while grouping by
+  // (lng_bucket, lat_bucket, f.families). Because `f.families` is a large jsonb
+  // blob, the planner pulled it into the GROUP BY sort key and DUPLICATED it
+  // across every one of the ~467k national `base` rows, forcing a multi-GB
+  // external-merge sort (measured 3.6 GB spill, ~147s — far past the 15s
+  // statement_timeout, so the national low-zoom request 503'd). Splitting the
+  // totals into `bucket_totals` (grouped on the two cheap float keys only, no
+  // jsonb in the sort key) and joining the prebuilt per-bucket jsonb afterward
+  // removes the giant sort entirely: national runtime drops from ~147s to
+  // ~2.3s at prod scale. The result is byte-identical — `f.families` was
+  // always functionally determined by the bucket key, so grouping by it never
+  // changed which rows came back, only the cost.
   const sql = `
     WITH base AS (
       SELECT
@@ -464,17 +480,25 @@ export async function getObservationsAggregated(
         ) AS families
       FROM per_family
       GROUP BY lng_bucket, lat_bucket
+    ),
+    bucket_totals AS (
+      SELECT
+        lng_bucket,
+        lat_bucket,
+        count(*)::int AS observation_count,
+        count(DISTINCT species_code)::int AS species_count
+      FROM base
+      GROUP BY lng_bucket, lat_bucket
     )
     SELECT
-      b.lng_bucket,
-      b.lat_bucket,
-      count(*)::int AS observation_count,
-      count(DISTINCT b.species_code)::int AS species_count,
+      t.lng_bucket,
+      t.lat_bucket,
+      t.observation_count,
+      t.species_count,
       COALESCE(f.families, '[]'::jsonb) AS families
-    FROM base b
+    FROM bucket_totals t
     LEFT JOIN families f
-      ON f.lng_bucket = b.lng_bucket AND f.lat_bucket = b.lat_bucket
-    GROUP BY b.lng_bucket, b.lat_bucket, f.families
+      ON f.lng_bucket = t.lng_bucket AND f.lat_bucket = t.lat_bucket
   `;
 
   const { rows } = await pool.query<{


### PR DESCRIPTION
## Diagrams

National low-zoom 503 RCA + the query-plan change:

```mermaid
flowchart TB
    subgraph req["Failing prod request: gridMultiplier=2, since=14d, whole-US, no bbox/state"]
      direction LR
      A["~550k observations<br/>(~467k in 14d window)"]
    end

    subgraph before["BEFORE (#859) — ~147s, 503"]
      B1["base: 467k rows<br/>(geom→bucket, family join)"]
      B2["per_species → ranked → per_family → families<br/>(per-bucket jsonb)  ~1.7s ✅"]
      B3["FINAL: count(*) over ALL base<br/>GROUP BY (lng,lat, <b>f.families jsonb</b>)"]
      B4["jsonb blob pulled into sort key,<br/>duplicated across 467k rows<br/>→ 3.6 GB external-merge sort 💥"]
      B1 --> B2 --> B3 --> B4
      B4 -->|"> 15s statement_timeout"| B5["57014 cancel → HTTP 503"]
    end

    subgraph after["AFTER (#862) — ~2.3s ✅"]
      C1["base (unchanged)"]
      C2["families CTE (unchanged jsonb)"]
      C3["bucket_totals: count(*) + count(DISTINCT sp)<br/>GROUP BY (lng,lat) only — <b>no jsonb in key</b>"]
      C4["LEFT JOIN families onto bucket_totals<br/>(no giant sort)"]
      C1 --> C2 --> C4
      C1 --> C3 --> C4
      C4 --> C5["byte-identical result, well under 15s"]
    end

    A --> before
    A --> after
```

## Summary

- **Why it 503'd.** The coarsest national aggregated request exceeded the read-api pool's 15s `statement_timeout` (`packages/db-client/src/pool.ts`). `EXPLAIN (ANALYZE, BUFFERS)` at prod scale (~550k obs, ~467k in the 14d window, ~5.6k coarse buckets) showed the #859 final SELECT computed the bucket totals over **all** of `base` while `GROUP BY (lng_bucket, lat_bucket, f.families)`. Because `f.families` is a large per-bucket jsonb blob, the planner pulled it into the GROUP BY sort key and duplicated it across every one of the ~467k national base rows, forcing a **3.6 GB external-merge sort to disk → ~147s**. The per-family jsonb CTE chain itself was fast (~1.7s); the sort was the whole cost.
- **The fix is a pure query restructure — no index, no migration.** Split the bucket totals into their own `bucket_totals` CTE keyed only on `(lng_bucket, lat_bucket)` (no jsonb in the sort key), then `LEFT JOIN` the prebuilt families jsonb onto it. The multi-GB sort disappears. The output is **byte-identical** — `f.families` was always functionally determined by the bucket key, so grouping by it never changed which rows came back, only the cost. The 39 existing #859 nesting/ordering/NULL-family tests pass unchanged, and OLD-vs-NEW was verified multiset-equal at prod scale.
- **Before/after national timings at prod scale (~550k rows):** ~147s (parallel) / ~100s (serial) → **~2.3–3.0s**. Well under the <3s target and the 5s ceiling; ~5x under the 15s timeout even on the slower serial plan.
- **Adds the perf guard #859 was missing** (it measured payload bytes but never query time): a real-PostGIS testcontainer test seeds ~550k CONUS observations and asserts the national query finishes under 8s **and** is byte-identical on re-run. It FAILS on the pre-#862 query (~100s) and PASSES on the fix — pinning the regression. Follow-up to #860/#859.

## Screenshots

N/A — not UI (db-client query + integration test only; no `frontend/**` changes).

## Test plan

- [x] `npm run test --workspace @bird-watch/db-client` — green (15 files, 129 passed / 1 todo), incl. the new perf guard and the migrations-down-chain test
- [x] `npm run test --workspace @bird-watch/read-api` — green (170 passed)
- [x] New integration test added: `observations-aggregated-perf.test.ts` (prod-scale perf guard + byte-identical re-run). Confirmed it FAILS on `origin/main`'s query (`expected 100223 to be less than 8000`) and PASSES on the fix (~2.3–3.0s)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npx knip` — no new findings (exit 0; only the pre-existing `docs/plans/...prototype` hint, `knip.ts` untouched)
- [x] N/A — not UI, no Playwright MCP smoke

## Plan reference

Out of plan — production incident hotfix. Follow-up to #860 / #859 (the national species-aggregation work that introduced the per-family jsonb nesting); this PR fixes the query-time regression that #859's payload-only measurement missed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)