### PR TITLE
perf(frontend): clean page-side-by-side cross-fade for the field-guide sheet morph (#916)

### DIFF
--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -5,12 +5,17 @@ import { AppPage } from './pages/app-page.js';
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 
 /**
- * Wait until the field-guide sheet's reveal transitions (#907 recipe-18 /
- * recipe-07) have settled to full opacity. axe color-contrast reads the
- * alpha-blended computed color, so a mid-transition snapshot of opacity:0→1
- * text reports false sub-contrast. We poll the most-muted revealed element
- * (the teaser text) until its computed opacity is 1 — deterministic, not a
- * fixed timeout. Resolves immediately when no sheet/teaser is present.
+ * Wait until the field-guide sheet's reveal transitions have settled to full
+ * opacity. axe color-contrast reads the alpha-blended computed color, so a
+ * mid-transition snapshot of opacity:0→1 text reports false sub-contrast. We
+ * poll the revealed elements until their computed opacity is 1 — deterministic,
+ * not a fixed timeout. Resolves immediately when no sheet is present.
+ *
+ * Page-side-by-side (#08): the sheet body is two cross-fading pages. Only the
+ * ACTIVE page's reveals matter for the scan — the inactive page is opacity:0 +
+ * inert (axe skips it). We scope the poll to the active page (.sheet-page whose
+ * own computed opacity is 1) so the inactive page's not-yet-revealed elements
+ * never stall the wait.
  */
 async function waitForRevealSettled(
   page: import('@playwright/test').Page,
@@ -19,7 +24,12 @@ async function waitForRevealSettled(
     .waitForFunction(() => {
       const sheet = document.querySelector('.species-detail-sheet');
       if (!sheet) return true;
-      const revealed = sheet.querySelectorAll(
+      // The active page is the one the #08 cross-fade has resolved to opacity:1.
+      const activePage = Array.from(
+        sheet.querySelectorAll('.sheet-page'),
+      ).find((p) => Number(getComputedStyle(p as Element).opacity) >= 0.999);
+      if (!activePage) return true;
+      const revealed = activePage.querySelectorAll(
         '.sheet-fg-sci, .sheet-fg-record, .sheet-fg-teaser, .sheet-fg-teaser-text, .sheet-fg-taxonomy, .sheet-fg-about',
       );
       // Every reveal element that is laid out (not display:none in this tier)
@@ -298,8 +308,11 @@ test.describe('axe-core WCAG scans', () => {
         .toBeVisible({ timeout: 10_000 });
       // #907: the field-guide sheet photo is DECORATIVE on mobile (alt="") — the
       // species name sits adjacent — so locate the rendered <img> by its stable
-      // .photo__img class, not by alt text.
-      await expect(page.locator('.sheet-fg-photo .photo__img')).toBeVisible();
+      // .photo__img class, not by alt text. The sheet renders the photo in BOTH
+      // page-side-by-side (#08) pages; scope to the active .sheet-page--card
+      // (mid detent on open) to avoid a strict-mode match on the inactive entry
+      // page's duplicate photo.
+      await expect(page.locator('.sheet-page--card .sheet-fg-photo .photo__img')).toBeVisible();
       await waitForRevealSettled(page);
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
       if (results.violations.length) {

--- a/frontend/e2e/sheet-focus-trap.spec.ts
+++ b/frontend/e2e/sheet-focus-trap.spec.ts
@@ -38,16 +38,18 @@ test.describe('SpeciesDetailSheet focus trap at full (#910)', () => {
     await expect(sheet).toHaveAttribute('role', 'dialog');
     await expect(app.mapLayer).toHaveAttribute('inert', '');
 
-    // Wait for the mid→full reveal to settle: at full the mid-only teaser
-    // ("Read account") transitions to opacity:0 (recipe-18). Until it settles,
-    // the teaser button still computes as visible, so the focusable set (and the
-    // wrap target) is non-deterministic. Poll the teaser to opacity:0 — the same
-    // settle discipline axe.spec.ts uses — so first/last are stable.
+    // Wait for the mid→full #08 cross-fade to settle: at full the card PAGE
+    // (which holds the mid-only "Read account" teaser button) transitions to
+    // opacity:0 and inert. Until it settles, the read-account button still
+    // computes as visible, so the focusable set (and the wrap target) is
+    // non-deterministic. Poll the card page to opacity:0 — the ancestor that
+    // actually fades — so first/last are stable. (The teaser ELEMENT'S own
+    // opacity stays 1 at rest; it's the page-level cross-fade that hides it.)
     await page
       .waitForFunction(() => {
-        const teaser = document.querySelector('.sheet-fg-teaser');
-        if (!teaser) return true;
-        return Number(getComputedStyle(teaser).opacity) === 0;
+        const cardPage = document.querySelector('.sheet-page--card');
+        if (!cardPage) return true;
+        return Number(getComputedStyle(cardPage).opacity) === 0;
       }, undefined, { timeout: 5_000 })
       .catch(() => {
         /* best-effort settle; assertions below still run */

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -310,9 +310,13 @@ test.describe('species detail surface — photo rendering (#327 task-12)', () =>
         // alt ("<comName> photo"); on MOBILE the field-guide sheet renders the
         // photo DECORATIVELY (alt="") because the species name sits adjacent —
         // so the alt-text locator only works on desktop. Locate by the stable
-        // .photo__img class on mobile.
+        // .photo__img class on mobile. The sheet now renders the photo in BOTH
+        // page-side-by-side (#08) pages (card + entry); the sheet opens at the
+        // mid detent, so scope to the active .sheet-page--card (the inactive
+        // entry page also carries a .sheet-fg-photo, which would make a bare
+        // .sheet-fg-photo locator strict-mode-ambiguous).
         const photo = viewport.label === 'mobile'
-          ? page.locator('.sheet-fg-photo .photo__img')
+          ? page.locator('.sheet-page--card .sheet-fg-photo .photo__img')
           : page.getByAltText('Vermilion Flycatcher photo');
         await expect(photo).toBeVisible();
         await expect(photo).toHaveAttribute('src', 'https://photos.bird-maps.com/vermfly.jpg');
@@ -322,7 +326,7 @@ test.describe('species detail surface — photo rendering (#327 task-12)', () =>
         // — which would mean the photo render branch is silently broken.
         await expect.poll(() => photo.evaluate((img: HTMLImageElement) => img.naturalWidth))
           .toBeGreaterThan(0);
-        // Silhouette is NOT rendered on the photo branch.
+        // Silhouette is NOT rendered on the photo branch (neither page).
         // photo--silhouette class is present only when <Photo> is in the
         // fallback state (src=null or onError). Using the CSS class as the
         // locator avoids a test-only prop on the shared DS primitive.
@@ -346,8 +350,12 @@ test.describe('species detail surface — photo rendering (#327 task-12)', () =>
         // Silhouette IS visible. Use the CSS class-based locator — the
         // silhouetteTestId prop was removed from the shared DS Photo
         // primitive; .photo--silhouette is the stable, production-present
-        // selector for the fallback state.
-        const silhouette = page.locator('.photo--silhouette');
+        // selector for the fallback state. On mobile the sheet renders the photo
+        // in BOTH #08 pages (card + entry), so scope to the active
+        // .sheet-page--card (mid detent) to avoid a strict-mode ambiguity.
+        const silhouette = viewport.label === 'mobile'
+          ? page.locator('.sheet-page--card .photo--silhouette')
+          : page.locator('.photo--silhouette');
         await expect(silhouette).toBeVisible();
       });
     });

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -1122,12 +1122,13 @@ describe('<SpeciesDetailSheet> — F10 announce on readable detent (#910)', () =
 
 describe('<SpeciesDetailSheet> — F14 reduced-motion resting end-state (#910)', () => {
   // motion.css collapses all transition/animation durations to 0ms under
-  // prefers-reduced-motion. The reveal channels (sci/record/teaser/taxonomy/
-  // about) start at opacity:0 + translateY + blur and only reach the resting
-  // end-state via a [data-content='<tier>'] selector. This asserts that for
-  // each tier the resting end-state RULE exists in the authored CSS — so under
-  // reduced-motion (instant transition) the content lands at its resting state,
-  // never stuck invisible.
+  // prefers-reduced-motion. Under the page-side-by-side (#08) architecture the
+  // RESTING state of every reveal/page is opacity:1 (the hidden from-state keys
+  // on a NON-resting selector: [data-content='compact'] for the card-page
+  // reveals, and the inactive-page base for the cross-fade). So under reduced-
+  // motion (instant transition) live-tier content always lands VISIBLE, never
+  // stuck invisible (F14 invariant). This asserts the resting end-states exist
+  // in the authored CSS.
   // import.meta.url is not always a file:// URL under jsdom; resolve via
   // import.meta.dirname + join like tokens.css.test.ts (release-1 note).
   const css = readFileSync(join(import.meta.dirname, '../styles.css'), 'utf8');
@@ -1142,17 +1143,27 @@ describe('<SpeciesDetailSheet> — F14 reduced-motion resting end-state (#910)',
     expect(motion).toMatch(/animation-duration:\s*0ms\s*!important/);
   });
 
-  it('every reveal channel has a resting end-state (opacity:1) at its tier', () => {
-    // MID reveal channels resolve to opacity:1 under [data-content='mid'].
+  it('card-page reveals rest at opacity:1 (hidden from-state keys on compact, not the resting tier)', () => {
+    // The unconditional card-page reveal channel is the RESTING state: opacity:1.
     expect(css).toMatch(
-      /\[data-content='mid'\][^{]*\.sheet-fg-record[\s\S]*?opacity:\s*1/,
+      /\.sheet-page--card\s+\.sheet-fg-record[\s\S]*?opacity:\s*1/,
     );
-    // FULL reveal channels resolve to opacity:1 under [data-content='full'].
+    // The HIDDEN from-state is keyed on [data-content='compact'] (NOT on the
+    // resting mid tier) so mid content is present + visible at rest.
     expect(css).toMatch(
-      /\[data-content='full'\][^{]*\.sheet-fg-about[\s\S]*?opacity:\s*1/,
+      /\[data-content='compact'\][^{]*\.sheet-page--card[^{]*\.sheet-fg-record[\s\S]*?opacity:\s*0/,
+    );
+  });
+
+  it('the active page rests at opacity:1 via the #08 page-active selector', () => {
+    // recipe #08: the page selected by [data-page] resolves to opacity:1, so the
+    // entry page (taxonomy + About) + the card page land visible at rest under
+    // reduced-motion — there is no display:none→block entry to get stuck on.
+    expect(css).toMatch(
+      /\.sheet-pages\[data-page='card'\]\s+\.sheet-page--card[\s\S]*?opacity:\s*1/,
     );
     expect(css).toMatch(
-      /\[data-content='full'\][^{]*\.sheet-fg-taxonomy[\s\S]*?opacity:\s*1/,
+      /\.sheet-pages\[data-page='entry'\]\s+\.sheet-page--entry[\s\S]*?opacity:\s*1/,
     );
   });
 });

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -650,6 +650,21 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const prevTierRef = useRef<ContentTier>('mid');
   const content = resolveContentTier(height, prevTierRef.current, vh);
   prevTierRef.current = content;
+  // ── Page-side-by-side (#08) page selection ────────────────────────────────
+  // The sheet body is split into two STABLE, separately-rendered layout pages
+  // (the catalog `.t-page` model) that cross-dissolve on the mid↔full leg:
+  //   • card page  — photo-LEFT layout; serves compact AND mid (same structure,
+  //                  compact just hides sci/rule/record/teaser). compact↔mid is
+  //                  therefore an IN-PAGE card-resize (#01) + panel-reveal (#07),
+  //                  NO cross-fade (the card page stays active across both).
+  //   • entry page — photo-TOP masthead; serves full (taxonomy + About + the IO
+  //                  sentinel; the only scrolling layout).
+  // `page` drives data-page on the .sheet-pages container: compact|mid → 'card',
+  // full → 'entry'. The mid↔full cross-dissolve and the container-height tween
+  // both read the single --sheet-settle clock, so they start+finish on one frame.
+  const page: 'card' | 'entry' = content === 'full' ? 'entry' : 'card';
+  const cardActive = page === 'card';
+  const entryActive = page === 'entry';
   const famColor = resolveColor(data?.familyCode);
   // descriptionBody is sanitized HTML (rendered via SpeciesDescription at full);
   // the mid teaser wants a plain-text 2-line clamp, so strip tags for it.
@@ -669,6 +684,14 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       data-snap-state={snap}
       data-dragging={dragging ? 'true' : 'false'}
       data-content={content}
+      // #08 settle gate. Pure state-derived attr (NOT a measure/reflow): the
+      // page cross-dissolve + the in-page reveals fire ONLY at settle. During a
+      // drag [data-settled='false'] pins them transition:none (alongside the
+      // existing [data-dragging] height gate) so the drag is 1:1 and the
+      // mid/full page swap is an instant hard-cut; the cross-fade plays on
+      // release. resolveContentTier still blooms content DURING the drag — only
+      // the MOTION is gated, never the presence.
+      data-settled={dragging ? 'false' : 'true'}
       // #907 finding 2 — programmatically focusable (no tab stop) so open-focus
       // can land on the dialog container instead of the visible species name,
       // which avoided a stray :focus-visible ring on the title.
@@ -719,122 +742,194 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       >
         <span aria-hidden="true" className="sheet-handle-grip" />
       </button>
-      {/* Field-guide layout: three size-appropriate tiers in one grid that
-          re-templates per [data-content]. The photo is a SINGLE <Photo>
-          element kept mounted across detents; only its frame morphs via CSS.
-          The grid scrolls (tabIndex=0 satisfies axe scrollable-region-focusable).
-          scrollerRef is the IntersectionObserver root for the bottom sentinel
-          at the full detent — see the panel_scrolled_to_bottom effect. */}
-      <div className="sheet-fg" tabIndex={0} ref={scrollerRef}>
-        <div className="sheet-fg-photo">
-          {/* Decorative photo (alt=""): the species name always sits adjacent
-              and we have no plumage metadata, so a non-empty alt would triple-
-              announce. <Photo> owns the no-photo silhouette fallback (emits
-              .photo--silhouette) and the family shape/color via the resolvers. */}
-          <Photo
-            src={data?.photoUrl ?? null}
-            alt=""
-            family={(data?.familyCode as FamilyCode | null) ?? null}
-            color={resolveColor(data?.familyCode)}
-            pathD={resolvePath(data?.familyCode)}
-            imgUrl={resolveImgUrl(data?.familyCode)}
-            priority
-            layout="masthead"
-          />
-        </div>
-
-        <div className="sheet-fg-identity">
-          {/* h2: the map identity ("Bird Maps") owns the page h1; the species
-              name is the top heading INSIDE the dialog. Not a focus target:
-              open-focus lands on the dialog container (#907 finding 2), so this
-              heading carries no tabIndex and never paints a focus ring. */}
-          <h2 id="detail-title" className="sheet-fg-name">
-            {data?.comName ?? 'Loading…'}
-          </h2>
-          <p className="sheet-fg-sci">
-            <em>{data?.sciName}</em>
-          </p>
-          <p className="sheet-fg-family">
-            <span
-              className="sheet-fg-family-dot"
-              aria-hidden="true"
-              style={{ background: famColor }}
+      {/* Field-guide body: TWO stable layout pages cross-dissolved by recipe #08
+          (page-side-by-side). data-page selects the active page; the inactive
+          page is opacity:0 + pointer-events:none + a short translate/blur per
+          #08 (CSS). Each page owns its OWN grid that NEVER re-templates — the
+          mid→full morph is a genuine cross-fade between two stable layouts, not
+          a grid re-template snap. The container height still card-resize-tweens
+          on the sheet root, so mid→full reads as: height grows + card fades out
+          + entry fades in, one clean motion. */}
+      <div className="sheet-pages" data-page={page}>
+        {/* ── CARD PAGE (photo-LEFT) — compact + mid ─────────────────────────
+            Same structure for both detents; compact just hides sci/rule/record/
+            teaser. compact↔mid is an in-page card-resize (#01) on the photo
+            (44↔120, both fixed px, top-left anchored) + panel-reveal (#07) for
+            sci/rule/record/teaser. NO page swap on compact↔mid (this page stays
+            active). Inert + aria-hidden when the entry page is active so its
+            DUPLICATED name/sci/family are not tabbable or double-announced. */}
+        <section
+          className="sheet-page sheet-page--card"
+          data-page-id="card"
+          aria-hidden={cardActive ? undefined : 'true'}
+          // `inert` removes the inactive page from tab order + pointer + the
+          // a11y tree; React renders the boolean attribute when true only.
+          {...(cardActive ? {} : { inert: '' })}
+        >
+          <div className="sheet-fg-photo">
+            {/* Decorative photo (alt=""): the species name always sits adjacent
+                and we have no plumage metadata, so a non-empty alt would triple-
+                announce. <Photo> owns the no-photo silhouette fallback (emits
+                .photo--silhouette) and the family shape/color via the resolvers.
+                The SAME cached photoUrl is rendered in both pages — no double
+                network load (the <img> src is identical + browser-cached). */}
+            <Photo
+              src={data?.photoUrl ?? null}
+              alt=""
+              family={(data?.familyCode as FamilyCode | null) ?? null}
+              color={resolveColor(data?.familyCode)}
+              pathD={resolvePath(data?.familyCode)}
+              imgUrl={resolveImgUrl(data?.familyCode)}
+              priority
+              layout="masthead"
             />
-            {data?.familyName}
-          </p>
-        </div>
+          </div>
 
-        <div className="sheet-fg-rule" aria-hidden="true" style={{ background: famColor }} />
-
-        {/* MID tier — labeled field record (real <dl> so AT ties label→value) */}
-        <dl className="sheet-fg-record">
-          <div className="sheet-fg-cell">
-            <dt className="sheet-fg-label">Family</dt>
-            <dd className="sheet-fg-value">{data?.familyName ?? '—'}</dd>
-          </div>
-          <div className="sheet-fg-cell">
-            <dt className="sheet-fg-label">eBird taxonomic order</dt>
-            <dd className="sheet-fg-value">
-              {data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}
-            </dd>
-          </div>
-        </dl>
-        <div className="sheet-fg-teaser">
-          <p className="sheet-fg-teaser-text">
-            {descPlain || 'No description available.'}
-          </p>
-          <button
-            type="button"
-            className="sheet-fg-readaccount"
-            aria-expanded={isFull}
-            aria-controls="sheet-fg-account"
-            onClick={() => goToSnap('full')}
-          >
-            Read account <span aria-hidden="true">⌄</span>
-          </button>
-        </div>
-
-        {/* FULL tier — taxonomy table + ABOUT prose + credits */}
-        <dl className="sheet-fg-taxonomy">
-          <div className="sheet-fg-taxrow">
-            <dt>Scientific name</dt>
-            <dd><em>{data?.sciName}</em></dd>
-          </div>
-          <div className="sheet-fg-taxrow">
-            <dt>Family</dt>
-            <dd>{data?.familyName}</dd>
-          </div>
-          <div className="sheet-fg-taxrow">
-            <dt>eBird taxonomic order</dt>
-            <dd>{data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}</dd>
-          </div>
-        </dl>
-        <div className="sheet-fg-about" id="sheet-fg-account">
-          {data?.descriptionBody ? (
-            <>
-              <h3 className="sheet-fg-about-eyebrow">About</h3>
-              <SpeciesDescription
-                descriptionBody={data.descriptionBody}
-                descriptionAttributionUrl={data.descriptionAttributionUrl}
+          <div className="sheet-fg-identity">
+            {/* No id here — #detail-title lives on the ENTRY page (the full
+                dialog heading) so the two pages don't collide on a duplicate id
+                (axe duplicate-id). The dialog's accessible name comes from
+                aria-label on the root, not aria-labelledby, so the card heading
+                needs no id. */}
+            <h2 className="sheet-fg-name">{data?.comName ?? 'Loading…'}</h2>
+            <p className="sheet-fg-sci">
+              <em>{data?.sciName}</em>
+            </p>
+            <p className="sheet-fg-family">
+              <span
+                className="sheet-fg-family-dot"
+                aria-hidden="true"
+                style={{ background: famColor }}
               />
-            </>
-          ) : (
-            <p className="sheet-fg-prose">No description available.</p>
-          )}
-        </div>
+              {data?.familyName}
+            </p>
+          </div>
 
-        {/* Bottom sentinel for panel_scrolled_to_bottom (T3 #909). A DIRECT
-            child of .sheet-fg AFTER the About block with NO tier-gated
-            display:none: the .sheet-fg-about/.sheet-fg-taxonomy blocks are
-            display:none until full, and a display:none element has a zero box
-            that never intersects. The sentinel must stay in layout so the
-            IntersectionObserver can fire when the user scrolls the About prose
-            into view at the full detent (the only detent .sheet-fg scrolls). */}
-        <div
-          ref={sentinelRef}
-          data-testid="detail-bottom-sentinel"
-          aria-hidden="true"
-        />
+          <div className="sheet-fg-rule" aria-hidden="true" style={{ background: famColor }} />
+
+          {/* MID tier — labeled field record (real <dl> so AT ties label→value) */}
+          <dl className="sheet-fg-record">
+            <div className="sheet-fg-cell">
+              <dt className="sheet-fg-label">Family</dt>
+              <dd className="sheet-fg-value">{data?.familyName ?? '—'}</dd>
+            </div>
+            <div className="sheet-fg-cell">
+              <dt className="sheet-fg-label">eBird taxonomic order</dt>
+              <dd className="sheet-fg-value">
+                {data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}
+              </dd>
+            </div>
+          </dl>
+          <div className="sheet-fg-teaser">
+            <p className="sheet-fg-teaser-text">
+              {descPlain || 'No description available.'}
+            </p>
+            <button
+              type="button"
+              className="sheet-fg-readaccount"
+              aria-expanded={isFull}
+              aria-controls="sheet-fg-account"
+              onClick={() => goToSnap('full')}
+            >
+              Read account <span aria-hidden="true">⌄</span>
+            </button>
+          </div>
+        </section>
+
+        {/* ── ENTRY PAGE (photo-TOP masthead) — full ─────────────────────────
+            The only scrolling layout: scrollerRef is the IntersectionObserver
+            root and the bottom sentinel is its direct child (after About).
+            tabIndex=0 satisfies axe scrollable-region-focusable. The focus trap
+            queries focusables in THIS page. Inert + aria-hidden when the card
+            page is active so its duplicated content stays out of the a11y tree
+            and the tab order until full. */}
+        <section
+          className="sheet-page sheet-page--entry sheet-fg"
+          data-page-id="entry"
+          tabIndex={entryActive ? 0 : -1}
+          ref={scrollerRef}
+          aria-hidden={entryActive ? undefined : 'true'}
+          {...(entryActive ? {} : { inert: '' })}
+        >
+          <div className="sheet-fg-photo">
+            <Photo
+              src={data?.photoUrl ?? null}
+              alt=""
+              family={(data?.familyCode as FamilyCode | null) ?? null}
+              color={resolveColor(data?.familyCode)}
+              pathD={resolvePath(data?.familyCode)}
+              imgUrl={resolveImgUrl(data?.familyCode)}
+              priority
+              layout="masthead"
+            />
+          </div>
+
+          <div className="sheet-fg-identity">
+            {/* h2: the map identity ("Bird Maps") owns the page h1; the species
+                name is the top heading INSIDE the dialog. Not a focus target:
+                open-focus lands on the dialog container (#907 finding 2), so this
+                heading carries no tabIndex and never paints a focus ring.
+                #detail-title is unique to the entry page (the card heading has no
+                id) so the two always-rendered pages never duplicate the id. */}
+            <h2 id="detail-title" className="sheet-fg-name">
+              {data?.comName ?? 'Loading…'}
+            </h2>
+            <p className="sheet-fg-sci">
+              <em>{data?.sciName}</em>
+            </p>
+            <p className="sheet-fg-family">
+              <span
+                className="sheet-fg-family-dot"
+                aria-hidden="true"
+                style={{ background: famColor }}
+              />
+              {data?.familyName}
+            </p>
+          </div>
+
+          <div className="sheet-fg-rule" aria-hidden="true" style={{ background: famColor }} />
+
+          {/* FULL tier — taxonomy table + ABOUT prose + credits */}
+          <dl className="sheet-fg-taxonomy">
+            <div className="sheet-fg-taxrow">
+              <dt>Scientific name</dt>
+              <dd><em>{data?.sciName}</em></dd>
+            </div>
+            <div className="sheet-fg-taxrow">
+              <dt>Family</dt>
+              <dd>{data?.familyName}</dd>
+            </div>
+            <div className="sheet-fg-taxrow">
+              <dt>eBird taxonomic order</dt>
+              <dd>{data?.taxonOrder != null ? `#${data.taxonOrder}` : '—'}</dd>
+            </div>
+          </dl>
+          <div className="sheet-fg-about" id="sheet-fg-account">
+            {data?.descriptionBody ? (
+              <>
+                <h3 className="sheet-fg-about-eyebrow">About</h3>
+                <SpeciesDescription
+                  descriptionBody={data.descriptionBody}
+                  descriptionAttributionUrl={data.descriptionAttributionUrl}
+                />
+              </>
+            ) : (
+              <p className="sheet-fg-prose">No description available.</p>
+            )}
+          </div>
+
+          {/* Bottom sentinel for panel_scrolled_to_bottom (T3 #909). A DIRECT
+              child of the entry page (.sheet-fg, the only scroll container)
+              AFTER the About block. The entry page is always rendered (the #08
+              cross-fade keeps both pages mounted), so the sentinel stays in
+              layout; the observer is still armed only at snap==='full' (#914),
+              the only detent the entry page is active and .sheet-fg scrolls. */}
+          <div
+            ref={sentinelRef}
+            data-testid="detail-bottom-sentinel"
+            aria-hidden="true"
+          />
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1459,19 +1459,71 @@ aside.species-detail-rail .species-detail-rail-close {
   background: var(--color-text-muted);
 }
 
-/* ── Field-guide detent layouts ────────────────────────────────────────────
-   One grid (.sheet-fg) re-templates per [data-content] (compact|mid|full),
-   driven by live sheet height in SpeciesDetailSheet.tsx (resolveContentTier,
-   hysteresed). The photo (.sheet-fg-photo) is a single <Photo> kept mounted
-   across detents; only its frame morphs (44px thumb -> 120px plate -> full-
-   bleed masthead). Hairlines use a theme-neutral translucent grey. */
-.sheet-fg {
+/* ── Field-guide detent layouts (page-side-by-side, recipe #08) ─────────────
+   The sheet body is TWO stable, separately-rendered layout pages cross-
+   dissolved by recipe #08, driven by [data-page] on .sheet-pages
+   (SpeciesDetailSheet.tsx, resolveContentTier → page):
+     • .sheet-page--card  — photo-LEFT; serves compact AND mid. compact↔mid is
+       an IN-PAGE card-resize (#01) on the photo (44↔120) + panel-reveal (#07)
+       for sci/rule/record/teaser — NO page swap (this page stays active).
+     • .sheet-page--entry — photo-TOP masthead; serves full. The only scrolling
+       page (carries .sheet-fg) + the IO bottom sentinel.
+   mid↔full is the #08 cross-dissolve between the two pages PLUS the container
+   height card-resize (#01) on the sheet root. NOTHING re-templates and nothing
+   travels — one clean motion. Each page's grid is STABLE; the photo cross-fades
+   plate↔masthead within the dissolve (accepted: a dissolve, not a glide).
+   Hairlines use a theme-neutral translucent grey. */
+
+/* The pages container fills the sheet under the handle and stacks the two
+   absolutely-positioned pages so #08 can cross-fade them in place. */
+.sheet-pages {
+  position: relative;
   flex: 1;
   min-height: 0;
+}
+
+/* recipe #08 base — every page starts hidden + offset + blurred; the active
+   page (selected by [data-page] on the container) resolves to visible. Pages
+   are ALWAYS rendered (never display:none) so the cross-fade has no
+   display→block entry problem (no @starting-style needed for the page swap).
+   The card page exits left, the entry page exits right (#08 convention). */
+.sheet-pages .sheet-page {
+  position: absolute;
+  inset: 0;
   display: grid;
   align-content: start;
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-lg) var(--space-md);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity   var(--page-fade-dur)  var(--page-fade-ease),
+    transform var(--page-slide-dur) var(--page-slide-ease),
+    filter    var(--page-slide-dur) var(--page-slide-ease);
+  will-change: opacity, transform, filter;
+}
+.sheet-pages .sheet-page--card {
+  --t-page-from-x: calc(var(--page-slide-distance) * -1);
+  transform: translateX(var(--t-page-from-x));
+  filter: blur(var(--page-blur));
+}
+.sheet-pages .sheet-page--entry {
+  --t-page-from-x: var(--page-slide-distance);
+  transform: translateX(var(--t-page-from-x));
+  filter: blur(var(--page-blur));
+}
+.sheet-pages[data-page='card'] .sheet-page--card,
+.sheet-pages[data-page='entry'] .sheet-page--entry {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+  filter: blur(0);
+}
+
+/* The entry page is the only scroll container (full detent). Side padding is
+   already supplied by the shared .sheet-page rule above; .sheet-fg adds the
+   scroll behaviour only. */
+.sheet-fg {
   overflow-y: auto;
   overflow-x: clip;
   touch-action: pan-y;
@@ -1550,11 +1602,12 @@ aside.species-detail-rail .species-detail-rail-close {
   align-self: start;
 }
 
-/* MID-only + FULL-only blocks hidden by default; placed per data-content below */
+/* Card-page record/teaser are MID-only: display:none at compact, shown at mid
+   (an in-page #07 panel-reveal — see the motion section). taxonomy/about live in
+   the entry page, which only renders at full, so they need no per-tier display
+   gate — they are always laid out within their (cross-fading) page. */
 .sheet-fg-record,
-.sheet-fg-teaser,
-.sheet-fg-taxonomy,
-.sheet-fg-about { display: none; }
+.sheet-fg-teaser { display: none; }
 .sheet-fg-record { grid-area: record; }
 .sheet-fg-teaser { grid-area: teaser; }
 .sheet-fg-taxonomy { grid-area: taxonomy; }
@@ -1656,27 +1709,15 @@ aside.species-detail-rail .species-detail-rail-close {
    (.species-detail-description-credit), styled in its own section below. Folds
    the T1+T2-era bot dead-CSS suggestions. */
 
-/* ── COMPACT layout (identity row): photo 44px left, identity right ──────── */
-.species-detail-sheet[data-content='compact'] .sheet-fg {
-  grid-template-columns: 44px 1fr;
-  grid-template-areas: 'photo identity';
-  align-items: center;
-  column-gap: var(--space-md);
-  /* Small-mode padding rebalance: tight at the top (the name sits close under
-     the handle), breathing room at the bottom. Total height stays PEEK_PX. */
-  padding-top: 0;
-  padding-bottom: var(--space-lg);
-}
-/* Shorter handle in compact so the centered grip doesn't push the name down a
-   full 44px; still ≥24px (WCAG 2.5.8 AA) as a drag/tap target. */
-.species-detail-sheet[data-content='compact'] .sheet-handle { min-height: 30px; }
-.species-detail-sheet[data-content='compact'] .sheet-fg-photo { width: 44px; height: 44px; }
-.species-detail-sheet[data-content='compact'] .sheet-fg-sci,
-.species-detail-sheet[data-content='compact'] .sheet-fg-rule { display: none; }
-
-/* ── MID layout (plate card) ─────────────────────────────────────────────── */
-.species-detail-sheet[data-content='mid'] .sheet-fg {
-  grid-template-columns: 120px 1fr;
+/* ── CARD PAGE grid (photo-LEFT) — serves compact AND mid ──────────────────
+   ONE stable grid for both detents (it never re-templates — the morph between
+   compact and mid is an in-page card-resize + reveal, not a re-template). The
+   photo column is `auto` so it tracks the photo's own card-resize width
+   (44↔120) without the template changing. In compact, rule/record/teaser are
+   display:none (their rows collapse) and sci is hidden, so the stable 4-row
+   template visually reduces to the `photo identity` identity row. */
+.sheet-page--card {
+  grid-template-columns: auto 1fr;
   grid-template-areas:
     'photo identity'
     'rule  rule'
@@ -1685,19 +1726,52 @@ aside.species-detail-rail .species-detail-rail-close {
   align-items: start;
   column-gap: var(--space-md);
 }
-.species-detail-sheet[data-content='mid'] .sheet-fg-photo { width: 120px; height: 120px; }
-.species-detail-sheet[data-content='mid'] .sheet-fg-record {
+.sheet-page--card .sheet-fg-photo { width: 120px; height: 120px; }
+.sheet-page--card .sheet-fg-record {
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: var(--space-md);
 }
-.species-detail-sheet[data-content='mid'] .sheet-fg-teaser { display: block; }
+.sheet-page--card .sheet-fg-teaser { display: block; }
 /* Center the name/sci/family stack against the 120px plate; bump name to lg. */
-.species-detail-sheet[data-content='mid'] .sheet-fg-identity { align-self: center; }
-.species-detail-sheet[data-content='mid'] .sheet-fg-name { font-size: var(--type-lg); }
+.sheet-page--card .sheet-fg-identity { align-self: center; }
+.sheet-page--card .sheet-fg-name { font-size: var(--type-lg); }
 
-/* ── FULL layout (field-guide entry) ─────────────────────────────────────── */
-.species-detail-sheet[data-content='full'] .sheet-fg {
+/* COMPACT specialisation of the card page (identity row). Same grid, but the
+   photo shrinks to 44px (card-resize tweens this on settle), the top padding
+   tightens, and sci/rule/record/teaser hide (their rows collapse to nothing,
+   leaving the bare identity row). */
+.species-detail-sheet[data-content='compact'] .sheet-page--card {
+  align-items: center;
+  /* Small-mode padding rebalance: tight at the top (the name sits close under
+     the handle), breathing room at the bottom. Total height stays PEEK_PX. */
+  padding-top: 0;
+  padding-bottom: var(--space-lg);
+}
+/* Shorter handle in compact so the centered grip doesn't push the name down a
+   full 44px; still ≥24px (WCAG 2.5.8 AA) as a drag/tap target. */
+.species-detail-sheet[data-content='compact'] .sheet-handle { min-height: 30px; }
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-photo {
+  width: 44px;
+  height: 44px;
+}
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-identity {
+  align-self: center;
+}
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-name {
+  font-size: var(--type-md);
+}
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-sci,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-rule,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-record,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-teaser {
+  display: none;
+}
+
+/* ── ENTRY PAGE grid (photo-TOP masthead) — serves full ────────────────────
+   Stable single-column grid; only renders/cross-fades at full so it needs no
+   per-tier gating. padding-top:0 lets the masthead sit flush under the handle. */
+.sheet-page--entry {
   grid-template-columns: 1fr;
   grid-template-areas:
     'photo'
@@ -1708,11 +1782,11 @@ aside.species-detail-rail .species-detail-rail-close {
   gap: var(--space-md);
   padding-top: 0;
 }
-.species-detail-sheet[data-content='full'] .sheet-fg-photo {
-  /* full-bleed masthead — cancel the .sheet-fg side padding. Use an EXPLICIT
-     height (not aspect-ratio): aspect-ratio on a grid item with negative
-     margins doesn't reliably feed back into auto-track sizing, so the row
-     collapses and the name overlaps the photo. 62.5vw ≈ 16/10 of full width. */
+.sheet-page--entry .sheet-fg-photo {
+  /* full-bleed masthead — cancel the page side padding. Use an EXPLICIT height
+     (not aspect-ratio): aspect-ratio on a grid item with negative margins
+     doesn't reliably feed back into auto-track sizing, so the row collapses and
+     the name overlaps the photo. 62.5vw ≈ 16/10 of full width. */
   margin: 0 calc(-1 * var(--space-lg));
   width: auto;
   height: min(62.5vw, 300px);
@@ -1726,7 +1800,7 @@ aside.species-detail-rail .species-detail-rail-close {
    into the heading region. Decorative + non-interactive (pointer-events:none),
    theme-neutral (a black wash reads correctly on both the white and navy card),
    and below the photo's own children only by stacking after the <img>. */
-.species-detail-sheet[data-content='full'] .sheet-fg-photo::after {
+.sheet-page--entry .sheet-fg-photo::after {
   content: '';
   position: absolute;
   inset-inline: 0;
@@ -1738,118 +1812,84 @@ aside.species-detail-rail .species-detail-rail-close {
 /* Lift the subject out of the vertical center so the masthead doesn't crop low
    with empty sky up top (a11y/design punch-list). Targets the <Photo> primitive's
    inner <img> (.photo__img). */
-.species-detail-sheet[data-content='full'] .sheet-fg-photo .photo__img { object-position: center 35%; }
-.species-detail-sheet[data-content='full'] .sheet-fg-name {
+.sheet-page--entry .sheet-fg-photo .photo__img { object-position: center 35%; }
+.sheet-page--entry .sheet-fg-name {
   font-size: var(--type-hero);
   font-weight: var(--font-weight-bold);
   line-height: 1.1;
 }
-.species-detail-sheet[data-content='full'] .sheet-fg-taxonomy { display: block; }
-.species-detail-sheet[data-content='full'] .sheet-fg-about { display: block; }
 
-/* ── Field-guide motion: photo morph + tier content reveals ────────────────
-   Reduced-motion is owned globally by motion.css (collapses every transition /
-   animation here to 0ms); each rule's resting end-state is the correct static
-   state, so there are no per-element prefers-reduced-motion guards.
+/* ── Field-guide motion ────────────────────────────────────────────────────
+   ONE clock for every leg: --sheet-settle-dur (300ms) / --sheet-settle-ease.
+   recipe #08 (page cross-dissolve) reads --page-* (retuned to 300ms in
+   tokens.css); recipe #01 (photo card-resize + the container height tween) and
+   recipe #07 (card-page reveals) read --sheet-settle-*. All start+finish on one
+   frame → no two-stage. Reduced-motion is owned globally by motion.css
+   (collapses every transition here to 0ms); each rule's resting end-state is
+   the correct static state, so there are no per-element prefers-reduced-motion
+   guards.
 
-   Photo morph. The photo reads as ONE continuous element across detents
-   because the properties that change its rendered box all tween together:
-   width/height/border-radius on the frame, the full-bleed negative `margin` at
-   full, AND `grid-template-columns` on the parent grid (the column track that
-   holds the photo: 44px → 120px → 1fr). grid-template-AREAS is NOT animatable —
-   the mid→full reposition (photo moves from the left column to a top masthead)
-   is the one accepted discontinuity; aspect-ratio is never animated. */
-.sheet-fg {
-  transition: grid-template-columns var(--sheet-settle-dur) var(--sheet-settle-ease);
-}
-.sheet-fg-photo {
+   SETTLE GATE. The page cross-fade + the in-page reveals + the photo card-
+   resize fire ONLY at settle ([data-settled='true']). During an active drag
+   [data-settled='false'] pins them transition:none, so the drag is 1:1 and the
+   mid/full page swap is an instant hard-cut at the boundary (acceptable mid-
+   finger); the cross-fade plays on release. The container height has its own
+   [data-dragging] gate on the sheet root (unchanged).
+
+   compact↔mid PHOTO — true card-resize (#01). Both axes are fixed px (44↔120),
+   top-left anchored by the grid origin, so the box genuinely tweens; no
+   translate, no re-template. The masthead photo lives in a SEPARATE page and is
+   reached only by the #08 cross-dissolve, so width:120px↔auto is never
+   interpolated. */
+.species-detail-sheet[data-settled='true'] .sheet-page--card .sheet-fg-photo {
   transition:
     width var(--sheet-settle-dur) var(--sheet-settle-ease),
-    height var(--sheet-settle-dur) var(--sheet-settle-ease),
-    border-radius var(--sheet-settle-dur) var(--sheet-settle-ease),
-    margin var(--sheet-settle-dur) var(--sheet-settle-ease);
+    height var(--sheet-settle-dur) var(--sheet-settle-ease);
 }
-/* 1:1 during drag — the photo + grid snap to the tier size at the threshold,
-   no lag behind the finger. */
-.species-detail-sheet[data-dragging='true'] .sheet-fg,
-.species-detail-sheet[data-dragging='true'] .sheet-fg-photo { transition: none; }
-
-/* MID-tier reveal — transitions-dev recipe 18 (texts-reveal). The sci-name,
-   the field-record strip, and the teaser rise in with a staggered blur as they
-   enter the mid detent. Each starts translated-down + blurred + invisible; the
-   [data-content='mid'] state flips them to rest. The name+family SPINE is NOT
-   in this channel (it is always present, never display:none'd).
-
-   record/teaser are display:none in other tiers, so the channel also tweens the
-   discrete `display` change (transition-behavior: allow-discrete) and seeds the
-   entrance from-state with @starting-style — without these the show would snap.
-   sci-name is never display:none'd (it stays in the spine), so it tweens with
-   the plain opacity/transform/filter set. */
-.sheet-fg-sci,
-.sheet-fg-record,
-.sheet-fg-teaser {
-  opacity: 0;
-  transform: translateY(var(--stagger-distance, 12px));
-  filter: blur(var(--stagger-blur, 3px));
-  transition:
-    opacity var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    transform var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    filter var(--stagger-dur, 600ms) var(--stagger-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    display var(--stagger-dur, 600ms) allow-discrete;
-  will-change: transform, opacity, filter;
+/* 1:1 during drag — the photo snaps to the tier size at the threshold, the page
+   swap is instant; the cross-fade + reveals play on release. */
+.species-detail-sheet[data-settled='false'] .sheet-pages .sheet-page,
+.species-detail-sheet[data-settled='false'] .sheet-page--card .sheet-fg-photo,
+.species-detail-sheet[data-settled='false'] .sheet-fg-sci,
+.species-detail-sheet[data-settled='false'] .sheet-fg-record,
+.species-detail-sheet[data-settled='false'] .sheet-fg-teaser {
+  transition: none;
 }
-/* Stagger: record holds 1 step, teaser 2 steps, so the eye lands on the
-   sci-name first then walks down the card. */
-.sheet-fg-record { transition-delay: var(--stagger-stagger, 40ms); }
-.sheet-fg-teaser { transition-delay: calc(var(--stagger-stagger, 40ms) * 2); }
-.species-detail-sheet[data-content='mid'] .sheet-fg-sci,
-.species-detail-sheet[data-content='mid'] .sheet-fg-record,
-.species-detail-sheet[data-content='mid'] .sheet-fg-teaser,
-.species-detail-sheet[data-content='full'] .sheet-fg-sci {
+
+/* compact↔mid REVEALS — recipe #07 (panel-reveal) retuned to the settle clock.
+   sci/rule/record/teaser rise in with a short translate + cross-blur as the
+   card page grows compact→mid. RESTING state is opacity:1 / transform:none so
+   reduced-motion (motion.css 0ms) lands VISIBLE; the hidden from-state keys on
+   [data-content='compact'] (NOT an unconditional base) so live content is
+   PRESENT at every settled tier. record/teaser also toggle display:none in
+   compact — the reveal is not load-bearing for the leg feel (the card-resize
+   carries it), so a plain show is fine without @starting-style. */
+.sheet-page--card .sheet-fg-sci,
+.sheet-page--card .sheet-fg-rule,
+.sheet-page--card .sheet-fg-record,
+.sheet-page--card .sheet-fg-teaser {
   opacity: 1;
   transform: translateY(0);
   filter: blur(0);
+  transition:
+    opacity   var(--sheet-settle-dur) var(--sheet-settle-ease),
+    transform var(--sheet-settle-dur) var(--sheet-settle-ease),
+    filter    var(--sheet-settle-dur) var(--sheet-settle-ease);
+  will-change: transform, opacity, filter;
 }
-@starting-style {
-  .species-detail-sheet[data-content='mid'] .sheet-fg-record,
-  .species-detail-sheet[data-content='mid'] .sheet-fg-teaser {
-    opacity: 0;
-    transform: translateY(var(--stagger-distance, 12px));
-    filter: blur(var(--stagger-blur, 3px));
-  }
-}
-
-/* FULL-tier reveal — transitions-dev recipe 07 (panel-reveal). The taxonomy
-   table and the About panel slide up from a half-travel with a cross-blur so a
-   short translate still reads as a full open. Both are display:none until the
-   full detent, so the channel tweens `display` (allow-discrete) and seeds the
-   from-state via @starting-style, mirroring the mid channel. */
-.sheet-fg-taxonomy,
-.sheet-fg-about {
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-sci,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-rule,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-record,
+.species-detail-sheet[data-content='compact'] .sheet-page--card .sheet-fg-teaser {
+  opacity: 0;
   transform: translateY(var(--panel-translate-y-sheet, 32px));
-  opacity: 0;
   filter: blur(var(--panel-blur, 2px));
-  transition:
-    transform var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    opacity var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    filter var(--panel-open-dur, 400ms) var(--panel-ease, cubic-bezier(0.22, 1, 0.36, 1)),
-    display var(--panel-open-dur, 400ms) allow-discrete;
-  will-change: transform, opacity, filter;
 }
-.species-detail-sheet[data-content='full'] .sheet-fg-taxonomy,
-.species-detail-sheet[data-content='full'] .sheet-fg-about {
-  transform: translateY(0);
-  opacity: 1;
-  filter: blur(0);
-}
-@starting-style {
-  .species-detail-sheet[data-content='full'] .sheet-fg-taxonomy,
-  .species-detail-sheet[data-content='full'] .sheet-fg-about {
-    opacity: 0;
-    transform: translateY(var(--panel-translate-y-sheet, 32px));
-    filter: blur(var(--panel-blur, 2px));
-  }
-}
+
+/* The entry page's taxonomy + About need no separate reveal: the whole entry
+   page cross-dissolves in via recipe #08 as one unit (opacity + translate +
+   blur), so the blocks arrive together with the page. Resting state (opacity:1)
+   is the page-active state above — reduced-motion lands them visible. */
 
 /* ==========================================================================
    W2 orphan-CSS sweep — 8 classNames referenced in JSX with no rule.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1401,7 +1401,7 @@ aside.species-detail-rail .species-detail-rail-close {
      [data-dragging='true'] below so the drag tracks the finger 1:1.
      Reduced-motion is owned globally by motion.css (collapses this to 0ms);
      no per-element guard here, per repo convention. */
-  --sheet-settle-dur: 300ms;
+  --sheet-settle-dur: 240ms;
   --sheet-settle-ease: cubic-bezier(0.22, 1, 0.36, 1);
   transition: height var(--sheet-settle-dur) var(--sheet-settle-ease);
   will-change: height;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -151,10 +151,14 @@
      frame (no two-stage desync). --page-slide-distance is kept SMALL (8px) so
      the cross-fade reads as a dissolve, not a slide; the photo cross-fades
      plate↔masthead within it. Reduced-motion is owned globally by motion.css. */
-  --page-slide-dur:      300ms;
-  --page-fade-dur:       300ms;
+  --page-slide-dur:      240ms;
+  --page-fade-dur:       240ms;
   --page-slide-distance: 8px;
-  --page-blur:           3px;
+  /* Heavier blur (14px) is deliberate: cross-fading two *different* layouts
+     double-exposes at the crossover; a strong blur on both layers mushes the
+     midpoint into a soft dissolve instead of a readable double-image. Tuned
+     live (#916) — 3px showed a ghost; 14px reads as one soft beat. */
+  --page-blur:           14px;
   --page-slide-ease:     cubic-bezier(0.22, 1, 0.36, 1);
   --page-fade-ease:      cubic-bezier(0.22, 1, 0.36, 1);
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -142,6 +142,21 @@
      open (recipe-07 note). Named -sheet so it doesn't collide if the canonical
      --panel-translate-y (100px) is later imported wholesale. */
   --panel-translate-y-sheet: 32px;
+
+  /* recipe-08 (page-side-by-side) — drives the mid↔full cross-dissolve between
+     the two stable sheet pages (.sheet-page--card ↔ .sheet-page--entry). The
+     catalog default is 200ms; the sheet retunes to the single 300ms settle
+     clock (--sheet-settle-dur/-ease) so the page cross-fade, the in-page
+     reveals (#07), and the container-height tween (#01) all start+finish on one
+     frame (no two-stage desync). --page-slide-distance is kept SMALL (8px) so
+     the cross-fade reads as a dissolve, not a slide; the photo cross-fades
+     plate↔masthead within it. Reduced-motion is owned globally by motion.css. */
+  --page-slide-dur:      300ms;
+  --page-fade-dur:       300ms;
+  --page-slide-distance: 8px;
+  --page-blur:           3px;
+  --page-slide-ease:     cubic-bezier(0.22, 1, 0.36, 1);
+  --page-fade-ease:      cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */


### PR DESCRIPTION

## Diagrams

```mermaid
flowchart LR
  subgraph sheet["SpeciesDetailSheet — one box (height = card-resize #01)"]
    card["card page<br/>(photo-LEFT)<br/>compact + mid"]
    entry["entry page<br/>(photo-TOP masthead)<br/>full"]
  end
  card -- "compact↔mid: in-page card-resize + panel-reveal (no swap)" --> card
  card -- "mid↔full: #08 cross-dissolve (data-page swap)" --> entry
  entry -- "full↔mid: #08 cross-dissolve (reverse)" --> card
```

## Summary

Rebuilds the detent morph as a **clean transitions-dev page-side-by-side (#08) cross-fade**, replacing a janky two-stage morph. Closes **#916**.

- **Why:** the morph felt two-staged ("the card moves, then the elements update a second later") and a prior fix-attempt still snapped. Root cause: a single `.sheet-fg` grid that **re-templated** `grid-template-areas`/`-columns` between detents — an instant *structural snap* no overlay could hide — plus reveals that outlasted the box. (An interim FLIP attempt was rejected: FLIP isn't in the transitions-dev catalog.)
- **What:** two stable layout **pages** (`.t-page` model) inside the sheet — a **card page** (photo-left, serves compact+mid) and an **entry page** (photo-top masthead, serves full). compact↔mid is a clean in-page `card-resize (#01)` + `panel-reveal (#07)` (no swap, same structure). mid↔full is the `#08` **cross-dissolve** between the two pages + the container-height `card-resize`. Nothing re-templates, nothing travels → **no snap, no cross, no FLIP, no blur-hack.**
- **One 300→240ms clock**, gated to settle via `data-settled` (frozen 1:1 during drag). Pure-CSS → reduced-motion owned globally by motion.css (no per-element guards).
- **Tuning (live-approved):** cross-fading two *different* layouts double-exposes at the crossover; `--page-blur` 3→**14px** mushes that midpoint into a soft dissolve (the catalog's own cross-blur primitive, turned up), and the settle clock 300→**240ms** flashes it by faster.
- **Invariants wired to the active page:** IO bottom-sentinel + scroll → entry page; focus-trap (full) → entry page; inactive page `inert`+`aria-hidden` (no double-announce / duplicate-id); inert↔role sequencing + open-focus stay on the root; single data fetch rendered into both pages (same cached photo).

Scope: mobile sheet only; desktop rail untouched.

## Screenshots

**Mobile sheet (390×844) — resting detents + the morph midpoint (light/dark):**

| mid · light | mid · dark | full · light | full · dark | mid→full cross-dissolve (mid-flight) |
|---|---|---|---|---|
| <img width="180" alt="01-390-mid-light" src="https://github.com/user-attachments/assets/1bd1bc50-0cda-4343-a845-f0288b584558"> | <img width="180" alt="02-390-mid-dark" src="https://github.com/user-attachments/assets/8ca52b32-151c-41d6-b93c-3c74b97e10ff"> | <img width="180" alt="03-390-full-light" src="https://github.com/user-attachments/assets/72d730d1-459c-4c04-b9bf-0c4475eef2dd"> | <img width="180" alt="04-390-full-dark" src="https://github.com/user-attachments/assets/582dc24c-8c0d-4c17-acbe-3946b0f36398"> | <img width="180" alt="05-390-crossfade-midflight-light" src="https://github.com/user-attachments/assets/566e83e4-ddf7-4536-a567-cee09e3ecb86"> |

The cross-dissolve frame shows the #08 crossover: the outgoing card layout blurs to a soft cloud (no readable double-image) as the entry layout resolves — verified live on-device; the resting detents are unchanged from the shipped sheet.

**Tablet / small-laptop (full detent, light/dark):**

| 768 · light | 768 · dark | 1024 · light | 1024 · dark |
|---|---|---|---|
| <img width="200" alt="06-768-full-light" src="https://github.com/user-attachments/assets/f9f1a128-7144-4b14-99c1-c36c4df849b1"> | <img width="200" alt="07-768-full-dark" src="https://github.com/user-attachments/assets/6d8e4cc6-d4ce-43ba-b633-232b44b21463"> | <img width="200" alt="08-1024-full-light" src="https://github.com/user-attachments/assets/e3714cb1-45c3-4668-923a-0dc8f90495c0"> | <img width="200" alt="09-1024-full-dark" src="https://github.com/user-attachments/assets/a9218492-2595-47b4-91b1-52bf94381d56"> |

**Desktop rail (≥1200px — untouched by this PR; no-regression):**

| 1440 · light | 1440 · dark | 1920 · light | 1920 · dark |
|---|---|---|---|
| <img width="180" alt="10-1440-rail-light" src="https://github.com/user-attachments/assets/6175e858-dcc7-446f-bf36-69563b144181"> | <img width="180" alt="11-1440-rail-dark" src="https://github.com/user-attachments/assets/29aac99c-e4ca-4dd6-b80c-966985245f88"> | <img width="180" alt="12-1920-rail-light" src="https://github.com/user-attachments/assets/38b2b3d0-1d60-41ee-818a-5fff4f2a5bc1"> | <img width="180" alt="13-1920-rail-dark" src="https://github.com/user-attachments/assets/a87e47c1-37d0-4356-87be-ebe74aad6653"> |

Console: **0 errors** at all five viewports.

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (page-side-by-side resting contract + data-settled gate + inert/aria-hidden inactive page)
- [x] `npm run build`, `lint`, `npx knip`, `bash scripts/check-orphan-classnames.sh` — clean
- [x] Sheet e2e (`--project=dev-server`): sheet-snap, sheet-focus-trap (entry page), sheet-analytics (sentinel in entry page), species-detail, axe — pass
- [x] Live (Playwright + on-device): compact↔mid in-page resize; mid↔full cross-dissolve (data-page swaps; inactive page inert); the crossover reads as one soft dissolve (blur-masked); console 0 errors at all 5 viewports
- [x] **Feel approved on-device** (Julian)

## Plan reference

Out of plan — field-guide mobile species-sheet morph follow-up. Closes **#916**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
