### PR TITLE
feat(frontend): field-guide sheet a11y contract — F8 trap, F9 restore, F10 announce + tuning (#910)

### DIFF
--- a/frontend/e2e/sheet-focus-trap.spec.ts
+++ b/frontend/e2e/sheet-focus-trap.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect, VERMFLY_WITH_PHOTO } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+
+/**
+ * F8 (#910) — real focus trap at the FULL detent.
+ *
+ * At full the sheet is role="dialog"/aria-modal, but `inert` only covers
+ * #map-layer (the O1 unified target). The AppHeader floating chrome sits above
+ * the backdrop and stays tabbable, so Tab used to escape the dialog into an
+ * AppHeader control. T4 installs a Tab/Shift+Tab wrap (mirror of the
+ * filters-panel trap) active ONLY at snap==='full'. This live spec drives the
+ * real DOM + keyboard pipeline:
+ *   • Tab from the LAST focusable in the sheet stays in the sheet AND the
+ *     AppHeader Filters trigger is NOT the active element.
+ *   • Shift+Tab from the FIRST focusable wraps to the last (stays in sheet).
+ */
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.describe('SpeciesDetailSheet focus trap at full (#910)', () => {
+  test('Tab from the last focusable stays in the sheet (AppHeader Filters not active); Shift+Tab from first → last', async ({
+    page,
+    apiStub,
+  }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+    await apiStub.stubPhotoImage();
+    const app = new AppPage(page);
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    const sheet = page.locator('[data-testid=species-detail-sheet]');
+    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+
+    // Advance half → full so the trap is installed and inert covers #map-layer.
+    await page.getByRole('button', { name: /expand/i }).click();
+    await expect(sheet).toHaveAttribute('data-snap-state', 'full');
+    await expect(sheet).toHaveAttribute('role', 'dialog');
+    await expect(app.mapLayer).toHaveAttribute('inert', '');
+
+    // Wait for the mid→full reveal to settle: at full the mid-only teaser
+    // ("Read account") transitions to opacity:0 (recipe-18). Until it settles,
+    // the teaser button still computes as visible, so the focusable set (and the
+    // wrap target) is non-deterministic. Poll the teaser to opacity:0 — the same
+    // settle discipline axe.spec.ts uses — so first/last are stable.
+    await page
+      .waitForFunction(() => {
+        const teaser = document.querySelector('.sheet-fg-teaser');
+        if (!teaser) return true;
+        return Number(getComputedStyle(teaser).opacity) === 0;
+      }, undefined, { timeout: 5_000 })
+      .catch(() => {
+        /* best-effort settle; assertions below still run */
+      });
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    // Focus the LAST focusable inside the sheet, then Tab forward. The wrap must
+    // keep focus inside the sheet (and specifically NOT move it to the AppHeader
+    // Filters trigger, which is reachable absent a trap because inert covers only
+    // #map-layer).
+    await sheet.evaluate((el, sel) => {
+      // Match the component's isVisible: walk UP to the sheet checking computed
+      // display/visibility/opacity. The opacity:0 lives on the .sheet-fg-teaser
+      // PARENT, not the readaccount button, so an element-only check would keep
+      // the button — the ancestor walk is what excludes it (mirroring the trap).
+      const visible = (i: HTMLElement): boolean => {
+        let node: HTMLElement | null = i;
+        while (node && node !== el.parentElement) {
+          const cs = getComputedStyle(node);
+          if (
+            cs.display === 'none' ||
+            cs.visibility === 'hidden' ||
+            cs.opacity === '0'
+          ) {
+            return false;
+          }
+          node = node.parentElement;
+        }
+        return true;
+      };
+      const items = Array.from(el.querySelectorAll<HTMLElement>(sel)).filter(
+        visible,
+      );
+      items[items.length - 1]?.focus();
+    }, focusableSelector);
+
+    // Sanity: the AppHeader Filters trigger exists and is NOT currently focused.
+    await expect(app.filtersTrigger).toBeVisible();
+    await page.keyboard.press('Tab');
+
+    // Focus stayed inside the sheet …
+    const focusInSheetAfterTab = await sheet.evaluate(
+      (el) => el.contains(document.activeElement),
+    );
+    expect(focusInSheetAfterTab).toBe(true);
+    // … and the AppHeader Filters trigger is NOT the active element.
+    const filtersIsActive = await app.filtersTrigger.evaluate(
+      (el) => el === document.activeElement,
+    );
+    expect(filtersIsActive).toBe(false);
+    // The forward-from-last wrap lands on the FIRST sheet focusable.
+    const onFirstAfterTab = await sheet.evaluate((el, sel) => {
+      // Match the component's visibility filter: at full the mid-only teaser
+      // (with the "Read account" button) is hidden via opacity:0, so it is not
+      // a real focus target and must be excluded when computing first/last.
+      // Match the component's isVisible: walk UP to the sheet checking computed
+      // display/visibility/opacity. The opacity:0 lives on the .sheet-fg-teaser
+      // PARENT, not the readaccount button, so an element-only check would keep
+      // the button — the ancestor walk is what excludes it (mirroring the trap).
+      const visible = (i: HTMLElement): boolean => {
+        let node: HTMLElement | null = i;
+        while (node && node !== el.parentElement) {
+          const cs = getComputedStyle(node);
+          if (
+            cs.display === 'none' ||
+            cs.visibility === 'hidden' ||
+            cs.opacity === '0'
+          ) {
+            return false;
+          }
+          node = node.parentElement;
+        }
+        return true;
+      };
+      const items = Array.from(el.querySelectorAll<HTMLElement>(sel)).filter(
+        visible,
+      );
+      return items[0] === document.activeElement;
+    }, focusableSelector);
+    expect(onFirstAfterTab).toBe(true);
+
+    // Now focus the FIRST focusable and Shift+Tab back → wraps to the LAST.
+    await sheet.evaluate((el, sel) => {
+      // Match the component's isVisible: walk UP to the sheet checking computed
+      // display/visibility/opacity. The opacity:0 lives on the .sheet-fg-teaser
+      // PARENT, not the readaccount button, so an element-only check would keep
+      // the button — the ancestor walk is what excludes it (mirroring the trap).
+      const visible = (i: HTMLElement): boolean => {
+        let node: HTMLElement | null = i;
+        while (node && node !== el.parentElement) {
+          const cs = getComputedStyle(node);
+          if (
+            cs.display === 'none' ||
+            cs.visibility === 'hidden' ||
+            cs.opacity === '0'
+          ) {
+            return false;
+          }
+          node = node.parentElement;
+        }
+        return true;
+      };
+      const items = Array.from(el.querySelectorAll<HTMLElement>(sel)).filter(
+        visible,
+      );
+      items[0]?.focus();
+    }, focusableSelector);
+    await page.keyboard.press('Shift+Tab');
+
+    const onLastAfterShiftTab = await sheet.evaluate((el, sel) => {
+      // Match the component's visibility filter: at full the mid-only teaser
+      // (with the "Read account" button) is hidden via opacity:0, so it is not
+      // a real focus target and must be excluded when computing first/last.
+      // Match the component's isVisible: walk UP to the sheet checking computed
+      // display/visibility/opacity. The opacity:0 lives on the .sheet-fg-teaser
+      // PARENT, not the readaccount button, so an element-only check would keep
+      // the button — the ancestor walk is what excludes it (mirroring the trap).
+      const visible = (i: HTMLElement): boolean => {
+        let node: HTMLElement | null = i;
+        while (node && node !== el.parentElement) {
+          const cs = getComputedStyle(node);
+          if (
+            cs.display === 'none' ||
+            cs.visibility === 'hidden' ||
+            cs.opacity === '0'
+          ) {
+            return false;
+          }
+          node = node.parentElement;
+        }
+        return true;
+      };
+      const items = Array.from(el.querySelectorAll<HTMLElement>(sel)).filter(
+        visible,
+      );
+      return items[items.length - 1] === document.activeElement;
+    }, focusableSelector);
+    expect(onLastAfterShiftTab).toBe(true);
+    const filtersActiveAfterShift = await app.filtersTrigger.evaluate(
+      (el) => el === document.activeElement,
+    );
+    expect(filtersActiveAfterShift).toBe(false);
+  });
+});

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -657,6 +659,518 @@ describe('<SpeciesDetailSheet>', () => {
         restore();
       }
     });
+
+    it('fires panel_scrolled_to_bottom AT MOST ONCE per species across a full→half→full round-trip (#910 once-per-species latch)', async () => {
+      // T3 bot finding: firedRef reset on every full re-arm, so a full→half→full
+      // round-trip re-fired the event for the SAME species (an over-count). The
+      // latch is now keyed on speciesCode — it does NOT reset when merely
+      // re-entering full for the same species (resets only on a species change).
+      const { observers, restore } = installIOMock();
+      try {
+        const captureSpy = vi.spyOn(analytics, 'capture');
+        render(
+          <SpeciesDetailSheet
+            speciesCode="vermfly"
+            apiClient={makeClient()}
+            onClose={vi.fn()}
+            mainRef={{ current: mainEl }}
+          />,
+        );
+        const sheet = await screen.findByTestId('species-detail-sheet');
+        const sentinel = await screen.findByTestId('detail-bottom-sentinel');
+
+        // First full: arm + intersect → fire once.
+        const expand = await screen.findByRole('button', { name: /expand/i });
+        await userEvent.click(expand);
+        await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+        const wired1 = observers.find(o =>
+          o.observe.mock.calls.some(call => call[0] === sentinel),
+        );
+        expect(wired1).toBeDefined();
+        captureSpy.mockClear();
+        act(() => {
+          wired1!.callback(
+            [{ isIntersecting: true } as IntersectionObserverEntry],
+            wired1 as unknown as IntersectionObserver,
+          );
+        });
+        expect(
+          captureSpy.mock.calls.filter(([name]) => name === 'panel_scrolled_to_bottom'),
+        ).toHaveLength(1);
+
+        // full → half (the observer disarms) ...
+        const collapse = await screen.findByRole('button', { name: /collapse/i });
+        await userEvent.click(collapse);
+        await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+
+        // ... then back to full (re-arm for the SAME species). The latch must NOT
+        // reset — a second intersection must not re-fire.
+        const expand2 = await screen.findByRole('button', { name: /expand/i });
+        await userEvent.click(expand2);
+        await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+        captureSpy.mockClear();
+        for (const o of observers) {
+          act(() => {
+            o.callback(
+              [{ isIntersecting: true } as IntersectionObserverEntry],
+              o as unknown as IntersectionObserver,
+            );
+          });
+        }
+        expect(
+          captureSpy.mock.calls.filter(([name]) => name === 'panel_scrolled_to_bottom'),
+        ).toHaveLength(0);
+        captureSpy.mockRestore();
+      } finally {
+        restore();
+      }
+    });
+  });
+});
+
+// ─── F8/F9/F10 a11y contract (T4 #910) ──────────────────────────────────────
+//
+// F8 — real focus trap at full. At full the sheet is role=dialog/aria-modal but
+//   inert only covers #map-layer; Tab used to escape into the still-tabbable
+//   AppHeader. The sheet now installs a Tab/Shift+Tab wrap (mirror of the
+//   filters-panel trap in App.tsx) active ONLY at snap==='full'.
+// F9 — focus restore on close. The sheet captures document.activeElement on
+//   mount and restores it (if still attached) on EVERY close path; else falls
+//   back to #main-surface.
+// F10 — announce on reaching a readable detent. A visually-hidden
+//   aria-live="polite" region inside the sheet root announces once per readable
+//   detent (first peek→half), not re-firing on full→half, and never at peek.
+
+describe('<SpeciesDetailSheet> — F8 focus trap at full (#910)', () => {
+  let mainEl: HTMLElement;
+  let headerBtn: HTMLButtonElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    // A real <main id="main-surface"> so the F9 fallback (and its non-null
+    // assertion) resolves; an AppHeader control sibling so the trap has an
+    // off-sheet focusable to (not) escape to.
+    mainEl = document.createElement('main');
+    mainEl.id = 'main-surface';
+    mainEl.tabIndex = 0;
+    document.body.appendChild(mainEl);
+    headerBtn = document.createElement('button');
+    headerBtn.type = 'button';
+    headerBtn.textContent = 'Filters';
+    document.body.appendChild(headerBtn);
+    __resetSpeciesDetailCache();
+  });
+
+  it('F9 fallback target #main-surface is present in the DOM (cannot silently no-op)', () => {
+    // The restore fallback queries #main-surface; if that element is ever
+    // renamed/removed the fallback drops focus onto <body> silently. This guard
+    // asserts the fallback selector resolves in the test harness DOM.
+    expect(document.querySelector('#main-surface')).not.toBeNull();
+  });
+
+  it('Tab from the LAST focusable in the sheet wraps to the first (stays in sheet, AppHeader not reachable)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const items = Array.from(sheet.querySelectorAll<HTMLElement>(focusableSelector));
+    expect(items.length).toBeGreaterThan(0);
+    const first = items[0]!;
+    const last = items[items.length - 1]!;
+
+    // Land on the last focusable, then Tab forward — the wrap must return focus
+    // to the first sheet focusable, never to the AppHeader Filters button.
+    last.focus();
+    expect(last).toHaveFocus();
+    await userEvent.tab();
+    expect(sheet.contains(document.activeElement)).toBe(true);
+    expect(headerBtn).not.toHaveFocus();
+    expect(first).toHaveFocus();
+  });
+
+  it('Shift+Tab from the FIRST focusable wraps to the last (stays in sheet)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const items = Array.from(sheet.querySelectorAll<HTMLElement>(focusableSelector));
+    const first = items[0]!;
+    const last = items[items.length - 1]!;
+
+    first.focus();
+    expect(first).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(sheet.contains(document.activeElement)).toBe(true);
+    expect(headerBtn).not.toHaveFocus();
+    expect(last).toHaveFocus();
+  });
+
+  it('the trap is NOT installed at half (Tab can leave the sheet) and not at peek', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // Opens at half — NOT full. At half the map underneath is interactive, so
+    // a trap would be wrong (and the role is region, not dialog).
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const items = Array.from(sheet.querySelectorAll<HTMLElement>(focusableSelector));
+    const last = items[items.length - 1]!;
+    last.focus();
+    // No wrap handler at half → Tab is NOT preventDefault'd. We assert the
+    // sheet did NOT force focus back to its first element (the half-detent
+    // behavior is the browser's native order; the trap must be absent).
+    await userEvent.tab();
+    expect(items[0]).not.toHaveFocus();
+  });
+
+  it('the trap tears down when leaving full → half (Tab no longer wrapped)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+
+    // Collapse back to half — the trap must be removed.
+    const collapse = await screen.findByRole('button', { name: /collapse/i });
+    await userEvent.click(collapse);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const items = Array.from(sheet.querySelectorAll<HTMLElement>(focusableSelector));
+    const last = items[items.length - 1]!;
+    last.focus();
+    await userEvent.tab();
+    // No wrap at half → focus is not forced back to the first item.
+    expect(items[0]).not.toHaveFocus();
+  });
+});
+
+describe('<SpeciesDetailSheet> — F9 focus restore on close (#910)', () => {
+  let mainEl: HTMLElement;
+  let opener: HTMLButtonElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    mainEl = document.createElement('main');
+    mainEl.id = 'main-surface';
+    mainEl.tabIndex = 0;
+    document.body.appendChild(mainEl);
+    // The element that "opened" the sheet — focus on mount, restored on close.
+    opener = document.createElement('button');
+    opener.type = 'button';
+    opener.textContent = 'Open detail';
+    document.body.appendChild(opener);
+    __resetSpeciesDetailCache();
+  });
+
+  it('restores focus on the keyboard close path (ESC at peek collapses → onClose → restore)', async () => {
+    // The sheet has no dedicated close BUTTON — the handle toggles
+    // expand/collapse and closing is the collapse() call at the peek detent,
+    // reached by ESC (keyboard) or drag-dismiss (pointer). This covers the
+    // keyboard close: ESC with focus inside the sheet at peek → collapse() →
+    // closeWithRestore() → onClose, restoring focus to the opener.
+    const onClose = vi.fn();
+    opener.focus();
+    expect(opener).toHaveFocus();
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={onClose}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    // Drag half → peek (a slow short downward drag settles to the nearest detent).
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 1, bubbles: true }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+    // ESC with focus inside the sheet at peek → collapse() → onClose.
+    handle.focus();
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    await waitFor(() => expect(opener).toHaveFocus());
+  });
+
+  it('restores focus on ESC close stepping down from half (ESC half→peek, ESC peek→onClose → restore)', async () => {
+    const onClose = vi.fn();
+    opener.focus();
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={onClose}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    // Pure-keyboard close: ESC with focus inside the sheet steps the detent down
+    // (collapse): half → peek, then peek → onClose. No pointer drag involved.
+    handle.focus();
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+    handle.focus();
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    await waitFor(() => expect(opener).toHaveFocus());
+  });
+
+  it('restores focus on drag-dismiss close', async () => {
+    const onClose = vi.fn();
+    opener.focus();
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={onClose}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    // A long drag-down past the dismiss floor calls onClose directly.
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 3, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 700, pointerId: 3, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 700, pointerId: 3, bubbles: true }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    await waitFor(() => expect(opener).toHaveFocus());
+  });
+
+  it('falls back to #main-surface when the previously-focused element is detached at close', async () => {
+    const onClose = vi.fn();
+    opener.focus();
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={onClose}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    // Detach the opener BEFORE close so document.contains(previous) is false →
+    // the restore must fall back to #main-surface, not silently drop to <body>.
+    opener.remove();
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 4, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 700, pointerId: 4, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 700, pointerId: 4, bubbles: true }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    await waitFor(() => expect(mainEl).toHaveFocus());
+  });
+});
+
+describe('<SpeciesDetailSheet> — F10 announce on readable detent (#910)', () => {
+  let mainEl: HTMLElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    mainEl = document.createElement('main');
+    mainEl.id = 'main-surface';
+    mainEl.tabIndex = 0;
+    document.body.appendChild(mainEl);
+    __resetSpeciesDetailCache();
+  });
+
+  /** The visually-hidden live region is a descendant of the sheet root so it is
+   *  announced under aria-modal at full. It carries aria-live="polite". */
+  const liveRegion = (sheet: HTMLElement) =>
+    sheet.querySelector<HTMLElement>('[data-testid="sheet-live-region"]');
+
+  it('renders an aria-live="polite" region inside the sheet root (sr-only)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const region = liveRegion(sheet);
+    expect(region).not.toBeNull();
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    // Must be a DESCENDANT of the sheet root so it is announced under aria-modal.
+    expect(sheet.contains(region)).toBe(true);
+    // Visually hidden — the sr-only convention used app-wide.
+    expect(region!.className).toMatch(/sr-only/);
+  });
+
+  it('announces the species once on opening at the readable half detent', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    // The species name resolves and the half detent is readable → announce.
+    await waitFor(() =>
+      expect(liveRegion(sheet)!.textContent).toMatch(/vermilion flycatcher/i),
+    );
+  });
+
+  it('does NOT re-announce on full→half (single announce per readable detent)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    await waitFor(() =>
+      expect(liveRegion(sheet)!.textContent).toMatch(/vermilion flycatcher/i),
+    );
+    // Advance half → full. At full the heading-focus move owns the announce
+    // (we do NOT double-fire the live region at full).
+    const expand = await screen.findByRole('button', { name: /expand/i });
+    await userEvent.click(expand);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+    // Clear the live region's text via a re-read marker: capture the current
+    // text, return to half, and assert the live region content did NOT change
+    // (no re-announce on full→half — the half detent was already announced).
+    const before = liveRegion(sheet)!.textContent;
+    const collapse = await screen.findByRole('button', { name: /collapse/i });
+    await userEvent.click(collapse);
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    // The re-entry to half must NOT push a fresh announce (same text reference).
+    expect(liveRegion(sheet)!.textContent).toBe(before);
+  });
+
+  it('does NOT announce at the peek detent (map focus is preserved)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeNoPhotoClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    // The half open already announced; drag to peek and assert peek did not add
+    // a fresh announce beyond the half one (text unchanged) — peek is below the
+    // readable threshold. (We assert peek itself doesn't push an announce by
+    // checking the announce count via the text not flipping to empty/peek-only.)
+    const halfText = liveRegion(sheet)!.textContent;
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 5, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 5, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 5, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 5, bubbles: true }));
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+    expect(liveRegion(sheet)!.textContent).toBe(halfText);
+  });
+});
+
+describe('<SpeciesDetailSheet> — F14 reduced-motion resting end-state (#910)', () => {
+  // motion.css collapses all transition/animation durations to 0ms under
+  // prefers-reduced-motion. The reveal channels (sci/record/teaser/taxonomy/
+  // about) start at opacity:0 + translateY + blur and only reach the resting
+  // end-state via a [data-content='<tier>'] selector. This asserts that for
+  // each tier the resting end-state RULE exists in the authored CSS — so under
+  // reduced-motion (instant transition) the content lands at its resting state,
+  // never stuck invisible.
+  // import.meta.url is not always a file:// URL under jsdom; resolve via
+  // import.meta.dirname + join like tokens.css.test.ts (release-1 note).
+  const css = readFileSync(join(import.meta.dirname, '../styles.css'), 'utf8');
+
+  it('global reduced-motion policy collapses transitions/animations to 0ms', () => {
+    const motion = readFileSync(
+      join(import.meta.dirname, '../styles/motion.css'),
+      'utf8',
+    );
+    expect(motion).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(motion).toMatch(/transition-duration:\s*0ms\s*!important/);
+    expect(motion).toMatch(/animation-duration:\s*0ms\s*!important/);
+  });
+
+  it('every reveal channel has a resting end-state (opacity:1) at its tier', () => {
+    // MID reveal channels resolve to opacity:1 under [data-content='mid'].
+    expect(css).toMatch(
+      /\[data-content='mid'\][^{]*\.sheet-fg-record[\s\S]*?opacity:\s*1/,
+    );
+    // FULL reveal channels resolve to opacity:1 under [data-content='full'].
+    expect(css).toMatch(
+      /\[data-content='full'\][^{]*\.sheet-fg-about[\s\S]*?opacity:\s*1/,
+    );
+    expect(css).toMatch(
+      /\[data-content='full'\][^{]*\.sheet-fg-taxonomy[\s\S]*?opacity:\s*1/,
+    );
+  });
+});
+
+describe('<SpeciesDetailSheet> — F8 false-comment cleanup + dead CSS (#910)', () => {
+  const css = readFileSync(join(import.meta.dirname, '../styles.css'), 'utf8');
+
+  it('the false "non-interactive" chrome comment is removed', () => {
+    // The block claimed "chrome remains visible but non-interactive while the
+    // modal sheet is open." — false once the AppHeader is reachable by Tab. F8
+    // installs a real trap; the comment must go (the --z-modal rationale stays).
+    expect(css).not.toMatch(/non-interactive\s+while the modal sheet is open/);
+  });
+
+  it('dead .sheet-fg-credits CSS is removed (credit comes from <SpeciesDescription>)', () => {
+    // No `sheet-fg-credits` className is rendered; the credit is the
+    // .species-detail-description-credit paragraph inside <SpeciesDescription>.
+    expect(css).not.toMatch(/\.sheet-fg-credits\b/);
   });
 });
 

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -143,6 +143,21 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const { speciesCode, apiClient, onClose, mainRef, onSnapChange } = props;
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
+  // F9 (#910) — focus restore on close. Capture document.activeElement on mount
+  // so EVERY close path (button, ESC, drag-dismiss) can return focus to whatever
+  // opened the sheet. Mirrors SpeciesDetailRail/AttributionModal's
+  // document.contains-guarded restore; the fallback is #main-surface (a real,
+  // focusable <main tabIndex={0}>, App.tsx) — NOT the dead #surface-tab-map.
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  // F10 (#910) — visually-hidden polite live region. At HALF the identity
+  // becomes legible but, unlike full, no focus moves into the dialog, so AT
+  // gets no entry announcement. We announce the species into this region on the
+  // FIRST readable detent (peek→half) only — never at peek (map focus must
+  // persist) and never again on full→half (the full focus-move owns the full
+  // announce; re-announcing would double-fire). `announcedRef` is the
+  // once-per-readable-detent latch.
+  const [liveMessage, setLiveMessage] = useState<string>('');
+  const announcedRef = useRef<boolean>(false);
   // Open at `half` (the plate-card detent) for immediate readability; the
   // identity-row detent (`peek`) is the map-preserving collapsed state,
   // reached by dragging down.
@@ -215,8 +230,17 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   // sentinel, once per species. The sentinel is a DIRECT child of .sheet-fg
   // (the only detent scroll container) AFTER the About block, with no tier-gated
   // display:none — a display:none element has a zero box and never intersects,
-  // so it must stay in layout to be observable. firedRef + observer.disconnect()
-  // is the no-double-fire guard (no re-fire across detent changes).
+  // so it must stay in layout to be observable. firedForSpeciesRef +
+  // observer.disconnect() is the no-double-fire guard.
+  //
+  // ONCE PER SPECIES (#910 T3 bot finding): the latch is keyed on speciesCode,
+  // NOT a plain boolean that resets on every full re-arm. A full→half→full
+  // round-trip re-arms the observer (the effect re-runs on the snap change), but
+  // the latch must NOT reset for the SAME species — otherwise a second
+  // intersection re-fires `panel_scrolled_to_bottom` for a species we already
+  // counted. We reset the latch only when the species changes (the stored code
+  // differs from the current one), so each species fires the event at most once
+  // across the whole detail session.
   //
   // DETENT GATE (#914 bot finding): the observer is armed ONLY at the `full`
   // snap. At peek/half the About + taxonomy blocks are display:none, so the
@@ -232,7 +256,10 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   // into the scroller's box, not merely that it overlaps the layout viewport.
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
-  const firedRef = useRef<boolean>(false);
+  // Stores the speciesCode that already fired `panel_scrolled_to_bottom`. The
+  // latch is "has THIS species fired?" — keyed on the code, not a boolean that
+  // resets on every full re-arm (#910). null = nothing fired yet.
+  const firedForSpeciesRef = useRef<string | null>(null);
   const speciesCodeForObserver = data?.speciesCode;
   useEffect(() => {
     if (!speciesCodeForObserver) return;
@@ -243,12 +270,14 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
     if (typeof IntersectionObserver === 'undefined') return;
-    firedRef.current = false;
+    // Already fired for THIS species? Don't re-arm — a full→half→full round-trip
+    // for the same species must not re-fire the event (#910 once-per-species).
+    if (firedForSpeciesRef.current === speciesCodeForObserver) return;
     const observer = new IntersectionObserver(
       entries => {
         const intersected = entries.some(entry => entry.isIntersecting);
-        if (intersected && !firedRef.current) {
-          firedRef.current = true;
+        if (intersected && firedForSpeciesRef.current !== speciesCodeForObserver) {
+          firedForSpeciesRef.current = speciesCodeForObserver;
           analytics.capture('panel_scrolled_to_bottom', {
             species_code: speciesCodeForObserver,
           });
@@ -338,6 +367,25 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     [mainRef],
   );
 
+  // F9 (#910) — close + restore focus. Restore to the previously-focused
+  // element if it's still attached (calling .focus() on a detached node is a
+  // silent no-op that drops focus onto <body>), otherwise fall back to the
+  // stable #main-surface landmark. Used by every close path so keyboard users
+  // never lose their place when the sheet dismisses.
+  const closeWithRestore = useCallback(() => {
+    const previous = previouslyFocusedRef.current;
+    const isAttached =
+      previous !== null &&
+      typeof previous.focus === 'function' &&
+      document.contains(previous);
+    if (isAttached) {
+      previous!.focus();
+    } else {
+      document.querySelector<HTMLElement>('#main-surface')?.focus();
+    }
+    onClose();
+  }, [onClose]);
+
   const expand = useCallback(() => {
     if (snap === 'peek') goToSnap('half');
     else if (snap === 'half') goToSnap('full');
@@ -346,8 +394,8 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const collapse = useCallback(() => {
     if (snap === 'full') goToSnap('half');
     else if (snap === 'half') goToSnap('peek');
-    else onClose();
-  }, [snap, goToSnap, onClose]);
+    else closeWithRestore();
+  }, [snap, goToSnap, closeWithRestore]);
 
   // ESC scoped: only collapse when focus is inside the sheet. If focus
   // is on a map element (cluster button), MapLibre handles ESC itself.
@@ -442,7 +490,8 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       // Dismiss: released well below peek while not flicking back upward.
       if (finalH < PEEK_PX * 0.6 && d.vy >= 0) {
         setLiveHeight(null);
-        onClose();
+        // F9 (#910) — drag-dismiss is a close path; restore focus.
+        closeWithRestore();
         return;
       }
 
@@ -464,8 +513,19 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
 
       settleTo(target);
     },
-    [heightFor, onClose, settleTo],
+    [heightFor, closeWithRestore, settleTo],
   );
+
+  // F9 (#910) — capture the element that had focus when the sheet mounted so
+  // every close path can restore to it. Mount-only: the sheet is keyed on
+  // state.detail in App.tsx (remounts per species), so a fresh capture per
+  // species is correct. queueMicrotask is NOT used — we want the activeElement
+  // as it stands at mount, before the sheet moves focus anywhere.
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    // Mount-only effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Initial focus on mount: move focus to the DIALOG CONTAINER (not the visible
   // species name) only when the sheet opens at full — at peek/half the user
@@ -486,6 +546,99 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       sheetRef.current?.focus();
     });
   }, [snap]);
+
+  // F8 (#910) — real focus trap at FULL. At full the sheet is
+  // role="dialog"/aria-modal, but `inert` only covers #map-layer (the O1
+  // unified target); the AppHeader floating chrome sits above the backdrop and
+  // stays tabbable, so Tab used to escape the dialog into AppHeader controls.
+  // Mirror the filters-panel Tab-wrap (App.tsx ~L287): collect focusables with
+  // the same selector and wrap first↔last. Active ONLY at snap==='full' and
+  // torn down when leaving full or unmounting. This is a PURE keydown handler —
+  // it does NOT touch the inert/role timing (goToSnap/settleTo/useLayoutEffect
+  // own that sequencing; the MutationObserver tests stay green).
+  useEffect(() => {
+    if (snap !== 'full') return;
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), input:not([disabled]), ' +
+      'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    // Exclude tier-hidden controls so the wrap lands on a focusable element.
+    // At full the mid-only .sheet-fg-teaser (and its "Read account" button)
+    // stays in the DOM but is hidden by the reveal channel (display + opacity:0
+    // / visibility), so .focus() on it is a silent no-op that would break the
+    // wrap. We can't use offsetParent (always null in jsdom → would exclude
+    // everything in unit tests); instead walk up to the sheet checking computed
+    // display/visibility/opacity. The real browser resolves these from the
+    // stylesheet (excluding the opacity:0 teaser at full); jsdom does NOT apply
+    // the stylesheet cascade to getComputedStyle, so every control stays
+    // included there — which keeps the unit Tab-wrap tests meaningful.
+    const isVisible = (el: HTMLElement): boolean => {
+      let node: HTMLElement | null = el;
+      while (node && node !== sheet.parentElement) {
+        const cs = getComputedStyle(node);
+        if (
+          cs.display === 'none' ||
+          cs.visibility === 'hidden' ||
+          cs.opacity === '0'
+        ) {
+          return false;
+        }
+        node = node.parentElement;
+      }
+      return true;
+    };
+    const focusables = (): HTMLElement[] =>
+      Array.from(sheet.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        isVisible,
+      );
+
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (!first || !last) {
+        e.preventDefault();
+        return;
+      }
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        // Backward from the first control (or from outside the sheet) → last.
+        if (active === first || !sheet.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Forward from the last control (or from outside the sheet) → first.
+        if (active === last || !sheet.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    sheet.addEventListener('keydown', onKeyDown);
+    return () => sheet.removeEventListener('keydown', onKeyDown);
+  }, [snap]);
+
+  // F10 (#910) — announce the species the first time a READABLE detent is
+  // reached. `half` is the first readable detent (the identity card is legible)
+  // and it does NOT move focus, so the polite live region is the only entry
+  // announcement AT gets there. Fire exactly once, on the first time we are at
+  // half with a resolved species name:
+  //   • peek  → no announce (the map keeps focus; the row is too compact)
+  //   • half  → announce once (first peek→half), latched so full→half won't
+  //             re-fire
+  //   • full  → no live-region push (the dialog focus-move announces via
+  //             aria-label; a second push here would double-fire)
+  useEffect(() => {
+    if (snap !== 'half') return;
+    if (announcedRef.current) return;
+    if (!speciesName) return;
+    announcedRef.current = true;
+    setLiveMessage(speciesName);
+  }, [snap, speciesName]);
 
   const isFull = snap === 'full';
   const height = liveHeight ?? heightFor(snap);
@@ -532,6 +685,18 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
           : `calc(${height}px + env(safe-area-inset-bottom, 0px))`,
       }}
     >
+      {/* F10 (#910) — visually-hidden polite live region. A DESCENDANT of the
+          sheet root so it is announced under aria-modal at full. It carries the
+          species name once a readable detent (half) is first reached; at full
+          the dialog focus-move owns the announce, so this is not re-pushed. */}
+      <div
+        data-testid="sheet-live-region"
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+      >
+        {liveMessage}
+      </div>
       <button
         ref={handleRef}
         type="button"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1427,13 +1427,6 @@ aside.species-detail-rail .species-detail-rail-close {
   overflow: hidden;
 }
 
-/* #761 (S2/O5): the AppHeader is `position: fixed` floating chrome on
-   `--z-chrome` (42). The full-snap sheet is now on `--z-modal` (50) via
-   the .species-detail-sheet--full modifier above, so at full snap the sheet
-   correctly outranks the chrome. The pointer-events arrangement is unchanged:
-   the floating header click-through at full snap is preserved by the modal
-   `inert` on #map-layer (O1, O4) — chrome remains visible but non-interactive
-   while the modal sheet is open. */
 .sheet-handle {
   /* Drag-region: own the gesture entirely; do not pan-scroll the page.
      min-height: 44px satisfies Apple HIG / WCAG 2.5.5 touch-target (MOB-7).
@@ -1642,7 +1635,10 @@ aside.species-detail-rail .species-detail-rail-close {
 
 /* FULL about + credits */
 .sheet-fg-about-eyebrow {
-  margin: 0 0 var(--space-xs);
+  /* #910 eyebrow rhythm — more breathing room ABOVE the "About" label (it
+     starts a new section after the taxonomy table) and a tighter gap BELOW so
+     the label hugs the prose it introduces. */
+  margin: var(--space-sm) 0 2px;
   font-size: var(--type-xs);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
@@ -1655,13 +1651,10 @@ aside.species-detail-rail .species-detail-rail-close {
   line-height: 1.6;
   color: var(--color-text-body);
 }
-.sheet-fg-credits {
-  margin: var(--space-md) 0 0;
-  font-size: var(--type-xs);
-  color: var(--color-text-subtle);
-}
-/* AA-safe link recipe (#830) — see .sheet-fg-readaccount note. */
-.sheet-fg-credits a { color: var(--color-text-strong); text-decoration: underline; }
+/* #910: dead credit-block CSS removed — no matching className is rendered. The
+   inline Wikipedia credit comes from <SpeciesDescription>
+   (.species-detail-description-credit), styled in its own section below. Folds
+   the T1+T2-era bot dead-CSS suggestions. */
 
 /* ── COMPACT layout (identity row): photo 44px left, identity right ──────── */
 .species-detail-sheet[data-content='compact'] .sheet-fg {
@@ -1724,6 +1717,23 @@ aside.species-detail-rail .species-detail-rail-close {
   width: auto;
   height: min(62.5vw, 300px);
   border-radius: 0;
+  /* position context for the bottom-edge scrim pseudo-element below. */
+  position: relative;
+}
+/* #910 masthead bottom-edge scrim — a transparent→~12%-black gradient over the
+   lower ~64px of the full-bleed masthead. It grounds the photo against the
+   light identity card below so a bright/low-contrast bird image doesn't bleed
+   into the heading region. Decorative + non-interactive (pointer-events:none),
+   theme-neutral (a black wash reads correctly on both the white and navy card),
+   and below the photo's own children only by stacking after the <img>. */
+.species-detail-sheet[data-content='full'] .sheet-fg-photo::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: 64px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.12));
+  pointer-events: none;
 }
 /* Lift the subject out of the vertical center so the masthead doesn't crop low
    with empty sky up top (a11y/design punch-list). Targets the <Photo> primitive's


### PR DESCRIPTION

## Diagrams

```mermaid
flowchart TD
  open[Sheet opens at half] -->|first peek to half| announce["F10: aria-live announces the species (once)"]
  open -->|expand to full| trap["F8: focus trap armed (Tab/Shift+Tab wrap inside dialog)"]
  trap -->|ESC / drag-dismiss / collapse| restore["F9: restore focus to opener, else #main-surface"]
  trap -->|leave full| untrap[trap torn down]
```

## Summary

Closes the field-guide sheet's a11y contract (the three diagnosis findings) + final tuning + cleanup. Epic **#906**, last task.

- **F8 — real focus trap at full.** A `keydown` Tab/Shift+Tab wrap (mirroring the App.tsx filters-panel) armed only at `snap==='full'`, torn down on leave/unmount. Does **not** touch the inert↔role MutationObserver timing. Handles the `opacity:0` (not `display:none`) mid-teaser via an ancestor-visibility filter so the last focusable is real in both jsdom and the browser.
- **F9 — focus restore on close.** Captures the opener on mount; on every close path (ESC→collapse, drag-dismiss, collapse-at-peek) restores to it if still attached, else falls back to **`#main-surface`** (not the dead `#surface-tab-map`).
- **F10 — announce on readable detent.** A visually-hidden `role="status" aria-live="polite"` region announces the species once on first peek→half; never re-fires on full→half, never at peek, never double-fires with the full focus-move.
- **Analytics latch (T3 #914 bot follow-up):** `panel_scrolled_to_bottom` is now once-per-species (`firedForSpeciesRef` keyed on speciesCode), not re-firing on a full→half→full round-trip.
- **Tuning:** masthead bottom-edge gradient scrim (transparent→12% black over the lower 64px) so the hero name stays legible over bright photos; About eyebrow rhythm.
- **Cleanup:** deleted the false "non-interactive" comment + dead `.sheet-fg-credits` CSS (folds the T1/T2 bot dead-CSS suggestions).

Scope: mobile sheet only; desktop rail untouched.

## Screenshots

**Full detent — masthead bottom scrim + About eyebrow rhythm (mobile sheet), both themes:**

| 390 · light | 390 · dark |
|---|---|
| <img width="250" alt="01-390-full-light" src="https://github.com/user-attachments/assets/ca217919-1a06-4acc-9b32-c729a2dfe82f"> | <img width="250" alt="02-390-full-dark" src="https://github.com/user-attachments/assets/e70d24d3-af56-4ee0-b449-a2f3f9897abc"> |

| 768 · light | 768 · dark | 1024 · light | 1024 · dark |
|---|---|---|---|
| <img width="220" alt="05-768-full-light" src="https://github.com/user-attachments/assets/bee55079-3bbb-4a18-8f44-db589b2dc4f0"> | <img width="220" alt="06-768-full-dark" src="https://github.com/user-attachments/assets/22458165-6459-4e51-8748-4d629d521777"> | <img width="220" alt="07-1024-full-light" src="https://github.com/user-attachments/assets/0bcc0c94-0838-4079-a852-0aea97983720"> | <img width="220" alt="08-1024-full-dark" src="https://github.com/user-attachments/assets/62c847e2-3f81-45bf-8419-eae15ecde843"> |

**Desktop rail (≥1200px — untouched by this PR; shown for no-regression):**

| 1440 · light | 1440 · dark | 1920 · light | 1920 · dark |
|---|---|---|---|
| <img width="180" alt="09-1440-rail-light" src="https://github.com/user-attachments/assets/d8aaea48-5208-451a-a304-69a63d335111"> | <img width="180" alt="10-1440-rail-dark" src="https://github.com/user-attachments/assets/4c800130-e098-4529-8222-3e8ede58d833"> | <img width="180" alt="11-1920-rail-light" src="https://github.com/user-attachments/assets/185b6812-89b4-4c34-b235-7f1f0ac23473"> | <img width="180" alt="12-1920-rail-dark" src="https://github.com/user-attachments/assets/0db161b3-fbb6-4620-a64e-17190611f781"> |

Console: **0 errors** at all five viewports. F8 trap / F9 restore / F10 announce are behavioral — verified by the unit + `sheet-focus-trap.spec.ts` e2e (Tab cycles stay in the dialog at full; ESC/drag restore focus).

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — **1157 pass** (+514 lines of unit tests: F8 trap wrap/teardown, F9 restore + `#main-surface` non-null, F10 single-announce, the once-per-species latch)
- [x] New e2e `sheet-focus-trap.spec.ts` — at full, Tab from the last focusable does not land on the AppHeader Filters trigger (1 pass); `axe.spec.ts` full-snap dialog scan green
- [x] `build`, `lint`, `knip`, `orphan-classname-check` — clean
- [x] Playwright MCP 5×2: scrim + eyebrow render; Tab cycles stay inside the dialog at full; ESC/drag close restores focus; console 0/0

## Plan reference

Out of plan — field-guide mobile species-sheet redesign. Implements **#910** (epic **#906**).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
