### PR TITLE
feat(frontend): field-guide design on the desktop detail card + transitions-dev animations (#918, closes #911)

### DIFF
--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -24,10 +24,15 @@ test.describe('species detail surface (#151)', () => {
     // container rather than <main>. The AttributionModal family names are in a
     // separate dialog.attribution-modal — use getByRole to avoid collisions.
     await expect(page.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText('Pyrocephalus rubinus')).toBeVisible();
-    // Family name appears in the detail surface; scope to species-detail-family
-    // class to avoid hitting the AttributionModal Phylopic section.
-    await expect(page.locator('.species-detail-family')).toHaveText(/Tyrant Flycatchers/);
+    // #918 Restated-data decision: the scientific name appears TWICE — once in
+    // the identity spine (.detail-fg-sci) and again in the taxonomy <dl> as
+    // labeled reference data — so a bare getByText is strict-mode-ambiguous.
+    // Scope to the identity spine.
+    await expect(page.locator('.detail-fg-sci')).toContainText('Pyrocephalus rubinus');
+    // Family name likewise appears in the identity dot+name row AND the taxonomy
+    // <dl> Family row; scope to .detail-fg-family (the field-guide dot+name row)
+    // to avoid the taxonomy row AND the AttributionModal Phylopic section.
+    await expect(page.locator('.detail-fg-family')).toHaveText(/Tyrant Flycatchers/);
 
     // URL carries detail and view params.
     await expect.poll(() => new URL(page.url()).searchParams.get('detail'), { timeout: 5_000 })

--- a/frontend/src/components/SpeciesDetailRail.test.tsx
+++ b/frontend/src/components/SpeciesDetailRail.test.tsx
@@ -108,6 +108,46 @@ describe('<SpeciesDetailRail>', () => {
     document.body.removeChild(trigger);
   });
 
+  // #911 — the default fallbackFocusSelector was the dead `#surface-tab-map`
+  // (deleted in the map-first re-architecture), so on close — when the trigger
+  // is gone — focus restore was a silent no-op that dropped focus onto <body>
+  // (WCAG 2.4.3 regression). The default is now `#main-surface`, the real
+  // focusable <main tabIndex={0}> in App.tsx.
+  it('#911: restores focus to the default #main-surface when trigger is detached and no fallback prop is passed', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Trigger (will be detached)';
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    // The real App.tsx landmark: <main id="main-surface" tabIndex={0}>.
+    const mainSurface = document.createElement('main');
+    mainSurface.id = 'main-surface';
+    mainSurface.tabIndex = 0;
+    document.body.appendChild(mainSurface);
+
+    const onClose = vi.fn();
+    render(
+      <SpeciesDetailRail
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={onClose}
+        triggerRef={{ current: trigger }}
+        // NO fallbackFocusSelector — assert the DEFAULT resolves to #main-surface.
+      />
+    );
+    await screen.findByRole('complementary');
+
+    // Detach the trigger so the close handler must use the fallback selector.
+    document.body.removeChild(trigger);
+    expect(document.contains(trigger)).toBe(false);
+
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => expect(document.activeElement).toBe(mainSurface));
+
+    document.body.removeChild(mainSurface);
+  });
+
   it('falls back to fallbackFocusSelector when trigger is detached from document', async () => {
     const trigger = document.createElement('button');
     trigger.textContent = 'Trigger (will be detached)';

--- a/frontend/src/components/SpeciesDetailRail.tsx
+++ b/frontend/src/components/SpeciesDetailRail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { SpeciesDetailSurface } from './SpeciesDetailSurface.js';
 
@@ -14,9 +14,14 @@ export interface SpeciesDetailRailProps {
   triggerRef?: RefObject<HTMLElement | null>;
   /**
    * CSS selector for the stable focus target to use when the original
-   * trigger is no longer in the document. Defaults to `#surface-tab-map`
-   * — the in-place rail coexists with the Map, so on close the user is
-   * still on the map surface and the Map tab is the right landmark.
+   * trigger is no longer in the document. Defaults to `#main-surface`
+   * — the real focusable `<main tabIndex={0}>` (App.tsx). The in-place
+   * rail coexists with the Map, so on close the user is still on the map
+   * surface and the main landmark is the right place to land focus.
+   *
+   * (#911: the prior default `#surface-tab-map` was deleted in the
+   * map-first re-architecture, so focus-restore was a silent no-op that
+   * dropped focus onto <body> — a WCAG 2.4.3 regression. Restored here.)
    */
   fallbackFocusSelector?: string;
 }
@@ -49,11 +54,21 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
     apiClient,
     onClose,
     triggerRef,
-    fallbackFocusSelector = '#surface-tab-map',
+    fallbackFocusSelector = '#main-surface',
   } = props;
   const asideRef = useRef<HTMLElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  // recipe #07 (panel-reveal) + recipe #18 (texts-reveal): start in the
+  // resting OFF-state, then flip ON in a post-paint mount effect so the
+  // entrance plays. The rail remounts per species (key={state.detail} in
+  // App.tsx), so this single flag drives BOTH the aside slide-in (data-open)
+  // AND the identity stagger (passed down as `revealed`) on open + species
+  // switch — no reflow-replay machinery needed. The close tween is skipped
+  // by design: the rail unmounts via React conditional render, so there is
+  // no exit frame to animate (animating close would need an unmount-defer
+  // state machine — out of scope; the entrance is the win).
+  const [revealed, setRevealed] = useState(false);
 
   const doClose = useCallback(() => {
     // Focus return discipline: restore to the original trigger if it's
@@ -89,6 +104,22 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Post-paint reveal: flip ON after the browser has painted the resting
+  // OFF-state at least once so the CSS transition actually runs (a same-frame
+  // flip would jump straight to the end-state with no tween). A double rAF is
+  // the portable way to land on the frame after first paint. Mount-only.
+  useEffect(() => {
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setRevealed(true));
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // ESC handler — document-level so it catches the key regardless of
   // current focus location (focus may have moved into the Map by the
   // time the user presses ESC).
@@ -106,7 +137,8 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
   return (
     <aside
       ref={asideRef}
-      className="species-detail-rail"
+      className="species-detail-rail t-panel-slide"
+      data-open={revealed ? 'true' : 'false'}
       role="complementary"
       aria-labelledby="detail-title"
     >
@@ -122,6 +154,7 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
       <SpeciesDetailSurface
         speciesCode={speciesCode}
         apiClient={apiClient}
+        revealed={revealed}
       />
     </aside>
   );

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import { SpeciesDetailSurface } from './SpeciesDetailSurface.js';
 import { ApiClient } from '../api/client.js';
 import type { SpeciesMeta, FamilySilhouette } from '@bird-watch/shared-types';
@@ -57,13 +57,106 @@ describe('SpeciesDetailSurface', () => {
       getSpecies: vi.fn().mockResolvedValue(VERMFLY),
       getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
-    render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
     await waitFor(() =>
       expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
     );
-    const sci = screen.getByText('Pyrocephalus rubinus');
+
+    // #918 Restated-data decision: the identity block (B–D) shows the
+    // scientific + family names once as IDENTITY; the taxonomy <dl> (F) restates
+    // them as formal labeled REFERENCE data — by design (matches the mobile
+    // field-guide entry page). So each text now appears in exactly TWO nodes:
+    // the identity row and the taxonomy row. Scope to the identity block for the
+    // identity-tagline assertion (and assert the count is 2, not de-duplicated).
+    const identityBlock = container.querySelector('.detail-fg-identity') as HTMLElement;
+    expect(identityBlock).not.toBeNull();
+    const sci = within(identityBlock).getByText('Pyrocephalus rubinus');
     expect(sci.tagName).toBe('EM');
-    expect(screen.getByText('Tyrant Flycatchers')).toBeInTheDocument();
+    expect(within(identityBlock).getByText('Tyrant Flycatchers')).toBeInTheDocument();
+    // Restated, not de-duplicated: 2 nodes each (identity row + taxonomy row).
+    expect(screen.getAllByText('Pyrocephalus rubinus')).toHaveLength(2);
+    expect(screen.getAllByText('Tyrant Flycatchers')).toHaveLength(2);
+  });
+
+  // #918 — the taxonomy <dl> is the field-guide reference block. It must be a
+  // real <dl> with three label→value rows (Scientific name / Family / eBird
+  // taxonomic order) so the restated data is COVERED, not merely tolerated.
+  it('renders a taxonomy <dl> with labeled Scientific-name, Family, and taxon-order rows', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
+    );
+    const dl = container.querySelector('dl.detail-fg-taxonomy') as HTMLElement;
+    expect(dl).not.toBeNull();
+    const rows = dl.querySelectorAll('.detail-fg-taxrow');
+    expect(rows).toHaveLength(3);
+    // Labels (dt) and the values they tie to (dd).
+    const labels = Array.from(dl.querySelectorAll('dt')).map((el) => el.textContent);
+    expect(labels).toEqual(['Scientific name', 'Family', 'eBird taxonomic order']);
+    const tax = within(dl);
+    // Scientific name restated in the dl (italic <em>) — the second of the 2 nodes.
+    expect(tax.getByText('Pyrocephalus rubinus').tagName).toBe('EM');
+    // Family restated in the dl.
+    expect(tax.getByText('Tyrant Flycatchers')).toBeInTheDocument();
+    // taxonOrder rendered as #4400.
+    expect(tax.getByText('#4400')).toBeInTheDocument();
+  });
+
+  // #918 — the identity block carries the family dot (inline family-color bg +
+  // aria-hidden) and the family-accent rule; both are field-guide structural
+  // signals. The dot's inline background comes from resolveColor(familyCode).
+  it('renders the family dot (inline color, aria-hidden) and the accent rule', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(VERMFLY),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
+    );
+    const dot = container.querySelector('.detail-fg-family-dot') as HTMLElement;
+    expect(dot).not.toBeNull();
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+    // Inline background resolved from the family color (#C77A2E in the fixture).
+    // jsdom normalizes the hex to its rgb() form.
+    expect(dot.style.background).toBe('rgb(199, 122, 46)');
+    // The 3px family-accent rule carries the same inline color.
+    const rule = container.querySelector('.detail-fg-rule') as HTMLElement;
+    expect(rule).not.toBeNull();
+    expect(rule).toHaveAttribute('aria-hidden', 'true');
+    expect(rule.style.background).toBe('rgb(199, 122, 46)');
+  });
+
+  // #918 — the About section leads with an "About" eyebrow heading when a
+  // description is present (the field-guide section divider).
+  it('renders the "About" eyebrow heading when descriptionBody is present', async () => {
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue({
+        ...VERMFLY,
+        descriptionBody: '<p>Body.</p>',
+        descriptionAttributionUrl: 'https://en.wikipedia.org/wiki/Vermilion_flycatcher',
+      }),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    const { container } = render(
+      <SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />,
+    );
+    const eyebrow = await waitFor(() => {
+      const el = container.querySelector('.detail-fg-about-eyebrow');
+      if (!el) throw new Error('About eyebrow not yet rendered');
+      return el;
+    });
+    expect(eyebrow.textContent).toBe('About');
   });
 
   it('shows loading state initially', () => {

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -12,6 +12,15 @@ import type { FamilyCode } from '../config/family-palette.js';
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
   apiClient: ApiClient;
+  /**
+   * Drives the recipe #18 (texts-reveal) entrance on the identity block.
+   * The wrapper (SpeciesDetailRail) starts this `false` on mount and flips
+   * it `true` in a post-paint effect so the staggered name/sci/family lines
+   * play from their resting off-state. Defaults to `true` so any consumer
+   * that does NOT orchestrate the reveal (a direct render, a future modal,
+   * the unit tests) shows the resting end-state immediately.
+   */
+  revealed?: boolean;
 }
 
 /**
@@ -37,7 +46,7 @@ export interface SpeciesDetailSurfaceProps {
  * inside the wrapper's scroll container (modal or sheet), not <main>.
  */
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
-  const { speciesCode, apiClient } = props;
+  const { speciesCode, apiClient, revealed = true } = props;
   const detail = useSpeciesDetail(apiClient, speciesCode);
   const { loading, error, data } = detail;
   // useSilhouettes provides the family-color payload. The data is cached at
@@ -138,27 +147,90 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
     return null;
   }
 
+  const famColor = resolveColor(data.familyCode);
+
   return (
     <div className="species-detail-body">
-      <Photo
-        src={data.photoUrl ?? null}
-        alt={`${data.comName} photo`}
-        family={data.familyCode as FamilyCode | null}
-        color={resolveColor(data.familyCode)}
-        pathD={resolvePath(data.familyCode)}
-        imgUrl={resolveImgUrl(data.familyCode)}
-        priority={true}
-        layout="masthead"
+      {/* A. Masthead photo — full-bleed hero (the .species-detail-body > .photo
+          rule cancels the body gutter; .detail-fg-masthead pins the 232px
+          height + scrim + object-position). */}
+      <div className="detail-fg-masthead">
+        <Photo
+          src={data.photoUrl ?? null}
+          alt={`${data.comName} photo`}
+          family={data.familyCode as FamilyCode | null}
+          color={famColor}
+          pathD={resolvePath(data.familyCode)}
+          imgUrl={resolveImgUrl(data.familyCode)}
+          priority={true}
+          layout="masthead"
+        />
+      </div>
+
+      {/* B–D. Identity block — recipe #18 (texts-reveal): name=line1, sci=line2,
+          family-row=line3. `.is-shown` is added post-paint by the wrapper
+          (SpeciesDetailRail) so the stagger plays from the resting off-state on
+          mount + per-species remount. */}
+      <div className={`detail-fg-identity t-stagger${revealed ? ' is-shown' : ''}`}>
+        <h1
+          id="detail-title"
+          tabIndex={-1}
+          className="detail-name detail-fg-name t-stagger-line t-stagger-line--1"
+        >
+          {data.comName}
+        </h1>
+        <p className="detail-fg-sci t-stagger-line t-stagger-line--2">
+          <em>{data.sciName}</em>
+        </p>
+        <p className="detail-fg-family t-stagger-line t-stagger-line--3">
+          <span
+            className="detail-fg-family-dot"
+            aria-hidden="true"
+            style={{ background: famColor }}
+          />
+          {data.familyName}
+        </p>
+      </div>
+
+      {/* E. Family-accent rule — the strongest field-guide signal. */}
+      <div
+        className="detail-fg-rule"
+        aria-hidden="true"
+        style={{ background: famColor }}
       />
-      <h1 id="detail-title" tabIndex={-1} className="detail-name">
-        {data.comName}
-      </h1>
-      <p className="species-detail-sci-name"><em>{data.sciName}</em></p>
-      <p className="species-detail-family">{data.familyName}</p>
-      <SpeciesDescription
-        descriptionBody={data.descriptionBody}
-        descriptionAttributionUrl={data.descriptionAttributionUrl}
-      />
+
+      {/* F. Taxonomy — real <dl> so AT ties label→value. Intentionally restates
+          Scientific name + Family as formal labeled reference data (matches the
+          mobile field-guide entry page); do NOT de-duplicate against B–D. */}
+      <dl className="detail-fg-taxonomy">
+        <div className="detail-fg-taxrow">
+          <dt>Scientific name</dt>
+          <dd><em>{data.sciName}</em></dd>
+        </div>
+        <div className="detail-fg-taxrow">
+          <dt>Family</dt>
+          <dd>{data.familyName}</dd>
+        </div>
+        <div className="detail-fg-taxrow">
+          <dt>eBird taxonomic order</dt>
+          <dd>{data.taxonOrder != null ? `#${data.taxonOrder}` : '—'}</dd>
+        </div>
+      </dl>
+
+      {/* G. About — eyebrow + Wikipedia-credited prose. */}
+      <div className="detail-fg-about">
+        {data.descriptionBody ? (
+          <>
+            <h2 className="detail-fg-about-eyebrow">About</h2>
+            <SpeciesDescription
+              descriptionBody={data.descriptionBody}
+              descriptionAttributionUrl={data.descriptionAttributionUrl}
+            />
+          </>
+        ) : null}
+      </div>
+
+      {/* H. Sentinel — must remain the LAST child for the IntersectionObserver. */}
       <div
         ref={sentinelRef}
         data-testid="detail-bottom-sentinel"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -697,24 +697,151 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   display: block;
   margin: 0 0 12px 0;
 }
-/* Renamed from .species-detail-common-name to match JSX className="detail-name" (#443).
-   Font-size promoted from --type-lg (22px) to --type-hero (34px) per
-   tokens.md:135 "detail-surface species name". */
-.detail-name {
-  margin: 0 0 4px 0;
+/* ==========================================================================
+   #918 — Desktop detail card field-guide restyle (.detail-fg-*).
+   SpeciesDetailSurface (desktop rail body) was a flat stacked card; this
+   block brings the mobile sheet's field-guide entry shape to the desktop:
+   masthead + scrim → 34px hero name → italic sci → family dot(+ring)+name
+   → 3px family-accent rule → 3-row taxonomy <dl> → About eyebrow + prose.
+   Tokens are REUSED from tokens.css (--type-hero/-sm/-xs, --space-*,
+   --sheet-dot-ring, --font-weight-*); these are NEW selectors so they don't
+   inherit the sheet's detent/drag/grid machinery (.sheet-fg-* stays mobile).
+   The .detail-fg-identity stagger is recipe #18 (texts-reveal); the rail
+   slide-in is recipe #07 (panel-reveal) — both in the motion section below.
+
+   .detail-name keeps its id/class hooks (rail aria-labelledby + tests). */
+
+/* A. Masthead — full-bleed hero with a fixed 232px height (NOT aspect-ratio
+   /vw: an explicit height avoids the auto-track collapse + the 38vw rail
+   width clamp over-growing the photo at 1920). The body gutter is cancelled
+   by the shared `.species-detail-body > .photo` rule; this wrapper just owns
+   the height, the object-position lift, and the bottom-edge scrim. */
+.detail-fg-masthead {
+  margin-inline: calc(-1 * var(--space-lg));
+  width: calc(100% + 2 * var(--space-lg));
+  height: 232px;
+  margin-bottom: var(--space-md);
+  position: relative;
+  overflow: hidden;
+}
+.detail-fg-masthead .photo {
+  --photo-radius: 0;
+  aspect-ratio: auto;
+  width: 100%;
+  height: 100%;
+}
+.detail-fg-masthead .photo__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  /* Lift the subject so the masthead doesn't crop low with empty sky up top
+     (matches the sheet entry masthead). */
+  object-position: center 35%;
+}
+.detail-fg-masthead .family-silhouette {
+  width: 100%;
+  height: 100%;
+}
+/* Bottom-edge scrim — transparent→~12%-black over the lower 64px. Grounds a
+   bright/low-contrast photo against the card below so it doesn't bleed into
+   the heading region. Decorative + non-interactive; a black wash reads on
+   both light and dark cards (mirrors .sheet-page--entry .sheet-fg-photo::after). */
+.detail-fg-masthead::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: 64px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.12));
+  pointer-events: none;
+}
+
+/* B–D. Identity block. */
+.detail-fg-identity {
+  margin: 0;
+}
+/* .detail-name keeps the promoted --type-hero (34px) size + bold weight from
+   the pre-#918 rule (tokens.md "detail-surface species name") and the id/class
+   hooks the rail/tests depend on. */
+.detail-name,
+.detail-fg-name {
+  margin: 0 0 2px 0;
   font-size: var(--type-hero);
   font-weight: var(--font-weight-bold);
   line-height: 1.1;
 }
-.species-detail-sci-name {
-  margin: 0 0 12px 0;
+.detail-fg-sci {
+  margin: 2px 0 0;
   font-size: var(--type-sm);
   color: var(--color-text-muted);
 }
-.species-detail-family {
+.detail-fg-family {
+  margin: var(--space-xs) 0 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+}
+.detail-fg-family-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+  /* 1px contrast ring so the family hue isn't the only signal (WCAG 1.4.11
+     non-text contrast). --sheet-dot-ring is the SAME per-theme solid color the
+     sheet dot uses (≥3:1 on both card surfaces); reuse it verbatim. */
+  box-shadow: 0 0 0 1px var(--sheet-dot-ring);
+}
+
+/* E. Family-accent rule — the strongest field-guide signal (color set inline). */
+.detail-fg-rule {
+  height: 3px;
+  border-radius: 2px;
+  margin: var(--space-md) 0 0;
+}
+
+/* F. Taxonomy <dl> — 132px label / value grid, uppercase --type-xs labels,
+   hairline borders (mirrors .sheet-fg-taxonomy / -taxrow). Intentionally
+   restates Scientific name + Family as formal labeled reference data. */
+.detail-fg-taxonomy {
+  margin: var(--space-md) 0 0;
+}
+.detail-fg-taxrow {
+  display: grid;
+  grid-template-columns: 132px 1fr;
+  gap: var(--space-md);
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.22);
+}
+.detail-fg-taxrow:first-child {
+  border-top: 1px solid rgba(127, 127, 127, 0.22);
+}
+.detail-fg-taxrow dt {
+  margin: 0;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.detail-fg-taxrow dd {
   margin: 0;
   font-size: var(--type-sm);
-  color: var(--color-text-body);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-strong);
+}
+
+/* G. About — eyebrow + prose (SpeciesDescription carries the Wikipedia credit). */
+.detail-fg-about {
+  margin: var(--space-md) 0 0;
+}
+.detail-fg-about-eyebrow {
+  margin: var(--space-sm) 0 2px;
+  font-size: var(--type-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
 }
 .species-detail-loading { color: var(--color-text-muted); font-size: var(--type-sm); margin: 8px 0 0 0; }
 .species-detail-error {
@@ -1360,6 +1487,89 @@ aside.species-detail-rail .species-detail-rail-close {
   cursor: pointer;
   color: var(--color-text-strong);
   z-index: 1;
+}
+
+/* ==========================================================================
+   #918 — Desktop detail card entrance motion (transitions-dev catalog only).
+
+   Recipe #07 (panel-reveal) on the rail itself + recipe #18 (texts-reveal)
+   on the identity block. Catalog snippets pasted verbatim from
+   ~/.claude/skills/transitions-dev/{07-panel-reveal,18-texts-reveal}.md:
+   exact enumerated properties, will-change, and the required
+   @media (prefers-reduced-motion: reduce) guards kept. NO FLIP, NO
+   View-Transitions API, NO clip-path, NO WAAPI morph, NO getBoundingClientRect.
+
+   The rail uses #07 (NOT modal #06): it slides into the top-right region of a
+   still-interactive map (role="complementary"), so a panel slide — not a
+   centered scale — is the right surface. The exit/close tween is intentionally
+   skipped: the rail unmounts via React conditional render (App.tsx
+   `{scopeActive && state.detail && !isCompact && <SpeciesDetailRail/>}`), so
+   there is no exit frame to animate without an unmount-defer state machine
+   (out of scope; the entrance is the win).
+
+   The rail remounts per species (key={state.detail}), so ONE post-paint mount
+   effect in SpeciesDetailRail.tsx sets BOTH data-open="true" (here) and the
+   identity .is-shown — the stagger plays from the resting off-state on open
+   and on every species switch, no reflow-replay needed.
+
+   --panel-translate-y is overridden to 16px (a docked card travels a short
+   distance, not a full panel); --panel-open-dur (400ms), --panel-ease, and
+   --panel-blur (2px) are reused from tokens.css.
+   ========================================================================== */
+
+/* Recipe #07 — panel-reveal (verbatim CSS; --panel-translate-y → 16px). */
+aside.species-detail-rail.t-panel-slide {
+  --panel-translate-y: 16px;
+  transform: translateY(var(--panel-translate-y));
+  opacity: 0;
+  filter: blur(var(--panel-blur));
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity   var(--panel-open-dur) var(--panel-ease),
+    filter    var(--panel-open-dur) var(--panel-ease);
+  will-change: transform, opacity, filter;
+}
+aside.species-detail-rail.t-panel-slide[data-open='true'] {
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity   var(--panel-open-dur) var(--panel-ease),
+    filter    var(--panel-open-dur) var(--panel-ease);
+}
+/* The catalog snippet sets pointer-events on the resting/open states to gate
+   interaction during a full panel reveal. The rail is keyboard-focused on
+   mount (close button) and the entrance is short, so pointer-events stay
+   default here — gating them would briefly swallow clicks on the open card. */
+@media (prefers-reduced-motion: reduce) {
+  aside.species-detail-rail.t-panel-slide { transition: none !important; }
+}
+
+/* Recipe #18 — texts-reveal (verbatim CSS) on the identity block. Lines:
+   name=--1, sci=--2, family-row=--3 (the --3 delay is added below). */
+.detail-fg-identity.t-stagger .t-stagger-line {
+  display: block;
+  opacity: 0;
+  transform: translateY(var(--stagger-distance));
+  filter: blur(var(--stagger-blur));
+  transition:
+    opacity   var(--stagger-dur) var(--stagger-ease),
+    transform var(--stagger-dur) var(--stagger-ease),
+    filter    var(--stagger-dur) var(--stagger-ease);
+  will-change: transform, opacity, filter;
+}
+.detail-fg-identity .t-stagger-line--1 { transition-delay: 0s; }
+.detail-fg-identity .t-stagger-line--2 { transition-delay: var(--stagger-stagger); }
+.detail-fg-identity .t-stagger-line--3 { transition-delay: calc(var(--stagger-stagger) * 2); }
+
+.detail-fg-identity.t-stagger.is-shown .t-stagger-line {
+  opacity: 1;
+  transform: translateY(0);
+  filter: blur(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .detail-fg-identity.t-stagger .t-stagger-line { transition: none !important; }
 }
 
 /* ==========================================================================


### PR DESCRIPTION

## Diagrams

N/A — desktop detail restyle (field-guide port) + two transitions-dev catalog animations; no new flow to diagram.

## Summary

Brings the **field-guide design** (shipped on the mobile sheet) to the **desktop detail card** (the >1199px rail), which previously read as a flat stacked card. Closes **#918**; also closes **#911**.

- **Restyled `SpeciesDetailSurface`** (the desktop body the rail renders) to the field-guide entry shape with new `.detail-fg-*` classes reading the EXISTING tokens (`--type-hero`, `--sheet-dot-ring`, `--space-*`, `--panel-*`, `--stagger-*`): full-bleed **masthead** (fixed 232px + bottom scrim) → hero name → italic sci → **family dot + contrast ring + name** → **3px family-accent rule** → **taxonomy `<dl>`** (Scientific name / Family / eBird taxonomic order) → **About** eyebrow + `<SpeciesDescription>` + credit.
- **Animations — transitions-dev catalog only** (no FLIP/VT/clip-path): rail open = **recipe #07 panel-reveal** (`.t-panel-slide` on the aside; it slides into the top-right region of a live map, `role="complementary"`, not a modal; `--panel-translate-y` 16px); identity reveal on open/species-switch = **recipe #18 texts-reveal** (name/sci/family staggered). One post-paint mount effect drives both; one clock; reduced-motion owned globally by motion.css. (The rail had no entrance animation before.)
- **Safe seam:** the mobile `SpeciesDetailSheet` does NOT import `SpeciesDetailSurface` (it owns its `.sheet-fg-*` layout), so this cannot regress mobile — confirmed: 1024/768/390 still render the sheet unchanged.
- **Restated data (deliberate):** the taxonomy `<dl>` restates sci + family as labeled reference data (matching the mobile field-guide); the surface test's single-match `getByText` was updated to scoped/`getAllByText` queries (structural update, not a weakening) + a taxonomy-row test added.
- **#911:** `SpeciesDetailRail`'s `fallbackFocusSelector` default `#surface-tab-map` (dead) → `#main-surface` (real focusable `<main>`), with a focus-restore test.

Scope: desktop detail only; the rail's geometry/width-clamp/z/corner (four-corner contract) are untouched.

## Screenshots

**Desktop detail rail — the field-guide port (the change), both themes:**

| 1440 · light | 1440 · dark | 1920 · light | 1920 · dark |
|---|---|---|---|
| <img width="200" alt="01-1440-light" src="https://github.com/user-attachments/assets/ee0c6284-cf44-4525-8a68-0e7030e67e2f"> | <img width="200" alt="02-1440-dark" src="https://github.com/user-attachments/assets/4043b39d-aa1b-4c2c-8f51-ffeaefd8f3d4"> | <img width="200" alt="03-1920-light" src="https://github.com/user-attachments/assets/66328db0-d682-4e2b-a5ad-d94f47c49c24"> | <img width="200" alt="04-1920-dark" src="https://github.com/user-attachments/assets/6695d393-bf9d-4f02-974a-2e1ee89e488c"> |

**Below 1199px — the mobile sheet, UNCHANGED (no-regression; change confined to >1199px):**

| 1024 · light | 1024 · dark | 768 · light | 768 · dark | 390 · light | 390 · dark |
|---|---|---|---|---|---|
| <img width="120" alt="05-1024-sheet-light" src="https://github.com/user-attachments/assets/feb7d3ed-5da8-4d2b-9365-ef9d6430782c"> | <img width="120" alt="06-1024-sheet-dark" src="https://github.com/user-attachments/assets/bcaf199f-9b3b-4bb0-b1e4-dab9943383c2"> | <img width="120" alt="07-768-sheet-light" src="https://github.com/user-attachments/assets/215671ba-e2b8-4ff3-ba2e-7d1b3dd0be21"> | <img width="120" alt="08-768-sheet-dark" src="https://github.com/user-attachments/assets/6271c8f4-12c2-4020-90ed-3a7770cf2b11"> | <img width="120" alt="09-390-sheet-light" src="https://github.com/user-attachments/assets/e1eda4a2-f1df-460a-b9bf-fa59801bcd4b"> | <img width="120" alt="10-390-sheet-dark" src="https://github.com/user-attachments/assets/358d0220-cf5c-46f0-bf67-f016500bd684"> |

Console: **0 errors** at all five viewports. The #07 panel-reveal entrance + #18 texts-reveal are animations (verified live; static stills show the resting state).

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (new surface structural tests: dot+inline-bg, accent rule, taxonomy `<dl>` 3 rows, About eyebrow; restated-data queries; #911 `#main-surface` focus-restore test)
- [x] `npm run build`, `lint`, `npx knip`, `bash scripts/check-orphan-classnames.sh` — clean (new `.detail-fg-*` / `.t-panel-slide` / `.t-stagger*` classes all have matching CSS)
- [x] Rail/surface e2e (`--project=dev-server`) — pass (dual-viewport console-clean sweep)
- [x] Live (Playwright): field-guide elements present at 1440/1920 (masthead 232px, dot, accent rule, 3 taxonomy rows); 1024 still renders the SHEET (no rail, no `.detail-fg`); console 0 errors at all 5 viewports; #07 entrance + #18 reveal play
- [x] transitions-dev recipes installed verbatim, catalog-only (no FLIP/VT/clip-path/WAAPI)

## Plan reference

Closes **#918** (field-guide → desktop detail). Closes **#911** (dead focus-restore fallback).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
