### PR TITLE
fix(frontend): family-dot ring contrast ≥3:1 + falsifiable audit + silhouette tests (#908)

### DIFF
--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -18,9 +18,28 @@ const VERMFLY_WITH_PHOTO: SpeciesMeta = {
   photoLicense: 'CC-BY-4.0',
 };
 
+// No-photo VERMFLY: photoUrl omitted (it is optional on SpeciesMeta), so the
+// sheet passes src=null to <Photo> and the family-silhouette fallback renders.
+// Mirrors the canonical e2e VERMFLY fixture (frontend/e2e/fixtures.ts).
+const VERMFLY_NO_PHOTO: SpeciesMeta = {
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus',
+  familyCode: 'songbird',
+  familyName: 'Tyrant Flycatchers',
+  taxonOrder: 4400,
+};
+
 function makeClient(): ApiClient {
   const client = new ApiClient({ baseUrl: '' });
   client.getSpecies = vi.fn().mockResolvedValue(VERMFLY_WITH_PHOTO);
+  client.getSilhouettes = vi.fn().mockResolvedValue([]);
+  return client;
+}
+
+function makeNoPhotoClient(): ApiClient {
+  const client = new ApiClient({ baseUrl: '' });
+  client.getSpecies = vi.fn().mockResolvedValue(VERMFLY_NO_PHOTO);
   client.getSilhouettes = vi.fn().mockResolvedValue([]);
   return client;
 }
@@ -336,6 +355,110 @@ describe('<SpeciesDetailSheet>', () => {
 
     // Cleanup must have removed inert — the modal that takes over starts clean.
     expect(mainEl).not.toHaveAttribute('inert');
+  });
+});
+
+describe('<SpeciesDetailSheet> — photoless silhouette fallback (#908 T2)', () => {
+  let mainEl: HTMLElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    mainEl = document.createElement('main');
+    mainEl.id = 'main-surface';
+    document.body.appendChild(mainEl);
+    __resetSpeciesDetailCache();
+  });
+
+  // The silhouette is a SINGLE <Photo> kept mounted across detents; only its
+  // frame morphs per [data-content]. So .photo--silhouette must be present at
+  // EVERY tier for a no-photo species — never a flat block. We assert presence
+  // within .sheet-fg-photo (the morphing frame) at compact / mid / full.
+  const silhouetteInFrame = (sheet: HTMLElement) =>
+    sheet.querySelector('.sheet-fg-photo .photo--silhouette');
+
+  it('renders .photo--silhouette at the MID tier (mount default = half snap)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeNoPhotoClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // Opens at half → MID content tier.
+    await waitFor(() => expect(sheet).toHaveAttribute('data-content', 'mid'));
+    // The no-photo branch renders the family silhouette glyph, not the <img>.
+    expect(silhouetteInFrame(sheet)).not.toBeNull();
+    expect(sheet.querySelector('.sheet-fg-photo .family-silhouette')).not.toBeNull();
+    expect(sheet.querySelector('.sheet-fg-photo svg')).not.toBeNull();
+    expect(sheet.querySelector('.sheet-fg-photo img')).toBeNull();
+  });
+
+  it('renders .photo--silhouette at the FULL tier (masthead detent)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeNoPhotoClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // One expand tap advances half → full → FULL (masthead) content tier.
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-content', 'full'));
+    expect(silhouetteInFrame(sheet)).not.toBeNull();
+    expect(sheet.querySelector('.sheet-fg-photo img')).toBeNull();
+  });
+
+  it('renders .photo--silhouette at the COMPACT tier (peek / 44px identity row)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeNoPhotoClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    // Drag down from half toward peek (settles to the peek detent — 104px —
+    // which resolves to the COMPACT content tier) WITHOUT crossing the dismiss
+    // floor. A slow, short downward drag keeps velocity under the flick
+    // threshold so it settles by position to the nearest detent (peek).
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 9, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 9, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 9, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 9, bubbles: true }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-content', 'compact'));
+    expect(silhouetteInFrame(sheet)).not.toBeNull();
+    expect(sheet.querySelector('.sheet-fg-photo img')).toBeNull();
+  });
+
+  it('with-photo species renders the <img>, NOT the silhouette', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // The <img> mounts immediately (loading state) for a species with photoUrl.
+    await waitFor(() => expect(sheet.querySelector('.sheet-fg-photo img')).not.toBeNull());
+    expect(sheet.querySelector('.sheet-fg-photo .photo__img')).toHaveAttribute(
+      'src',
+      'https://photos.bird-maps.com/vermfly.jpg'
+    );
+    // No silhouette on the photo branch.
+    expect(silhouetteInFrame(sheet)).toBeNull();
   });
 });
 

--- a/frontend/src/config/family-dot-ring-contrast.test.ts
+++ b/frontend/src/config/family-dot-ring-contrast.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { contrastRatio } from '../utils/wcag-contrast.js';
+import { FAMILY_PALETTE, getFamilyChannel, type FamilyCode } from './family-palette.js';
+import { SHEET_DOT_RING, SHEET_SURFACE, type ThemeKey } from './family-dot-ring.js';
+
+/**
+ * Falsifiable family-dot-ring contrast audit (#908 review refinement).
+ *
+ * The species-detail-sheet family dot (`.sheet-fg-family-dot`) is filled with
+ * the family accent color and bounded by a 1px ring (`--sheet-dot-ring`). The
+ * bot flagged the ≥3:1 audit as a manual spot-check; this suite makes it a
+ * palette-iterating assertion so a future palette OR ring edit that breaks the
+ * non-text-contrast floor (WCAG 2.2 SC 1.4.11) fails CI instead of shipping.
+ *
+ * Boundary model: the dot is perceivable when its BOUNDARY clears 3:1 against
+ * the adjacent surface. The fill cannot guarantee this on both themes (proved
+ * below), so the ring is the boundary — and the ring is hue-independent, so a
+ * single passing ring per theme covers EVERY family. We still iterate the full
+ * palette so the assertion names each family if the invariant ever regresses.
+ */
+
+const ALL_FAMILY_CODES: FamilyCode[] = [
+  'raptor',
+  'waterfowl',
+  'woodpecker',
+  'songbird',
+  'shorebird',
+  'hummingbird',
+  'corvid',
+];
+
+const THEMES: ThemeKey[] = ['light', 'dark'];
+
+const MIN_NON_TEXT_CONTRAST = 3.0;
+
+describe('family-dot-ring contrast audit (WCAG 2.2 SC 1.4.11, ≥3:1)', () => {
+  it('the per-theme ring color clears 3:1 against its surface on BOTH themes', () => {
+    for (const theme of THEMES) {
+      const ratio = contrastRatio(SHEET_DOT_RING[theme], SHEET_SURFACE[theme]);
+      expect(
+        ratio,
+        `${theme} ring ${SHEET_DOT_RING[theme]} on surface ${SHEET_SURFACE[theme]} = ${ratio.toFixed(2)}:1`,
+      ).toBeGreaterThanOrEqual(MIN_NON_TEXT_CONTRAST);
+    }
+  });
+
+  it('every family dot is perceivable on BOTH themes (ring boundary ≥3:1 for each hue)', () => {
+    // The ring is hue-independent, so this proves the dot boundary clears 3:1
+    // for every family on both surfaces — the audit the bot asked to be made
+    // falsifiable. Iterating per family means a regression names the family.
+    for (const code of ALL_FAMILY_CODES) {
+      // Touch the fill so the audit is anchored to the real palette entry — a
+      // family removed from the palette fails here rather than silently passing.
+      expect(getFamilyChannel(code).fill).toMatch(/^#[0-9a-fA-F]{6}$/);
+      for (const theme of THEMES) {
+        const ratio = contrastRatio(SHEET_DOT_RING[theme], SHEET_SURFACE[theme]);
+        expect(
+          ratio,
+          `${code} dot ring on ${theme} surface = ${ratio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(MIN_NON_TEXT_CONTRAST);
+      }
+    }
+  });
+
+  it('the null-family neutral dot is perceivable on BOTH themes', () => {
+    expect(getFamilyChannel(null).fill).toMatch(/^#[0-9a-fA-F]{6}$/);
+    for (const theme of THEMES) {
+      const ratio = contrastRatio(SHEET_DOT_RING[theme], SHEET_SURFACE[theme]);
+      expect(ratio).toBeGreaterThanOrEqual(MIN_NON_TEXT_CONTRAST);
+    }
+  });
+
+  it('documents WHY the ring is load-bearing: the fill alone fails 3:1 on the dark surface', () => {
+    // Regression guard for the design rationale. If the palette is ever
+    // re-tuned so every fill clears 3:1 on navy unaided, this test is the
+    // signal to revisit whether the ring is still required (it would not be
+    // wrong, just no longer the sole boundary). At least one family fill must
+    // currently fail on the dark navy surface — that is precisely why the ring
+    // exists and why the audit asserts the ring, not the fill.
+    const fillsFailingOnDark = ALL_FAMILY_CODES.filter(
+      (code) => contrastRatio(FAMILY_PALETTE[code].fill, SHEET_SURFACE.dark) < MIN_NON_TEXT_CONTRAST,
+    );
+    expect(fillsFailingOnDark.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/config/family-dot-ring.ts
+++ b/frontend/src/config/family-dot-ring.ts
@@ -1,0 +1,48 @@
+/**
+ * Family-dot ring — the perceivable boundary for the family-color dot.
+ *
+ * The species-detail-sheet identity row paints a small dot
+ * (`.sheet-fg-family-dot`) filled with the family accent color. The accent
+ * fill alone CANNOT guarantee a perceivable boundary on both theme surfaces:
+ * the family hues are mid-tones, so several of them fall below 3:1 against the
+ * dark navy card surface (e.g. corvid #2e3a4e → 1.29:1, woodpecker #6b3a2a →
+ * 1.60:1). WCAG 2.2 SC 1.4.11 (non-text contrast) requires the dot's visual
+ * boundary to clear 3:1 against the adjacent surface regardless of the fill.
+ *
+ * So the BOUNDARY is the ring, not the fill. This module is the single source
+ * of truth for the two per-theme ring colors and the two surface colors they
+ * sit on; the CSS tokens (`--sheet-dot-ring`, set per `[data-theme]` in
+ * tokens.css) carry the SAME values, and `family-dot-ring-contrast.test.ts`
+ * iterates these to make the ≥3:1 audit FALSIFIABLE (per the #908 review
+ * refinement — replacing the manual spot-check the bot flagged).
+ *
+ * If a ring or surface value moves here, move it in tokens.css too — the test
+ * asserts the ratios, not the cross-file sync, so they are kept in step by
+ * this comment and the shared literal values.
+ */
+
+/** The two theme surfaces the family dot is painted on (= `--color-bg-surface`). */
+export const SHEET_SURFACE = {
+  /** Light theme card surface — tokens.css :root[data-theme="light"]. */
+  light: '#ffffff',
+  /** Dark theme card surface (navy) — tokens.css :root[data-theme="dark"]. */
+  dark: '#1b2742',
+} as const;
+
+/**
+ * Per-theme dot-ring color. Solid (not alpha) so the rendered boundary color
+ * is exactly this value — an alpha ring composites differently on each surface
+ * and the original `rgba(128,128,128,.55)` ring resolved to only ~1.96:1 on
+ * white and ~2.08:1 on navy (BOTH failing). Solid per-theme colors clear 3:1
+ * with comfortable margin on their own surface:
+ *   light #767676 vs #ffffff → 4.54:1
+ *   dark  #aeb6c2 vs #1b2742 → 7.26:1
+ */
+export const SHEET_DOT_RING = {
+  /** Mirrors `--sheet-dot-ring` in tokens.css :root[data-theme="light"]. */
+  light: '#767676',
+  /** Mirrors `--sheet-dot-ring` in tokens.css :root[data-theme="dark"]. */
+  dark: '#aeb6c2',
+} as const;
+
+export type ThemeKey = keyof typeof SHEET_SURFACE;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1542,8 +1542,12 @@ aside.species-detail-rail .species-detail-rail-close {
   border-radius: 50%;
   flex: none;
   /* 1px ring so the dot's boundary is perceivable on any family hue / theme
-     (a11y: non-text contrast, family color must not be the only signal). */
-  box-shadow: 0 0 0 1px rgba(128, 128, 128, 0.55);
+     (a11y: non-text contrast, family color must not be the only signal).
+     The old rgba(128,128,128,.55) ring composited to only ~1.96:1 on the
+     white card / ~2.08:1 on the navy card — BOTH failing WCAG 2.2 SC 1.4.11.
+     --sheet-dot-ring is a solid per-theme color (tokens.css) clearing ≥3:1 on
+     each surface; the audit is falsified by family-dot-ring-contrast.test.ts. */
+  box-shadow: 0 0 0 1px var(--sheet-dot-ring);
 }
 
 .sheet-fg-rule {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -213,6 +213,14 @@
   --color-error-bg:     #fdecec;
   --color-error-border: #d48e8e;
   --color-error-text:   #8a1f1f;
+
+  /* Family-dot ring (#908) — the perceivable BOUNDARY of the species-sheet
+     family dot (.sheet-fg-family-dot). The accent fill alone can't clear
+     WCAG 2.2 SC 1.4.11 (≥3:1 non-text) on both surfaces, so a solid per-theme
+     ring carries the boundary. #767676 → 4.54:1 on the #ffffff card surface.
+     Single-sourced with src/config/family-dot-ring.ts, which the falsifiable
+     contrast audit (family-dot-ring-contrast.test.ts) iterates. */
+  --sheet-dot-ring: #767676;
 }
 
 /* ── Layer 2: Semantic — dark mode ──────────────────────────────────── */
@@ -294,6 +302,13 @@
   --color-error-bg:     #3a1a1a;
   --color-error-border: #6a3030;
   --color-error-text:   #f5b8a8;
+
+  /* Family-dot ring (#908) — dark override. A grey ring (the light value
+     #767676) only reads ~1.x:1 on the #1b2742 navy card; a light blue-grey
+     ring is the perceivable boundary instead. #aeb6c2 → 7.26:1 on #1b2742,
+     well past the 3:1 SC 1.4.11 floor. Single-sourced with
+     src/config/family-dot-ring.ts (SHEET_DOT_RING.dark). */
+  --sheet-dot-ring: #aeb6c2;
 }
 
 /* ── Layer 3: Component aliases ─────────────────────────────────────── */


### PR DESCRIPTION

## Diagrams

N/A — accessibility contrast fix (CSS token) + new audit/silhouette tests; no flow to diagram.

## Summary

- **Why:** making the family-dot ≥3:1 audit *falsifiable* (per the T1 bot/punch-list) surfaced a real **WCAG 2.2 SC 1.4.11** failure — the dot's `rgba(128,128,128,.55)` ring composited to only **~1.96:1 (light)** and **~2.08:1 (dark)**, below the 3:1 non-text floor. The family fills can't carry the boundary either (e.g. corvid 1.29:1 on navy), so a contrast-clearing ring is load-bearing.
- **Fix:** solid per-theme `--sheet-dot-ring` token — light `#767676` (4.54:1 on `#fff`), dark `#aeb6c2` (7.26:1 on navy) — single-sourced in `family-dot-ring.ts` so the test reads the same literals the CSS carries.
- Adds a palette-iterating contrast test (asserts every family + null-family ring clears 3:1 on both surfaces, and that ≥1 fill fails on dark → proves the ring is required) and silhouette-fallback tests (no-photo species renders `.photo--silhouette` at all 3 detents). Scope: mobile sheet only.

## Screenshots

**The family-color dot + its new ≥3:1 ring on the species sheet (mobile), both themes:**

| 390 mid · light | 390 mid · dark |
|---|---|
| <img width="250" alt="01-390-mid-light" src="https://github.com/user-attachments/assets/0fb121dc-d033-483d-be38-06f1e2093414"> | <img width="250" alt="02-390-mid-dark" src="https://github.com/user-attachments/assets/eb788574-cbc4-4bb9-8617-d31f4fbc90b6"> |

| 768 · light | 768 · dark | 1024 · light | 1024 · dark |
|---|---|---|---|
| <img width="220" alt="05-768-mid-light" src="https://github.com/user-attachments/assets/ff862980-19e2-4b48-a4f2-de7c51387100"> | <img width="220" alt="06-768-mid-dark" src="https://github.com/user-attachments/assets/385a42a6-c3c6-45c6-a86f-c9e5602a0dea"> | <img width="220" alt="07-1024-mid-light" src="https://github.com/user-attachments/assets/125cfb26-c452-4c20-bcfb-37e37eb112bd"> | <img width="220" alt="08-1024-mid-dark" src="https://github.com/user-attachments/assets/54d32ea7-fc09-4076-9dce-cbd0e5671271"> |

**Desktop rail (≥1200px — the dot-ring change does not reach the rail; shown for no-regression):**

| 1440 · light | 1440 · dark | 1920 · light | 1920 · dark |
|---|---|---|---|
| <img width="180" alt="09-1440-rail-light" src="https://github.com/user-attachments/assets/7e6c89ef-c1a6-46d0-9d04-3d0f0ae7ca83"> | <img width="180" alt="10-1440-rail-dark" src="https://github.com/user-attachments/assets/63e3c4e1-33dd-4521-a9b8-f955693aec6f"> | <img width="180" alt="11-1920-rail-light" src="https://github.com/user-attachments/assets/b25e735e-04ea-4541-b811-2a5d86d5d49c"> | <img width="180" alt="12-1920-rail-dark" src="https://github.com/user-attachments/assets/c7424893-8919-4876-b4e2-6bf069cc6654"> |

Console: **0 errors / 0 warnings** at all five viewports.

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — 1132 pass (new contrast + silhouette tests included)
- [x] Falsifiability verified: reverting the ring to the old `rgba(128,128,128,.55)` fails 3/4 contrast assertions
- [x] `npm run build -w @bird-watch/frontend`, `npm run lint`, `npx knip`, `bash scripts/check-orphan-classnames.sh` — clean
- [x] Playwright MCP 5×2: dot ring legible in both themes; console 0/0

## Plan reference

Out of plan — field-guide mobile species-sheet redesign. Implements **#908** (epic **#906**).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
