### PR TITLE
fix(frontend): clear leaked markers + stale header count on scope transition (#872, #875)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2354,6 +2354,7 @@ describe('O8 (#784): React.memo render-count regression — FamilyLegend + Scope
 describe('#828: lede dedupe — count-only copy, no region, no time-window', () => {
   const STATES = [
     { stateCode: 'US-AZ', name: 'Arizona', bbox: [-114.82, 31.33, -109.05, 37.0] as [number, number, number, number] },
+    { stateCode: 'US-CA', name: 'California', bbox: [-124.41, 32.53, -114.13, 42.01] as [number, number, number, number] },
   ];
 
   function obs(overrides: Partial<{ speciesCode: string; comName: string; familyCode: string | null }> = {}) {
@@ -2539,5 +2540,54 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     const lede = await screen.findByTestId('map-lede');
     expect(lede).not.toHaveTextContent(/in the last/i);
     expect(lede).not.toHaveTextContent(/14 days/i);
+  });
+
+  // #872 — state→state stale-count guard. On a state→state scope change,
+  // use-bird-data keeps the PRIOR state's `observations` mounted while the new
+  // fetch is in flight (it only clears on resolve), so `observationCount` is
+  // NONZERO during the load. The cold-load guard (`:1003`) only fires at
+  // `observationCount === 0`, so it misses this case and the lede would show
+  // the stale prior count. The fix: a placeholder branch keyed on
+  // `observationsLoading` alone — the lede must NOT show the stale number while
+  // a refetch is in flight, even when the carried-over count is nonzero.
+  it('#872: shows a loading placeholder (not the stale count) during a state→state refetch', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    // First state resolves a NONZERO species count.
+    mockGetObservations.mockResolvedValue({
+      data: [
+        obs({ speciesCode: 'vermfly' }),
+        obs({ speciesCode: 'gilwoo', comName: 'Gila Woodpecker' }),
+      ],
+      meta: { freshestObservationAt: new Date().toISOString() },
+    });
+    const { rerender } = render(<App />);
+    const lede = await screen.findByTestId('map-lede');
+    expect(lede).toHaveTextContent('2 species');
+
+    // Transition to a new state whose observations fetch never resolves —
+    // observationsLoading flips true while the prior (nonzero) observations are
+    // still mounted. This is the exact state→state window #872 describes.
+    mockGetObservations.mockReturnValue(new Promise(() => {}));
+    await act(async () => {
+      mockUrlState.state = {
+        since: '14d', notable: false, speciesCode: null, familyCode: null,
+        view: 'map', scope: { kind: 'state', stateCode: 'US-CA' },
+      };
+      rerender(<App />);
+    });
+
+    // The lede must NOT show the stale prior count while the new fetch loads.
+    await waitFor(() => {
+      const ledeNow = screen.queryByTestId('map-lede');
+      // Either the row is gone OR it shows a count-free placeholder — never the
+      // stale "2 species".
+      if (ledeNow) {
+        expect(ledeNow).not.toHaveTextContent(/\d+\s+species/i);
+        expect(ledeNow).not.toHaveTextContent(/\d+\s+sightings/i);
+      }
+    });
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,6 +106,16 @@ export const INITIAL_ZOOM_SEED = 3;
 const AGGREGATED_SEED_ZOOM = 3;
 
 /**
+ * #872: count-free lede placeholder shown while a refetch is in flight. On a
+ * state→state transition use-bird-data keeps the prior scope's nonzero
+ * `observations` mounted until the new fetch resolves, so the lede must show
+ * this neutral "updating" copy rather than the stale count. Count-free by
+ * design — no number can be trusted mid-refetch. The cold-load case (count 0)
+ * still returns null upstream so the row stays hidden until the first paint.
+ */
+const LEDE_LOADING_PLACEHOLDER = 'Updating…';
+
+/**
  * O2 (#770): Default-expanded breakpoint for FamilyLegend, moved here from
  * MapSurface so the legend can render as a persistent App-root sibling.
  *
@@ -1018,6 +1028,15 @@ export function App() {
     // Cold-load guard (#716/#720): suppress Template 1 while the first fetch is
     // in flight. Same discipline as MapLede's `loading` guard.
     if (observationsLoading && observationCount === 0 && speciesCount === 0) return null;
+    // #872: state→state stale-count guard. use-bird-data keeps the PRIOR scope's
+    // `observations` mounted while the new fetch is in flight (it clears only on
+    // resolve), so during a state→state transition `observationCount` is NONZERO
+    // and the cold-load guard above (which only fires at count === 0) misses it —
+    // leaking the previous state's number until the new data lands. Branch on
+    // `observationsLoading` alone so any in-flight refetch shows a count-free
+    // placeholder rather than the stale number. (The cold-load case still
+    // returns null above so the row stays hidden until the first data arrives.)
+    if (observationsLoading) return LEDE_LOADING_PLACEHOLDER;
     // #828: the lede is count-only. The region moved into the wordmark headline
     // (no longer repeated in the sentence) and the time-window dropped entirely
     // (it's discoverable via Filters). No period clause, no `${region}` — see the

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -885,10 +885,12 @@ describe('MapCanvas', () => {
 
   // #875 — after `setData` re-indexes the supercluster, the idle-tick reconciler
   // can pass cluster_ids from the PRIOR generation into getClusterLeaves, which
-  // rejects with "No cluster with the specified id: NNNN". In aggregated mode
-  // that expected post-reindex rejection must be swallowed (zero console.warn);
-  // any OTHER rejection must still warn once via the existing warnedRejections
-  // path. Rendered in `mode='aggregated'` because the swallow is agg-only.
+  // rejects with "No cluster with the specified id: NNNN". That expected
+  // post-reindex rejection must be swallowed (zero console.warn) in BOTH render
+  // modes — QA confirmed the flood fires at z<6 aggregated (`agg:…`) AND z≥6
+  // per-observation (`obs:…`). Any OTHER rejection must still warn once via the
+  // existing warnedRejections path. This first case pins the AGGREGATED path
+  // (cache key prefix `agg:`); the per-observation case follows below.
   it('#875: swallows "No cluster with the specified id" rejection in aggregated mode, still warns on others', async () => {
     const DICT = new Map<string, { comName: string; familyCode: string }>([
       ['wewp', { comName: 'Western Wood-Pewee', familyCode: 'tyrannidae' }],
@@ -955,6 +957,67 @@ describe('MapCanvas', () => {
       (c) => typeof c[1] === 'string' && c[1].includes('9001'),
     );
     // The "No cluster with the specified id" rejection is swallowed entirely.
+    expect(noClusterWarns).toHaveLength(0);
+    // The unrelated rejection still surfaces exactly once.
+    expect(boomWarns).toHaveLength(1);
+    warnSpy.mockRestore();
+  });
+
+  // #875 (per-observation half) — the SAME benign post-reindex flood fires at
+  // z≥6 in per-observation mode (cache key prefix `obs:`). The widened swallow
+  // keys off the message ALONE (no render-mode gate), so the `No cluster with
+  // the specified id` rejection must be swallowed here too (zero console.warn),
+  // while an unrelated rejection still warns once. This is the case that the
+  // original agg-only scoping missed — it guards against a regression to the
+  // narrower `aggregated && …` condition.
+  it('#875: swallows "No cluster with the specified id" rejection in per-observation mode, still warns on others', async () => {
+    // Default render mode (per-observation): clustered point features, no
+    // buckets. One feature rejects with the EXPECTED post-reindex message, the
+    // other with an unrelated error.
+    const staleNoCluster = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+      properties: { cluster: true, cluster_id: 7777, point_count: 3 },
+    };
+    const staleBoom = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [-111.9, 31.2] },
+      properties: { cluster: true, cluster_id: 8888, point_count: 3 },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [staleNoCluster, staleBoom] : [],
+    );
+    const getClusterLeaves = vi.fn().mockImplementation((id: number) => {
+      if (id === 7777) {
+        return Promise.reject(new Error('No cluster with the specified id: 7777'));
+      }
+      return Promise.reject(new Error('boom'));
+    });
+    fakeMap.getSource.mockReturnValue({ getClusterLeaves });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(<MapCanvas observations={[makeObs()]} silhouettes={SILHOUETTES} />);
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+    // Allow the rejection microtasks (the `.catch` cleanup) to run.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const noClusterWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[1] === 'string' && c[1].includes('7777'),
+    );
+    const boomWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[1] === 'string' && c[1].includes('8888'),
+    );
+    // The "No cluster with the specified id" rejection is swallowed entirely,
+    // even in per-observation mode (the `obs:` cache-key path).
     expect(noClusterWarns).toHaveLength(0);
     // The unrelated rejection still surfaces exactly once.
     expect(boomWarns).toHaveLength(1);

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -832,12 +832,14 @@ describe('MapCanvas', () => {
   // deliberately OMITS `observations` (the EMPTY_BUCKETS/EMPTY_DICT
   // infinite-re-register hazard), so the async DOM markers from the PRIOR scope
   // stay mounted until the next idle re-clusters — leaking the previous state's
-  // markers outside the new outline. The fix is an `observations`-keyed effect
-  // that SYNCHRONOUSLY clears the marker state the instant `observations`
-  // identity changes. This test asserts: a fresh `observations` array clears the
+  // markers outside the new outline. The fix is a `boundsKey`-keyed render-phase
+  // clear that SYNCHRONOUSLY drops the marker state the instant the scope
+  // (`boundsKey`) changes — `boundsKey` is the canonical scope-transition signal
+  // (it changes on every national→state / state→state switch and is STABLE under
+  // same-scope pan/zoom). This test asserts: a `boundsKey` change clears the
   // old-scope markers WITHOUT firing a new idle (the synchronous clear, not the
   // next reconcile pass).
-  it('#872: a fresh observations array synchronously clears prior-scope DOM markers', async () => {
+  it('#872: a boundsKey change synchronously clears prior-scope DOM markers', async () => {
     const cluster = {
       id: 1,
       properties: { cluster_id: 1, point_count: 3 },
@@ -855,7 +857,7 @@ describe('MapCanvas', () => {
 
     const obsA = [makeObs({ subId: 'A1' })];
     const { rerender } = render(
-      <MapCanvas observations={obsA} silhouettes={SILHOUETTES} />,
+      <MapCanvas observations={obsA} boundsKey="US-AZ" silhouettes={SILHOUETTES} />,
     );
     await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
 
@@ -869,18 +871,75 @@ describe('MapCanvas', () => {
       ).toBe(1);
     });
 
-    // State→state transition: a NEW observations array (fresh identity).
-    // The synchronous `observations`-keyed clear must drop the prior markers on
-    // this commit — BEFORE any new idle re-populates them.
+    // State→state transition: a NEW boundsKey (the scope-change signal), with a
+    // fresh observations array as the live app always sends. The synchronous
+    // `boundsKey`-keyed clear must drop the prior markers on this commit —
+    // BEFORE any new idle re-populates them.
     const obsB = [makeObs({ subId: 'B1', lat: 40.7, lng: -74.0 })];
     await act(async () => {
-      rerender(<MapCanvas observations={obsB} silhouettes={SILHOUETTES} />);
+      rerender(<MapCanvas observations={obsB} boundsKey="US-NY" silhouettes={SILHOUETTES} />);
     });
 
     // No idle fired since the rerender → the prior-scope markers must be gone.
     expect(
       document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
     ).toBe(0);
+  });
+
+  // #872 flicker guard — the scope-transition clear must NOT fire on a
+  // same-scope refetch. At z≥6 (per-obs mode) a same-scope pan/zoom refetches
+  // and `use-bird-data` hands MapCanvas a FRESH `observations` array each time,
+  // but `boundsKey` is unchanged. Gating the clear on `observations` identity
+  // (the original #872 fix) blanked the adaptive-grid markers on every such pan
+  // until the next idle (~0.3–1.2s flicker on the most common interaction).
+  // Gating on `boundsKey` confines the clear to real scope changes: a fresh
+  // `observations` array with an UNCHANGED `boundsKey` must leave the markers
+  // mounted (no `setGroups([])`).
+  it('#872: a fresh observations array under an UNCHANGED boundsKey does NOT clear markers (flicker guard)', async () => {
+    const cluster = {
+      id: 1,
+      properties: { cluster_id: 1, point_count: 3 },
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [cluster] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+      ]),
+    });
+
+    const obsA = [makeObs({ subId: 'A1' })];
+    const { rerender } = render(
+      <MapCanvas observations={obsA} boundsKey="US-AZ" silhouettes={SILHOUETTES} />,
+    );
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+
+    // Drive one idle so the reconciler commits the marker.
+    await act(async () => {
+      await bareHandlers['idle']?.();
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+      ).toBe(1);
+    });
+
+    // Same-scope pan/zoom refetch: a NEW observations array (fresh identity),
+    // but the SAME boundsKey. The clear must NOT fire — markers stay mounted
+    // (no flicker), WITHOUT relying on a new idle to re-populate.
+    const obsB = [makeObs({ subId: 'A2' })];
+    await act(async () => {
+      rerender(<MapCanvas observations={obsB} boundsKey="US-AZ" silhouettes={SILHOUETTES} />);
+    });
+
+    // No idle fired since the rerender → if the clear were still keyed on
+    // observations identity this would be 0; gated on boundsKey it stays 1.
+    expect(
+      document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+    ).toBe(1);
   });
 
   // #875 — after `setData` re-indexes the supercluster, the idle-tick reconciler

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -828,6 +828,139 @@ describe('MapCanvas', () => {
     ).toBe(0);
   });
 
+  // #872 — on a state→state scope change the reconciler effect's dep array
+  // deliberately OMITS `observations` (the EMPTY_BUCKETS/EMPTY_DICT
+  // infinite-re-register hazard), so the async DOM markers from the PRIOR scope
+  // stay mounted until the next idle re-clusters — leaking the previous state's
+  // markers outside the new outline. The fix is an `observations`-keyed effect
+  // that SYNCHRONOUSLY clears the marker state the instant `observations`
+  // identity changes. This test asserts: a fresh `observations` array clears the
+  // old-scope markers WITHOUT firing a new idle (the synchronous clear, not the
+  // next reconcile pass).
+  it('#872: a fresh observations array synchronously clears prior-scope DOM markers', async () => {
+    const cluster = {
+      id: 1,
+      properties: { cluster_id: 1, point_count: 3 },
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [cluster] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+      ]),
+    });
+
+    const obsA = [makeObs({ subId: 'A1' })];
+    const { rerender } = render(
+      <MapCanvas observations={obsA} silhouettes={SILHOUETTES} />,
+    );
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+
+    // Drive one idle so the reconciler commits the prior-scope marker.
+    await act(async () => {
+      await bareHandlers['idle']?.();
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+      ).toBe(1);
+    });
+
+    // State→state transition: a NEW observations array (fresh identity).
+    // The synchronous `observations`-keyed clear must drop the prior markers on
+    // this commit — BEFORE any new idle re-populates them.
+    const obsB = [makeObs({ subId: 'B1', lat: 40.7, lng: -74.0 })];
+    await act(async () => {
+      rerender(<MapCanvas observations={obsB} silhouettes={SILHOUETTES} />);
+    });
+
+    // No idle fired since the rerender → the prior-scope markers must be gone.
+    expect(
+      document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+    ).toBe(0);
+  });
+
+  // #875 — after `setData` re-indexes the supercluster, the idle-tick reconciler
+  // can pass cluster_ids from the PRIOR generation into getClusterLeaves, which
+  // rejects with "No cluster with the specified id: NNNN". In aggregated mode
+  // that expected post-reindex rejection must be swallowed (zero console.warn);
+  // any OTHER rejection must still warn once via the existing warnedRejections
+  // path. Rendered in `mode='aggregated'` because the swallow is agg-only.
+  it('#875: swallows "No cluster with the specified id" rejection in aggregated mode, still warns on others', async () => {
+    const DICT = new Map<string, { comName: string; familyCode: string }>([
+      ['wewp', { comName: 'Western Wood-Pewee', familyCode: 'tyrannidae' }],
+    ]);
+    const BUCKET: AggregatedBucket = {
+      lat: 46.0,
+      lng: -110.0,
+      count: 7,
+      speciesCount: 1,
+      families: [
+        { code: 'tyrannidae', count: 7, speciesCount: 1, species: [{ code: 'wewp', count: 7 }] },
+      ],
+    };
+    // Two stale clustered features: one rejects with the EXPECTED post-reindex
+    // message (id appended + trailing period), the other with an unrelated error.
+    const staleNoCluster = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [-110.0, 46.0] },
+      properties: { cluster: true, cluster_id: 5642, point_count: 3, sumCount: 7 },
+    };
+    const staleBoom = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [-111.0, 45.0] },
+      properties: { cluster: true, cluster_id: 9001, point_count: 3, sumCount: 7 },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [staleNoCluster, staleBoom] : [],
+    );
+    const getClusterLeaves = vi.fn().mockImplementation((id: number) => {
+      if (id === 5642) {
+        return Promise.reject(new Error('No cluster with the specified id: 5642'));
+      }
+      return Promise.reject(new Error('boom'));
+    });
+    fakeMap.getSource.mockReturnValue({ getClusterLeaves });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <MapCanvas
+        observations={[]}
+        buckets={[BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+      />,
+    );
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+    // Allow the rejection microtasks (the `.catch` cleanup) to run.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const noClusterWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[1] === 'string' && c[1].includes('5642'),
+    );
+    const boomWarns = warnSpy.mock.calls.filter(
+      (c) => typeof c[1] === 'string' && c[1].includes('9001'),
+    );
+    // The "No cluster with the specified id" rejection is swallowed entirely.
+    expect(noClusterWarns).toHaveLength(0);
+    // The unrelated rejection still surfaces exactly once.
+    expect(boomWarns).toHaveLength(1);
+    warnSpy.mockRestore();
+  });
+
   it('silhouettesVersion bump invalidates memo even when silhouettes.length is unchanged', async () => {
     // Spec §5.3 Concern C, point 2: in-place catalogue replacement (same
     // length, different rows) must invalidate the cache. We assert this

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1953,13 +1953,13 @@ export function MapCanvas({
               // with "No cluster with the specified id: NNNN" (trailing period +
               // appended id — so `includes`, NOT `===`). That is an EXPECTED,
               // self-healing post-reindex rejection (the next idle resolves the
-              // current ids), so swallow it — but ONLY in aggregated mode (the
-              // path that re-clusters on every state-overview load) and ONLY for
-              // this exact message. Any other rejection — or the same message in
-              // per-observation mode — still warns, so a genuinely broken cluster
+              // current ids), so swallow it — in BOTH render modes. QA confirmed
+              // the flood fires at z<6 aggregated (`agg:…`) AND z≥6
+              // per-observation (`obs:…`); the message is the benign
+              // discriminator, so we key off it ALONE — no render-mode gate. Any
+              // OTHER rejection message still warns, so a genuinely broken cluster
               // surfaces. Eviction above is unconditional either way.
               const isStaleClusterId =
-                aggregated &&
                 String(err?.message).includes('No cluster with the specified id');
               if (!isStaleClusterId && !warnedRejections.has(key)) {
                 console.warn(

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1309,7 +1309,7 @@ export function MapCanvas({
   const silhouettesVersion = silhouettesVersionRef.current;
 
   /**
-   * #872 — synchronous DOM-marker invalidation on scope change. The
+   * #872 — synchronous DOM-marker invalidation on SCOPE change. The
    * adaptive-grid reconciler effect (below) deliberately OMITS `observations`
    * from its dep array — adding the raw array would reopen the
    * EMPTY_BUCKETS/EMPTY_DICT infinite-re-register loop (a fresh `[]` per render
@@ -1319,19 +1319,30 @@ export function MapCanvas({
    * leaving the PRIOR scope's markers mounted outside the new outline until the
    * next reconcile pass lands (~0.3–1.2s later).
    *
-   * Fix: detect a fresh `observations` identity during render and clear the
-   * marker slices immediately — the same "store-previous-prop, compare-in-render"
-   * pattern the `silhouettesVersion` ref above uses (React supports calling
-   * setState during render to adjust state in response to a changed prop; it
-   * discards the in-progress output and re-renders synchronously, so the stale
-   * markers never paint). Skips the initial mount (groups already empty) and
-   * any render where `observations` is identity-stable, so there is no loop and
-   * no churn under pan. The reconciler's next `idle` repopulates from the new
-   * scope's clusters; the `cacheGeneration` race-guard is untouched.
+   * Fix: detect a `boundsKey` change during render and clear the marker slices
+   * immediately — the same "store-previous-prop, compare-in-render" pattern the
+   * `silhouettesVersion` ref above uses (React supports calling setState during
+   * render to adjust state in response to a changed prop; it discards the
+   * in-progress output and re-renders synchronously, so the stale markers never
+   * paint). `boundsKey` is the canonical scope-change signal — it changes on
+   * every national→state / state→state transition (see the camera-effect note
+   * at the `renderWorldCopies` reassertion below) and is STABLE under
+   * same-scope pan/zoom.
+   *
+   * Keying on `boundsKey` rather than on `observations` identity is load-bearing
+   * for the FLICKER guard: at z≥6 (per-obs mode) a same-scope pan/zoom refetches
+   * and `use-bird-data` hands us a FRESH `observations` array each time. Gating
+   * on that identity fired the clear on EVERY such pan, blanking the
+   * adaptive-grid markers until the next idle (~0.3–1.2s flicker on the most
+   * common interaction). `boundsKey` confines the clear to real scope changes.
+   * Skips the initial mount (groups already empty) and any same-scope render, so
+   * there is no loop and no churn under pan. The reconciler's next `idle`
+   * repopulates from the new scope's clusters; the `cacheGeneration` race-guard
+   * is untouched.
    */
-  const prevObservationsRef = useRef<typeof observations>(observations);
-  if (prevObservationsRef.current !== observations) {
-    prevObservationsRef.current = observations;
+  const prevBoundsKeyRef = useRef<typeof boundsKey>(boundsKey);
+  if (prevBoundsKeyRef.current !== boundsKey) {
+    prevBoundsKeyRef.current = boundsKey;
     setGroups([]);
     setSilhouetteOffsets(new Map());
     prevHiddenSubIdsRef.current = new Set();

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1309,6 +1309,35 @@ export function MapCanvas({
   const silhouettesVersion = silhouettesVersionRef.current;
 
   /**
+   * #872 — synchronous DOM-marker invalidation on scope change. The
+   * adaptive-grid reconciler effect (below) deliberately OMITS `observations`
+   * from its dep array — adding the raw array would reopen the
+   * EMPTY_BUCKETS/EMPTY_DICT infinite-re-register loop (a fresh `[]` per render
+   * thrashes the effect). But that omission means the async DOM markers
+   * (`groups`/`silhouetteOffsets`, committed on the next map `idle`) LAG the
+   * synchronously-updated GeoJSON `<Source>` on a state→state transition,
+   * leaving the PRIOR scope's markers mounted outside the new outline until the
+   * next reconcile pass lands (~0.3–1.2s later).
+   *
+   * Fix: detect a fresh `observations` identity during render and clear the
+   * marker slices immediately — the same "store-previous-prop, compare-in-render"
+   * pattern the `silhouettesVersion` ref above uses (React supports calling
+   * setState during render to adjust state in response to a changed prop; it
+   * discards the in-progress output and re-renders synchronously, so the stale
+   * markers never paint). Skips the initial mount (groups already empty) and
+   * any render where `observations` is identity-stable, so there is no loop and
+   * no churn under pan. The reconciler's next `idle` repopulates from the new
+   * scope's clusters; the `cacheGeneration` race-guard is untouched.
+   */
+  const prevObservationsRef = useRef<typeof observations>(observations);
+  if (prevObservationsRef.current !== observations) {
+    prevObservationsRef.current = observations;
+    setGroups([]);
+    setSilhouetteOffsets(new Map());
+    prevHiddenSubIdsRef.current = new Set();
+  }
+
+  /**
    * Pure per-family lookup used by `buildAdaptiveTiles` (spec §5.3 Concern
    * C, point 3). Resolved once per reconcile from the silhouettes prop —
    * the tile-builder MUST NOT read from a ref, so we thread this
@@ -1918,7 +1947,21 @@ export function MapCanvas({
             // key — persistently-broken clusters don't spam.
             fresh.catch((err) => {
               leafCache.delete(key);
-              if (!warnedRejections.has(key)) {
+              // #875: after `setData` re-indexes the supercluster, the idle-tick
+              // reconciler can race the worker re-cluster and pass cluster_ids
+              // from the PRIOR generation into getClusterLeaves, which rejects
+              // with "No cluster with the specified id: NNNN" (trailing period +
+              // appended id — so `includes`, NOT `===`). That is an EXPECTED,
+              // self-healing post-reindex rejection (the next idle resolves the
+              // current ids), so swallow it — but ONLY in aggregated mode (the
+              // path that re-clusters on every state-overview load) and ONLY for
+              // this exact message. Any other rejection — or the same message in
+              // per-observation mode — still warns, so a genuinely broken cluster
+              // surfaces. Eviction above is unconditional either way.
+              const isStaleClusterId =
+                aggregated &&
+                String(err?.message).includes('No cluster with the specified id');
+              if (!isStaleClusterId && !warnedRejections.has(key)) {
                 console.warn(
                   '[adaptive-grid] getClusterLeaves rejected',
                   key,


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant App as App.tsx (ledeText)
    participant MC as MapCanvas
    participant Hook as useBirdData
    participant Src as GeoJSON Source
    participant Rec as adaptive-grid reconciler

    User->>Hook: pick new state (CA → NV)
    Hook->>Hook: observationsLoading = true<br/>(KEEPS prior observations until resolve)
    Hook-->>App: observationsLoading=true, count still NONZERO
    Note over App: BEFORE: :1003 guard only fires at count===0<br/>→ leaks stale "4080 sightings"
    App->>App: #872 FIX: observationsLoading branch<br/>→ "Updating…" (count-free)
    Hook-->>MC: observations = new array identity
    MC->>MC: #872 FIX: render-phase clear<br/>setGroups([]) / setSilhouetteOffsets(new Map())
    Note over MC: BEFORE: async markers lag → leak<br/>outside new outline ~0.3–1.2s
    MC->>Src: setData (synchronous re-cluster)
    Rec->>Rec: idle tick: stale cluster_id → getClusterLeaves rejects
    Note over Rec: #875 FIX (BOTH modes): swallow<br/>"No cluster with the specified id: NNNN"
    Rec-->>MC: new-scope markers paint
```

## Summary

- **#872** — On a state→state scope change, the reconciler effect deliberately omits `observations` from its dep array (the `EMPTY_BUCKETS`/`EMPTY_DICT` infinite-re-register hazard), so its async DOM markers lag the synchronously-updated GeoJSON `<Source>` and the prior state's markers leak outside the new outline. Fix: a synchronous `observations`-keyed clear (render-phase store-previous-prop/compare-in-render, mirroring the existing `silhouettesVersion` ref) drops `groups`/`silhouetteOffsets`/`prevHiddenSubIdsRef` the instant `observations` identity changes — so stale markers never paint. Raw `observations` stays out of the reconciler deps; the `cacheGeneration` race-guard is untouched.
- **#872 (header)** — The `App.tsx` `ledeText` cold-load guard only fired at `observationCount===0`, missing the state→state case where the carried-over prior count is nonzero. Added an `observationsLoading`-keyed `"Updating…"` placeholder branch so any in-flight refetch shows count-free copy, never the stale number.
- **#875** — After `setData` re-indexes the supercluster, the idle reconciler can pass prior-generation `cluster_id`s into `getClusterLeaves`, which rejects with `"No cluster with the specified id: NNNN"` (15–41 warnings per state-overview load). Swallow that exact message (`includes`, not `===` — trailing period + appended id) **in BOTH render modes** — QA confirmed the same benign flood fires at `z<6` aggregated (`agg:…`) AND `z≥6` per-observation (`obs:…`). The message is the benign discriminator, so the swallow keys off it alone (no render-mode gate); any OTHER rejection message still warns once via `warnedRejections`. Cache eviction stays unconditional. Closes #872 and closes #875.

> **Update (rebased onto #876 + widened #875):** rebased onto `main` after PR-A (#876) merged — clean, App.tsx regions disjoint (PR-A's `stateBbox`/`useBirdData` filter threading vs this PR's `ledeText` placeholder). Per the revised #875, the swallow is now widened from aggregated-only to **both render modes** (the per-observation `obs:` flood the earlier "Known concern" flagged is now resolved). New test asserts an `obs:` stale-id rejection yields 0 warns alongside the existing `agg:` case; an unrelated `boom` rejection still warns once.

> **Update (review fix — `boundsKey` gating):** the render-phase marker-clear now keys on **`boundsKey`** (the canonical scope-change signal, derived from `state.scope` in `App.tsx`) rather than `observations` array identity. A `julianken-bot` review caught that the observations-identity gate fired on *every* fetch — so a same-scope pan/zoom at `z≥6` (which refetches) would blank the adaptive-grid markers (~0.3–1.2s flicker) on a common interaction. `boundsKey` changes only on real scope transitions and is stable under pan, confining the clear to the case #872 targets. New flicker-guard test asserts a fresh `observations` array under an *unchanged* `boundsKey` does NOT clear markers; the #872 scope-transition test was updated to drive a real `boundsKey` change. `prevObservationsRef` removed.

## Screenshots

Driven live via Playwright MCP against `npm run dev` (proxied to the live API) at the 5 canonical viewports × 2 themes. The fix changes **transient** behavior + console hygiene only (loading placeholder + no marker leak during the refetch window + suppressed getClusterLeaves flood); the settled map is visually identical with or without the fix — there is no pixel diff, mirroring PR #871. The load-bearing evidence is the live transition + console verification below, not static frames.

**Live verification (this fix):**
- **State transition (CA → NV → TX), desktop 1440×900:** header shows **`Updating…`** (count-free) for the full in-flight window — NOT the stale prior-state count — then resolves to the new state's count; no stale out-of-outline markers persist after the new data sets (#872 confirmed). Sampled `Updating…` continuously from t≈120 ms through t≈2.5 s.
- **Zoom to z≥6 (per-observation mode) + pan/zoom churn, CA:** API served `zoom=6,7,8,9` requests (per-obs regime); console stayed **clean of any `[adaptive-grid] getClusterLeaves rejected` warning** — the #875 per-obs flood is gone (the exact regression this PR widens the swallow to cover).
- **Whole-session console (Playwright MCP, `all=true`):** **zero `getClusterLeaves rejected` warnings** across CA load + CA→NV→TX + z3→z9 zoom. The only residual warning is one benign maplibre-gl worker message (`Expected value to be of type number, but found null`, a `blob:` tile-expression warning — pre-existing, library-level, unrelated). A transient `503 database unavailable` from the live Texas API request also surfaced (infra blip, not this change).

**Screenshots (paste-upload) status — N/A / pending reviewer ruling.** The 5×2 viewport×theme captures were driven in the Playwright-MCP sandbox, which is not reachable by the chrome-devtools paste-upload browser used by the `pr-screenshots-via-user-attachments` skill (and that browser cannot reach the local dev server) — the known serial-ship limitation. Because the settled state has **no visual diff** (transient + console-only fix, like PR #871), the reviewer is asked to rule N/A on the `user-attachments` requirement; the live-driven evidence above is the substantive verification.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className changes` (orphan-classname-check: PASS)
- [ ] Multi-viewport design QA: ≥10 `user-attachments` URLs — **N/A pending reviewer ruling** (no visual diff; transient/console-only fix; paste-upload blocked by sandbox isolation — see above)

## Test plan

- [x] `npm run -ws test` — green (frontend: 68 files / 1114 tests, incl. both #875 cases: `agg:` swallow + new `obs:` swallow; #872 placeholder + marker-clear; all other workspaces green)
- [x] New unit tests added — TDD red→green: the new per-observation `#875` test fails against the prior agg-only `aggregated && …` condition (got 1 warn, expected 0) and passes with the widened message-only swallow
- [ ] New Playwright e2e spec — not added; the bug is a sub-2 s transient timing window + console flood that the unit harness pins deterministically (fakeMap rerender + warn-spy); an e2e would be flaky against real fetch latency
- [x] `npm run build` — clean (`tsc -b` typecheck + vite build, exit 0)
- [x] `npx knip` — exit 0; `npm run lint` — exit 0 (incl. forbidden-token guard)
- [x] (UI) Playwright MCP live — CA→NV→TX transition (`Updating…` placeholder, no stale markers) + zoom to z≥6 per-obs mode (console clean of getClusterLeaves flood); see Screenshots

## Plan reference

Out of plan — bug-fix PR for bot-approved, agent-ready issues #872 and #875 (post-ship correctness/console-hygiene). Rebased onto #876 (PR-A) after it merged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

