### PR TITLE
perf(read-api,frontend): collapse state-scope cache key + dedup in-flight obs fetches (#873 #874)

### DIFF
--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, STATES_FIXTURE } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
-import { canonicalFetchBbox, type Bbox } from '@bird-watch/geo';
+import { snapFetchBbox, type Bbox } from '@bird-watch/geo';
 
 /**
  * C9 (#741) — chooser-first scope IA: chooser landing, state-select, `?scope=us`
@@ -138,31 +138,34 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
    * envelope, so AFTER the fix the post-switch bbox matches within tol — RED on
    * main (CONUS seed), GREEN after fix.
    *
-   * #868 — `client.ts` now reconstructs a CANONICAL fetch bbox from the
-   * (snapped-midpoint, zoom) + a fixed per-zoom half-extent, clamped to
-   * CONUS_BOUNDS, so the reseed fetch carries `canonicalFetchBbox(envelope,
-   * seedZoom)`, NOT the raw or edge-snapped envelope. Compare against the
-   * CANONICAL envelope so the assertion tracks the real on-the-wire contract.
+   * #873 — for a STATE scope in the aggregated path (`zoom < 6`), `client.ts`
+   * now sends the state's FIXED envelope (`StateSummary.bbox`) snapped OUTWARD
+   * to the cache grid via `snapFetchBbox(envelope, seedZoom)` — NOT the
+   * center-varying `canonicalFetchBbox` of the viewport (that center-varying box
+   * was the 100%-MISS defect #873 fixes). So the reseed/settle fetch for a state
+   * now carries the snapped fixed envelope; assert against that. (Before #873
+   * this compared against `canonicalFetchBbox(envelope, seedZoom)`; the contract
+   * changed with the fixed-envelope key.)
    *
    * The RED-on-main / GREEN-after-fix discriminator is preserved: each state's
-   * canonical box is distinct from the CONUS cold-mount seed's canonical box
-   * (`canonicalFetchBbox(INITIAL_BBOX_SEED, 3) = -130,20,-65,52` since #870; was
-   * `-129,…` while the seed was the legacy `[-125,24,-66,50]`), which is what an
-   * UNPATCHED post-switch fetch carries. The state canonical boxes are
-   * AZ `-130,20,-78,52` / FL `-118,20,-65,52` / NY `-110,20,-65,52` — none equal
-   * the `-130,20,-65,52` CONUS-seed box (AZ shares only the W/S/N edges; its E
-   * edge -78 differs), so a missing reseed still fails this assertion.
-   * (`bboxIntersects` above stays a separate, weaker guard: the canonical box is
-   * a CONUS-clamped superset that always intersects the target state, which is
-   * what the server `?state=` ST_Intersects clip relies on for correctness.)
+   * snapped fixed envelope is distinct from the CONUS cold-mount seed's canonical
+   * box (`canonicalFetchBbox(INITIAL_BBOX_SEED, 3) = -130,20,-65,52`), which is
+   * what an UNPATCHED post-switch fetch carries. The state snapped envelopes are
+   * AZ `-115,31,-109,37` / FL `-88,24,-80,31` / NY `-80,40,-71,46` (each axis
+   * floored W/S, ceiled E/N to the z3 1.0° grid) — none equal the
+   * `-130,20,-65,52` CONUS-seed box, so a missing reseed/envelope still fails
+   * this assertion. (`bboxIntersects` above stays a separate, weaker guard: the
+   * state envelope always intersects the target state, which is what the server
+   * `?state=` ST_Intersects clip relies on for correctness.)
    */
   function bboxMatchesEnvelope(
     bbox: [number, number, number, number],
     envelope: [number, number, number, number],
     tol = 0.5,
   ): boolean {
-    const canonical = canonicalFetchBbox(envelope as Bbox, AGGREGATED_SEED_ZOOM);
-    return bbox.every((v, i) => Math.abs(v - canonical[i]) <= tol);
+    // #873 — state scopes transmit the fixed envelope snapped to the grid.
+    const expected = snapFetchBbox(envelope as Bbox, AGGREGATED_SEED_ZOOM);
+    return bbox.every((v, i) => Math.abs(v - expected[i]) <= tol);
   }
 
   /** Pull the bbox off the LAST /api/observations request carrying `state`. */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -376,6 +376,32 @@ export function App() {
   // server clips via ST_Intersects). UNSCOPED and `?scope=us` both leave
   // `stateCode` unset, so the backend stays untouched (data invariant, #735).
   const scopeStateCode = state.scope.kind === 'state' ? state.scope.stateCode : undefined;
+
+  // #740 (C6) — the CONUS state name + envelope table (#732/#748). Drives the
+  // chooser/control `<select>` display names AND the per-state camera
+  // `fitBounds`/`maxBounds` envelope. Cached for the tab lifetime (see
+  // useStates). Threaded into regionLabelFor (state name) below.
+  // #758: `error` is threaded into <ScopeChooser> so a terminal /api/states
+  // outage shows an honest "Couldn't load states" placeholder instead of a
+  // perpetual "Loading states…" — on failure `statesLoading` flips false but
+  // `states` stays empty, so the loading copy would otherwise stick forever.
+  // (Hoisted above useBirdData so #873 can thread the active state's fixed
+  // envelope into the observations filters; useStates depends only on the
+  // apiClient, so the hoist is order-independent.)
+  const { states, loading: statesLoading, error: statesError } = useStates(apiClient);
+
+  // #873 — the active state's FIXED bounding envelope (`StateSummary.bbox`),
+  // looked up from the cached `/api/states` table. Threaded into the
+  // observations filters so the client can collapse every viewport/pan of a
+  // state to ONE cache key in the aggregated path (see client.ts getObservations
+  // / ObservationFilters.stateBbox). `undefined` until the states table has
+  // loaded OR when not state-scoped — the client falls back to the canonical
+  // viewport key in that window.
+  const scopeStateBbox = useMemo<[number, number, number, number] | undefined>(() => {
+    if (!scopeStateCode) return undefined;
+    return states.find(s => s.stateCode === scopeStateCode)?.bbox;
+  }, [scopeStateCode, states]);
+
   const { loading, observationsLoading, error, observations, buckets, mode, refetch } = useBirdData(
     apiClient,
     {
@@ -384,6 +410,7 @@ export function App() {
       ...(state.speciesCode ? { speciesCode: state.speciesCode } : {}),
       ...(state.familyCode ? { familyCode: state.familyCode } : {}),
       ...(scopeStateCode ? { stateCode: scopeStateCode } : {}),
+      ...(scopeStateBbox ? { stateBbox: scopeStateBbox } : {}),
       bbox: debouncedBbox,
       zoom: debouncedZoom,
     },
@@ -406,16 +433,6 @@ export function App() {
     if (!scopeActive) return;
     prefetchMapCanvas();
   }, [scopeActive]);
-
-  // #740 (C6) — the CONUS state name + envelope table (#732/#748). Drives the
-  // chooser/control `<select>` display names AND the per-state camera
-  // `fitBounds`/`maxBounds` envelope. Cached for the tab lifetime (see
-  // useStates). Threaded into regionLabelFor (state name) below.
-  // #758: `error` is threaded into <ScopeChooser> so a terminal /api/states
-  // outage shows an honest "Couldn't load states" placeholder instead of a
-  // perpetual "Loading states…" — on failure `statesLoading` flips false but
-  // `states` stays empty, so the loading copy would otherwise stick forever.
-  const { states, loading: statesLoading, error: statesError } = useStates(apiClient);
 
   // #859: in aggregated mode the per-observation array is empty, so the family
   // filter options derive from the buckets' families instead (the species

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -99,6 +99,93 @@ describe('ApiClient', () => {
     expect(call[0]).toContain('state=US-AZ');
   });
 
+  // ── #873 — state-scope FIXED-ENVELOPE cache key (aggregated path) ──────────
+  //
+  // Before #873 a state-scoped aggregated request transmitted the canonical
+  // CONUS-centered box reconstructed from the *viewport* midpoint, so every
+  // state and every pan minted a NEW Cloudflare key (100% MISS, 12-14s CONUS
+  // scans). After #873, when a fixed state envelope is known we send THAT
+  // envelope (snapped outward to the cache grid) as the bbox in aggregated mode
+  // — so all viewports of a state collapse to ONE key per (state, zoom, filters)
+  // and the origin query is state-tight. The ST_Intersects state clip makes the
+  // response viewport-independent, so the frontend's viewport bucket-clip keeps
+  // render byte-identical. Scoped to zoom < 6 ONLY (the zoom >= 6 10k-truncation
+  // brake stays untouched, exactly as #868/#869).
+
+  it('sends the FIXED state envelope (snapped) as bbox when state-scoped at zoom < 6 (#873)', async () => {
+    const envelope = JSON.stringify({ data: [], meta: { freshestObservationAt: null } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    // California's fixed envelope (StateSummary.bbox). The VIEWPORT bbox below is
+    // an off-center pan inside CA — pre-#873 it would canonicalize to a
+    // CONUS-centered box; post-#873 the bbox === the snapped CA envelope.
+    await client.getObservations({
+      stateCode: 'US-CA',
+      stateBbox: [-124.41, 32.53, -114.13, 42.01],
+      bbox: [-122.5, 36.8, -120.1, 38.9],
+      zoom: 5,
+    });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    const got = new URL(call[0], 'http://x').searchParams.get('bbox');
+    // snapFetchBbox at z5 (0.25° step): floor W/S, ceil E/N →
+    // [-124.50, 32.50, -114.00, 42.25].
+    expect(got).toBe('-124.50,32.50,-114.00,42.25');
+    expect(call[0]).toContain('state=US-CA');
+  });
+
+  it('collapses two different viewport pans of the SAME state to ONE bbox key at zoom < 6 (#873)', async () => {
+    const envelope = JSON.stringify({ data: [], meta: { freshestObservationAt: null } });
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response(envelope, { status: 200 }))
+      .mockResolvedValueOnce(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    const stateBbox: [number, number, number, number] = [-106.65, 25.84, -93.51, 36.5]; // TX
+    // Two genuinely different viewport pans within Texas at z5.
+    await client.getObservations({ stateCode: 'US-TX', stateBbox, bbox: [-100, 30, -97, 32], zoom: 5 });
+    await client.getObservations({ stateCode: 'US-TX', stateBbox, bbox: [-103, 28, -99, 31], zoom: 5 });
+    const calls = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls;
+    const bbox = (u: string) => new URL(u, 'http://x').searchParams.get('bbox');
+    expect(bbox(calls[0]![0])).toBe(bbox(calls[1]![0]));
+  });
+
+  it('does NOT apply the fixed envelope at zoom >= 6 — viewport bbox passes through (state-scoped, #873)', async () => {
+    const envelope = JSON.stringify({
+      mode: 'observations', data: [], meta: { freshestObservationAt: null },
+    });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    // zoom >= 6: the 10k-truncation brake (observations.ts:241) relies on the
+    // viewport bbox narrowing a dense state — the fixed envelope must NOT apply.
+    await client.getObservations({
+      stateCode: 'US-CA',
+      stateBbox: [-124.41, 32.53, -114.13, 42.01],
+      bbox: [-118.241, 33.998, -117.237, 34.5],
+      zoom: 7,
+    });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    const got = new URL(call[0], 'http://x').searchParams.get('bbox');
+    // Passthrough of the VIEWPORT bbox (canonical serializer only, no envelope).
+    expect(got).toBe('-118.24,34.00,-117.24,34.50');
+  });
+
+  it('falls back to the canonical viewport key when state-scoped but no stateBbox is known (#873)', async () => {
+    // The states table may not be loaded yet on the very first scoped paint;
+    // without a fixed envelope we keep the prior canonical-viewport behavior
+    // rather than dropping the bbox (correctness floor).
+    const envelope = JSON.stringify({ data: [], meta: { freshestObservationAt: null } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(envelope, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getObservations({
+      stateCode: 'US-CA',
+      bbox: [-118.241, 33.998, -107.237, 40.051],
+      zoom: 5,
+    });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    const got = new URL(call[0], 'http://x').searchParams.get('bbox');
+    // Same canonical box the pre-#873 path produced for this viewport at z5.
+    expect(got).toBe('-130.00,24.75,-90.50,49.25');
+  });
+
   it('sends NO ?state= for unscoped/whole-US queries (data invariant, #735)', async () => {
     // Both the unscoped landing and the explicit ?scope=us escape hatch leave
     // ObservationFilters.stateCode unset, so the backend stays byte-for-byte
@@ -228,6 +315,100 @@ describe('ApiClient', () => {
       expect(apiErr.status).toBe(503);
       expect(apiErr.body).toBe('internal database pool exhausted');
     }
+  });
+
+  // ── #874 — in-flight /api/observations dedup + cancellation ────────────────
+  //
+  // `getObservations` is the single network boundary every caller funnels
+  // through. During a rapid scope/pan change (CA→NV→TX) several fetches fire in
+  // quick succession; without dedup all of them hit the network and the late
+  // (settle) one can resolve AFTER an earlier one, racing the rendered state.
+  // #874 adds (1) supersede-cancel — a new /api/observations aborts the prior
+  // in-flight one (passing an AbortSignal to fetch); and (2) concurrent-key
+  // coalesce — a byte-identical request already in flight returns the SHARED
+  // promise instead of issuing a second network call. The #849 reseed is NOT
+  // touched.
+
+  /** A fetch mock whose Responses resolve only when we say so. */
+  function deferredFetch() {
+    const resolvers: Array<(r: Response) => void> = [];
+    const calls: { url: string; signal: AbortSignal | undefined }[] = [];
+    const fn = vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, signal: init?.signal ?? undefined });
+      return new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        if (signal) {
+          signal.addEventListener('abort', () =>
+            reject(signal.reason ?? new DOMException('Aborted', 'AbortError')),
+          );
+        }
+        resolvers.push(resolve);
+      });
+    });
+    return { fn, resolvers, calls };
+  }
+  const okBody = () =>
+    new Response(JSON.stringify({ data: [], meta: { freshestObservationAt: null } }), { status: 200 });
+
+  it('passes an AbortSignal to fetch for /api/observations (#874)', async () => {
+    const d = deferredFetch();
+    vi.spyOn(global, 'fetch').mockImplementation(d.fn as unknown as typeof fetch);
+    const client = new ApiClient({ baseUrl: '' });
+    const p = client.getObservations({ stateCode: 'US-AZ' });
+    expect(d.calls[0]!.signal).toBeInstanceOf(AbortSignal);
+    d.resolvers[0]!(okBody());
+    await p;
+  });
+
+  it('aborts the prior in-flight /api/observations when a new one supersedes it (#874)', async () => {
+    const d = deferredFetch();
+    vi.spyOn(global, 'fetch').mockImplementation(d.fn as unknown as typeof fetch);
+    const client = new ApiClient({ baseUrl: '' });
+    // Three rapid scope changes (CA → NV → TX), none resolved yet.
+    const pCA = client.getObservations({ stateCode: 'US-CA' });
+    const pNV = client.getObservations({ stateCode: 'US-NV' });
+    const pTX = client.getObservations({ stateCode: 'US-TX' });
+    // The two superseded promises reject with AbortError.
+    await expect(pCA).rejects.toMatchObject({ name: 'AbortError' });
+    await expect(pNV).rejects.toMatchObject({ name: 'AbortError' });
+    // Their underlying fetch signals are aborted; only the latest stays live.
+    expect(d.calls[0]!.signal!.aborted).toBe(true);
+    expect(d.calls[1]!.signal!.aborted).toBe(true);
+    expect(d.calls[2]!.signal!.aborted).toBe(false);
+    // The latest resolves normally.
+    d.resolvers[2]!(okBody());
+    await expect(pTX).resolves.toMatchObject({ mode: 'observations' });
+  });
+
+  it('coalesces a concurrent byte-identical /api/observations into ONE network call (#874)', async () => {
+    const d = deferredFetch();
+    vi.spyOn(global, 'fetch').mockImplementation(d.fn as unknown as typeof fetch);
+    const client = new ApiClient({ baseUrl: '' });
+    const f = { stateCode: 'US-AZ', bbox: [-114.82, 31.33, -109.05, 37.0] as [number, number, number, number], zoom: 5 };
+    const p1 = client.getObservations(f);
+    const p2 = client.getObservations({ ...f });
+    // Only ONE underlying network call despite two getObservations() invocations.
+    expect(d.fn).toHaveBeenCalledTimes(1);
+    d.resolvers[0]!(okBody());
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual(r2);
+  });
+
+  it('does NOT abort a different concurrent endpoint (getHotspots) (#874)', async () => {
+    const d = deferredFetch();
+    vi.spyOn(global, 'fetch').mockImplementation(d.fn as unknown as typeof fetch);
+    const client = new ApiClient({ baseUrl: '' });
+    const pHot = client.getHotspots();
+    // A superseding observations fetch must not abort the unrelated hotspots one.
+    const pObs1 = client.getObservations({ stateCode: 'US-CA' });
+    const pObs2 = client.getObservations({ stateCode: 'US-NV' });
+    await expect(pObs1).rejects.toMatchObject({ name: 'AbortError' });
+    // hotspots call (index 0) was never aborted.
+    expect(d.calls[0]!.url).toContain('/api/hotspots');
+    expect(d.calls[0]!.signal?.aborted ?? false).toBe(false);
+    d.resolvers[0]!(new Response(JSON.stringify([]), { status: 200 }));
+    d.resolvers[2]!(okBody());
+    await Promise.all([pHot, pObs2]);
   });
 
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,7 @@ import type {
   Hotspot, Observation, ObservationsResponse, SpeciesMeta, ObservationFilters,
   FamilySilhouette, StateSummary, SpeciesDictEntry,
 } from '@bird-watch/shared-types';
-import { canonicalFetchBboxParam, serializeBbox } from '@bird-watch/geo';
+import { canonicalFetchBboxParam, serializeBbox, snapFetchBboxParam } from '@bird-watch/geo';
 
 export interface ApiClientOptions {
   baseUrl?: string;
@@ -16,6 +16,24 @@ export class ApiError extends Error {
 
 export class ApiClient {
   private readonly baseUrl: string;
+
+  // #874 — in-flight /api/observations dedup + cancellation. Rapid scope/pan
+  // changes (CA→NV→TX) fire several observations fetches in quick succession;
+  // without this a superseded fetch keeps running (wasted origin work, and the
+  // late one can resolve AFTER an earlier one and race the rendered state), and
+  // a byte-identical concurrent request issues a redundant second network call.
+  //
+  //  - `observationsInFlight` tracks the CURRENTLY-live observations request:
+  //    its full request key, its AbortController (so a superseding fetch can
+  //    cancel it), and the shared promise (so a concurrent byte-identical key
+  //    coalesces onto it instead of hitting the network again).
+  //
+  // Scoped to /api/observations ONLY — other endpoints (hotspots, states,
+  // species, silhouettes) are immutable/idempotent and never superseded, so
+  // they keep the plain `get<T>` path with no signal.
+  private observationsInFlight:
+    | { key: string; controller: AbortController; promise: Promise<ObservationsResponse> }
+    | null = null;
 
   constructor(opts: ApiClientOptions = {}) {
     this.baseUrl = opts.baseUrl ?? '';
@@ -48,9 +66,30 @@ export class ApiClient {
       // filterBucketsByBounds(buckets, viewportBounds) against the RAW map bounds
       // (App.tsx, frontend/src/lib/viewport-filter.ts) — the canonical superset's
       // extra buckets fall outside viewportBounds and are clipped before counting.
-      const bboxParam = f.zoom !== undefined
-        ? canonicalFetchBboxParam(f.bbox, f.zoom)
-        : serializeBbox(f.bbox);
+      //
+      // #873 — STATE-SCOPE FIXED ENVELOPE (aggregated path only). When a state is
+      // scoped AND we know its fixed envelope (`stateBbox` from /api/states) AND
+      // we're in aggregated mode (`zoom < 6`), send the state's FIXED envelope
+      // (snapped outward to the cache grid) instead of the center-varying
+      // canonical viewport box. Every viewport/pan of a state then collapses to
+      // ONE Cloudflare key per (state, zoom, filters) → CF HIT after the first
+      // load (and warmable), and the origin query becomes state-tight (killing
+      // the 12-14s CONUS scan-then-clip). Render is unchanged: the server already
+      // clips the result to the state polygon via ST_Intersects (response is
+      // viewport-independent), and the frontend clips display to the viewport via
+      // filterBucketsByBounds. STRICTLY zoom < 6 — at zoom >= 6 the per-obs path
+      // applies a 10k-row truncation brake (observations.ts:241) that relies on
+      // the viewport bbox narrowing a dense state; substituting the whole-state
+      // envelope there would flip `truncated:true` and change what renders. So we
+      // mirror #868/#869 and touch only the aggregated branch.
+      const useStateEnvelope =
+        f.stateCode !== undefined && f.stateBbox !== undefined &&
+        f.zoom !== undefined && f.zoom < 6;
+      const bboxParam = useStateEnvelope
+        ? snapFetchBboxParam(f.stateBbox!, f.zoom!)
+        : f.zoom !== undefined
+          ? canonicalFetchBboxParam(f.bbox, f.zoom)
+          : serializeBbox(f.bbox);
       url.searchParams.set('bbox', bboxParam);
     }
     if (f.zoom !== undefined) url.searchParams.set('zoom', String(f.zoom));
@@ -59,22 +98,57 @@ export class ApiClient {
     // `stateCode` unset, so the backend stays byte-for-byte untouched (no
     // `?state=` ⇒ unclipped national query, locked decision #4).
     if (f.stateCode) url.searchParams.set('state', f.stateCode);
-    // Tolerate two shapes — (a) { data, meta } without `mode` (post-#456,
-    // pre-#627) and (b) the discriminated union (#627) — normalizing both to the
-    // discriminated union so callers can switch on `mode` unconditionally.
-    //
-    // The bare-Observation[] branch (pre-#456) was REMOVED in #830 (item B,
-    // Remedy 1): the live read-api never returns a bare array, and that branch
-    // was the only path that could yield non-empty `data` with a fabricated
-    // `freshestObservationAt: null`. Keeping the normalization is still correct
-    // defensive hygiene. (The licensing invariant that #830 tied to the freshness
-    // label changed under #828: the always-visible eBird credit now lives in the
-    // bottom-right .map-attribution corner, gated on map-visible rather than on a
-    // freshness label, so the deleted deriveFreshness path no longer gates it.)
+
+    const key = url.pathname + url.search;
+
+    // #874 — coalesce a concurrent byte-identical request onto the in-flight
+    // promise (no second network call). The key is the full path+search, so two
+    // invocations with identical filters share one fetch; a different key falls
+    // through to supersede-cancel below.
+    if (this.observationsInFlight && this.observationsInFlight.key === key) {
+      return this.observationsInFlight.promise;
+    }
+
+    // #874 — supersede-cancel: a NEW, distinct observations request aborts the
+    // prior in-flight one (rapid scope/pan change). The aborted promise rejects
+    // with a DOMException `AbortError`; callers (use-bird-data.ts) ignore that
+    // name so a deliberately-cancelled fetch never surfaces as a UI error.
+    this.observationsInFlight?.controller.abort();
+
+    const controller = new AbortController();
+    const promise = this.fetchObservations(key, controller.signal)
+      .finally(() => {
+        // Clear the slot only if it still points at THIS request — a later
+        // supersede may have already replaced it.
+        if (this.observationsInFlight?.controller === controller) {
+          this.observationsInFlight = null;
+        }
+      });
+    this.observationsInFlight = { key, controller, promise };
+    return promise;
+  }
+
+  /**
+   * #874 — the single network leg for /api/observations, isolated so the dedup
+   * bookkeeping in `getObservations` stays readable. Passes the abort `signal`
+   * to `fetch` and normalizes the (legacy | discriminated) envelope.
+   *
+   * Tolerates two shapes — (a) `{ data, meta }` without `mode` (post-#456,
+   * pre-#627) and (b) the discriminated union (#627) — normalizing both to the
+   * discriminated union so callers can switch on `mode` unconditionally.
+   *
+   * The bare-Observation[] branch (pre-#456) was REMOVED in #830 (item B,
+   * Remedy 1): the live read-api never returns a bare array, and that branch
+   * was the only path that could yield non-empty `data` with a fabricated
+   * `freshestObservationAt: null`. Keeping the normalization is still correct
+   * defensive hygiene.
+   */
+  private async fetchObservations(
+    path: string,
+    signal: AbortSignal,
+  ): Promise<ObservationsResponse> {
     type LegacyEnvelope = { data: Observation[]; meta: { freshestObservationAt: string | null } };
-    const raw = await this.get<ObservationsResponse | LegacyEnvelope>(
-      url.pathname + url.search,
-    );
+    const raw = await this.get<ObservationsResponse | LegacyEnvelope>(path, signal);
     if (!('mode' in raw)) {
       return { mode: 'observations', data: raw.data, meta: raw.meta };
     }
@@ -108,9 +182,12 @@ export class ApiClient {
     return this.get<StateSummary[]>('/api/states');
   }
 
-  private async get<T>(path: string): Promise<T> {
+  private async get<T>(path: string, signal?: AbortSignal): Promise<T> {
     const url = `${this.baseUrl}${path}`;
-    const res = await fetch(url, { method: 'GET' });
+    // `RequestInit.signal` is `AbortSignal | null`; only attach the property
+    // when a signal exists (exactOptionalPropertyTypes forbids `signal: undefined`).
+    const init: RequestInit = signal ? { method: 'GET', signal } : { method: 'GET' };
+    const res = await fetch(url, init);
     if (!res.ok) {
       throw new ApiError(res.status, await res.text());
     }

--- a/frontend/src/data/use-bird-data.ts
+++ b/frontend/src/data/use-bird-data.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ApiClient } from '../api/client.js';
 import type {
   Hotspot, Observation, ObservationFilters, AggregatedBucket,
@@ -107,6 +107,20 @@ export function useBirdData(
   // remount. Added to both dep arrays below.
   const [reloadKey, setReloadKey] = useState(0);
 
+  // #873 — latest fixed state envelope (`filters.stateBbox`), held in a ref so
+  // the observations effect can read the FRESHEST value at fetch time WITHOUT
+  // taking it as a trigger dep. The envelope arrives asynchronously (once the
+  // /api/states table loads), often a tick AFTER the scope change that fires the
+  // fetch; if it were a dep, that late arrival would mint a SECOND fetch per
+  // scope change and break the #849/#740 single-fetch invariant. By reading it
+  // through a ref instead, the first fetch uses whatever envelope is known then
+  // (the canonical viewport key if states hasn't loaded yet), and the NEXT real
+  // trigger (a pan/zoom, or a return to the state once states is cached) sends
+  // the collapsed fixed-envelope key — exactly the "CF HIT on the second
+  // distinct-viewport load" the issue targets. Updated on every render.
+  const stateBboxRef = useRef(filters.stateBbox);
+  stateBboxRef.current = filters.stateBbox;
+
   // One-time load (gated — no hotspots fetch while unscoped)
   useEffect(() => {
     if (!enabled) {
@@ -143,7 +157,15 @@ export function useBirdData(
     }
     let cancelled = false;
     setObservationsLoading(true);
-    client.getObservations(filters)
+    // #873 — merge the freshest fixed state envelope (read from the ref, not a
+    // dep) so a state scope sends the collapsed cache key as soon as the states
+    // table is known, without that late arrival forcing an extra fetch. Spread
+    // conditionally — `exactOptionalPropertyTypes` forbids `stateBbox: undefined`.
+    client.getObservations(
+      stateBboxRef.current
+        ? { ...filters, stateBbox: stateBboxRef.current }
+        : filters,
+    )
       .then(envelope => {
         if (cancelled) return;
         if (envelope.mode === 'aggregated') {
@@ -163,7 +185,15 @@ export function useBirdData(
         }
         setFreshestObservationAt(envelope.meta.freshestObservationAt);
       })
-      .catch(err => { if (!cancelled) setError(err as Error); })
+      .catch(err => {
+        // #874 — a fetch the client deliberately superseded rejects with a
+        // DOMException `AbortError`; it is not a real failure, so never surface
+        // it as a UI error (the replacing fetch owns the state). The effect's
+        // `cancelled` guard already covers the cross-effect-run case; this also
+        // covers any same-run abort defensively.
+        if ((err as { name?: string }).name === 'AbortError') return;
+        if (!cancelled) setError(err as Error);
+      })
       .finally(() => { if (!cancelled) setObservationsLoading(false); });
     return () => { cancelled = true; };
     // bbox is an array — serialize to a stable string for the dep list so
@@ -179,6 +209,9 @@ export function useBirdData(
     filters.speciesCode,
     filters.familyCode,
     filters.stateCode,
+    // #873 — filters.stateBbox is deliberately NOT a trigger dep (read via
+    // stateBboxRef at fetch time): it arrives async with the /api/states table
+    // and must not mint a second fetch per scope change. See the ref above.
     filters.bbox?.join(','),
     filters.zoom,
     reloadKey,

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -220,6 +220,51 @@ resource "google_monitoring_alert_policy" "read_api_latency" {
   }
 }
 
+# ── S4b: Read-API p95 latency near statement_timeout (#873) ──────────────
+#
+# Near-timeout guard for the state-scope `/api/observations` path that #873
+# fixes. In prod, state-scoped low-zoom requests ran 12-14s against the
+# pool's 15s `statement_timeout` (packages/db-client/src/pool.ts:35,
+# `statement_timeout: opts.statement_timeout ?? 15_000`) — masked by green
+# 200s, one slow cold buffer away from a 504. This alert fires BEFORE that
+# cliff so the silent near-misses become visible.
+#
+# THRESHOLD: 0.6 × statement_timeout. The DURABLE part is the 0.6 fraction
+# (60% of the hard query ceiling = "getting dangerous, not yet failing"); the
+# absolute 9000ms is DERIVED from the currently-configured 15_000ms timeout.
+# If pool.ts's statement_timeout changes, recompute this as 0.6 × the new
+# value — do NOT treat 9000 as a standalone constant. The S4 policy above
+# (2s, "user tabs away") catches everyday UX degradation; this one catches the
+# distinct, rarer "about to trip the DB timeout" failure mode, so both exist.
+#
+# SCOPE NOTE: Cloud Run's `request_latencies` metric is not broken out per
+# URL route, so this is service-wide p95. That is acceptable and conservative
+# here: no other read-api route runs anywhere near 9s, so a 9s p95 IS the
+# observations near-timeout signal. A per-route refinement would need a
+# log-based duration distribution emitted by the handler (a follow-up if the
+# service-wide proxy ever proves too coarse).
+
+resource "google_monitoring_alert_policy" "read_api_near_statement_timeout" {
+  display_name          = "Read API p95 latency > 0.6 x statement_timeout (9s) (S4b #873)"
+  combiner              = "OR"
+  notification_channels = [google_monitoring_notification_channel.email_julian.id]
+
+  conditions {
+    display_name = "p95 > 9000ms (0.6 x 15s statement_timeout) over 10min"
+    condition_threshold {
+      filter          = "metric.type=\"run.googleapis.com/request_latencies\" AND resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"bird-read-api\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 9000 # 0.6 x 15_000ms statement_timeout (pool.ts:35). Recompute if the timeout changes.
+      duration        = "600s"
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_PERCENTILE_95"
+        cross_series_reducer = "REDUCE_MAX"
+      }
+    }
+  }
+}
+
 # ── S5: Cloud Run instance crash / OOM ───────────────────────────────────
 #
 # Log-based metric: counts severity>=ERROR messages matching the

--- a/packages/db-client/src/observations-aggregated-perf.test.ts
+++ b/packages/db-client/src/observations-aggregated-perf.test.ts
@@ -205,6 +205,10 @@ beforeAll(async () => {
   // numbers are not representative of prod (which runs autovacuum/ANALYZE).
   await pool.query('ANALYZE observations');
   await pool.query('ANALYZE species_meta');
+  // #873 — the state-scope perf guard below clips against state_boundaries
+  // (seeded by migration 50). ANALYZE it too so the planner sizes the GIST
+  // state-polygon `&&` join realistically.
+  await pool.query('ANALYZE state_boundaries');
   // Sanity-check the seed actually reached prod scale and the `since` filter is
   // selective (not an all-time scan, not a no-op).
   const { rows: tot } = await pool.query<{ c: string }>('SELECT count(*)::text AS c FROM observations');
@@ -342,6 +346,104 @@ describe('getObservationsAggregated national perf guard (#862)', () => {
         expect(b.count).toBeGreaterThan(0);
         expect(b.speciesCount).toBeGreaterThan(0);
       }
+    },
+    120_000,
+  );
+});
+
+// ── #873 — STATE-SCOPE aggregated perf guard ────────────────────────────────
+//
+// Mirrors the #862/#868 national guards but for a STATE scope — the path #873
+// fixes. In prod, state-scoped low-zoom `/api/observations` requests took
+// 12-14s (CA z5 12.6s; TX z5 13.6/12.9/12.4/13.6s) — sitting on the 15s
+// `statement_timeout` cliff, masked by green 200s. The #873 fix makes the
+// client send the state's FIXED envelope (instead of the center-varying
+// canonical CONUS box) so the origin query is state-tight and the CF key
+// collapses. This guard pins that the state-scoped aggregated query — shaped
+// EXACTLY as the client now sends it (stateCode + the fixed state envelope as
+// bbox) — runs well under the timeout at prod scale, so a future change that
+// re-broadens the state scan trips here.
+//
+// The perf suite previously covered only national (#862) and full-CONUS (#868),
+// never a state scope — this fills that gap (issue AC).
+describe('getObservationsAggregated state-scope perf guard (#873)', () => {
+  // Texas — a large, dense state and one of the prod-observed 12-14s offenders.
+  // Envelope = state_boundaries min/max (migration 50), i.e. the StateSummary
+  // bbox the client threads as ObservationFilters.stateBbox.
+  const TX = 'US-TX';
+  const TX_ENVELOPE: [number, number, number, number] = [-106.64548, 25.84012, -93.50829, 36.50044];
+
+  it(
+    'runs the state-scoped aggregated query (stateCode + fixed envelope, since=14d, z5 grid) well under the timeout',
+    async () => {
+      // gridMultiplier 8 = the z5 metro grid (the read-api maps zoom 5 → mult 8),
+      // the finest aggregated tier and the level a state view actually requests.
+      const GRID = 8;
+
+      // Shape — exactly what the #873 client now sends for a state scope at
+      // zoom < 6: the state clip AND the fixed state envelope as bbox. The
+      // envelope is co-extensive with the state's bounding box, so it adds no
+      // meaningful scan work over the state clip alone (both are GIST-backed).
+      const t0 = performance.now();
+      const buckets = await getObservationsAggregated(
+        pool,
+        { since: '14d', stateCode: TX, bbox: TX_ENVELOPE },
+        GRID,
+      );
+      const elapsedMs = performance.now() - t0;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[#873 perf guard] TX state-scope query (fixed envelope): ${elapsedMs.toFixed(0)}ms over ${TARGET_ROWS} rows → ${buckets.length} buckets (threshold ${PERF_THRESHOLD_MS}ms, pool statement_timeout 15000ms)`,
+      );
+
+      // PERF GUARD — comfortably under the timeout (same conservative 8s ceiling
+      // as the national guards; the state scope is a strict subset of CONUS).
+      expect(elapsedMs).toBeLessThan(PERF_THRESHOLD_MS);
+
+      // The seed spreads observations across CONUS, so a TX clip is non-empty
+      // and carries real totals — not a degenerate empty box.
+      expect(buckets.length).toBeGreaterThan(0);
+      for (const b of buckets) {
+        expect(b.count).toBeGreaterThan(0);
+        expect(b.speciesCount).toBeGreaterThan(0);
+        expect(b.speciesCount).toBeLessThanOrEqual(b.count);
+        // Every returned bucket centroid must sit within ~1° of the TX envelope
+        // — proves the clip actually bounds the result (the render byte-identity
+        // rests on the server clipping to the state, not the wide bbox). The 1°
+        // pad absorbs the 0.125° grid-bucket centroid rounding at mult 8.
+        expect(b.lng).toBeGreaterThanOrEqual(TX_ENVELOPE[0] - 1);
+        expect(b.lng).toBeLessThanOrEqual(TX_ENVELOPE[2] + 1);
+        expect(b.lat).toBeGreaterThanOrEqual(TX_ENVELOPE[1] - 1);
+        expect(b.lat).toBeLessThanOrEqual(TX_ENVELOPE[3] + 1);
+      }
+    },
+    120_000,
+  );
+
+  it(
+    'is render-equivalent with vs without the fixed envelope — the ST_Intersects state clip bounds the result either way (#873)',
+    async () => {
+      // The core #873 correctness claim: adding the fixed envelope as bbox does
+      // NOT change which buckets come back, because the state polygon clip
+      // already bounds the result. So the two queries (state clip alone vs state
+      // clip + fixed envelope) must be byte-identical — render is unchanged, the
+      // envelope only collapses the cache key. (This is the DB-side guarantee
+      // behind "Screenshots: N/A — no visual change".)
+      const GRID = 8;
+      const withoutEnvelope = await getObservationsAggregated(
+        pool,
+        { since: '14d', stateCode: TX },
+        GRID,
+      );
+      const withEnvelope = await getObservationsAggregated(
+        pool,
+        { since: '14d', stateCode: TX, bbox: TX_ENVELOPE },
+        GRID,
+      );
+      expect(fingerprint(withEnvelope)).toBe(fingerprint(withoutEnvelope));
+      // And the result is real (non-empty), so the equality is meaningful.
+      expect(withEnvelope.length).toBeGreaterThan(0);
     },
     120_000,
   );

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -219,6 +219,20 @@ export type ObservationFilters = {
    * `CONUS_STATE_CODES` before it reaches the data layer (plan task B1).
    */
   stateCode?: string;
+  /**
+   * #873 — the active state's FIXED bounding envelope (`StateSummary.bbox`,
+   * `[west, south, east, north]`), threaded from the `/api/states` table when a
+   * `US-XX` scope is active. CLIENT-ONLY: it is NEVER serialized to the wire as
+   * its own param — instead, in the AGGREGATED path (`zoom < 6`) the client
+   * substitutes this envelope (snapped to the cache grid) for the center-varying
+   * viewport bbox, so every viewport/pan of a state collapses to ONE Cloudflare
+   * cache key per `(state, zoom, filters)` and the origin query is state-tight.
+   * At `zoom >= 6` it is ignored (the viewport bbox keeps narrowing the dense
+   * per-observation query, preserving the 10k-truncation brake). Absent until
+   * the states table has loaded — the client falls back to the canonical
+   * viewport key in that window.
+   */
+  stateBbox?: [number, number, number, number];
 };
 
 /**


### PR DESCRIPTION
## Diagrams

Two composing levers on the state-scope `/api/observations` path. **#873** collapses the cache key (and tightens the origin scan) by sending the state's *fixed* envelope instead of the center-varying canonical viewport box, in the aggregated path only. **#874** dedups/cancels in-flight fetches at the single client boundary.

```mermaid
flowchart TB
    subgraph A["#873 — state-scope cache key (zoom < 6 ONLY)"]
        pan["3 different CA pans<br/>(viewport centers differ)"] -->|"BEFORE: center-varying<br/>canonicalFetchBbox(viewport)"| miss["3 distinct CONUS-centered keys<br/>→ 100% CF MISS<br/>→ 12–14s CONUS scan-then-clip"]
        pan -->|"AFTER: snapFetchBbox(StateSummary.bbox)"| hit["ONE key per (state, zoom, filters)<br/>-124.50,32.50,-114.00,42.25<br/>→ CF HIT 2nd load + warmable<br/>→ state-tight origin query"]
    end

    subgraph B["#874 — in-flight dedup (client.ts getObservations)"]
        rapid["rapid scope/pan<br/>CA→NV→TX"] -->|"new fetch supersedes"| abort["AbortController.abort() prior<br/>(use-bird-data ignores AbortError)"]
        dup["concurrent byte-identical key"] -->|"coalesce"| shared["return shared promise<br/>(ONE network call)"]
    end
```

```mermaid
flowchart LR
    states["/api/states<br/>StateSummary.bbox"] --> appmemo["App.tsx scopeStateBbox<br/>(useMemo on states + scope)"]
    appmemo -->|"ObservationFilters.stateBbox"| hook["useBirdData<br/>(read via stateBboxRef at fetch-time,<br/>NOT a trigger dep → no extra fetch)"]
    hook --> client["client.ts getObservations<br/>zoom<6 + state + stateBbox<br/>→ snapFetchBboxParam(stateBbox, zoom)"]
    client -->|"?bbox=<fixed snapped envelope>&state=US-XX"| edge["CF edge: one key per (state, zoom)"]
```

## Summary

- **Why (#873):** every state-scoped `/api/observations` was a CF **MISS** (vs national HIT) and re-ran **12–14s** CONUS-wide scan-then-clip queries — sitting on the 15s `statement_timeout` cliff, masked by green 200s. Root cause (verified by the bot against `origin/main`): `canonicalFetchBboxParam` already applies to state scopes (no `stateCode` branch), but the canonical box is **center-varying** — reconstructed from the viewport midpoint clamped to CONUS — so each state/pan mints a new key. Since the `ST_Intersects` state clip already fully bounds the result, the wide bbox is redundant *for scoping* and only fragments the key.
- **Fix (#873):** in the **aggregated path (`zoom < 6`) ONLY**, when a state is scoped and its fixed envelope is known, send the state's **fixed bounding envelope** (`StateSummary.bbox`, snapped outward to the cache grid via the existing `@bird-watch/geo` `snapFetchBboxParam`) as the bbox. Every viewport/pan of a state → **one** key per `(state, zoom, filters)` → CF HIT after the first load + warmable, and the origin query becomes state-tight. Render is **unchanged**: the server's `ST_Intersects` clip already bounds the result to the state polygon (viewport-independent), and the frontend clips display to the viewport via `filterBucketsByBounds`. The `zoom >= 6` 10k-truncation brake (`observations.ts:241`) is **untouched** — mirroring #868/#869.
- **Design choice (#873): fixed envelope over the quantize fallback.** Quantizing the viewport bbox still mints several keys across a state's pans; the fixed envelope gives **one** key per `(state, zoom)` regardless of pan, is warmable, and makes the origin scan state-tight. The envelope is already available frontend-side via `StateSummary.bbox` (`/api/states`). Threaded `App → useBirdData` via `ObservationFilters.stateBbox` and read through a **ref at fetch time (NOT a trigger dep)**: it arrives async with the `/api/states` table, so making it a dep would mint a second fetch per scope change and break the #849/#740 single-fetch invariant.
- **Guard + alarm (#873):** new TX state-scope aggregated **perf guard** (`packages/db-client`) mirroring the #862/#868 national guards (runs well under the 8s threshold; a second case asserts the fixed envelope is **render-equivalent** to the state clip alone — the DB-side basis for "no visual change"). New near-timeout **alert policy** in `infra/terraform/monitoring.tf` at **0.6 × the configured `statement_timeout`** (read from `pool.ts`: `15_000ms` → **9000ms**); the `0.6` fraction is the durable part, the 9s is derived. `terraform fmt` + `validate` clean; **apply is gated by #298 (IAM)**.
- **Why (#874):** `client.ts getObservations` had no `AbortController` and no concurrent-key collapse, so a superseded fetch during a rapid scope/pan change kept running and a byte-identical concurrent key issued a redundant second call. Added an `AbortController` + in-flight-key map at the single client boundary: a new `/api/observations` aborts the prior in-flight one, and a concurrent byte-identical key returns the shared promise (one network call). Scoped to `/api/observations` only; `use-bird-data` ignores the resulting `AbortError`. **The #849 reseed is NOT touched.**

## Screenshots

**N/A — no visual change.** This PR changes the fetch-bbox the client transmits for state scopes (aggregated path) and adds request dedup/cancellation; the rendered output is byte-identical to `main` (the server's `ST_Intersects` clip already returned the same state-bounded buckets, proven by the new DB-side render-equivalence test). The ≥10-screenshot multi-viewport QA is therefore N/A — captures would be identical to `main`.

Live UI verification was still performed via Playwright MCP (modeling PR #871):
- `?state=US-CA` and `?state=US-TX` driven at 1440×900, light **and** dark — the state view renders correctly (state-artboard mask, identity card "Bird Maps · California / 91 sightings", controls + attribution), zero console **errors**, zero **warnings** (one benign pre-existing MapLibre `circle-11` basemap-sprite transient on theme toggle, unrelated to this change).
- **The behavioral change, captured from the network panel:** a CA scope's z5 settle fetch transmits the **fixed CA envelope** `bbox=-124.50,32.50,-114.00,42.25&zoom=5&state=US-CA`, and **three genuinely different in-CA pans** (initial fit, Sacramento `-121.5,38.6`, LA/San Diego `-117.8,33.4`) all collapse to that **ONE byte-identical key**. Pre-#873, each distinct center would have minted a distinct center-varying CONUS-centered box. TX collapses to `-106.75,25.75,-93.50,36.75`. (The first paint's `-130,20,-65,52&zoom=3` seed fetch fires before `/api/states` loads → canonical fallback by design; the second distinct-viewport load gets the collapsed key — exactly the AC.)

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className added (data-flow + Terraform + test change)`
- [x] Multi-viewport design QA: **N/A — no visible UI change** (fetch-bbox + dedup change; render byte-identical to `main`). Playwright live verification performed above (CA + TX, light + dark; the collapsed key + zero console errors).

## Test plan

- [x] `npm run build && npm test` — green (frontend 1110, db-client 132 + 1 todo, read-api 170, geo 31, shared-types typecheck)
- [x] New unit / integration tests added — `client.test.ts` (+4 #873: fixed-envelope bbox, two-pan one-key collapse, zoom≥6 passthrough, no-stateBbox fallback; +4 #874: AbortSignal passed, supersede-abort, concurrent coalesce → 1 call, getHotspots not aborted); `observations-aggregated-perf.test.ts` (+2 #873: TX state-scope perf guard under timeout, fixed-envelope render-equivalence)
- [x] New Playwright e2e spec — updated `state-scope.spec.ts` `bboxMatchesEnvelope` to assert the #873 snapped fixed envelope (AZ `-115,31,-109,37` / FL `-88,24,-80,31` / NY `-80,40,-71,46`) the state fetch now carries; RED-on-main discriminator preserved (none equal the `-130,20,-65,52` CONUS seed). All 9 state-scope specs + the #848 midmotion + unscoped specs pass locally and in CI.
- [x] `npm run build` — clean production build
- [x] (UI) Playwright MCP smoke — ran `npm run dev`, drove `?state=US-CA` / `?state=US-TX` at 1440×900 light+dark; `browser_console_messages` zero errors/warnings; network confirmed the collapsed fixed-envelope `/api/observations` key across three distinct in-CA pans
- [x] `knip` — clean (only the pre-existing `2026-04-22-map-v1-prototype` configuration hint)
- [x] `terraform fmt -check` + `terraform validate` — clean on `monitoring.tf` (apply gated by #298)

## Plan reference

Out of plan — perf follow-up to #868/#869/#871 (canonical cache keys).

Closes #873
Closes #874

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

