### PR TITLE
fix(map): open species popover when a lone unclustered bucket silhouette is clicked at low zoom (#864)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1468,6 +1468,160 @@ describe('#860 — lone clustered bucket opens its real species (coarse pointer)
   });
 });
 
+/* ── #864: a lone UNCLUSTERED bucket silhouette is clickable at low zoom ──────
+ *
+ * #860 set clusterMinPoints=1 so most lone buckets become degenerate clusters,
+ * but maplibre still emits TRULY isolated buckets (no neighbour AND/or past
+ * clusterMaxZoom) as UNCLUSTERED points. Those paint a bare family silhouette
+ * via the `unclustered-point` SDF symbol layer. The canvas click handler keys
+ * solely on `subId`; bucket features carry `count`/`speciesCount`/`familiesJson`
+ * but never a `subId`, so the handler no-ops and the silhouette is a dead click.
+ *
+ * Fix: when the clicked `unclustered-point` feature has NO `subId` but carries
+ * `familiesJson` (an aggregated bucket), open the SAME real-species popover the
+ * cluster path opens — parse the one bucket via `mergeLeafBuckets` and mount the
+ * `<ClusterListPopover>` anchored at the click. The per-observation `subId`
+ * branch is untouched.
+ */
+describe('#864 — lone unclustered bucket silhouette opens its real species', () => {
+  const LONE_BUCKET: AggregatedBucket = {
+    lat: 46.0,
+    lng: -110.0,
+    count: 7,
+    speciesCount: 2,
+    families: [
+      {
+        code: 'tyrannidae',
+        count: 7,
+        speciesCount: 2,
+        species: [
+          { code: 'wewp', count: 5 },
+          { code: 'sayphoebe', count: 2 },
+        ],
+      },
+    ],
+  };
+  const DICT = new Map<string, { comName: string; familyCode: string }>([
+    ['wewp', { comName: 'Western Wood-Pewee', familyCode: 'tyrannidae' }],
+    ['sayphoebe', { comName: "Say's Phoebe", familyCode: 'tyrannidae' }],
+  ]);
+
+  beforeEach(() => {
+    capturedSourceProps = {};
+    capturedLayerFilters = {};
+    capturedSourcesById = {};
+    capturedLayerPaint = {};
+    registeredHandlers = {};
+    bareHandlers = {};
+    bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
+    fakeMap = makeFakeMap();
+    document.documentElement.removeAttribute('data-theme');
+    __resetAdaptiveGridCacheForTesting();
+  });
+
+  it('clicking an unclustered bucket (familiesJson, no subId) opens the real-species popover', async () => {
+    render(
+      <MapCanvas
+        observations={[]}
+        buckets={[LONE_BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+      />,
+    );
+    await waitFor(() =>
+      expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+    );
+
+    // The unclustered bucket feature: dominant family silhouette properties +
+    // serialized real families, NO subId (exactly what bucketsToGeoJson writes
+    // for a bucket that maplibre never clustered).
+    const bucketFeature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [LONE_BUCKET.lng, LONE_BUCKET.lat] },
+      properties: {
+        count: LONE_BUCKET.count,
+        speciesCount: LONE_BUCKET.speciesCount,
+        familiesJson: JSON.stringify(LONE_BUCKET.families),
+        familyCode: 'tyrannidae',
+        silhouetteId: 'tyrannidae',
+        color: '#c3772d',
+      },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('unclustered-point') ? [bucketFeature] : [],
+    );
+
+    const handler = registeredHandlers['click:unclustered-point'];
+    if (!handler) throw new Error('click:unclustered-point handler missing');
+    await act(async () => {
+      handler({ point: [120, 120] });
+      await Promise.resolve();
+    });
+
+    // The bucket's REAL families/species reach the user via the cluster-list
+    // popover — not a dead click.
+    const popover = await waitFor(() =>
+      screen.getByTestId('cluster-list-popover'),
+    );
+    expect(popover).toBeInTheDocument();
+    const familyToggle = screen.getByTestId(
+      'cluster-list-popover-family-tyrannidae',
+    );
+    expect(familyToggle).toHaveTextContent('Tyrannidae (7)');
+
+    // Expand → the real common name (resolved via the dictionary) renders, with
+    // a working species link (non-null code ⇒ <a role="link">).
+    await act(async () => {
+      fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
+      await Promise.resolve();
+    });
+    const link = screen.getByText(/Western Wood-Pewee/);
+    expect(link).toBeInTheDocument();
+    expect(link.closest('[role="link"]')).not.toBeNull();
+  });
+
+  it('clicking an unclustered feature WITH a subId still opens the observation popover (unchanged)', async () => {
+    // Per-observation mode: a real Observation row legitimately carries a subId
+    // and must still open the ObservationPopover. The #864 fix must NOT touch
+    // this branch.
+    const obs = makeObs({ subId: 'S864', comName: 'Vermilion Flycatcher' });
+    render(<MapCanvas observations={[obs]} silhouettes={SILHOUETTES} />);
+    await waitFor(() =>
+      expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+    );
+
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('unclustered-point')
+          ? [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [obs.lng, obs.lat] },
+                properties: { subId: 'S864' },
+              },
+            ]
+          : [],
+    );
+
+    const handler = registeredHandlers['click:unclustered-point'];
+    if (!handler) throw new Error('click:unclustered-point handler missing');
+    await act(async () => {
+      handler({ point: [120, 120] });
+      await Promise.resolve();
+    });
+
+    // The observation popover (not the cluster-list popover) opens.
+    expect(
+      await screen.findByRole('dialog', { name: /Details for Vermilion Flycatcher/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('cluster-list-popover')).toBeNull();
+  });
+});
+
 // Popover-originated onSelectSpecies wire.
 // These tests run in a separate describe block that resets modules to
 // pick up the pointer:fine matchMedia stub for AdaptiveGridMarker.

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -739,7 +739,10 @@ export function MapCanvas({
    * the bottom of the function.
    */
   const [clusterList, setClusterList] = useState<{
-    group: DeconflictGroup;
+    // The DeconflictGroup whose pill/marker click opened this popover. Absent on
+    // the #864 unclustered-bucket-silhouette path (a bare canvas click has no
+    // group); the mount never reads `group`, so it stays informational.
+    group?: DeconflictGroup;
     families: FamilyAggregate[];
     speciesByFamily: ReadonlyMap<string, ReadonlyArray<SpeciesAggregate>>;
     // #859: per-family distinct-species overflow (drives the active "+N more"
@@ -1333,6 +1336,15 @@ export function MapCanvas({
   const onViewportChangeRef = useRef(onViewportChange);
   onViewportChangeRef.current = onViewportChange;
 
+  // #864: the `unclustered-point` click handler is registered once in handleLoad
+  // ([] deps), so — like onViewportChange above — it reads `aggregated` and the
+  // species `dictionary` through refs to see the live values when a lone bucket
+  // silhouette is clicked, not the values captured at map-load time.
+  const aggregatedRef = useRef(aggregated);
+  aggregatedRef.current = aggregated;
+  const dictionaryRef = useRef(dictionary);
+  dictionaryRef.current = dictionary;
+
   // Sprite-registration completion gate. Flips true after `Promise.all`
   // in the sprite-registration effect resolves. The symbol layer JSX is
   // conditioned on this so MapLibre never tries to paint icons before
@@ -1499,7 +1511,54 @@ export function MapCanvas({
       if (subId) {
         const obs = obsLookupRef.current[subId];
         if (obs) openPopover(obs);
+        return;
       }
+
+      // #864: no subId ⇒ this is an aggregated BUCKET painted unclustered (a
+      // lone bucket past clusterRadius / clusterMaxZoom that #860's
+      // clusterMinPoints=1 didn't fold into a degenerate cluster). It carries
+      // its real families/species in `familiesJson` — open the SAME real-species
+      // popover the cluster path opens (mergeLeafBuckets on this one bucket →
+      // ClusterListPopover), so a click resolves names + working links instead
+      // of no-op'ing on a dead silhouette. Gated on aggregated mode + presence
+      // of familiesJson so the per-observation path is untouched.
+      const familiesJson = feature.properties?.familiesJson as
+        | string
+        | undefined;
+      if (!aggregatedRef.current || typeof familiesJson !== 'string') return;
+
+      // One-bucket "merge": mergeLeafBuckets reads `properties.familiesJson` off
+      // each leaf, so the clicked feature IS a valid single-element leaf array.
+      // Reuses the exact bucket→popover machinery the cluster path uses (#859).
+      const merged = mergeLeafBuckets(
+        [feature as unknown as { properties?: { familiesJson?: unknown } }],
+        dictionaryRef.current,
+      );
+      if (merged.families.length === 0) return;
+
+      const totalCount =
+        typeof feature.properties?.count === 'number'
+          ? (feature.properties.count as number)
+          : merged.families.reduce((s, f) => s + f.count, 0);
+
+      const geom = feature.geometry;
+      const center: [number, number] | undefined =
+        geom.type === 'Point'
+          ? (geom.coordinates as [number, number])
+          : undefined;
+
+      setClusterList({
+        families: merged.families,
+        speciesByFamily: merged.speciesByFamily,
+        overflowByFamily: merged.overflowByFamily,
+        totalCount,
+        uniqueFamilies: merged.families.length,
+        // No DOM anchor exists for a bare canvas click; the map canvas is a
+        // stable, focusable focus-return target (ClusterListPopover only uses
+        // anchorEl for .focus() on dismiss — positioning is sheet-style CSS).
+        anchorEl: map.getCanvas(),
+        ...(center ? { drillCenter: center } : {}),
+      });
     });
 
     // Cluster click — the 'clusters' layer's filter is `['boolean', false]`


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Click["click on unclustered-point feature"] --> HasSubId{"feature.properties.subId?"}
    HasSubId -->|yes| Obs["openPopover(obs)\n(per-observation — UNCHANGED)"]
    HasSubId -->|"no (a bucket)"| Agg{"aggregated mode\n&& familiesJson present?"}
    Agg -->|no| Noop["return (per-observation path,\nno bucket data)"]
    Agg -->|yes| Merge["mergeLeafBuckets([feature], dictionary)\n(1-bucket 'merge' — reuses #859 machinery)"]
    Merge --> Mount["setClusterList(...)\n→ &lt;ClusterListPopover&gt;\nreal families · top-8 species · real comNames\n· working links · collapse-default · +N more"]

    classDef bug fill:#fdd
    class Noop bug
```

Before this PR, the `no subId` branch fell through to nothing — a clicked lone silhouette opened nothing (the red node is what the user actually hit).

## Summary

- **RCA.** At low/aggregated zoom a genuinely isolated bucket (no neighbour within `clusterRadius`, or past `clusterMaxZoom`) is emitted **unclustered** and painted as a bare family silhouette by the `unclustered-point` SDF symbol layer. The canvas click handler keyed solely on `subId`; bucket features carry `count`/`speciesCount`/`familiesJson` but **never a `subId`**, so the handler no-op'd — a dead click.
- **Why #860 didn't cover it.** `clusterMinPoints={aggregated ? 1 : 2}` (#860) folds *most* lone buckets into degenerate 1-point clusters, but maplibre still emits truly isolated points (and anything past `clusterMaxZoom`) unclustered. Same class of bug, different zoom condition — this is the follow-up to #860.
- **The fix.** Make the `unclustered-point` click handler bucket-aware: when the clicked feature has **no `subId`** but **is an aggregated bucket** (aggregated mode + a `familiesJson` payload), parse that one bucket via the existing `mergeLeafBuckets` (a 1-element leaf "merge") and open the **same** `<ClusterListPopover>` the cluster path opens — real families → top-8 species → real common names via the dictionary → working species links → collapse-default → "+N more" drill-in. No synthetic data; the bucket's real `familiesJson` is used.
- The per-observation `subId` branch is **unchanged** (it now early-returns but behaves identically). `aggregated` + `dictionary` are read through refs because `handleLoad` registers the handler once (`[]` deps), mirroring the existing `onViewportChangeRef`.

## Screenshots

N/A — no new visual surface or `className`. This PR re-routes a previously-dead click into the **already-shipped** `<ClusterListPopover>` (#717/#859), which is unchanged. A live multi-viewport drive against production data is **blocked by CORS** from `localhost` (the prod API rejects cross-origin fetches), so the behavior is verified by unit tests instead (failing-first → passing). **Surface to drive on the live site to confirm:** at national/low zoom in a sparse state (MT/WY/NV), click a lone family silhouette that shows no count badge / no grid box → the species popover opens with real names + working links (previously opened nothing).

- [x] No new/renamed `className` in this PR — orphan-classname check `N/A`.
- [x] Multi-viewport design QA — `N/A — not a new UI surface` (reuses the unchanged `<ClusterListPopover>`; live prod drive blocked by localhost CORS).

## Test plan

- [x] `npx tsc -p frontend/tsconfig.test.json --noEmit` — 74 errors before AND after (all pre-existing baseline); **zero new** errors in touched files.
- [x] New unit tests added (TDD, failing-first confirmed): `MapCanvas.test.tsx` `#864` block — (1) clicking an unclustered bucket (`familiesJson`, no `subId`) opens the real-species popover with the dictionary-resolved common name + a working `role="link"`; (2) clicking a feature **with** a `subId` still opens the ObservationPopover (per-observation path unchanged, no cluster-list popover).
- [x] `npm run test --workspace @bird-watch/frontend` — green (1095 passed).
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build.
- [x] `npm run lint` · `npx knip` · `bash scripts/check-orphan-classnames.sh` — clean / no new findings.
- [ ] (UI) Playwright MCP smoke — N/A: prod-data drive blocked by localhost CORS; reuses the unchanged shipped popover. See Screenshots for the live-site surface to confirm.

## Plan reference

Out of plan — live prod bugfix (#864), follow-up to #860 (`clusterMinPoints`) and #859 (the aggregated low-zoom render path).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)