### PR TITLE
feat(frontend): colloquial family names in cluster popovers + shared resolveFamilyName helper

### DIFF
--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -203,6 +203,11 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
   // already threads `species` per tile; no re-aggregation needed).
   const families = tiles.map((t) => ({ familyCode: t.familyCode, count: t.count }));
   const speciesByFamily = new Map(tiles.map((t) => [t.familyCode, t.species]));
+  // #920: each tile already carries its resolved colloquial `displayName`
+  // (`resolveFamilyName(familyCode, { commonName })`). Thread it to the
+  // <ClusterListPopover> so the family-toggle headers show the curated name
+  // instead of the scientific `prettyFamily(code)`.
+  const familyNames = new Map(tiles.map((t) => [t.familyCode, t.displayName]));
 
   // Single-leaf preservation (spec §4.10): clusters with totalCount === 1 fall
   // through to the existing onClick handler (which routes to setSelectedObs in
@@ -409,6 +414,7 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
           detailOpen ? null : (
             <CellHoverPreview
               familyCode={activeTile.familyCode}
+              familyName={activeTile.displayName}
               familyCount={activeTile.count}
               species={activeTile.species}
               id={previewId!}
@@ -419,6 +425,7 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
           cellRefs.current[activeCell.index] ? (
             <CellPopover
               familyCode={activeTile.familyCode}
+              familyName={activeTile.displayName}
               familyCount={activeTile.count}
               species={activeTile.species}
               anchorEl={cellRefs.current[activeCell.index]!}
@@ -436,6 +443,7 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
       {clusterListInteractive && isClusterListOpen && outerRef.current && (
         <ClusterListPopover
           families={families}
+          familyNames={familyNames}
           speciesByFamily={speciesByFamily}
           totalCount={props.totalCount}
           uniqueFamilies={props.uniqueFamilies}

--- a/frontend/src/components/map/CellHoverPreview.tsx
+++ b/frontend/src/components/map/CellHoverPreview.tsx
@@ -14,8 +14,13 @@ import { prettyFamily } from '../../derived.js';
  * management (tooltips don't take focus per WAI-ARIA tooltip pattern).
  */
 export interface CellHoverPreviewProps {
-  /** Family code; resolved to display name via `prettyFamily`. */
+  /** Family code; resolved to display name via `prettyFamily` when `familyName` is absent. */
   familyCode: string;
+  /**
+   * #920: pre-resolved colloquial family name (the tile's `displayName`).
+   * When omitted, the header falls back to `prettyFamily(familyCode)`.
+   */
+  familyName?: string;
   /** Total observations of this family in the cluster (badge value). */
   familyCount: number;
   /** Species in descending count order; consumer slices to ≤ 3 if desired. */
@@ -34,7 +39,7 @@ export interface CellHoverPreviewProps {
 const PREVIEW_CAP = 3;
 
 export function CellHoverPreview(props: CellHoverPreviewProps) {
-  const { familyCode, familyCount, species, id, cursorPos } = props;
+  const { familyCode, familyName, familyCount, species, id, cursorPos } = props;
   const visible = species.slice(0, PREVIEW_CAP);
   const hasMore = species.length > PREVIEW_CAP;
 
@@ -63,7 +68,7 @@ export function CellHoverPreview(props: CellHoverPreviewProps) {
       style={positionStyle}
     >
       <div className="cell-hover-preview__header">
-        {prettyFamily(familyCode)} ({familyCount})
+        {familyName ?? prettyFamily(familyCode)} ({familyCount})
       </div>
       <ul className="cell-hover-preview__rows">
         {visible.map((s) => (

--- a/frontend/src/components/map/CellPopover.tsx
+++ b/frontend/src/components/map/CellPopover.tsx
@@ -81,6 +81,13 @@ function computePopoverPosition(
 }
 export interface CellPopoverProps {
   familyCode: string;
+  /**
+   * #920: pre-resolved colloquial family name (the tile's `displayName`,
+   * `resolveFamilyName(familyCode, { commonName })`). When omitted, the header
+   * falls back to `prettyFamily(familyCode)` so legacy/test callers that pass
+   * only a code still render the capitalized scientific label.
+   */
+  familyName?: string;
   familyCount: number;
   species: ReadonlyArray<SpeciesAggregate>;
   /**
@@ -104,7 +111,7 @@ const POPOVER_CAP = 8;
 
 export function CellPopover(props: CellPopoverProps) {
   const {
-    familyCode, familyCount, species, overflowCount, anchorEl,
+    familyCode, familyName, familyCount, species, overflowCount, anchorEl,
     onDismiss, onSelectSpecies, onDrillIn,
   } = props;
   const headingId = useId();
@@ -202,7 +209,7 @@ export function CellPopover(props: CellPopoverProps) {
           tabIndex={-1}
           data-testid="cell-popover-heading"
         >
-          {prettyFamily(familyCode)} ({familyCount})
+          {familyName ?? prettyFamily(familyCode)} ({familyCount})
         </h2>
       </header>
       <ul className="cell-popover__rows">

--- a/frontend/src/components/map/ClusterListPopover.tsx
+++ b/frontend/src/components/map/ClusterListPopover.tsx
@@ -31,6 +31,14 @@ import { prettyFamily } from '../../derived.js';
 export interface ClusterListPopoverProps {
   /** All families in the cluster, descending count order (from `aggregateClusterFamilies`). */
   families: ReadonlyArray<FamilyAggregate>;
+  /**
+   * #920: per-family resolved colloquial display name, keyed by familyCode
+   * (`resolveFamilyName(familyCode, { commonName })`). The family-toggle header
+   * reads it; a missing entry falls back to `prettyFamily(familyCode)`, so a
+   * caller that omits the map (or a family absent from it) still renders the
+   * capitalized scientific label.
+   */
+  familyNames?: ReadonlyMap<string, string>;
   /** Species lookup keyed by familyCode. */
   speciesByFamily: ReadonlyMap<string, ReadonlyArray<SpeciesAggregate>>;
   /**
@@ -62,6 +70,7 @@ const POPOVER_CAP_PER_FAMILY = 8;
 export function ClusterListPopover(props: ClusterListPopoverProps) {
   const {
     families,
+    familyNames,
     speciesByFamily,
     overflowByFamily,
     totalCount,
@@ -204,7 +213,7 @@ export function ClusterListPopover(props: ClusterListPopoverProps) {
                 {/* The collapsed/expanded caret (▶ / ▼) is a CSS ::before
                     pseudo-element driven by the `--expanded` modifier on the
                     parent `.cluster-list-popover__family` (ds-primitives.css). */}
-                {prettyFamily(fam.familyCode)} ({fam.count})
+                {familyNames?.get(fam.familyCode) ?? prettyFamily(fam.familyCode)} ({fam.count})
               </button>
               {isExpanded && (
                 <ul className="cluster-list-popover__rows">

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1829,7 +1829,10 @@ describe('#860 — lone clustered bucket opens its real species (coarse pointer)
     const familyToggle = screen.getByTestId(
       'cluster-list-popover-family-tyrannidae',
     );
-    expect(familyToggle).toHaveTextContent('Tyrannidae (7)');
+    // #920: header shows the curated colloquial name (from the silhouette
+    // catalogue's commonName), NOT the scientific `Tyrannidae`. The testid stays
+    // code-keyed — only the visible text resolves through resolveFamilyName.
+    expect(familyToggle).toHaveTextContent('Tyrant Flycatchers (7)');
 
     // Expand the family → the REAL common name resolved via the dictionary
     // appears, proving the bucket's species reached the user (#859), not a
@@ -1945,7 +1948,8 @@ describe('#864 — lone unclustered bucket silhouette opens its real species', (
     const familyToggle = screen.getByTestId(
       'cluster-list-popover-family-tyrannidae',
     );
-    expect(familyToggle).toHaveTextContent('Tyrannidae (7)');
+    // #920: curated colloquial header, not the scientific `Tyrannidae`.
+    expect(familyToggle).toHaveTextContent('Tyrant Flycatchers (7)');
 
     // Expand → the real common name (resolved via the dictionary) renders, with
     // a working species link (non-null code ⇒ <a role="link">).

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -79,6 +79,7 @@ import {
   type DeconflictGroup,
   type DeconflictInput,
 } from './deconflict.js';
+import { resolveFamilyName } from '../../derived.js';
 
 /**
  * Adaptive-grid reconciler memoization (epic #539 spec §5.3).
@@ -1356,16 +1357,47 @@ export function MapCanvas({
    * produces all-`pending` tiles.
    */
   const silhouettesById = useMemo<SilhouettesById>(() => {
-    const map = new Map<string, { svgData: string | null; color: string; colorDark: string }>();
+    const map = new Map<
+      string,
+      { svgData: string | null; color: string; colorDark: string; commonName: string | null }
+    >();
     for (const s of silhouettes) {
       map.set(s.familyCode.toLowerCase(), {
         svgData: s.svgData,
         color: s.color,
         colorDark: s.colorDark,
+        // #920: carry the curated colloquial name so the tile builders can
+        // resolve each tile's `displayName` and the popovers show
+        // "Tyrant Flycatchers" instead of the scientific "Tyrannidae".
+        commonName: s.commonName,
       });
     }
     return map;
   }, [silhouettes]);
+
+  /**
+   * #920: resolved colloquial display name per family for the standalone
+   * `<ClusterListPopover>` opened from a `<ClusterPill>` outer-tap (the
+   * `clusterList` state path). That path's `families` come from
+   * `aggregateClusterFamilies` / `mergeLeafBuckets` and carry no name, so we
+   * resolve each here from the silhouette catalogue — the same "resolve once
+   * from the catalogue" rule the tile builders follow. The AdaptiveGridMarker's
+   * OWN internal ClusterListPopover gets its names from the tiles' `displayName`
+   * and does not use this map.
+   */
+  const clusterListFamilyNames = useMemo<ReadonlyMap<string, string>>(() => {
+    const map = new Map<string, string>();
+    if (!clusterList) return map;
+    for (const fam of clusterList.families) {
+      map.set(
+        fam.familyCode,
+        resolveFamilyName(fam.familyCode, {
+          commonName: silhouettesById.get(fam.familyCode)?.commonName,
+        }),
+      );
+    }
+    return map;
+  }, [clusterList, silhouettesById]);
 
   // Issue #351: ref to the current onViewportChange prop. handleLoad has
   // [] deps (registers listeners exactly once per maplibre instance), so
@@ -2949,6 +2981,7 @@ export function MapCanvas({
       {clusterList && (
         <ClusterListPopover
           families={clusterList.families}
+          familyNames={clusterListFamilyNames}
           speciesByFamily={clusterList.speciesByFamily}
           {...(clusterList.overflowByFamily ? { overflowByFamily: clusterList.overflowByFamily } : {})}
           totalCount={clusterList.totalCount}

--- a/frontend/src/components/map/adaptive-grid.test.ts
+++ b/frontend/src/components/map/adaptive-grid.test.ts
@@ -320,6 +320,27 @@ describe('buildAdaptiveTiles', () => {
     expect(tiles[0]?.count).toBe(3);
     expect(tiles[0]?.species.reduce((s, x) => s + x.count, 0)).toBe(tiles[0]?.count);
   });
+
+  it('resolves a colloquial displayName per tile from the catalogue commonName (#920)', () => {
+    const leaves = [leaf('fam-00'), leaf('fam-01')];
+    const catalogue: SilhouettesById = new Map([
+      ['fam-00', { svgData: 'M0 0Z', color: '#111', colorDark: '#111', commonName: 'Tyrant Flycatchers' }],
+      // No commonName → resolver falls through to prettyFamily(familyCode).
+      ['fam-01', { svgData: 'M1 1Z', color: '#222', colorDark: '#222', commonName: null }],
+    ]);
+    const tiles = buildAdaptiveTiles(leaves, catalogue, SHAPE_2x2);
+    const byFam = new Map(tiles.map((t) => [t.familyCode, t]));
+    expect(byFam.get('fam-00')?.displayName).toBe('Tyrant Flycatchers');
+    expect(byFam.get('fam-01')?.displayName).toBe('Fam-01');
+  });
+
+  it('pending tiles still carry a displayName from the resolver (#920)', () => {
+    // Empty catalogue → pending, but the header must NOT be blank: it falls
+    // through to prettyFamily(familyCode).
+    const tiles = buildAdaptiveTiles([leaf('fam-00')], new Map(), SHAPE_2x2);
+    expect(tiles[0]?.kind).toBe('pending');
+    expect(tiles[0]?.displayName).toBe('Fam-00');
+  });
 });
 
 describe('tilesFromAggregates (#859 — bucket-mode tile builder)', () => {
@@ -384,6 +405,22 @@ describe('tilesFromAggregates (#859 — bucket-mode tile builder)', () => {
     ]);
     const tiles = tilesFromAggregates(families, speciesByFamily, CAT, SHAPE_2x2);
     expect(tiles[0]?.speciesCount).toBeUndefined();
+  });
+
+  it('resolves a colloquial displayName per tile from the catalogue commonName (#920)', () => {
+    const families: FamilyAggregate[] = [
+      { familyCode: 'tyrannidae', count: 9 },
+      { familyCode: 'cardinalidae', count: 4 },
+    ];
+    const cat: SilhouettesById = new Map([
+      ['tyrannidae', { svgData: 'M0 0Z', color: '#c3772d', colorDark: '#c3772d', commonName: 'Tyrant Flycatchers' }],
+      // fallback kind (svgData null) still resolves a display name.
+      ['cardinalidae', { svgData: null, color: '#b5202a', colorDark: '#b5202a', commonName: 'Cardinals & Allies' }],
+    ]);
+    const tiles = tilesFromAggregates(families, new Map(), cat, SHAPE_2x2);
+    expect(tiles[0]?.displayName).toBe('Tyrant Flycatchers');
+    expect(tiles[1]?.kind).toBe('fallback');
+    expect(tiles[1]?.displayName).toBe('Cardinals & Allies');
   });
 });
 

--- a/frontend/src/components/map/adaptive-grid.ts
+++ b/frontend/src/components/map/adaptive-grid.ts
@@ -23,6 +23,8 @@
  *     ascending familyCode tie-break, null-familyCode dropout.
  */
 
+import { resolveFamilyName } from '../../derived.js';
+
 export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
 
 export function toPositiveInt(n: number): PositiveInt {
@@ -129,10 +131,17 @@ export interface FamilyAggregate {
  * silhouette-resolution rule from spec §5.3 Concern C). An empty map
  * signals "catalogue not loaded yet" — distinct from "loaded but no art
  * for this family" — and produces `kind: 'pending'` tiles.
+ *
+ * `commonName` (#920) is the curated colloquial family name from
+ * `family_silhouettes.common_name` (carried on `FamilySilhouette.commonName`
+ * via `/api/silhouettes`). Optional so pre-#920 test fixtures that build the
+ * map without it still type-check; the production memo in `MapCanvas` always
+ * supplies it. `buildAdaptiveTiles`/`tilesFromAggregates` resolve each tile's
+ * `displayName` from it via `resolveFamilyName`.
  */
 export type SilhouettesById = ReadonlyMap<
   string,
-  { svgData: string | null; color: string; colorDark: string }
+  { svgData: string | null; color: string; colorDark: string; commonName?: string | null }
 >;
 
 /**
@@ -155,13 +164,19 @@ export type SilhouettesById = ReadonlyMap<
  * offer the active drill-in. Optional: the per-observation path can't know a
  * true distinct count beyond the leaves it merged, so it omits the field and
  * the popover falls back to the rendered-row remainder.
+ *
+ * `displayName` (#920) is the resolved colloquial family name shown in the
+ * cell popover / hover-preview headers — `resolveFamilyName(familyCode,
+ * { commonName })`. Threaded onto EVERY variant (incl. `pending`) so the
+ * header is never blank during a cold load; the resolver's terminal
+ * `prettyFamily` fallback guarantees a non-empty label for a real code.
  */
 export type AdaptiveTile =
-  | { kind: 'rendered'; familyCode: string; svgData: string; color: string; colorDark: string;
+  | { kind: 'rendered'; familyCode: string; displayName: string; svgData: string; color: string;
+      colorDark: string; count: number; species: ReadonlyArray<SpeciesAggregate>; speciesCount?: number }
+  | { kind: 'fallback'; familyCode: string; displayName: string; color: string; colorDark: string;
       count: number; species: ReadonlyArray<SpeciesAggregate>; speciesCount?: number }
-  | { kind: 'fallback'; familyCode: string; color: string; colorDark: string;
-      count: number; species: ReadonlyArray<SpeciesAggregate>; speciesCount?: number }
-  | { kind: 'pending'; familyCode: string;
+  | { kind: 'pending'; familyCode: string; displayName: string;
       count: number; species: ReadonlyArray<SpeciesAggregate>; speciesCount?: number };
 
 /**
@@ -250,16 +265,24 @@ export function tilesFromAggregates(
     // Only attach `speciesCount` when the caller supplied one — leaving it
     // `undefined` keeps the per-observation tiles on the legacy footer path.
     const countField = speciesCount === undefined ? {} : { speciesCount };
-    if (silhouettesById.size === 0) {
-      return { kind: 'pending', familyCode: fam.familyCode, count: fam.count, species, ...countField };
-    }
     const silhouette = silhouettesById.get(fam.familyCode);
+    // #920: resolve the colloquial display name once per tile. The chain falls
+    // through to prettyFamily(familyCode) when the catalogue carries no
+    // commonName (and on the pending path where the catalogue is empty), so a
+    // cold-load header is never blank.
+    const displayName = resolveFamilyName(fam.familyCode, {
+      commonName: silhouette?.commonName,
+    });
+    if (silhouettesById.size === 0) {
+      return { kind: 'pending', familyCode: fam.familyCode, displayName, count: fam.count, species, ...countField };
+    }
     if (!silhouette || silhouette.svgData === null) {
       const fallbackColor = silhouette?.color ?? '#888888';
       const fallbackColorDark = silhouette?.colorDark ?? fallbackColor;
       return {
         kind: 'fallback',
         familyCode: fam.familyCode,
+        displayName,
         color: fallbackColor,
         colorDark: fallbackColorDark,
         count: fam.count,
@@ -270,6 +293,7 @@ export function tilesFromAggregates(
     return {
       kind: 'rendered',
       familyCode: fam.familyCode,
+      displayName,
       svgData: silhouette.svgData,
       color: silhouette.color,
       colorDark: silhouette.colorDark,

--- a/frontend/src/derived.test.ts
+++ b/frontend/src/derived.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Observation } from '@bird-watch/shared-types';
-import { deriveFamilies, deriveSpeciesIndex } from './derived.js';
+import { deriveFamilies, deriveSpeciesIndex, resolveFamilyName } from './derived.js';
 
 function obs(partial: Partial<Observation>): Observation {
   return {
@@ -119,5 +119,55 @@ describe('deriveFamilies', () => {
       obs({ speciesCode: 'mystery', familyCode: null, silhouetteId: null }),
     ]);
     expect(families).toEqual([]);
+  });
+});
+
+describe('resolveFamilyName', () => {
+  // The 3-way precedence chain (issue #920): family.name (server, PR4) wins,
+  // then silhouette.commonName (the entire visible win today), then the
+  // prettyFamily capitalized-code fallback.
+  it('prefers `name` over `commonName` over `prettyFamily`', () => {
+    expect(
+      resolveFamilyName('tyrannidae', {
+        name: 'Tyrant Flycatchers (server)',
+        commonName: 'Tyrant Flycatchers (silhouette)',
+      }),
+    ).toBe('Tyrant Flycatchers (server)');
+  });
+
+  it('falls through to `commonName` when `name` is absent', () => {
+    expect(
+      resolveFamilyName('tyrannidae', { commonName: 'Tyrant Flycatchers' }),
+    ).toBe('Tyrant Flycatchers');
+  });
+
+  it('falls through to `commonName` when `name` is null/undefined', () => {
+    expect(
+      resolveFamilyName('tyrannidae', { name: null, commonName: 'Tyrant Flycatchers' }),
+    ).toBe('Tyrant Flycatchers');
+    expect(
+      resolveFamilyName('tyrannidae', { name: undefined, commonName: 'Tyrant Flycatchers' }),
+    ).toBe('Tyrant Flycatchers');
+  });
+
+  it('falls through to `prettyFamily(familyCode)` when both names are absent', () => {
+    expect(resolveFamilyName('tyrannidae')).toBe('Tyrannidae');
+    expect(resolveFamilyName('tyrannidae', {})).toBe('Tyrannidae');
+    expect(
+      resolveFamilyName('tyrannidae', { name: null, commonName: null }),
+    ).toBe('Tyrannidae');
+  });
+
+  it('returns "" for empty/undefined familyCode when no names are supplied — matching prettyFamily', () => {
+    expect(resolveFamilyName('')).toBe('');
+    expect(resolveFamilyName('', {})).toBe('');
+    expect(resolveFamilyName('', { name: null, commonName: null })).toBe('');
+  });
+
+  it('a supplied name still wins even when the familyCode is empty', () => {
+    // Defensive: the resolver trusts the explicit name over the (empty) code.
+    expect(resolveFamilyName('', { commonName: 'Tyrant Flycatchers' })).toBe(
+      'Tyrant Flycatchers',
+    );
   });
 });

--- a/frontend/src/derived.ts
+++ b/frontend/src/derived.ts
@@ -93,7 +93,11 @@ export function prettyFamily(code: string): string {
  */
 export function resolveFamilyName(
   familyCode: string,
-  opts?: { name?: string | null; commonName?: string | null },
+  // The value types include `undefined` (not just the `?` presence flag) so a
+  // direct `silhouette?.commonName` access — which is `string | null | undefined`
+  // — type-checks under `exactOptionalPropertyTypes: true` without forcing every
+  // caller to coalesce first.
+  opts?: { name?: string | null | undefined; commonName?: string | null | undefined },
 ): string {
   return opts?.name ?? opts?.commonName ?? prettyFamily(familyCode);
 }

--- a/frontend/src/derived.ts
+++ b/frontend/src/derived.ts
@@ -69,3 +69,31 @@ export function prettyFamily(code: string): string {
   if (!code) return '';
   return code.charAt(0).toUpperCase() + code.slice(1);
 }
+
+/**
+ * Resolve a family's display name from the unified colloquial-name chain
+ * (issue #920, epic #924):
+ *
+ *   family.name ?? silhouette.commonName ?? prettyFamily(familyCode)
+ *
+ * - `name` (`AggregatedFamily.name`) is the drift-proof server projection
+ *   `COALESCE(family_silhouettes.common_name, species_meta.family_name)`. It is
+ *   undefined until PR4 populates it — accepting the arg NOW means PR4 is a pure
+ *   server-side upgrade with zero call-site churn.
+ * - `commonName` (`FamilySilhouette.commonName`, from `/api/silhouettes` which
+ *   the app already fetches) covers all 95 observed families today and delivers
+ *   the entire visible win — exactly what `FamilyLegend.tsx` already does.
+ * - `prettyFamily(familyCode)` stays the terminal fallback. It must never return
+ *   `''` for a real code (its existing empty-code guard is preserved), so an
+ *   unseeded family still gets a capitalized scientific label rather than a
+ *   blank header.
+ *
+ * Both name inputs are nullish-coalesced, so an explicit `null` (the DB / wire
+ * absence value) falls through identically to `undefined`.
+ */
+export function resolveFamilyName(
+  familyCode: string,
+  opts?: { name?: string | null; commonName?: string | null },
+): string {
+  return opts?.name ?? opts?.commonName ?? prettyFamily(familyCode);
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -260,6 +260,16 @@ export interface AggregatedFamily {
   speciesCount: number;
   /** Top-8 species of this family in this cell, by observation count desc. */
   species: Array<{ code: string; count: number }>;
+  /**
+   * Colloquial family display name (issue #920, epic #924) —
+   * `COALESCE(family_silhouettes.common_name, species_meta.family_name)`.
+   * OPTIONAL for back-compat with pre-PR4 cached payloads: no producer projects
+   * it until PR4 wires the live + precompute CTEs, and stale CDN bodies predating
+   * that change deserialize with `name === undefined`. The frontend resolver
+   * (`resolveFamilyName`) treats `undefined`/`null` identically and falls through
+   * to the silhouette `commonName`, so a name-less payload renders correctly.
+   */
+  name?: string | null;
 }
 
 /**


### PR DESCRIPTION


## Diagrams

```mermaid
flowchart LR
    subgraph catalogue["/api/silhouettes (already fetched)"]
      cn["family_silhouettes.common_name"]
    end
    cn -->|commonName| sbi["silhouettesById memo<br/>(MapCanvas)"]
    sbi -->|"resolveFamilyName(code, {commonName})"| tiles["AdaptiveTile.displayName<br/>(tilesFromAggregates / buildAdaptiveTiles)"]
    tiles --> cp["CellPopover header"]
    tiles --> chp["CellHoverPreview header"]
    tiles -->|familyNames map| clp["ClusterListPopover toggle"]
    sbi -->|render-site resolve| clp2["standalone ClusterListPopover<br/>(ClusterPill outer-tap)"]

    chain["resolveFamilyName chain:<br/>name ?? commonName ?? prettyFamily(code)"]
    note["name is undefined until PR4<br/>→ commonName wins today<br/>→ prettyFamily is the floor"]
    chain -.-> note
```

## Summary

- The cluster cell popover showed the **scientific** family name (`Tyrannidae (3)`) because `CellPopover` / `CellHoverPreview` / `ClusterListPopover` called `prettyFamily(familyCode)` — a bare code-capitalizer with no access to the curated colloquial name. They now read `Tyrant Flycatchers (3)`.
- **Why this way:** the colloquial names already exist for every observed family in `family_silhouettes.common_name`, fetched via `/api/silhouettes` (`useSilhouettes`). This PR threads that `commonName` into `silhouettesById`, resolves a `displayName` per tile in the tile builders (single-resolve, option (a)), and the three popovers consume it — delivering the entire visible win with **no API/SQL change**.
- **Foundational for epic #924:** ships the shared `resolveFamilyName(code, { name?, commonName? })` helper, the optional `AggregatedFamily.name?` type, and the `commonName`-extended `silhouettesById` that PR2 and PR4 build on. `name` is accepted now but undefined until PR4 populates it server-side, so PR4 becomes a pure server upgrade with zero call-site churn.

## Screenshots

CellPopover header across all 5 canonical viewports × 2 themes, national (`?scope=us`) view zoomed into the dense Phoenix AZ area. Every header shows the curated colloquial name (`Swifts`, `Blackbirds, Orioles & Allies`, `Finches`, `Ducks, Geese & Swans`), never the scientific code. The 24-char `Blackbirds, Orioles & Allies (4)` fits one line at 390px (longer-name layout spot-check per AC). The family legend (bottom-left) shows the same colloquial set.

| Viewport | Light | Dark |
|---|---|---|
| **390×844** (mobile) | <img width="380" alt="pr920-cellpopover-390-light" src="https://github.com/user-attachments/assets/0353204d-5877-45a3-9ad4-a5a45106d61c"> | <img width="380" alt="pr920-cellpopover-390-dark" src="https://github.com/user-attachments/assets/539b26f0-589d-475e-9a49-71260d48dfe2"> |
| **768×1024** (tablet) | <img width="380" alt="pr920-cellpopover-768-light" src="https://github.com/user-attachments/assets/b3e6311c-7ef3-4062-9280-f0bb8b9cf74a"> | <img width="380" alt="pr920-cellpopover-768-dark" src="https://github.com/user-attachments/assets/70cd9f93-92cc-4f8d-9b95-a8934c22e4fe"> |
| **1024×768** (sm laptop) | <img width="380" alt="pr920-cellpopover-1024-light" src="https://github.com/user-attachments/assets/8ace7b64-0625-4be7-b3c3-a883f114e957"> | <img width="380" alt="pr920-cellpopover-1024-dark" src="https://github.com/user-attachments/assets/c4b89e25-0092-4361-9c2c-609993ee420f"> |
| **1440×900** (desktop) | <img width="380" alt="pr920-cellpopover-1440-light" src="https://github.com/user-attachments/assets/a4a2ecce-6781-4b54-9497-1193c45f8c5a"> | <img width="380" alt="pr920-cellpopover-1440-dark" src="https://github.com/user-attachments/assets/c96207f3-81c8-480f-a244-9e659361c28a"> |
| **1920×1080** (wide) | <img width="380" alt="pr920-cellpopover-1920-light" src="https://github.com/user-attachments/assets/29a76385-749c-449b-86a3-64cededc1184"> | <img width="380" alt="pr920-cellpopover-1920-dark" src="https://github.com/user-attachments/assets/3e0984e1-57a2-4fbe-9244-aed901901859"> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className added or renamed` (the header markup is unchanged; only the resolved text differs)
- [x] Multi-viewport design QA: PR body has 10 `user-attachments` URLs (5 viewports × 2 themes per #445)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (71 files, 1171 tests). Affected files: `derived.test.ts` (+6 `resolveFamilyName` cases), `adaptive-grid.test.ts` (+3 `displayName` cases), `MapCanvas.test.tsx` (2 fixtures flipped `Tyrannidae`→`Tyrant Flycatchers`).
- [x] New unit tests added — `resolveFamilyName` 3-way precedence + empty-code guard; tile `displayName` resolution (rendered/fallback/pending).
- [x] No new e2e spec — behavior is covered by the flipped `MapCanvas.test.tsx` fixtures + the live Playwright drive; `e2e/map-symbol-layer.spec.ts` is PR2's locus.
- [x] `npm run build` — clean (`tsc -b && vite build`). Fixed a real `exactOptionalPropertyTypes` error: `resolveFamilyName` opts accept `| undefined` value types so a direct `silhouette?.commonName` access type-checks.
- [x] `npm run lint` — clean (no forbidden raw token names).
- [x] knip — no new findings from this diff (pre-existing unlisted-binary + ignore-hint baseline only; the `knip (informational)` job is `continue-on-error: true`).
- [x] (UI) Playwright MCP smoke — drove `?scope=us` zoomed into AZ across 390×844 / 768×1024 / 1024×768 / 1440×900 / 1920×1080 × light/dark. Map markers + popovers produce **zero errors and zero warnings from app code**. The only console warnings are two OpenFreeMap **basemap** artifacts (a maplibre worker null-expression and a missing `circle-11` sprite in the dark basemap style), re-emitted on each `[data-theme]` reload — they originate in the maplibre/basemap layer, not this diff, and are present on `main`.

## Plan reference

Part of #924 (family-name unification epic). Closes #920. Research + 4-PR breakdown: `docs/analyses/2026-06-07-family-colloquial-names/report.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)