### PR TITLE
chore: family-name hygiene — silhouette dedupe, prettyFamily comment, legend title, stale cache docs

### DIFF
--- a/docs/runbooks/cache-purge.md
+++ b/docs/runbooks/cache-purge.md
@@ -13,39 +13,44 @@ the `family_silhouettes` table reaches production. Common triggers:
 ## What the purge does (and does not) invalidate
 
 There are two caches between the database and the user's screen. The
-script only touches one of them.
+header `/api/silhouettes` emits now scopes staleness almost entirely to
+the CDN, and the script touches exactly that tier.
 
-| Tier              | What it is                                            | TTL                        | Touched by `purge-silhouettes-cache.sh`? |
-| ----------------- | ----------------------------------------------------- | -------------------------- | ---------------------------------------- |
-| **Cloudflare CDN** | Edge copy at the colo nearest the requesting user     | Honors `Cache-Control`     | **Yes** — purged within ~30s             |
-| **User browser**   | Per-user copy in each visitor's HTTP cache            | `max-age=604800` (7 days)  | **No** — held until that user's clock ticks |
+| Tier              | What it is                                            | TTL                                          | Touched by `purge-silhouettes-cache.sh`? |
+| ----------------- | ----------------------------------------------------- | -------------------------------------------- | ---------------------------------------- |
+| **Cloudflare CDN** | Edge copy at the colo nearest the requesting user     | `s-maxage=3600` (1h) + `stale-while-revalidate=7200` (2h grace) | **Yes** — purged within ~30s             |
+| **User browser**   | Per-user copy in each visitor's HTTP cache            | None — `s-maxage` is CDN-only; a reload always hits the CDN | **No** — but there is effectively nothing to hold |
 
-`/api/silhouettes` is served with `Cache-Control: public, max-age=604800`
-(see `services/read-api/src/cache-headers.ts`). Notably, that header
-**no longer carries `immutable`** — issue #252 removed it precisely so
-browsers will revalidate when their per-user `max-age` clock expires
-instead of holding the response untouchably for the full week.
+`/api/silhouettes` is served with
+`Cache-Control: public, s-maxage=3600, stale-while-revalidate=7200`
+(see `services/read-api/src/cache-headers.ts`). This is the #586 hot-path
+treatment: `s-maxage` is a **CDN-only** directive — it does not apply to
+private (browser) caches — so browsers are intentionally NOT asked to hold
+stale copies. The CDN serves a cached object for up to 1h, then a further
+2h of `stale-while-revalidate` grace while it refreshes from origin in the
+background. (This supersedes the old `max-age=604800` / 7-day browser-hold
+header this runbook was originally written against; issue #586 migrated the
+hot read endpoints to `s-maxage` and #252's `immutable` discussion no longer
+applies here.)
 
 The cause-effect chain for a curation update is therefore:
 
 1. The migration lands; the API now returns the new SVG/color/attribution.
 2. The operator runs `purge-silhouettes-cache.sh`. Within ~30s the
    Cloudflare edge copy is gone.
-3. The next time a user's browser actually goes to the network for
-   `/api/silhouettes` (either a cold fetch or a conditional revalidation
-   after `max-age` expiry), the request reaches the API and gets the
-   fresh bytes. Without the purge, the edge would still hand back the
-   stale copy until its own TTL ticked.
-4. **Browser caches turn over per response `max-age` regardless of the
-   purge.** Most users see fresh data within hours (whenever their
-   browser's TTL next ticks); a worst-case user who fetched right before
-   the migration holds stale bytes for up to 7 days from their last
-   request, then revalidates and picks up the new copy.
+3. The next request for `/api/silhouettes` reaches origin and the CDN
+   caches the fresh bytes. Because browsers don't hold a private copy
+   (no `max-age`), users pick up the new data on their next fetch — a hard
+   reload always reaches the (now-fresh) CDN.
+4. **Even without a purge, edge staleness self-heals within ~1h** (the
+   `s-maxage` window), with up to 2h of SWR grace during which the edge
+   serves the old copy while revalidating. The purge just collapses that
+   ~1–3h tail to ~30s.
 
-If you need a hard guarantee that every user sees the new data
-immediately, neither the CDN purge nor the existing `max-age` window can
-provide it — that would require a versioned URL (e.g. `/api/silhouettes?v=2`)
-which we deliberately do not use.
+If you need a hard guarantee that every user sees the new data immediately,
+the CDN purge is the lever — it drops the only meaningful cache tier in ~30s.
+(There is no per-user browser `max-age` window left to wait out; a versioned
+URL like `/api/silhouettes?v=2` remains a deliberate non-goal.)
 
 ## How to run
 

--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -242,7 +242,7 @@ function FamilyLegendImpl({
                     {...(entry.silhouette.svgUrl != null ? { imgUrl: entry.silhouette.svgUrl } : {})}
                     {...(entry.silhouette.svgData != null ? { pathD: entry.silhouette.svgData } : {})}
                   />
-                  <span className="family-legend-entry-label">{entry.label}</span>
+                  <span className="family-legend-entry-label" title={entry.label}>{entry.label}</span>
                   <span
                     className="family-legend-entry-count"
                     aria-label={`${entry.count} observations in view`}

--- a/frontend/src/derived.ts
+++ b/frontend/src/derived.ts
@@ -60,9 +60,17 @@ export function deriveSpeciesIndex(observations: Observation[]): SpeciesOption[]
 // headers; that component was deleted but the function still has 9+ live
 // consumers across kept surfaces.
 //
-// We only capitalize the family code — we have no vernacular dictionary to
-// map codes like "Tyrannidae" → "Tyrant Flycatchers". A future enhancement
-// could add a static map if the display name matters more than simplicity.
+// This is the TERMINAL FALLBACK in the family-name resolver chain, NOT the
+// primary display path. A vernacular dictionary DOES exist: every observed
+// family has a curated colloquial name in `family_silhouettes.common_name`
+// (e.g. `tyrannidae` → "Tyrant Flycatchers"), reachable on the map via the
+// `/api/silhouettes` payload the app already fetches; the longer official
+// eBird name lives in `species_meta.family_name`. The shared `resolveFamilyName`
+// helper (issue #920) resolves `family.name ?? silhouette.commonName ??
+// prettyFamily(familyCode)`, so `prettyFamily` only runs when neither dictionary
+// has an entry — e.g. a brand-new family observed before its silhouette row
+// exists. It just capitalizes the lowercased `family_code` so that last-resort
+// case still renders something legible instead of `tyrannidae`.
 export function prettyFamily(code: string): string {
   // Defensive: a missing/empty code (malformed data, a stale-shape bucket) must
   // not crash a render. Return '' rather than throwing on `undefined`/empty.

--- a/migrations/1700000052000_dedupe_ptiliogonatidae_silhouette.sql
+++ b/migrations/1700000052000_dedupe_ptiliogonatidae_silhouette.sql
@@ -1,0 +1,48 @@
+-- Up Migration
+-- Issue #922 (family-name hygiene). Dedupe the spelling-variant duplicate in
+-- family_silhouettes for the silky-flycatcher family.
+--
+-- The table carries BOTH spellings of the Ptilogonatidae family:
+--   * `ptilogonatidae`  — the PROJECT CANONICAL key, which is
+--     `lower(familySciName)` (the same shape every other family_code uses,
+--     and the key observations.family_code / species_meta.family_code resolve
+--     against). Seeded in migration 15000, named 'Silky-Flycatchers' in 19500,
+--     dual-palette colored in 46000.
+--   * `ptiliogonatidae` — an extra-`i` variant matching eBird's own family
+--     scientific-name spelling (`Ptiliogonatidae`). Inserted as a separate row
+--     in migration 34000 (issue #495 AZ backfill) with common_name
+--     'Silky-flycatchers' (note the lowercase `f` — a casing inconsistency too).
+--
+-- Both rows currently carry a common_name, so rendering is fine TODAY. But two
+-- rows for one family is latent taxonomy drift, and once a `family_silhouettes`
+-- join is added on the read path (PR4 / issue #925), a `LEFT JOIN` on
+-- family_code could match two rows for this family. Removing the variant now
+-- keeps that join single-row-per-family.
+--
+-- We keep `ptilogonatidae` (the project canonical) and delete the
+-- `ptiliogonatidae` variant. No observation or species_meta row references the
+-- extra-`i` spelling (family_code is `lower(familySciName)` = `ptilogonatidae`),
+-- so nothing is orphaned. The surviving canonical row keeps its non-null
+-- common_name ('Silky-Flycatchers') unchanged.
+--
+-- eBird-join normalization note (scoped to a comment, NOT live code): the
+-- project's family_code is `lower(familySciName)`, while eBird's taxonomy
+-- spells this family `Ptiliogonatidae` (extra `i`) — so a future
+-- `lower(familySciName)` join against eBird's `familyComName` would need the
+-- alias `ptiliogonatidae -> ptilogonatidae`. No eBird name-refresh consumer
+-- ships in this work, so the alias stays documented-only until one exists; see
+-- docs/analyses/2026-06-07-family-colloquial-names/report.md (Authoritative
+-- source) for the full normalization gotcha.
+DELETE FROM family_silhouettes WHERE family_code = 'ptiliogonatidae';
+
+-- Down Migration
+-- Re-insert the `ptiliogonatidae` variant exactly as it stood in the
+-- fully-migrated forward state: NULL svg_data/source/license/creator (it was a
+-- skip-family row in 34000), common_name 'Silky-flycatchers', and the
+-- dual-palette colors set by migration 46000 (color/color_dark = #73596a).
+-- ON CONFLICT keeps this idempotent if the row somehow already exists.
+INSERT INTO family_silhouettes
+  (id, family_code, svg_data, color, color_dark, source, license, creator, common_name)
+VALUES
+  ('ptiliogonatidae', 'ptiliogonatidae', NULL, '#73596a', '#73596a', NULL, NULL, NULL, 'Silky-flycatchers')
+ON CONFLICT (id) DO NOTHING;

--- a/packages/db-client/src/family-silhouettes-contrast.test.ts
+++ b/packages/db-client/src/family-silhouettes-contrast.test.ts
@@ -147,6 +147,9 @@ describe('family palette WCAG 1.4.11 (3:1 non-text contrast) — dual-palette co
   // (#51665e, 2.76), podicipedidae (#406a65, 2.80), ptiliogonatidae (#73596a, 2.72),
   // ptilogonatidae (#5b5b9c, 2.77), rallidae (#63605a, 2.71), strigidae (#725e35, 2.72),
   // sturnidae (#6b5885, 2.72), trochilidae (#9637ad, 2.79), troglodytidae (#86582c, 2.79).
+  // (Historical snapshot from #570; migration 52000 (#922) since removed the
+  // spelling-variant `ptiliogonatidae` row, so only the canonical
+  // `ptilogonatidae` remains of that pair.)
   //
   // Re-enable to `it(...)` once migration 1700000047000 lands. See #583.
   it.todo('every family_silhouettes.color_dark is ≥ 3:1 against the dark legend card surface (#131C30) — pending migration 1700000047000 (tracked in #583)');

--- a/packages/db-client/src/migrations-down-chain.test.ts
+++ b/packages/db-client/src/migrations-down-chain.test.ts
@@ -65,7 +65,13 @@ describe('Down(14000→17000) rollback chain', () => {
   it('runs Down(17000) without leaving any NULL svg_data on the 25 seeded families', async () => {
     const migrationsDir = resolve(process.cwd(), '../../migrations');
 
-    // Roll down from 48000 → 14000 in reverse numeric order.
+    // Roll down from 52000 → 14000 in reverse numeric order.
+    // Migration 52000 (#922 family-name hygiene) DELETEs the spelling-variant
+    // `ptiliogonatidae` row (one of the svg_data=NULL skip-family rows from
+    // 34000). Its Up runs in beforeAll, so it must be rolled down FIRST or the
+    // deleted NULL row would deflate test 1's NULL count (6 not 7) and test 2's
+    // total count (53 not 54). Down(52000) re-inserts it, restoring the
+    // historical invariants. (Mirrors `node-pg-migrate down`: latest first.)
     // Migration 48000 (Phase 3a national-coverage flip) inserts 32 rows,
     // 15 of them with svg_data=NULL — must be rolled down first or its
     // NULL rows would (a) inflate test 1's NULL count past the 7 the
@@ -77,6 +83,7 @@ describe('Down(14000→17000) rollback chain', () => {
     // We only need to go back as far as 14000 to exercise the bug; rolling
     // all the way keeps the test realistic (matches `node-pg-migrate down`).
     const downSequence = [
+      '1700000052000_dedupe_ptiliogonatidae_silhouette.sql',
       '1700000048000_national_coverage_silhouettes.sql',
       '1700000046000_family_silhouettes_dual_palette.sql',
       '1700000019700_seed_fallback_common_name.sql',

--- a/packages/db-client/src/ptiliogonatidae-dedupe-migration.test.ts
+++ b/packages/db-client/src/ptiliogonatidae-dedupe-migration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Integration test for migration 1700000052000 —
+ * dedupe the spelling-variant duplicate in family_silhouettes for the
+ * silky-flycatcher family (`ptilogonatidae` vs `ptiliogonatidae`).
+ *
+ * Issue #922 (family-name hygiene). The table historically carried two rows for
+ * one family: the project-canonical `ptilogonatidae` (`lower(familySciName)`,
+ * the key observations/species_meta resolve against) and an extra-`i`
+ * `ptiliogonatidae` variant (matching eBird's own spelling), inserted by
+ * migration 34000. Both have a common_name so rendering is fine today, but the
+ * duplicate is latent taxonomy drift and would let PR4's `family_silhouettes`
+ * LEFT JOIN match two rows for the family.
+ *
+ * Invariants exercised here:
+ *   - Up leaves exactly ONE silky-flycatcher row, the canonical
+ *     `ptilogonatidae`, and it still has a non-null common_name.
+ *   - Up does not touch the canonical row's common_name.
+ *   - Down re-inserts the `ptiliogonatidae` variant (rollback restores the
+ *     pre-migration two-row state).
+ *
+ * No DB mocks — runs against a real PostGIS testcontainer per the project-wide
+ * rule (CLAUDE.md "No DB mocks in tests"). Test pattern mirrors
+ * species-meta-x00013-migration.test.ts: a one-off container with all
+ * migrations applied in beforeAll.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers before any query.
+import './pool.js';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+const MIGRATION_FILE = '1700000052000_dedupe_ptiliogonatidae_silhouette.sql';
+
+// The two spellings of the Ptilogonatidae (silky-flycatcher) family.
+const CANONICAL = 'ptilogonatidae'; // lower(familySciName) — kept
+const VARIANT = 'ptiliogonatidae'; // extra `i`, eBird spelling — removed
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const sql = readFileSync(filePath, 'utf-8');
+  const [rawUpPart = '', rawDownPart = ''] = sql.split(/-- Down Migration/i);
+  return {
+    up: rawUpPart.replace(/-- Up Migration/i, '').trim(),
+    down: rawDownPart.trim(),
+  };
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  // Apply all Up migrations in numeric order. Same logic as startTestDb.
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  for (const f of files) {
+    const { up } = parseMigration(join(migrationsDir, f));
+    if (up) {
+      await pool.query(up);
+    }
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Up', () => {
+  it('leaves exactly one silky-flycatcher row, the canonical spelling, with a non-null common_name', async () => {
+    const { rows } = await pool.query<{
+      family_code: string;
+      common_name: string | null;
+    }>(
+      `SELECT family_code, common_name
+         FROM family_silhouettes
+        WHERE family_code IN ($1, $2)`,
+      [CANONICAL, VARIANT]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.family_code).toBe(CANONICAL);
+    expect(rows[0]?.common_name).toBe('Silky-Flycatchers');
+    expect(rows[0]?.common_name).not.toBeNull();
+  });
+
+  it('removes the extra-`i` variant row entirely', async () => {
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM family_silhouettes WHERE family_code = $1`,
+      [VARIANT]
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+
+  it('is idempotent — re-running Up does not error and leaves one row', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    await pool.query(up);
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM family_silhouettes WHERE family_code IN ($1, $2)`,
+      [CANONICAL, VARIANT]
+    );
+    expect(Number(rows[0]?.count)).toBe(1);
+  });
+});
+
+describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Down', () => {
+  it('re-inserts the variant row (restores the two-row pre-migration state)', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { down, up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    expect(down).toBeTruthy();
+    await pool.query(down);
+
+    const { rows } = await pool.query<{
+      family_code: string;
+      common_name: string | null;
+      color: string;
+      color_dark: string;
+      svg_data: string | null;
+    }>(
+      `SELECT family_code, common_name, color, color_dark, svg_data
+         FROM family_silhouettes
+        WHERE family_code = $1`,
+      [VARIANT]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.common_name).toBe('Silky-flycatchers');
+    expect(rows[0]?.color).toBe('#73596a');
+    expect(rows[0]?.color_dark).toBe('#73596a');
+    expect(rows[0]?.svg_data).toBeNull();
+
+    // Both spellings present again after Down.
+    const both = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM family_silhouettes WHERE family_code IN ($1, $2)`,
+      [CANONICAL, VARIANT]
+    );
+    expect(Number(both.rows[0]?.count)).toBe(2);
+
+    // Re-apply Up so the container is left in forward state for any shared run.
+    await pool.query(up);
+  });
+});

--- a/packages/db-client/src/silhouettes.test.ts
+++ b/packages/db-client/src/silhouettes.test.ts
@@ -7,16 +7,18 @@ beforeAll(async () => { db = await startTestDb(); }, 90_000);
 afterAll(async () => { await db?.stop(); });
 
 describe('getSilhouettes', () => {
-  it('returns all 97 seeded families (96 real + _FALLBACK)', async () => {
+  it('returns all 96 seeded families (95 real + _FALLBACK)', async () => {
     // 15 from migration 9000 + 10 AZ-family expansion from migration 15000
     // (#244) + the `_FALLBACK` row from migration 18000 (#246) + icteridae
     // from migration 33000 (#482) + 38 observed-family backfill from
     // migration 34000 (#495) + 32 national-coverage rows from migration
-    // 48000 (Phase 3a US-wide flip). The _FALLBACK row backs the SDF symbol
+    // 48000 (Phase 3a US-wide flip) − 1 spelling-variant dedupe from
+    // migration 52000 (#922: dropped the extra-`i` `ptiliogonatidae`, leaving
+    // the canonical `ptilogonatidae`). The _FALLBACK row backs the SDF symbol
     // layer's fallback rendering for observations whose family has no
     // usable Phylopic silhouette.
     const rows = await getSilhouettes(db.pool);
-    expect(rows).toHaveLength(97);
+    expect(rows).toHaveLength(96);
     // _FALLBACK row exists with sentinel family_code.
     const fallback = rows.find(r => r.familyCode === '_FALLBACK');
     expect(fallback).toBeDefined();
@@ -185,7 +187,8 @@ describe('getSilhouettes', () => {
       polioptilidae: '#788ca0', // was #A8B5C2 (light-failing, darkened)
       psittacidae: '#3b9d4b',   // was #3FA850 (light-failing, darkened)
       psittaculidae: '#3d9790', // was #4FB8B0 (light-failing, darkened)
-      ptiliogonatidae: '#73596a', // was #1A1418
+      // ptiliogonatidae removed by migration 52000 (#922 dedupe) — the
+      // canonical `ptilogonatidae` (#5b5b9c, above) is the surviving row.
       rallidae: '#63605a',      // was #403E3A
       recurvirostridae: '#c47484', // was #E1B8C0 (light-failing, darkened)
       regulidae: '#68964b',     // was #6FA050 (light-failing, darkened)
@@ -246,12 +249,13 @@ describe('getSilhouettes', () => {
     expect(nullCommon).toEqual([]);
   });
 
-  it('common-name snapshot for all 97 seeded families (incl. _FALLBACK)', async () => {
+  it('common-name snapshot for all 96 seeded families (incl. _FALLBACK)', async () => {
     // Curated English common names per migration 1700000019500 (original 27
     // families) plus migration 1700000034000 (38 backfill families per
     // issue #495) plus migration 1700000048000 (32 national-coverage
-    // families, Phase 3a US-wide flip). Update both sides together if the
-    // seed text changes.
+    // families, Phase 3a US-wide flip) minus migration 1700000052000 (#922:
+    // dropped the spelling-variant `ptiliogonatidae`). Update both sides
+    // together if the seed text changes.
     const rows = await getSilhouettes(db.pool);
     const byFamily = Object.fromEntries(rows.map(r => [r.familyCode, r.commonName]));
     expect(byFamily).toEqual({
@@ -318,7 +322,8 @@ describe('getSilhouettes', () => {
       polioptilidae: 'Gnatcatchers',
       psittacidae: 'African & New World Parrots',
       psittaculidae: 'Old World Parrots',
-      ptiliogonatidae: 'Silky-flycatchers',
+      // ptiliogonatidae removed by migration 52000 (#922 dedupe); the
+      // canonical `ptilogonatidae: 'Silky-Flycatchers'` (above) survives.
       rallidae: 'Rails, Gallinules & Coots',
       recurvirostridae: 'Stilts & Avocets',
       regulidae: 'Kinglets',

--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -3,13 +3,22 @@
  * path and the ingestor cache-warmer (issue #866).
  *
  * The single job of this package is to make `/api/observations` cache keys
- * COLLIDE. The frontend serializes the full-precision float viewport bbox
- * straight into the query string, so every pan/zoom mints a unique Cloudflare
- * cache key → guaranteed MISS by construction (zone-wide HIT ratio was 0.67%).
+ * COLLIDE. BEFORE this package, the frontend serialized the full-precision
+ * float viewport bbox straight into the query string, so every pan/zoom minted
+ * a unique Cloudflare cache key → guaranteed MISS by construction. That was the
+ * pre-fix baseline (~0.67% zone-wide / ~5% /api HIT ratio measured 2026-06-03).
  * `snapFetchBbox` rounds the *fetch* bbox to a coarse, shared, deterministic
  * grid so nearby viewports resolve to one key, and `serializeBbox` emits the
  * one canonical decimal string both call sites produce — the actual collision
  * lever.
+ *
+ * **This collision layer is SHIPPED and prod-validated** (#866/#867 float-snap →
+ * #868/#869 canonical-extent keys → #870/#871 s-maxage→cadence tune): organic
+ * caching is live and cold-load national views hit a warmed key. The snapping
+ * is wired into BOTH call sites (`client.ts` getObservations + the cache-warmer),
+ * so the 0.67% figure above is HISTORY, not current state. The only remaining
+ * raw-float path is the `zoom >= 6` per-observation passthrough (see
+ * `snapFetchBbox` below) — a tracked v1 non-goal, not regressed by this package.
  *
  * **Source-only, consumer-compiled.** This package ships no `dist` build: its
  * `package.json` `exports.default` points at `./src/index.ts`. The frontend's

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -944,7 +944,7 @@ describe('error handling', () => {
 });
 
 describe('GET /api/silhouettes', () => {
-  it('returns all 97 seeded family silhouettes with the silhouettes cache header', async () => {
+  it('returns all 96 seeded family silhouettes with the silhouettes cache header', async () => {
     const app = createApp({ pool: db.pool });
     const res = await app.request('/api/silhouettes');
     expect(res.status).toBe(200);
@@ -965,8 +965,10 @@ describe('GET /api/silhouettes', () => {
     // 18000 (issue #246) + icteridae row from migration 33000 (issue #482)
     // + 38 observed-family backfill rows from migration 34000 (issue #495)
     // + 32 national-coverage rows from migration 48000 (Phase 3a US-wide
-    // flip — 17 with svg_data, 15 with NULL svg_data) → 97 total.
-    expect(body).toHaveLength(97);
+    // flip — 17 with svg_data, 15 with NULL svg_data) − 1 spelling-variant
+    // dedupe from migration 52000 (#922: dropped the extra-`i`
+    // `ptiliogonatidae`) → 96 total.
+    expect(body).toHaveLength(96);
     // Spot-check the _FALLBACK row round-trips through the Hono response
     // so the frontend's symbol-layer fallback path can rely on it.
     const fallback = body.find(r => r.familyCode === '_FALLBACK');


### PR DESCRIPTION
## Diagrams

Migration graph — the dedupe collapses two `family_silhouettes` rows for the Ptilogonatidae family into the project-canonical one, so PR4's (#923) join stays single-row-per-family:

```mermaid
graph TD
    subgraph "family_silhouettes BEFORE"
        A["ptilogonatidae<br/>(lower(familySciName), CANONICAL)<br/>common_name: 'Silky-Flycatchers'"]
        B["ptiliogonatidae<br/>(extra 'i', eBird spelling)<br/>common_name: 'Silky-flycatchers'"]
    end
    subgraph "family_silhouettes AFTER (Up 52000)"
        A2["ptilogonatidae<br/>common_name: 'Silky-Flycatchers'<br/>← single row for the family"]
    end
    A -->|kept| A2
    B -->|DELETE| X["(removed; Down re-inserts)"]
    A2 -->|"LEFT JOIN family_code (PR4 #923)"| J["one row per family ✓"]
```

Resolver chain the `prettyFamily` comment now points at (this PR only fixes the comment + the legend `title`; the wiring ships in #920/#921/#923):

```mermaid
graph LR
    F["family.name<br/>(server COALESCE, #923)"] --> S["silhouette.commonName<br/>(/api/silhouettes)"] --> P["prettyFamily(familyCode)<br/>TERMINAL FALLBACK (this file)"]
```

## Summary

- **Why a migration:** the table carried both `ptilogonatidae` (canonical) and the extra-`i` `ptiliogonatidae` (eBird's spelling) for one family. Both render fine today, but the duplicate is latent taxonomy drift and would let PR4's (#923) `family_silhouettes` LEFT JOIN match two rows per family — so it must land before PR4. Migration 52000 deletes the variant, keeping the canonical row + its non-null `common_name`; Down re-inserts it. The eBird-join normalization gotcha (`ptiliogonatidae` → `ptilogonatidae`) is captured as a documented comment, not live code — no name-refresh consumer ships here.
- **Why the comment/doc fixes:** three stale artifacts surfaced in the research. `prettyFamily`'s comment falsely claimed "no vernacular dictionary" (it exists in `family_silhouettes.common_name` + `species_meta.family_name`); `cache-purge.md` documented `/api/silhouettes` as `max-age=604800` (7-day browser hold) when the live header is `s-maxage=3600, stale-while-revalidate=7200` (1h, CDN-only) since #586; and the `packages/geo` `0.67%` comment read as if the bbox-quantize fix were still pending when it shipped + prod-validated (#866–#871).
- **Why the test churn:** the dedupe forces guardrail fixtures that pinned 97 rows to flip to 96 (`silhouettes.test.ts`, read-api `app.test.ts`), and the down-chain rollback test now rolls 52000 back first to restore its historical NULL/total invariants.

## Screenshots

N/A — not UI. The two `frontend/**` touches are a comment (`derived.ts`) and a single `title={entry.label}` hover-tooltip attribute on the legend label span (`FamilyLegend.tsx`); neither is a visible-UI change, so this PR is exempt from the Playwright multi-viewport drive per the repo's comment/attribute-only exemption (and the issue's own UI-verification note).

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no new className` (the only JSX change is a `title` attribute, no class added)
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm run test` — green (db-client 17 files / 150 tests + 1 todo incl. the new `ptiliogonatidae-dedupe-migration.test.ts`; read-api `app.test` 86 tests; frontend `FamilyLegend` + `derived` 42 tests)
- [x] New integration test added — `packages/db-client/src/ptiliogonatidae-dedupe-migration.test.ts` (testcontainers, no DB mocks): Up leaves exactly one canonical silky-flycatcher row with a non-null `common_name`; Down re-inserts the variant; idempotent re-run. Falsifiability checked: neutralizing the Up `DELETE` fails 3 of 4 assertions.
- [ ] New Playwright e2e spec added — N/A (no user-visible behavior change)
- [x] `npm run build` — clean production build (all 5 workspaces, incl. frontend `vite build`)
- [x] (UI only) Playwright MCP smoke — `N/A — not UI` (comment + `title` attribute only)
- [x] `npm run lint` clean (incl. the forbidden-raw-token grep guard) and `knip` exits 0 (no new findings)

## Plan reference

Plans live in issues, not `docs/plans/` for this work. Closes #922 · Part of #924 (PR3 of 4; independent of PR1/#920 and PR2/#921; should precede PR4/#923 so its `family_silhouettes` join is single-row-per-family). Full research + file:line breakdown: `docs/analyses/2026-06-07-family-colloquial-names/report.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)