### PR TITLE
fix(map): anchor portaled CellPopover to its cell via getBoundingClientRect (#863)

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -801,17 +801,27 @@ button.adaptive-grid-marker__cell {
    ───────────────────────────────────────────────────────────────────────────── */
 
 .cell-popover {
-  position: absolute;
-  /* #761 P1, #778 — above the rail, below the cluster popover.
+  /* POSITIONING: #859 portals this card to document.body (to escape the
+     transformed MapLibre marker's stacking context — the z-index fix). A portal
+     to <body> has NO positioned ancestor, so this `position: absolute` floor is
+     NOT what places the card. #863: CellPopover.tsx sets an INLINE
+     `position: fixed; left; top` (computed from anchorEl.getBoundingClientRect()),
+     which wins over this declaration and anchors the card to the clicked cell with
+     edge flip/clamp. This `absolute` floor is only the pre-mount / non-JS fallback;
+     the inline fixed style is the authority once mounted. (Pre-#863 this said
+     `position: absolute` with "no portal needed" — both stale: the portal landed
+     in #859 and, without a computed position, the absolute card collapsed to the
+     body origin / bottom-left, which #863 fixes.)
+     #761 P1, #778 — above the rail, below the cluster popover.
      #761 O6 (#782) ORDERING CONTRACT vs the detail rail: --z-cell-popover (44)
      resolves ABOVE the rail's current --z-rail (43), so this click-driven popover
      temporarily paints over an open SpeciesDetailRail. Re-tiering the rail ABOVE
      the popovers (into --z-modal with the #663 inert work) is O5's job (report R3);
      O6 does NOT move the rail's z value and leaves the temporary popover-over-rail
-     state as expected. Verified live (O6): this popover, though mounted inside the
-     transformed MapLibre marker container, escapes to a higher stacking context and
-     paints above the map-assist overlays (legend/scope at --z-overlay 40,
-     observation-popover at --z-popover 41) as the token intends — no portal needed. */
+     state as expected. Verified live (O6): this popover escapes to a higher
+     stacking context (via the #859 portal) and paints above the map-assist overlays
+     (legend/scope at --z-overlay 40, observation-popover at --z-popover 41). */
+  position: absolute;
   z-index: var(--z-cell-popover);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-strong);

--- a/frontend/src/components/map/CellPopover.test.tsx
+++ b/frontend/src/components/map/CellPopover.test.tsx
@@ -15,6 +15,26 @@ function makeAnchor(): HTMLElement {
   return btn;
 }
 
+/**
+ * Anchor whose `getBoundingClientRect()` returns a fixed, known rect — lets the
+ * positioning tests assert the popover's computed `top`/`left` deterministically
+ * (jsdom otherwise reports all-zero rects for every element). The rect is in
+ * viewport coordinates, which is exactly what the `position: fixed` math reads.
+ */
+function makeAnchorAt(rect: {
+  left: number; top: number; right: number; bottom: number; width: number; height: number;
+}): HTMLElement {
+  const btn = makeAnchor();
+  btn.getBoundingClientRect = () =>
+    ({
+      ...rect,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return btn;
+}
+
 describe('<CellPopover>', () => {
   it('renders role="dialog" on the root element', () => {
     const anchor = makeAnchor();
@@ -348,5 +368,71 @@ describe('<CellPopover>', () => {
       />
     );
     expect(document.activeElement?.getAttribute('data-testid')).toBe('cell-popover-heading');
+  });
+
+  // #863: the portaled popover (to document.body, #859) MUST compute its own
+  // on-screen position from the anchor's rect. Without it, `position: absolute`
+  // collapses to the body origin and the card lands in the bottom-left corner.
+  // The fix mirrors <CellHoverPreview>: inline `position: fixed` + computed
+  // left/top from `anchorEl.getBoundingClientRect()`, with edge flip/clamp.
+  describe('positioning (#863)', () => {
+    function renderAt(anchor: HTMLElement) {
+      render(
+        <CellPopover
+          familyCode="hummingbirds"
+          familyCount={5}
+          species={[species("Anna's Hummingbird", 5, 'annhum')]}
+          anchorEl={anchor}
+          onDismiss={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />
+      );
+      return screen.getByTestId('cell-popover');
+    }
+
+    it('anchors next to the clicked cell via position: fixed + computed left/top (not the static/absolute body origin)', () => {
+      // A cell comfortably inside the jsdom viewport (1024×768).
+      const anchor = makeAnchorAt({ left: 300, top: 200, right: 322, bottom: 222, width: 22, height: 22 });
+      const card = renderAt(anchor);
+
+      // The fix sets an INLINE position: fixed (wins over the CSS position:absolute).
+      expect(card.style.position).toBe('fixed');
+
+      // left/top are explicit pixel values derived from the anchor rect — NOT
+      // empty (which is what the bug produced) and NOT 0 (the body origin).
+      expect(card.style.left).not.toBe('');
+      expect(card.style.top).not.toBe('');
+      const left = parseFloat(card.style.left);
+      const top = parseFloat(card.style.top);
+
+      // Anchored adjacent to the cell: horizontally aligned with the cell's left
+      // edge (within the card width) and vertically just below the cell.
+      expect(left).toBeGreaterThanOrEqual(300 - 1);
+      expect(left).toBeLessThan(300 + 320); // within one card-width of the anchor left
+      expect(top).toBeGreaterThanOrEqual(222 - 1); // at or below the cell's bottom edge
+      expect(top).toBeLessThan(222 + 40);
+    });
+
+    it('flips/clamps so a right-edge anchor never overflows the right of the viewport', () => {
+      // Cell hugging the right edge of the 1024-wide jsdom viewport.
+      const anchor = makeAnchorAt({ left: 1010, top: 200, right: 1024, bottom: 222, width: 14, height: 22 });
+      const card = renderAt(anchor);
+      expect(card.style.position).toBe('fixed');
+      const left = parseFloat(card.style.left);
+      // Min card width is 240px; left must leave room for the card inside 1024.
+      expect(left).toBeGreaterThanOrEqual(0);
+      expect(left).toBeLessThanOrEqual(1024 - 240);
+    });
+
+    it('flips above so a bottom-edge anchor never overflows the bottom of the viewport', () => {
+      // Cell near the bottom of the 768-tall jsdom viewport.
+      const anchor = makeAnchorAt({ left: 300, top: 750, right: 322, bottom: 766, width: 22, height: 16 });
+      const card = renderAt(anchor);
+      expect(card.style.position).toBe('fixed');
+      const top = parseFloat(card.style.top);
+      // Flipped above the anchor: top must sit at or above the anchor's top edge.
+      expect(top).toBeLessThanOrEqual(750);
+      expect(top).toBeGreaterThanOrEqual(0);
+    });
   });
 });

--- a/frontend/src/components/map/CellPopover.tsx
+++ b/frontend/src/components/map/CellPopover.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useId, useRef } from 'react';
-import type { KeyboardEvent } from 'react';
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import type { CSSProperties, KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { SpeciesAggregate } from './adaptive-grid.js';
 import { prettyFamily } from '../../derived.js';
@@ -22,10 +22,63 @@ import { prettyFamily } from '../../derived.js';
  *
  * #859 E (structural z-index): the popover PORTALS to `document.body` so the
  * maplibre marker `<div>`'s `transform` (a stacking context) can't let the
- * cluster pills paint over it. Positioning/flip/shift/clamp is owned by the
- * caller via the anchor; the portal only changes the DOM parent, not the visual
- * placement. Mirrors the `<CellHoverPreview>` portal.
+ * cluster pills paint over it. The portal escapes that context — but a portal to
+ * `document.body` has NO positioned ancestor, so the bare CSS `position: absolute`
+ * would collapse to the body origin (bottom-left).
+ *
+ * #863 fix: because the card is portaled out of the marker, it must compute its
+ * own on-screen placement from `anchorEl.getBoundingClientRect()` and apply it as
+ * an inline `position: fixed; top; left` (the inline style wins over the CSS
+ * `position: absolute`). It anchors just below the clicked cell, left-aligned to
+ * the cell, with edge handling: flip above when it would overflow the bottom and
+ * clamp horizontally so it never runs off the right/left edge. This mirrors the
+ * `<CellHoverPreview>` pattern (inline `position: fixed` + computed `left`/`top` +
+ * portal). One-shot compute on mount is sufficient: the popover only lives while a
+ * cell is in `popover` mode and dismisses on map interaction (pan/zoom), so the
+ * anchor rect cannot go stale underneath an open card.
  */
+
+/** Gap between the anchor cell and the popover card, in CSS px. */
+const ANCHOR_GAP = 6;
+/** Viewport inset kept around the clamped card so it never kisses the edge. */
+const VIEWPORT_MARGIN = 8;
+/**
+ * Fallback card box used before the real rendered rect is measurable (and in
+ * jsdom, where layout is not computed). Mirrors `.cell-popover`'s CSS
+ * `min-width: 240px`; the height is a conservative estimate for the flip check.
+ */
+const FALLBACK_CARD_WIDTH = 240;
+const FALLBACK_CARD_HEIGHT = 200;
+
+/**
+ * Compute the popover's fixed-position `left`/`top` (viewport coordinates) from
+ * the anchor cell's rect and the card's own size, clamping/flipping so the card
+ * stays fully on screen.
+ */
+function computePopoverPosition(
+  anchorRect: DOMRect,
+  cardWidth: number,
+  cardHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): { left: number; top: number } {
+  // Horizontal: left-align to the cell, then clamp into the viewport so the
+  // card never overflows the right (flips effectively become a right-shift) or
+  // left edge.
+  const maxLeft = Math.max(VIEWPORT_MARGIN, viewportWidth - cardWidth - VIEWPORT_MARGIN);
+  const left = Math.min(Math.max(anchorRect.left, VIEWPORT_MARGIN), maxLeft);
+
+  // Vertical: prefer below the cell. If that would overflow the bottom, flip to
+  // above the cell. Clamp into the viewport as a final fallback.
+  const belowTop = anchorRect.bottom + ANCHOR_GAP;
+  const aboveTop = anchorRect.top - ANCHOR_GAP - cardHeight;
+  const overflowsBottom = belowTop + cardHeight > viewportHeight - VIEWPORT_MARGIN;
+  let top = overflowsBottom && aboveTop >= VIEWPORT_MARGIN ? aboveTop : belowTop;
+  const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - cardHeight - VIEWPORT_MARGIN);
+  top = Math.min(Math.max(top, VIEWPORT_MARGIN), maxTop);
+
+  return { left, top };
+}
 export interface CellPopoverProps {
   familyCode: string;
   familyCount: number;
@@ -57,6 +110,9 @@ export function CellPopover(props: CellPopoverProps) {
   const headingId = useId();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const headingRef = useRef<HTMLHeadingElement | null>(null);
+  // #863: the portaled card's fixed-position placement, computed from the
+  // anchor rect on mount. `null` until the layout effect runs (one paint).
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
 
   const visible = species.slice(0, POPOVER_CAP);
   // Overflow is the EXACT distinct-species remainder when the caller supplies
@@ -67,6 +123,22 @@ export function CellPopover(props: CellPopoverProps) {
   // The drill-in is active only when the caller wired a handler AND there is
   // overflow to drill into.
   const drillInActive = hasOverflow && typeof onDrillIn === 'function';
+
+  // #863: compute the fixed-position placement from the anchor rect before the
+  // browser paints (useLayoutEffect avoids a one-frame flash at the body origin).
+  // The card's own rendered size is read from rootRef when available; otherwise
+  // we fall back to the CSS min-width / an estimated height (jsdom, first pass).
+  useLayoutEffect(() => {
+    const anchorRect = anchorEl.getBoundingClientRect();
+    const cardRect = rootRef.current?.getBoundingClientRect();
+    const cardWidth = cardRect && cardRect.width > 0 ? cardRect.width : FALLBACK_CARD_WIDTH;
+    const cardHeight = cardRect && cardRect.height > 0 ? cardRect.height : FALLBACK_CARD_HEIGHT;
+    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 768;
+    setPosition(
+      computePopoverPosition(anchorRect, cardWidth, cardHeight, viewportWidth, viewportHeight),
+    );
+  }, [anchorEl]);
 
   // Move focus to the heading on mount (spec §4.8 — popover focus management).
   useEffect(() => {
@@ -104,6 +176,15 @@ export function CellPopover(props: CellPopoverProps) {
     }
   }
 
+  // #863: the inline `position: fixed` wins over the CSS `.cell-popover`'s
+  // `position: absolute`, anchoring the portaled card to the clicked cell. Until
+  // the layout effect has measured (one pre-paint pass), keep it off-screen so it
+  // never flashes at the body origin — `position` is set synchronously before the
+  // browser paints, so users only ever see the anchored placement.
+  const positionStyle: CSSProperties = position
+    ? { position: 'fixed', left: position.left, top: position.top }
+    : { position: 'fixed', left: -9999, top: -9999, visibility: 'hidden' };
+
   const content = (
     <div
       ref={rootRef}
@@ -111,6 +192,7 @@ export function CellPopover(props: CellPopoverProps) {
       aria-labelledby={headingId}
       className="cell-popover"
       data-testid="cell-popover"
+      style={positionStyle}
     >
       <header className="cell-popover__header">
         <h2


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    click["User clicks a family silhouette cell<br/>(aggregated / low zoom)"] --> mount["CellPopover mounts<br/>anchorEl = clicked cell button"]
    mount --> portal["createPortal to document.body<br/>(#859 — escapes the MapLibre marker's<br/>transform stacking context)"]

    subgraph bug["BEFORE (#863 bug)"]
        portal --> noPos["No computed position;<br/>relies on CSS position: absolute"]
        noPos --> origin["Portaled to body → no positioned ancestor,<br/>no left/top → collapses to body origin"]
        origin --> corner["Card renders in the<br/>BOTTOM-LEFT corner ❌"]
    end

    subgraph fix["AFTER (#863 fix)"]
        portal --> measure["useLayoutEffect:<br/>anchorEl.getBoundingClientRect()"]
        measure --> compute["computePopoverPosition()<br/>below + left-aligned to cell"]
        compute --> edge{"Off-screen?"}
        edge -->|overflows bottom| flip["flip above the cell"]
        edge -->|overflows right/left| clamp["clamp into viewport"]
        edge -->|fits| place["place below"]
        flip --> inline["inline position: fixed; left; top<br/>(wins over CSS position: absolute)"]
        clamp --> inline
        place --> inline
        inline --> anchored["Card anchors next to<br/>the clicked cell ✅"]
    end
```

## Summary

- **Why:** The per-family `CellPopover` was rendering in the **bottom-left corner** instead of next to the clicked cell. Root cause: #859 portaled the card to `document.body` (the z-index/stacking-context fix so cluster pills can't paint over it), but the card never computed a position — it relied on `.cell-popover`'s CSS `position: absolute`. Portaled to `document.body` there is no positioned ancestor and no `left`/`top`, so `absolute` collapses to the body origin.
- **Fix:** Mirror the existing `CellHoverPreview` pattern — compute placement from `anchorEl.getBoundingClientRect()` in a `useLayoutEffect` (pre-paint, no flash) and apply an inline `position: fixed; left; top` that wins over the CSS `absolute`. Anchors below + left-aligned to the cell, with edge handling (flip above on bottom overflow, clamp into the viewport on any edge). The `createPortal(..., document.body)` stays (removing it would reintroduce pills-over-popover).
- Follow-up to #859 (#860). `ClusterListPopover` (`position: fixed`, anchored to viewport edges by design), the popover content, the drill-in, and the z-index token are all deliberately untouched.

## Screenshots

⏳ **Pending — to be captured live by the orchestrator before merge.** This is a UI-positioning fix under `frontend/**`, so the canonical 5-viewport × 2-theme captures are required (≥10 `user-attachments` URLs per #445). Surface to drive: at aggregated/low zoom, **click a family silhouette cell** → the `CellPopover` must anchor adjacent to the clicked cell (not the bottom-left corner), including near the right/bottom edges where it flips/clamps to stay on-screen.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no new className; the fix adds an inline `style` only. `scripts/check-orphan-classnames.sh` passes.`
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes per #445) — **pending orchestrator live drive.**

## Test plan

- [x] `npx tsc -p frontend/tsconfig.test.json --noEmit` — zero NEW errors in touched files (error count unchanged at 80; all pre-existing `maplibre-gl`-resolution noise, none in `CellPopover.tsx`/`CellPopover.test.tsx`)
- [x] `npm run test --workspace @bird-watch/frontend` — green (67 files / 1093 tests)
- [x] New unit tests added: TDD red-first `positioning (#863)` block in `CellPopover.test.tsx` — asserts inline `position: fixed` + computed `left`/`top` from a mocked anchor rect, plus right-edge clamp and bottom-edge flip cases
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npm run lint` · `npx knip` · `bash scripts/check-orphan-classnames.sh` — clean / no new findings
- [ ] (UI only) Playwright MCP smoke — **deferred to the orchestrator**, who drives this live and captures the Screenshots section (per the dispatch brief)

## Plan reference

Out of plan — production bug fix (#863), follow-up to #859/#860.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Screenshots / live verification (orchestrator note):** the silhouette-grid marker that opens this `CellPopover` only renders against real zoom-gridded data — the local dev stub returns coarse national buckets that cluster into count-pills, so this exact surface is **not reproducible locally** (confirmed: grids never render in the stub at any zoom). This positioning fix is therefore verified by **failing-first unit tests** in `CellPopover.test.tsx` (interior anchor → `position:fixed` from the rect; right-edge → horizontal clamp; bottom-edge → flip-above), and will be **visually confirmed on prod immediately after deploy** (prod renders the grid markers — see the two prod screenshots in the incident thread showing the bug). `N/A — surface not stub-reproducible; unit-tested + prod-verified post-deploy.`