### PR TITLE
fix(frontend): skip empty reconciler commit while observations source re-tiles (#901)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -122,6 +122,13 @@ function makeFakeMap() {
     queryRenderedFeatures: vi.fn(),
     querySourceFeatures: vi.fn(() => []),
     getSource: vi.fn(),
+    // #901 — source-loaded signals. Default `true` (a settled source) so the
+    // empty-inputs commit still clears genuinely-empty viewports in every
+    // existing test. The #901 re-tile test overrides isSourceLoaded → false to
+    // simulate the GL worker re-indexing window where queryRenderedFeatures is
+    // transiently empty and the empty commit must be SKIPPED.
+    isSourceLoaded: vi.fn(() => true),
+    areTilesLoaded: vi.fn(() => true),
     // #763 — getLayer resolves against the in-memory style layer list so the
     // moveLayer/float guards and original-filter capture are testable. (The
     // #762 cluster tests that call getLayer.mockReturnValue still override it.)
@@ -940,6 +947,118 @@ describe('MapCanvas', () => {
     expect(
       document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
     ).toBe(1);
+  });
+
+  // #901 — on a z≥6 same-scope pan, the pan refetch's `setData` swaps the
+  // GeoJSON source and the GL worker re-tiles asynchronously. A STALE
+  // prior-settle `idle` can land after the swap but before the worker emits the
+  // new `sourcedata`, so `queryRenderedFeatures` returns an EMPTY set →
+  // `inputs = []` → without a guard the reconciler commits `setGroups([])` and
+  // the markers blank ~360ms until the next idle recovers. The fix discriminates
+  // on the source-loaded signal: when `inputs` is empty AND the source is still
+  // re-tiling (`isSourceLoaded('observations') === false`), SKIP the commit and
+  // keep the prior markers — the next idle reconciles. This test encodes the
+  // ORDERING: a populated idle commits the marker, then a stale empty idle fires
+  // mid re-tile (source NOT loaded) and must NOT blank it.
+  it('#901: an empty idle while the source is re-tiling (isSourceLoaded → false) keeps prior markers (no mid-pan blank)', async () => {
+    const cluster = {
+      id: 1,
+      properties: { cluster_id: 1, point_count: 3 },
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+    };
+    // First reconcile: the source is settled and a cluster is present.
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [cluster] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+      ]),
+    });
+    fakeMap.getZoom.mockReturnValue(7);
+
+    render(
+      <MapCanvas observations={[makeObs({ subId: 'A1' })]} boundsKey="US-AZ" silhouettes={SILHOUETTES} />,
+    );
+    await waitFor(() => expect(bareHandlersAll['idle']?.length ?? 0).toBeGreaterThan(0));
+
+    // Drive one idle so the reconciler commits the prior-scope marker.
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+      ).toBe(1);
+    });
+
+    // Now simulate the mid-pan re-tile window: setData swapped the source, the
+    // worker is still re-indexing, so queryRenderedFeatures returns EMPTY and
+    // isSourceLoaded('observations') reports false.
+    fakeMap.queryRenderedFeatures.mockImplementation(() => []);
+    fakeMap.isSourceLoaded.mockReturnValue(false);
+
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+
+    // The empty commit must be SKIPPED — the prior marker persists (no blank).
+    expect(
+      document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+    ).toBe(1);
+  });
+
+  // #901 complement — the guard must be bounded STRICTLY to "source still
+  // loading". When the source IS loaded (`isSourceLoaded → true`) and
+  // `queryRenderedFeatures` is empty, the viewport is GENUINELY bird-free (e.g.
+  // a settled source panned to an empty corner) and must still commit `[]` so
+  // stale markers don't strand. This guards against over-skipping.
+  it('#901: an empty idle with the source LOADED still commits [] (genuine empty clears)', async () => {
+    const cluster = {
+      id: 1,
+      properties: { cluster_id: 1, point_count: 3 },
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [cluster] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+      ]),
+    });
+    fakeMap.getZoom.mockReturnValue(7);
+
+    render(
+      <MapCanvas observations={[makeObs({ subId: 'A1' })]} boundsKey="US-AZ" silhouettes={SILHOUETTES} />,
+    );
+    await waitFor(() => expect(bareHandlersAll['idle']?.length ?? 0).toBeGreaterThan(0));
+
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+      ).toBe(1);
+    });
+
+    // Genuine empty: queryRenderedFeatures empty, but the source IS loaded
+    // (default true / explicit here). The commit must fire and clear the marker.
+    fakeMap.queryRenderedFeatures.mockImplementation(() => []);
+    fakeMap.isSourceLoaded.mockReturnValue(true);
+
+    await act(async () => {
+      await fireAllIdleHandlers();
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+      ).toBe(0);
+    });
   });
 
   // #875 — after `setData` re-indexes the supercluster, the idle-tick reconciler

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -2078,6 +2078,36 @@ export function MapCanvas({
       // mid-flight, drop this commit — the new effect-registration's
       // reconcile will produce the right tiles.
       if (cancelled || myGen !== cacheGeneration) return;
+
+      // #901 re-tile empty-commit guard. On a z≥6 same-scope pan the refetch's
+      // `setData` swaps the GeoJSON source and the GL worker re-tiles
+      // asynchronously. A STALE prior-settle `idle` can land after the swap but
+      // before the worker emits the new `sourcedata`, so `queryRenderedFeatures`
+      // returns an EMPTY set → `inputs === []` → committing here would
+      // `setGroups([])` and blank the markers ~360ms until the next idle
+      // recovers. When `inputs` is empty BECAUSE the source is still re-tiling
+      // (`!isSourceLoaded('observations')`), SKIP this commit and keep the prior
+      // markers — the next idle (after the re-tile completes) reconciles. This
+      // mirrors the existing "next idle tick will reconcile" precedents (the
+      // getClusterLeaves catch, the spritesReady/getLayer guard).
+      //
+      // The discriminator is the SOURCE-LOADED signal, NOT `observations.length`:
+      // `observations` is the whole bbox-debounced/quantized fetch fed wholesale
+      // into the source (~:1410), covering a region LARGER than the exact
+      // viewport — so `observations.length > 0 && inputs === []` is ALSO true for
+      // a settled source panned to a bird-free corner, which MUST still clear.
+      // Only `isSourceLoaded` disambiguates "re-tiling" from "settled-but-empty".
+      // Bounded strictly to "source still loading": a settled-but-empty source
+      // (genuine empty viewport, or a source that errored and finished) reports
+      // loaded → falls through and commits `[]` as today, so markers never strand.
+      if (
+        inputs.length === 0 &&
+        typeof map.isSourceLoaded === 'function' &&
+        !map.isSourceLoaded('observations')
+      ) {
+        return;
+      }
+
       // Run deconflict (pure, sync). Output: one group per overlap component.
       const nextGroups = buildGroups(inputs, floorZoom);
       setGroups(nextGroups);


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant Map as MapLibre GL
    participant Worker as GL re-tile worker
    participant R as idle reconciler

    User->>Map: z≥6 same-scope pan
    Map->>Map: refetch → setData(new GeoJSON)
    Note over Map,Worker: source swapped, worker re-tiling (isSourceLoaded=false)
    R->>Map: stale prior-settle idle → queryRenderedFeatures
    Map-->>R: [] (transiently empty mid re-tile)
    alt inputs===[] AND !isSourceLoaded('observations')
        R->>R: SKIP commit — keep prior markers
        Note over R: next idle reconciles (no ~360ms blank)
    else inputs===[] AND isSourceLoaded
        R->>Map: setGroups([]) — genuine empty clears
    end
    Worker-->>Map: sourcedata (re-tile done)
    Map->>R: next idle → buildGroups(real inputs) → commit
```

## Summary

- On a z≥6 same-scope pan the refetch's `setData` re-tiles the source asynchronously; a stale prior-settle `idle` querying `queryRenderedFeatures` mid re-tile got `[]` and committed `setGroups([])`, blanking the adaptive-grid markers ~360ms until the next idle recovered (#901). The blank coincided with the new pan data landing, not with any scope change.
- Fix: guard the empty commit with the **source-loaded** signal — when `inputs===[]` AND `!map.isSourceLoaded('observations')` (re-tile in flight), skip the commit and keep prior markers; the next idle reconciles. Mirrors the existing "next idle tick will reconcile" precedents.
- The discriminator is deliberately the source-loaded signal, **not** `observations.length`: `observations` is the bbox-quantized superset (larger than the viewport), so a settled source panned to a bird-free corner also has `inputs===[]` and MUST still clear `[]`. Bounded strictly to "source still loading" so settled-but-empty always commits `[]` and markers never strand. The #872 `boundsKey` scope-clear is untouched.

## Screenshots

N/A — not UI. This is a transient-behavior fix with no settled-state visual diff (markers render identically before and after; only the mid-pan flash is removed). Precedent: #877 / #871 (timing/transient fixes marked N/A). The behavior change was verified by live Playwright MCP drive at z<6 (national z4) and z≥6 (Pennsylvania z10) in both regimes — see Test plan.

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (1117 passed); `MapCanvas.test.tsx` 83 passed
- [x] New unit tests added (TDD, red→green): `#901: an empty idle while the source is re-tiling (isSourceLoaded → false) keeps prior markers (no mid-pan blank)` (confirmed RED on unguarded code → GREEN after guard) and `#901: an empty idle with the source LOADED still commits [] (genuine empty clears)`. Regression guards kept green: `#872: a boundsKey change synchronously clears prior-scope DOM markers`, `#872: ...UNCHANGED boundsKey does NOT clear markers (flicker guard)`, and the #875 swallow tests. `fakeMap` extended with `isSourceLoaded`/`areTilesLoaded` (default `true`).
- [x] `npm run lint` — clean
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx knip` — no dead-code findings
- [x] Playwright MCP live drive (`npm run dev`, proxy → prod API):
  - (a) z10 same-scope pan in PA, 40ms/20ms sampling across the full refetch+setData+re-tile window — markers updated in place and **never blanked while the source was re-tiling** (`isSourceLoaded=false`): across three pans the min count while re-tiling was 1, 6, and 15 respectively; `bugBlankWhileRetiling=false`. (One larger pan briefly hit 0 only while `isSourceLoaded=true` — the correct genuine-empty commit, not the bug.)
  - (b) national (z4 aggregated) and national→state (PA z10) transitions populated cleanly with no stale-marker leak; the #872 `boundsKey` clear is unchanged.
  - (c) `browser_console_messages` — 0 errors / 0 warnings at both z<6 (national z4) and z≥6 (PA z10).

## Plan reference

Out of plan — bug fix surfaced during prod validation of #877 (predates it; the `:2083` reconciler commit is pre-existing, untouched by #877). Closes #901.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)