### PR TITLE
feat(db-client): server drift-proof family names via COALESCE in both aggregated CTEs

### DIFF
--- a/packages/db-client/src/observation-grid-agg.test.ts
+++ b/packages/db-client/src/observation-grid-agg.test.ts
@@ -126,6 +126,17 @@ beforeAll(async () => {
        ('sp-0004','Com 4','Sci 4','fam-b','Fam B',10004)`,
   );
 
+  // #924 PR4: seed a family_silhouettes row for fam-a ONLY, with a curated
+  // common_name ('Antbirds') distinct from sm.family_name ('Fam A'). This makes
+  // the server COALESCE(fs.common_name, sm.family_name) projection observable on
+  // both arms: fam-a resolves via the silhouette FIRST arm ('Antbirds'), fam-b
+  // has no silhouette row so it falls through to the family_name SECOND arm
+  // ('Fam B'). id/svg_data/color/color_dark are NOT NULL — values are arbitrary.
+  await pool.query(
+    `INSERT INTO family_silhouettes (id, family_code, svg_data, color, color_dark, common_name) VALUES
+       ('fam-a','fam-a','<svg/>','#abc','#abc','Antbirds')`,
+  );
+
   await seedObservations(0, 600);
   await pool.query('ANALYZE observations');
   await pool.query('ANALYZE species_meta');
@@ -177,6 +188,28 @@ describe('refreshGridAgg ↔ getObservationsAggregated byte-identity (#878)', ()
         expect(fingerprint(cached)).toBe(fingerprint(live));
         expect(cached.length).toBeGreaterThan(0);
       }
+    }
+  });
+
+  it('projects COALESCE(family_silhouettes.common_name, species_meta.family_name) as family.name on both paths (#924 PR4)', async () => {
+    await refreshGridAgg(pool);
+    for (const m of STANDARD_GRID_MULTIPLIERS) {
+      const live = await getObservationsAggregated(pool, { since: '14d' }, m);
+      const cached = await getAggregatedGridFromCache(pool, NATIONAL_SCOPE_KEY, m);
+
+      // First arm (silhouette wins): fam-a has a family_silhouettes row with
+      // common_name 'Antbirds', distinct from its sm.family_name 'Fam A'.
+      const liveFamA = live.flatMap(b => b.families).find(f => f.code === 'fam-a');
+      const cachedFamA = cached.flatMap(b => b.families).find(f => f.code === 'fam-a');
+      expect(liveFamA?.name).toBe('Antbirds');
+      expect(cachedFamA?.name).toBe('Antbirds');
+
+      // Second arm (family_name fallback): fam-b has NO silhouette row, so it
+      // resolves via sm.family_name 'Fam B'.
+      const liveFamB = live.flatMap(b => b.families).find(f => f.code === 'fam-b');
+      const cachedFamB = cached.flatMap(b => b.families).find(f => f.code === 'fam-b');
+      expect(liveFamB?.name).toBe('Fam B');
+      expect(cachedFamB?.name).toBe('Fam B');
     }
   });
 

--- a/packages/db-client/src/observations.test.ts
+++ b/packages/db-client/src/observations.test.ts
@@ -688,12 +688,19 @@ describe('getObservationsAggregated (#627)', () => {
     expect(tyr.species[0]!.code).toBe('vermfly');
     const tro = az.families.find(f => f.code === 'trochilidae')!;
     expect(tro.species[0]!.code).toBe('annhum');
+    // #924 PR4 — family.name is projected from
+    // COALESCE(family_silhouettes.common_name, species_meta.family_name). No
+    // family_silhouettes rows are seeded in this test, so both resolve via the
+    // SECOND arm (sm.family_name, seeded at lines 17-18).
+    expect(tyr.name).toBe('Tyrant Flycatchers');
+    expect(tro.name).toBe('Hummingbirds');
 
     expect(ne.count).toBe(1);
     expect(ne.speciesCount).toBe(1);
     expect(ne.families).toHaveLength(1);
     expect(ne.families[0]!.code).toBe('tyrannidae');
     expect(ne.families[0]!.count).toBe(1);
+    expect(ne.families[0]!.name).toBe('Tyrant Flycatchers');
     expect(ne.families[0]!.species).toEqual([{ code: 'vermfly', count: 1 }]);
   });
 

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -432,14 +432,26 @@ export async function getObservationsAggregated(
         round(ST_X(o.geom) * $${gIdx}) / $${gIdx} AS lng_bucket,
         round(ST_Y(o.geom) * $${gIdx}) / $${gIdx} AS lat_bucket,
         o.species_code,
-        sm.family_code
+        sm.family_code,
+        -- #924 PR4: thread both COALESCE source columns to family level. The
+        -- family display name is functionally determined by family_code, so
+        -- it survives the GROUP BY via min() in per_family. fs.common_name is
+        -- the curated short house style (first arm, matches the frontend's
+        -- silhouette.commonName); sm.family_name is the eBird long-name drift
+        -- fallback (second arm). family_silhouettes.family_code is UNIQUE, so
+        -- this LEFT JOIN cannot multiply rows.
+        sm.family_name,
+        fs.common_name AS family_common_name
       FROM observations o
       LEFT JOIN species_meta sm ON sm.species_code = o.species_code
+      LEFT JOIN family_silhouettes fs ON fs.family_code = sm.family_code
       ${where}
     ),
     per_species AS (
       SELECT
         lng_bucket, lat_bucket, family_code, species_code,
+        min(family_common_name) AS family_common_name,
+        min(family_name) AS family_name,
         count(*)::int AS species_count
       FROM base
       WHERE family_code IS NOT NULL
@@ -448,6 +460,7 @@ export async function getObservationsAggregated(
     ranked AS (
       SELECT
         lng_bucket, lat_bucket, family_code, species_code, species_count,
+        family_common_name, family_name,
         ROW_NUMBER() OVER (
           PARTITION BY lng_bucket, lat_bucket, family_code
           ORDER BY species_count DESC, species_code ASC
@@ -457,6 +470,8 @@ export async function getObservationsAggregated(
     per_family AS (
       SELECT
         lng_bucket, lat_bucket, family_code,
+        min(family_common_name) AS family_common_name,
+        min(family_name) AS family_name,
         sum(species_count)::int AS family_count,
         count(*)::int AS family_species_count,
         jsonb_agg(
@@ -474,7 +489,8 @@ export async function getObservationsAggregated(
             'code', family_code,
             'count', family_count,
             'speciesCount', family_species_count,
-            'species', top_species
+            'species', top_species,
+            'name', COALESCE(family_common_name, family_name)
           )
           ORDER BY family_count DESC, family_code ASC
         ) AS families
@@ -689,9 +705,16 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
     const result = await client.query<{ n: string }>(
       `
       WITH recent AS (
-        SELECT o.geom, o.species_code, sm.family_code
+        -- #924 PR4: carry both COALESCE source columns from the read side so
+        -- the precompute path projects family.name byte-identically to the live
+        -- getObservationsAggregated CTE (the #878 byte-identity guard enforces
+        -- this). The NEW join is only family_silhouettes (UNIQUE family_code →
+        -- single row per family); species_meta was already LEFT-JOINed here.
+        SELECT o.geom, o.species_code, sm.family_code, sm.family_name,
+               fs.common_name AS family_common_name
         FROM observations o
         LEFT JOIN species_meta sm ON sm.species_code = o.species_code
+        LEFT JOIN family_silhouettes fs ON fs.family_code = sm.family_code
         WHERE o.obs_dt >= now() - (14 * interval '1 day')
       ),
       mult(grid_multiplier) AS (
@@ -699,13 +722,15 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
       ),
       scoped AS (
         -- National scope: every recent row, no clip.
-        SELECT $1::text AS scope_key, r.geom, r.species_code, r.family_code
+        SELECT $1::text AS scope_key, r.geom, r.species_code, r.family_code,
+               r.family_name, r.family_common_name
         FROM recent r
         UNION ALL
         -- State scope: each recent row tagged with the state polygon it falls
         -- in. ST_Intersects (NOT ST_Contains) matches the live state clip
         -- inclusive border idiom; the && prefilter uses obs_geom_idx.
-        SELECT sb.state_code AS scope_key, r.geom, r.species_code, r.family_code
+        SELECT sb.state_code AS scope_key, r.geom, r.species_code, r.family_code,
+               r.family_name, r.family_common_name
         FROM recent r
         JOIN state_boundaries sb
           ON r.geom && sb.geom AND ST_Intersects(sb.geom, r.geom)
@@ -717,13 +742,17 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
           round(ST_X(s.geom) * m.grid_multiplier) / m.grid_multiplier AS lng_bucket,
           round(ST_Y(s.geom) * m.grid_multiplier) / m.grid_multiplier AS lat_bucket,
           s.species_code,
-          s.family_code
+          s.family_code,
+          s.family_name,
+          s.family_common_name
         FROM scoped s
         CROSS JOIN mult m
       ),
       per_species AS (
         SELECT
           scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code, species_code,
+          min(family_common_name) AS family_common_name,
+          min(family_name) AS family_name,
           count(*)::int AS species_count
         FROM base
         WHERE family_code IS NOT NULL
@@ -732,6 +761,7 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
       ranked AS (
         SELECT
           scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code, species_code, species_count,
+          family_common_name, family_name,
           ROW_NUMBER() OVER (
             PARTITION BY scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code
             ORDER BY species_count DESC, species_code ASC
@@ -741,6 +771,8 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
       per_family AS (
         SELECT
           scope_key, grid_multiplier, lng_bucket, lat_bucket, family_code,
+          min(family_common_name) AS family_common_name,
+          min(family_name) AS family_name,
           sum(species_count)::int AS family_count,
           count(*)::int AS family_species_count,
           jsonb_agg(
@@ -758,7 +790,8 @@ export async function refreshGridAgg(pool: Pool): Promise<number> {
               'code', family_code,
               'count', family_count,
               'speciesCount', family_species_count,
-              'species', top_species
+              'species', top_species,
+              'name', COALESCE(family_common_name, family_name)
             )
             ORDER BY family_count DESC, family_code ASC
           ) AS families


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph read["getObservationsAggregated (live CTE)"]
        O1[observations] --> B1[base<br/>+ family_name<br/>+ fs.common_name]
        SM1[species_meta] -.LEFT JOIN.-> B1
        FS1[family_silhouettes<br/>UNIQUE family_code] -.LEFT JOIN.-> B1
        B1 --> PF1[per_family<br/>min&#40;common_name&#41;<br/>min&#40;family_name&#41;]
        PF1 --> J1["families jsonb_build_object<br/>'name', COALESCE&#40;common_name, family_name&#41;"]
    end
    subgraph precompute["refreshGridAgg (precompute CTE)"]
        O2[observations] --> R2[recent<br/>+ family_name<br/>+ fs.common_name]
        SM2[species_meta] -.LEFT JOIN.-> R2
        FS2[family_silhouettes<br/>UNIQUE family_code] -.LEFT JOIN.-> R2
        R2 --> PF2[per_family<br/>min&#40;common_name&#41;<br/>min&#40;family_name&#41;]
        PF2 --> J2["families jsonb_build_object<br/>'name', COALESCE&#40;common_name, family_name&#41;"]
    end
    J1 -. "byte-identical literal<br/>(#878 guard)" .- J2
    J2 --> AGG[(observation_grid_agg.families<br/>JSONB — no DDL)]
```

## Summary

- **Why:** PR1/PR2 deliver the entire *visible* win from `/api/silhouettes`. This PR upgrades the *invisible drift case* — a brand-new family observed before its `family_silhouettes` migration row exists has nothing in `/api/silhouettes`, but eBird `species_meta.family_name` does. Projecting `name` server-side names it anyway. The stale-cache window is user-invisible (the frontend already resolved the name from the silhouette layer), so **no Cloudflare `/api/observations` purge tooling is needed** — that is the de-risking the caching audit bought.
- **What:** Project `'name', COALESCE(family_silhouettes.common_name, species_meta.family_name)` into the `families` jsonb in **both** the live `getObservationsAggregated` CTE **and** the `refreshGridAgg` precompute CTE. The resolver order matches the frontend chain (curated short name first, eBird long name as the drift fallback), so a drift-case family renders identically server- and client-side. The two `jsonb_build_object` family literals are **character-identical** (same key order, same COALESCE expression), so the existing `#878` byte-identity guard enforces the live↔precompute invariant for free.
- **No DDL:** `observation_grid_agg.families` is `JSONB NOT NULL`; the new `name` key lives inside the existing jsonb. The only new join is `family_silhouettes` (UNIQUE `family_code` → single row per family, cannot multiply rows). `AggregatedFamily.name?` was added by PR1 (optional, for back-compat with pre-PR4 cached payloads).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/db-client` — green (16 files, 147 passed, 1 todo); byte-identity tests stay green at national + per-state across all multipliers
- [x] Integration tests run against real Postgres+PostGIS via `@testcontainers/postgresql` (no DB mocks)
- [x] Added COALESCE first-arm coverage: seeded one `family_silhouettes` row (`fam-a` → `Antbirds`, distinct from `sm.family_name 'Fam A'`) in `observation-grid-agg.test.ts`; asserts `family.name === 'Antbirds'` (silhouette wins) and `=== 'Fam B'` (family_name fallback) on both live + cached paths
- [x] Added `name` assertions to the AZ/NE aggregated buckets in `observations.test.ts` (`tyrannidae` → `Tyrant Flycatchers`, `trochilidae` → `Hummingbirds`, via `sm.family_name`)
- [x] No migration file added (no-DDL claim — `git diff --name-only` over `migrations/` is empty)
- [x] `npm run build` — clean production build across all workspaces
- [x] `npm run lint` — clean
- [x] `knip` — zero new findings on the branch (only the pre-existing unlisted-binary/config-hint set inherited from the base, byte-identical to PR1)
- [x] Verified both `jsonb_build_object` family literals are character-identical

**Deploy note:** Optionally `gcloud run jobs execute bird-ingestor --args recent` to force a `refreshGridAgg` rebuild of `observation_grid_agg`. **No Cloudflare `/api/observations` purge required** — the frontend already resolves the name from `/api/silhouettes` (PR1), so the ~30/~80-min stale window is invisible and causes zero user-visible regression.

## Plan reference

Closes #923
Part of #924 — plans-in-issues (no `docs/plans/` file). PR4 of the 4-PR family-colloquial-names epic; stacked on PR1 (base `feat/family-names-pr1`) for the optional `AggregatedFamily.name?` type. Research: `docs/analyses/2026-06-07-family-colloquial-names/report.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)