### PR TITLE
fix(db-client): exempt refreshGridAgg from the 15s statement_timeout so the grid populate completes (#878)

### DIFF
--- a/packages/db-client/src/observation-grid-agg.test.ts
+++ b/packages/db-client/src/observation-grid-agg.test.ts
@@ -289,3 +289,58 @@ describe('refreshGridAgg correctness across ingest delta + prune (#878)', () => 
     expect(fingerprint(afterPrune)).toBe(fingerprint(live));
   });
 });
+
+describe('refreshGridAgg statement_timeout exemption (#878 prod-timeout regression)', () => {
+  // Prod regression: pool.ts sets a 15s statement_timeout on every connection
+  // (#822) to protect the read-api request path. refreshGridAgg's populate is
+  // one heavy batch statement (14d `recent` CTE × 2/4/8 multipliers × national +
+  // 50-state ST_Intersects join) that exceeds 15s at prod scale, so Postgres
+  // cancelled it (SQLSTATE 57014), the txn rolled back, and zero grid rows
+  // committed — leaving every state scope on the 12–15s live fallback (CA 503s).
+  // The fix mirrors the #845 precedent: `SET LOCAL statement_timeout = 0`
+  // immediately after BEGIN, scoping the exemption to this transaction only.
+  // This test fails against the pre-fix code (no SET LOCAL) and passes after.
+  it("issues `SET LOCAL statement_timeout = 0` after BEGIN, before the populate", async () => {
+    const log: string[] = [];
+    // Wrap pool.connect so the returned client records every query text. We
+    // delegate to the real client (so the populate runs for real against the
+    // testcontainers DB) and only observe the call sequence.
+    const realConnect = pool.connect.bind(pool);
+    const spied = {
+      connect: async () => {
+        const client = await realConnect();
+        const realQuery = client.query.bind(client);
+        // pg's query() is heavily overloaded; capture the SQL text from the
+        // first arg (string, or { text } config object) and forward verbatim.
+        (client as unknown as { query: (...a: unknown[]) => unknown }).query = (
+          ...args: unknown[]
+        ) => {
+          const first = args[0];
+          const text =
+            typeof first === 'string'
+              ? first
+              : (first as { text?: string })?.text ?? '';
+          log.push(text);
+          return (realQuery as (...a: unknown[]) => unknown)(...args);
+        };
+        return client;
+      },
+    } as unknown as pg.Pool;
+
+    const n = await refreshGridAgg(spied);
+    expect(n).toBeGreaterThan(0);
+
+    const beginIdx = log.findIndex(q => /^\s*BEGIN/i.test(q));
+    const setLocalIdx = log.findIndex(q =>
+      /SET\s+LOCAL\s+statement_timeout\s*=\s*0/i.test(q),
+    );
+    const deleteIdx = log.findIndex(q => /DELETE\s+FROM\s+observation_grid_agg/i.test(q));
+
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(setLocalIdx).toBeGreaterThanOrEqual(0);
+    // The exemption must land AFTER BEGIN (so it's inside the txn and SET LOCAL
+    // is valid) and BEFORE the heavy DELETE/INSERT populate it's protecting.
+    expect(setLocalIdx).toBeGreaterThan(beginIdx);
+    expect(setLocalIdx).toBeLessThan(deleteIdx);
+  });
+});

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -660,6 +660,20 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
+    // #878 — exempt THIS transaction from the session statement_timeout.
+    // pool.ts defaults every connection to a 15s statement_timeout (#822, to
+    // protect the read-api from runaway queries). The populate below is one
+    // heavy batch statement (the 14d `recent` CTE × the 2/4/8 multipliers ×
+    // the national + 50-state `ST_Intersects` spatial join) that legitimately
+    // exceeds 15s at prod scale, so Postgres cancels it (SQLSTATE 57014), the
+    // txn rolls back, and zero grid rows commit — leaving every state scope on
+    // the 12–15s live-query fallback (the bug observed in the 04:02 ingest
+    // cycle, logged as bird_grid_agg_refresh_failed). `SET LOCAL` is
+    // transaction-scoped: it applies ONLY to the statements below and
+    // auto-reverts on COMMIT/ROLLBACK, so the read-api pool and every other
+    // query keep their 15s guard. Mirrors the #845 precedent above; the Cloud
+    // Run job's timeout remains the outer kill switch for the populate.
+    await client.query('SET LOCAL statement_timeout = 0');
     // Clear inside the transaction so a reader never sees a half-populated grid
     // (the INSERT below repopulates before COMMIT). DELETE not TRUNCATE: TRUNCATE
     // takes an ACCESS EXCLUSIVE lock that would block concurrent read-path


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Job as Ingestor Job
    participant Pool as pg Pool (15s statement_timeout, #822)
    participant PG as Postgres

    Note over Job,PG: BEFORE (#878 bug) — 04:02 prod cycle
    Job->>PG: BEGIN
    Job->>PG: DELETE + heavy populate (recent CTE × 2/4/8 × 50-state ST_Intersects)
    PG--xJob: SQLSTATE 57014 canceling statement due to statement timeout (>15s)
    Job->>PG: ROLLBACK (0 grid rows committed)
    Note over Job: refresh fails NON-FATALLY → ingest reports success<br/>every state scope falls back to 12–15s live query (CA 503s)

    Note over Job,PG: AFTER (this PR)
    Job->>PG: BEGIN
    Job->>PG: SET LOCAL statement_timeout = 0 (txn-scoped, mirrors #845)
    Job->>PG: DELETE + heavy populate (~25s @ 550k rows, testcontainers)
    Job->>PG: COMMIT (grid fully populated)
    Note over Pool: read-api pool keeps its 15s guard (SET LOCAL auto-reverts)
```

## Summary

- **Why:** `pool.ts` (#822) sets a 15s `statement_timeout` on every connection to protect the read-api request path. `refreshGridAgg`'s populate is one heavy batch statement (the 14d `recent` CTE × the 2/4/8 multipliers × the national + 50-state `ST_Intersects` spatial join) that legitimately exceeds 15s at prod scale, so Postgres cancelled it (SQLSTATE 57014), the txn rolled back, **zero grid rows committed**, and every state scope fell back to the 12–15s live query (CA 503s). The refresh fails non-fatally, so ingest still reports success — which is why CI/tests/review didn't catch it.
- **Fix:** add `SET LOCAL statement_timeout = 0` immediately after `BEGIN`, mirroring the **#845** precedent in the same file (the silhouette-stamp txn does exactly this). `SET LOCAL` is transaction-scoped — it applies only to the populate and auto-reverts on COMMIT/ROLLBACK, so the read-api pool and every other query keep their 15s guard. The Cloud Run job timeout remains the outer kill switch.
- **Regression test:** a new db-client test wraps `pool.connect` to capture the client query sequence and asserts `SET LOCAL statement_timeout = 0` is issued after `BEGIN` and before the populate `DELETE`. Confirmed RED on the pre-fix code (`setLocalIdx === -1`), GREEN after.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/db-client` — green (146 passed | 1 todo), incl. the new regression test and all existing #878 grid tests (equivalence, predicate, refresh-correctness, perf guard)
- [x] `npm run test --workspace @bird-watch/ingestor` — green (231 passed)
- [x] `npm run test --workspace @bird-watch/read-api` — green (174 passed; db-client `dist` rebuilt first)
- [x] New regression test added — RED→GREEN verified (pre-fix: `setLocalIdx === -1`)
- [x] `npm run lint` — clean (exit 0, no errors/warnings)
- [x] `npm run build` — clean production build
- [x] `npx knip` — clean (exit 0)

**Prod log evidence (04:02 ingest cycle):** `bird_grid_agg_refresh_failed: "canceling statement due to statement timeout"` — txn rolled back, 0 grid rows committed, state scopes fell back to the 12–15s live query.

**Testcontainers populate timing:** `refreshGridAgg` over 550k seeded prod-scale rows ran in **~25.2s** (serial-plan, single-CPU container — the conservative/slow case). This is above the 15s cap, directly confirming the timeout root cause; with the exemption the populate runs to completion. No disk-spill pathology (no #862-style 147s blowup). Comfortably inside the Cloud Run job's ~900s budget. See "chunking follow-up" note below.

## Plan reference

Out of plan — prod hotfix for the #878 precompute (grid populate trips the #822 15s `statement_timeout`). Refs #903.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)