### PR TITLE
perf(read-api,ingestor): precompute per-scope aggregation grid to kill 12–15s cold state fetch (#878)

### DIFF
--- a/migrations/1700000051000_observation_grid_agg.sql
+++ b/migrations/1700000051000_observation_grid_agg.sql
@@ -1,0 +1,43 @@
+-- Up Migration
+--
+-- observation_grid_agg — precomputed per-scope aggregation grid (#878).
+--
+-- The state-scope low-zoom `/api/observations` aggregation (getObservationsAggregated,
+-- packages/db-client/src/observations.ts) aggregates EVERY in-state observation at
+-- request time. For high-volume states (CA/TX, ~12-15s cold) the cost is the
+-- HashAggregate/WindowAgg/Sort over the in-scope row set, NOT row-finding (AZ runs
+-- the identical query + indexes in 0.13-0.22s; only row count differs). An index
+-- cannot help — it speeds finding rows, not aggregating them. So we precompute the
+-- aggregated grid per scope at ingest time and serve the default low-zoom view as a
+-- cheap PK lookup.
+--
+-- One row per (scope_key, grid_multiplier, lng_bucket, lat_bucket):
+--   scope_key       — a state code ('US-CA', …) OR the national key 'US'.
+--   grid_multiplier — the read-api zoom→grid switch (2/4/8; app.ts:242).
+--   lng_bucket /    — round(coord * grid_multiplier) / grid_multiplier, IDENTICAL
+--   lat_bucket        to the live `base` CTE bucket key (observations.ts:432-433).
+--   observation_count / species_count — the live `bucket_totals` (over ALL rows in
+--                     the cell, incl. NULL-family rows).
+--   families        — the live `families` per-bucket jsonb rollup, byte-identical to
+--                     the live CTE: families ordered (count desc, code asc); species
+--                     nested top-8 (count desc, code asc); NULL-family rows excluded
+--                     from families[] but counted in the totals.
+--
+-- This is the FIRST materialized aggregation in the schema (verified: zero
+-- materialized views / agg tables pre-#878). The populate (refreshGridAgg in
+-- db-client/observations.ts) runs ingest-side after each /recent ingest+reconcile
+-- AND after the 14-day prune — never on the request path. One ingest cycle of
+-- staleness (~30 min) is acceptable (the edge cache already runs ~40 min).
+CREATE TABLE observation_grid_agg (
+  scope_key         TEXT             NOT NULL,
+  grid_multiplier   INTEGER          NOT NULL,
+  lng_bucket        DOUBLE PRECISION NOT NULL,
+  lat_bucket        DOUBLE PRECISION NOT NULL,
+  observation_count INTEGER          NOT NULL,
+  species_count     INTEGER          NOT NULL,
+  families          JSONB            NOT NULL,
+  PRIMARY KEY (scope_key, grid_multiplier, lng_bucket, lat_bucket)
+);
+
+-- Down Migration
+DROP TABLE IF EXISTS observation_grid_agg;

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -4,6 +4,9 @@ export { getHotspots, upsertHotspots, type HotspotInput } from './hotspots.js';
 export {
   getObservations, getObservationsAggregated, upsertObservations,
   runReconcileStamping, getFreshestObservationAt,
+  // #878 — precomputed per-scope aggregation grid.
+  refreshGridAgg, getAggregatedGridFromCache, isPrecomputeEligible,
+  resolveScopeKey, NATIONAL_SCOPE_KEY, STANDARD_GRID_MULTIPLIERS,
   type ObservationInput,
 } from './observations.js';
 export {

--- a/packages/db-client/src/observation-grid-agg.test.ts
+++ b/packages/db-client/src/observation-grid-agg.test.ts
@@ -1,0 +1,291 @@
+/**
+ * #878 — precomputed per-scope aggregation grid (observation_grid_agg).
+ *
+ * Real Postgres+PostGIS testcontainer (no DB mocks, per repo convention). The
+ * seed is small but geometrically representative: rows inside two state
+ * polygons (US-AZ, US-CA) plus a few outside both, so the per-state clip and the
+ * national rollup are both exercised. The serial-plan GUC (max_parallel_workers
+ * _per_gather = 0) makes the float-keyed bucket aggregation run-to-run
+ * deterministic so the byte-identity assertion against the live CTE is exact.
+ *
+ * Guards:
+ *   1. EQUIVALENCE — refreshGridAgg's grid is byte-identical to the live
+ *      getObservationsAggregated CTE for the default unfiltered scope (national
+ *      AND a state), at every standard multiplier (2/4/8): same buckets, counts,
+ *      species counts, and families jsonb.
+ *   2. PREDICATE — isPrecomputeEligible is positive: default state/national view
+ *      (with the always-present state-envelope bbox) is eligible; any filter,
+ *      non-default since, or non-standard multiplier is not.
+ *   3. REFRESH CORRECTNESS — after an ingest delta AND after a prune the grid
+ *      reflects the new state with no stale cells.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers (NUMERIC → number).
+import './pool.js';
+import {
+  getObservationsAggregated,
+  refreshGridAgg,
+  getAggregatedGridFromCache,
+  isPrecomputeEligible,
+  resolveScopeKey,
+  NATIONAL_SCOPE_KEY,
+  STANDARD_GRID_MULTIPLIERS,
+} from './observations.js';
+import type { AggregatedBucket } from '@bird-watch/shared-types';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+// A handful of (lng, lat) points inside US-AZ and US-CA, plus a couple outside
+// both (a Gulf-of-Mexico point and a mid-Atlantic point) so the national grid
+// carries rows the per-state clips drop. AZ ≈ [-114.8..-109, 31.3..37]; CA ≈
+// [-124.4..-114.1, 32.5..42]. Coordinates use a +0.2 bucket-interior offset to
+// keep bucket assignment unambiguous across multipliers (mirrors the perf
+// guard's integer-index construction reasoning).
+const PTS: Array<{ lng: number; lat: number }> = [
+  // Arizona cluster
+  { lng: -112.1, lat: 33.5 }, { lng: -112.1, lat: 33.5 }, { lng: -111.9, lat: 33.3 },
+  { lng: -110.9, lat: 32.2 }, { lng: -111.7, lat: 35.2 },
+  // California cluster
+  { lng: -118.3, lat: 34.1 }, { lng: -118.3, lat: 34.1 }, { lng: -122.4, lat: 37.7 },
+  { lng: -121.5, lat: 38.6 }, { lng: -117.2, lat: 32.7 },
+  // Outside both states (national-only)
+  { lng: -90.0, lat: 27.0 }, { lng: -75.0, lat: 38.0 },
+];
+
+const SPECIES = ['sp-0001', 'sp-0002', 'sp-0003', 'sp-0004', 'sp-0005'];
+
+async function seedObservations(startSub: number, count: number): Promise<void> {
+  const subIds: string[] = [], codes: string[] = [], lats: number[] = [], lngs: number[] = [];
+  const dts: string[] = [], locIds: string[] = [], locNames: (string | null)[] = [];
+  const hows: (number | null)[] = [], notables: boolean[] = [];
+  const now = Date.now();
+  for (let i = 0; i < count; i++) {
+    const p = PTS[i % PTS.length]!;
+    subIds.push(`S${startSub + i}`);
+    codes.push(SPECIES[i % SPECIES.length]!);
+    lngs.push(p.lng);
+    lats.push(p.lat);
+    // All within the 14d window (age 0..10 days, whole days — no boundary fuzz).
+    dts.push(new Date(now - (i % 11) * 86_400_000).toISOString());
+    locIds.push('L0');
+    locNames.push(null);
+    hows.push(1);
+    notables.push(i % 7 === 0);
+  }
+  await pool.query(
+    `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+     SELECT * FROM unnest($1::text[],$2::text[],$3::float8[],$4::float8[],$5::timestamptz[],$6::text[],$7::text[],$8::int[],$9::bool[])
+     ON CONFLICT (sub_id, species_code) DO NOTHING`,
+    [subIds, codes, lats, lngs, dts, locIds, locNames, hows, notables],
+  );
+}
+
+/** Order-independent fingerprint of an aggregated result set. */
+function fingerprint(buckets: AggregatedBucket[]): string {
+  return JSON.stringify(
+    buckets
+      .map(b => ({ lng: b.lng, lat: b.lat, count: b.count, speciesCount: b.speciesCount, families: b.families }))
+      .sort((a, z) => a.lng - z.lng || a.lat - z.lat),
+  );
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  const uri = container.getConnectionUri();
+
+  // Serial plans → deterministic float-keyed aggregation (same rationale as the
+  // perf guard). Apply the GUC then build the pool after pg_reload_conf.
+  const cfg = new pg.Pool({ connectionString: uri, max: 1 });
+  await cfg.query('ALTER SYSTEM SET max_parallel_workers_per_gather = 0');
+  await cfg.query('SELECT pg_reload_conf()');
+  await cfg.end();
+
+  pool = new pg.Pool({ connectionString: uri, max: 4 });
+
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  for (const f of readdirSync(migrationsDir).filter(x => x.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(migrationsDir, f), 'utf-8');
+    const [rawUp = ''] = sql.split(/-- Down Migration/i);
+    const up = rawUp.replace(/-- Up Migration/i, '');
+    if (up.trim()) await pool.query(up);
+  }
+
+  // species_meta: sp-0001..0004 known (families fam-a/fam-b), sp-0005 NULL family
+  // (no species_meta row) so the NULL-family carve-out is exercised: counted in
+  // bucket totals, excluded from families[].
+  await pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order) VALUES
+       ('sp-0001','Com 1','Sci 1','fam-a','Fam A',10001),
+       ('sp-0002','Com 2','Sci 2','fam-a','Fam A',10002),
+       ('sp-0003','Com 3','Sci 3','fam-b','Fam B',10003),
+       ('sp-0004','Com 4','Sci 4','fam-b','Fam B',10004)`,
+  );
+
+  await seedObservations(0, 600);
+  await pool.query('ANALYZE observations');
+  await pool.query('ANALYZE species_meta');
+  await pool.query('ANALYZE state_boundaries');
+}, 600_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('refreshGridAgg ↔ getObservationsAggregated byte-identity (#878)', () => {
+  it('populates a non-empty grid for national + states across all standard multipliers', async () => {
+    const n = await refreshGridAgg(pool);
+    expect(n).toBeGreaterThan(0);
+    // National grid exists at every standard multiplier.
+    for (const m of STANDARD_GRID_MULTIPLIERS) {
+      const nat = await getAggregatedGridFromCache(pool, NATIONAL_SCOPE_KEY, m);
+      expect(nat.length).toBeGreaterThan(0);
+    }
+    // AZ + CA grids exist.
+    const az = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    const ca = await getAggregatedGridFromCache(pool, 'US-CA', 8);
+    expect(az.length).toBeGreaterThan(0);
+    expect(ca.length).toBeGreaterThan(0);
+  });
+
+  it('national precompute is byte-identical to the live CTE at every multiplier', async () => {
+    await refreshGridAgg(pool);
+    for (const m of STANDARD_GRID_MULTIPLIERS) {
+      const live = await getObservationsAggregated(pool, { since: '14d' }, m);
+      const cached = await getAggregatedGridFromCache(pool, NATIONAL_SCOPE_KEY, m);
+      expect(fingerprint(cached)).toBe(fingerprint(live));
+    }
+  });
+
+  it('per-state precompute is byte-identical to the live CTE (incl. the state envelope bbox) at every multiplier', async () => {
+    await refreshGridAgg(pool);
+    for (const stateCode of ['US-AZ', 'US-CA']) {
+      for (const m of STANDARD_GRID_MULTIPLIERS) {
+        // Live path with the state clip AND a wide bbox — the wide envelope must
+        // not change the result vs the precompute (server clips to the polygon).
+        const live = await getObservationsAggregated(
+          pool,
+          { since: '14d', stateCode, bbox: [-180, 0, 0, 90] },
+          m,
+        );
+        const cached = await getAggregatedGridFromCache(pool, stateCode, m);
+        expect(fingerprint(cached)).toBe(fingerprint(live));
+        expect(cached.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('NULL-family rows are counted in totals but excluded from families[] (matches live carve-out)', async () => {
+    await refreshGridAgg(pool);
+    const cached = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    // sp-0005 (NULL family) is seeded into AZ cells; some bucket must have a
+    // count strictly greater than the species nested under its families[].
+    const someBucketHasUnfamilied = cached.some(b => {
+      const speciesInFamilies = b.families.reduce((acc, fam) => acc + fam.speciesCount, 0);
+      return b.speciesCount > speciesInFamilies;
+    });
+    expect(someBucketHasUnfamilied).toBe(true);
+  });
+});
+
+describe('isPrecomputeEligible positive predicate (#878)', () => {
+  it('the default state view (state code + envelope bbox, default since, standard multiplier) IS eligible', () => {
+    expect(isPrecomputeEligible({ since: '14d', stateCode: 'US-CA', bbox: [-124.4, 32.5, -114.1, 42] }, 8)).toBe(true);
+    expect(resolveScopeKey({ since: '14d', stateCode: 'US-CA' })).toBe('US-CA');
+  });
+
+  it('the default national view (no state, default since, standard multiplier) IS eligible and resolves to US', () => {
+    expect(isPrecomputeEligible({ since: '14d', bbox: [-130, 20, -65, 52] }, 2)).toBe(true);
+    expect(resolveScopeKey({ since: '14d' })).toBe(NATIONAL_SCOPE_KEY);
+  });
+
+  it('unset since defaults to eligible (since defaults to 14d server-side)', () => {
+    expect(isPrecomputeEligible({ stateCode: 'US-TX' }, 4)).toBe(true);
+  });
+
+  it('a notable / species / family filter is NOT eligible (falls back to live)', () => {
+    expect(isPrecomputeEligible({ since: '14d', stateCode: 'US-CA', notable: true }, 8)).toBe(false);
+    expect(isPrecomputeEligible({ since: '14d', stateCode: 'US-CA', speciesCode: 'sp-0001' }, 8)).toBe(false);
+    expect(isPrecomputeEligible({ since: '14d', stateCode: 'US-CA', familyCode: 'fam-a' }, 8)).toBe(false);
+  });
+
+  it('a non-default since is NOT eligible', () => {
+    expect(isPrecomputeEligible({ since: '7d', stateCode: 'US-CA' }, 8)).toBe(false);
+    expect(isPrecomputeEligible({ since: '30d' }, 2)).toBe(false);
+  });
+
+  it('a non-standard grid multiplier is NOT eligible', () => {
+    expect(isPrecomputeEligible({ since: '14d', stateCode: 'US-CA' }, 16)).toBe(false);
+    expect(isPrecomputeEligible({ since: '14d' }, 3)).toBe(false);
+  });
+});
+
+describe('refreshGridAgg correctness across ingest delta + prune (#878)', () => {
+  it('reflects an ingest delta after re-refresh (no stale cells)', async () => {
+    await refreshGridAgg(pool);
+    const before = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    const beforeTotal = before.reduce((a, b) => a + b.count, 0);
+
+    // Add a fresh AZ-heavy delta (all at the first AZ point) then re-refresh.
+    const subIds: string[] = [], codes: string[] = [], lats: number[] = [], lngs: number[] = [];
+    const dts: string[] = [], locIds: string[] = [], locNames: (string | null)[] = [];
+    const hows: (number | null)[] = [], notables: boolean[] = [];
+    const now = Date.now();
+    for (let i = 0; i < 50; i++) {
+      subIds.push(`DELTA${i}`);
+      codes.push('sp-0001');
+      lngs.push(-112.1);
+      lats.push(33.5);
+      dts.push(new Date(now - (i % 5) * 86_400_000).toISOString());
+      locIds.push('L0'); locNames.push(null); hows.push(1); notables.push(false);
+    }
+    await pool.query(
+      `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       SELECT * FROM unnest($1::text[],$2::text[],$3::float8[],$4::float8[],$5::timestamptz[],$6::text[],$7::text[],$8::int[],$9::bool[])
+       ON CONFLICT (sub_id, species_code) DO NOTHING`,
+      [subIds, codes, lats, lngs, dts, locIds, locNames, hows, notables],
+    );
+    await refreshGridAgg(pool);
+
+    const after = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    const afterTotal = after.reduce((a, b) => a + b.count, 0);
+    expect(afterTotal).toBe(beforeTotal + 50);
+    // Still byte-identical to the live path post-delta.
+    const live = await getObservationsAggregated(pool, { since: '14d', stateCode: 'US-AZ' }, 8);
+    expect(fingerprint(after)).toBe(fingerprint(live));
+  });
+
+  it('reflects a prune (rows aged out) after re-refresh — pruned cells disappear', async () => {
+    // Insert a batch of OLD AZ rows (40 days) in a fresh bucket, refresh (they're
+    // outside 14d so the grid never carries them), then "prune" deletes them and
+    // a re-refresh must still match the live path. Then prove an in-window row
+    // that we delete drops out of the grid after refresh.
+    const now = Date.now();
+    // A unique-bucket fresh AZ point so we can watch it vanish on delete.
+    await pool.query(
+      `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       VALUES ('PRUNEME','sp-0001', 36.9, -113.9, $1, 'L0', NULL, 1, false)
+       ON CONFLICT (sub_id, species_code) DO NOTHING`,
+      [new Date(now - 2 * 86_400_000).toISOString()],
+    );
+    await refreshGridAgg(pool);
+    const withRow = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    const targetLng = Math.round(-113.9 * 8) / 8;
+    const targetLat = Math.round(36.9 * 8) / 8;
+    expect(withRow.some(b => b.lng === targetLng && b.lat === targetLat)).toBe(true);
+
+    // Prune that row, re-refresh: the cell must be gone (no stale cell).
+    await pool.query(`DELETE FROM observations WHERE sub_id = 'PRUNEME'`);
+    await refreshGridAgg(pool);
+    const afterPrune = await getAggregatedGridFromCache(pool, 'US-AZ', 8);
+    expect(afterPrune.some(b => b.lng === targetLng && b.lat === targetLat)).toBe(false);
+    // And still byte-identical to the live path.
+    const live = await getObservationsAggregated(pool, { since: '14d', stateCode: 'US-AZ' }, 8);
+    expect(fingerprint(afterPrune)).toBe(fingerprint(live));
+  });
+});

--- a/packages/db-client/src/observations-aggregated-perf.test.ts
+++ b/packages/db-client/src/observations-aggregated-perf.test.ts
@@ -43,7 +43,11 @@ import { performance } from 'node:perf_hooks';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers (NUMERIC → number).
 import './pool.js';
-import { getObservationsAggregated } from './observations.js';
+import {
+  getObservationsAggregated,
+  refreshGridAgg,
+  getAggregatedGridFromCache,
+} from './observations.js';
 
 // Prod-scale target. bird-maps.com carries ~550k observations nationally; the
 // failing request is the coarsest grid over the whole set. 550k reproduces the
@@ -141,6 +145,25 @@ beforeAll(async () => {
     richness: 100 + Math.floor(rng() * 97),
   }));
 
+  // #878 — single-high-volume-STATE concentration. The prior seed spread 550k
+  // rows across CONUS, which DILUTED per-state density: the heaviest state still
+  // only carried a thin slice, so the state-scope guard passed at ~5.8s instead
+  // of reproducing the 12–15s prod CA/TX cold-fill. To make the guard a real
+  // RED→GREEN discriminator we pin a large share of the seed INSIDE the Texas
+  // polygon interior so the live TX aggregation processes a prod-shaped in-state
+  // row count. TX interior box (well clear of every border so every point falls
+  // unambiguously in the US-TX polygon AND on an integer-indexed bucket
+  // interior): lng -101.0..-97.0 (idx -202..-194), lat 29.0..33.0 (idx 58..66).
+  const TX_LNG_IDX_MIN = -202, TX_LNG_IDX_SPAN = 8; // -101.0 .. -97.0
+  const TX_LAT_IDX_MIN = 58, TX_LAT_IDX_SPAN = 8; //   29.0 .. 33.0
+  // Dense TX hotspots inside that interior box (rich cells so the WindowAgg /
+  // jsonb_agg path is exercised at state scale, matching the prod offender).
+  const txHotspots = Array.from({ length: 40 }, () => ({
+    lngIdx: TX_LNG_IDX_MIN + Math.floor(rng() * TX_LNG_IDX_SPAN),
+    latIdx: TX_LAT_IDX_MIN + Math.floor(rng() * TX_LAT_IDX_SPAN),
+    richness: 120 + Math.floor(rng() * 77),
+  }));
+
   const now = Date.now();
   const BATCH = 20_000;
   let inserted = 0;
@@ -152,7 +175,18 @@ beforeAll(async () => {
     const hows: (number | null)[] = [], notables: boolean[] = [];
     for (let i = 0; i < n; i++) {
       let lngIdx: number, latIdx: number, sp: string;
-      if (rng() < 0.55) {
+      const roll = rng();
+      if (roll < 0.45) {
+        // #878 — TX-interior concentration (~45% of the seed). Jitter ±1 bucket
+        // index around a TX hotspot, staying inside the interior box so every
+        // point falls in the US-TX polygon. This is what makes a single state
+        // carry prod-shaped volume so the live state query reproduces the
+        // 12–15s cold cost (RED) that the precompute lookup then kills (GREEN).
+        const hs = txHotspots[Math.floor(rng() * txHotspots.length)]!;
+        lngIdx = hs.lngIdx + (Math.floor(rng() * 3) - 1);
+        latIdx = hs.latIdx + (Math.floor(rng() * 3) - 1);
+        sp = speciesMeta[Math.floor(Math.pow(rng(), 0.5) * Math.min(hs.richness, SPECIES))]!.code;
+      } else if (roll < 0.7) {
         // Dense hotspot cluster: jitter ±2 bucket indices around a hotspot, so
         // the cluster spans a few cells but every point still lands on an
         // integer-indexed bucket interior.
@@ -374,34 +408,35 @@ describe('getObservationsAggregated state-scope perf guard (#873)', () => {
   const TX_ENVELOPE: [number, number, number, number] = [-106.64548, 25.84012, -93.50829, 36.50044];
 
   it(
-    'runs the state-scoped aggregated query (stateCode + fixed envelope, since=14d, z5 grid) well under the timeout',
+    'serves the default TX state view (since=14d, z5 grid) well under the timeout via the precompute (#878)',
     async () => {
       // gridMultiplier 8 = the z5 metro grid (the read-api maps zoom 5 → mult 8),
       // the finest aggregated tier and the level a state view actually requests.
       const GRID = 8;
 
-      // Shape — exactly what the #873 client now sends for a state scope at
-      // zoom < 6: the state clip AND the fixed state envelope as bbox. The
-      // envelope is co-extensive with the state's bounding box, so it adds no
-      // meaningful scan work over the state clip alone (both are GIST-backed).
+      // #878 — the DEFAULT TX state view (stateCode + fixed envelope, default
+      // since, no filters) is now served by the precompute, not the live CTE.
+      // At the re-seeded single-state volume the LIVE TX aggregation runs ~9–15s
+      // (reproducing the prod cold-fill — see the #878 lookup guard below for the
+      // before/after), so the path that actually serves this view must be the
+      // precompute lookup. Build it as the ingestor would, then measure the
+      // lookup (what the read-api takes for this eligible request).
+      await refreshGridAgg(pool);
       const t0 = performance.now();
-      const buckets = await getObservationsAggregated(
-        pool,
-        { since: '14d', stateCode: TX, bbox: TX_ENVELOPE },
-        GRID,
-      );
+      const buckets = await getAggregatedGridFromCache(pool, TX, GRID);
       const elapsedMs = performance.now() - t0;
 
       // eslint-disable-next-line no-console
       console.log(
-        `[#873 perf guard] TX state-scope query (fixed envelope): ${elapsedMs.toFixed(0)}ms over ${TARGET_ROWS} rows → ${buckets.length} buckets (threshold ${PERF_THRESHOLD_MS}ms, pool statement_timeout 15000ms)`,
+        `[#878 state-scope guard] TX default view via precompute lookup: ${elapsedMs.toFixed(0)}ms over ${TARGET_ROWS} rows → ${buckets.length} buckets (threshold ${PERF_THRESHOLD_MS}ms, pool statement_timeout 15000ms)`,
       );
 
-      // PERF GUARD — comfortably under the timeout (same conservative 8s ceiling
-      // as the national guards; the state scope is a strict subset of CONUS).
+      // PERF GUARD — the served path is comfortably under the timeout. (Same 8s
+      // conservative ceiling; the lookup is in fact sub-second — the dedicated
+      // #878 guard pins the tighter 1s bound and the live-vs-lookup delta.)
       expect(elapsedMs).toBeLessThan(PERF_THRESHOLD_MS);
 
-      // The seed spreads observations across CONUS, so a TX clip is non-empty
+      // The seed concentrates observations inside TX, so the grid is non-empty
       // and carries real totals — not a degenerate empty box.
       expect(buckets.length).toBeGreaterThan(0);
       for (const b of buckets) {
@@ -444,6 +479,69 @@ describe('getObservationsAggregated state-scope perf guard (#873)', () => {
       expect(fingerprint(withEnvelope)).toBe(fingerprint(withoutEnvelope));
       // And the result is real (non-empty), so the equality is meaningful.
       expect(withEnvelope.length).toBeGreaterThan(0);
+    },
+    120_000,
+  );
+});
+
+// ── #878 — PRECOMPUTE perf guard (RED→GREEN discriminator) ───────────────────
+//
+// The #873 guard above pins that the LIVE state query is "under the timeout" at
+// 8s — but prod proved the cold CA/TX live aggregation actually runs 12–15s,
+// because the prior seed under-represented single-state volume (rows spread thin
+// over CONUS). With the TX-interior concentration added to the seed above, the
+// live TX aggregation now processes a prod-shaped in-state row count. This guard
+// asserts the FIX: the precompute lookup (getAggregatedGridFromCache after
+// refreshGridAgg) returns the same buckets as the live path but SUB-SECOND —
+// the AC's "comparable to AZ" target. It is the RED→GREEN discriminator: on
+// `main` (no precompute) the default TX view pays the full live aggregation;
+// after the fix it pays a PK lookup.
+describe('getObservationsAggregated precompute lookup perf guard (#878)', () => {
+  const TX = 'US-TX';
+  const TX_ENVELOPE: [number, number, number, number] = [-106.64548, 25.84012, -93.50829, 36.50044];
+  // The precompute lookup is a single PK range scan — it must be FAR under a
+  // second even on noisy CI. 1000ms is a generous ceiling vs the live 12–15s.
+  const LOOKUP_THRESHOLD_MS = 1_000;
+
+  it(
+    'the precomputed TX grid is byte-identical to the live CTE AND served sub-second (the cold-state fix)',
+    async () => {
+      const GRID = 8;
+
+      // Build the precompute exactly as the ingestor would after a recent/prune.
+      await refreshGridAgg(pool);
+
+      // RED baseline: time the LIVE TX aggregation (the path #878 replaces). At
+      // the re-seeded single-state volume this is the heavy aggregate the prod
+      // 12–15s cold-fill measured; logged so the PR can quote before/after.
+      const tLive0 = performance.now();
+      const live = await getObservationsAggregated(
+        pool,
+        { since: '14d', stateCode: TX, bbox: TX_ENVELOPE },
+        GRID,
+      );
+      const liveMs = performance.now() - tLive0;
+
+      // GREEN: the precompute LOOKUP for the same default TX view.
+      const tLookup0 = performance.now();
+      const cached = await getAggregatedGridFromCache(pool, TX, GRID);
+      const lookupMs = performance.now() - tLookup0;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[#878 perf guard] TX default view — live aggregate: ${liveMs.toFixed(0)}ms vs precompute lookup: ${lookupMs.toFixed(0)}ms over ${TARGET_ROWS} rows → ${cached.length} buckets (lookup threshold ${LOOKUP_THRESHOLD_MS}ms)`,
+      );
+
+      // PERF GUARD — the lookup is sub-second (the AC's "comparable to AZ"
+      // target) regardless of how heavy the live aggregation got.
+      expect(lookupMs).toBeLessThan(LOOKUP_THRESHOLD_MS);
+      // And materially faster than the live path it replaces (the whole point).
+      expect(lookupMs).toBeLessThan(liveMs);
+
+      // CORRECTNESS — the lookup returns EXACTLY what the live CTE would, so the
+      // read-path swap is invisible to the frontend.
+      expect(cached.length).toBeGreaterThan(0);
+      expect(fingerprint(cached)).toBe(fingerprint(live));
     },
     120_000,
   );

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -520,6 +520,280 @@ export async function getObservationsAggregated(
   }));
 }
 
+// ── #878 — PRECOMPUTED PER-SCOPE AGGREGATION GRID ───────────────────────────
+//
+// getObservationsAggregated aggregates EVERY in-scope observation at request
+// time. For high-volume states (CA/TX) the cost is the HashAggregate/WindowAgg/
+// Sort over the in-scope row set, not row-finding — ~12-15s cold, one bad scan
+// from the 15s statement_timeout. The fix precomputes the aggregated grid per
+// scope at ingest time (refreshGridAgg, ingestor-side) and serves the DEFAULT
+// low-zoom view as a cheap PK lookup (getAggregatedGridFromCache) on the
+// observation_grid_agg table (migration 1700000051000). Filtered / non-default
+// requests keep the exact live CTE path (getObservationsAggregated) unchanged.
+
+/**
+ * The national scope key in `observation_grid_agg.scope_key` (the unclipped,
+ * whole-US grid). State scopes use their `US-XX` code as the key.
+ */
+export const NATIONAL_SCOPE_KEY = 'US';
+
+/**
+ * The standard grid multipliers the read-api's closed zoom→grid switch emits
+ * (`services/read-api/src/app.ts`: zoom <= 3 → 2, zoom === 4 → 4, else → 8).
+ * Only these tiers are precomputed; any other multiplier (an upstream tamper,
+ * a future tier) falls through to the live CTE. Kept here, beside the populate
+ * + lookup that consume it, so the precompute set and the read-path predicate
+ * never drift from one list.
+ */
+export const STANDARD_GRID_MULTIPLIERS: readonly number[] = [2, 4, 8];
+
+/**
+ * Resolves the `scope_key` for a precompute lookup from the request filters:
+ * a `US-XX` state code when one is scoped, the national key otherwise. This is
+ * a pure function of the SCOPE — never of the bbox. A scoped state view ALWAYS
+ * sends the deterministic snapped state-envelope bbox (frontend client.ts), so
+ * "a bbox is present" must NOT route to the fallback or it defeats the whole
+ * fix; the server already clips to the state polygon, so the envelope bbox is a
+ * function of the scope, not a row-reducing filter.
+ */
+export function resolveScopeKey(f: ObservationFilters): string {
+  return f.stateCode ?? NATIONAL_SCOPE_KEY;
+}
+
+/**
+ * POSITIVE read-path predicate (#878). Use the precompute lookup ONLY when the
+ * request is the default unfiltered low-zoom view:
+ *   - a resolvable scope (a state code OR national — always true here, but kept
+ *     explicit so the intent reads in one place),
+ *   - the default `since` window (14d, or unset which defaults to 14d),
+ *   - NO `notable` / `speciesCode` / `familyCode` filter,
+ *   - a standard grid multiplier (2/4/8).
+ * The bbox is deliberately IGNORED — a scoped state view always carries the
+ * snapped state-envelope bbox, which is co-extensive with the state's polygon
+ * clip and adds no row-reducing work. Everything else (any filter, non-default
+ * `since`, a non-standard multiplier) falls through to the live CTE.
+ */
+export function isPrecomputeEligible(
+  f: ObservationFilters,
+  gridMultiplier: number,
+): boolean {
+  // Default `since` = 14d (unset defaults to 14d at the populate level too).
+  const sinceIsDefault = f.since === undefined || f.since === '14d';
+  const hasNoFilters =
+    f.notable !== true && f.speciesCode === undefined && f.familyCode === undefined;
+  const standardMultiplier = STANDARD_GRID_MULTIPLIERS.includes(gridMultiplier);
+  return sinceIsDefault && hasNoFilters && standardMultiplier;
+}
+
+/**
+ * Cheap PK lookup into `observation_grid_agg` for the default low-zoom view.
+ * Returns the precomputed buckets in the SAME shape getObservationsAggregated
+ * returns (so the read-api branch is a drop-in). The rows are byte-identical to
+ * what the live CTE would produce for `{ since: '14d', stateCode? }` at this
+ * multiplier (guaranteed by refreshGridAgg sharing the live pipeline).
+ *
+ * A scope/multiplier with no precomputed rows yields []. The caller decides
+ * whether an empty grid means "genuinely empty scope" or "not yet populated";
+ * in practice refreshGridAgg runs every ingest cycle so a live scope is never
+ * absent for long, and the read-path only takes this branch when eligible.
+ */
+export async function getAggregatedGridFromCache(
+  pool: Pool,
+  scopeKey: string,
+  gridMultiplier: number,
+): Promise<AggregatedBucket[]> {
+  const { rows } = await pool.query<{
+    lng_bucket: number;
+    lat_bucket: number;
+    observation_count: number;
+    species_count: number;
+    families: AggregatedFamily[] | null;
+  }>(
+    `SELECT lng_bucket, lat_bucket, observation_count, species_count, families
+       FROM observation_grid_agg
+      WHERE scope_key = $1 AND grid_multiplier = $2`,
+    [scopeKey, gridMultiplier],
+  );
+  return rows.map(r => ({
+    lng: Number(r.lng_bucket),
+    lat: Number(r.lat_bucket),
+    count: r.observation_count,
+    speciesCount: r.species_count,
+    families: r.families ?? [],
+  }));
+}
+
+/**
+ * Recomputes the ENTIRE `observation_grid_agg` table — all scopes (national +
+ * every CONUS state) × all standard grid multipliers (2/4/8) — and atomically
+ * swaps it in (#878). Runs ingestor-side after each /recent ingest+reconcile
+ * AND after the 14-day prune (never on the request path), so a state's grid
+ * always reflects the current observations table (no stale cells across an
+ * ingest delta or a prune — the table is fully rebuilt each call).
+ *
+ * State-assignment decision: each observation is assigned to its state with ONE
+ * GIST-backed `ST_Intersects` join against `state_boundaries` (the `&&`
+ * bounding-box prefilter uses obs_geom_idx), NOT 49 separate per-state polygon
+ * passes and NOT a denormalized `state_code` column on `observations`. A single
+ * spatial join over the pruned 14d table is far cheaper than 49 repeated scans
+ * AND avoids a schema change + per-ingest backfill of a state_code column (which
+ * would also have to be kept correct on every upsert). The national grid needs
+ * no join at all. The whole rebuild is one set-based statement per CTE chain, so
+ * the populate cost is a single 14d-window aggregation pass (the same volume the
+ * live national query already does in ~2.3s at prod scale) — comfortably inside
+ * the ingestor's 900s job budget and off the request path entirely.
+ *
+ * Byte-identity: this shares the EXACT pipeline shape getObservationsAggregated
+ * uses (base → per_species → ranked → per_family → families + bucket_totals),
+ * extended with a `scope_key` grouping key. For `scope_key = 'US'` the base is
+ * all 14d rows (= the live national query). For `scope_key = 'US-XX'` the base
+ * is the rows whose geom ST_Intersects that state polygon (= the live state
+ * query's clip). So a precomputed cell equals what the live CTE returns for the
+ * matching `{ since: '14d', stateCode? }` request, cell-for-cell.
+ *
+ * The grid multipliers and top-N cap are bound parameters / a CROSS JOIN over a
+ * fixed VALUES list — never interpolated — so the populate carries no injection
+ * surface. The rebuild runs in one transaction (TRUNCATE + INSERT) so a reader
+ * never sees a half-populated table.
+ */
+export async function refreshGridAgg(pool: Pool): Promise<number> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    // Clear inside the transaction so a reader never sees a half-populated grid
+    // (the INSERT below repopulates before COMMIT). DELETE not TRUNCATE: TRUNCATE
+    // takes an ACCESS EXCLUSIVE lock that would block concurrent read-path
+    // lookups for the rebuild's duration; a DELETE + INSERT under MVCC lets
+    // lookups keep serving the previous snapshot until COMMIT.
+    await client.query('DELETE FROM observation_grid_agg');
+    // The full per-scope/per-multiplier aggregation. `scoped` tags every 14d
+    // observation with each scope it belongs to: 'US' (national, no clip) UNION
+    // ALL its containing state ('US-XX', via the GIST ST_Intersects join).
+    // `mult(m)` CROSS JOINs the standard multipliers so one statement covers all
+    // tiers. The rest mirrors getObservationsAggregated exactly, with scope_key
+    // + grid_multiplier threaded through every GROUP BY / PARTITION BY.
+    const result = await client.query<{ n: string }>(
+      `
+      WITH recent AS (
+        SELECT o.geom, o.species_code, sm.family_code
+        FROM observations o
+        LEFT JOIN species_meta sm ON sm.species_code = o.species_code
+        WHERE o.obs_dt >= now() - (14 * interval '1 day')
+      ),
+      mult(grid_multiplier) AS (
+        VALUES (2::int), (4::int), (8::int)
+      ),
+      scoped AS (
+        -- National scope: every recent row, no clip.
+        SELECT $1::text AS scope_key, r.geom, r.species_code, r.family_code
+        FROM recent r
+        UNION ALL
+        -- State scope: each recent row tagged with the state polygon it falls
+        -- in. ST_Intersects (NOT ST_Contains) matches the live state clip
+        -- inclusive border idiom; the && prefilter uses obs_geom_idx.
+        SELECT sb.state_code AS scope_key, r.geom, r.species_code, r.family_code
+        FROM recent r
+        JOIN state_boundaries sb
+          ON r.geom && sb.geom AND ST_Intersects(sb.geom, r.geom)
+      ),
+      base AS (
+        SELECT
+          s.scope_key,
+          m.grid_multiplier,
+          round(ST_X(s.geom) * m.grid_multiplier) / m.grid_multiplier AS lng_bucket,
+          round(ST_Y(s.geom) * m.grid_multiplier) / m.grid_multiplier AS lat_bucket,
+          s.species_code,
+          s.family_code
+        FROM scoped s
+        CROSS JOIN mult m
+      ),
+      per_species AS (
+        SELECT
+          scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code, species_code,
+          count(*)::int AS species_count
+        FROM base
+        WHERE family_code IS NOT NULL
+        GROUP BY scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code, species_code
+      ),
+      ranked AS (
+        SELECT
+          scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code, species_code, species_count,
+          ROW_NUMBER() OVER (
+            PARTITION BY scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code
+            ORDER BY species_count DESC, species_code ASC
+          ) AS rn
+        FROM per_species
+      ),
+      per_family AS (
+        SELECT
+          scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code,
+          sum(species_count)::int AS family_count,
+          count(*)::int AS family_species_count,
+          jsonb_agg(
+            jsonb_build_object('code', species_code, 'count', species_count)
+            ORDER BY species_count DESC, species_code ASC
+          ) FILTER (WHERE rn <= $2) AS top_species
+        FROM ranked
+        GROUP BY scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code
+      ),
+      families AS (
+        SELECT
+          scope_key, grid_multiplier, lng_bucket, lat_bucket,
+          jsonb_agg(
+            jsonb_build_object(
+              'code', family_code,
+              'count', family_count,
+              'speciesCount', family_species_count,
+              'species', top_species
+            )
+            ORDER BY family_count DESC, family_code ASC
+          ) AS families
+        FROM per_family
+        GROUP BY scope_key, grid_multiplier, lng_bucket, lat_bucket
+      ),
+      bucket_totals AS (
+        SELECT
+          scope_key, grid_multiplier, lng_bucket, lat_bucket,
+          count(*)::int AS observation_count,
+          count(DISTINCT species_code)::int AS species_count
+        FROM base
+        GROUP BY scope_key, grid_multiplier, lng_bucket, lat_bucket
+      ),
+      grid AS (
+        SELECT
+          t.scope_key, t.grid_multiplier, t.lng_bucket, t.lat_bucket,
+          t.observation_count, t.species_count,
+          COALESCE(f.families, '[]'::jsonb) AS families
+        FROM bucket_totals t
+        LEFT JOIN families f
+          ON  f.scope_key = t.scope_key
+          AND f.grid_multiplier = t.grid_multiplier
+          AND f.lng_bucket = t.lng_bucket
+          AND f.lat_bucket = t.lat_bucket
+      ),
+      ins AS (
+        INSERT INTO observation_grid_agg
+          (scope_key, grid_multiplier, lng_bucket, lat_bucket,
+           observation_count, species_count, families)
+        SELECT scope_key, grid_multiplier, lng_bucket, lat_bucket,
+               observation_count, species_count, families
+        FROM grid
+        RETURNING 1
+      )
+      SELECT count(*)::text AS n FROM ins
+      `,
+      [NATIONAL_SCOPE_KEY, TOP_SPECIES_PER_FAMILY],
+    );
+    await client.query('COMMIT');
+    return Number(result.rows[0]?.n ?? 0);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 /**
  * Returns the ISO string of the most recently ingested observation
  * (MAX(ingested_at)), or null when the observations table is empty.

--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -526,6 +526,99 @@ describe('runCli', () => {
     await expect(runCli('bogus', deps)).rejects.toThrow(/prune/);
   });
 
+  // ── #878 — precompute grid refresh hook ───────────────────────────────────
+  // refreshGridAgg must fire after a `recent` ingest+reconcile AND after a
+  // `prune` (the "no stale cells" Must-NOT needs BOTH: recent adds rows, prune
+  // drops aged-out cells). It must NOT fire on other kinds, and must be skipped
+  // on a failed run (observations unchanged → prior grid still correct).
+  describe('precompute grid refresh (#878)', () => {
+    const recentSuccess: RunSummary = {
+      status: 'success', fetched: 10, upserted: 10, statesSucceeded: 49, statesFailed: 0,
+    };
+    const pruneSuccess = {
+      status: 'success' as const, deleted: 5, archived: 5,
+      archivedDays: 1, gcsPaths: ['gs://x'], retentionDays: 14,
+    };
+
+    it("fires refreshGridAgg after a successful 'recent' run, with the pool", async () => {
+      const refreshSpy = vi.fn().mockResolvedValue(150);
+      const deps = makeDeps({
+        runIngest: vi.fn().mockResolvedValue(recentSuccess),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('recent', deps);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy).toHaveBeenCalledWith(POOL_SENTINEL);
+    });
+
+    it("fires refreshGridAgg after a successful 'prune' run", async () => {
+      delete process.env.OBSERVATIONS_RETENTION_DAYS;
+      const refreshSpy = vi.fn().mockResolvedValue(150);
+      const deps = makeDeps({
+        runPrune: vi.fn().mockResolvedValue(pruneSuccess),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('prune', deps);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(refreshSpy).toHaveBeenCalledWith(POOL_SENTINEL);
+    });
+
+    it("fires after a 'partial' recent run (forward progress landed rows)", async () => {
+      const refreshSpy = vi.fn().mockResolvedValue(150);
+      const deps = makeDeps({
+        runIngest: vi.fn().mockResolvedValue({
+          ...recentSuccess, status: 'partial', statesFailed: 2,
+          failures: [{ state: 'US-CA', error: 'x' }, { state: 'US-TX', error: 'y' }],
+        }),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('recent', deps);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT fire on a FAILED recent run (observations unchanged → grid still valid)", async () => {
+      const refreshSpy = vi.fn().mockResolvedValue(150);
+      const deps = makeDeps({
+        runIngest: vi.fn().mockResolvedValue({
+          status: 'failure', fetched: 0, upserted: 0,
+          statesSucceeded: 0, statesFailed: 49, error: 'boom',
+        }),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('recent', deps);
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT fire on a non-recent/non-prune kind ('taxonomy')", async () => {
+      const refreshSpy = vi.fn().mockResolvedValue(150);
+      const deps = makeDeps({
+        runTaxonomy: vi.fn().mockResolvedValue({
+          status: 'success', totalFetched: 1, speciesInserted: 1,
+          nonSpeciesFiltered: 0, reconciled: 0,
+        } satisfies RunTaxonomySummary),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('taxonomy', deps);
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it("a refresh failure is non-fatal: the recent run still succeeds (exitCode untouched)", async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const refreshSpy = vi.fn().mockRejectedValue(new Error('grid boom'));
+      const deps = makeDeps({
+        runIngest: vi.fn().mockResolvedValue(recentSuccess),
+        refreshGridAgg: refreshSpy,
+      });
+      await runCli('recent', deps);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      // The ingest landed rows; a grid-refresh failure must not fail the job.
+      expect(process.exitCode).toBeUndefined();
+      // It is surfaced loudly so a persistently-stale grid is visible.
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+  });
+
   // ── cache-warm kind (issue #711) ──────────────────────────────────────
   // The cache-warm kind is pure HTTP — no DB pool, no eBird API. Its early
   // return must precede the EBIRD_API_KEY / DATABASE_URL guards so a manual

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from 'node:url';
 import {
   createPool as realCreatePool,
   closePool as realClosePool,
+  refreshGridAgg as realRefreshGridAgg,
   type Pool,
 } from '@bird-watch/db-client';
 import { runIngest as realRunIngest, type RunSummary } from './run-ingest.js';
@@ -69,6 +70,15 @@ export interface CliDeps {
   runPhotos: typeof realRunPhotos;
   runDescriptions: typeof realRunDescriptions;
   runPrune: typeof realRunPrune;
+  /**
+   * #878 — recomputes the precomputed per-scope aggregation grid
+   * (observation_grid_agg) after a `recent` ingest+reconcile AND after a
+   * `prune`. Off the request path (ingestor-side). Optional + injectable so
+   * tests can assert it fires exactly on those two kinds (and is skipped on a
+   * failed run) without standing up a real grid rebuild. Production wires the
+   * real `refreshGridAgg`.
+   */
+  refreshGridAgg?: typeof realRefreshGridAgg;
   runCacheWarm: typeof realRunCacheWarm;
   runDigest?: typeof realRunDigest;
   fetchWikipediaSummary: typeof realFetchWikipediaSummary;
@@ -380,6 +390,44 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
     } else {
       throw new Error(`Unknown kind: ${kind}. Try recent | hotspots | backfill | backfill-extended | taxonomy | photos | descriptions | prune | cache-warm | digest | probe-taxon | probe-wiki`);
     }
+
+    // #878 — recompute the precomputed per-scope aggregation grid after a
+    // `recent` ingest+reconcile AND after a `prune`. BOTH are required by the
+    // "no stale cells" Must-NOT: `recent` adds/updates rows (the grid must
+    // reflect new sightings) and `prune` deletes the 14-day tail (the grid must
+    // drop the aged-out cells). It runs ONLY on those two kinds, and only when
+    // the run did not fail — a failed `recent` (e.g. a 429 circuit-break that
+    // wrote zero rows) leaves observations unchanged, so the prior grid is still
+    // correct and rebuilding it would only waste a 14d aggregation pass. This is
+    // off the request path (ingestor-side), inside the shared Cloud Run job's
+    // 900s budget; a single set-based 14d rebuild is the same volume the live
+    // national query already does in ~2.3s at prod scale. A refresh failure is
+    // logged and downgrades the run to non-fatal degraded (the next cycle
+    // retries) — it does NOT mask the upstream ingest/prune success, because the
+    // observations themselves did land.
+    if ((kind === 'recent' || kind === 'prune') && summary.status !== 'failure') {
+      const refreshGridAgg = deps.refreshGridAgg ?? realRefreshGridAgg;
+      try {
+        const gridRows = await refreshGridAgg(pool);
+        console.log(JSON.stringify({
+          severity: 'INFO',
+          message: 'bird_grid_agg_refreshed',
+          kind,
+          grid_rows: gridRows,
+        }));
+      } catch (err) {
+        // Non-fatal: the ingest/prune already committed. Surface it loudly so a
+        // persistently-stale grid is visible, but do not fail the job — the next
+        // cycle re-refreshes.
+        console.error(JSON.stringify({
+          severity: 'ERROR',
+          message: 'bird_grid_agg_refresh_failed',
+          kind,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      }
+    }
+
     // Cloud Run / Cloud Logging splits stdout on newlines and treats each
     // resulting line as its own `textPayload` entry — pretty-printed JSON
     // therefore shreds into N rows with zero `jsonPayload.*` coverage, and
@@ -491,6 +539,7 @@ if (isEntrypoint) {
     runPhotos: realRunPhotos,
     runDescriptions: realRunDescriptions,
     runPrune: realRunPrune,
+    refreshGridAgg: realRefreshGridAgg,
     runCacheWarm: realRunCacheWarm,
     runDigest: realRunDigest,
     sendDigestEmail,

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -7,6 +7,7 @@ import {
   upsertObservations,
   insertSpeciesPhoto,
   insertSpeciesDescription,
+  refreshGridAgg,
 } from '@bird-watch/db-client';
 import { createApp } from './app.js';
 
@@ -744,6 +745,117 @@ describe('GET /api/observations', () => {
           locId: 'L2', locName: 'Y', howMany: 1, isNotable: true },
       ]);
     });
+  });
+});
+
+// ── #878 — precompute read-path routing ─────────────────────────────────────
+//
+// The aggregated low-zoom default view (state scope or national, default since,
+// no filters, standard multiplier) must route to the PRECOMPUTE LOOKUP
+// (observation_grid_agg); any filter / non-default since routes to the live CTE
+// FALLBACK. The discriminator: refresh the grid, then mutate `observations`
+// WITHOUT refreshing. An eligible request returns the STALE precomputed grid
+// (proving it read the cache); an ineligible request reflects the live mutated
+// table (proving it ran the CTE). Both paths return mode=aggregated, identical
+// envelope shape.
+describe('GET /api/observations precompute routing (#878)', () => {
+  const AZ_ENVELOPE = '-114.81651,31.33218,-109.04528,37.00426';
+  const seedAzRows = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      subId: `G${i}`, speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+      lat: 33.45, lng: -112.07,
+      obsDt: new Date(Date.now() - (i % 10) * 86400_000).toISOString(),
+      locId: 'L1', locName: 'X', howMany: 1, isNotable: i % 4 === 0,
+    }));
+
+  beforeAll(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    ]);
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, seedAzRows(40));
+    // Build the precompute grid for the current table state.
+    await refreshGridAgg(db.pool);
+  });
+
+  afterAll(async () => {
+    await db.pool.query('TRUNCATE observations');
+    await db.pool.query('DELETE FROM observation_grid_agg');
+    await upsertObservations(db.pool, [
+      { subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: new Date(Date.now() - 5*86400_000).toISOString(),
+        locId: 'L1', locName: 'X', howMany: 1, isNotable: false },
+    ]);
+  });
+
+  type AggEnvelope = { mode: string; buckets: Array<{ count: number }> };
+  const totalCount = (b: AggEnvelope) => b.buckets.reduce((s, x) => s + x.count, 0);
+
+  it('default state scope (state + envelope bbox, default since, z5) routes to the LOOKUP and is sub-second', async () => {
+    const app = createApp({ pool: db.pool });
+    const t0 = performance.now();
+    const res = await app.request(
+      `/api/observations?state=US-AZ&bbox=${AZ_ENVELOPE}&zoom=5&since=14d`,
+    );
+    const elapsedMs = performance.now() - t0;
+    expect(res.status).toBe(200);
+    const body = await res.json() as AggEnvelope;
+    expect(body.mode).toBe('aggregated');
+    // The precompute carries all 40 seeded AZ rows.
+    expect(totalCount(body)).toBe(40);
+    // Cheap PK lookup — comfortably sub-second.
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  it('the default lookup returns the STALE grid after an unrefreshed mutation (proves it read the cache, not the live CTE)', async () => {
+    // Mutate observations WITHOUT refreshing the grid: delete half the rows.
+    await db.pool.query(`DELETE FROM observations WHERE sub_id LIKE 'G2%' OR sub_id LIKE 'G3%'`);
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(
+      `/api/observations?state=US-AZ&bbox=${AZ_ENVELOPE}&zoom=5&since=14d`,
+    );
+    const body = await res.json() as AggEnvelope;
+    // Still 40 — the lookup served the pre-mutation precompute, NOT the live
+    // (now-smaller) table. This is the load-bearing proof the default routes to
+    // the cache.
+    expect(totalCount(body)).toBe(40);
+    // Re-seed so the next test's fallback math is from a known state.
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, seedAzRows(40));
+  });
+
+  it('a notable filter routes to the live FALLBACK (reflects the live table, ignores the cache)', async () => {
+    // Grid was last refreshed with 40 rows; the live notable subset is the
+    // i%4===0 rows = 10 of 40. A notable request must NOT use the cache (the
+    // precompute carries no notable-only variant), so it must report the live
+    // notable count, not the 40-row cached total.
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(
+      `/api/observations?state=US-AZ&bbox=${AZ_ENVELOPE}&zoom=5&since=14d&notable=true`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as AggEnvelope;
+    expect(body.mode).toBe('aggregated');
+    expect(totalCount(body)).toBe(10);
+  });
+
+  it('a non-default since routes to the live FALLBACK', async () => {
+    // since=7d keeps only rows aged 0..6 days = ages {0,1,2,3,4,5,6} of the i%10
+    // cycle → 4 full decades of 7 + remainder. We assert it differs from the
+    // cached 40 by reflecting the live since-filtered subset (i.e. < 40), which
+    // only the live CTE can produce.
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(
+      `/api/observations?state=US-AZ&bbox=${AZ_ENVELOPE}&zoom=5&since=7d`,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as AggEnvelope;
+    expect(body.mode).toBe('aggregated');
+    // 7d window prunes the 7,8,9-day-old rows → strictly fewer than 40.
+    expect(totalCount(body)).toBeLessThan(40);
+    expect(totalCount(body)).toBeGreaterThan(0);
   });
 });
 

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -8,6 +8,8 @@ import {
   getSpeciesMeta, getSpeciesDictionary, getSilhouettes,
   getSpeciesPhenology,
   listStatesWithBbox,
+  // #878 — precomputed per-scope aggregation grid.
+  isPrecomputeEligible, getAggregatedGridFromCache, resolveScopeKey,
 } from '@bird-watch/db-client';
 import type { ObservationsResponse } from '@bird-watch/shared-types';
 import { cacheControlFor } from './cache-headers.js';
@@ -240,8 +242,28 @@ export function createApp(deps: AppDeps): Hono {
     // grids. Multiplier choice rationale lives in getObservationsAggregated.
     if (bbox !== undefined && zoom !== undefined && zoom < 6) {
       const gridMultiplier = zoom <= 3 ? 2 : zoom === 4 ? 4 : 8;
+      // #878 — precompute lookup for the DEFAULT low-zoom view. The predicate is
+      // POSITIVE: a resolvable scope (state code or national) + default since
+      // (14d) + no notable/species/family filter + a standard multiplier. The
+      // bbox is deliberately ignored — a scoped state view ALWAYS sends the
+      // snapped state-envelope bbox, which is co-extensive with the server's
+      // ST_Intersects polygon clip and adds no row-reducing work; routing on
+      // "bbox present" would send the exact default view this fix targets back
+      // to the 12-15s live aggregation. The precompute is refreshed ingestor-
+      // side after each /recent and after the prune (off the request path), so
+      // the grid is byte-identical to what the live CTE would return for this
+      // { since:'14d', stateCode? } request. Anything ineligible (any filter,
+      // non-default since, non-standard multiplier) falls through to the live
+      // CTE below, unchanged. An eligible scope with no precomputed rows yet
+      // (e.g. immediately post-deploy before the first refresh) also falls back
+      // so the response is never spuriously empty.
+      const precomputed = isPrecomputeEligible(filters, gridMultiplier)
+        ? await getAggregatedGridFromCache(deps.pool, resolveScopeKey(filters), gridMultiplier)
+        : null;
       const [buckets, freshestObservationAt] = await Promise.all([
-        getObservationsAggregated(deps.pool, filters, gridMultiplier),
+        precomputed !== null && precomputed.length > 0
+          ? Promise.resolve(precomputed)
+          : getObservationsAggregated(deps.pool, filters, gridMultiplier),
         getFreshestObservationAt(deps.pool),
       ]);
       c.header('Cache-Control', cacheControlFor('observations'));


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser
    participant ReadAPI
    participant Postgres
    participant Ingestor

    Note over Ingestor,Postgres: off the request path (every cycle)
    Ingestor->>Postgres: recent ingest + reconcile (upsert)
    Ingestor->>Postgres: refreshGridAgg() — rebuild observation_grid_agg
    Ingestor->>Postgres: prune (14d delete)
    Ingestor->>Postgres: refreshGridAgg() — rebuild (drop aged-out cells)

    Note over Browser,Postgres: default state view (eligible)
    Browser->>ReadAPI: GET /api/observations?state=US-TX&bbox=<envelope>&zoom=5&since=14d
    ReadAPI->>ReadAPI: isPrecomputeEligible? (scope + default since + no filters + std mult)
    ReadAPI->>Postgres: PK lookup observation_grid_agg (US-TX, mult 8)  ~19ms
    Postgres-->>ReadAPI: precomputed buckets (byte-identical to live CTE)
    ReadAPI-->>Browser: mode=aggregated

    Note over Browser,Postgres: filtered / non-default (fallback)
    Browser->>ReadAPI: ...&notable=true  (or since=7d, or non-std mult)
    ReadAPI->>Postgres: live 5-CTE getObservationsAggregated (unchanged)
```

```mermaid
flowchart LR
    obs[observations<br/>14d window] -->|ST_Intersects join<br/>state_boundaries| scoped[scoped rows<br/>US + US-XX]
    scoped -->|CROSS JOIN mult 2/4/8| base[base buckets]
    base --> pipeline[per_species → ranked →<br/>per_family → families<br/>+ bucket_totals]
    pipeline --> grid[(observation_grid_agg<br/>scope_key, grid_multiplier,<br/>lng/lat_bucket, counts, families)]
```

## Summary

- **Why:** the state-scope low-zoom aggregation aggregates *every* in-state observation at request time — `EXPLAIN (ANALYZE, BUFFERS)` on a realistically-seeded high-volume Texas scope shows **14,119ms over 240,980 in-TX rows**, with the runtime in the `Sort`/`GroupAggregate`/`WindowAgg` nodes over `base`, NOT the GIST row-find (which returns 240k rows in ~948ms). This is the prod 12–15s cold CA/TX fill, one bad scan from the 15s `statement_timeout`. An index can't help — it speeds *finding* rows, not *aggregating* them (confirmed by AZ vs CA/TX running the identical query+indexes).
- **What:** precompute the aggregated grid per scope (national + every CONUS state) × the 3 standard grid multipliers (2/4/8) into a new `observation_grid_agg` table at ingest time, and serve the default low-zoom view as a cheap PK lookup. The populate shares the **exact** live CTE pipeline (extended with a `scope_key` key), so a precomputed cell is byte-identical to the live query for the matching `{ since:'14d', stateCode? }` request. The read-path predicate is **positive** (scope resolves + default `since` + no `notable`/`species`/`family` + standard multiplier); the snapped state-envelope `bbox` is **ignored** in the decision (it's a function of the scope, co-extensive with the polygon clip — routing on "bbox present" would defeat the fix). Everything else falls through to the live CTE, unchanged.

## Screenshots

N/A — not UI. Backend-only change (migration + db-client + read-api routing + ingestor hook); the frontend is untouched and the response shape/contents are byte-identical to the live path.

## Test plan

- [x] `npm run test` (affected workspaces) — green: db-client 145 pass, read-api 174 pass, ingestor 231 pass
- [x] New unit / integration tests added (real Postgres+PostGIS testcontainers, no mocks):
  - `observation-grid-agg.test.ts` — **equivalence** (precompute byte-identical to live CTE for national + per-state at every multiplier), **positive predicate** (`isPrecomputeEligible`), **refresh correctness across an ingest delta AND a prune** (no stale cells)
  - `app.test.ts` (#878 routing) — default state scope routes to the **lookup** (sub-second) proven via a stale-cache discriminator; a `notable` filter and a non-default `since` route to the live **fallback**
  - `cli.test.ts` (#878) — refresh fires after a successful `recent` AND `prune`, fires on `partial`, **skipped** on a failed run and on other kinds, refresh failure is non-fatal
  - `observations-aggregated-perf.test.ts` — re-seeded to single-high-volume-state (TX) scale; the **RED→GREEN discriminator**: live TX aggregate **9244ms** vs precompute lookup **19ms** (state-scope guard lookup ~55ms), byte-identical (258 buckets)
- [x] `npm run build` — clean production build (all workspaces)
- [x] `npx knip` — clean (only the pre-existing unrelated config hint on the old prototype dir)
- [x] EXPLAIN (ANALYZE, BUFFERS) RED baseline captured (cold high-volume TX, live path):
  ```
  Execution Time: 14119.128 ms   (240,980 in-TX rows, 14d window)
  CTE base → Index Scan obs_geom_idx: actual 1.760..455.895 rows=240980   (row-find is cheap)
  GroupAggregate ← Sort (external merge, Disk: 8040kB): 1313..1392ms       (cost is the aggregate)
  WindowAgg / GroupAggregate / Incremental Sort: loops=258 over CTE base
  ```
  After the fix the same default TX view is a PK lookup: **~19ms** (live aggregate **9244ms** at the in-process testcontainer measurement → lookup **19ms**).

## Plan reference

Out of plan — fixes #878 (P2 latent reliability: cold high-volume state aggregation 12–15s, near `statement_timeout`). Follow-up to #873 (fixed the cache/loading, not the origin aggregation cost).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
