### PR TITLE
feat(frontend): colloquial family names in filters, count lede + a11y (marker aria-label)

### DIFF
--- a/frontend/e2e/map-symbol-layer.spec.ts
+++ b/frontend/e2e/map-symbol-layer.spec.ts
@@ -160,6 +160,14 @@ test.describe('Map symbol layer + popover detail link', () => {
       test.skip(true, 'hit-layer mounted but no markers projected (no observations after geo filter)');
       return;
     }
+
+    // #921: the marker aria-label announces the curated colloquial family name
+    // (from the silhouette catalogue's `commonName`), NOT the raw lowercase
+    // scientific code that used to leak (`…, tyrannidae, …`).
+    const ariaLabel = (await hitButton.getAttribute('aria-label')) ?? '';
+    expect(ariaLabel).toContain('Tyrant Flycatchers');
+    expect(ariaLabel).not.toContain('tyrannidae');
+
     await hitButton.click();
 
     // ObservationPopover dialog opens with the species name + detail link.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -462,13 +462,46 @@ export function App() {
     prefetchMapCanvas();
   }, [scopeActive]);
 
+  // Family color + silhouette SOT (issue #55 option (a)): colors and
+  // silhouette payloads resolve via the DB-backed `/api/silhouettes`
+  // endpoint. The hook caches aggressively (response is static per deploy
+  // + 1-week immutable Cache-Control) so mounting it here is effectively
+  // free. Issue #249 threads the resulting `silhouettes` value to
+  // MapSurface → FamilyLegend; descendants that need a color resolver
+  // can still compose `buildFamilyColorResolver` from
+  // `./data/family-color.js`. Single mount, prop-thread to consumers
+  // (per #246's strict-mount discipline). Hoisted above the family-options
+  // derivation (#921) so `silhouettes` is in scope to resolve colloquial
+  // family names for the FiltersBar `<select>` + count lede.
+  const {
+    silhouettes,
+    loading: silhouettesLoading,
+    error: silhouettesError,
+  } = useSilhouettes(apiClient);
+
+  // #921: familyCode → curated colloquial name, from the `/api/silhouettes`
+  // catalogue the app already fetches. Threaded into both derive functions so
+  // the FiltersBar `<select>` options AND the count lede read `Tyrant
+  // Flycatchers` instead of the scientific `Tyrannidae`. Keys are lowercased to
+  // match the server's lowercase family_code on both the observation and bucket
+  // paths. A cold catalogue yields an empty map → both functions fall back to
+  // `prettyFamily` (never a blank label).
+  const familyNamesByCode = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const s of silhouettes) map.set(s.familyCode.toLowerCase(), s.commonName);
+    return map;
+  }, [silhouettes]);
+
   // #859: in aggregated mode the per-observation array is empty, so the family
   // filter options derive from the buckets' families instead (the species
   // autocomplete index has no aggregated analogue — codes carry no names on the
   // wire — so it stays observation-only and is simply empty at low zoom).
   const families = useMemo(
-    () => (mode === 'aggregated' ? deriveFamiliesFromBuckets(buckets) : deriveFamilies(observations)),
-    [mode, buckets, observations],
+    () =>
+      mode === 'aggregated'
+        ? deriveFamiliesFromBuckets(buckets, familyNamesByCode)
+        : deriveFamilies(observations, familyNamesByCode),
+    [mode, buckets, observations, familyNamesByCode],
   );
   const speciesIndex = useMemo(() => deriveSpeciesIndex(observations), [observations]);
 
@@ -800,21 +833,6 @@ export function App() {
       });
     }, 250);
   }, []);
-
-  // Family color + silhouette SOT (issue #55 option (a)): colors and
-  // silhouette payloads resolve via the DB-backed `/api/silhouettes`
-  // endpoint. The hook caches aggressively (response is static per deploy
-  // + 1-week immutable Cache-Control) so mounting it here is effectively
-  // free. Issue #249 threads the resulting `silhouettes` value to
-  // MapSurface → FamilyLegend; descendants that need a color resolver
-  // can still compose `buildFamilyColorResolver` from
-  // `./data/family-color.js`. Single mount, prop-thread to consumers
-  // (per #246's strict-mount discipline).
-  const {
-    silhouettes,
-    loading: silhouettesLoading,
-    error: silhouettesError,
-  } = useSilhouettes(apiClient);
 
   // #859: species code→{comName} dictionary. Loaded once (tab-lifetime cache,
   // immutable Cache-Control) and threaded to MapSurface → MapCanvas so the

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -2609,17 +2609,30 @@ export function MapCanvas({
       const lngLat: [number, number] = displaced
         ? [displaced.longitude, displaced.latitude]
         : [o.lng, o.lat];
+      // #921: resolve the colloquial family name UPSTREAM, where the silhouette
+      // catalogue (`silhouettesById`) is in scope. The leaf `MapMarkerHitLayer`
+      // gets no catalogue, so without this it fell back to the RAW lowercase
+      // `familyCode` in the screen-reader aria-label (`…, tyrannidae, …`). The
+      // resolver chain stays `name ?? commonName ?? prettyFamily`; `name`
+      // (AggregatedFamily.name) has no per-observation analogue, so only the
+      // silhouette `commonName` participates here.
+      const familyName = o.familyCode
+        ? resolveFamilyName(o.familyCode, {
+            commonName: silhouettesById.get(o.familyCode.toLowerCase())?.commonName,
+          })
+        : undefined;
       return {
         subId: o.subId,
         comName: o.comName,
         familyCode: o.familyCode,
+        familyName,
         locName: o.locName,
         obsDt: o.obsDt,
         isNotable: o.isNotable,
         lngLat,
       };
     });
-  }, [observations, mapZoom, silhouetteOffsets]);
+  }, [observations, mapZoom, silhouetteOffsets, silhouettesById]);
 
   const handleHitSelect = useCallback(
     (subId: string) => {

--- a/frontend/src/components/map/MapMarkerHitLayer.test.tsx
+++ b/frontend/src/components/map/MapMarkerHitLayer.test.tsx
@@ -12,6 +12,7 @@ function makeMarker(partial: Partial<HitTargetMarker> = {}): HitTargetMarker {
     subId: partial.subId ?? 'S001',
     comName: partial.comName ?? 'House Finch',
     familyCode: 'familyCode' in partial ? partial.familyCode! : 'fringillidae',
+    familyName: 'familyName' in partial ? partial.familyName! : undefined,
     locName: 'locName' in partial ? partial.locName! : 'Sabino Canyon',
     obsDt: partial.obsDt ?? '2026-04-15T10:00:00Z',
     isNotable: partial.isNotable ?? false,
@@ -83,11 +84,12 @@ describe('MapMarkerHitLayer', () => {
     expect(btn.style.height).toBe('40px');
   });
 
-  it('emits a full aria-label including comName, family, location, date, notable flag', () => {
+  it('emits a full aria-label including comName, colloquial family, location, date, notable flag', () => {
     const markers = [
       makeMarker({
         comName: 'Vermilion Flycatcher',
         familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers',
         locName: 'Sweetwater Wetlands',
         obsDt: '2026-04-15T10:00:00Z',
         isNotable: true,
@@ -103,9 +105,34 @@ describe('MapMarkerHitLayer', () => {
     const btn = screen.getByRole('button');
     const label = btn.getAttribute('aria-label') ?? '';
     expect(label).toContain('Vermilion Flycatcher');
-    expect(label).toContain('tyrannidae');
+    // #921: the colloquial name is announced, NOT the raw lowercase scientific
+    // code that used to leak (worse than the visible popover ever was).
+    expect(label).toContain('Tyrant Flycatchers');
+    expect(label).not.toContain('tyrannidae');
     expect(label).toContain('Sweetwater Wetlands');
     expect(label).toContain('notable');
+  });
+
+  it('falls back to prettyFamily(familyCode) when familyName is absent (#921 cold load)', () => {
+    // No resolved familyName yet (silhouette catalogue not loaded) — the label
+    // must show the capitalized scientific code, never the raw lowercase code
+    // and never blank.
+    const markers = [makeMarker({ familyCode: 'tyrannidae' })];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    const label = screen.getByRole('button').getAttribute('aria-label') ?? '';
+    expect(label).toContain('Tyrannidae');
+    expect(label).not.toContain('tyrannidae');
+  });
+
+  it('falls back to "unknown family" when both familyName and familyCode are null (#921)', () => {
+    const markers = [makeMarker({ familyCode: null })];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    const label = screen.getByRole('button').getAttribute('aria-label') ?? '';
+    expect(label).toContain('unknown family');
   });
 
   it('renders hit-target buttons with tabIndex=-1 (skip-link is the keyboard entry, not Tab cycling)', () => {

--- a/frontend/src/components/map/MapMarkerHitLayer.tsx
+++ b/frontend/src/components/map/MapMarkerHitLayer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { prettyFamily } from '../../derived.js';
 
 /**
  * Per-marker hit-target overlay rendered above the map canvas.
@@ -25,6 +26,19 @@ export interface HitTargetMarker {
   subId: string;
   comName: string;
   familyCode: string | null;
+  /**
+   * #921: the resolved colloquial family name (e.g. `Tyrant Flycatchers`),
+   * resolved UPSTREAM in MapCanvas's `hitMarkers` memo where the silhouette
+   * catalogue is in scope. Optional so legacy/test callers passing only a code
+   * still type-check; `formatAriaLabel` falls back to `prettyFamily(familyCode)`
+   * when absent (cold catalogue) — never the raw lowercase code that used to
+   * leak into the screen-reader label.
+   *
+   * The value type includes `undefined` (not just the `?` presence flag) so the
+   * `hitMarkers` memo can assign a `string | undefined` from the resolver
+   * directly under `exactOptionalPropertyTypes: true` without coalescing first.
+   */
+  familyName?: string | null | undefined;
   locName: string | null;
   obsDt: string;
   isNotable: boolean;
@@ -58,12 +72,16 @@ const HIT_SIZE_COARSE = 48;
  * Build the per-marker `aria-label`. Format:
  *   "{comName}, {family}, {location}, {date}[, notable]"
  *
- * Family fallback: "unknown family" when familyCode is null. Location
- * fallback: "unknown location" when locName is null. Notable suffix appears
- * only when isNotable is true. Date is locale-formatted to a short form.
+ * Family resolution (#921): the colloquial `familyName` (resolved upstream from
+ * the silhouette catalogue) when present; else `prettyFamily(familyCode)` (a
+ * CAPITALIZED scientific code on a cold catalogue — never the raw lowercase
+ * code that used to leak); else "unknown family" when familyCode is null too.
+ * Location fallback: "unknown location" when locName is null. Notable suffix
+ * appears only when isNotable is true. Date is locale-formatted to a short form.
  */
 function formatAriaLabel(m: HitTargetMarker): string {
-  const family = m.familyCode ?? 'unknown family';
+  const family =
+    m.familyName ?? (m.familyCode ? prettyFamily(m.familyCode) : null) ?? 'unknown family';
   const location = m.locName ?? 'unknown location';
   let dateStr = m.obsDt;
   try {

--- a/frontend/src/data/bucket-aggregates.test.ts
+++ b/frontend/src/data/bucket-aggregates.test.ts
@@ -125,7 +125,42 @@ describe('familyCountsFromBuckets / deriveFamiliesFromBuckets', () => {
   it('a family present in ANY bucket appears in the derived legend options', () => {
     const fams = deriveFamiliesFromBuckets(buckets);
     expect(fams.map(f => f.code).sort()).toEqual(['cardinalidae', 'tyrannidae']);
-    // prettyFamily-capitalised display name.
+    // Cold call (no name source): prettyFamily-capitalised scientific code is
+    // the terminal fallback — never blank.
+    expect(fams.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrannidae');
+  });
+
+  it('resolves the curated colloquial name from the silhouette name source (#921)', () => {
+    const names = new Map<string, string | null>([
+      ['tyrannidae', 'Tyrant Flycatchers'],
+      ['cardinalidae', 'Cardinals & Allies'],
+    ]);
+    const fams = deriveFamiliesFromBuckets(buckets, names);
+    expect(fams.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrant Flycatchers');
+    expect(fams.find(f => f.code === 'cardinalidae')?.name).toBe('Cardinals & Allies');
+    // Switching scientific→colloquial reorders the options (sort is by display
+    // name): Cardinals & Allies (C) before Tyrant Flycatchers (T).
+    expect(fams.map(f => f.code)).toEqual(['cardinalidae', 'tyrannidae']);
+  });
+
+  it('prefers the server AggregatedFamily.name over the silhouette name source (#921 PR4 forward-compat)', () => {
+    // A bucket family carrying a server-projected `name` (PR4) wins over the
+    // silhouette commonName, per the chain name ?? commonName ?? prettyFamily.
+    const serverNamed: AggregatedBucket[] = [
+      {
+        lat: 31, lng: -111, count: 5, speciesCount: 1,
+        families: [{ code: 'tyrannidae', count: 5, speciesCount: 1, species: [], name: 'Server Flycatchers' }],
+      },
+    ];
+    const names = new Map<string, string | null>([['tyrannidae', 'Tyrant Flycatchers']]);
+    const fams = deriveFamiliesFromBuckets(serverNamed, names);
+    expect(fams.find(f => f.code === 'tyrannidae')?.name).toBe('Server Flycatchers');
+  });
+
+  it('falls back to prettyFamily when the name source lacks the family (#921 cold load)', () => {
+    const names = new Map<string, string | null>([['cardinalidae', 'Cardinals & Allies']]);
+    const fams = deriveFamiliesFromBuckets(buckets, names);
+    // tyrannidae absent from the name source → terminal prettyFamily fallback.
     expect(fams.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrannidae');
   });
 

--- a/frontend/src/data/bucket-aggregates.ts
+++ b/frontend/src/data/bucket-aggregates.ts
@@ -2,7 +2,7 @@ import type { AggregatedBucket, AggregatedFamily } from '@bird-watch/shared-type
 import type { FamilyAggregate, SpeciesAggregate } from '../components/map/adaptive-grid.js';
 import type { SpeciesDictionary } from './use-species-dictionary.js';
 import type { FamilyOption } from '../components/FiltersBar.js';
-import { prettyFamily } from '../derived.js';
+import { prettyFamily, resolveFamilyName, type FamilyNameSource } from '../derived.js';
 
 /**
  * Pure aggregation helpers for the #859 low-zoom (aggregated) render path.
@@ -116,14 +116,40 @@ export function familyCountsFromBuckets(
  * Family options (code + display name) for every family present in any bucket,
  * sorted by display name — the aggregated-mode analogue of
  * `deriveFamilies(observations)`.
+ *
+ * #921: `names` is the optional `familyCode → colloquial commonName` source
+ * threaded from the `/api/silhouettes` catalogue. Each option resolves its
+ * display name through the unified chain
+ * `AggregatedFamily.name ?? silhouette.commonName ?? prettyFamily(code)` — so
+ * the aggregated-mode FiltersBar options and the count lede read the curated
+ * `Tyrant Flycatchers`. The bucket family's own `name` (server-projected by PR4,
+ * undefined until then) wins when present; otherwise the silhouette `commonName`
+ * carries the entire visible win today; `prettyFamily` is the terminal fallback
+ * so a label is never blank on a cold catalogue.
  */
 export function deriveFamiliesFromBuckets(
   buckets: ReadonlyArray<AggregatedBucket>,
+  names?: FamilyNameSource,
 ): FamilyOption[] {
+  // First non-null server `name` per code wins (a family can span buckets; a
+  // later bucket missing the name must not clobber an earlier one carrying it).
+  const serverName = new Map<string, string>();
   const codes = new Set<string>();
-  for (const b of buckets) for (const f of b.families) codes.add(f.code);
+  for (const b of buckets)
+    for (const f of b.families) {
+      codes.add(f.code);
+      if (f.name != null && !serverName.has(f.code)) serverName.set(f.code, f.name);
+    }
   return Array.from(codes)
-    .map(code => ({ code, name: prettyFamily(code) }))
+    .map(code => ({
+      code,
+      name: resolveFamilyName(code, {
+        name: serverName.get(code),
+        commonName: names?.get(code),
+      }),
+    }))
+    // Sort by the RESOLVED display name — switching scientific→colloquial
+    // intentionally reorders the options.
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/frontend/src/derived.test.ts
+++ b/frontend/src/derived.test.ts
@@ -120,6 +120,36 @@ describe('deriveFamilies', () => {
     ]);
     expect(families).toEqual([]);
   });
+
+  it('resolves the curated colloquial name from the name source (#921)', () => {
+    const names = new Map<string, string | null>([
+      ['tyrannidae', 'Tyrant Flycatchers'],
+      ['ardeidae', 'Herons & Egrets'],
+    ]);
+    const families = deriveFamilies(
+      [
+        obs({ speciesCode: 'vermfly', familyCode: 'tyrannidae' }),
+        obs({ speciesCode: 'greheR', familyCode: 'ardeidae' }),
+      ],
+      names,
+    );
+    // Sorted by display name: Herons & Egrets (H) before Tyrant Flycatchers (T).
+    expect(families.map(f => f.code)).toEqual(['ardeidae', 'tyrannidae']);
+    expect(families.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrant Flycatchers');
+    expect(families.find(f => f.code === 'ardeidae')?.name).toBe('Herons & Egrets');
+  });
+
+  it('falls back to prettyFamily when the name source is absent or lacks the family (#921 cold load)', () => {
+    // No name source at all.
+    const cold = deriveFamilies([obs({ speciesCode: 'vermfly', familyCode: 'tyrannidae' })]);
+    expect(cold.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrannidae');
+    // Name source present but missing this family.
+    const partial = deriveFamilies(
+      [obs({ speciesCode: 'vermfly', familyCode: 'tyrannidae' })],
+      new Map<string, string | null>([['ardeidae', 'Herons & Egrets']]),
+    );
+    expect(partial.find(f => f.code === 'tyrannidae')?.name).toBe('Tyrannidae');
+  });
 });
 
 describe('resolveFamilyName', () => {

--- a/frontend/src/derived.ts
+++ b/frontend/src/derived.ts
@@ -19,7 +19,20 @@ import type { FamilyOption, SpeciesOption } from './components/FiltersBar.js';
 //     `familyCode === undefined`; the falsy guards below treat `null`
 //     and `undefined` identically, so no cache bump is required.
 
-export function deriveFamilies(observations: Observation[]): FamilyOption[] {
+/**
+ * #921: optional `familyCode → colloquial commonName` source threaded from the
+ * `/api/silhouettes` catalogue (built in App.tsx). When supplied, each option's
+ * display name resolves through `resolveFamilyName` so the FiltersBar `<select>`
+ * and the count lede read the curated `Tyrant Flycatchers` instead of the
+ * scientific `Tyrannidae`. Absent / cold (catalogue not yet loaded), every
+ * option falls back to `prettyFamily(code)` — a label is never blank.
+ */
+export type FamilyNameSource = ReadonlyMap<string, string | null | undefined>;
+
+export function deriveFamilies(
+  observations: Observation[],
+  names?: FamilyNameSource,
+): FamilyOption[] {
   const set = new Map<string, string>();
   for (const o of observations) {
     // Skip observations with no resolvable family — do NOT bucket them
@@ -28,7 +41,10 @@ export function deriveFamilies(observations: Observation[]): FamilyOption[] {
     set.set(o.familyCode, o.familyCode);
   }
   return Array.from(set.entries())
-    .map(([code]) => ({ code, name: prettyFamily(code) }))
+    .map(([code]) => ({ code, name: resolveFamilyName(code, { commonName: names?.get(code) }) }))
+    // Sort by the RESOLVED display name: switching scientific→colloquial
+    // intentionally reorders the FiltersBar options (e.g. `Ardeidae` under A
+    // moves to `Herons & Egrets` under H).
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    API["/api/silhouettes<br/>(commonName per family)"] --> App[App.tsx]
    App -->|familyCode→commonName map| dF["deriveFamilies<br/>(per-obs)"]
    App -->|familyCode→commonName map| dFB["deriveFamiliesFromBuckets<br/>(aggregated)"]
    dF --> FAM[families array]
    dFB --> FAM
    FAM --> SEL["FiltersBar &lt;select&gt;<br/>Tyrant Flycatchers"]
    FAM --> LEDE["count lede<br/>N species of Tyrant Flycatchers"]
    LEDE -->|same ledeText, byte-identical| SR["sr-only aria-live echo<br/>role=status"]
    API -.->|silhouettesById commonName| MC[MapCanvas hitMarkers memo]
    MC -->|familyName per marker| HIT["MapMarkerHitLayer<br/>aria-label: …, Tyrant Flycatchers, …"]

    subgraph chain["resolveFamilyName chain (PR1)"]
        R["name ?? commonName ?? prettyFamily(code)"]
    end
    dF -.-> chain
    dFB -.-> chain
    MC -.-> chain
```

## Summary

- **Why:** after PR1 fixed the cluster popovers, four surfaces still showed scientific `prettyFamily` names — the FiltersBar family `<select>`, the count lede (`N species of Tyrannidae`), its screen-reader `aria-live` echo, and the **marker `aria-label`**, which was the worst leak because it emitted the *raw lowercase* code (`…, tyrannidae, …`). All four now route through PR1's unified resolver chain `name ?? commonName ?? prettyFamily(code)`.
- **One chokepoint for three of them:** the FiltersBar select AND the count lede both derive from one `families` array. Threading a `familyCode → commonName` map (from the `/api/silhouettes` catalogue the app already fetches) into **both** derive functions (`deriveFamilies` per-obs + `deriveFamiliesFromBuckets` aggregated) fixes the select, the lede, and — because the `role=status` echo renders the same `ledeText` string by construction — the screen-reader echo, with no separate edit and no drift risk. `deriveFamiliesFromBuckets` also prefers the bucket family's server-projected `name` (`AggregatedFamily.name`, undefined until PR4) so PR4 stays a pure server upgrade.
- **Marker aria-label** resolved **upstream** in MapCanvas's `hitMarkers` memo (where `silhouettesById` is in scope; the leaf `MapMarkerHitLayer` gets no catalogue) and pushed onto each `HitTargetMarker` as `familyName`; `formatAriaLabel` reads `familyName ?? prettyFamily(familyCode) ?? 'unknown family'`, keeping the capitalized-code fallback and the null guard.
- **Sort-order side effect (intended, reviewer-surprising):** both derive functions sort by the *resolved* display name, so switching scientific→colloquial reorders the FiltersBar options (e.g. `Ardeidae` under A → `Herons & Egrets` under H). Verified live — see the option list in the screenshots.
- **Pre-existing, out of scope:** at extreme zoom (z22, where the HTML hit-layer mounts) the live API can return observations with duplicate `subId`, producing React duplicate-key warnings from `MapMarkerHitLayer`. The hit-layer has keyed on `subId` since before PR1; this PR adds only a `familyName` field and touches no key logic — neither introduced nor in scope here.

## Screenshots

Arizona, `?family=cardinalidae` (identity-card lede reads **13 species of Cardinals & Allies**, Filters → Family select reads **Cardinals & Allies**, legend reads **Cardinals & Allies**). 5 canonical viewports × 2 themes, captured via Playwright MCP. Zero console errors/warnings at the captured (normal-zoom) state.

| Viewport | Light | Dark |
|---|---|---|
| 1. 390×844 (mobile) | <img width="380" alt="pr2-v1-390-light" src="https://github.com/user-attachments/assets/fc402ff5-40b0-43ed-9a12-431674ab5cce"> | <img width="380" alt="pr2-v1-390-dark" src="https://github.com/user-attachments/assets/3c2a29ef-4b8c-4416-aea0-b27f0047831a"> |
| 2. 768×1024 (tablet) | <img width="380" alt="pr2-v2-768-light" src="https://github.com/user-attachments/assets/24f6c045-f7e5-4910-bffa-51fcdfb67dcc"> | <img width="380" alt="pr2-v2-768-dark" src="https://github.com/user-attachments/assets/1e6d819f-70ec-4b4b-afbb-70ec811ee22b"> |
| 3. 1024×768 (sm laptop) | <img width="380" alt="pr2-v3-1024-light" src="https://github.com/user-attachments/assets/108f2298-343b-4b07-9fba-ffcb660bbfe5"> | <img width="380" alt="pr2-v3-1024-dark" src="https://github.com/user-attachments/assets/5a7e4db3-7e3f-4f8e-a5ae-d70ab3645f8d"> |
| 4. 1440×900 (desktop) | <img width="380" alt="pr2-v4-1440-light" src="https://github.com/user-attachments/assets/938bbd85-fd8e-4c3a-9a51-46f934c27093"> | <img width="380" alt="pr2-v4-1440-dark" src="https://github.com/user-attachments/assets/7a83af39-2e47-432e-848c-15bc4d79e86b"> |
| 5. 1920×1080 (wide) | <img width="380" alt="pr2-v5-1920-light" src="https://github.com/user-attachments/assets/43ee03d1-88f7-458e-9cce-0fc640314f79"> | <img width="380" alt="pr2-v5-1920-dark" src="https://github.com/user-attachments/assets/d4bba8ad-6fd4-4938-a3a5-e253516f7a28"> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule (or `N/A`) — **N/A — no className changes (text/type-only)**
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes)

## Test plan

- [x] `npm run build` — clean production build (workspace `tsc -b` + vite; surfaced and fixed an `exactOptionalPropertyTypes` issue on `HitTargetMarker.familyName`)
- [x] `npm run test --workspace @bird-watch/frontend` — green (69 files / 1178 tests; the 2-file flake was unbuilt workspace packages, resolved by `npm run build` first)
- [x] New unit tests: `deriveFamilies` colloquial-resolution + cold-load fallback; `deriveFamiliesFromBuckets` colloquial + server-`name`-precedence + cold-load; `MapMarkerHitLayer` colloquial aria-label + **negative assertion that the raw lowercase code never leaks** + `prettyFamily`/`unknown family` fallbacks
- [x] New e2e assertion in `map-symbol-layer.spec.ts`: marker aria-label contains `Tyrant Flycatchers`, not `tyrannidae`
- [x] `knip` — clean (exit 0)
- [x] Lint token-guard grep — clean; no DB-write in e2e (`grep` guard clean)
- [x] Playwright MCP smoke — `npm run dev` against the live API, drove the FiltersBar select + count lede + sr-only echo across all 5 viewports × 2 themes; the visible lede and the `role=status` echo are **byte-identical** (`13 species of Cardinals & Allies`); zero console errors/warnings at the captured state

## Plan reference

Closes #921. Part of #924. Plans live in the epic + child issues (not `docs/plans/`). Research + 4-PR breakdown: `docs/analyses/2026-06-07-family-colloquial-names/report.md`. Stacked on PR1 (`feat/family-names-pr1`) for the `resolveFamilyName` helper + `silhouettesById.commonName` extension.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)