### PR TITLE
perf: tune cache-warming freshness — s-maxage 1800→2400 + retire the legacy CONUS seed

### DIFF
--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -131,8 +131,9 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
    * degrees)? This is the DETERMINISTIC, WebGL-independent differentiator
    * between the bug and the fix: in this no-WebGL CI the map never settles a
    * state-tight viewport into `debouncedBbox`, so on UNPATCHED `main` the
-   * post-switch fetch carries the cold-mount CONUS seed (`-125,24,-66,50`),
-   * which `intersects` (but does NOT match) the new state's envelope.
+   * post-switch fetch carries the cold-mount CONUS seed (`INITIAL_BBOX_SEED`,
+   * `-130,20,-65,52` since #870), which `intersects` (but does NOT match) the
+   * new state's envelope.
    * The render-phase reseed sets `debouncedBbox` to the new scope's exact
    * envelope, so AFTER the fix the post-switch bbox matches within tol — RED on
    * main (CONUS seed), GREEN after fix.
@@ -145,10 +146,12 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
    *
    * The RED-on-main / GREEN-after-fix discriminator is preserved: each state's
    * canonical box is distinct from the CONUS cold-mount seed's canonical box
-   * (`canonicalFetchBbox([-125,24,-66,50], 3) = -129,20,-65,52`), which is what
-   * an UNPATCHED post-switch fetch carries. The state canonical boxes are
+   * (`canonicalFetchBbox(INITIAL_BBOX_SEED, 3) = -130,20,-65,52` since #870; was
+   * `-129,…` while the seed was the legacy `[-125,24,-66,50]`), which is what an
+   * UNPATCHED post-switch fetch carries. The state canonical boxes are
    * AZ `-130,20,-78,52` / FL `-118,20,-65,52` / NY `-110,20,-65,52` — none equal
-   * the `-129,…` CONUS-seed box, so a missing reseed still fails this assertion.
+   * the `-130,20,-65,52` CONUS-seed box (AZ shares only the W/S/N edges; its E
+   * edge -78 differs), so a missing reseed still fails this assertion.
    * (`bboxIntersects` above stays a separate, weaker guard: the canonical box is
    * a CONUS-clamped superset that always intersects the target state, which is
    * what the server `?state=` ST_Intersects clip relies on for correctness.)

--- a/frontend/src/App.seed.test.ts
+++ b/frontend/src/App.seed.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalFetchBboxParam, CONUS_BOUNDS } from '@bird-watch/geo';
+import { INITIAL_BBOX_SEED, INITIAL_ZOOM_SEED } from './App.js';
+
+// #870 — the initial `debouncedBbox` seed must canonicalize to the WARMED
+// `-130,20,-65,52` key, not the cold `-129`/`-125` key, so that any code path
+// which fetches off the seed before the map's first `idle` settles mints the
+// key the cache-warmer already warmed (a HIT), never the legacy `-129` (a MISS).
+//
+// The legacy seed `[-125, 24, -66, 50]` canonicalized to `-129.00,...` at the
+// initial aggregated zoom (3) — a latent foot-gun. Seeding from the geo
+// `CONUS_BOUNDS` (`[-130, 20, -65, 52]`) instead makes the seed land on the
+// warmed key. These are pure assertions on the exported constants; no React
+// render is needed.
+describe('#870 initial bbox seed canonicalizes to the warmed CONUS key', () => {
+  it('seeds the initial aggregated zoom at 3 (the pre-settle, aggregated-mode zoom)', () => {
+    expect(INITIAL_ZOOM_SEED).toBe(3);
+  });
+
+  it('the seed canonicalizes to the SAME key as CONUS_BOUNDS at the seed zoom', () => {
+    // The load-bearing assertion: at the actual pre-settle zoom the seed is sent
+    // with, the seed and the warmed CONUS envelope produce one identical key.
+    expect(canonicalFetchBboxParam(INITIAL_BBOX_SEED, INITIAL_ZOOM_SEED))
+      .toBe(canonicalFetchBboxParam(CONUS_BOUNDS, INITIAL_ZOOM_SEED));
+  });
+
+  it('that shared key is exactly the warmed `-130.00,20.00,-65.00,52.00`', () => {
+    expect(canonicalFetchBboxParam(INITIAL_BBOX_SEED, INITIAL_ZOOM_SEED))
+      .toBe('-130.00,20.00,-65.00,52.00');
+  });
+
+  it('rejects the legacy `[-125, 24, -66, 50]` seed (which minted the cold -129 key)', () => {
+    // Regression guard: prove the legacy seed really did diverge at the seed
+    // zoom, so this test would have caught the foot-gun before it was fixed.
+    const legacySeed: [number, number, number, number] = [-125, 24, -66, 50];
+    expect(canonicalFetchBboxParam(legacySeed, INITIAL_ZOOM_SEED))
+      .toBe('-129.00,20.00,-65.00,52.00');
+    expect(canonicalFetchBboxParam(INITIAL_BBOX_SEED, INITIAL_ZOOM_SEED))
+      .not.toBe(canonicalFetchBboxParam(legacySeed, INITIAL_ZOOM_SEED));
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
+// #870 — the canonical-key CONUS envelope (`[-130, 20, -65, 52]`) shared with
+// the cache-warmer. Aliased because App keeps a separate MapLibre-shaped
+// `CONUS_BOUNDS` (nested `[[w,s],[e,n]]`) for the camera below; this flat geo
+// one seeds the initial `/api/observations` bbox so it lands on the warmed key.
+import { CONUS_BOUNDS as GEO_CONUS_BOUNDS } from '@bird-watch/geo';
 import { analytics } from './analytics.js';
 import { ApiClient, ApiError } from './api/client.js';
 import { useUrlState, DEFAULTS } from './state/url-state.js';
@@ -52,6 +57,37 @@ const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? 
  * chunk into the entry bundle just to read a constant.
  */
 const CONUS_BOUNDS: [[number, number], [number, number]] = [[-130, 20], [-65, 52]];
+
+/**
+ * #870 — the initial `debouncedBbox` seed for the first `/api/observations`
+ * call, flat `[west, south, east, north]`. It is the SAME canonical-key CONUS
+ * envelope the cache-warmer warms (`CONUS_BOUNDS` in `@bird-watch/geo`,
+ * `[-130, 20, -65, 52]`), and the same envelope the map inits/clamps at (the
+ * MapLibre nested-pair `CONUS_BOUNDS` above). Sourcing it from the geo constant
+ * (rather than re-typing the literal) makes the seed canonicalize to the WARMED
+ * `-130.00,20.00,-65.00,52.00` key at the initial aggregated zoom
+ * (`INITIAL_ZOOM_SEED` = 3), so no pre-settle request can ever mint the cold
+ * `-129`/`-125` key.
+ *
+ * Replaces the legacy `DEFAULT_BBOX_CONUS = [-125, 24, -66, 50]` seed, which
+ * canonicalized to the cold `-129` key at z3 — a latent foot-gun for any future
+ * code path that fetches off `debouncedBbox` before the map's first `idle`. The
+ * map fires `idle` shortly after mount with the actual fitted bounds, which then
+ * drives the bbox state via `onViewportChange` below. Exported (with
+ * `INITIAL_ZOOM_SEED`) so App.seed.test.ts can assert the canonical-key landing.
+ */
+export const INITIAL_BBOX_SEED: [number, number, number, number] = [...GEO_CONUS_BOUNDS];
+
+/**
+ * #870/#627 — the zoom seeded alongside `INITIAL_BBOX_SEED`. Mirrors MapCanvas's
+ * CONUS framing (zoom 3 narrow / 4 desktop). The actual map reports a real value
+ * on first `idle`; meanwhile 3 keeps the very first `/api/observations` call in
+ * aggregated mode (`zoom < 6` → the canonical-key path), so it never pulls the
+ * full CONUS observation set on cold start AND it collides on the warmed
+ * canonical key. (At z4 the legacy seed also collapsed to `-130`, but z3 is the
+ * actual pre-settle zoom and is where the legacy seed diverged to `-129`.)
+ */
+export const INITIAL_ZOOM_SEED = 3;
 
 /**
  * #847 — the zoom seeded alongside the scope-envelope bbox on a scope change
@@ -288,17 +324,18 @@ export function App() {
     (state.speciesCode ? 1 : 0) +
     (state.familyCode ? 1 : 0);
   // CONUS bbox [west, south, east, north] — initial-mount default for
-  // /api/observations. Matches MapCanvas's CONUS_LONGITUDE/CONUS_LATITUDE
-  // initial view (zoom 3–4 framing); the map fires `idle` shortly after
-  // mount with the actual fitted bounds, which then drives the bbox state
-  // via `onViewportChange` below.
-  const DEFAULT_BBOX_CONUS: [number, number, number, number] = [-125, 24, -66, 50];
-  const [debouncedBbox, setDebouncedBbox] = useState<[number, number, number, number]>(DEFAULT_BBOX_CONUS);
+  // /api/observations. #870: seeded from `INITIAL_BBOX_SEED` (the geo
+  // `CONUS_BOUNDS` envelope) so it canonicalizes to the WARMED `-130` key, not
+  // the legacy `-129`. Matches MapCanvas's CONUS framing; the map fires `idle`
+  // shortly after mount with the actual fitted bounds, which then drives the
+  // bbox state via `onViewportChange` below.
+  const [debouncedBbox, setDebouncedBbox] = useState<[number, number, number, number]>(INITIAL_BBOX_SEED);
   // Initial zoom mirrors MapCanvas's CONUS framing (zoom 3 narrow / 4 desktop).
   // The actual map reports a real value on first `idle`; meanwhile we send
-  // 3 so the very first /api/observations call hits aggregated mode and never
-  // pulls the full CONUS observation set on cold start. Issue #627.
-  const [debouncedZoom, setDebouncedZoom] = useState<number>(3);
+  // 3 (`INITIAL_ZOOM_SEED`) so the very first /api/observations call hits
+  // aggregated mode and never pulls the full CONUS observation set on cold
+  // start. Issue #627.
+  const [debouncedZoom, setDebouncedZoom] = useState<number>(INITIAL_ZOOM_SEED);
 
   // hotspots intentionally fetched but unused — cheap insurance for v2
   // hotspot-marker layer (Plan 7 decision 5, docs/plans/2026-04-22-plan-7-map-v1.md).
@@ -307,7 +344,7 @@ export function App() {
   // observation set on every map load. The bbox is held in a debounced
   // state (250ms) below; the value passed here is the debounced one so
   // continuous panning doesn't hammer the API. Initial value frames CONUS
-  // (`DEFAULT_BBOX_CONUS`) rather than `undefined` — passing `undefined`
+  // (`INITIAL_BBOX_SEED`) rather than `undefined` — passing `undefined`
   // would degrade to a full-region fetch on first paint, exactly the
   // failure mode this wiring exists to prevent.
   // Issue #720: split loading into hotspots- vs observations-specific flags

--- a/infra/terraform/cache-rule.tf
+++ b/infra/terraform/cache-rule.tf
@@ -4,7 +4,7 @@
 # Cloudflare's default cache key already includes the full URI with query
 # string, so we only need `ignore_query_strings_order` here. Both ttl modes
 # use `respect_origin` so the origin's `Cache-Control` (e.g. observations'
-# `public, s-maxage=1800, stale-while-revalidate=1800` since #868) is the
+# `public, s-maxage=2400, stale-while-revalidate=2400` since #870) is the
 # single source of truth for TTLs.
 #
 # The expression mirrors infra/terraform/rate-limit.tf exactly — same scope,

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -98,7 +98,7 @@ describe('GET /api/observations', () => {
     const res = await app.request(`/api/observations?since=14d&bbox=${BBOX_AZ}`);
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control'))
-      .toBe('public, s-maxage=1800, stale-while-revalidate=1800');
+      .toBe('public, s-maxage=2400, stale-while-revalidate=2400');
     const body = await res.json() as ObsEnvelope;
     // Only S1 falls within 14d (S2 is 20d old).
     expect(body.data).toHaveLength(1);
@@ -541,14 +541,14 @@ describe('GET /api/observations', () => {
       expect(res.status).toBe(400);
     });
 
-    it('preserves the s-maxage=1800 cache header when bbox present', async () => {
+    it('preserves the s-maxage=2400 cache header when bbox present', async () => {
       const app = createApp({ pool: db.pool });
       const res = await app.request(
         '/api/observations?bbox=-112,31,-110,33'
       );
       expect(res.status).toBe(200);
       expect(res.headers.get('cache-control'))
-        .toBe('public, s-maxage=1800, stale-while-revalidate=1800');
+        .toBe('public, s-maxage=2400, stale-while-revalidate=2400');
     });
   });
 
@@ -722,12 +722,13 @@ describe('GET /api/observations', () => {
     it('(f) ?state= request rides the shared observations cache header (#734 B7)', async () => {
       // #734 B7 — `?state=` rides the existing full-URL cache key exactly like
       // `?bbox=`. The observations TTL is the shared cache-headers.ts value
-      // (raised to s-maxage=1800/SWR=1800 in #868); `?state=` does not special-case it.
+      // (raised to s-maxage=1800/SWR=1800 in #868, then 2400/2400 in #870);
+      // `?state=` does not special-case it.
       const app = createApp({ pool: db.pool });
       const res = await app.request('/api/observations?state=US-AZ');
       expect(res.status).toBe(200);
       expect(res.headers.get('cache-control'))
-        .toBe('public, s-maxage=1800, stale-while-revalidate=1800');
+        .toBe('public, s-maxage=2400, stale-while-revalidate=2400');
     });
 
     // Restore the canonical S1/S2 fixture for any later describe that assumes

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -176,14 +176,14 @@ export function createApp(deps: AppDeps): Hono {
     // #734 (plan task B7) — `?state=` rides the existing full-URL cache key
     // exactly like `?bbox=`, so no cache-headers.ts change is needed: a
     // `?state=` observations response rides the shared observations TTL
-    // (s-maxage=1800/SWR=1800 since #868; asserted in app.test.ts B5 case (f)).
-    // No new Endpoint value, no Vary change.
+    // (s-maxage=2400/SWR=2400 since #870, raised from 1800/1800 in #868;
+    // asserted in app.test.ts B5 case (f)). No new Endpoint value, no Vary change.
 
     // #619 — optional viewport-bbox filter, Phase 2 going-national
     // pre-condition. Format: bbox=minLon,minLat,maxLon,maxLat (EPSG:4326).
     // Backward-compatible: no bbox param → full set unchanged. The bbox
     // becomes part of the canonical URL so Cloudflare caches per-bbox under
-    // the shared observations TTL (s-maxage=1800/SWR=1800 since #868).
+    // the shared observations TTL (s-maxage=2400/SWR=2400 since #870).
     const bboxRaw = c.req.query('bbox');
     let bbox: [number, number, number, number] | undefined;
     if (bboxRaw !== undefined) {

--- a/services/read-api/src/cache-headers.test.ts
+++ b/services/read-api/src/cache-headers.test.ts
@@ -10,17 +10,21 @@ describe('cacheControlFor', () => {
   // and lets the CDN serve stale-while-revalidate windows without hammering
   // Cloud Run / Neon. Browsers are not asked to hold stale copies.
 
-  it('returns a 30-min s-maxage with equal SWR for /observations (#868 Lever 3)', () => {
-    // #868 — raised from s-maxage=300/SWR=600 to 1800/1800 so a warmed/organic
-    // canonical key stays fresh from t+2min through the next ~30-min ingest tick
-    // (there is no ingest cache-purge, so the prior 5-min window left keys cold
-    // ~13min of every 30-min cycle → the warmer measured hit=0/run). Response
-    // bodies are viewport-independent for a given canonical key
-    // (meta.freshestObservationAt is a whole-table MAX), so two devices on one
-    // key get byte-identical bodies. Accepted ~30-min staleness (0.15% of the
-    // 14-day window) is a logged product call.
+  it('returns a 40-min s-maxage with equal SWR for /observations (#870 freshness margin)', () => {
+    // #868 raised this from s-maxage=300/SWR=600 to 1800/1800. #870 raises it
+    // again 1800→2400: `s-maxage=1800` exactly EQUALS the 30-min warm cadence,
+    // so a warmed object reaches its TTL boundary right as the cycle ends — real
+    // cold-loads late in a cycle hit a just-expired object and stale-serve
+    // (`EXPIRED`) instead of a clean HIT (the #869 prod validation caught this on
+    // the *correct* `-130` key). `2400s (40 min) > 1800s (30-min cadence)` gives
+    // a ~10-min margin so a warmed/organic object stays fresh through the whole
+    // cycle until the next warm refreshes it. Response bodies are
+    // viewport-independent for a given canonical key (meta.freshestObservationAt
+    // is a whole-table MAX), so two devices on one key get byte-identical bodies.
+    // Accepted ~40-min edge staleness (0.2% of the 14-day window) is a logged
+    // product call (#868/#870 staleness decision).
     expect(cacheControlFor('observations'))
-      .toBe('public, s-maxage=1800, stale-while-revalidate=1800');
+      .toBe('public, s-maxage=2400, stale-while-revalidate=2400');
   });
 
   it('returns medium s-maxage with 2× SWR for /hotspots (~10min freshness)', () => {

--- a/services/read-api/src/cache-headers.ts
+++ b/services/read-api/src/cache-headers.ts
@@ -15,16 +15,21 @@ export type Endpoint = 'observations' | 'hotspots' | 'species' | 'species-dict' 
 // rarely, and was already long-cached on both browser + CDN via `max-age`.
 const TABLE: Record<Endpoint, string> = {
   // Freshest surface — observation rows roll forward every ingest cycle
-  // (~30min). #868 raised this from 300/600 to a 30min CDN window + equal SWR
-  // to cover the full ingest cadence. There is NO ingest cache-purge
-  // (run-ingest.ts issues zero CF purge calls), so the prior 5min window left
-  // warmed/organic keys cold ~13min of every 30min cycle — which is why the
-  // warmer measured hit=0/run. 1800/1800 keeps a key fresh from t+2min through
-  // the next ingest tick. Bodies are viewport-independent for a given canonical
-  // key (#868; meta.freshestObservationAt is a whole-table MAX), so co-keyed
-  // devices get byte-identical responses. The ~30min staleness on the displayed
-  // freshness (0.15% of the 14-day window) is an accepted product call.
-  observations: 'public, s-maxage=1800, stale-while-revalidate=1800',
+  // (~30min). #868 raised this from 300/600 to 1800/1800 to cover the full
+  // ingest cadence. There is NO ingest cache-purge (run-ingest.ts issues zero CF
+  // purge calls), so the cache lives on TTL alone.
+  // #870 raised it 1800→2400: `s-maxage=1800` exactly EQUALS the 30min warm
+  // cadence, so a warmed object hits its TTL boundary right as the cycle ends —
+  // a real cold-load late in a cycle lands on a just-expired object and
+  // stale-serves (`EXPIRED`) instead of a clean HIT (the #869 prod validation
+  // caught this on the *correct* `-130` key). `2400s (40min) > 1800s (30min
+  // cadence)` gives a ~10min margin so a warmed/organic object stays fresh
+  // through the whole cycle until the next warm refreshes it. Bodies are
+  // viewport-independent for a given canonical key (#868;
+  // meta.freshestObservationAt is a whole-table MAX), so co-keyed devices get
+  // byte-identical responses. The ~40min edge staleness (0.2% of the 14-day
+  // window) is an accepted product call (#868/#870 staleness decision).
+  observations: 'public, s-maxage=2400, stale-while-revalidate=2400',
   // Hotspot list shifts only on backfill — a 10min CDN window with 20min
   // SWR is conservative; the data is effectively static between rebuilds.
   hotspots:     'public, s-maxage=600, stale-while-revalidate=1200',


### PR DESCRIPTION
## Diagrams

Two independent levers on the `/api/observations` cache path, both surfaced by the #869 prod validation. Lever A widens the edge TTL so a warmed object survives the full warm cycle; Lever B seeds the frontend's first request on the *same* canonical key the warmer warms.

```mermaid
flowchart TB
    subgraph A["Lever A — read-api TTL (cadence boundary)"]
        warm["cache-warmer<br/>every 30 min"] -->|writes object| edge["CF edge object"]
        edge -->|"s-maxage=1800 == cadence<br/>→ EXPIRED at cycle end"| old["late-cycle cold load:<br/>stale-serve (MISS-ish)"]
        edge -->|"s-maxage=2400 (40 min)<br/>~10-min margin"| new["late-cycle cold load:<br/>clean HIT ✅"]
    end

    subgraph B["Lever B — frontend seed (canonical key)"]
        legacy["legacy DEFAULT_BBOX_CONUS<br/>[-125,24,-66,50]"] -->|"canonicalFetchBbox(_,3)"| cold["-129,20,-65,52<br/>(cold key → MISS)"]
        seed["INITIAL_BBOX_SEED = CONUS_BOUNDS<br/>[-130,20,-65,52] (from @bird-watch/geo)"] -->|"canonicalFetchBbox(_,3)"| warmkey["-130,20,-65,52<br/>(warmed key → HIT) ✅"]
    end
```

## Summary

- **Why (Lever A):** `s-maxage=1800` exactly equals the 30-min warm cadence, so a warmed object hits its TTL boundary right as the cycle ends — a real cold-load late in a cycle lands on a just-expired object and stale-serves (`EXPIRED`) instead of a clean HIT (what the #869 desktop probe caught on the *correct* `-130` key: a freshness-timing artifact, not a key mismatch). `2400s (40 min) > 1800s` gives a ~10-min margin so the object stays fresh through the whole cycle until the next warm refreshes it. Edge-staleness ceiling rises ~30→~40 min (0.2% of the 14-day window) — accepted per the #868/#870 staleness decision.
- **Why (Lever B):** the legacy `DEFAULT_BBOX_CONUS = [-125, 24, -66, 50]` seed canonicalized to the COLD `-129` key, not the warmed `-130`. It doesn't fire today (the map inits directly at CONUS_BOUNDS), but it's a latent foot-gun — any future path that fetches off the initial `debouncedBbox` before the map settles would mint `-129` and MISS. Seeding `debouncedBbox` from `@bird-watch/geo`'s `CONUS_BOUNDS` (imported, not re-typed) makes the seed canonicalize to the warmed `-130.00,20.00,-65.00,52.00` key.
- Lifts the seed + zoom to exported `INITIAL_BBOX_SEED` / `INITIAL_ZOOM_SEED` so a pure unit test asserts the canonical-key collision; also refreshes the now-stale `1800` comments (app.ts, cache-rule.tf) and the `state-scope.spec.ts` RED-on-main discriminator comments (`-129` → `-130`).

## Screenshots

National cold-load (`?scope=us`) driven live through Playwright MCP at all 5 canonical viewports × 2 themes. The map renders, the lede ("sightings") + family legend are present and counts are unchanged, and **every `/api/observations` request carried only the canonical `-130,20,-65,52` key — zero `-129`/`-125` requests** (verified across 16 requests over the full session). Console: zero errors (one benign MapLibre `_FALLBACK` sprite-timing transient at cold load, unrelated to this change — it touches neither sprite registration nor the silhouette fetch).

**No visible UI change** — this PR changes a fetch-bbox seed constant (`App.tsx`) and the read-api observations TTL; the rendered cold-load is byte-identical to `main` (same national view, same data, same chrome). The ≥10-screenshot multi-viewport QA is therefore **N/A — no visual delta to capture** (captures would be identical to `main`). Live UI verification was still performed (above) via Playwright MCP at all 5 canonical viewports × 2 themes, confirming the only behavioral change — that every `/api/observations` request now carries the canonical `-130,20,-65,52` key (zero `-129`/`-125`) — with correct render and zero console errors.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className added (logic + comment-only frontend change)`
- [x] Multi-viewport design QA: **N/A — no visible UI change** (seed-value + TTL change; render byte-identical to `main`). Playwright 5×2 UI verification performed above (only the `-130` request fires; zero console errors).

## Test plan

- [x] `npm run typecheck && npm run test` — green (frontend 1102, read-api 170)
- [x] New unit / integration tests added — `frontend/src/App.seed.test.ts` (4 cases: seed canonicalizes to the warmed key, exact `-130.00,…` string, z3 aggregated, legacy-`-129` regression guard); read-api cache-headers + app.test.ts TTL assertions updated to `2400`
- [x] New Playwright e2e spec added — N/A (no new user-visible behavior; the seed value change is covered by the unit test + the existing `state-scope.spec.ts` discriminator, comment-refreshed here)
- [x] `npm run build` — clean production build
- [x] (UI) Playwright MCP smoke — ran `npm run dev`, drove `?scope=us` national cold-load at 390×844 / 768×1024 / 1024×768 / 1440×900 / 1920×1080 × light+dark; `browser_console_messages` zero errors; network showed only the `-130` `/api/observations` key
- [x] `knip` — clean (only the pre-existing `2026-04-22-map-v1-prototype` configuration hint)

## Plan reference

Out of plan — perf follow-up to #869 (canonical cache keys, prod-validated 2026-06-05). Closes #870.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
