### PR TITLE
feat(frontend): field-guide mobile species sheet — port + harden (#907)

### DIFF
--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -4,6 +4,36 @@ import { AppPage } from './pages/app-page.js';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
+/**
+ * Wait until the field-guide sheet's reveal transitions (#907 recipe-18 /
+ * recipe-07) have settled to full opacity. axe color-contrast reads the
+ * alpha-blended computed color, so a mid-transition snapshot of opacity:0→1
+ * text reports false sub-contrast. We poll the most-muted revealed element
+ * (the teaser text) until its computed opacity is 1 — deterministic, not a
+ * fixed timeout. Resolves immediately when no sheet/teaser is present.
+ */
+async function waitForRevealSettled(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page
+    .waitForFunction(() => {
+      const sheet = document.querySelector('.species-detail-sheet');
+      if (!sheet) return true;
+      const revealed = sheet.querySelectorAll(
+        '.sheet-fg-sci, .sheet-fg-record, .sheet-fg-teaser, .sheet-fg-teaser-text, .sheet-fg-taxonomy, .sheet-fg-about',
+      );
+      // Every reveal element that is laid out (not display:none in this tier)
+      // must have reached full opacity.
+      for (const el of Array.from(revealed)) {
+        const cs = getComputedStyle(el as Element);
+        if (cs.display === 'none') continue;
+        if (Number(cs.opacity) < 0.999) return false;
+      }
+      return true;
+    }, undefined, { timeout: 5_000 })
+    .catch(() => { /* best-effort settle; the assertions below still run */ });
+}
+
 test.describe('axe-core WCAG scans', () => {
   test('initial load has no WCAG 2/2.1 A/AA violations', async ({ page }) => {
     const app = new AppPage(page);
@@ -237,6 +267,12 @@ test.describe('axe-core WCAG scans', () => {
       await app.waitForAppReady();
       await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
         .toBeVisible({ timeout: 10_000 });
+      // #907: the field-guide sheet reveals mid-tier content with an
+      // opacity/transform/blur transition (recipe-18). axe color-contrast reads
+      // the computed (alpha-blended) color, so it must scan the SETTLED state —
+      // wait until the revealed teaser text reaches full opacity before
+      // analyzing, otherwise a mid-transition snapshot reports false sub-contrast.
+      await waitForRevealSettled(page);
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
       if (results.violations.length) {
         await test.info().attach('axe-violations', {
@@ -260,7 +296,11 @@ test.describe('axe-core WCAG scans', () => {
       await app.waitForAppReady();
       await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
         .toBeVisible({ timeout: 10_000 });
-      await expect(page.getByAltText('Vermilion Flycatcher photo')).toBeVisible();
+      // #907: the field-guide sheet photo is DECORATIVE on mobile (alt="") — the
+      // species name sits adjacent — so locate the rendered <img> by its stable
+      // .photo__img class, not by alt text.
+      await expect(page.locator('.sheet-fg-photo .photo__img')).toBeVisible();
+      await waitForRevealSettled(page);
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
       if (results.violations.length) {
         await test.info().attach('axe-violations', {
@@ -287,12 +327,11 @@ test.describe('axe-core WCAG scans', () => {
       const sheet = page.locator('.species-detail-sheet');
       await expect(sheet).toBeVisible();
 
-      // The sheet opens at peek by default. Drive it to full via the
-      // exposed test handle — the implementation MUST expose either a
-      // `data-snap-state` attribute (preferred — declarative) or a
-      // testing-only setter on `window` for the snap state. Phase 4 uses
-      // `data-snap-state="peek|half|full"` on the sheet root.
-      await sheet.getByRole('button', { name: /expand/i }).click();
+      // The field-guide sheet opens at `half` by default; one expand tap drives
+      // it to `full` (peek is reached by dragging down, not the expand button).
+      // The implementation exposes a declarative `data-snap-state` attribute
+      // ("peek|half|full") on the sheet root.
+      await expect(sheet).toHaveAttribute('data-snap-state', 'half');
       await sheet.getByRole('button', { name: /expand/i }).click();
       await expect(sheet).toHaveAttribute('data-snap-state', 'full');
 

--- a/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
+++ b/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
@@ -164,7 +164,7 @@ test.describe('R6 — legend width cap at 390px (O5 #783)', () => {
 test.describe('force-collapsed — detail sheet at half/full (O5 #783)', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
-  test('legend is data-force-collapsed when sheet advances to half snap', async ({
+  test('legend is data-force-collapsed whenever the detail sheet is open on mobile', async ({
     page,
     apiStub,
   }) => {
@@ -182,27 +182,39 @@ test.describe('force-collapsed — detail sheet at half/full (O5 #783)', () => {
     await app.waitForAppReady();
 
     const sheet = page.locator('[data-testid=species-detail-sheet]');
-    await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
-
-    // At peek: legend should NOT be force-collapsed (peek is below overlay band)
-    await expect(page.locator('.family-legend')).not.toHaveAttribute(
-      'data-force-collapsed',
-      'true',
-    );
-
-    // Advance to half — force-collapse kicks in
-    const expand = page.getByRole('button', { name: /expand/i });
-    await expand.click();
+    // The field-guide sheet opens at half — already past the overlay band.
     await expect(sheet).toHaveAttribute('data-snap-state', 'half');
 
-    // Legend must be force-collapsed at half snap on mobile
+    // #907: App.tsx now force-collapses the legend whenever a detail sheet is
+    // open AT ALL (the `!!state.detail` signal) — the small sheet preserves the
+    // map and the legend would otherwise bury it. So the legend is force-
+    // collapsed at the open (half) detent.
     await expect(page.locator('.family-legend')).toHaveAttribute(
       'data-force-collapsed',
       'true',
     );
-
     // Entries must not render while force-collapsed
     await expect(page.locator('.family-legend-entries')).not.toBeVisible();
+
+    // Dragging down to the peek (identity-row) detent keeps it force-collapsed:
+    // the sheet is still open (state.detail set), so the `!!state.detail` signal
+    // holds even though peek itself is below the half/full overlay band.
+    const handle = page.locator('[data-testid=species-detail-sheet-handle]');
+    const hb = await handle.boundingBox();
+    const sb = await sheet.boundingBox();
+    if (!hb || !sb) throw new Error('handle/sheet bounding box unavailable');
+    const cx = hb.x + hb.width / 2;
+    const cy = hb.y + hb.height / 2;
+    // Drag down by ~ (half height − peek) so it settles at peek, not dismiss.
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx, cy + (sb.height - 140), { steps: 20 });
+    await page.mouse.up();
+    await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
+    await expect(page.locator('.family-legend')).toHaveAttribute(
+      'data-force-collapsed',
+      'true',
+    );
 
     // The stored preference must be intact (not mutated to false)
     const stored = await page.evaluate(() =>
@@ -239,13 +251,13 @@ test.describe('force-collapsed counter-case — iPad landscape 1024×768 (O5 #78
     const sheet = page.locator('[data-testid=species-detail-sheet]');
     await expect(sheet).toBeVisible({ timeout: 10_000 });
 
-    // Advance to half snap
-    const expand = page.getByRole('button', { name: /expand/i });
-    await expand.click();
+    // The sheet opens at half snap (field-guide default).
     await expect(sheet).toHaveAttribute('data-snap-state', 'half');
 
     // At 1024px (>480px, isPhone=false) the legend must NOT be force-collapsed
-    // even though the sheet is at half snap — locks in the ≤480px scope.
+    // even though the sheet is open at half snap — locks in the ≤480px scope.
+    // (The #907 `!!state.detail` force-collapse is also gated on isPhone, so it
+    // does not fire here.)
     const legendEl = page.locator('.family-legend');
     const hasForceCollapsed = await legendEl.getAttribute('data-force-collapsed');
     expect(

--- a/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
+++ b/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
@@ -7,9 +7,12 @@ import type { Observation } from '@bird-watch/shared-types';
  *
  * Covers:
  *   - Width cap: at 390px the legend renders ≤280px regardless of expanded state
- *   - force-collapsed: data-force-collapsed="true" when another overlay holds
- *     focus on mobile (detail sheet at half/full; filters sheet)
- *   - Counter-case: iPad landscape (1024×768) does NOT force-collapse
+ *   - force-collapsed (phone ≤480px): data-force-collapsed="true" when another
+ *     overlay holds focus on mobile (detail sheet at half/full; filters sheet)
+ *   - force-collapsed (compact ≤1199px, #907): data-force-collapsed="true"
+ *     whenever a detail sheet is open at 1024 / 768 — the bottom-docked sheet
+ *     would otherwise collide with the auto-expanded bottom-left legend
+ *   - Counter-case: at compact widths with NO detail open, NOT force-collapsed
  *   - Stored expanded preference is NOT mutated by force-collapse
  *
  * Repo e2e conventions:
@@ -225,47 +228,82 @@ test.describe('force-collapsed — detail sheet at half/full (O5 #783)', () => {
 
 });
 
-// ─── force-collapsed counter-case: 1024×768 (iPad landscape) ─────────────────
+// ─── force-collapsed at compact widths when the detail sheet is open ─────────
+//
+// #907 design-review finding 1: the bottom-docked field-guide sheet renders at
+// the whole compact range (≤1199px, useIsCompact), and the legend auto-expands
+// at ≥1024px (LEGEND_EXPAND_MIN_WIDTH). At tablet/small-laptop widths the open
+// sheet collided with the expanded bottom-left legend, occluding the photo
+// plate / hero name / Read-account button. The `isCompact && !!state.detail`
+// signal in App.tsx now force-collapses the legend across the compact range —
+// not just on phones. These cases lock that in at 1024 AND 768.
 
-test.describe('force-collapsed counter-case — iPad landscape 1024×768 (O5 #783)', () => {
-  // Must be in its own describe block to use test.use at the file scope level
-  test.use({ viewport: { width: 1024, height: 768 } });
+for (const { width, height, label } of [
+  { width: 1024, height: 768, label: 'iPad landscape / small laptop' },
+  { width: 768, height: 1024, label: 'iPad portrait' },
+]) {
+  test.describe(`force-collapsed — detail sheet open at ${width}×${height} (${label}) (#907)`, () => {
+    test.use({ viewport: { width, height } });
 
-  test('legend is NOT force-collapsed at 1024×768 when sheet advances to half snap', async ({
-    page,
-    apiStub,
-  }) => {
-    await setupRoutes(page, apiStub);
-    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
-    await apiStub.stubPhotoImage();
-    await page.addInitScript(() => {
-      try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
-      } catch { /* noop */ }
+    test(`legend is force-collapsed at ${width}×${height} when a detail sheet is open`, async ({
+      page,
+      apiStub,
+    }) => {
+      await setupRoutes(page, apiStub);
+      await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+      await apiStub.stubPhotoImage();
+      await page.addInitScript(() => {
+        try {
+          window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        } catch { /* noop */ }
+      });
+      const app = new AppPage(page);
+      // At these widths isCompact=true so the sheet renders (not the rail).
+      await app.goto('detail=vermfly&view=detail');
+      await app.waitForAppReady();
+
+      const sheet = page.locator('[data-testid=species-detail-sheet]');
+      await expect(sheet).toBeVisible({ timeout: 10_000 });
+      // The sheet opens at half snap (field-guide default).
+      await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+
+      // The open sheet must force-collapse the legend so it cannot bury the
+      // sheet's photo plate / hero name / Read-account button.
+      const legendEl = page.locator('.family-legend');
+      await expect(legendEl).toHaveAttribute('data-force-collapsed', 'true');
+      // Entries must not render while force-collapsed.
+      await expect(page.locator('.family-legend-entries')).not.toBeVisible();
+
+      // The stored expanded preference is NOT mutated by force-collapse.
+      const stored = await page.evaluate(() =>
+        window.localStorage.getItem('family-legend-expanded.v2'),
+      );
+      expect(stored).toBe('true');
     });
-    const app = new AppPage(page);
-    // At 1024px isCompact=true so the sheet renders (not the rail)
-    await app.goto('detail=vermfly&view=detail');
-    await app.waitForAppReady();
 
-    const sheet = page.locator('[data-testid=species-detail-sheet]');
-    await expect(sheet).toBeVisible({ timeout: 10_000 });
+    test(`legend is NOT force-collapsed at ${width}×${height} with no detail open`, async ({
+      page,
+      apiStub,
+    }) => {
+      await setupRoutes(page, apiStub);
+      await page.addInitScript(() => {
+        try {
+          window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        } catch { /* noop */ }
+      });
+      const app = new AppPage(page);
+      await app.goto('view=map');
+      await app.waitForAppReady();
 
-    // The sheet opens at half snap (field-guide default).
-    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+      const legendEl = page.locator('.family-legend');
+      await expect(legendEl).toBeVisible({ timeout: 10_000 });
 
-    // At 1024px (>480px, isPhone=false) the legend must NOT be force-collapsed
-    // even though the sheet is open at half snap — locks in the ≤480px scope.
-    // (The #907 `!!state.detail` force-collapse is also gated on isPhone, so it
-    // does not fire here.)
-    const legendEl = page.locator('.family-legend');
-    const hasForceCollapsed = await legendEl.getAttribute('data-force-collapsed');
-    expect(
-      hasForceCollapsed,
-      'Legend must NOT be force-collapsed at 1024×768 — isPhone is false above 480px',
-    ).not.toBe('true');
+      // No detail sheet open → the compact-scoped signal does not fire, and the
+      // phone-scoped signals are off above 480px. Legend stays expandable.
+      await expect(legendEl).not.toHaveAttribute('data-force-collapsed', 'true');
+    });
   });
-});
+}
 
 // ─── force-collapsed: filters sheet open on mobile ───────────────────────────
 

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -312,18 +312,18 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
   });
 
   // ───────────────────────────────────────────────────────────────────────────
-  // #830 — peek-snap detail sheet clearance vs the family legend.
+  // #830 / #907 — peek-snap detail sheet clearance vs the family legend.
   //
   // The bottom-right MapLibre attribution bar was removed (#830 item A), so the
-  // old legend-vs-attribution guard is gone (it asserted a control that no
-  // longer renders). The only remaining bottom-left collision risk is the
-  // species-detail bottom sheet at its PEEK snap on phones: at half/full the
-  // legend is already force-collapsed (App.tsx legendForceCollapsed), so peek is
-  // the one state where the un-collapsed legend shares the bottom band with the
-  // sheet. The `body:has(.species-detail-sheet--peek) .family-legend` rule lifts
-  // the legend by calc(--card-inset + 120px + --space-md) so the two never
-  // overlap. This guard asserts the legend's bottom edge sits at or ABOVE the
-  // peek sheet's top edge at 390×844 (the AC viewport).
+  // old legend-vs-attribution guard is gone. The remaining bottom-left collision
+  // risk is the species-detail bottom sheet at its PEEK (identity-row) snap on
+  // phones. #907 made the sheet open at HALF and force-collapse the legend
+  // whenever a detail sheet is open at all (App.tsx `!!state.detail`), so the
+  // legend is force-collapsed (header-pill height) at every detent including
+  // peek. The `body:has(.species-detail-sheet--peek) .family-legend` clearance
+  // rule still lifts it clear of the peek band. This guard drags the sheet down
+  // to peek and asserts the legend's bottom edge sits at or ABOVE the peek
+  // sheet's top edge at 390×844 (the AC viewport) — no overlap.
   // ───────────────────────────────────────────────────────────────────────────
   test.describe('#830: peek-snap detail sheet clearance vs family legend', () => {
     test.use({ viewport: { width: 390, height: 844 } });
@@ -335,8 +335,9 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
       await setupRoutes(page, apiStub);
       await stubSilhouettesForLegend(page);
       await apiStub.stubSpecies('vermfly', VERMFLY);
-      // Start from a known (expanded) legend state regardless of prior
-      // persistence — the expanded legend is the taller box and the harder case.
+      // Start from a known (expanded) legend preference regardless of prior
+      // persistence. The detail sheet force-collapses it anyway (#907), but this
+      // keeps the test's starting state deterministic.
       await page.addInitScript(() => {
         try {
           window.localStorage.removeItem('family-legend-expanded');
@@ -348,25 +349,32 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
 
       const app = new AppPage(page);
       // Scope to AZ (so the legend mounts with AZ silhouettes) AND deep-link the
-      // detail param so the bottom sheet opens. At 390×844 it lands at peek.
+      // detail param so the bottom sheet opens. At 390×844 it lands at half.
       await app.goto('state=US-AZ&detail=vermfly&view=detail');
       await app.waitForAppReady();
 
-      // The sheet mounts at peek (data-snap-state="peek" → the
-      // .species-detail-sheet--peek class that the :has() rule keys on).
       const sheet = page.locator('[data-testid=species-detail-sheet]');
       await expect(sheet).toBeVisible({ timeout: 10_000 });
-      await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
+      await expect(sheet).toHaveAttribute('data-snap-state', 'half');
 
       // The legend mounts once silhouettes resolve (App-root sibling — no WebGL
-      // dependency). At peek it is NOT force-collapsed, so it renders normally.
+      // dependency).
       await expect(page.locator('.family-legend')).toBeVisible({ timeout: 10_000 });
-      // Ensure the legend is expanded (the taller, harder case).
-      const toggle = page.locator('.family-legend [aria-expanded]');
-      if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
-        await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-expanded', 'true');
-      }
+
+      // Drag the sheet down from half to the peek (identity-row) detent so the
+      // .species-detail-sheet--peek clearance rule is exercised. Travel ≈
+      // (half height − peek) so it settles at peek, not dismiss.
+      const handle = page.locator('[data-testid=species-detail-sheet-handle]');
+      const hb = await handle.boundingBox();
+      const sb = await sheet.boundingBox();
+      if (!hb || !sb) throw new Error('handle/sheet bounding box unavailable');
+      const cx = hb.x + hb.width / 2;
+      const cy = hb.y + hb.height / 2;
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx, cy + (sb.height - 140), { steps: 20 });
+      await page.mouse.up();
+      await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
 
       const m = await measureLegendVsSheet(page);
       expect(m, '.species-detail-sheet / .family-legend not found').not.toBeNull();

--- a/frontend/e2e/safe-area.spec.ts
+++ b/frontend/e2e/safe-area.spec.ts
@@ -129,9 +129,13 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
 
     // ── 2. padding-top authored CSS source-string assertion ───────────────────
     //
-    // The production declaration at styles.css:1218:
-    //   padding-top: max(var(--space-xs, 4px), env(safe-area-inset-top, 0px));
-    // must also appear — this clears the Dynamic Island / status bar at full snap.
+    // The production declaration on the FULL modifier:
+    //   .species-detail-sheet--full { padding-top:
+    //     max(var(--space-xs, 4px), env(safe-area-inset-top, 0px)); }
+    // must appear — this clears the Dynamic Island / status bar at full snap.
+    // (#907 moved it OFF the base rule: applying it at every detent added ~47px
+    //  of dead space above the handle at peek/half; only the full sheet reaches
+    //  the notch.)
     const safeAreaTopResult = await page.evaluate(() => {
       const matchedPaddingTopValues: string[] = [];
 
@@ -144,7 +148,8 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
         }
         for (const rule of Array.from(rules)) {
           if (!(rule instanceof CSSStyleRule)) continue;
-          if (rule.selectorText !== '.species-detail-sheet') continue;
+          // #907: safe-area-inset-top now lives on the --full modifier, not base.
+          if (rule.selectorText !== '.species-detail-sheet--full') continue;
           const paddingTop = rule.style.getPropertyValue('padding-top');
           if (paddingTop) matchedPaddingTopValues.push(paddingTop);
         }
@@ -157,10 +162,10 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
       safeAreaTopResult.matchedPaddingTopValues.some((v) =>
         v.includes('env(safe-area-inset-top'),
       ),
-      `Expected at least one .species-detail-sheet CSS rule to have ` +
+      `Expected the .species-detail-sheet--full CSS rule to have ` +
       `padding-top containing env(safe-area-inset-top). ` +
       `Found: ${JSON.stringify(safeAreaTopResult.matchedPaddingTopValues)}. ` +
-      `This fails if styles.css:1218 (padding-top: max(..., env(safe-area-inset-top, 0px))) is removed.`,
+      `This fails if the --full modifier's padding-top: max(..., env(safe-area-inset-top, 0px)) is removed.`,
     ).toBe(true);
 
     // ── 3. Optional computed-style probe (informational, not falsifiable) ─────

--- a/frontend/e2e/sheet-snap.spec.ts
+++ b/frontend/e2e/sheet-snap.spec.ts
@@ -4,7 +4,7 @@ import { AppPage } from './pages/app-page.js';
 test.use({ viewport: { width: 390, height: 844 } });
 
 test.describe('SpeciesDetailSheet snap behavior', () => {
-  test('opens at peek; expand button advances peek → half → full; role flips at full', async ({ page, apiStub }) => {
+  test('opens at half; expand button advances half → full; role flips at full', async ({ page, apiStub }) => {
     await apiStub.stubEmpty();
     await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
     await apiStub.stubPhotoImage();
@@ -13,14 +13,13 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     await app.waitForAppReady();
 
     const sheet = page.locator('[data-testid=species-detail-sheet]');
-    await expect(sheet).toHaveAttribute('data-snap-state', 'peek');
-    await expect(sheet).toHaveAttribute('role', 'region');
-
-    const expand = page.getByRole('button', { name: /expand/i });
-    await expand.click();
+    // The field-guide sheet opens at `half` (plate-card detent), not peek.
     await expect(sheet).toHaveAttribute('data-snap-state', 'half');
     await expect(sheet).toHaveAttribute('role', 'region');
 
+    // A single expand tap now advances half → full (peek is reached by
+    // dragging down, not by the expand button).
+    const expand = page.getByRole('button', { name: /expand/i });
     await expand.click();
     await expect(sheet).toHaveAttribute('data-snap-state', 'full');
     await expect(sheet).toHaveAttribute('role', 'dialog');
@@ -76,20 +75,26 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     await app.goto('detail=vermfly&view=detail');
     await app.waitForAppReady();
 
+    const sheet = page.locator('[data-testid=species-detail-sheet]');
+    // The sheet opens at half (~0.6 vh tall). Dismiss fires when the dragged
+    // height settles below PEEK_PX * 0.6 (≈62px) without an upward flick — i.e.
+    // a long, deliberate downward pull. Compute the travel from the live sheet
+    // box so the test is viewport-stable: drag from the handle down to just
+    // past the bottom of the screen, shrinking the height under the floor.
     const handle = page.locator('[data-testid=species-detail-sheet-handle]');
     const handleBox = await handle.boundingBox();
-    if (!handleBox) throw new Error('handle bounding box unavailable');
+    const sheetBox = await sheet.boundingBox();
+    if (!handleBox || !sheetBox) throw new Error('handle/sheet bounding box unavailable');
 
-    // Synthesize a touch drag-down from the handle well past DISMISS_THRESHOLD_PX
-    // (80px). We compute the target from the handle's own position so the test
-    // is stable regardless of where the peek sheet sits vertically — at 390×844
-    // the 120px peek sheet has its handle near y≈724, so a fixed y=800 target
-    // only gives ~68px of travel. Using handleBox.y + 200 guarantees ≥200px.
     const startX = handleBox.x + handleBox.width / 2;
     const startY = handleBox.y + handleBox.height / 2;
+    // Travel = the sheet's own height + a margin, so finalH collapses well below
+    // the dismiss floor. Slow steps keep velocity downward (vy >= 0), not a
+    // back-up flick.
+    const travel = sheetBox.height + 80;
     await page.mouse.move(startX, startY);
     await page.mouse.down();
-    await page.mouse.move(startX, startY + 200, { steps: 20 });
+    await page.mouse.move(startX, startY + travel, { steps: 24 });
     await page.mouse.up();
 
     // URL must flip away from detail. Per #662 + #663: onCloseDetail
@@ -103,5 +108,66 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
       { timeout: 5_000 },
     ).toBeNull();
     await expect(page.locator('[data-testid=species-detail-sheet]')).toHaveCount(0);
+  });
+
+  test('drag-up grows the sheet ~1:1; a fast up-flick snaps to full', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+    await apiStub.stubPhotoImage();
+    const app = new AppPage(page);
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    const sheet = page.locator('[data-testid=species-detail-sheet]');
+    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+
+    const handle = page.locator('[data-testid=species-detail-sheet-handle]');
+    const handleBox = await handle.boundingBox();
+    const startBox = await sheet.boundingBox();
+    if (!handleBox || !startBox) throw new Error('handle/sheet bounding box unavailable');
+
+    const startX = handleBox.x + handleBox.width / 2;
+    const startY = handleBox.y + handleBox.height / 2;
+
+    // Phase 1 — a slow, stepped drag UP by 120px. The sheet should track the
+    // finger ~1:1: its rendered height grows by ≈120px (minus rounding +
+    // safe-area). data-dragging flips true during the gesture. We hold (no
+    // mouse-up yet) and assert the live height mid-drag.
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX, startY - 60, { steps: 12 });
+    await page.mouse.move(startX, startY - 120, { steps: 12 });
+    await expect(sheet).toHaveAttribute('data-dragging', 'true');
+    const midBox = await sheet.boundingBox();
+    if (!midBox) throw new Error('mid-drag bounding box unavailable');
+    // 1:1 within a generous tolerance (rounding + env(safe-area) reservation).
+    expect(midBox.height - startBox.height).toBeGreaterThan(90);
+    expect(midBox.height - startBox.height).toBeLessThan(150);
+    // Release slowly so this gesture itself does NOT flick — it settles by
+    // position back to a detent (height grew toward full → likely full, but we
+    // only assert dragging cleared and the flick case below owns the snap=full
+    // assertion).
+    await page.mouse.up();
+    await expect(sheet).toHaveAttribute('data-dragging', 'false');
+
+    // Phase 2 — a fast up-flick from half. A rapid upward swipe (high velocity)
+    // advances a detent past the nearest-by-position result → full. The flick is
+    // detected from the LAST pointermove's velocity (vy = Δy / Δt, px/ms), so the
+    // final move must be a single large upward jump issued back-to-back with the
+    // prior one: even if the dev server is under parallel load and Δt stretches,
+    // an 80px jump keeps |vy| well over the 0.5px/ms threshold.
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+    const hb2 = await handle.boundingBox();
+    if (!hb2) throw new Error('handle bounding box unavailable (flick)');
+    const fx = hb2.x + hb2.width / 2;
+    const fy = hb2.y + hb2.height / 2;
+    await page.mouse.move(fx, fy);
+    await page.mouse.down();
+    await page.mouse.move(fx, fy - 20);
+    await page.mouse.move(fx, fy - 100); // large final jump → unambiguous up-flick
+    await page.mouse.up();
+    await expect(sheet).toHaveAttribute('data-snap-state', 'full');
   });
 });

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -305,10 +305,15 @@ test.describe('species detail surface — photo rendering (#327 task-12)', () =>
         await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' }))
           .toBeVisible({ timeout: 10_000 });
 
-        // The photo render branch produces an <img> with alt="<comName> photo".
-        // Ends-with match (`alt$=` style) via getByAltText regex avoids
-        // collisions with any future alt text containing the species name.
-        const photo = page.getByAltText('Vermilion Flycatcher photo');
+        // The photo render branch produces an <img> inside the <Photo>
+        // primitive (.photo__img). On DESKTOP the surface gives it a descriptive
+        // alt ("<comName> photo"); on MOBILE the field-guide sheet renders the
+        // photo DECORATIVELY (alt="") because the species name sits adjacent —
+        // so the alt-text locator only works on desktop. Locate by the stable
+        // .photo__img class on mobile.
+        const photo = viewport.label === 'mobile'
+          ? page.locator('.sheet-fg-photo .photo__img')
+          : page.getByAltText('Vermilion Flycatcher photo');
         await expect(photo).toBeVisible();
         await expect(photo).toHaveAttribute('src', 'https://photos.bird-maps.com/vermfly.jpg');
         // The IMG must have actually loaded (naturalWidth>0). The stubbed

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -217,7 +217,11 @@ export function App() {
     isPhone && (
       state.scope.kind === 'unscoped' ||
       filtersOpen ||
-      (sheetSnap === 'half' || sheetSnap === 'full')
+      (sheetSnap === 'half' || sheetSnap === 'full') ||
+      // Also collapse at the identity-row detent — whenever a detail sheet is
+      // open at all — so the small sheet's preserved map is not buried under
+      // the legend card.
+      !!state.detail
     );
 
   // O4 (#780) — ref to the floating filters sheet panel. Focus moves into the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,8 +176,11 @@ export function App() {
   const { state, set } = useUrlState();
   const isCompact = useIsCompact();
   // O5 (#783): phone-only hook keyed to ≤480px (P1's overlay breakpoint).
-  // Deliberately separate from isCompact (1199px) so force-collapse does NOT
-  // trigger on tablet (768×1024) or laptop (1024×768) viewports.
+  // Distinct from isCompact (≤1199px): the phone-scoped force-collapse signals
+  // (unscoped chooser, filters, sheet half/full) only collide with the legend
+  // at ≤480px. The detail-sheet-open signal, by contrast, fires across the
+  // whole compact range (≤1199px) because the bottom-docked sheet overlaps the
+  // bottom-left legend at 768/1024 too — see `legendForceCollapsed` below.
   const isPhone = useIsPhone();
   // Tag the current Clarity session with the active view so dashboards can
   // filter sessions by surface (map | detail). Fires on initial mount
@@ -204,25 +207,36 @@ export function App() {
   const [sheetSnap, setSheetSnap] = useState<SnapState>('peek');
 
   // O5 (#783) — forceCollapsed: collapse the legend while another overlay holds
-  // focus on mobile (≤480px). Scoped to isPhone so it does NOT fire at 1024×768
-  // (iPad landscape) or 1440×900 (laptop) — those use isCompact/rail, not isPhone.
-  // Three overlay signals:
-  //   - !scopeActive: S1 chooser scrim is open (unscoped landing)
-  //   - filtersOpen: O4 filters sheet is open
-  //   - sheetSnap !== 'peek': detail sheet is at half or full (not just peeking)
+  // focus. Two scopes, by signal:
+  //
+  //   Phone-only (≤480px, isPhone) — P1's overlay breakpoint. These overlays
+  //   only render the bottom-band collision risk on phones; at tablet/laptop
+  //   the legend and these overlays don't overlap, so we keep them phone-scoped:
+  //     - state.scope.kind === 'unscoped': S1 chooser scrim is open
+  //     - filtersOpen: O4 filters sheet is open
+  //     - sheetSnap half/full: detail sheet advanced past peek
+  //
+  //   Compact (≤1199px, isCompact) — the breakpoint at which the field-guide
+  //   sheet renders instead of the desktop rail (useIsCompact). The sheet is
+  //   bottom-docked and the legend auto-expands at ≥1024px
+  //   (LEGEND_EXPAND_MIN_WIDTH), so at 768/1024 an open sheet collides with the
+  //   expanded "Bird families in view" legend — occluding the sheet's photo
+  //   plate / hero name / Read-account button (#907 design-review finding 1).
+  //   The sheet renders exactly when `scopeActive && state.detail && isCompact`,
+  //   so `isCompact && !!state.detail` is the correct "sheet is open" signal and
+  //   must force-collapse the legend across the whole compact range — not just
+  //   on phones.
+  //
   // forceCollapsed is derived here (at render time) — no extra state needed.
   // The `scopeActive` ref is not yet available at this point; use
   // `state.scope.kind !== 'unscoped'` directly (same derivation as line 269).
   const legendForceCollapsed =
-    isPhone && (
-      state.scope.kind === 'unscoped' ||
-      filtersOpen ||
-      (sheetSnap === 'half' || sheetSnap === 'full') ||
-      // Also collapse at the identity-row detent — whenever a detail sheet is
-      // open at all — so the small sheet's preserved map is not buried under
-      // the legend card.
-      !!state.detail
-    );
+    (isPhone &&
+      (state.scope.kind === 'unscoped' ||
+        filtersOpen ||
+        sheetSnap === 'half' ||
+        sheetSnap === 'full')) ||
+    (isCompact && !!state.detail);
 
   // O4 (#780) — ref to the floating filters sheet panel. Focus moves into the
   // panel on open (specifically the close button, first focusable element).

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { SpeciesDetailSheet } from './SpeciesDetailSheet.js';
+import { SpeciesDetailSheet, resolveContentTier } from './SpeciesDetailSheet.js';
 import { ApiClient } from '../api/client.js';
 import type { SpeciesMeta } from '@bird-watch/shared-types';
 import { __resetSpeciesDetailCache } from '../data/use-species-detail.js';
@@ -43,7 +43,7 @@ describe('<SpeciesDetailSheet>', () => {
     __resetSpeciesDetailCache();
   });
 
-  it('opens at peek snap with role="region" and aria-label "Selected sighting"', async () => {
+  it('opens at half snap with role="region" and aria-label "Selected sighting"', async () => {
     render(
       <SpeciesDetailSheet
         speciesCode="vermfly"
@@ -53,14 +53,18 @@ describe('<SpeciesDetailSheet>', () => {
       />
     );
     const sheet = await screen.findByTestId('species-detail-sheet');
-    expect(sheet).toHaveAttribute('data-snap-state', 'peek');
+    // The field-guide sheet opens at `half` (the plate-card detent) for
+    // immediate readability — NOT peek. peek is the map-preserving collapsed
+    // state reached by dragging down.
+    expect(sheet).toHaveAttribute('data-snap-state', 'half');
     expect(sheet).toHaveAttribute('role', 'region');
     expect(sheet).toHaveAttribute('aria-label', 'Selected sighting');
     expect(sheet).not.toHaveAttribute('aria-modal');
+    // No inert on the (synthetic) main target — only set at full.
     expect(mainEl).not.toHaveAttribute('inert');
   });
 
-  it('expand button advances peek → half → full', async () => {
+  it('expand button advances half → full', async () => {
     render(
       <SpeciesDetailSheet
         speciesCode="vermfly"
@@ -70,13 +74,13 @@ describe('<SpeciesDetailSheet>', () => {
       />
     );
     const sheet = await screen.findByTestId('species-detail-sheet');
-    const expand = await screen.findByRole('button', { name: /expand/i });
-
-    await userEvent.click(expand);
+    // Opens at half.
     expect(sheet).toHaveAttribute('data-snap-state', 'half');
-    expect(sheet).toHaveAttribute('role', 'region'); // still region at half
+    expect(sheet).toHaveAttribute('role', 'region');
     expect(mainEl).not.toHaveAttribute('inert');
 
+    // One expand tap advances half → full (role flips to dialog + aria-modal).
+    const expand = await screen.findByRole('button', { name: /expand/i });
     await userEvent.click(expand);
     expect(sheet).toHaveAttribute('data-snap-state', 'full');
     expect(sheet).toHaveAttribute('role', 'dialog');
@@ -111,15 +115,15 @@ describe('<SpeciesDetailSheet>', () => {
     const sheet = await screen.findByTestId('species-detail-sheet');
     obs.observe(sheet, { attributes: true, attributeFilter: ['role'] });
 
+    // Opens at half → one expand reaches full.
     const expand = await screen.findByRole('button', { name: /expand/i });
-    await userEvent.click(expand);
     await userEvent.click(expand);
 
     await waitFor(() => expect(sheet).toHaveAttribute('role', 'dialog'));
     obs.disconnect();
 
-    // Filter to the half→full transition's mutations (the initial render
-    // also fires events for both attributes via React's commit ordering).
+    // The half→full transition writes inert synchronously inside the click
+    // handler BEFORE setSnap, so the inert mutation lands before the role flip.
     const inertIdx = order.lastIndexOf('inert');
     const roleIdx = order.lastIndexOf('role');
     expect(inertIdx).toBeGreaterThanOrEqual(0);
@@ -138,7 +142,6 @@ describe('<SpeciesDetailSheet>', () => {
     );
     const sheet = await screen.findByTestId('species-detail-sheet');
     const expand = await screen.findByRole('button', { name: /expand/i });
-    await userEvent.click(expand);
     await userEvent.click(expand);
     expect(sheet).toHaveAttribute('role', 'dialog');
     expect(mainEl).toHaveAttribute('inert', '');
@@ -164,7 +167,6 @@ describe('<SpeciesDetailSheet>', () => {
     const sheet = await screen.findByTestId('species-detail-sheet');
     const expand = await screen.findByRole('button', { name: /expand/i });
     await userEvent.click(expand);
-    await userEvent.click(expand);
     expect(sheet).toHaveAttribute('data-snap-state', 'full');
 
     // Move focus outside the sheet (back into <main>) — ESC should NOT
@@ -174,7 +176,7 @@ describe('<SpeciesDetailSheet>', () => {
     await userEvent.keyboard('{Escape}');
     expect(sheet).toHaveAttribute('data-snap-state', 'full');
 
-    // Move focus back inside the sheet — ESC should collapse it.
+    // Move focus back inside the sheet — ESC should collapse it (full → half).
     expand.focus();
     await userEvent.keyboard('{Escape}');
     await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
@@ -192,21 +194,100 @@ describe('<SpeciesDetailSheet>', () => {
     );
     const handle = await screen.findByTestId('species-detail-sheet-handle');
 
-    // Synthesize a Pointer Events drag-down sequence ending well below
-    // the peek threshold. The component reads `clientY` deltas from
-    // pointermove → uses pointerdown's clientY as the anchor.
+    // Synthesize a Pointer Events drag-down sequence from the open (half) state
+    // ending far below the peek detent so the release falls under the dismiss
+    // floor (PEEK_PX * 0.6). The component drives `liveHeight` from the
+    // pointerdown anchor + the running delta; a large downward delta shrinks the
+    // height past the dismiss threshold.
     handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 1, bubbles: true }));
-    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 400, pointerId: 1, bubbles: true }));
-    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 400, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 700, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 700, pointerId: 1, bubbles: true }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  it('1:1 drag-up grows the sheet height by the drag delta', async () => {
+    // jsdom has no layout; window.innerHeight defaults to 768. The sheet opens
+    // at half = round(768 * 0.6) = 461px. A slow drag UP by 120px (clientY
+    // 400 → 280, no flick) should drive liveHeight to ~half + 120, tracking the
+    // finger 1:1 — and data-dragging flips to "true" while the gesture is live.
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+
+    const half = Math.round(window.innerHeight * 0.6);
+
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+    // Multiple small steps so the velocity stays well under the flick threshold.
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 340, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 280, pointerId: 1, bubbles: true }));
+
+    await waitFor(() => expect(sheet).toHaveAttribute('data-dragging', 'true'));
+    // height is `${liveHeight}px + env(...)` at non-full detents; assert the
+    // px component is ≈ half + 120 (±2px rounding tolerance).
+    const styleHeight = (sheet as HTMLElement).style.height;
+    const px = Number(styleHeight.match(/([\d.]+)px/)?.[1]);
+    expect(px).toBeGreaterThanOrEqual(half + 120 - 2);
+    expect(px).toBeLessThanOrEqual(half + 120 + 2);
+  });
+
+  it('velocity flick up advances to full; flick down retracts to peek', async () => {
+    // A fast UP flick (large negative dy in one tiny dt) advances a detent past
+    // the position-nearest result; a fast DOWN flick retracts. We start at half
+    // and assert each direction lands on the velocity-biased detent.
+    const { unmount } = render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+
+    // Fast up-flick: a small upward move that, by nearest-position, would settle
+    // back near half, but the velocity (>0.5px/ms up) advances it to full.
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 380, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 360, pointerId: 1, bubbles: true }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
+    unmount();
+
+    // Fresh mount (opens at half) for the down-flick case.
+    __resetSpeciesDetailCache();
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet2 = (await screen.findAllByTestId('species-detail-sheet')).at(-1)!;
+    const handle2 = (await screen.findAllByTestId('species-detail-sheet-handle')).at(-1)!;
+    // Fast down-flick: small downward move + velocity > 0.5px/ms down retracts
+    // half → peek (one detent), NOT all the way to dismiss.
+    handle2.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 2, bubbles: true }));
+    handle2.dispatchEvent(new PointerEvent('pointermove', { clientY: 420, pointerId: 2, bubbles: true }));
+    handle2.dispatchEvent(new PointerEvent('pointerup', { clientY: 440, pointerId: 2, bubbles: true }));
+    await waitFor(() => expect(sheet2).toHaveAttribute('data-snap-state', 'peek'));
+  });
+
   it('unmounting at full snap cleans up inert on <main> (viewport-flip regression)', async () => {
-    // Simulate: mobile user opens sheet, drags to full snap (inert set), then
-    // rotates device. App.tsx's viewport router unmounts SpeciesDetailSheet
-    // and mounts SpeciesDetailModal. Without the cleanup function the inert
-    // attribute leaks onto <main> and blocks all pointer events + tab order.
+    // Simulate: mobile user opens sheet (at half), advances to full snap (inert
+    // set), then rotates device. App.tsx's viewport router unmounts
+    // SpeciesDetailSheet and mounts SpeciesDetailModal. Without the cleanup
+    // function the inert attribute leaks onto <main> and blocks all pointer
+    // events + tab order.
     const { unmount } = render(
       <SpeciesDetailSheet
         speciesCode="vermfly"
@@ -217,8 +298,7 @@ describe('<SpeciesDetailSheet>', () => {
     );
     const expand = await screen.findByRole('button', { name: /expand/i });
 
-    // Advance to half, then full — inert is set on <main> by goToSnap('full').
-    await userEvent.click(expand);
+    // Advance half → full — inert is set on <main> by goToSnap('full').
     await userEvent.click(expand);
     expect(mainEl).toHaveAttribute('inert', '');
 
@@ -227,5 +307,55 @@ describe('<SpeciesDetailSheet>', () => {
 
     // Cleanup must have removed inert — the modal that takes over starts clean.
     expect(mainEl).not.toHaveAttribute('inert');
+  });
+});
+
+describe('resolveContentTier (hysteresis)', () => {
+  // Use a viewport where the detent heights are easy to reason about.
+  // vh = 1000 → half = 600, full = 992, midFullBoundary = 796.
+  // compact↔mid boundary = PEEK_PX(104) + 64 = 168.
+  // Dead-band = ±24px.
+  const VH = 1000;
+
+  it('ascending crosses each boundary at boundary + 24 (up-threshold)', () => {
+    // Just below the compact→mid up-threshold (168 + 24 = 192): stays compact.
+    expect(resolveContentTier(191, 'compact', VH)).toBe('compact');
+    // At the up-threshold: promotes to mid.
+    expect(resolveContentTier(192, 'compact', VH)).toBe('mid');
+    // Just below the mid→full up-threshold (796 + 24 = 820): stays mid.
+    expect(resolveContentTier(819, 'mid', VH)).toBe('mid');
+    // At the up-threshold: promotes to full.
+    expect(resolveContentTier(820, 'mid', VH)).toBe('full');
+  });
+
+  it('descending holds the previous tier inside the ±24px dead-band', () => {
+    // Coming DOWN from full, the height must drop below midFullBoundary − 24
+    // (796 − 24 = 772) before demoting. Within the band (772..820) full holds.
+    expect(resolveContentTier(800, 'full', VH)).toBe('full');
+    expect(resolveContentTier(772, 'full', VH)).toBe('full'); // exactly the band edge holds
+    expect(resolveContentTier(771, 'full', VH)).toBe('mid');  // one px past → demote
+    // Coming DOWN from mid, must drop below 168 − 24 = 144 to reach compact.
+    expect(resolveContentTier(150, 'mid', VH)).toBe('mid');
+    expect(resolveContentTier(144, 'mid', VH)).toBe('mid');
+    expect(resolveContentTier(143, 'mid', VH)).toBe('compact');
+  });
+
+  it('oscillation inside a band keeps the previous tier (no thrash)', () => {
+    // A finger hovering at 180px (between the 144 demote-floor and the 192
+    // promote-ceiling around the compact↔mid boundary) keeps whatever tier it
+    // already had — mid stays mid, compact stays compact.
+    expect(resolveContentTier(180, 'mid', VH)).toBe('mid');
+    expect(resolveContentTier(180, 'compact', VH)).toBe('compact');
+    // Same dead-band behavior around the mid↔full boundary at 790px.
+    expect(resolveContentTier(790, 'full', VH)).toBe('full');
+    expect(resolveContentTier(790, 'mid', VH)).toBe('mid');
+  });
+
+  it('promotes/demotes by more than one tier when the height jumps far', () => {
+    // A large jump (e.g. a flick) from compact straight into the full band
+    // promotes across both boundaries in one call.
+    expect(resolveContentTier(900, 'compact', VH)).toBe('full');
+    // And a collapse from full straight to the bottom demotes to compact.
+    expect(resolveContentTier(50, 'full', VH)).toBe('compact');
   });
 });

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -89,6 +89,35 @@ describe('<SpeciesDetailSheet>', () => {
     expect(mainEl).toHaveAttribute('inert', '');
   });
 
+  it('open-focus at full lands on the dialog CONTAINER, not the visible name (#907 finding 2)', async () => {
+    // Regression guard: focusing the visible #detail-title heading painted a
+    // stray :focus-visible ring around the species name on keyboard-driven
+    // open. Open-focus must land on the sheet root (role="dialog",
+    // tabIndex=-1) so neither pointer nor keyboard open rings the name. The
+    // dialog's accessible name is still the species name via aria-label.
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
+    // The focus microtask runs after the snap commit — wait for it to land on
+    // the dialog container.
+    await waitFor(() => expect(sheet).toHaveFocus());
+    // The visible species name must NOT be the focus target.
+    const heading = sheet.querySelector('#detail-title');
+    expect(heading).not.toBe(document.activeElement);
+    // Container is programmatically focusable (no tab stop).
+    expect(sheet).toHaveAttribute('tabindex', '-1');
+  });
+
   it('inert is set BEFORE the role flips (sequencing contract)', async () => {
     // We observe via a MutationObserver: the inert attribute must appear
     // on mainEl before the role attribute on the sheet flips to "dialog".

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -2,33 +2,97 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type RefObject,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import type { ApiClient } from '../api/client.js';
-import { SpeciesDetailSurface } from './SpeciesDetailSurface.js';
 import { useSpeciesDetail } from '../data/use-species-detail.js';
+import { useSilhouettes } from '../data/use-silhouettes.js';
+import {
+  buildFamilyColorResolver,
+  buildFamilyPathResolver,
+  buildFamilyImgUrlResolver,
+} from '../data/family-color.js';
+import { SpeciesDescription } from './SpeciesDescription.js';
+import { Photo } from './ds/Photo.js';
+import type { FamilyCode } from '../config/family-palette.js';
 
 export type SnapState = 'peek' | 'half' | 'full';
 
-// MOB-6: PEEK_PX raised from 96 → 120 so the peek strip is comfortably
-// reachable by a thumb at the bottom of a 390×844 screen (96px was tight
-// against the safe-area-inset-bottom on notched devices). DISMISS_THRESHOLD_PX
-// lowered from 160 → 80 so a short downward flick dismisses the sheet — the
-// old 160px required a deliberate two-thirds swipe that felt sluggish.
-const PEEK_PX = 120;
+export type ContentTier = 'compact' | 'mid' | 'full';
+
+// PEEK_PX — the identity-row detent: tall enough for the handle + a compact
+// header (thumbnail + name + family), short enough to keep the map visible.
+const PEEK_PX = 104;
 // half + full are computed at runtime against window.innerHeight so they
 // honor the actual viewport (post safe-area, post URL-bar collapse on
 // mobile Safari). Constants here are the FRACTIONS:
 const HALF_FRACTION = 0.6;
 const FULL_INSET_PX = 8;
-// Drag dismissal: dragging the handle down past peek by this many pixels
-// dismisses the sheet (calls onClose). 80px ≈ one thumb's travel.
-const DISMISS_THRESHOLD_PX = 80;
-// Drag transition thresholds — half travel between adjacent snaps flips.
-const SNAP_TRANSITION_RATIO = 0.5;
+// A flick faster than this (>500px/s) advances or retracts a detent on release,
+// independent of where the drag settled by position.
+const VELOCITY_FLICK_PX_PER_MS = 0.5;
+// The sheet can shrink below peek during a downward drag toward the dismiss
+// threshold; it never renders shorter than this.
+const DRAG_MIN_HEIGHT_PX = 56;
+const order: SnapState[] = ['peek', 'half', 'full'];
+
+// Content-tier hysteresis. The visible content tier ([data-content]) is driven
+// by the LIVE sheet height so content blooms during the drag — but a single
+// boundary thrashes when the finger hovers near it. resolveContentTier applies
+// a ±HYSTERESIS_PX dead-band around each boundary: a tier only changes once the
+// height crosses the boundary by more than the band, and within the band the
+// previous tier holds. Pure + exported so it is unit-testable in isolation.
+const HYSTERESIS_PX = 24;
+// compact↔mid boundary: just above the peek detent height.
+const COMPACT_MID_BOUNDARY_PX = PEEK_PX + 64;
+
+/**
+ * Map a live sheet height to a content tier with a ±24px hysteresis dead-band.
+ *
+ * Boundaries:
+ *   compact ↔ mid  at COMPACT_MID_BOUNDARY_PX (PEEK_PX + 64)
+ *   mid     ↔ full at the midpoint between the half and full detent heights
+ *                  (derived from `vh` so it tracks the live viewport)
+ *
+ * Hysteresis: ascending, the tier promotes only once height exceeds a boundary
+ * by more than HYSTERESIS_PX; descending, it demotes only once height drops
+ * below the boundary by more than HYSTERESIS_PX. Inside the ±band the tier
+ * holds at `prevTier` — so a finger oscillating around a boundary does not
+ * thrash the layout.
+ */
+export function resolveContentTier(
+  height: number,
+  prevTier: ContentTier,
+  vh: number,
+): ContentTier {
+  const half = Math.round(vh * HALF_FRACTION);
+  const full = vh - FULL_INSET_PX;
+  const midFullBoundary = (half + full) / 2;
+
+  // Order the tiers low→high so we can reason about promote/demote uniformly.
+  const tiers: ContentTier[] = ['compact', 'mid', 'full'];
+  const boundaries = [COMPACT_MID_BOUNDARY_PX, midFullBoundary];
+
+  const prevIdx = tiers.indexOf(prevTier);
+  // Defensive: an unrecognized prevTier collapses to the position-only result.
+  const safePrevIdx = prevIdx < 0 ? 0 : prevIdx;
+
+  // Promote upward as long as the height clears the next boundary by the band.
+  let idx = safePrevIdx;
+  while (idx < boundaries.length && height >= boundaries[idx]! + HYSTERESIS_PX) {
+    idx++;
+  }
+  // Demote downward as long as the height falls below the current lower
+  // boundary by the band.
+  while (idx > 0 && height < boundaries[idx - 1]! - HYSTERESIS_PX) {
+    idx--;
+  }
+  return tiers[idx]!;
+}
 
 export interface SpeciesDetailSheetProps {
   speciesCode: string;
@@ -46,11 +110,13 @@ export interface SpeciesDetailSheetProps {
 }
 
 /**
- * Mobile bottom-sheet detail surface (Sky Atlas Phase 4). Apple Maps
- * "Look Up" idiom: three snap points (peek 120px / half 60vh / full
- * 100vh−8px). The sheet is NOT a <dialog> at peek/half — peek/half
- * leave the map underneath interactive, which a modal <dialog> by
- * definition cannot. The role flips with snap state per
+ * Mobile bottom-sheet detail surface (field-guide direction). Apple Maps
+ * "Look Up" idiom: three detents (peek 104px identity row / half 60vh
+ * plate card / full 100vh−8px field-guide entry). Opens at `half` for
+ * immediate readability; `peek` is the map-preserving collapsed state
+ * reached by dragging down. The sheet is NOT a <dialog> at peek/half —
+ * peek/half leave the map underneath interactive, which a modal <dialog>
+ * by definition cannot. The role flips with snap state per
  * accessibility.md §New contract — bottom-sheet ARIA:
  *
  *   peek/half → role="region", aria-label="Selected sighting"
@@ -70,15 +136,29 @@ export interface SpeciesDetailSheetProps {
  * Drag implementation uses native Pointer Events — no third-party
  * gesture library. touch-action discipline:
  *   - .sheet-handle: touch-action: none (we own the gesture)
- *   - .species-detail-body: touch-action: pan-y (browser owns scroll)
+ *   - .sheet-fg: touch-action: pan-y (browser owns scroll)
  */
 export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const { speciesCode, apiClient, onClose, mainRef, onSnapChange } = props;
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
-  const [snap, setSnap] = useState<SnapState>('peek');
-  const [dragOffset, setDragOffset] = useState<number>(0); // px: positive = pulled down
-  const dragStartRef = useRef<{ y: number; snap: SnapState } | null>(null);
+  // Open at `half` (the plate-card detent) for immediate readability; the
+  // identity-row detent (`peek`) is the map-preserving collapsed state,
+  // reached by dragging down.
+  const [snap, setSnap] = useState<SnapState>('half');
+  const [dragging, setDragging] = useState<boolean>(false);
+  // During a drag we drive the sheet HEIGHT directly (1:1 with the finger);
+  // null means "use the detent height for `snap`".
+  const [liveHeight, setLiveHeight] = useState<number | null>(null);
+  const dragRef = useRef<{
+    startY: number;
+    startHeight: number;
+    lastY: number;
+    lastT: number;
+    vy: number; // px/ms, positive = moving down
+    moved: boolean;
+  } | null>(null);
+  const didDragRef = useRef<boolean>(false);
 
   // O5 (#783) — notify App.tsx of snap changes so it can drive forceCollapsed
   // on FamilyLegend. Fires on every snap transition (peek→half→full and back).
@@ -92,6 +172,15 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   // a no-op second mount.
   const { data } = useSpeciesDetail(apiClient, speciesCode);
   const speciesName = data?.comName;
+  // Family-resolvers for the accent rule / dot and the <Photo> silhouette
+  // fallback. useSilhouettes is module-cached — no extra network call. The
+  // color/path/imgUrl trio mirrors SpeciesDetailSurface so the sheet's
+  // masthead fallback renders the operator-curated family shape, not the
+  // generic glyph.
+  const { silhouettes } = useSilhouettes(apiClient);
+  const resolveColor = useMemo(() => buildFamilyColorResolver(silhouettes), [silhouettes]);
+  const resolvePath = useMemo(() => buildFamilyPathResolver(silhouettes), [silhouettes]);
+  const resolveImgUrl = useMemo(() => buildFamilyImgUrlResolver(silhouettes), [silhouettes]);
 
   // Compute snap heights against the live viewport. Recompute on
   // resize so an orientation change or mobile-Safari URL-bar collapse
@@ -193,67 +282,107 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     return () => document.removeEventListener('keydown', handler);
   }, [collapse]);
 
-  // Pointer Events drag handlers. Bound on the handle, NOT the sheet
-  // body — touch-action discipline requires the sheet body to keep its
-  // native pan-y scroll behavior.
+  // Height-driven 1:1 drag. Bound on the handle only (touch-action discipline
+  // unchanged — .sheet-handle owns the gesture; .sheet-fg keeps native pan-y).
+  // We drive `liveHeight` directly so the sheet tracks the finger in BOTH
+  // directions, then settle to a detent on release using velocity + position.
+  // The CSS height transition is gated off while `dragging` (via
+  // [data-dragging="true"]) so the drag is 1:1, not eased.
+  const settleTo = useCallback(
+    (next: SnapState) => {
+      const main = mainRef.current;
+      // Preserve inert sequencing: write inert BEFORE the snap/role commit.
+      if (next === 'full' && main && !main.hasAttribute('inert')) {
+        main.setAttribute('inert', '');
+      }
+      setLiveHeight(null);
+      setSnap(next);
+    },
+    [mainRef],
+  );
+
   const onPointerDown = useCallback(
     (e: ReactPointerEvent<HTMLButtonElement>) => {
       // setPointerCapture is not available in JSDOM (only real browsers).
       if (typeof e.currentTarget.setPointerCapture === 'function') {
         e.currentTarget.setPointerCapture(e.pointerId);
       }
-      dragStartRef.current = { y: e.clientY, snap };
-      setDragOffset(0);
+      dragRef.current = {
+        startY: e.clientY,
+        startHeight: heightFor(snap),
+        lastY: e.clientY,
+        lastT: performance.now(),
+        vy: 0,
+        moved: false,
+      };
+      didDragRef.current = false;
+      setDragging(true);
     },
-    [snap],
+    [snap, heightFor],
   );
 
-  const onPointerMove = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
-    const start = dragStartRef.current;
-    if (!start) return;
-    setDragOffset(e.clientY - start.y);
-  }, []);
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLButtonElement>) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const now = performance.now();
+      const dt = Math.max(1, now - d.lastT);
+      d.vy = (e.clientY - d.lastY) / dt; // px/ms, positive = moving down
+      d.lastY = e.clientY;
+      d.lastT = now;
+      if (Math.abs(e.clientY - d.startY) > 4) d.moved = true;
+      // Drag up (clientY decreases) grows the sheet; drag down shrinks it.
+      const grow = d.startY - e.clientY;
+      const maxH = heightFor('full');
+      const next = Math.min(maxH, Math.max(DRAG_MIN_HEIGHT_PX, d.startHeight + grow));
+      setLiveHeight(next);
+    },
+    [heightFor],
+  );
 
   const onPointerUp = useCallback(
     (e: ReactPointerEvent<HTMLButtonElement>) => {
       if (typeof e.currentTarget.releasePointerCapture === 'function') {
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
-      const start = dragStartRef.current;
-      dragStartRef.current = null;
-      const delta = e.clientY - (start?.y ?? e.clientY);
-      setDragOffset(0);
+      const d = dragRef.current;
+      dragRef.current = null;
+      setDragging(false);
+      if (!d) return;
+      didDragRef.current = d.moved;
 
-      // Dismiss path: dragging down from peek by more than
-      // DISMISS_THRESHOLD_PX dismisses the sheet entirely.
-      if (snap === 'peek' && delta > DISMISS_THRESHOLD_PX) {
+      const maxH = heightFor('full');
+      const finalH = Math.min(
+        maxH,
+        Math.max(DRAG_MIN_HEIGHT_PX, d.startHeight + (d.startY - d.lastY)),
+      );
+
+      // Dismiss: released well below peek while not flicking back upward.
+      if (finalH < PEEK_PX * 0.6 && d.vy >= 0) {
+        setLiveHeight(null);
         onClose();
         return;
       }
 
-      // Snap-transition: which adjacent snap is closest, after the drag?
-      // We measure delta against the height-difference between the
-      // current snap and the adjacent snap in the drag direction.
-      const order: SnapState[] = ['peek', 'half', 'full'];
-      const currentIdx = order.indexOf(snap);
-
-      if (delta < 0) {
-        // Drag up: maybe advance.
-        const nextIdx = Math.min(order.length - 1, currentIdx + 1);
-        if (nextIdx === currentIdx) return;
-        const nextSnap = order[nextIdx]!;
-        const span = heightFor(nextSnap) - heightFor(snap);
-        if (-delta > span * SNAP_TRANSITION_RATIO) goToSnap(nextSnap);
-      } else if (delta > 0) {
-        // Drag down: maybe retract.
-        const prevIdx = Math.max(0, currentIdx - 1);
-        if (prevIdx === currentIdx) return; // already at peek
-        const prevSnap = order[prevIdx]!;
-        const span = heightFor(snap) - heightFor(prevSnap);
-        if (delta > span * SNAP_TRANSITION_RATIO) goToSnap(prevSnap);
+      // Settle to the nearest detent by height, then bias by flick velocity:
+      // a fast upward flick advances a detent, a fast downward flick retracts.
+      let nearest: SnapState = order[0]!;
+      let best = Infinity;
+      for (const s of order) {
+        const diff = Math.abs(heightFor(s) - finalH);
+        if (diff < best) {
+          best = diff;
+          nearest = s;
+        }
       }
+      let target = nearest;
+      const idx = order.indexOf(nearest);
+      if (d.vy < -VELOCITY_FLICK_PX_PER_MS) target = order[Math.min(order.length - 1, idx + 1)]!;
+      else if (d.vy > VELOCITY_FLICK_PX_PER_MS) target = order[Math.max(0, idx - 1)]!;
+
+      settleTo(target);
     },
-    [snap, heightFor, goToSnap, onClose],
+    [heightFor, onClose, settleTo],
   );
 
   // Initial focus on mount: heading first only when the sheet opens at
@@ -270,8 +399,25 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   }, [snap]);
 
   const isFull = snap === 'full';
-  const height = heightFor(snap);
-  const translate = Math.max(0, dragOffset);
+  const height = liveHeight ?? heightFor(snap);
+  // Three size-appropriate content tiers, chosen by LIVE height so content
+  // blooms DURING the drag. compact → identity row; mid → plate card; full →
+  // field-guide entry. resolveContentTier hysteresizes the boundaries (±24px
+  // dead-band) so a finger near a threshold doesn't thrash the layout; the
+  // previous tier is carried across renders in prevTierRef.
+  const prevTierRef = useRef<ContentTier>('mid');
+  const content = resolveContentTier(height, prevTierRef.current, vh);
+  prevTierRef.current = content;
+  const famColor = resolveColor(data?.familyCode);
+  // descriptionBody is sanitized HTML (rendered via SpeciesDescription at full);
+  // the mid teaser wants a plain-text 2-line clamp, so strip tags for it.
+  const descPlain = data?.descriptionBody
+    ? data.descriptionBody
+        .replace(/<\/(p|div|li|h\d)>/gi, ' ') // block-close → a single space
+        .replace(/<[^>]+>/g, '') // strip inline tags WITHOUT a space (no " ," artifact)
+        .replace(/\s+/g, ' ')
+        .trim()
+    : '';
 
   return (
     <div
@@ -279,12 +425,18 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       data-testid="species-detail-sheet"
       className={`species-detail-sheet species-detail-sheet--${snap}`}
       data-snap-state={snap}
+      data-dragging={dragging ? 'true' : 'false'}
+      data-content={content}
       role={isFull ? 'dialog' : 'region'}
       aria-label={isFull ? (speciesName ?? 'Species detail') : 'Selected sighting'}
       {...(isFull ? { 'aria-modal': 'true' as const } : {})}
       style={{
-        height: `${height}px`,
-        transform: `translateY(${translate}px)`,
+        // Reserve the bottom safe-area BELOW the detent content so the collapsed
+        // row is neither clipped by the home indicator nor padded with slack.
+        // Not added at full — full already spans to the inset.
+        height: isFull
+          ? `${height}px`
+          : `calc(${height}px + env(safe-area-inset-bottom, 0px))`,
       }}
     >
       <button
@@ -293,7 +445,15 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
         data-testid="species-detail-sheet-handle"
         className="sheet-handle"
         aria-label={isFull ? 'Collapse species detail' : 'Expand species detail'}
-        onClick={isFull ? collapse : expand}
+        onClick={() => {
+          // Suppress the click that fires after a drag (pointerup → click).
+          // A pure tap (no movement) still expands/collapses as a fallback.
+          if (didDragRef.current) {
+            didDragRef.current = false;
+            return;
+          }
+          (isFull ? collapse : expand)();
+        }}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
@@ -301,17 +461,105 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       >
         <span aria-hidden="true" className="sheet-handle-grip" />
       </button>
-      {/* axe `scrollable-region-focusable` (WCAG 2.1.1): .sheet-scroll has
-          overflow-y: auto so it can scroll when species detail content
-          (photo + prose) exceeds the sheet height. Keyboard users must be
-          able to focus the scrollable region itself — tabIndex={0} adds
-          it to the tab order. Mirrors the same fix on #main-surface in
-          App.tsx. */}
-      <div className="sheet-scroll" tabIndex={0}>
-        <SpeciesDetailSurface
-          speciesCode={speciesCode}
-          apiClient={apiClient}
-        />
+      {/* Field-guide layout: three size-appropriate tiers in one grid that
+          re-templates per [data-content]. The photo is a SINGLE <Photo>
+          element kept mounted across detents; only its frame morphs via CSS.
+          The grid scrolls (tabIndex=0 satisfies axe scrollable-region-focusable). */}
+      <div className="sheet-fg" tabIndex={0}>
+        <div className="sheet-fg-photo">
+          {/* Decorative photo (alt=""): the species name always sits adjacent
+              and we have no plumage metadata, so a non-empty alt would triple-
+              announce. <Photo> owns the no-photo silhouette fallback (emits
+              .photo--silhouette) and the family shape/color via the resolvers. */}
+          <Photo
+            src={data?.photoUrl ?? null}
+            alt=""
+            family={(data?.familyCode as FamilyCode | null) ?? null}
+            color={resolveColor(data?.familyCode)}
+            pathD={resolvePath(data?.familyCode)}
+            imgUrl={resolveImgUrl(data?.familyCode)}
+            priority
+            layout="masthead"
+          />
+        </div>
+
+        <div className="sheet-fg-identity">
+          {/* h2: the map identity ("Bird Maps") owns the page h1; the species
+              name is the top heading INSIDE the dialog. */}
+          <h2 id="detail-title" tabIndex={-1} className="sheet-fg-name">
+            {data?.comName ?? 'Loading…'}
+          </h2>
+          <p className="sheet-fg-sci">
+            <em>{data?.sciName}</em>
+          </p>
+          <p className="sheet-fg-family">
+            <span
+              className="sheet-fg-family-dot"
+              aria-hidden="true"
+              style={{ background: famColor }}
+            />
+            {data?.familyName}
+          </p>
+        </div>
+
+        <div className="sheet-fg-rule" aria-hidden="true" style={{ background: famColor }} />
+
+        {/* MID tier — labeled field record (real <dl> so AT ties label→value) */}
+        <dl className="sheet-fg-record">
+          <div className="sheet-fg-cell">
+            <dt className="sheet-fg-label">Family</dt>
+            <dd className="sheet-fg-value">{data?.familyName ?? '—'}</dd>
+          </div>
+          <div className="sheet-fg-cell">
+            <dt className="sheet-fg-label">eBird taxonomic order</dt>
+            <dd className="sheet-fg-value">
+              {data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}
+            </dd>
+          </div>
+        </dl>
+        <div className="sheet-fg-teaser">
+          <p className="sheet-fg-teaser-text">
+            {descPlain || 'No description available.'}
+          </p>
+          <button
+            type="button"
+            className="sheet-fg-readaccount"
+            aria-expanded={isFull}
+            aria-controls="sheet-fg-account"
+            onClick={() => goToSnap('full')}
+          >
+            Read account <span aria-hidden="true">⌄</span>
+          </button>
+        </div>
+
+        {/* FULL tier — taxonomy table + ABOUT prose + credits */}
+        <dl className="sheet-fg-taxonomy">
+          <div className="sheet-fg-taxrow">
+            <dt>Scientific name</dt>
+            <dd><em>{data?.sciName}</em></dd>
+          </div>
+          <div className="sheet-fg-taxrow">
+            <dt>Family</dt>
+            <dd>{data?.familyName}</dd>
+          </div>
+          <div className="sheet-fg-taxrow">
+            <dt>eBird taxonomic order</dt>
+            <dd>{data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}</dd>
+          </div>
+        </dl>
+        <div className="sheet-fg-about" id="sheet-fg-account">
+          {data?.descriptionBody ? (
+            <>
+              <h3 className="sheet-fg-about-eyebrow">About</h3>
+              <SpeciesDescription
+                descriptionBody={data.descriptionBody}
+                descriptionAttributionUrl={data.descriptionAttributionUrl}
+              />
+            </>
+          ) : (
+            <p className="sheet-fg-prose">No description available.</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -385,16 +385,23 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     [heightFor, onClose, settleTo],
   );
 
-  // Initial focus on mount: heading first only when the sheet opens at
-  // full (not peek/half — at peek/half the user expects map focus to
-  // persist so they can keep clicking clusters). At full the heading
-  // gets focus exactly like the desktop modal.
+  // Initial focus on mount: move focus to the DIALOG CONTAINER (not the visible
+  // species name) only when the sheet opens at full — at peek/half the user
+  // expects map focus to persist so they can keep clicking clusters.
+  //
+  // #907 design-review finding 2: focusing the visible `#detail-title` heading
+  // painted a stray `:focus-visible` ring around the species name on
+  // keyboard-driven open. Focus the sheet root instead (tabIndex={-1} makes it
+  // programmatically focusable without a tab stop). The dialog's accessible
+  // name is still the species name via `aria-label`, so AT announces the same
+  // thing on entry; the visible name no longer rings on either pointer or
+  // keyboard open.
   useEffect(() => {
     if (snap !== 'full') return;
     const sheet = sheetRef.current;
     if (!sheet) return;
     queueMicrotask(() => {
-      sheet.querySelector<HTMLElement>('#detail-title')?.focus();
+      sheetRef.current?.focus();
     });
   }, [snap]);
 
@@ -427,6 +434,10 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       data-snap-state={snap}
       data-dragging={dragging ? 'true' : 'false'}
       data-content={content}
+      // #907 finding 2 — programmatically focusable (no tab stop) so open-focus
+      // can land on the dialog container instead of the visible species name,
+      // which avoided a stray :focus-visible ring on the title.
+      tabIndex={-1}
       role={isFull ? 'dialog' : 'region'}
       aria-label={isFull ? (speciesName ?? 'Species detail') : 'Selected sighting'}
       {...(isFull ? { 'aria-modal': 'true' as const } : {})}
@@ -485,8 +496,10 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
 
         <div className="sheet-fg-identity">
           {/* h2: the map identity ("Bird Maps") owns the page h1; the species
-              name is the top heading INSIDE the dialog. */}
-          <h2 id="detail-title" tabIndex={-1} className="sheet-fg-name">
+              name is the top heading INSIDE the dialog. Not a focus target:
+              open-focus lands on the dialog container (#907 finding 2), so this
+              heading carries no tabIndex and never paints a focus ring. */}
+          <h2 id="detail-title" className="sheet-fg-name">
             {data?.comName ?? 'Loading…'}
           </h2>
           <p className="sheet-fg-sci">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1390,14 +1390,25 @@ aside.species-detail-rail .species-detail-rail-close {
   z-index: 10;
   display: flex;
   flex-direction: column;
-  /* MOB-5: notched devices need env(safe-area-inset-top) so the sheet
-     handle clears the Dynamic Island / status bar when fully expanded.
-     max() keeps the sheet from losing its rounded-corner top edge if
-     the safe-area inset is larger than the default padding. */
-  padding-top: max(var(--space-xs, 4px), env(safe-area-inset-top, 0px));
+  /* The safe-area-inset-top clearance is only needed at FULL, when the sheet
+     covers the notch. Applying it at every detent added ~47px of dead space
+     above the handle on notched phones at peek/half — moved to
+     .species-detail-sheet--full below. */
+  padding-top: var(--space-xs, 4px);
   padding-bottom: env(safe-area-inset-bottom, 0);
-  transition: height 200ms ease, transform 200ms ease;
-  will-change: height, transform;
+  /* Settle tween uses the transitions-dev card-resize tuning (recipe
+     01-card-resize). The transition is gated OFF during an active drag via
+     [data-dragging='true'] below so the drag tracks the finger 1:1.
+     Reduced-motion is owned globally by motion.css (collapses this to 0ms);
+     no per-element guard here, per repo convention. */
+  --sheet-settle-dur: 300ms;
+  --sheet-settle-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  transition: height var(--sheet-settle-dur) var(--sheet-settle-ease);
+  will-change: height;
+}
+
+.species-detail-sheet[data-dragging='true'] {
+  transition: none;
 }
 
 .species-detail-sheet--full {
@@ -1410,6 +1421,10 @@ aside.species-detail-rail .species-detail-rail-close {
      controls tiers so the map remains interactive while the sheet is partially
      open (see styles.css for --peek/--half comments). */
   z-index: var(--z-modal);
+  /* Only the full sheet reaches the notch — clear it here. */
+  padding-top: max(var(--space-xs, 4px), env(safe-area-inset-top, 0px));
+  /* Clip the full-bleed masthead to the sheet's rounded top. */
+  overflow: hidden;
 }
 
 /* #761 (S2/O5): the AppHeader is `position: fixed` floating chrome on
@@ -1451,17 +1466,380 @@ aside.species-detail-rail .species-detail-rail-close {
   background: var(--color-text-muted);
 }
 
-.sheet-scroll {
-  /* Body: native vertical scroll; handle owns horizontal/vertical
-     gesture decisions at the top. */
-  touch-action: pan-y;
+/* ── Field-guide detent layouts ────────────────────────────────────────────
+   One grid (.sheet-fg) re-templates per [data-content] (compact|mid|full),
+   driven by live sheet height in SpeciesDetailSheet.tsx (resolveContentTier,
+   hysteresed). The photo (.sheet-fg-photo) is a single <Photo> kept mounted
+   across detents; only its frame morphs (44px thumb -> 120px plate -> full-
+   bleed masthead). Hairlines use a theme-neutral translucent grey. */
+.sheet-fg {
   flex: 1;
+  min-height: 0;
+  display: grid;
+  align-content: start;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-lg) var(--space-md);
   overflow-y: auto;
-  /* The detail body's full-bleed hero photo bleeds ±16px; contain it
-     explicitly rather than relying on overflow-y:auto implicitly promoting
-     overflow-x. (julianken-bot suggestion, PR #820.) */
   overflow-x: clip;
+  touch-action: pan-y;
   -webkit-overflow-scrolling: touch;
+}
+
+.sheet-fg-photo {
+  grid-area: photo;
+  overflow: hidden;
+  border-radius: 10px;
+  background: var(--color-bg-tint);
+}
+/* §1.2 inner-node sizing — make the <Photo> primitive fill the morphing frame
+   so the per-tier width/height on .sheet-fg-photo (44px → 120px → masthead) is
+   what drives the photo size. <Photo> defaults to its own aspect-ratio
+   (4/3 inline, 16/10 masthead); override that to auto + 100%/100% here so the
+   frame, not the primitive, owns the box. The <img> and the no-photo
+   <FamilySilhouette> both inherit the frame the same way. */
+.sheet-fg-photo .photo {
+  aspect-ratio: auto;
+  width: 100%;
+  height: 100%;
+}
+.sheet-fg-photo .photo__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.sheet-fg-photo .family-silhouette {
+  width: 100%;
+  height: 100%;
+}
+
+.sheet-fg-identity { grid-area: identity; min-width: 0; }
+.sheet-fg-name {
+  margin: 0;
+  font-size: var(--type-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.15;
+  color: var(--color-text-strong);
+}
+/* Programmatic focus (AT context on open) paints NO box; keyboard focus gets a
+   tokenized high-contrast ring — fixes the stray focus box on the name. */
+.sheet-fg-name:focus { outline: none; }
+.sheet-fg-name:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.sheet-fg-sci {
+  margin: 2px 0 0;
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+}
+.sheet-fg-family {
+  margin: var(--space-xs) 0 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+}
+.sheet-fg-family-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  /* 1px ring so the dot's boundary is perceivable on any family hue / theme
+     (a11y: non-text contrast, family color must not be the only signal). */
+  box-shadow: 0 0 0 1px rgba(128, 128, 128, 0.55);
+}
+
+.sheet-fg-rule {
+  grid-area: rule;
+  height: 3px;
+  border-radius: 2px;
+  align-self: start;
+}
+
+/* MID-only + FULL-only blocks hidden by default; placed per data-content below */
+.sheet-fg-record,
+.sheet-fg-teaser,
+.sheet-fg-taxonomy,
+.sheet-fg-about { display: none; }
+.sheet-fg-record { grid-area: record; }
+.sheet-fg-teaser { grid-area: teaser; }
+.sheet-fg-taxonomy { grid-area: taxonomy; }
+.sheet-fg-about { grid-area: about; }
+
+/* MID field record strip — borderless, inter-cell gap (not a heavy boxed table) */
+.sheet-fg-record { margin: 0; }
+.sheet-fg-cell { margin: 0; }
+.sheet-fg-label {
+  display: block;
+  margin: 0;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.sheet-fg-value {
+  display: block;
+  margin: 2px 0 0;
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-strong);
+}
+
+/* MID teaser — 2-line clamp + read-account button */
+.sheet-fg-teaser-text {
+  margin: 0;
+  font-size: var(--type-base);
+  line-height: 1.5;
+  color: var(--color-text-body);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.sheet-fg-readaccount {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 44px; /* WCAG 2.5.8 touch target */
+  padding: 8px 0;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: var(--type-sm);
+  /* AA-safe link recipe (#830): --color-text-strong + underline reads as a
+     link on the white sheet surface (~17:1 light / ~13.8:1 dark). NOT
+     --color-text-link — that orange (#f5853b) is only 2.53:1 on #fff and fails
+     WCAG 1.4.3 (tokens.css §decision-point note). NOT the family accent either. */
+  color: var(--color-text-strong);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.sheet-fg-readaccount:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* FULL taxonomy table */
+.sheet-fg-taxonomy { margin: 0; }
+.sheet-fg-taxrow {
+  display: grid;
+  grid-template-columns: 132px 1fr;
+  gap: var(--space-md);
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.22);
+}
+.sheet-fg-taxrow:first-child { border-top: 1px solid rgba(127, 127, 127, 0.22); }
+.sheet-fg-taxrow dt {
+  margin: 0;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.sheet-fg-taxrow dd { margin: 0; font-size: var(--type-sm); color: var(--color-text-strong); }
+
+/* FULL about + credits */
+.sheet-fg-about-eyebrow {
+  margin: 0 0 var(--space-xs);
+  font-size: var(--type-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+.sheet-fg-prose {
+  margin: 0;
+  font-size: var(--type-base);
+  line-height: 1.6;
+  color: var(--color-text-body);
+}
+.sheet-fg-credits {
+  margin: var(--space-md) 0 0;
+  font-size: var(--type-xs);
+  color: var(--color-text-subtle);
+}
+/* AA-safe link recipe (#830) — see .sheet-fg-readaccount note. */
+.sheet-fg-credits a { color: var(--color-text-strong); text-decoration: underline; }
+
+/* ── COMPACT layout (identity row): photo 44px left, identity right ──────── */
+.species-detail-sheet[data-content='compact'] .sheet-fg {
+  grid-template-columns: 44px 1fr;
+  grid-template-areas: 'photo identity';
+  align-items: center;
+  column-gap: var(--space-md);
+  /* Small-mode padding rebalance: tight at the top (the name sits close under
+     the handle), breathing room at the bottom. Total height stays PEEK_PX. */
+  padding-top: 0;
+  padding-bottom: var(--space-lg);
+}
+/* Shorter handle in compact so the centered grip doesn't push the name down a
+   full 44px; still ≥24px (WCAG 2.5.8 AA) as a drag/tap target. */
+.species-detail-sheet[data-content='compact'] .sheet-handle { min-height: 30px; }
+.species-detail-sheet[data-content='compact'] .sheet-fg-photo { width: 44px; height: 44px; }
+.species-detail-sheet[data-content='compact'] .sheet-fg-sci,
+.species-detail-sheet[data-content='compact'] .sheet-fg-rule { display: none; }
+
+/* ── MID layout (plate card) ─────────────────────────────────────────────── */
+.species-detail-sheet[data-content='mid'] .sheet-fg {
+  grid-template-columns: 120px 1fr;
+  grid-template-areas:
+    'photo identity'
+    'rule  rule'
+    'record record'
+    'teaser teaser';
+  align-items: start;
+  column-gap: var(--space-md);
+}
+.species-detail-sheet[data-content='mid'] .sheet-fg-photo { width: 120px; height: 120px; }
+.species-detail-sheet[data-content='mid'] .sheet-fg-record {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: var(--space-md);
+}
+.species-detail-sheet[data-content='mid'] .sheet-fg-teaser { display: block; }
+/* Center the name/sci/family stack against the 120px plate; bump name to lg. */
+.species-detail-sheet[data-content='mid'] .sheet-fg-identity { align-self: center; }
+.species-detail-sheet[data-content='mid'] .sheet-fg-name { font-size: var(--type-lg); }
+
+/* ── FULL layout (field-guide entry) ─────────────────────────────────────── */
+.species-detail-sheet[data-content='full'] .sheet-fg {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'photo'
+    'identity'
+    'rule'
+    'taxonomy'
+    'about';
+  gap: var(--space-md);
+  padding-top: 0;
+}
+.species-detail-sheet[data-content='full'] .sheet-fg-photo {
+  /* full-bleed masthead — cancel the .sheet-fg side padding. Use an EXPLICIT
+     height (not aspect-ratio): aspect-ratio on a grid item with negative
+     margins doesn't reliably feed back into auto-track sizing, so the row
+     collapses and the name overlaps the photo. 62.5vw ≈ 16/10 of full width. */
+  margin: 0 calc(-1 * var(--space-lg));
+  width: auto;
+  height: min(62.5vw, 300px);
+  border-radius: 0;
+}
+/* Lift the subject out of the vertical center so the masthead doesn't crop low
+   with empty sky up top (a11y/design punch-list). Targets the <Photo> primitive's
+   inner <img> (.photo__img). */
+.species-detail-sheet[data-content='full'] .sheet-fg-photo .photo__img { object-position: center 35%; }
+.species-detail-sheet[data-content='full'] .sheet-fg-name {
+  font-size: var(--type-hero);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.1;
+}
+.species-detail-sheet[data-content='full'] .sheet-fg-taxonomy { display: block; }
+.species-detail-sheet[data-content='full'] .sheet-fg-about { display: block; }
+
+/* ── Field-guide motion: photo morph + tier content reveals ────────────────
+   Reduced-motion is owned globally by motion.css (collapses every transition /
+   animation here to 0ms); each rule's resting end-state is the correct static
+   state, so there are no per-element prefers-reduced-motion guards.
+
+   Photo morph. The photo reads as ONE continuous element across detents
+   because the properties that change its rendered box all tween together:
+   width/height/border-radius on the frame, the full-bleed negative `margin` at
+   full, AND `grid-template-columns` on the parent grid (the column track that
+   holds the photo: 44px → 120px → 1fr). grid-template-AREAS is NOT animatable —
+   the mid→full reposition (photo moves from the left column to a top masthead)
+   is the one accepted discontinuity; aspect-ratio is never animated. */
+.sheet-fg {
+  transition: grid-template-columns var(--sheet-settle-dur) var(--sheet-settle-ease);
+}
+.sheet-fg-photo {
+  transition:
+    width var(--sheet-settle-dur) var(--sheet-settle-ease),
+    height var(--sheet-settle-dur) var(--sheet-settle-ease),
+    border-radius var(--sheet-settle-dur) var(--sheet-settle-ease),
+    margin var(--sheet-settle-dur) var(--sheet-settle-ease);
+}
+/* 1:1 during drag — the photo + grid snap to the tier size at the threshold,
+   no lag behind the finger. */
+.species-detail-sheet[data-dragging='true'] .sheet-fg,
+.species-detail-sheet[data-dragging='true'] .sheet-fg-photo { transition: none; }
+
+/* MID-tier reveal — transitions-dev recipe 18 (texts-reveal). The sci-name,
+   the field-record strip, and the teaser rise in with a staggered blur as they
+   enter the mid detent. Each starts translated-down + blurred + invisible; the
+   [data-content='mid'] state flips them to rest. The name+family SPINE is NOT
+   in this channel (it is always present, never display:none'd).
+
+   record/teaser are display:none in other tiers, so the channel also tweens the
+   discrete `display` change (transition-behavior: allow-discrete) and seeds the
+   entrance from-state with @starting-style — without these the show would snap.
+   sci-name is never display:none'd (it stays in the spine), so it tweens with
+   the plain opacity/transform/filter set. */
+.sheet-fg-sci,
+.sheet-fg-record,
+.sheet-fg-teaser {
+  opacity: 0;
+  transform: translateY(var(--stagger-distance, 12px));
+  filter: blur(var(--stagger-blur, 3px));
+  transition:
+    opacity var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    transform var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    filter var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    display var(--stagger-dur, 600ms) allow-discrete;
+  will-change: transform, opacity, filter;
+}
+/* Stagger: record holds 1 step, teaser 2 steps, so the eye lands on the
+   sci-name first then walks down the card. */
+.sheet-fg-record { transition-delay: var(--stagger-stagger, 40ms); }
+.sheet-fg-teaser { transition-delay: calc(var(--stagger-stagger, 40ms) * 2); }
+.species-detail-sheet[data-content='mid'] .sheet-fg-sci,
+.species-detail-sheet[data-content='mid'] .sheet-fg-record,
+.species-detail-sheet[data-content='mid'] .sheet-fg-teaser,
+.species-detail-sheet[data-content='full'] .sheet-fg-sci {
+  opacity: 1;
+  transform: translateY(0);
+  filter: blur(0);
+}
+@starting-style {
+  .species-detail-sheet[data-content='mid'] .sheet-fg-record,
+  .species-detail-sheet[data-content='mid'] .sheet-fg-teaser {
+    opacity: 0;
+    transform: translateY(var(--stagger-distance, 12px));
+    filter: blur(var(--stagger-blur, 3px));
+  }
+}
+
+/* FULL-tier reveal — transitions-dev recipe 07 (panel-reveal). The taxonomy
+   table and the About panel slide up from a half-travel with a cross-blur so a
+   short translate still reads as a full open. Both are display:none until the
+   full detent, so the channel tweens `display` (allow-discrete) and seeds the
+   from-state via @starting-style, mirroring the mid channel. */
+.sheet-fg-taxonomy,
+.sheet-fg-about {
+  transform: translateY(var(--panel-translate-y-sheet, 32px));
+  opacity: 0;
+  filter: blur(var(--panel-blur, 2px));
+  transition:
+    transform var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    opacity var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    filter var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
+    display var(--panel-open-dur, 400ms) allow-discrete;
+  will-change: transform, opacity, filter;
+}
+.species-detail-sheet[data-content='full'] .sheet-fg-taxonomy,
+.species-detail-sheet[data-content='full'] .sheet-fg-about {
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+}
+@starting-style {
+  .species-detail-sheet[data-content='full'] .sheet-fg-taxonomy,
+  .species-detail-sheet[data-content='full'] .sheet-fg-about {
+    opacity: 0;
+    transform: translateY(var(--panel-translate-y-sheet, 32px));
+    filter: blur(var(--panel-blur, 2px));
+  }
 }
 
 /* ==========================================================================
@@ -1558,7 +1936,7 @@ aside.species-detail-rail .species-detail-rail-close {
 .species-detail-sheet--half {
   /* Half-height state — above the map (z-15) but intentionally BELOW the
      overlay band so map overlays remain interactive around the sheet.
-     Overflow hidden keeps the sheet clean at the snap boundary; .sheet-scroll
+     Overflow hidden keeps the sheet clean at the snap boundary; .sheet-fg
      inside handles scrollable content via its own touch-action. */
   z-index: 15;
   overflow: hidden;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1520,14 +1520,9 @@ aside.species-detail-rail .species-detail-rail-close {
   line-height: 1.15;
   color: var(--color-text-strong);
 }
-/* Programmatic focus (AT context on open) paints NO box; keyboard focus gets a
-   tokenized high-contrast ring — fixes the stray focus box on the name. */
-.sheet-fg-name:focus { outline: none; }
-.sheet-fg-name:focus-visible {
-  outline: 2px solid var(--color-text-strong);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
+/* #907 finding 2 — the species name is no longer a focus target (open-focus
+   lands on the dialog container), so it needs no focus / :focus-visible ring.
+   The container's own focus is invisible (programmatic, tabIndex={-1}). */
 .sheet-fg-sci {
   margin: 2px 0 0;
   font-size: var(--type-sm);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -122,6 +122,26 @@
    * Named for what it is (the cluster height), NOT --header-height which is a
    * retired layout-reservation token. Added 2026-05-30 (#801). */
   --controls-cluster-h: 54px;
+
+  /* ── transitions-dev recipe tokens ──────────────────────────────────────
+   * Semantic motion vars consumed by the field-guide sheet reveals
+   * (SpeciesDetailSheet / styles.css). Values are the live transitions.dev
+   * tunings. recipe-18 (texts-reveal) drives the mid-tier sci/record/teaser;
+   * recipe-07 (panel-reveal) drives the full-tier taxonomy/About. Reduced-
+   * motion is handled globally in motion.css — no per-recipe guard here. */
+  --stagger-dur:         600ms;
+  --stagger-distance:    12px;
+  --stagger-stagger:     40ms;
+  --stagger-blur:        3px;
+  --stagger-ease:        cubic-bezier(0.22, 1, 0.36, 1);
+  --panel-open-dur:      400ms;
+  --panel-blur:          2px;
+  --panel-ease:          cubic-bezier(0.22, 1, 0.36, 1);
+  /* Half-travel for the full-tier panel slide; the sheet's own height already
+     supplies most of the open distance so a short translate reads as a full
+     open (recipe-07 note). Named -sheet so it doesn't collide if the canonical
+     --panel-translate-y (100px) is later imported wholesale. */
+  --panel-translate-y-sheet: 32px;
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */


### PR DESCRIPTION


## Diagrams

```mermaid
stateDiagram-v2
    [*] --> half: open (tap species)
    peek --> half: drag up / flick
    half --> peek: drag down
    half --> full: drag up / flick / Read account
    full --> half: drag down / collapse
    peek --> [*]: drag down past dismiss

    note right of peek
      content=compact · identity row (104px)
    end note
    note right of half
      content=mid · plate card (60vh)
      resolveContentTier(height, prevTier, vh), ±24px hysteresis
    end note
    note right of full
      content=full · field-guide entry (100vh-8)
      role=dialog + aria-modal, #map-layer inert
    end note
```

## Summary

- **Why:** the mobile species sheet opened unreadable (120px peek), the up-drag was dead (`Math.max(0,dragOffset)` clamp), and the handle tap-cycled states instead of dragging (#907 / diagnosis). This ports the on-device-validated **field-guide** redesign into production.
- 3 size-appropriate detents (compact identity row / mid plate-card / full field-guide entry), height-driven **1:1 drag** + velocity flick + dismiss, opens at the readable `half`.
- Photo slot composed via the shared `<Photo>` primitive (real silhouette fallback; removes the orphan `.sheet-fg-img--silhouette` class); content tiers driven by a hysteresed `resolveContentTier`; reveals via pure-CSS transitions-dev recipes 18/07 (no animation lib). Fixed a WCAG 1.4.3 contrast bug on the "Read account"/credit links.
- Scope: **mobile sheet only** — desktop `SpeciesDetailRail`/`SpeciesDetailSurface` untouched.

## Screenshots

**Mobile (390×844) — the field-guide sheet, three size-appropriate detents:**

| mid · default open | full | compact · collapsed |
|---|---|---|
| <img width="250" alt="01-390-mid-light" src="https://github.com/user-attachments/assets/91a9e751-41d3-4d00-822d-11274232c8ce"> | <img width="250" alt="03-390-full-light" src="https://github.com/user-attachments/assets/60fbdbab-2170-4703-bea3-ed80c454b353"> | <img width="250" alt="04-390-compact-light" src="https://github.com/user-attachments/assets/61858b94-9322-479c-8e26-e46c8ff21953"> |

**Dark theme + tablet / small-laptop (compact → sheet):**

| 390 mid · dark | 768 · light | 768 · dark |
|---|---|---|
| <img width="250" alt="02-390-mid-dark" src="https://github.com/user-attachments/assets/5d6c8917-443c-4d86-bdff-615a9bea9994"> | <img width="250" alt="05-768-mid-light" src="https://github.com/user-attachments/assets/f8df78ca-0f53-41cb-bf23-b8df57bad274"> | <img width="250" alt="06-768-mid-dark" src="https://github.com/user-attachments/assets/5b0a18c0-28a5-441b-834d-6c4573a7aac1"> |

| 1024 · light | 1024 · dark |
|---|---|
| <img width="250" alt="07-1024-mid-light" src="https://github.com/user-attachments/assets/f7bb3503-d2a7-453a-bbe2-b530112a8860"> | <img width="250" alt="08-1024-mid-dark" src="https://github.com/user-attachments/assets/04d2050b-6313-4e82-b5a5-55c255e01c06"> |

**Desktop rail (≥1200px — unchanged by this PR; shown for no-regression):**

| 1440 · light | 1440 · dark | 1920 · light | 1920 · dark |
|---|---|---|---|
| <img width="180" alt="09-1440-rail-light" src="https://github.com/user-attachments/assets/f36617c9-17dc-4b9d-bbbe-462807e0d0c2"> | <img width="180" alt="10-1440-rail-dark" src="https://github.com/user-attachments/assets/70781b19-56c5-4dd8-99c1-7dbb340a70f5"> | <img width="180" alt="11-1920-rail-light" src="https://github.com/user-attachments/assets/e446f0a8-b983-4460-a081-7f201cf42472"> | <img width="180" alt="12-1920-rail-dark" src="https://github.com/user-attachments/assets/b1dc8755-9bf7-4c11-b3c3-54d4ad1db1ef"> |

Console: **0 errors / 0 warnings** at all five viewports (Playwright MCP drive).

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (1123 pass; SpeciesDetailSheet 13/13)
- [x] New unit specs: open-at-half, 1:1 drag, velocity-snap, `resolveContentTier` hysteresis
- [x] New/updated e2e: `sheet-snap.spec.ts` (open-at-half + drag-up/flick), `species-detail.spec.ts` mobile locators
- [x] `npm run build -w @bird-watch/frontend` — clean
- [x] `npx knip` + `bash scripts/check-orphan-classnames.sh` — clean (orphan silhouette class removed)
- [x] Playwright MCP smoke at 390×844: opens at `half`, `<Photo>` composed, console 0 errors / 0 warnings (full 5×2 in Screenshots)

## Plan reference

Out of plan — field-guide mobile species-sheet redesign (discovered during UX review). Implements **#907** (epic **#906**).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
