### PR TITLE
docs(plans): field-guide mobile species-sheet redesign — implementation plan + companions

### DIFF
--- a/docs/plans/2026-06-06-field-guide-mobile-sheet/diagnosis-report.md
+++ b/docs/plans/2026-06-06-field-guide-mobile-sheet/diagnosis-report.md
@@ -1,0 +1,109 @@
+# Mobile Species-Detail Bottom Sheet — Diagnosis & Decision Report
+
+Scope: the live compact (≤1199px) species detail surface, `SpeciesDetailSheet`. Three lenses (code, ux, options) plus three adversarial critiques. Where a critique refuted or downgraded a claim, this report defers to the critique.
+
+---
+
+## 1. TL;DR
+
+- **It opens unreadable.** The sheet opens at a 120px peek; the body's first element is a full-bleed 16:10 hero photo (~244px tall at 390px wide) that alone is 2× the peek height, so the species name, scientific name, family, and description are all clipped below an `overflow:hidden` fold. The user sees a grab handle and a sliver of photo. (F2 — confirmed)
+- **Drag up is dead.** `translate = Math.max(0, dragOffset)` pins all upward motion to 0px (the sheet never follows the finger up), and the snap threshold additionally requires a single >193px pull to advance peek→half — so a normal upward drag produces no movement, no snap, no feedback. (F4 — confirmed)
+- **The one direction that moves, lags.** Down-drag tracks the finger, but `transition: transform 200ms ease` is live during the drag, so each frame eases toward the target instead of sticking 1:1. There is also no velocity/flick detection (displacement-only thresholds). (F5, F6 — confirmed)
+- **So tapping the bar is the only thing that "works."** The handle stacks `onClick` (tap cycles peek→half→full) on top of the half-built drag handlers. Because drag is broken, tap is the only reliable detent change — exactly the user's "it just changes states when I click the bar." This is an inverted affordance: native handles are drag targets. (F3 — confirmed)
+- **Three a11y defects the original diagnosis missed.** At full the sheet claims `role=dialog`/`aria-modal` but installs no focus trap and only inerts the map subtree, so Tab escapes into the still-interactive AppHeader (F8); there is no focus restoration on close (F9); heading focus fires only at full, so expanding to the readable half state announces nothing to assistive tech (F10).
+- **Fix direction:** open at a content-legible detent (recommended: the existing `half`), make the active drag track the finger 1:1 (gate the CSS transition off during drag), add velocity/flick snapping, and either add a real focus trap at full or stop asserting `aria-modal`. The recommended path is to fix the hand-rolled sheet in place — no library — because every library candidate breaks the per-snap non-modal contract and forces a full test rewrite.
+
+---
+
+## 2. Root-cause findings (CONFIRMED after critique)
+
+All findings below survived adversarial fact-checking. Citation corrections from the critique are folded in (noted inline). F11 is included because it *refutes* a feared bug, which is decision-relevant.
+
+| Finding | Severity | Evidence | Maps to user complaint |
+|---|---|---|---|
+| **F2 — Opens at peek=120px; identity content clipped below the fold** | HIGH (BLOCKER per ux) | `SpeciesDetailSheet.tsx:79` `useState('peek')`, `:21` `PEEK_PX=120`, `:111-112`; first body element is `<Photo layout='masthead'>` (`SpeciesDetailSurface.tsx:143-152`); masthead aspect-ratio is `.photo--masthead{aspect-ratio:16/10}` at **`ds-primitives.css:282-283`** (critique correction: the lens mis-cited `Photo.tsx:15`, a JSDoc comment; `.species-detail-photo` at `styles.css:680-695` is a stale/unused class); peek clip via `.species-detail-sheet--peek{overflow:hidden}` `styles.css:1555` | "opens stuck to the bottom, not in a readable state" |
+| **F4 — Drag UP is dead (clamp + 50%-of-386px threshold)** | HIGH | `SpeciesDetailSheet.tsx:274` `translate=Math.max(0,dragOffset)`; `dragOffset=e.clientY-start.y` `:214` (negative when dragging up → clamped to 0); up-branch advances only if `-delta > span*0.5` where span = 506−120 = 386 → 193px (`:240-246,25,31`) | "drag doesn't work" (expand direction) |
+| **F5 — Down-drag lags (transition live during drag)** | MEDIUM | inline `transform:translateY` `:287`; `.species-detail-sheet{transition: height 200ms ease, transform 200ms ease}` `styles.css:1399-1400`; never disabled during drag; reduced-motion users get 1:1 only incidentally via `motion.css:20-27` | "drag is laggy/janky" (retract direction) |
+| **F6 — No velocity/flick; rigid slide, not resize** | MEDIUM | `dragStartRef={y,snap}` with no timestamp `:205`; displacement-only thresholds (`DISMISS_THRESHOLD_PX=80` `:229`, `SNAP_TRANSITION_RATIO=0.5` `:246/253`); height fixed during drag (`:273`), only transform moves | reinforces "drag feels broken / not native" |
+| **F3 — Handle stacks tap-cycle + drag; no drag-vs-tap discrimination** | MEDIUM | `:296` `onClick={isFull?collapse:expand}` AND `:297-300` `onPointer*` on the same `<button>`; latent double-advance (browsers usually suppress click after pointer-capture+move, so this is latent, not guaranteed live) | "3 states when you click the bar" |
+| **F8 — Full snap asserts `aria-modal` but has NO focus trap** | HIGH | `:282-284` set role/aria-modal; inert written only on `#map-layer` (`:162-164`, `App.tsx:1474`); `App.tsx:264-268` documents AppHeader stays tabbable, which is why the filters panel adds an explicit Tab-wrap (`App.tsx:269-293`); sheet adds none. Bonus drift: `styles.css:1415-1421` comment claims chrome is "non-interactive while the modal sheet is open" — false for keyboard Tab | (missed by orchestrator; broken aria-modal contract) |
+| **F9 — No focus restoration on close/unmount** | MEDIUM | sheet has no `previouslyFocusedRef`; `onClose`→`App.tsx:1468-1473`/`1117-1120` only clears detail; contrast `SpeciesDetailModal.tsx:129-140` which restores to trigger with `document.contains` guard | (missed; keyboard regression vs desktop) |
+| **F10 — Heading focus fires only at full** | MEDIUM | `:263-264` `if (snap!=='full') return;` gates the `#detail-title` focus. Critique nuance: at peek/half content is **not** inerted and `.sheet-scroll` is `tabIndex=0` (`:310`), so content is reachable manually — only auto-announcement is missing | (adjacent to "opens not in a readable state") |
+| **F11 — Feared scroll-vs-drag interception is REFUTED** | LOW | drag bound only to `.sheet-handle` (`:297-300`), not `.sheet-scroll`; `.sheet-handle{touch-action:none}` `:1427`, `.sheet-scroll{touch-action:pan-y}` `:1457` → no conflict. Real (minor) gap: cannot drag from the content body | (rules out a hypothesized cause) |
+| **F13 — PEEK_PX/CSS desync hazard** | LOW | `PEEK_PX=120` `:21`; hand-synced `+120px` legend offset `styles.css:1142-1145` ("MUST stay synced to PEEK_PX"); **exactly one** stale "96px" comment at `styles.css:1553` (critique correction: the lens claimed two — the other "96px" hits at `SpeciesDetailSheet.tsx:17` and `styles.css:677` are an accurate history note and an unrelated silhouette-glyph size) | (latent maintenance hazard) |
+| **F15 — onSnapChange→legend reset only via onClose** | PARTIAL | `:85-87` fires onSnapChange; `App.tsx:216-221` derives `legendForceCollapsed` gated on `isPhone` (≤480px); reset lives in onClose (`App.tsx:1471`). Benign today because the viewport-flip to rail is ≥1200px (different breakpoint), but reset-on-close-only is fragile | (none) |
+
+Confirmed-but-low-relevance findings F1 (component routing: sheet ≤1199px, rail ≥1200px — exact), F7 (dead WIP files — see §5), F12 (test guidance — see §4/§5), and F14 (reduced-motion is global and does not mask the JS-logic drag flaws) are all TRUE and back the analysis but are not user-facing defects.
+
+---
+
+## 3. The native target
+
+Every native reference (Apple Maps / Google Maps place sheets, iOS `UISheetPresentationController`, Material 3 bottom sheet) shares a single invariant the current sheet violates:
+
+- **Open at the smallest detent where core identity is *legible*, never a content-clipping sliver.** *(Critique correction to the ux lens: it is overstated to say native always opens at a "medium ~40-55%" detent — Apple Maps actually opens its place sheet at a small/collapsed detent showing name + subtitle + one action row, a few hundred px, and `selectedDetentIdentifier` is nil-until-interaction. The correct, defensible rule is "legible identity, not clipped," not "medium is the native default.")*
+- **1:1, zero-latency finger tracking in both directions during the drag**; transitions/springs animate only the settle *after* release. Up and down symmetric.
+- **Velocity-aware snapping** — a fast flick advances to the next detent even on tiny travel; slow drags use a displacement threshold against the projected terminal position.
+- **Non-modal at partial detents** — no scrim, map stays pannable/zoomable/tappable behind the sheet; modality (and any dim) appears only at the largest detent. This is the defining property of a map place-sheet.
+- **Drag is the primary handle gesture.** *(Critique correction: tap-to-cycle is NOT non-native in general — Material 3's `BottomSheetDragHandleView` documents click-to-cycle as the single-pointer/a11y alternative. It is undocumented only on iOS. The valid conclusion survives: drag must be the working primary path; tap-only is the bug.)*
+- Settle motion is a velocity-seeded spring; under `prefers-reduced-motion`, a near-instant non-springy move.
+
+**Recommended default detent: `half`** (the existing `HALF_FRACTION=0.6` → 506px @ 844vh; math verified). It is the smallest existing detent at which name + sci-name + family + lede render without a gesture, it keeps the map visible above the sheet (non-modal), and it gives a natural two-way affordance (flick up to full for the long description, down to peek/dismiss).
+
+**Two map-specific risks the ux lens did not resolve (flagged here, not yet answered):**
+1. A 506px sheet leaves only ~338px of map above it on an 844px screen — a thin strip, and **the tapped marker may sit *under* the sheet**. For a map app, keeping the focused feature in view matters; this likely requires offsetting MapLibre's bottom padding / recentering on snap change, which no lens specified.
+2. `half` overlaps the bottom-left FamilyLegend and bottom-right `.map-attribution` license-floor (the four-corner anchor contract, CLAUDE.md §3 / spec §3). Resolving this collision is a **precondition** for `half`, not a follow-up. A peek-plus-identity-row detent (taller than 120px, far shorter than 506px) is an unconsidered alternative that may better preserve map context — see Open Questions.
+
+---
+
+## 4. Forward options
+
+Three distinct paths. (Two library candidates the options lens scored low — `react-spring-bottom-sheet`, abandoned ~4yr / React-18 cap / deprecated transitive deps; and `vaul`, fixed Radix `role=dialog` fighting the per-snap flip — are excluded here; full write-ups exist in the options lens if needed.)
+
+### Option A — Fix the hand-rolled sheet (no library) — RECOMMENDED
+- **What it is:** ~6 edits in `SpeciesDetailSheet.tsx` + CSS: remove the upward `Math.max(0,…)` clamp on the active-drag transform; open at `half`; gate the CSS transition behind an `is-dragging` flag so the drag tracks 1:1 and the transition only runs on settle; add a velocity/flick model (px/ms over last N pointer samples) and replace the 50%-of-gap snap with a velocity+position decision; remove/repurpose the tap-cycle now that drag works. Plus the a11y fixes (F8/F9/F10) and the legend-collision resolution.
+- **a11y-contract fit:** Fully preserved by construction — the inert→role sequencing, region↔dialog flip, heading-focus, and unmount cleanup are untouched; the fix is orthogonal gesture math. (Note: F8/F9/F10 are *additive* a11y work this option must still do — the existing contract is preserved, but the missing focus trap / restore / half-announcement should be fixed in the same pass.)
+- **map-interactive-partial fit:** Unchanged and correct — peek (z-10) / half (z-15) never set inert; only full inerts `#map-layer`. This is the single hardest property for any library to express per-snap, and the hand-rolled code already nails it.
+- **Effort (agentic):** One TDD implementer pass (failing unit specs for open-at-half, up-drag-moves, velocity-advance, settle-to-nearest, no-transition-while-dragging → implement → green) + one Playwright verification pass across the 5 canonical viewports × 2 themes (`sheet-snap.spec.ts`, `axe.spec.ts`, `safe-area.spec.ts`). No fan-out. **Test tax is near-zero:** there is no existing test asserting upward-advance or 1:1 tracking (F12), so F4/F5 are test-free to fix; the load-bearing inert↔role sequencing tests (`SpeciesDetailSheet.test.tsx:88-152`) stay green; only open-at-peek (`:46-61`) and the tap-cycle assertion (`:63-86`) need conscious updates.
+- **Pros:** Zero new bytes (repo ships no animation/gesture lib — verified in `frontend/package.json`); all `data-testid`/`data-snap-state`/role selectors stay green; respects the global reduced-motion single-source-of-truth in `motion.css`; defects are individually small and already root-caused.
+- **Cons:** You own the velocity/flick/momentum code by hand — the part libraries give free; needs a deliberate velocity model to feel polished; does not pay down any longer-term "adopt a standard sheet primitive" desire.
+
+### Option B — Build on `motion` (framer-motion successor) — principled escalation only
+- **What it is:** Keep all markup, role/inert/testid wiring, and the test suite; swap only the gesture internals for `motion` primitives (`drag="y"`, `useDragControls`, `useMotionValue`, spring `animate`).
+- **a11y-contract fit:** Fully preservable — `motion` supplies only drag+spring, no portal/role/focus-trap, so the contract and selectors survive (same posture as Option A).
+- **map-interactive-partial fit:** Identical to Option A — modality stays entirely ours.
+- **Effort:** Comparable to Option A plus a dependency add and a `matchMedia('(prefers-reduced-motion: reduce)')` bridge (a JS spring bypasses the global `motion.css` rule, creating a second reduced-motion source of truth to keep in sync). Drag-simulation unit specs shift from synthetic PointerEvents to motion's model.
+- **Pros:** Production-grade spring/velocity/flick for free while keeping the contract and DOM shape; most test-preserving of the library options; current and well-maintained (React 18/19).
+- **Cons:** Adds an animation runtime (~30–50KB gz, est.) to a bundle that today ships zero; reduced-motion becomes a second source of truth; you still hand-assemble the snap-point state machine — only the physics are free.
+
+### Option C — Adopt `react-modal-sheet` (turn-key, healthiest library) — not recommended
+- **What it is:** Replace the surface with the library's compound `Sheet.*` components; map `snapPoints`/`initialSnap`/`onSnap`/`dragVelocityThreshold`.
+- **a11y-contract fit:** Best of the libraries *by omission* — ships no built-in focus trap, so it doesn't fight our role/inert flip; but you re-own all a11y and must re-express the synchronous inert→role ordering around the library's settle callback.
+- **map-interactive-partial fit:** Conditional — no first-class non-modal flag; you assemble it by omitting the backdrop and disabling scroll-lock (easy to get subtly wrong); it always portals to `document.body`.
+- **Effort:** Two passes + a full unit-test rewrite (portal DOM shape invalidates current selectors and the MutationObserver order test).
+- **Pros:** Actively maintained (published 2026-03); first-class snap points + velocity flick + a `prefersReducedMotion` prop.
+- **Cons:** Pulls the full `motion` runtime as a peer (heaviest add); portal forces the test rewrite; you keep owning a11y *and* take on a heavy dep; second reduced-motion source of truth.
+
+### RECOMMENDED: Option A (fix the hand-rolled sheet). Escalate to Option B (`motion`) only if hand-tuned physics feel inadequate after the fix.
+**Rationale:** The defects are confirmed small, local gesture bugs, not architectural limits — the dead up-drag is one clamp, open-at-peek is one initial-state line, the lag is one always-on transition to gate, the velocity gap is one flick model. Against that, the repo's non-negotiable constraint is the thing libraries handle worst: **non-modal at peek/half, modal only at full, with inert sequenced before the role flip on advance and after it on collapse** — a per-snap contract that every library expresses only as a single per-instance prop, forcing an against-the-grain toggle. Every library also portals to body, changing the DOM shape and forcing a full rewrite of the inert→role ordering tests — pure tax with no reduction in the a11y surface we still own. Option A is zero bytes, keeps the entire test suite green, and respects the global reduced-motion source of truth. Option B is the only *library* path that also preserves the contract and tests, so it is the correct escalation if spring feel is judged essential — at the cost of one dependency and a reduced-motion bridge.
+
+**Provisional-claim flag (defer to critique):** The options lens repeatedly justified avoiding a library via a "mobile bundle budget guard" (`mobile-bundle-e.spec.ts`). **That is FALSE** — per the options critique, that spec is issue #514's touch-target/overflow a11y suite (asserts `body.scrollWidth <= 390` and 44pt targets); it measures no bytes, and a repo-wide grep finds no bundle-size budget anywhere. The underlying merit (the repo deliberately ships zero animation libs, so adding one is a real footprint regression) holds and is verified; the *named CI enforcement mechanism does not exist*. Do not brief an implementer that adding `motion` would fail a bundle-size gate. Bundle-size figures (vaul ~15–25KB gz, motion ~30–50KB gz) are unverified estimates, not measured against this repo's tree-shaken build. Separately: the React-19 forward-compat argument is speculative — the repo is on React 18.2.0 today.
+
+---
+
+## 5. Out-of-scope but noted
+
+- **Dead WIP files — do not mistake for the live path.** `SpeciesDetailModal.tsx` and `lib/use-is-mobile.ts` are untracked, unimported, and dead (F7, confirmed). The Modal passes `bbox`/`onClearBbox` into `SpeciesDetailSurface`, whose props are only `{speciesCode, apiClient}` — it would not even typecheck against the live surface. The live phone hook is `useIsPhone` (≤480px), not `useIsMobile` (≤760px); the live compact gate is `useIsCompact` (≤1199px). An implementer should treat these as cleanup-adjacent, not as the surface to fix.
+- **Half-state legend z-collision (must be resolved as part of Option A/B).** At `half`, the collapsed FamilyLegend pill overlaps the description text and the bottom attribution (bottom-left z-collision). Opening at `half` makes this user-visible, so it is a *precondition* for the recommended detent, addressed within the four-corner anchor + z-tier system (peek=z-10 / half=z-15 / full=`var(--z-modal)` already encode the tier intent), not a deferred follow-up.
+- **PEEK_PX desync hazard (F13).** If the fix changes peek height, three sites must move together: `PEEK_PX` (`SpeciesDetailSheet.tsx:21`), the hand-synced legend offset (`styles.css:1142-1145`), and the stale "96px" comment (`styles.css:1553`).
+- **Documentation drift (F8 bonus).** `styles.css:1415-1421` asserts chrome is "non-interactive while the modal sheet is open" — true only for pointer click-through, not Tab focus. Fix or delete this comment when adding the focus trap.
+
+---
+
+## 6. Open questions for the user
+
+1. **Default detent: `half` (506px) or a shorter identity-row detent?** `half` guarantees legibility but leaves only ~338px of map and may hide the tapped marker. A custom peek-plus-identity detent (taller than 120px, shorter than 506px) is closer to what Apple Maps actually does and preserves more map context. Which do you want as the open state?
+2. **Should the map recenter / inset its bottom padding on snap change** so the tapped marker stays visible above the sheet? This is the standard native technique and is currently unimplemented. In scope for this fix, or a follow-up?
+3. **At full, add a real focus trap, or drop the `aria-modal` claim?** Both are valid (F8). A focus trap preserves the modal semantics; dropping `aria-modal` (and inerting AppHeader too, or treating full as still-non-modal) is simpler. Which direction?
+4. **Keep tap-to-cycle on the handle as a documented a11y shortcut** (Material 3 precedent) once drag works, or remove it entirely to avoid the inverted-affordance confusion?
+5. **Is adopting a standard sheet primitive a longer-term goal?** If yes, that argues for Option B/`motion` now to pre-pay the runtime; if the answer is "keep it lean and hand-rolled," Option A is unambiguous.

--- a/docs/plans/2026-06-06-field-guide-mobile-sheet/fg-tuning-punchlist.md
+++ b/docs/plans/2026-06-06-field-guide-mobile-sheet/fg-tuning-punchlist.md
@@ -1,0 +1,184 @@
+# Field-Guide Sheet — Tuning Punch-List
+
+Merged + deduped from the design and a11y critiques of the field-guide prototype
+(`fg-compact-390.png`, `fg-mid-390.png`, `fg-mid-dark-390.png`, `fg-full-390.png`).
+Scoped to the **locked Field-guide direction** (`mid-full-redesign.md` §3 / Recommendation):
+keep the small row + 3px family accent thread, 120px mid plate, two-cell record strip,
+full-bleed 16/10 masthead, 3-row TAXONOMY table. Items that conflict with that direction
+or with `tokens.css` were dropped (see "Dropped" at the bottom).
+
+Severity: **[H]** high · **[M]** medium · **[L]** low. Token/px in the fix.
+
+---
+
+## ALL DETENTS
+
+- [ ] **[H]** Wikipedia source string leaks raw markup / spacing artifacts into the teaser & prose
+  (`<p>`/`<b>` tags as literal text on light mid; ` ,` space-before-comma on dark mid) →
+  Sanitize once at the source: flatten Wikipedia inline HTML to text (or sanitized inline
+  `<b>/<i>`) and collapse "removed-span + punctuation" so a stripped `<b>` leaves no leading
+  space. One sanitization path feeds compact teaser, mid teaser, and full About prose.
+  *(merges mid-html-leak + mid-dark-comma-artifact + a11y-teaser-clamp-reachability render half)*
+
+- [ ] **[M]** Photoless species render a flat family-color block at every slot →
+  Render the family silhouette glyph centered on the family-color ground, tinted to contrast
+  per theme, at all three slots (44px thumb / 120px plate / masthead). One fallback component
+  sized by the slot so compact/mid/full stay consistent.
+  *(cross-detent-photoless-block)*
+
+- [ ] **[M]** Family-color dot is the only encoding of family identity and can drop below 3:1
+  (light family hue on cream, any hue on navy) → 1.4.11. Keep the family-name **text**
+  co-located with the dot as the canonical signal (already true on the sheet — preserve it),
+  and add a 1px contrasting ring (`rgba` border) on the dot at every detent so its boundary is
+  perceivable regardless of hue/theme. Audit the full family palette against `#fff` and the
+  navy surface at 3:1, not just cardinal-red.
+  *(merges a11y-family-color-only-signal + a11y-family-dot-nontext-contrast + family-dot-size-align border half)*
+
+- [ ] **[L]** Family dot is small and sits below the cap-height of the 13px family text →
+  Standardize the dot at 8px diameter in a flex row with `align-items:center` and `--space-xs`
+  (4–6px) gap (not inline baseline). Identical dot geometry at compact/mid/full.
+  *(family-dot-size-align)*
+
+---
+
+## COMPACT
+
+- [ ] **[L]** 44px thumb renders square; text block sits optically high against it →
+  Round the thumb to `--card-radius-inner` (8px) to match the plate/family shape language;
+  center the two-line text block to the thumb with `align-items:center`. Thumb stays 44px
+  (touch-target + identity-row spec).
+  *(compact-thumb-radius-center)*
+
+- [ ] **[L]** Common name (17px) and family line sit with near-zero gap; family competes for
+  emphasis → Add 2px between name and family; set family line to `--color-text-muted` (#555)
+  at `--type-sm` (13). Keep name at `--type-md` (17) / 600.
+  *(compact-name-family-rhythm)*
+
+---
+
+## MID
+
+- [ ] **[H]** "Read account" expand control is distinguished by cardinal-red color alone, has
+  no button affordance, fails 1.4.1, and (dark) the red fails AA contrast on navy → Render it
+  as a real `<button aria-expanded aria-controls="account-body">` with a **persistent underline**
+  (`text-decoration: underline`), labeled "Read account", colored with `--color-text-link`
+  (= `--color-decision-point`: orange on light, cyan on dark — both theme-tuned). Do NOT mark
+  interactivity with the per-family accent. Reflect clamp state in `aria-expanded`; on expand,
+  move focus into / reveal the full account so truncated content is keyboard- & AT-reachable.
+  *(merges a11y-read-account-link-color-only + a11y-read-account-dark-contrast + a11y-teaser-clamp-reachability + dark-mid-accent-balance link half)*
+
+- [ ] **[H]** Two-cell record strip ("FAMILY · EBIRD TAXONOMIC ORDER") is built as visual-only
+  cells → no programmatic label/value tie (1.3.1) → Build as a real `<dl>` with `<dt>`/`<dd>`
+  pairs (name/value data, not cross-reference). CSS `text-transform:uppercase` on the label is
+  fine; keep source text normal-case so AT doesn't spell it out.
+  *(a11y-taxonomy-table-semantics, mid half)*
+
+- [ ] **[M]** "Read account" chevron points up while collapsed (up = collapse, but tapping
+  expands) → Use a down-chevron (⌄) in the collapsed/teaser state to mean "expand"; reserve the
+  up-chevron for a collapse affordance if one exists at full. (Matches §3A spec glyph.)
+  *(mid-readaccount-chevron)*
+
+- [ ] **[M]** 120px plate has a large empty gutter before the name stack; 17px name reads
+  under-scaled against plate mass; stack is top-aligned → Set plate→text gap to `--space-md`
+  (12px); bump the name to `--type-lg` (22px) / 600 to match plate mass (per §3A locked spec);
+  vertically center the name/sci/family stack against the plate.
+  *(mid-plate-name-gap — option b only; option a "drop plate to 96px" dropped, conflicts with §3A 120px + type-lg)*
+
+- [ ] **[M]** Name / sci-name / family read as one undifferentiated block →
+  Add 2px `margin-top` to the sci-name and `--space-xs` (4px) above the family line;
+  name line-height ~1.15, sci-name ~1.2.
+  *(mid-sci-name-spacing)*
+
+- [ ] **[M]** 3px accent rule runs full sheet width and stacks ~12px above the record strip's
+  own top border → two heavy stacked dividers → De-double: either inset the accent rule to start
+  at plate-right + 12px (reads as a name underline) OR keep full-width and remove/lighten the
+  record-strip top border. Then tighten accent-rule→strip gap to `--space-sm` (8px). In dark,
+  optionally drop the accent rule to 2px against the lifted navy surface.
+  *(merges accent-rule-fullbleed + dark-mid-accent-balance rule-weight half)*
+
+- [ ] **[M]** Record strip reads as a heavy table: tall padding, hard center divider, large
+  label→value gap → Tighten cells to `--space-sm` (8px) vertical / `--space-md` (12px)
+  horizontal; label→value gap 2px; replace the 1px center rule with a 12px inter-cell gap.
+  Labels `--type-xs` (11) caps muted; values `--type-sm` (13) / 500.
+  *(mid-record-strip-density)*
+
+- [ ] **[M]** Expand control + chevron hit area ~13–17px, below the 24×24 WCAG 2.5.8 floor →
+  Give the control a padded block hit area ≥44×44px (min-height + vertical padding, or wrap
+  text+chevron in a block-level button spanning the teaser width). Ensure padding doesn't
+  overlap the record strip. (Plate/thumb already meet target.)
+  *(a11y-touch-target-read-account)*
+
+- [ ] **[L]** Record-strip labels at `--type-xs` (11) uppercase: confirm contrast in both
+  themes; dark muted-gray on navy must be re-verified → Confirm every label token ≥4.5:1 at
+  11px in light AND dark; consider `--type-sm` (13) or heavier weight for low-vision legibility.
+  Ensure values use the strong-contrast text token, not muted.
+  *(a11y-record-strip-label-contrast)*
+
+---
+
+## FULL
+
+- [ ] **[H]** 3-row TAXONOMY block built as divs → six unlinked fragments for AT (1.3.1) →
+  Build as a real `<dl>` with `<dt>`/`<dd>` pairs. CSS uppercasing of labels is fine; keep
+  source text normal-case.
+  *(a11y-taxonomy-table-semantics, full half)*
+
+- [ ] **[H]** Hero species name shows a stray rectangular focus/outline box (reads as a
+  selection box; off-brand; low-contrast blue on navy) on a non-interactive heading →
+  Remove the outline/box from the name element. If the sheet moves focus on open for AT context,
+  put it on the dialog container (or a visually-hidden heading) and use `:focus-visible`, not
+  `:focus`, so pointer/programmatic focus paints no ring on the title. Define a tokenized focus
+  ring (2px solid + 2px offset, neutral high-contrast color ≥3:1 on BOTH cream and navy — not
+  the variable family accent).
+  *(merges full-name-focus-artifact + a11y-focus-visibility-accent)*
+
+- [ ] **[M]** TAXONOMY rows have inconsistent heights and an arbitrary label-column width →
+  Fixed label-column width (~38% / ~120px); top-align label and value per row
+  (`align-items:start`); uniform `--space-sm` (8px) vertical padding per row. Labels
+  `--type-xs` (11) caps muted; values `--type-sm` (13) / 500. Clean key/value grid.
+  *(full-taxonomy-table-align)*
+
+- [ ] **[M]** Heading outline: promoting the species name to a global `h1` collides with the
+  map's "Bird Maps - Arizona" identity → two h1s / broken outline (2.4.6) → Scope headings to
+  the dialog: species name = highest heading **inside** the dialog (h2 if map identity is h1),
+  "About" the next level (h3); mark "ABOUT" as a real heading element, not a styled `<span>`.
+  Give the sheet `role="dialog"` + `aria-labelledby` pointing at the species-name heading.
+  *(a11y-heading-order)*
+
+- [ ] **[M]** Masthead photo / 120px plate / 44px thumb alt text unspecified → either redundant
+  with the adjacent name or discards plumage info; risks triple-announce → Give the image
+  informative, non-redundant alt where metadata exists (e.g. "Male northern cardinal perched
+  on a branch"); fall back to `alt=""` (decorative) when the name already precedes it and no
+  descriptive metadata exists. Only one instance shows per detent, so decide per-detent and keep
+  it consistent. Put photographer/source credit in visible text, not only in alt.
+  *(a11y-masthead-alt-text)*
+
+- [ ] **[L]** Masthead crops the subject low with empty branch up top and no seam treatment
+  where the name meets the photo → Add a bottom-edge gradient scrim (transparent → ~12% black
+  over the lower ~64px); set `object-position: center 35%` to lift the subject. Keep the
+  `min(62.5vw,300px)` masthead height; verify the name clears it by `--space-md` (12px).
+  *(full-masthead-crop)*
+
+- [ ] **[L]** "ABOUT" eyebrow has equal space above/below → doesn't bond to the prose it heads
+  → Increase space above to `--space-lg` (16px), reduce below to `--space-xs` (4px). Eyebrow
+  `--type-xs` (11) caps, letter-spacing 0.06em, `--color-text-muted`.
+  *(full-about-eyebrow-rhythm)*
+
+- [ ] **[L]** "From Wikipedia, CC BY-SA" credit blends into the last prose line; license
+  attribution must read as separate and be programmatically tied to its prose (1.3.1) →
+  Set the credit on its own line, `--type-xs` (11), at a token clearing 4.5:1 in both themes,
+  with `--space-sm` (8px) top margin; keep it inside the scrollable About block, associated with
+  the prose by same-section proximity (or `aria-describedby`). Keep the CC BY-SA / Wikipedia
+  link keyboard-focusable with the same underline + contrast treatment as other links.
+  *(merges full-credit-placement + a11y-eyebrow-decorative-eom)*
+
+---
+
+## Dropped (conflict with locked direction or tokens, or pure dup)
+
+- `mid-plate-name-gap` **option (a)** "drop plate to ~96px" — conflicts with §3A's locked 120px
+  plate + `--type-lg` name; kept option (b) only.
+- `mid-readaccount-chevron` clause "keep it in cardinal accent" — conflicts with the a11y
+  contrast finding and `--color-text-link`; resolved toward the link token (orange/cyan).
+- `full-credit-placement` `--color-text-subtle` (#5c5c5c) suggestion — superseded by the a11y
+  requirement that license text clears 4.5:1 in both themes; use a confirmed-AA token instead.

--- a/docs/plans/2026-06-06-field-guide-mobile-sheet/mid-full-redesign.md
+++ b/docs/plans/2026-06-06-field-guide-mobile-sheet/mid-full-redesign.md
@@ -1,0 +1,443 @@
+# Species-Sheet Detent Redesign — Mid + Full Directions & Transitions Plan
+
+Decision-ready brief synthesizing two design directions (Editorial, Field-guide) plus a shared
+transitions/motion plan for the mobile `SpeciesDetailSheet` detent redesign. Companion to
+`diagnosis-report.md` (the root-cause findings) — this document answers "what should mid and full
+*look like*, and how does the photo travel between them."
+
+---
+
+## 1. TL;DR — the shared principle
+
+**Size-appropriate content per detent.** The bug today (diagnosis F2) is that all three detents render
+*the same body* — a full-bleed hero photo + full prose — and just clip it with `overflow:hidden`. So
+the small detent shows a sliver of photo and the mid detent shows "the full view with the bottom cut
+off." The fix both directions converge on:
+
+- **Keep the loved small row exactly.** Grab handle + 44px rounded thumbnail + comName + familyName +
+  ⌃ cue, ~104px tall. The *only* nudge is a 3px family-color accent on the thumbnail's left edge — a
+  visual "thread" seed that grows into the mid plate-frame and the full taxon-rule.
+- **Redesign mid into its own layout** — NOT the full body clipped. A small *bounded* square photo
+  plate with identity/metadata arranged *around* it. Zero clipped prose: what shows is complete.
+- **Redesign full into a designed page** — a structured top-to-bottom reading layout, not "photo slab
+  then plain paragraph."
+- **One photo DOM node travels across all three detents** (thumbnail → plate → hero), animated in pure
+  CSS, so growing the sheet feels like one object zooming rather than three screens swapping.
+
+Both directions share that skeleton. They differ in *editorial voice* (magazine spread) vs *naturalist
+voice* (field-guide record card with a taxonomy table). The transitions plan is direction-agnostic and
+applies to whichever is chosen.
+
+---
+
+## 2. Direction A — Modern Editorial / Magazine ("the field-guide spread")
+
+**North star:** each detent is a distinct editorial layout — small = the byline, mid = a magazine
+"entry card" with a square art-directed plate and metadata set around it, full = a one-column feature
+spread with a framed plate, a deck, and rhythm prose. The sheet reads as a *designed page* that gains
+depth, not a single body that gets clipped or stretched.
+
+**Small adjustment:** keep the identity row exactly; add a 3px family-color tick on the LEFT edge of
+the 44px thumbnail — the same accent that becomes the plate frame at mid and the rule above the deck at
+full. Row stays ~104px.
+
+### 2A. Editorial — MID
+
+```
+┌────────────────────────────────────────────┐ ← sheet top, --card-radius 12px
+│                  ▬▬▬▬                      │  grab handle (centered)
+│                                            │
+│  ┌──────────────┐   NORTHERN CARDINAL     │
+│  │▏             │   ── type-md/semibold    │
+│  │▏   136×136   │   Cardinalis cardinalis  │
+│  │▏   PLATE     │   ── type-sm italic·subtle
+│  │▏  (square,   │                          │
+│  │▏  family-    │   CARDINALS & ALLIES     │
+│  │▏  framed)    │   ── type-xs·tracked·caps │
+│  └──────────────┘   ───────────────────    │ ← 3px family rule
+│   ▲3px family tick   no. 17226  ·  taxon    │  type-xs·subtle (omit if null)
+│                                            │
+│  The northern cardinal is a mid-sized      │ deck: type-base/1.5, 2-line clamp
+│  songbird found across eastern North …     │  justified, ends with ellipsis
+│                                            │
+│  From Wikipedia · CC BY-SA      ⌃ Expand    │ byline type-xs·subtle · affordance
+└──────────────────────────────────────────┘
+   (map sightings remain visible + tappable below the sheet)
+```
+
+**Concept:** a magazine "entry card." The photo is demoted from full-bleed hero to a fixed ~136px
+SQUARE plate pinned top-left (12px radius, 3px family-color frame). Identity sets to its RIGHT in a
+tight L-shaped column — comName / sci-name / family eyebrow / a thin taxon rule — so the eye reads
+name-first, plate-second, like a field-guide index entry. Below the plate+identity zone: a single
+justified deck of the description (2 lines, clamped) plus an italic source byline. Map stays visible
+behind; nothing full-bleed (honors the transient-surface contract).
+
+**Content SHOWN:**
+- 44px→136px square plate (photoUrl, or family silhouette in family color if absent)
+- comName (type-md / semibold)
+- sciName italic (type-sm)
+- familyName as tracked all-caps eyebrow (type-xs)
+- family-color hairline rule + taxonOrder line (type-xs, hidden when taxonOrder is null)
+- first ~2 clamped lines of descriptionBody as a justified deck (type-base)
+- compact source byline: descriptionLicense + attribution (type-xs) + an "Expand" chevron affordance
+
+**Content DEFERRED:**
+- the full multi-paragraph descriptionBody
+- photo attribution/license (photoAttribution, photoLicense) — held for the full plate caption
+- the larger framed feature plate and its breathing room
+- any future secondary metadata
+
+**Creative hook:** it is an L-shaped index entry, not a shrunk hero — the photo never spans the width;
+it's a fixed square plate with type wrapping to its right. That single move makes mid feel like a
+magazine entry card rather than the full view with the bottom cut off. The family-color frame on the
+plate is the same accent that was a tick on the small thumbnail, so growing the sheet feels like the
+same object zooming, not a new screen.
+
+### 2B. Editorial — FULL
+
+```
+┌──────────────────────────────────────────┐ ← full, modal (scrim behind)
+│                  ▬▬▬▬                  ✕   │ grab handle · close
+│                                            │
+│  CARDINALS & ALLIES                        │ eyebrow type-xs·tracked·caps·subtle
+│  Northern Cardinal                         │ HEADLINE type-hero/bold (34)
+│  Cardinalis cardinalis                     │ subhead type-lg italic·muted
+│  ──────────────────                        │ 3px family-color rule (the thread)
+│                                            │
+│  ┌────────────────────────────────────┐   │
+│  │▏                                    │   │ framed feature plate
+│  │▏        ~3:2  FEATURE  PLATE        │   │  content-width, 3px family frame
+│  │▏     (photo, or family silhouette  │   │
+│  │▏      filling frame in family hue) │   │
+│  └────────────────────────────────────┘   │
+│  Photo: M. Smith · Macaulay Library/CC     │ figure caption type-xs italic·subtle
+│                                            │
+│  A mid-sized songbird, the cardinal is     │ DECK / standfirst type-md/1.45·strong
+│  among the most recognizable in the East.  │  (first sentence, pulled out)
+│                                            │
+│  The northern cardinal is found across     │ body type-base/1.6 justified
+│  eastern North America from Maine south …  │  full descriptionBody, scrolls
+│  …woodlands, gardens, and shrublands. It   │
+│  was introduced to Hawaii in 1929 and …    │
+│                                            │
+│  ─────────                                 │ thin divider
+│  FROM WIKIPEDIA · CC BY-SA  ↗              │ source small-caps type-xs·subtle·link
+└──────────────────────────────────────────┘
+```
+
+**Concept:** a one-column feature spread. The plate is RE-COMPOSED, not just enlarged — it becomes a
+framed, captioned figure (full content-width, ~3:2, 3px family frame) with photo attribution set as an
+italic caption beneath it. Above it sits a masthead block: tracked all-caps family eyebrow → comName as
+a true display heading (type-hero) → italic sci-name subhead. A family-color rule separates masthead
+from a DECK — the first sentence pulled out at type-md as a standfirst — which flows into full
+justified body prose. A small-caps source line closes the column. Map is masked behind a modal scrim.
+Reads top-to-bottom as designed: eyebrow → headline → subhead → plate+caption → deck → body → credit.
+
+**Content SHOWN:**
+- family eyebrow (tracked all-caps, type-xs)
+- comName as display headline (type-hero)
+- sciName italic subhead (type-lg)
+- 3px family-color rule under the masthead
+- framed ~3:2 feature plate (photoUrl, or family silhouette filling the frame in family color)
+- photo caption: photoAttribution + photoLicense (italic, type-xs) — shown only when present
+- deck/standfirst: first sentence of descriptionBody pulled out at type-md
+- full descriptionBody body prose (type-base, scrolls within the sheet)
+- taxonOrder as an optional metadata line under the eyebrow when present
+- source credit: descriptionLicense + descriptionAttributionUrl as a small-caps link with ↗
+
+**Creative hook:** the reorder *is* the idea — eyebrow → headline → sci-name → rule → captioned plate →
+pulled deck → body. The photo is a captioned FIGURE inside the article (credit as its caption), not a
+banner the text hangs off. That single inversion makes it read "designed magazine spread" instead of
+"image header + paragraph." The family-color rule under the headline is the grown-up version of the mid
+plate-frame and the small thumbnail tick — closing the three-detent continuity.
+
+---
+
+## 3. Direction B — Field-Guide / Naturalist ("the plate, the taxon line, the family accent")
+
+**North star:** treat the sheet like a field-guide plate — each detent is a self-complete taxonomic
+record at its own scale. The photo, the silhouette-in-family-color, and the taxon line do the
+identifying work — never a hero photo with prose clipped off below.
+
+**Small adjustment:** identical to Editorial — keep the row exactly; add a 3px family-accent left edge
+to the thumbnail (the same accent that becomes the taxon rule and family chip dot at mid/full). On
+silhouette fallback the thumb already tints to family color, so the edge reads as a deliberate spine.
+~104px, same type, same ⌃.
+
+### 3A. Field-guide — MID
+
+```
+┌───────────────────────────────────────┐
+│                 ▭▭▭▭                    │  grab handle
+│                                         │
+│  ┌──────────┐   Northern Cardinal       │  plate 120²
+│  │▞▞▞▞▞▞▞▞▞▞│   Cardinalis cardinalis   │  + accent
+│  │▞ photo  ▞│   ◤ italic sci name       │  inner frame
+│  │▞ plate  ▞│                            │
+│  │▞▞▞▞▞▞▞▞▞▞│   ●▲ Cardinals & Allies   │  family chip
+│  └──────────┘      accent-dot + sil.    │  (dot=accent)
+│ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  │  accent rule
+│  ┌─────────────────┬──────────────────┐ │
+│  │ FAMILY          │ TAXONOMIC ORDER  │ │  field record
+│  │ Cardinalidae    │ #17 of order     │ │  2 labeled cells
+│  └─────────────────┴──────────────────┘ │
+│                                         │
+│  The northern cardinal is a mid-sized   │  2-line teaser
+│  songbird found across eastern North…   │  fade-to-surface
+│  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ Read account ⌄ │  defer-to-full
+└───────────────────────────────────────┘
+```
+
+**Concept:** a "plate card" — the seed idea made literal. The photo shrinks to a ~120px SQUARE plate
+pinned top-left (framed specimen plate, 1px accent inner-frame), with taxonomic identity wrapping to
+its right: common name, italic scientific name, a family chip carrying a tiny silhouette glyph + accent
+dot. Below the plate row, a labeled two-cell "field record" strip (FAMILY / ORDER) using the real
+taxonOrder field — never rendered before — gives the layout taxonomic weight without inventing data. A
+2-line description teaser with a soft fade-to-surface sits at the bottom with a "Read full account"
+affordance. Structurally a record card, not a truncated full view.
+
+**Content SHOWN:**
+- Square photo PLATE (~120px) with 1px family-accent inner frame; silhouette-in-family-color if absent
+- comName at --type-lg 22 semibold
+- sciName italic at --type-base 15 in --color-text-muted
+- Family chip: tiny family silhouette glyph + accent dot + familyName at --type-sm 13
+- Family-accent horizontal rule (the taxon line) separating identity from record
+- "Field record" two-cell strip: FAMILY (familyName) + TAXONOMIC ORDER (taxonOrder), --type-xs 11 caps labels
+- 2-line description teaser with fade mask + "Read account ⌄" control that flicks to full
+
+**Content DEFERRED:**
+- Full descriptionBody prose (only 2 lines shown, rest masked)
+- Photo attribution + license (photoAttribution / photoLicense)
+- Description attribution/license footer (descriptionAttributionUrl / descriptionLicense)
+- Large-format photo — the plate stays small and bounded at mid by design
+
+**Creative hook:** the "field record" meta strip surfaces taxonOrder — a real SpeciesMeta field the UI
+has never shown — turning dead data into the naturalist signal that makes mid feel like a guide entry.
+The plate's accent inner-frame + the accent taxon rule + the family-chip dot are the SAME family color
+in three roles (frame / rule / dot). Crucially the photo is small and square here — the opposite of the
+current clipped full-bleed.
+
+### 3B. Field-guide — FULL
+
+```
+┌───────────────────────────────────────┐
+│                 ▭▭▭▭                    │  handle
+│ ╔═════════════════════════════════════╗ │
+│ ║                                     ║ │
+│ ║      full-bleed masthead photo      ║ │  16/10 hero
+│ ║                          eBird ↗    ║ │  attribution
+│ ╚═════════════════════════════════════╝ │
+│                                         │
+│  Northern Cardinal                      │  --type-hero 34
+│ ━━━━━━━━━━  accent taxon rule           │
+│  Cardinalis cardinalis  · Cardinals &…  │  sci · family
+│                                         │
+│  ┌─ TAXONOMY ──────────────────────────┐│
+│  │ Scientific  Cardinalis cardinalis   ││  labeled table
+│  │ Family      Cardinals and Allies ●▲ ││  accent+silh.
+│  │ Order       #17 in taxonomic order  ││  taxonOrder
+│  └─────────────────────────────────────┘│
+│                                         │
+│  ABOUT                                   │  section eyebrow
+│  The northern cardinal, also called the │
+│  redbird, is a mid-sized songbird of    │  full prose,
+│  the genus Cardinalis. It is found from  │  readable measure
+│  the eastern United States south to…    │
+│  …(full descriptionBody continues)      │
+│                                         │
+│ ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ │
+│  Text: Wikipedia, CC BY-SA · Photo ↗    │  license footer
+└───────────────────────────────────────┘
+```
+
+**Concept:** the rich field-guide entry. The plate photo expands back to a full-bleed 16/10 masthead
+(shared element grows up), but the entry below is structured like a printed guide page: an accent taxon
+rule under the name, a proper 3-row TAXONOMY table (Scientific name / Family / Order), then full
+descriptionBody at a readable measure, closed by a licensed attribution footer. On silhouette fallback
+the masthead becomes a family-color tinted ground with the large silhouette centered — a deliberate
+"no specimen photographed" plate, not a grey box.
+
+**Content SHOWN:**
+- Full-bleed 16/10 masthead photo with bottom-right photo attribution chip (photoAttribution + ↗)
+- comName at --type-hero 34
+- Family-accent taxon rule directly under the name
+- sciName italic + familyName as a single "sci · family" subline
+- TAXONOMY table: Scientific name, Family (with accent dot + silhouette glyph), Order (taxonOrder) — labeled rows
+- "ABOUT" section eyebrow + full descriptionBody prose at readable measure
+- License footer: descriptionLicense + descriptionAttributionUrl, and photo license — all credits land here
+- On photoUrl absent: masthead becomes family-color tinted ground with large centered silhouette
+
+**Creative hook:** the taxonomy table promotes taxonOrder and family to first-class, labeled rows — the
+thing a real field guide leads with and that bird-maps has been hiding. The accent taxon rule under the
+hero name is the grown-up sibling of the small row's accent edge and the mid plate frame: one family
+color threads peek→mid→full as edge → frame/rule → hero rule. The silhouette-fallback masthead is
+designed as an intentional plate, so a photo-less species still looks like a guide entry.
+
+---
+
+## 4. Photo continuity + morph / transition plan
+
+This plan is direction-agnostic — it applies to whichever direction wins. It is the single
+highest-leverage fix for the "hard pop" between detents.
+
+### 4.1 The shared-element photo verdict — FEASIBLE in pure CSS
+
+**Today there are TWO photo DOM nodes**, toggled by `display:none`: the 44px `<img class='sheet-compact-thumb'>`
+inside `.sheet-compact`, and a separate `<Photo layout='masthead'>` inside `.sheet-scroll`. They are
+different elements, so there is *zero* continuity — the thumbnail blinks out and the hero blinks in.
+
+**Approach (recommended):** render ONE `<Photo>` as a direct child of `.species-detail-sheet`, OUTSIDE
+both `.sheet-compact` and `.sheet-scroll`, so it is never `display:none`'d and never remounts
+(preserving the decoded bitmap — no reload flash, no LCP re-fire). The detent class drives only its
+frame geometry:
+
+- **peek/compact:** 44px square pinned left in the identity row (text flows beside it); radius ~9px.
+- **mid:** larger inset "quarter"/plate card; radius 12px; small top margin; square-ish framing.
+- **full:** full-bleed hero — negative-gutter margin to span edge-to-edge; radius 0 (top corners
+  rounded by the sheet's own overflow clip); ~16/10 framing.
+
+**Why object-fit makes it work:** `object-fit:cover` is already on `.photo__img`. Cover means the CROP
+recomputes as the frame resizes — a square 44px crop grows into a hero crop with the subject staying
+covered, no letterboxing, no distortion. Transition the frame size (explicit height/width + margin) +
+border-radius with the SAME card-resize ease/dur as the container.
+
+**Silhouette fallback** rides the same single element: `FamilySilhouette` centered via flex/grid inside
+`.photo--silhouette`; sizing the glyph as a % of the frame scales it with the morph. No special-casing.
+
+**Fallback if single-element proves too invasive / flaky on Safari:** repurpose recipe 14
+(skeleton-reveal) as a photo cross-fade — stack thumbnail and hero as two absolutely-positioned layers
+in the same slot, cross-fade opacity + 2px blur on the threshold crossing. Loses true positional
+continuity (reads as a soft dissolve, not a morph) and pays a brief double-decode. **Recommend the
+single-element morph; fall back only if grid-area continuity is flaky.**
+
+### 4.2 Morph table — transitions-dev recipes per detent boundary
+
+| Boundary | Container | Content reveal | Photo | Recipes |
+|---|---|---|---|---|
+| **small ↔ mid** | Keep existing card-resize height tween EXACTLY (recipe 01: `transition: height var(--sheet-settle-dur) var(--sheet-settle-ease)`; 300ms cubic-bezier(0.22,1,0.36,1); gated OFF during drag via `[data-dragging='true']{transition:none}` so height tracks the finger 1:1). The drag IS the morph driver — no competing container animation. | Replace the binary `display:none` cut. sci-name + 2–3 line description clamp REVEAL via texts-reveal (recipe 18): wrap in a `.t-stagger` block, add `.is-shown` when the mid threshold is crossed during the up-drag (driven by live height), `.is-hiding` on the down-drag back below. The name+family SPINE stays mounted the whole time (never `display:none`'d; only restyles size). | Shared-element frame resize (object-fit:cover, explicit height/margin/radius transition). | **01-card-resize** + **18-texts-reveal** + shared-element photo resize |
+| **mid ↔ full** | Same single card-resize height tween — no second mechanism. The role/inert flip to `dialog` at full is orthogonal to motion (already sequenced in goToSnap/settleTo — keep untouched). Do NOT raise `--sheet-settle-dur`; 300ms reads well across the full 104→836px range. | Mid is a genuinely DIFFERENT layout (quarter/plate photo + clamped description + fade-mask), then full-only extras reveal on the crossing via panel-reveal (recipe 07): `.description-rest` block, `data-open` flips true at `[data-content='full']`, translateY(~24px) + opacity + 2px cross-blur. The line-clamp fade-mask animates away (mask-image transition) so the cut-off gradient lifts as full prose arrives. | Shared-element frame morphs quarter→hero full-bleed (margin un-insets to negative gutter, radius→0, hero crop). | **01-card-resize** + **07-panel-reveal** + shared-element photo quarter→hero |
+
+### 4.3 Content-swap strategy — 3-state, live-height driven
+
+Replace today's binary `display:none` cut (`showCompact = height < PEEK_PX+60`, toggling
+`.sheet-compact` vs `.sheet-scroll`) with a THREE-state `data-content` ('compact' | 'mid' | 'full')
+computed from `liveHeight ?? heightFor(snap)` on *every* render — so content blooms DURING the drag,
+not snapping at one boundary. Two thresholds (e.g. `height < PEEK_PX+60 ⇒ compact`; `< ~HALF*1.15 ⇒
+mid`; else `full`).
+
+**Stop using `display:none` to gate content.** ALWAYS render the body; clip with the sheet's existing
+`overflow:hidden` at small detents. What changes per detent is which lines are *visible-via-opacity*,
+not which are in the DOM. Tier into reveal groups:
+
+- **SPINE** (name + family): never hidden, always opacity 1 — the continuity anchor. Font-size
+  transitions on the card-resize ease.
+- **MID-TIER** (sci-name + clamped description): `.t-stagger` (recipe 18). `.is-shown` at
+  `[data-content='mid']` or `'full'`; `.is-hiding` (quiet fade, no Y-return) on the way back down.
+- **FULL-TIER** (rest of the long prose + attribution): `.t-panel-slide` (recipe 07). `data-open` at
+  `[data-content='full']`.
+
+Because container height is finger-tracked (transition gated off during drag) while reveal channels
+(opacity/translateY/blur) run their own 600ms/400ms timing, new content fades/rises in OVER the growing
+sheet — no frame where empty space suddenly fills with a hard block of text. **Not recipe 14 for text:**
+skeleton-reveal implies loading→loaded; using it for detent→detent would falsely signal "was a
+placeholder." texts-reveal + panel-reveal match the semantics (existing content entering view).
+
+### 4.4 Reduced-motion
+
+**Fully covered by `motion.css`'s global rule** (`transition-duration:0ms !important` on
+`*,::before,::after`). The height tween, the `.t-stagger` line transitions, the `.t-panel-slide` prose,
+the mask-image release, and the photo-frame transition all collapse to instant — and **every channel's
+0ms end state is the correct resting state** (`.is-shown` → opacity:1/translateY(0)/blur(0); container
+→ detent height; photo → detent frame; mask → removed). **Add NO per-element guards.**
+
+### 4.5 Transition risks (call out in the plan)
+
+1. **aspect-ratio does not tween smoothly on all engines** — animating it directly STEPS. Drive an
+   explicit height transition (or width + %-padding box) and let object-fit:cover recompute the crop;
+   reserve aspect-ratio for the static per-detent resting frame only.
+2. **flex-direction cannot animate** — peek is inline (photo beside text), mid/full stacks. A
+   flex-row→column switch hard-jumps. Use **CSS Grid template-area transitions** (animatable track
+   sizes) so the photo track grows and text reflows below without a discrete switch.
+3. **Continuity vs remount** — if the single `<Photo>` is conditionally rendered or its key changes,
+   React remounts the `<img>`, the bitmap re-decodes (flash) and LCP/eager-fetch can re-fire. Render
+   exactly one stable sibling; only className/grid placement changes.
+4. **Live-height threshold thrash** — a per-frame 3-state can flip-flop at a boundary, retriggering
+   reveals → flicker. Add **hysteresis** (different up vs down thresholds / dead-band) or debounce.
+5. **overflow-x during the un-inset** — as the photo goes inset→negative-gutter, a mid-morph frame can
+   momentarily exceed content width → horizontal scrollbar. Keep `.sheet-scroll overflow-x:clip` and
+   clip x on the sheet root.
+6. **line-clamp + mask-image release** — `-webkit-line-clamp` is non-standard and mask-image transition
+   support is uneven; a botched release snaps a hard gradient edge. Test on Safari; fall back to a
+   simple opacity fade on a gradient overlay element if flaky.
+7. **Reveal timing trailing the settle** — 600ms/400ms reveals trailing the 300ms settle on a fast
+   flick reads as content lagging. Acceptable; if loose, shorten reveal durations toward settle dur for
+   flick-initiated transitions. Verify the feel live.
+8. **Scope creep beyond a motion PR** — making mid a new layout + the single-element photo refactor
+   touches `SpeciesDetailSurface` structure, not just CSS. The repo's frontend-plan CSS sub-task gate
+   and live Playwright verification at all canonical viewports apply. Guard against an under-scoped PR
+   that ships motion without the mid redesign and still feels like a clipped full view.
+
+---
+
+## 5. Comparison — Editorial vs Field-guide
+
+| Dimension | A · Editorial (magazine) | B · Field-guide (naturalist) |
+|---|---|---|
+| **Mid concept** | L-shaped "entry card": 136px square plate top-left + name/sci/eyebrow/rule to the right + 2-line justified deck + source byline | "Plate card": 120px square plate + name/sci + family chip (silhouette+dot) + **labeled FAMILY/ORDER field-record strip** + 2-line teaser w/ fade |
+| **Full concept** | One-column feature spread: eyebrow → headline → sci subhead → rule → **captioned framed ~3:2 figure** → pulled deck/standfirst → justified body → small-caps source | Field-guide entry: **full-bleed 16/10 masthead** → name + taxon rule → sci·family subline → **3-row TAXONOMY table** → ABOUT prose → license footer |
+| **Info density** | Medium. Editorial restraint — deck + body, metadata kept light (one taxon line). Prose-forward. | Higher. Surfaces taxonOrder twice (mid strip + full table) as labeled data. Data/record-forward. |
+| **Build complexity** | Moderate. Deck = "first sentence" parsing (naive — needs ~160-char clamp + fallback). Justify+hyphens risk at 390px. Captioned-figure full is a clean re-flow. | Moderate–higher. Two-cell strip + 3-row table = more layout primitives (grid cells, labels, em-dash null states). taxonOrder nullable handling in two places. Full keeps the existing full-bleed masthead (less photo-morph re-composition than Editorial's figure). |
+| **Photo at full** | Re-composed: framed ~3:2 **figure** with caption (bigger morph delta from mid plate). | Full-bleed 16/10 **masthead** (matches today's full; the 1/1→16/10 aspect change is the one real morph discontinuity). |
+| **Fit with the loved small row** | Excellent — both keep the row verbatim + the 3px family tick seed. | Excellent — identical small-row treatment. |
+| **New data surfaced** | taxonOrder as one optional line. | taxonOrder + family promoted to **first-class labeled rows** (the "dead data → naturalist signal" story). |
+| **Voice** | Designed editorial page; reads like a magazine feature. | Printed field guide; reads like a specimen record. |
+| **Risk hotspots** | Justified rivers at 390px (mitigate: hyphens:auto or left-align <768px); naive sentence parse for the deck. | Field-record strip crowding at 390px with long family names (wrap to 2 lines); 1/1→16/10 masthead aspect cross-fade is the trickiest single transition. |
+
+### Recommendation
+
+**Lead with Field-guide (Direction B), borrowing Editorial's captioned-figure discipline at full.**
+
+Rationale:
+- **It is the most on-brand for bird-maps** — a field-guide/naturalist voice fits a bird-sighting map
+  better than a lifestyle-magazine voice, and it does the one genuinely new thing: promoting
+  `taxonOrder` + family to labeled, first-class data (the "we've been hiding real data" win). That is a
+  product improvement, not just a re-skin.
+- **Its full state keeps the existing full-bleed masthead**, so the *structural* delta from today's
+  full is smaller (re-order + add a taxonomy table) — lower-risk than Editorial's figure re-composition,
+  even though it pays the one 1/1→16/10 aspect morph.
+- **One caveat to carry over from Editorial:** at full, treat the photo attribution as a *caption-style*
+  credit and consider Editorial's captioned-figure framing if user-testing finds the bare masthead +
+  attribution chip reads as "header + dump." The two directions are not mutually exclusive at the
+  component level — the shared photo-element + 3-state reveal plumbing is identical.
+
+Both directions share the exact same small row, the same shared-element photo morph, and the same
+3-state content-swap motion plan — so **the transitions work is committed regardless of which visual
+direction wins.** That plumbing (single `<Photo>` node + `data-content` 3-state + recipe 01/07/18) is
+the safe thing to build first; the visual direction can be chosen in parallel.
+
+---
+
+## 6. Open questions for the user
+
+1. **Direction:** Field-guide (recommended), Editorial, or a hybrid (Field-guide structure + Editorial's
+   captioned-figure full)? This is the one decision that unblocks the visual layer.
+2. **Mid layout sizing:** Editorial mid is ~136px plate + L-column; Field-guide mid is ~120px plate +
+   field-record strip + teaser, landing around ~506px tall. Does the field-record strip earn its
+   vertical cost at the `half` detent, or should mid stay leaner (defer the strip to full)?
+3. **taxonOrder presentation:** "#17 of order" / "#17 in taxonomic order" is a raw eBird sort index, not
+   a human-meaningful rank. Show it verbatim, relabel it ("eBird taxonomic order"), or drop the numeric
+   and keep only Family? (It is nullable — both directions already collapse the cell when absent.)
+4. **Deck/standfirst (Editorial only):** the "first sentence pulled out" parse is naive. Accept the
+   ~160-char clamp + body-lead fallback, or skip the standfirst entirely and go straight masthead→body?
+5. **Justify at 390px (Editorial only):** justify-with-hyphens, or left-align on mobile and treat
+   justify as a ≥768px enhancement?
+6. **Photo morph vs cross-fade:** commit to the single-element geometric morph (recommended), or
+   pre-approve the recipe-14 cross-fade fallback if Safari grid-area continuity proves flaky during
+   implementation?
+7. **Scope of the first PR:** ship the transitions plumbing (single `<Photo>` + 3-state reveal) and the
+   mid redesign together (recommended — motion-only would still feel like a clipped full view), or split
+   into a motion PR then a layout PR? Note the repo's frontend CSS sub-task gate + canonical-viewport
+   Playwright verification apply either way.
+8. **Modal contract at full:** the redesign assumes the diagnosis's separate a11y fixes (focus trap /
+   `aria-modal` — F8/F9/F10) land alongside or before this. Confirm they are in scope or explicitly
+   sequenced first.

--- a/docs/plans/2026-06-06-field-guide-mobile-sheet/plan.md
+++ b/docs/plans/2026-06-06-field-guide-mobile-sheet/plan.md
@@ -178,7 +178,7 @@ structural changes. The shared body component stays exactly as it is for the rai
   wrap first↔last). Active **only at full** (`snap==='full'`), torn down when leaving full or
   unmounting. Keep it inside `SpeciesDetailSheet` (the handle is the first focusable). Install the
   Tab handler WITHOUT touching `inert`/`role` timing so the MutationObserver sequencing tests stay
-  green. Delete the stale `styles.css:1414–1421` comment claiming chrome is "non-interactive" — true
+  green. Delete the stale `styles.css:1435` comment (block ~1429–1436) claiming chrome is "non-interactive" — true
   for pointer, false for Tab.
 - **F9 — focus restore on close. `[R2-fix]` resolve the fallback selector to a REAL rendered id.**
   The sheet has no `previouslyFocusedRef`. Mirror `SpeciesDetailModal.tsx:55–167` /
@@ -446,7 +446,7 @@ mock away, and analytics were silently dropped once before): at 390×844, open t
 **Files:** `SpeciesDetailSheet.tsx` (focus trap at full; `previouslyFocusedRef` + restore on every
 close path with the **`#main-surface`** fallback; in-sheet live-region announce), `styles.css`
 (masthead scrim, compact/mid/full tuning deltas, delete legacy `.sheet-compact`/`.sheet-scroll` +
-unused `.sheet-fg-credits`, fix the stale `1414–1421` comment). **No `App.tsx` change needed for the
+unused `.sheet-fg-credits`, fix the stale "non-interactive" comment (styles.css ~1429–1436, key line 1435)). **No `App.tsx` change needed for the
 fallback** — `#main-surface` already exists and is focusable (`App.tsx:1361`/`1380`), so the sheet
 just targets it; do NOT add a new landmark.
 

--- a/docs/plans/2026-06-06-field-guide-mobile-sheet/plan.md
+++ b/docs/plans/2026-06-06-field-guide-mobile-sheet/plan.md
@@ -1,0 +1,556 @@
+# Field-Guide Mobile Species-Sheet — Production Implementation Plan
+
+Status: ready to execute (**rev 2** — folds in the architecture / a11y / test-ci adversarial
+reviews of rev 1; every mustFix is addressed inline and tagged `[R2-fix]`). Source of truth for
+the visual + motion direction is `./mid-full-redesign.md` (locked
+**Direction B — Field-guide**, borrowing Editorial's captioned-figure discipline at full).
+Root-cause + a11y findings: `diagnosis-report.md`. Design/a11y tuning: `fg-tuning-punchlist.md`.
+
+The prototype lives uncommitted on `proto/mobile-sheet-strategy-2`. Production tasks branch
+off `main`. This plan ports the prototype's proven shape into production-grade code, folds in
+the F8/F9/F10 a11y work and the remaining punch-list items, and keeps the CI gate
+(`test` / `lint` / `build` / `e2e` + `knip` + `orphan-classname-check`) **green on every PR** — no
+task may leave any required check red for a later PR to repair.
+
+> **Verified-ground-truth note (rev 2).** Every file path, line number, prop signature, and DOM
+> shape below was checked against the working tree on `proto/mobile-sheet-strategy-2` on
+> 2026-06-06. Where rev 1 asserted a fact the source contradicts, the correction is called out
+> with `[R2-fix]` and the verifying file:line. Implementers: trust this revision's paths over any
+> remembered ones, and over the decoy copies under `.claude/worktrees/`.
+
+---
+
+## 1. Goal + scope
+
+**Ships:** the mobile (`useIsCompact()` ≤1199px) `SpeciesDetailSheet` becomes a three-detent
+field-guide sheet:
+
+- **peek / compact** — the loved identity row (44px photo + comName + family), ~104px.
+- **half / mid** — the field-guide "plate card": 120px square plate, identity spine, 3px
+  family accent rule, two-cell `<dl>` field-record strip (Family · eBird taxonomic order),
+  2-line teaser with a real "Read account" `<button>`.
+- **full / dialog** — the field-guide entry: full-bleed 16/10 masthead, hero name, accent
+  taxon rule, 3-row `<dl>` taxonomy table, "About" prose via `<SpeciesDescription>`, credits.
+
+Plus the motion (height-driven 1:1 drag, velocity flick, dismiss, single-element photo morph,
+texts/panel reveal) and the a11y contract (focus trap at full, focus restore on close,
+announce-on-reaching-a-readable-detent).
+
+### 1.1 Desktop decision — SHEET-ONLY. Do not touch the rail/modal layout.
+
+`SpeciesDetailSurface` is shared by `SpeciesDetailRail` (≥1200px, the live desktop surface) and
+the dead-but-tracked `SpeciesDetailModal`. The prototype deliberately stopped composing
+`SpeciesDetailSurface` inside the sheet and inlined a parallel field-guide DOM tree
+(`.sheet-fg-*`). **We keep that split** for the *page-level layout* (grid, detents, scroll,
+dismiss). Rationale:
+
+- The four-corner anchor contract and the `#801` inset-floating-card rail are desktop-only and
+  orthogonal to the detent model — the rail has no detents, no drag, no peek.
+- Adopting the field-guide layout into `SpeciesDetailSurface` would force a simultaneous rail
+  redesign and re-baseline of `SpeciesDetailSurface.test.tsx` (25KB) + the desktop half of
+  `species-detail.spec.ts` (rail landmark, `#801` inset geometry, photo/silhouette at 1440 &
+  1920). That is a separate epic, out of scope here (see §6).
+- **Consequence we must own:** `SpeciesDetailSurface` is the only place `panel_opened` /
+  `panel_dwell_ms` / `panel_scrolled_to_bottom` fire (verified `SpeciesDetailSurface.tsx:73–115`).
+  Removing it from the sheet dropped mobile analytics — Task 4 re-wires them natively. Desktop
+  analytics (via the rail's surface) are unaffected.
+
+**Scope-split clarification `[R2-fix]` (architecture review).** "Keep the split" applies to the
+*page layout shell* (`.sheet-fg` grid, detents, drag, scroll, dismiss). It does **not** require
+hand-inlining the photo/silhouette primitive. The reviews are correct that the prototype's
+hand-rolled `<img>`/`<div>` photo pair (`SpeciesDetailSheet.tsx:406–414`) is the wrong level of
+reuse. **Task 2 composes the existing `<Photo>` primitive (`frontend/src/components/ds/Photo.tsx`)
+for the photo slot** — `<Photo>` is one outer `<span className="photo …">`, owns the
+null/loading/loaded/errored state machine, threads `src/alt/family/color/pathD/imgUrl/priority/
+layout`, renders `<FamilySilhouette>` automatically for the no-photo/errored branch, and emits the
+`.photo--silhouette` class the existing e2e already targets. This is the level the split was always
+meant to draw the line at: share leaf DS primitives, don't share the page surface. §1.2 below
+records why this supersedes rev 1's "inline a parallel DOM tree" wording.
+
+### 1.2 What `<Photo>` composition resolves (and its one real cost)
+
+Composing `<Photo>` (vs. the prototype's hand-inlined `<img>`/`<div>` pair) is the architecturally
+correct move and collapses **four** rev-1 problems into one decision:
+
+1. **Silhouette wiring** — `<Photo>` internally builds `<FamilySilhouette>` from
+   `family`/`color`/`pathD`/`imgUrl` (`Photo.tsx:109–121`); we just thread the resolvers in (the
+   same `resolveColor`/`resolvePath`/`resolveImgUrl` useMemos `SpeciesDetailSurface.tsx:51–71`
+   already builds). No hand-rolled silhouette div.
+2. **Orphan class** — the prototype's `.sheet-fg-img--silhouette` div (`SpeciesDetailSheet.tsx:410`,
+   **no CSS rule** — verified absent in `styles.css`) disappears entirely. `<Photo>` emits
+   `.photo--silhouette`, which has real CSS and is already exercised by e2e. The orphan-classname
+   gate is satisfied without an allowlist entry.
+3. **e2e locator divergence** — the existing `#327 task-12` mobile silhouette assertion targets
+   `.photo--silhouette` (`species-detail.spec.ts:345`). With `<Photo>` in the sheet, that locator
+   keeps working on mobile **unchanged** — no T1↔T2 disagreement about the silhouette DOM shape.
+4. **Decode stability (redesign §4.5 risk 3)** — for a given species, `src` is stable across
+   detents, so `<Photo>`'s internal `<img>` (`Photo.tsx:128`) stays mounted and the decoded bitmap
+   is preserved; no LCP re-fire on detent change. The photo↔silhouette boundary is a render branch
+   *inside one component on a stable outer `<span>`*, and for a fixed species `src` does not flip,
+   so the boundary never crosses mid-session. (Honest caveat: `<Photo>` is not literally a single
+   leaf node — `<img>` and `<FamilySilhouette>` are alternative children — but the bitmap-stability
+   property the redesign actually cares about holds, because `src` is per-species-stable. This is
+   strictly better than the prototype, which had the *same* property only by accident and carried
+   an orphan-class div on the no-photo branch.)
+
+**The one real cost we must own `[R2-fix]`:** `<Photo>` ships its own aspect-ratio CSS model keyed
+on `layout` (`masthead 16/10`, `inline 4/3`, `thumb 1/1` — `Photo.tsx:14–17`), whereas the FG morph
+drives an *explicit* width/height/border-radius/margin geometry per `[data-content]` on
+`.sheet-fg-photo`. Composing `<Photo>` therefore means the morph CSS targets the **container plus
+the Photo's inner nodes**: `.sheet-fg-photo .photo`, `.sheet-fg-photo .photo__img`, and
+`.sheet-fg-photo .family-silhouette` must inherit the frame size (width/height: 100%) so the morph
+on `.sheet-fg-photo` drives them, and `<Photo>`'s own `aspect-ratio` must be neutralized inside the
+sheet (`.sheet-fg-photo .photo { aspect-ratio: auto; }`). Pass `layout="masthead"` for the family
+fallback's tint/scale, but the *frame* geometry stays owned by the FG morph, not the Photo layout
+token. Task 2's AC gates on this composition working at all three detents.
+
+**Out of scope for desktop:** rail visual changes, modal changes, `SpeciesDetailSurface`
+structural changes. The shared body component stays exactly as it is for the rail.
+
+---
+
+## 2. Prototype inventory — proven vs. PROTOTYPE-GRADE
+
+### 2.1 What the prototype already proves (port as-is, harden)
+
+- **Three-detent state machine.** `SnapState = peek|half|full`; `PEEK_PX=104`; half=`0.6·vh`;
+  full=`vh−8`. Opens at `half`. `goToSnap`/`settleTo` write `inert` on the **`mainRef.current`
+  element** BEFORE the role flip; the collapse-side `useLayoutEffect` removes it AFTER, with the
+  unmount-cleanup that fixes the viewport-flip inert leak.
+  **`[R2-fix]` inert target is `#map-layer`, not `#main-surface`.** App passes
+  `mainRef={mapLayerRef}` (`App.tsx:1478`), so in production the inerted element is `#map-layer`
+  (O1 #776). The component is id-agnostic — it inerts whatever `mainRef.current` points at — but
+  every *assertion* (unit and e2e) must name the right element (see Task 1 TDD). **This sequencing
+  is load-bearing and correct — preserve it verbatim.**
+- **Height-driven 1:1 drag** on the handle (`liveHeight` tracks the finger both directions; CSS
+  height transition gated off via `[data-dragging='true']`), **velocity flick**
+  (`VELOCITY_FLICK_PX_PER_MS=0.5` advances/retracts a detent), **dismiss** (`finalH <
+  PEEK_PX·0.6 && vy ≥ 0` → `onClose`), and **drag-vs-tap discrimination** (`didDragRef`
+  suppresses the post-drag click; pure tap still cycles). Verified `SpeciesDetailSheet.tsx:240–322`.
+- **Field-guide DOM + CSS** — `.sheet-fg` grid re-templates per `[data-content]`; `<dl>` record
+  strip + taxonomy table; 3px accent rule; family dot with contrast ring; `<SpeciesDescription>`
+  for About. (Photo slot is the one piece we upgrade — see 2.2c.)
+- **ESC scoped to focus-inside-sheet.** Preserve (`SpeciesDetailSheet.tsx:208–219`).
+
+### 2.2 PROTOTYPE-GRADE — must be upgraded for production
+
+| # | Prototype shortcut | Production requirement |
+|---|---|---|
+| **(a)** | **mid→full photo is a positional JUMP.** `.sheet-fg-photo` transitions only `width`/`height`/`border-radius` (`styles.css:1779–1784`), but at full it adds `margin: 0 calc(-1*var(--space-lg))` + explicit `height` while the grid re-templates `120px 1fr` → `1fr` and swaps `grid-template-areas` (`styles.css:1722–1754`). Neither `margin` nor `grid-template-columns` is on the transition list, and **`grid-template-areas` cannot animate at all** — the area-name remap (photo moving from a 2-col cell to a full-width row) is a discrete jump. | Make the mid→full photo read as ONE element growing: add `margin` **and** `grid-template-columns` to the transition consideration; transition the track sizes on `.sheet-fg`. **`[R2-fix]` the `grid-template-areas` remap is NOT animatable** (architecture review correct; redesign §4.5 risk 2 was optimistic). Accept the 1/1→16/10 aspect change as the one real discontinuity (drive explicit height, never animate `aspect-ratio` — verified the prototype already does, `styles.css:1755–1764`). **T1 acceptance now gates on this** (see Task 1 AC + the explicit Safari/iOS live check), or T1 explicitly accepts a stepping un-inset and schedules the recipe-14 cross-fade as a **named** T1 sub-task — it may NOT merge green with a silently-stepping marquee morph. |
+| **(b)** | **Content tiers swap via `display:none` gating + a single `fg-reveal` keyframe.** | Implement the planned reveal channels: MID-tier (sci-name + record + teaser) via **texts-reveal (recipe 18)** — opacity/translateY stagger with `.is-shown`/`.is-hiding`; FULL-tier (taxonomy + About) via **panel-reveal (recipe 07)** — translateY(~24px)+opacity+blur on the crossing. The SPINE (name+family) is never `display:none`'d. Use the `transitions-dev` skill (recipes 18 + 07 + 01). Pure CSS, no library. **`[R2-fix]` reduced-motion is asserted, not assumed** (a11y review): every channel's 0ms end-state IS its resting state (add NO per-element guards — `motion.css` owns the collapse), AND T5 adds an explicit AC + test that under `prefers-reduced-motion: reduce` the three reveal channels render at their resting end-state and the velocity-flick settle is instantaneous (diagnosis F14). |
+| **(c)** | **Photoless species render a FLAT family-color block** via `<div class="sheet-fg-img sheet-fg-img--silhouette" style="background: famColor">` (`SpeciesDetailSheet.tsx:409–413`). `.sheet-fg-img--silhouette` has **no CSS rule** (orphan className → trips `orphan-classname-check`) and renders no glyph. | **`[R2-fix]` Compose `<Photo>` (see §1.1/§1.2), do NOT hand-roll a silhouette div.** `<Photo>` renders `<FamilySilhouette>` for the no-photo branch and emits `.photo--silhouette`. Thread the real DB shape via `resolveColor`/`resolvePath`/`resolveImgUrl` (the resolvers `SpeciesDetailSurface.tsx:51–71` already builds; **rev 1 wrongly said they were already imported by the sheet — they are NOT;** the sheet imports only `buildFamilyColorResolver`, `SpeciesDetailSheet.tsx:14`). Pass `family={data.familyCode as FamilyCode \| null}` (the family **CODE**, not `familyName` — `<FamilySilhouette>.family` is `FamilyCode \| string \| null`, verified `FamilySilhouette.tsx:33`). Glyph scales with the frame via the §1.2 inner-node sizing rules. |
+| **(d)** | **Mobile analytics DROPPED.** `panel_opened` / `panel_dwell_ms` / `panel_scrolled_to_bottom` lived only in `SpeciesDetailSurface`, which the sheet no longer mounts. | Re-wire all three natively in the sheet (Task 4). `panel_opened` on data-arrival; `panel_dwell_ms` on unmount; `panel_scrolled_to_bottom` via an `IntersectionObserver` on a bottom sentinel. **`[R2-fix]` the sentinel must NOT live inside a `display:none` block** (architecture + test-ci): `.sheet-fg-about` and siblings are `display:none` until full (`styles.css:1610–1613`), so a sentinel placed after About would be `display:none` at compact/mid and at full only render once About is in DOM — but a `display:none` element has zero box and never intersects. Place the sentinel as a **direct child of the scroll container `.sheet-fg`, after the About block, with NO tier-gated `display:none`** (it inherits the FG grid but carries its own always-rendered rule, e.g. `height:1px`), so it is in the layout and intersectable at full. Same event names + prop shapes as `SpeciesDetailSurface`. |
+| **(e)** | **Live-height 3-state can THRASH at thresholds.** `content` is recomputed every render from single hard boundaries (`SpeciesDetailSheet.tsx:342–344`). A finger hovering a boundary flip-flops → reveals retrigger → flicker (redesign §4.5 risk 4). | Add **hysteresis**: a pure helper `resolveContentTier(height, prevTier, vh)` with a dead-band (±24px), unit-testable in isolation. **`[R2-fix]` fold the helper into T1, not T3** (see §4 + the T1↔T3 coupling fix): T1 introduces `resolveContentTier` from the start so it is not "add an un-hysteresed assertion in T1, then rewrite it in T3." T3 is dropped as a separate task; its content shrinks to nothing once the helper lands in T1. |
+
+### 2.3 Also fix while here (cheap, in-prototype)
+
+- `.sheet-fg-credits` CSS exists (`styles.css:1703–1708`) but is never rendered (credits come from
+  `<SpeciesDescription>`). Either render it or delete the rule (knip/orphan hygiene). Decide in T5.
+- The legacy `.sheet-compact` / `.sheet-scroll` CSS blocks (`styles.css:1469`, `1487–1524`) and the
+  `[data-content='compact'] .sheet-scroll` / `[data-content='full'] .sheet-compact` rules are dead
+  once `.sheet-fg` is the only body — remove in T5 to avoid orphan-CSS + knip drift.
+
+---
+
+## 3. Accessibility work to fold in
+
+### 3.1 Already done in the prototype (verify, do not redo)
+
+- **`<dl>` semantics** on the record strip + taxonomy table.
+- **Heading order** — species name is `h2#detail-title tabIndex={-1}` (`SpeciesDetailSheet.tsx:420`);
+  "About" is `h3` (`.sheet-fg-about-eyebrow`). Page identity keeps the `h1`.
+- **Family-dot contrast ring**; family **text** co-located as the canonical signal.
+- **"Read account" is a real `<button>`** with `aria-expanded`/`aria-controls="sheet-fg-account"`,
+  link color (NOT family accent), persistent underline, `min-height:44px`, down-chevron,
+  `:focus-visible` ring.
+- **Decorative `alt=""`** on the photo. **`[R2-fix]` with `<Photo>` composition (Task 2):** `<Photo>`
+  takes a required `alt` string. For the sheet, pass `alt=""` (decorative — name sits adjacent),
+  which `<Photo>` forwards to its `<img alt="">` (`Photo.tsx:130`). The full-bleed masthead is still
+  decorative; the photo credit lives in visible text via `<SpeciesDescription>`, not alt.
+- **Description sanitize**; **Name focus ring** (`:focus-visible` only).
+
+### 3.2 Must ADD (the three diagnosis findings)
+
+- **F8 — real focus trap at full.** At full the sheet asserts `role=dialog`/`aria-modal` but only
+  inerts `#map-layer`; Tab escapes into the still-tabbable AppHeader. **Mirror the filters-panel
+  Tab-wrap** in `App.tsx:247–315` (collect focusables with the same selector
+  `a[href], button:not([disabled]), input…, [tabindex]:not([tabindex="-1"])`; on `Tab`/`Shift+Tab`
+  wrap first↔last). Active **only at full** (`snap==='full'`), torn down when leaving full or
+  unmounting. Keep it inside `SpeciesDetailSheet` (the handle is the first focusable). Install the
+  Tab handler WITHOUT touching `inert`/`role` timing so the MutationObserver sequencing tests stay
+  green. Delete the stale `styles.css:1414–1421` comment claiming chrome is "non-interactive" — true
+  for pointer, false for Tab.
+- **F9 — focus restore on close. `[R2-fix]` resolve the fallback selector to a REAL rendered id.**
+  The sheet has no `previouslyFocusedRef`. Mirror `SpeciesDetailModal.tsx:55–167` /
+  `SpeciesDetailRail.tsx:52–76`: capture `document.activeElement` on mount; on `onClose`, restore to
+  it if `document.contains(previous)`, else fall back to a **real, focusable landmark**.
+  **The Rail/Modal default `#surface-tab-map` is a DEAD selector — it is never rendered anywhere in
+  `frontend/src`** (verified by grep; the only rendered ids are `id="main-surface"` and
+  `id="map-layer"`, `App.tsx:1361`/`1289`). So the Rail's `fallback?.focus()` is a silent no-op
+  today (the Rail is invoked without a `fallbackFocusSelector` prop, `App.tsx:1460–1465`). **Do NOT
+  inherit `#surface-tab-map`.** Use **`#main-surface`** as the sheet's fallback: it is rendered
+  (`App.tsx:1361`) and **focusable** (`<main tabIndex={0}>`, `App.tsx:1380`). (`#map-layer` exists
+  but is not inherently focusable, so it is the wrong restore target.) Restore must fire on the
+  dismiss path (drag-down + ESC-at-peek) too, not just a button close. **Add a unit assertion that
+  `document.querySelector('#main-surface') !== null` so the no-op can never silently ship.**
+- **F10 — announce on reaching a readable detent. `[R2-fix]` live region lives INSIDE the sheet,
+  de-conflicted with the existing full-snap focus effect.** Today heading focus fires only at full
+  (`SpeciesDetailSheet.tsx:328–335`, early-returns when `snap!=='full'`). At **half** the identity
+  becomes legible but nothing is announced. Add a polite live announcement (a visually-hidden
+  `aria-live="polite"` region rendered **as a descendant of the sheet root**, so it is inside the
+  `aria-modal` subtree and still announced at full — an *external* live region like the app-root
+  `role="status"` at `App.tsx:1389`, which is a sibling of `#map-layer`, can be ignored by AT once
+  the sheet asserts `aria-modal="true"`). De-confliction rules:
+  - **Single announce per readable detent.** Fire the half-announce only on the *first* transition
+    into `half` from `peek`; do not re-fire on `full→half`.
+  - **No double-fire with the full focus-move.** The existing effect already moves focus to
+    `#detail-title` at full; on a fast flick `half→full`, the half live-region update and the full
+    focus-move must not stutter. Choose the **live-region** option (NOT the "move focus to
+    `#detail-title` at half" option), because moving focus to the same heading at both half and full
+    would announce it twice. Debounce/guard so a flick straight through half to full produces at most
+    one half announcement (or suppress the half announce entirely if `full` is reached within the
+    same gesture). Do not steal map focus at `peek`.
+  - Add a unit test for single-announce-per-readable-detent.
+
+### 3.3 Remaining tuning-punch-list items (NOT yet applied — fold in)
+
+Most HIGH items are done (§3.1). Remaining, by detent:
+
+- **ALL:** photoless silhouette glyph (= 2.2c, via `<Photo>`). Audit the **full** family palette vs
+  `#fff` and the navy surface at 3:1 for the dot ring (spot-check, not just cardinal-red).
+- **COMPACT:** thumb radius → `--card-radius-inner` (8px); vertically center the text block to the
+  thumb (`align-items:center`). 2px between name and family; family at `--color-text-muted`.
+- **MID:** plate→text gap `--space-md`; name `--type-lg` (done) + vertically center stack against
+  the plate (`align-self:center` done — verify); sci-name `margin-top:2px`; de-double the accent
+  rule vs the record-strip border; tighten record-strip density; `<dl>` semantics (done); 44×44 hit
+  area on Read-account (done). Confirm record-strip label contrast ≥4.5:1 at 11px in BOTH themes.
+- **FULL:** taxonomy row alignment (verify uniform row heights & top-align); masthead bottom-edge
+  gradient scrim + `object-position:center 35%` (object-position done; **scrim not done** — add
+  transparent→~12% black over lower ~64px); About eyebrow rhythm; credit on its own line at a
+  confirmed-AA token; **alt text** — keep decorative `alt=""` and ensure photo credit is in visible
+  text, not alt.
+
+---
+
+## 4. Task decomposition (1-PR-sized, CI-green each)
+
+The work does **not** cleanly split into "motion PR then layout PR" — motion without the mid
+redesign still reads as a clipped full view (redesign §4.5 risk 8), and the layout already exists
+in the prototype. We split by **risk surface + test surface** so each PR is independently
+green-able.
+
+> **`[R2-fix]` Task count change.** Rev 1 had 5 tasks (T3 = hysteresis). The reviews showed
+> T1↔T3 had a test-coupling conflict (T1 added an un-hysteresed boundary assertion that T3 would
+> then rewrite — the exact "leave a test then rewrite it next PR" anti-pattern §4's own rule
+> forbids). **Resolution: fold the `resolveContentTier` hysteresis helper into T1.** The plan is now
+> **4 implementation tasks** (T1, T2-silhouette, T3-analytics, T4-a11y) + the epic. 4 > 2 ⇒ epic.
+
+### Epic
+
+> **Epic: Production field-guide mobile species sheet (off-prototype).** Tracks T1–T4. Links
+> `mid-full-redesign.md`, `diagnosis-report.md`, `fg-tuning-punchlist.md`, this plan. Child PRs
+> land in order; the epic closes after T4 + final 5-viewport × 2-theme design review.
+
+### Dependency order
+
+```
+T1 (port shell + hysteresis helper + tests rebaseline) ──┬── T2 (Photo-composed silhouette glyph) ──┐
+                                                          └── T3 (analytics rewire) ───────────────┴── T4 (a11y F8/F9/F10 + tuning + cleanup)
+                                                          (motion polish + reveal recipes folded into T1)
+```
+
+T1 is the foundation (it makes the FG sheet the production component, introduces the hysteresis
+helper, and rebaselines the broken tests). T2/T3 are independent after T1 and may run in parallel
+worktrees. T4 is last because the focus trap interacts with the final DOM and the tuning pass wants
+the silhouette + analytics already present.
+
+> **`[R2-fix]` Same-file collision warning (test-ci review).** T2, T3, **and** T4 all edit
+> `SpeciesDetailSheet.tsx` **and** `SpeciesDetailSheet.test.tsx`. They ship serial per the
+> multi-PR batch rule (`multi_pr_serial_ship`), but each rebase after a merge is a **guaranteed
+> manual conflict** in those two files, not a clean replay. The implementer must expect to resolve
+> the component + test-file conflict by hand AND re-run the full unit suite locally on each rebase
+> (a bot re-dispatch alone is insufficient — branch-protection dismisses the stale APPROVE on
+> rebase, so re-dispatch the bot *after* the manual rebase + local-green confirmation).
+
+> **CI-coupling rule (memory: plan_ci_coupling).** Each task below leaves
+> `test`/`lint`/`build`/`e2e`/`knip`/`orphan-classname-check` GREEN. No "leave a check red, fix
+> next PR." Where a test's *assertion* must change because the behavior intentionally changed, the
+> rewrite lands **in the same PR** as the behavior change (T1).
+
+---
+
+#### Task 1 — Port the field-guide sheet to production + hysteresis helper + rebaseline the broken specs
+
+**Why first / why one PR:** the behavior changes (open-at-half, drag, FG layout, hysteresis) and the
+test rewrites those changes force are inseparable — splitting them strands CI red.
+
+**Files touched:**
+- `frontend/src/components/SpeciesDetailSheet.tsx` — port the prototype minus the PROTOTYPE-grade
+  shortcuts T2/T3 own; remove the `PROTOTYPE`/`Strategy 1` comment scaffolding; keep the inert↔role
+  sequencing comments. **Add `resolveContentTier(height, prevTier, vh)`** (pure, exported) and drive
+  `[data-content]` through it (replaces the inline single-boundary expression at lines 342–344).
+- `frontend/src/styles.css` — port `.sheet-fg-*`; replace `@keyframes fg-reveal` with the **recipe 18
+  (texts-reveal) + recipe 07 (panel-reveal)** channels (use `transitions-dev`); add `margin` AND
+  `grid-template-columns` to the morph transition consideration (2.2a). **`[R2-fix]` the
+  `.sheet-fg-img--silhouette` orphan class is resolved IN THIS PR, not deferred:** since T1 ports the
+  shell but T2 does the `<Photo>` swap, T1 must NOT port the orphan `<div className="sheet-fg-img
+  sheet-fg-img--silhouette">` verbatim. **Pick ONE explicitly: (a)** pull the `<Photo>` swap forward
+  into T1 (preferred — removes the orphan at the source and there's no interim orphan to allowlist),
+  OR **(b)** if T1 must keep the no-photo branch as a placeholder, give `.sheet-fg-img--silhouette` a
+  real CSS rule for the duration. Do NOT ship T1 with an unrules orphan class on the promise T2 will
+  fix it — `orphan-classname-check` gates Mergify and would block the whole queue. **Recommended: do
+  (a)** — fold the `<Photo>` composition into T1 and drop T2's component change to a pure
+  tuning/audit pass. (If kept separate, T1 takes path (b) and T2 deletes the placeholder + rule.)
+  Do NOT yet delete the legacy `.sheet-compact`/`.sheet-scroll` rules (T4).
+- `frontend/src/components/SpeciesDetailSheet.test.tsx` — rewrite (see below).
+- `frontend/e2e/sheet-snap.spec.ts` — rewrite open-at-* expectations + add drag e2e (see below).
+- `frontend/e2e/species-detail.spec.ts` — fix the **mobile** variants (see below).
+
+**Acceptance criteria:**
+- Sheet opens at `half`, role `region`; advancing reaches `full` with `role=dialog`+`aria-modal`
+  and the `mainRef` element (`#map-layer` in App) inert; collapse reverses. Drag up grows 1:1; drag
+  down past dismiss closes; velocity flick advances/retracts. `[data-content]` = compact|mid|full
+  driven by `resolveContentTier` (hysteresed).
+- **`[R2-fix]` mid→full morph reads as a continuous element on Safari/iOS** (drive live during T1).
+  EITHER this passes and is part of the AC, OR T1 explicitly documents acceptance of a stepping
+  un-inset and lands the recipe-14 cross-fade as a named sub-task in the same PR. T1 may NOT merge
+  with a silently-stepping morph.
+- `npm run -w @bird-watch/frontend test`, `lint`, `build`, and `e2e` all green.
+- Zero console errors/warnings at all 5 canonical viewports × 2 themes (live Playwright drive).
+- `orphan-classname-check` and `knip` clean (no orphan `.sheet-fg-img--silhouette`; add ignore rules
+  with dated comments only for true FPs).
+
+**TDD strategy (unit — `SpeciesDetailSheet.test.tsx`):**
+
+> **`[R2-fix]` Inert-target wording (test-ci review).** The existing unit suite creates a synthetic
+> `mainEl` (`SpeciesDetailSheet.test.tsx:38–39`, `id="main-surface"`) and passes it as `mainRef`.
+> The component is id-agnostic, so these tests are valid as written — they assert inert on the
+> element the test passed. Do NOT loosely say "#main/map not inert." Be target-specific: **unit
+> tests assert inert on the passed `mainRef.current` element** (the fixture's `mainEl`); **e2e tests
+> assert inert on `#map-layer`** (`app.mapLayer`, the real production target per `App.tsx:1478`).
+
+*Assertions that BREAK and MUST be rewritten:*
+- **`opens at peek snap …` (lines 46–61)** → assert **opens at `half`**, `role=region`,
+  `aria-label="Selected sighting"`, no `aria-modal`, `mainRef` element NOT inert.
+- **`expand button advances peek → half → full` (63–86)** → now **half → full** (two detents from
+  open, not three). Re-derive the click count.
+- **The implicit tap-cycle behavior:** keep one explicit test that a pure tap on the handle still
+  expands/collapses (Material-3 fallback), but assert it does NOT double-advance after a drag
+  (`didDragRef` suppression).
+
+*Assertions that MUST STAY GREEN (do not weaken):*
+- **`inert is set BEFORE the role flips` (88–128)** — the MutationObserver sequencing test.
+- **`collapse path … removes inert AFTER role flips back` (130–152)**.
+- **`unmounting at full snap cleans up inert` (205–230)** — viewport-flip regression.
+- **`ESC scoped …` (154–181)** and **`drag-down past peek dismisses` (183–203)** — adjust for
+  open-at-half.
+
+*New unit specs to add (this PR):*
+- open-at-`half` initial detent; `[data-content]` resolves to `mid` at the half height.
+- 1:1 drag: a `pointermove` of Δy=−120 from `half` sets `liveHeight ≈ heightFor(half)+120`.
+- velocity-snap: a fast up-flick (`vy < −0.5`) from `half` settles to `full`; fast down-flick to
+  `peek`.
+- **`resolveContentTier` hysteresis (folded in from former T3):** table-driven — ascending heights
+  cross compact→mid→full at the up-thresholds; descending heights hold each tier until the lower
+  edge of the ±24px dead-band; a height oscillating inside the band keeps `prevTier`. **This replaces
+  rev 1's "assert the un-hysteresed boundary" spec** so there is nothing for a later task to rewrite.
+
+**TDD strategy (e2e):**
+- **`sheet-snap.spec.ts`** — rewrite `opens at peek` → `opens at half`; keep the role-flip,
+  `#map-layer` inert (`app.mapLayer`), z-tier probe, collapse, and drag-down-dismiss assertions. Run
+  at 390×844.
+- **`[R2-fix]` ADD a concrete drag-UP / flick e2e** (test-ci review — drag-up/flick currently has
+  ZERO e2e, only synthetic-PointerEvent unit coverage; the brief lists drag as required e2e):
+  drag the handle up from `half` and assert sheet `height` grows ~1:1 with the drag distance; then a
+  fast upward flick from `half` settles `data-snap-state='full'`. Use Playwright pointer
+  (`mouse.move`/`mouse.down`/`mouse.up` with intermediate steps) so velocity is real.
+- **`species-detail.spec.ts` mobile breakage (the brief's hidden landmine):** line 30 asserts
+  `.species-detail-family` and the `#327 task-12` block asserts the silhouette at **both 1440 AND
+  390** (loop `species-detail.spec.ts:288–349`). The FG sheet renders `.sheet-fg-family` (not
+  `.species-detail-family`). **`[R2-fix]` with `<Photo>` composition the mobile silhouette locator
+  STAYS `.photo--silhouette`** (Photo emits it, `Photo.tsx:104`) — do NOT point it at
+  `.sheet-fg-img--silhouette` (rev 1 was wrong; that class is being deleted). **Fix:** scope the
+  family-name locator per-surface — desktop (rail) keeps `.species-detail-family`; the mobile (sheet)
+  variant asserts `.sheet-fg-family`. The mobile photo is decorative (`alt=""`), so the mobile
+  `getByAltText('… photo')` assertion must change to the FG decorative-photo expectation. The
+  silhouette assertion (`.photo--silhouette`) works on both surfaces unchanged. Do this in T1 so e2e
+  is green the moment the sheet swaps.
+
+---
+
+#### Task 2 — `<Photo>`-composed family silhouette glyph (2.2c + punch-list)
+
+> **`[R2-fix]` If T1 took path (a)** (folded the `<Photo>` swap forward), this task shrinks to the
+> silhouette **tuning/audit** items only (palette contrast, dot-ring spot-check, per-theme tint) and
+> the no-photo e2e assertion verification. The component swap below describes path (b) where T1 kept
+> the placeholder.
+
+**Files:** `SpeciesDetailSheet.tsx` (replace the hand-rolled photo pair with `<Photo>` threaded with
+`src`/`alt=""`/`family={data.familyCode as FamilyCode|null}`/`color`/`pathD`/`imgUrl`/
+`priority`/`layout="masthead"`; **add the missing imports** `buildFamilyPathResolver` +
+`buildFamilyImgUrlResolver` from `../data/family-color.js` and the `resolvePath`/`resolveImgUrl`
+useMemos mirroring `SpeciesDetailSurface.tsx:51–71`), `styles.css` (the §1.2 inner-node sizing rules:
+`.sheet-fg-photo .photo { aspect-ratio:auto; width:100%; height:100% }`, `.sheet-fg-photo .photo__img`
++ `.sheet-fg-photo .family-silhouette` inherit the frame; **delete** the orphan
+`.sheet-fg-img--silhouette` placeholder + any rule path (b) added).
+
+**Correct file path `[R2-fix]`:** `frontend/src/components/ds/FamilySilhouette.tsx` and
+`frontend/src/components/ds/Photo.tsx` (rev 1 wrote `ds/FamilySilhouette.tsx` — implementers must use
+the full path; ignore the `.claude/worktrees/` copies). **Before writing the failing test, read
+`Photo.tsx`, `FamilySilhouette.tsx`, and `FamilySilhouette.test.tsx`** to confirm the prop surface.
+
+**AC:** a no-photo species renders the family glyph (via `<Photo>`→`<FamilySilhouette>`) centered on
+the family-color ground at 44/120/masthead, per-theme contrast; the morph still works (glyph scales
+with the frame via §1.2 sizing); decode-stability holds (the `<img>` does not remount across detents
+for a fixed species); dot-ring palette audit ≥3:1; `orphan-classname-check` clean (no
+`.sheet-fg-img--silhouette`).
+
+**TDD:** unit — no-photo fixture (`VERMFLY`) renders `<FamilySilhouette>` (`data-testid=
+"family-silhouette"` present, via `.photo--silhouette` wrapper) at each `[data-content]`; with-photo
+fixture renders the `<img>` (`.photo--silhouette` absent). e2e — the `#327 task-12` mobile silhouette
+assertion (`.photo--silhouette`) already passes after T1; verify it stays green; 5-viewport × 2-theme
+console-clean.
+
+---
+
+#### Task 3 — Re-wire mobile analytics (2.2d)
+
+**Files:** `SpeciesDetailSheet.tsx` (import `analytics`; `panel_opened` on data-arrival,
+`panel_dwell_ms` on unmount via effect-cleanup, `panel_scrolled_to_bottom` via
+`IntersectionObserver` on a bottom sentinel). Optional: a tiny `use-detail-analytics.ts` hook sharing
+the shape with `SpeciesDetailSurface`'s logic (do not import the surface).
+
+**`[R2-fix]` Sentinel placement (architecture + test-ci):** render the sentinel as a **direct child
+of `.sheet-fg` after the About block, with NO tier-gated `display:none`** (it must NOT sit inside
+`.sheet-fg-about`/`.sheet-fg-taxonomy`/etc., which are `display:none` until full —
+`styles.css:1610–1613` — and a `display:none` element never intersects). The `IntersectionObserver`
+roots on the nearest scroll ancestor (`.sheet-fg`, the scroll container only at full — compact/mid
+don't scroll), so the sentinel only meaningfully intersects at full, which is the intended semantic.
+
+**AC:** same event names + prop shapes (`species_code`, `has_description`, `dwell_ms`) as
+`SpeciesDetailSurface` (verified `SpeciesDetailSurface.tsx:78–115`); `panel_scrolled_to_bottom` fires
+once when About scrolls into view at full; no double-fire across detent changes.
+
+**TDD:** unit — mock `analytics.capture`; assert `panel_opened` fires once on data resolve,
+`panel_dwell_ms` on unmount, sentinel-intersection fires `panel_scrolled_to_bottom` once
+(IntersectionObserver mocked, mirroring `SpeciesDetailSurface.test.tsx`). **`[R2-fix]` ADD a real
+e2e** (test-ci — `panel_scrolled_to_bottom` depends on a live IntersectionObserver that unit tests
+mock away, and analytics were silently dropped once before): at 390×844, open to full, scroll
+`.sheet-fg` to the bottom, and assert the PostHog capture via a route-intercept or a `window` spy on
+`analytics.capture` for `panel_scrolled_to_bottom`.
+
+---
+
+#### Task 4 — A11y F8/F9/F10 + remaining tuning + dead-code cleanup
+
+**Files:** `SpeciesDetailSheet.tsx` (focus trap at full; `previouslyFocusedRef` + restore on every
+close path with the **`#main-surface`** fallback; in-sheet live-region announce), `styles.css`
+(masthead scrim, compact/mid/full tuning deltas, delete legacy `.sheet-compact`/`.sheet-scroll` +
+unused `.sheet-fg-credits`, fix the stale `1414–1421` comment). **No `App.tsx` change needed for the
+fallback** — `#main-surface` already exists and is focusable (`App.tsx:1361`/`1380`), so the sheet
+just targets it; do NOT add a new landmark.
+
+**AC:** at full, Tab/Shift+Tab cycle within the sheet (cannot reach AppHeader); ESC + drag-dismiss
+restore focus to the trigger-or-`#main-surface`; reaching `half` announces once to AT via the
+in-sheet live region; reduced-motion collapses all reveal channels to resting end-state (F14);
+punch-list tuning items applied; `axe.spec.ts` clean at all 5 viewports × 2 themes;
+`knip`/`orphan-classname-check` clean.
+
+**TDD (unit — the focus-trap spec is the headline):**
+- **focus-trap:** at full, programmatically focus the last focusable, dispatch `Tab` → focus wraps
+  to the first; `Shift+Tab` from the first → last; at peek/half the trap is NOT installed.
+- **focus-restore:** render with a known `activeElement`; close via button, via ESC, and via
+  drag-dismiss → focus returns to it (and to `#main-surface` when the trigger is detached, guarded by
+  `document.contains`). **Assert `document.querySelector('#main-surface') !== null`** so the fallback
+  can never be a silent no-op (the dead `#surface-tab-map` lesson).
+- **announce:** transitioning peek→half fires the in-sheet live region exactly once; a flick
+  peek→full does not double-announce; peek does not steal map focus.
+- **reduced-motion:** under `prefers-reduced-motion: reduce` the reveal channels render at their
+  resting end-state.
+- **Keep green:** all the inert↔role sequencing tests (the trap must not perturb the MutationObserver
+  order — install the Tab handler without touching `inert`/`role` timing).
+- **e2e — `[R2-fix]` concrete focus-trap assertion** (test-ci — F8 is the headline a11y fix and must
+  be falsifiable, not just covered by axe): at full (390×844), focus the last focusable inside the
+  sheet → press `Tab` → assert focus is back inside the sheet (the handle/first focusable) and that
+  an AppHeader control (e.g. the Filters trigger) is **NOT** the active element; `Shift+Tab` from the
+  first focusable → focus lands on the last inside the sheet. Plus `axe.spec.ts` clean, 5 viewports ×
+  2 themes.
+
+---
+
+## 5. Risks + migration
+
+- **Migration off `proto/mobile-sheet-strategy-2`.** Do NOT branch production work off the proto
+  branch. Each task branches off `main`. T1 ports the proto file content into a clean `main`-based
+  branch; the proto branch is then abandoned (its uncommitted state is the reference, not the
+  ancestor). Confirm `main` has not drifted the sheet/CSS since the proto snapshot before porting
+  (note: this revision was verified against the proto branch; re-diff against `main` first).
+- **Multi-PR serial-ship discipline + same-file collisions** (memory: multi_pr_serial_ship). T2/T3
+  implement in parallel worktrees but **ship serial**. Per the §4 `[R2-fix]` warning, T2/T3/T4 all
+  touch `SpeciesDetailSheet.tsx` + `.test.tsx`, so each rebase is a **manual conflict** — resolve by
+  hand, re-run the full unit suite locally, THEN re-dispatch the bot (branch-protection dismisses the
+  stale APPROVE on rebase). Mergify `batch_size:1`.
+- **Mid→full photo morph on Safari/iOS** (redesign §4.5 risks 1–3). The 1/1→16/10 aspect change +
+  margin un-inset + the **non-animatable `grid-template-areas` remap** is the trickiest transition;
+  `aspect-ratio` must not be animated. T1's AC now gates on this reading as continuous on Safari, or
+  on an explicit documented acceptance of stepping + the recipe-14 cross-fade landed in T1.
+- **`overflow-x` during the un-inset** (risk 5) — keep `overflow-x: clip` on `.sheet-fg` and the
+  sheet root so the morphing photo never spawns a horizontal scrollbar (the `mobile-bundle-e.spec`
+  asserts `body.scrollWidth ≤ 390`).
+- **Reveal timing trailing the settle on a fast flick** (risk 7) — acceptable; shorten reveal
+  durations toward the 300ms settle if it reads as lag. Verify the feel live.
+- **`knip` + `orphan-classname-check` gate Mergify** (CLAUDE.md) — both block the queue even when
+  "informational." `.sheet-fg-img--silhouette` is resolved in T1 (no interim orphan). Removing
+  `.sheet-compact`/`.sheet-scroll`/`.sheet-fg-credits` (T4) must not leave a JSX className without a
+  CSS rule or vice-versa; run both checks per PR before `@Mergifyio queue`.
+- **PR workflow** — `.github/PULL_REQUEST_TEMPLATE.md` verbatim (5 sections, Screenshots REQUIRED on
+  `frontend/**` — ≥10 `user-attachments` URLs, 5 viewports × 2 themes, via the
+  `pr-screenshots-via-user-attachments` skill, never committed PNGs); design-review subagent
+  (`ui-design:ui-designer`, `model: opus`) must PASS all 5 viewports before bot review; bot review
+  via the `julianken-bot` Agent; never `gh pr merge`.
+
+---
+
+## 6. Out of scope / follow-ups
+
+- **Desktop rail/modal field-guide adoption.** Separate epic: redesign `SpeciesDetailSurface`,
+  re-baseline its 25KB unit suite + the desktop half of `species-detail.spec.ts`, reconcile with the
+  four-corner anchor contract.
+- **Fix the dead `#surface-tab-map` default in the Rail/Modal.** `[R2-fix]` This revision discovered
+  that `SpeciesDetailRail`/`SpeciesDetailModal` default `fallbackFocusSelector` to `#surface-tab-map`,
+  which is **never rendered** — so their detached-trigger focus restore is a silent no-op today. The
+  sheet avoids it (uses `#main-surface`), but the Rail/Modal bug is real and should be filed
+  separately (pass a real selector or change the default to `#main-surface`). Not in this epic's
+  critical path, but it is a latent a11y regression worth a tracking issue.
+- **Map recenter / bottom-inset on snap change** so the tapped marker stays visible above the sheet
+  (diagnosis open-Q 2). Defer.
+- **Deck/standfirst "first sentence pulled out"** (Editorial-only) — not in the locked Field-guide
+  direction; skip.
+- **Runtime DOMPurify defense-in-depth** for descriptions — already deferred to v2 (epic #368).
+- **`SpeciesDetailModal.tsx` / `lib/use-is-mobile.ts` dead WIP** (diagnosis §5) — untracked,
+  unimported; clean up opportunistically, not in this epic's critical path.
+- **Delete the proto branch** `proto/mobile-sheet-strategy-2` after T1 merges.
+
+---
+
+## 7. Decision — RESOLVED (Julian, 2026-06-06): Option A
+
+**T1↔T2 boundary (the `<Photo>` swap timing) — RESOLVED to Option A.** The `<Photo>` composition is
+folded into **T1** (no interim orphan class, no allowlist churn; the silhouette / decode-stability /
+e2e-locator fixes all land in T1). **T2 shrinks to a pure silhouette tuning/audit pass** (family
+palette ≥3:1 spot-check, per-theme tint, no-photo e2e verification). The original framing is retained
+below for the record.
+
+**T1↔T2 boundary (the `<Photo>` swap timing).** The orphan-class fix forces a choice the plan can
+frame but not unilaterally settle without your steer:
+
+- **Option A (recommended):** fold the `<Photo>` composition into **T1**. Pro: no interim orphan
+  class, no allowlist churn, the silhouette/decode-stability/e2e-locator fixes all land together, and
+  T2 shrinks to a pure tuning/audit pass. Con: T1 grows larger (it already carries the shell port +
+  hysteresis + test rebaseline).
+- **Option B:** keep T1 as the shell port and give `.sheet-fg-img--silhouette` a temporary real CSS
+  rule, then do the `<Photo>` swap + delete in T2. Pro: smaller T1. Con: ships a throwaway CSS rule
+  for one PR's lifetime; the swap-and-delete is pure churn.
+
+Everything else from the three reviews is folded in deterministically; this is the only place where
+the right call depends on your appetite for T1 size vs. interim churn.


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
  E[Epic: production field-guide mobile sheet] --- T1
  T1["T1 · port FG sheet + Photo + hysteresis<br/>+ reveal recipes 18/07 + rebaseline specs"] --> T2["T2 · silhouette tuning / palette audit"]
  T1 --> T3["T3 · re-wire mobile analytics"]
  T2 --> T4["T4 · a11y F8/F9/F10 + tuning + dead-CSS cleanup"]
  T3 --> T4
```

## Summary

- Promotes the **field-guide mobile species-sheet redesign** plan (+ its 3 companion docs) into `docs/plans/` — the durable artifact behind the epic + 4 child issues filed alongside this PR.
- Docs-only; no code. The validated prototype lives on `proto/mobile-sheet-strategy-2`; production tasks branch off `main` per the plan.
- The plan was adversarially reviewed (architecture / a11y / test-CI); the T1↔T2 boundary is resolved to Option A (fold `<Photo>` into T1).

## Screenshots

N/A — not UI (docs only).

## Test plan

N/A — docs only (no code, no build/test surface). `knip` / `orphan-classname-check` unaffected (no source change).

## Plan reference

Out of plan — mobile species-sheet redesign discovered during UX review; **this PR is the plan** (`docs/plans/2026-06-06-field-guide-mobile-sheet/`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
