### PR TITLE
feat(frontend): re-wire mobile sheet analytics dropped by the field-guide port (#909)

### DIFF
--- a/frontend/e2e/sheet-analytics.spec.ts
+++ b/frontend/e2e/sheet-analytics.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, VERMFLY_WITH_PHOTO } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * T3 (#909) — mobile field-guide sheet analytics, driven live.
+ *
+ * T1 (#907) stopped composing <SpeciesDetailSurface> inside the sheet, which
+ * silently dropped three detail-panel events. T3 re-wires them IN the sheet
+ * with the SAME event names + prop shapes as the surface. The unit test mocks
+ * the IntersectionObserver away, so this live spec is the belt-and-suspenders
+ * check that the real observer fires `panel_scrolled_to_bottom` when the user
+ * scrolls `.sheet-fg` to the bottom at the full detent — the only detent the
+ * sheet scrolls. (Analytics were silently dropped once before; this verifies
+ * the wiring survives the real Vite + React + IntersectionObserver pipeline.)
+ *
+ * Spy mechanism: `main.tsx` exposes the singleton `analytics` object on
+ * `window` in DEV. An init-script installs an accessor that wraps the object's
+ * `capture` method the instant `main.tsx` assigns it, recording every event
+ * name into `window.__capturedAnalytics` BEFORE any `panel_opened` can fire.
+ */
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+type CapturedEvent = { name: string; props?: Record<string, unknown> };
+type AnalyticsLike = {
+  capture: (name: string, props?: Record<string, unknown>) => void;
+};
+/** Window augmentation used by the addInitScript spy payload. */
+type WindowWithAnalytics = typeof window & {
+  __capturedAnalytics: CapturedEvent[];
+  analytics?: AnalyticsLike;
+};
+
+/**
+ * Install the analytics spy as an init-script so it is in place before the app
+ * bundle runs. We define an accessor on `window.analytics`: when `main.tsx`
+ * assigns the singleton (the setter fires), we patch its `capture` method to
+ * record into `window.__capturedAnalytics`, then store the patched object.
+ */
+async function installAnalyticsSpy(app: AppPage): Promise<void> {
+  await app.page.addInitScript(() => {
+    const w = window as WindowWithAnalytics;
+    w.__capturedAnalytics = [];
+    let stored: AnalyticsLike | undefined;
+    Object.defineProperty(window, 'analytics', {
+      configurable: true,
+      get() {
+        return stored;
+      },
+      set(value: AnalyticsLike) {
+        stored = value;
+        if (value && typeof value.capture === 'function') {
+          const original = value.capture.bind(value);
+          value.capture = (name: string, props?: Record<string, unknown>) => {
+            w.__capturedAnalytics.push({ name, props });
+            return original(name, props);
+          };
+        }
+      },
+    });
+  });
+}
+
+function countEvents(app: AppPage, name: string): Promise<number> {
+  return app.page.evaluate(
+    (eventName) =>
+      ((window as WindowWithAnalytics).__capturedAnalytics ?? []).filter(
+        (e) => e.name === eventName,
+      ).length,
+    name,
+  );
+}
+
+function firstEventProps(
+  app: AppPage,
+  name: string,
+): Promise<Record<string, unknown> | undefined> {
+  return app.page.evaluate(
+    (eventName) =>
+      ((window as WindowWithAnalytics).__capturedAnalytics ?? []).find(
+        (e) => e.name === eventName,
+      )?.props,
+    name,
+  );
+}
+
+test.describe('SpeciesDetailSheet analytics (#909)', () => {
+  test('panel_opened fires on data-arrival; panel_scrolled_to_bottom fires when .sheet-fg scrolls to bottom at full', async ({
+    page,
+    apiStub,
+  }) => {
+    const app = new AppPage(page);
+    await installAnalyticsSpy(app);
+    await apiStub.stubEmpty();
+    // A long description guarantees the About prose makes .sheet-fg scrollable
+    // at full so the bottom sentinel is reached only after a real scroll.
+    await apiStub.stubSpecies('vermfly', {
+      ...VERMFLY_WITH_PHOTO,
+      descriptionBody:
+        '<p>' +
+        'The Vermilion Flycatcher is a small passerine bird in the tyrant flycatcher family. '.repeat(
+          40,
+        ) +
+        '</p>',
+      descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+    });
+    await apiStub.stubPhotoImage();
+
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    const sheet = page.locator('[data-testid=species-detail-sheet]');
+    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+
+    // panel_opened must have fired once on species data-arrival with the
+    // species_code + has_description shape mirrored from the surface.
+    await expect.poll(() => countEvents(app, 'panel_opened')).toBe(1);
+    expect(await firstEventProps(app, 'panel_opened')).toMatchObject({
+      species_code: 'vermfly',
+      has_description: true,
+    });
+
+    // Advance to full — the only detent at which .sheet-fg scrolls and the
+    // sentinel (after the About block) becomes reachable.
+    const expand = page.getByRole('button', { name: /expand/i });
+    await expand.click();
+    await expect(sheet).toHaveAttribute('data-snap-state', 'full');
+
+    // Scroll the .sheet-fg container to its bottom so the bottom sentinel
+    // crosses the viewport and the IntersectionObserver fires once.
+    await page.locator('.sheet-fg').evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    await expect.poll(() => countEvents(app, 'panel_scrolled_to_bottom')).toBe(1);
+    expect(await firstEventProps(app, 'panel_scrolled_to_bottom')).toMatchObject({
+      species_code: 'vermfly',
+    });
+  });
+});

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SpeciesDetailSheet, resolveContentTier } from './SpeciesDetailSheet.js';
 import { ApiClient } from '../api/client.js';
 import type { SpeciesMeta } from '@bird-watch/shared-types';
 import { __resetSpeciesDetailCache } from '../data/use-species-detail.js';
+import { analytics } from '../analytics.js';
 
 const VERMFLY_WITH_PHOTO: SpeciesMeta = {
   speciesCode: 'vermfly',
@@ -355,6 +356,240 @@ describe('<SpeciesDetailSheet>', () => {
 
     // Cleanup must have removed inert — the modal that takes over starts clean.
     expect(mainEl).not.toHaveAttribute('inert');
+  });
+
+  // ─── Analytics instrumentation (T3 #909, re-wired off SpeciesDetailSurface) ──
+  //
+  // T1 (#907) stopped composing <SpeciesDetailSurface> inside the sheet, which
+  // silently dropped the three detail-panel analytics events. T3 re-wires them
+  // IN the sheet with the SAME event names + prop shapes as the surface
+  // (SpeciesDetailSurface.tsx:78-115):
+  //
+  //   - `panel_opened` on species data-arrival, props {species_code, has_description}
+  //   - `panel_dwell_ms` on unmount (effect cleanup), props {species_code, dwell_ms}
+  //   - `panel_scrolled_to_bottom` on first IntersectionObserver hit on the
+  //     bottom sentinel, prop {species_code}
+  //
+  // `analytics.capture` flows through `safeClarity` (clarity.ts); in jsdom
+  // `window.clarity` is undefined so the wrapper no-ops. We spy on
+  // `analytics.capture` directly to assert the events fire with the right shape.
+
+  describe('analytics instrumentation', () => {
+    function makeClientWith(meta: SpeciesMeta): ApiClient {
+      const client = new ApiClient({ baseUrl: '' });
+      client.getSpecies = vi.fn().mockResolvedValue(meta);
+      client.getSilhouettes = vi.fn().mockResolvedValue([]);
+      return client;
+    }
+
+    it('fires panel_opened once on data resolve with has_description=false when no description', async () => {
+      const captureSpy = vi.spyOn(analytics, 'capture');
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument(),
+      );
+      const openCalls = captureSpy.mock.calls.filter(([name]) => name === 'panel_opened');
+      expect(openCalls).toHaveLength(1);
+      expect(captureSpy).toHaveBeenCalledWith('panel_opened', {
+        species_code: 'vermfly',
+        has_description: false,
+      });
+      captureSpy.mockRestore();
+    });
+
+    it('fires panel_opened with has_description=true when descriptionBody is present', async () => {
+      const captureSpy = vi.spyOn(analytics, 'capture');
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClientWith({
+            ...VERMFLY_WITH_PHOTO,
+            descriptionBody: '<p>Body.</p>',
+            descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+          })}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument(),
+      );
+      expect(captureSpy).toHaveBeenCalledWith('panel_opened', {
+        species_code: 'vermfly',
+        has_description: true,
+      });
+      captureSpy.mockRestore();
+    });
+
+    it('does NOT fire panel_opened before species data resolves', async () => {
+      const captureSpy = vi.spyOn(analytics, 'capture');
+      const client = new ApiClient({ baseUrl: '' });
+      // getSpecies never resolves — the effect's data-arrival guard means
+      // panel_opened must not fire while the sheet is still loading.
+      client.getSpecies = vi.fn().mockReturnValue(new Promise(() => {}));
+      client.getSilhouettes = vi.fn().mockResolvedValue([]);
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={client}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      expect(sheet).toBeInTheDocument();
+      const openCalls = captureSpy.mock.calls.filter(([name]) => name === 'panel_opened');
+      expect(openCalls).toHaveLength(0);
+      captureSpy.mockRestore();
+    });
+
+    it('fires panel_dwell_ms on unmount with species_code and a numeric dwell_ms', async () => {
+      const captureSpy = vi.spyOn(analytics, 'capture');
+      const { unmount } = render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument(),
+      );
+      // panel_opened fired on data resolve; clear so we isolate the unmount call.
+      captureSpy.mockClear();
+      unmount();
+      expect(captureSpy).toHaveBeenCalledWith(
+        'panel_dwell_ms',
+        expect.objectContaining({
+          species_code: 'vermfly',
+          dwell_ms: expect.any(Number),
+        }),
+      );
+      // The dwell payload carries no has_description (analyst groups on the
+      // open-event property at query time) — mirror of the surface contract.
+      const dwellCalls = captureSpy.mock.calls.filter(([name]) => name === 'panel_dwell_ms');
+      for (const [, payload] of dwellCalls) {
+        expect(payload as Record<string, unknown>).not.toHaveProperty('has_description');
+      }
+      captureSpy.mockRestore();
+    });
+
+    it('renders the bottom sentinel as a direct child of .sheet-fg AFTER the About block (no display:none)', async () => {
+      const { container } = render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sentinel = await screen.findByTestId('detail-bottom-sentinel');
+      // aria-hidden so SR users don't perceive an empty element at the end.
+      expect(sentinel).toHaveAttribute('aria-hidden', 'true');
+      // CRITICAL: the sentinel must be a DIRECT child of the scroll container
+      // (.sheet-fg) — the tier-gated .sheet-fg-about block is display:none until
+      // full and never intersects. Direct-child placement keeps it in layout.
+      const scroller = container.querySelector('.sheet-fg');
+      expect(scroller).not.toBeNull();
+      expect(sentinel.parentElement).toBe(scroller);
+      // Must sit AFTER the About block so it only intersects once the user has
+      // scrolled past every content node.
+      const about = container.querySelector('.sheet-fg-about');
+      expect(about).not.toBeNull();
+      expect(
+        about!.compareDocumentPosition(sentinel) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      // The sentinel itself must NOT carry a tier-gated display:none class — it
+      // is the only .sheet-fg child that is intersectable at every detent.
+      expect(sentinel.className).not.toMatch(/sheet-fg-about|sheet-fg-taxonomy/);
+    });
+
+    it('fires panel_scrolled_to_bottom once on first sentinel intersection then disconnects', async () => {
+      // jsdom has no IntersectionObserver; install a controllable class mock
+      // that records each registered callback for manual triggering — same
+      // pattern as SpeciesDetailSurface.test.tsx.
+      type IOInstance = {
+        callback: IntersectionObserverCallback;
+        observe: ReturnType<typeof vi.fn>;
+        disconnect: ReturnType<typeof vi.fn>;
+        unobserve: ReturnType<typeof vi.fn>;
+        takeRecords: ReturnType<typeof vi.fn>;
+      };
+      const observers: IOInstance[] = [];
+      class IOMock {
+        callback: IntersectionObserverCallback;
+        observe = vi.fn();
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+        takeRecords = vi.fn(() => []);
+        constructor(callback: IntersectionObserverCallback) {
+          this.callback = callback;
+          observers.push(this as unknown as IOInstance);
+        }
+      }
+      const originalIO = (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+      (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = IOMock;
+
+      try {
+        const captureSpy = vi.spyOn(analytics, 'capture');
+        const { container } = render(
+          <SpeciesDetailSheet
+            speciesCode="vermfly"
+            apiClient={makeClient()}
+            onClose={vi.fn()}
+            mainRef={{ current: mainEl }}
+          />,
+        );
+        const sentinel = await screen.findByTestId('detail-bottom-sentinel');
+        expect(container).toBeTruthy();
+        expect(observers.length).toBeGreaterThan(0);
+        // Find the observer wired to the sentinel.
+        const wired = observers.find(o =>
+          o.observe.mock.calls.some(call => call[0] === sentinel),
+        );
+        expect(wired).toBeDefined();
+
+        captureSpy.mockClear();
+        act(() => {
+          wired!.callback(
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            wired as unknown as IntersectionObserver,
+          );
+        });
+        expect(captureSpy).toHaveBeenCalledWith('panel_scrolled_to_bottom', {
+          species_code: 'vermfly',
+        });
+        const fires = captureSpy.mock.calls.filter(([name]) => name === 'panel_scrolled_to_bottom');
+        expect(fires).toHaveLength(1);
+        expect(wired!.disconnect).toHaveBeenCalled();
+
+        // Second intersection must NOT re-fire (binary-only contract).
+        captureSpy.mockClear();
+        act(() => {
+          wired!.callback(
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            wired as unknown as IntersectionObserver,
+          );
+        });
+        const reFires = captureSpy.mock.calls.filter(([name]) => name === 'panel_scrolled_to_bottom');
+        expect(reFires).toHaveLength(0);
+        captureSpy.mockRestore();
+      } finally {
+        if (originalIO === undefined) {
+          delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+        } else {
+          (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = originalIO;
+        }
+      }
+    });
   });
 });
 

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -512,17 +512,18 @@ describe('<SpeciesDetailSheet>', () => {
       expect(sentinel.className).not.toMatch(/sheet-fg-about|sheet-fg-taxonomy/);
     });
 
-    it('fires panel_scrolled_to_bottom once on first sentinel intersection then disconnects', async () => {
-      // jsdom has no IntersectionObserver; install a controllable class mock
-      // that records each registered callback for manual triggering — same
-      // pattern as SpeciesDetailSurface.test.tsx.
-      type IOInstance = {
-        callback: IntersectionObserverCallback;
-        observe: ReturnType<typeof vi.fn>;
-        disconnect: ReturnType<typeof vi.fn>;
-        unobserve: ReturnType<typeof vi.fn>;
-        takeRecords: ReturnType<typeof vi.fn>;
-      };
+    // jsdom has no IntersectionObserver; install a controllable class mock that
+    // records each registered callback for manual triggering — same pattern as
+    // SpeciesDetailSurface.test.tsx. Returns the observer list + a restore fn so
+    // both the full-detent and mid-detent cases can share the harness.
+    type IOInstance = {
+      callback: IntersectionObserverCallback;
+      observe: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+      unobserve: ReturnType<typeof vi.fn>;
+      takeRecords: ReturnType<typeof vi.fn>;
+    };
+    function installIOMock(): { observers: IOInstance[]; restore: () => void } {
       const observers: IOInstance[] = [];
       class IOMock {
         callback: IntersectionObserverCallback;
@@ -537,7 +538,20 @@ describe('<SpeciesDetailSheet>', () => {
       }
       const originalIO = (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
       (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = IOMock;
+      return {
+        observers,
+        restore: () => {
+          if (originalIO === undefined) {
+            delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
+          } else {
+            (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = originalIO;
+          }
+        },
+      };
+    }
 
+    it('fires panel_scrolled_to_bottom once on first sentinel intersection then disconnects (at FULL)', async () => {
+      const { observers, restore } = installIOMock();
       try {
         const captureSpy = vi.spyOn(analytics, 'capture');
         const { container } = render(
@@ -550,6 +564,14 @@ describe('<SpeciesDetailSheet>', () => {
         );
         const sentinel = await screen.findByTestId('detail-bottom-sentinel');
         expect(container).toBeTruthy();
+
+        // Advance half → full: the observer is gated on snap === 'full' (#914),
+        // so it only arms once the About content is shown and .sheet-fg scrolls.
+        const expand = await screen.findByRole('button', { name: /expand/i });
+        await userEvent.click(expand);
+        const sheet = await screen.findByTestId('species-detail-sheet');
+        await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
         expect(observers.length).toBeGreaterThan(0);
         // Find the observer wired to the sentinel.
         const wired = observers.find(o =>
@@ -583,11 +605,56 @@ describe('<SpeciesDetailSheet>', () => {
         expect(reFires).toHaveLength(0);
         captureSpy.mockRestore();
       } finally {
-        if (originalIO === undefined) {
-          delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver;
-        } else {
-          (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = originalIO;
+        restore();
+      }
+    });
+
+    it('does NOT arm panel_scrolled_to_bottom at the MID detent — no over-count on open (#914)', async () => {
+      // The bug: the observer used to arm the moment species data resolved, which
+      // is the MID (half) detent on open. At mid the About/taxonomy blocks are
+      // display:none, so .sheet-fg content is short and the trailing sentinel can
+      // already sit within the viewport → the observer fired on open with no real
+      // scroll (an over-count). The detent gate (snap === 'full') means no
+      // observer is wired to the sentinel at mid, so even a simulated intersection
+      // cannot fire the event.
+      const { observers, restore } = installIOMock();
+      try {
+        const captureSpy = vi.spyOn(analytics, 'capture');
+        render(
+          <SpeciesDetailSheet
+            speciesCode="vermfly"
+            apiClient={makeClient()}
+            onClose={vi.fn()}
+            mainRef={{ current: mainEl }}
+          />,
+        );
+        const sheet = await screen.findByTestId('species-detail-sheet');
+        const sentinel = await screen.findByTestId('detail-bottom-sentinel');
+        // Sheet opens at half → MID content tier; the observer must NOT be armed.
+        await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+
+        // No observer is wired to the sentinel at the mid detent.
+        const wired = observers.find(o =>
+          o.observe.mock.calls.some(call => call[0] === sentinel),
+        );
+        expect(wired).toBeUndefined();
+
+        // Even if some pre-existing observer's callback is triggered against the
+        // sentinel, the event must not fire — nothing armed it at mid.
+        captureSpy.mockClear();
+        for (const o of observers) {
+          act(() => {
+            o.callback(
+              [{ isIntersecting: true } as IntersectionObserverEntry],
+              o as unknown as IntersectionObserver,
+            );
+          });
         }
+        const fires = captureSpy.mock.calls.filter(([name]) => name === 'panel_scrolled_to_bottom');
+        expect(fires).toHaveLength(0);
+        captureSpy.mockRestore();
+      } finally {
+        restore();
       }
     });
   });

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -217,28 +217,52 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   // display:none — a display:none element has a zero box and never intersects,
   // so it must stay in layout to be observable. firedRef + observer.disconnect()
   // is the no-double-fire guard (no re-fire across detent changes).
+  //
+  // DETENT GATE (#914 bot finding): the observer is armed ONLY at the `full`
+  // snap. At peek/half the About + taxonomy blocks are display:none, so the
+  // .sheet-fg content is short enough that the trailing sentinel can already sit
+  // within the viewport the moment data resolves — a viewport-rooted observer
+  // would then fire `panel_scrolled_to_bottom` ON OPEN with no actual scroll
+  // (an over-count). The surface (SpeciesDetailSurface.tsx) never collapses, so
+  // its sentinel is reliably below the fold and it can arm on data-resolve; the
+  // sheet's detent collapse breaks that invariant, so we gate on snap === 'full'
+  // — the only detent where the About content is shown and .sheet-fg scrolls.
+  // We also root the observer on the .sheet-fg scroll container (not the
+  // viewport) so "intersecting" means the sentinel has actually been scrolled
+  // into the scroller's box, not merely that it overlaps the layout viewport.
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
   const firedRef = useRef<boolean>(false);
   const speciesCodeForObserver = data?.speciesCode;
   useEffect(() => {
     if (!speciesCodeForObserver) return;
+    // Only count a real scroll-to-bottom at the full detent — peek/half keep the
+    // About/taxonomy blocks display:none, so the sentinel can be visible on open
+    // (over-count). Not arming the observer outside full is the fix.
+    if (snap !== 'full') return;
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
     if (typeof IntersectionObserver === 'undefined') return;
     firedRef.current = false;
-    const observer = new IntersectionObserver(entries => {
-      const intersected = entries.some(entry => entry.isIntersecting);
-      if (intersected && !firedRef.current) {
-        firedRef.current = true;
-        analytics.capture('panel_scrolled_to_bottom', {
-          species_code: speciesCodeForObserver,
-        });
-        observer.disconnect();
-      }
-    });
+    const observer = new IntersectionObserver(
+      entries => {
+        const intersected = entries.some(entry => entry.isIntersecting);
+        if (intersected && !firedRef.current) {
+          firedRef.current = true;
+          analytics.capture('panel_scrolled_to_bottom', {
+            species_code: speciesCodeForObserver,
+          });
+          observer.disconnect();
+        }
+      },
+      // Root on the scroll container so the intersection is relative to the
+      // .sheet-fg box, not the layout viewport. Falls back to the viewport if
+      // the ref is not yet attached.
+      { root: scrollerRef.current ?? null },
+    );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [speciesCodeForObserver]);
+  }, [speciesCodeForObserver, snap]);
 
   // Compute snap heights against the live viewport. Recompute on
   // resize so an orientation change or mobile-Safari URL-bar collapse
@@ -533,8 +557,10 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       {/* Field-guide layout: three size-appropriate tiers in one grid that
           re-templates per [data-content]. The photo is a SINGLE <Photo>
           element kept mounted across detents; only its frame morphs via CSS.
-          The grid scrolls (tabIndex=0 satisfies axe scrollable-region-focusable). */}
-      <div className="sheet-fg" tabIndex={0}>
+          The grid scrolls (tabIndex=0 satisfies axe scrollable-region-focusable).
+          scrollerRef is the IntersectionObserver root for the bottom sentinel
+          at the full detent — see the panel_scrolled_to_bottom effect. */}
+      <div className="sheet-fg" tabIndex={0} ref={scrollerRef}>
         <div className="sheet-fg-photo">
           {/* Decorative photo (alt=""): the species name always sits adjacent
               and we have no plumage metadata, so a non-empty alt would triple-

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -16,6 +16,7 @@ import {
   buildFamilyPathResolver,
   buildFamilyImgUrlResolver,
 } from '../data/family-color.js';
+import { analytics } from '../analytics.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
 import { Photo } from './ds/Photo.js';
 import type { FamilyCode } from '../config/family-palette.js';
@@ -181,6 +182,63 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const resolveColor = useMemo(() => buildFamilyColorResolver(silhouettes), [silhouettes]);
   const resolvePath = useMemo(() => buildFamilyPathResolver(silhouettes), [silhouettes]);
   const resolveImgUrl = useMemo(() => buildFamilyImgUrlResolver(silhouettes), [silhouettes]);
+
+  // ── Analytics (T3 #909) ──────────────────────────────────────────────────
+  // Re-wired off SpeciesDetailSurface (SpeciesDetailSurface.tsx:73-115): T1
+  // (#907) stopped composing the surface inside this sheet and silently dropped
+  // these three events. They are reproduced here verbatim — same event names
+  // and prop shapes — so the mobile funnel keeps emitting them. The sheet must
+  // NOT import SpeciesDetailSurface (it owns its own layout); only the analytics
+  // contract is shared.
+  //
+  // panel_opened / panel_dwell_ms — fire on species data-arrival, dwell on
+  // effect cleanup. Keyed on data?.speciesCode so a species change re-fires the
+  // pair (dwell for the old, open for the new).
+  useEffect(() => {
+    if (!data?.speciesCode) return;
+    const t0 = Date.now();
+    const code = data.speciesCode;
+    analytics.capture('panel_opened', {
+      species_code: code,
+      has_description: !!data.descriptionBody,
+    });
+    return () => {
+      analytics.capture('panel_dwell_ms', {
+        species_code: code,
+        dwell_ms: Date.now() - t0,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.speciesCode]);
+
+  // panel_scrolled_to_bottom — first IntersectionObserver hit on the bottom
+  // sentinel, once per species. The sentinel is a DIRECT child of .sheet-fg
+  // (the only detent scroll container) AFTER the About block, with no tier-gated
+  // display:none — a display:none element has a zero box and never intersects,
+  // so it must stay in layout to be observable. firedRef + observer.disconnect()
+  // is the no-double-fire guard (no re-fire across detent changes).
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const firedRef = useRef<boolean>(false);
+  const speciesCodeForObserver = data?.speciesCode;
+  useEffect(() => {
+    if (!speciesCodeForObserver) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+    firedRef.current = false;
+    const observer = new IntersectionObserver(entries => {
+      const intersected = entries.some(entry => entry.isIntersecting);
+      if (intersected && !firedRef.current) {
+        firedRef.current = true;
+        analytics.capture('panel_scrolled_to_bottom', {
+          species_code: speciesCodeForObserver,
+        });
+        observer.disconnect();
+      }
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [speciesCodeForObserver]);
 
   // Compute snap heights against the live viewport. Recompute on
   // resize so an orientation change or mobile-Safari URL-bar collapse
@@ -573,6 +631,19 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
             <p className="sheet-fg-prose">No description available.</p>
           )}
         </div>
+
+        {/* Bottom sentinel for panel_scrolled_to_bottom (T3 #909). A DIRECT
+            child of .sheet-fg AFTER the About block with NO tier-gated
+            display:none: the .sheet-fg-about/.sheet-fg-taxonomy blocks are
+            display:none until full, and a display:none element has a zero box
+            that never intersects. The sentinel must stay in layout so the
+            IntersectionObserver can fire when the user scrolls the About prose
+            into view at the full detent (the only detent .sheet-fg scrolls). */}
+        <div
+          ref={sentinelRef}
+          data-testid="detail-bottom-sentinel"
+          aria-hidden="true"
+        />
       </div>
     </div>
   );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './App.js';
+import { analytics } from './analytics.js';
 // Importing for the side effect: `clarity.ts` reads `VITE_CLARITY_PROJECT_ID`
 // and (in production builds only) calls `Clarity.init` once at app
 // startup. When the env var is empty OR the build is non-production, the
@@ -10,6 +11,17 @@ import './styles/tokens.css';
 import './styles.css';
 import './styles/motion.css';
 import './components/ds/ds-primitives.css';
+
+// Dev/test-only analytics spy hook (T3 #909). Exposes the singleton `analytics`
+// object on `window` so e2e specs can wrap `window.analytics.capture` and assert
+// events that otherwise have no observable surface in dev (Clarity is never
+// init'd outside production builds, so `analytics.capture` is a silent no-op).
+// Because components import the SAME `analytics` object, replacing its `capture`
+// property via `window.analytics` is observed by every call site. Gated by
+// `import.meta.env.DEV` → tree-shaken entirely from production builds.
+if (import.meta.env.DEV) {
+  (window as unknown as { analytics?: typeof analytics }).analytics = analytics;
+}
 
 // Dev-only design-system preview shim. Activated by ?ds-preview=<key>.
 // import.meta.env.DEV is false in production builds (tree-shaken entirely).


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
  participant User
  participant Sheet as SpeciesDetailSheet
  participant A as analytics
  User->>Sheet: open species detail (data resolves)
  Sheet->>A: panel_opened {species_code, has_description}
  User->>Sheet: scroll .sheet-fg to bottom at full (sentinel intersects)
  Sheet->>A: panel_scrolled_to_bottom {species_code}
  User->>Sheet: close (unmount)
  Sheet->>A: panel_dwell_ms {species_code, dwell_ms}
```

## Summary

- **Why:** T1 (#912) stopped composing `SpeciesDetailSurface` inside the mobile sheet, which silently dropped the three mobile analytics events (`panel_opened` / `panel_dwell_ms` / `panel_scrolled_to_bottom`). This re-wires them natively in `SpeciesDetailSheet`, with the **same event names + prop shapes** as the surface.
- The `panel_scrolled_to_bottom` sentinel is a direct child of `.sheet-fg` with **no tier-gated `display:none`** (a `display:none` element never intersects) — it only meaningfully intersects at the full detent, the only one `.sheet-fg` scrolls.
- Scope: mobile sheet only; does not import `SpeciesDetailSurface`.

## Screenshots

N/A — not UI. The only DOM addition is an empty, `aria-hidden`, zero-box sentinel `<div>` (no className, no visible layout change); confirmed by the passing 390×844 zero-console e2e sweep.

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — 1138 pass (incl. 6 new analytics unit tests: panel_opened-once, has_description t/f, no-fire-before-resolve, dwell-on-unmount, sentinel placement, scroll-once-then-disconnect)
- [x] New e2e `sheet-analytics.spec.ts` — opens to full, scrolls `.sheet-fg` to bottom, asserts `panel_opened` + `panel_scrolled_to_bottom` via a `window` analytics spy — **1 passed**
- [x] `npm run build -w @bird-watch/frontend`, `lint`, `knip`, `orphan-classname-check` — clean
- [x] Rebased onto T2 (#913); full suite green post-rebase

## Plan reference

Out of plan — field-guide mobile species-sheet redesign. Implements **#909** (epic **#906**).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
