### PR TITLE
fix(frontend): keep family row flex so the color dot doesn't collapse to a hairline

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1563,6 +1563,18 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
 .detail-fg-identity .t-stagger-line--2 { transition-delay: var(--stagger-stagger); }
 .detail-fg-identity .t-stagger-line--3 { transition-delay: calc(var(--stagger-stagger) * 2); }
 
+/* The family row is the one stagger line that must stay a flex row: its
+   color dot (.detail-fg-family-dot) is an inline <span> that only gets its
+   8×8 size by being a flex *item*. The texts-reveal rule above forces every
+   line to `display: block` (specificity 0,3,0), which outranks
+   `.detail-fg-family { display: flex }` (0,1,0) — collapsing the dot to a
+   0px-wide box whose 1px box-shadow ring paints as a hairline next to the
+   family name. Restore flex on the family line specifically (0,4,0 wins);
+   transform/opacity/filter still animate normally on a flex container. */
+.detail-fg-identity.t-stagger .detail-fg-family.t-stagger-line {
+  display: flex;
+}
+
 .detail-fg-identity.t-stagger.is-shown .t-stagger-line {
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    P["&lt;p class='detail-fg-family t-stagger-line'&gt;"]
    R1[".detail-fg-family { display: flex }<br/>specificity (0,1,0)"]
    R2[".detail-fg-identity.t-stagger .t-stagger-line { display: block }<br/>specificity (0,3,0) — texts-reveal, added in #919"]
    R3["NEW: .detail-fg-identity.t-stagger .detail-fg-family.t-stagger-line { display: flex }<br/>specificity (0,4,0)"]

    R1 -->|loses to| R2
    R2 -->|"forces display:block → dot leaves flex layout"| BUG["dot span is display:inline<br/>width/height ignored → 0px-wide box<br/>only its 1px box-shadow ring paints<br/>= vertical hairline beside family name"]
    R3 -->|"wins → restores flex item"| FIX["dot is a flex item again<br/>honors 8×8 → round color dot"]
    P --- R1
    P --- R2
    P --- R3
```

## Summary

- The desktop detail-card family row renders a hairline instead of the family-color dot. Root cause is a CSS specificity collision: the texts-reveal stagger rule (`.detail-fg-identity.t-stagger .t-stagger-line`, 0,3,0) forces `display: block` on every identity line, outranking `.detail-fg-family { display: flex }` (0,1,0). The dot (`.detail-fg-family-dot`) is an inline `<span>` that only gets its 8×8 size by being a *flex item* — knocked out of flex layout it collapses to a 0px-wide box, and only its 1px `box-shadow` contrast ring paints, reading as a thin vertical line.
- Fix is one rule: restore `display: flex` on the family line specifically (`.detail-fg-identity.t-stagger .detail-fg-family.t-stagger-line`, 0,4,0). `transform`/`opacity`/`filter` animate identically on a flex container, so the reveal is unchanged.
- Regression from #919 (field-guide design on the desktop detail card), where the stagger reveal was layered onto the pre-existing flex row. Mobile (`.sheet-fg-family`) was never affected.

## Screenshots

Captured against the branch build (`npm run dev`, proxy → prod API), `?detail=macwar&view=detail&scope=us`, dark + light per viewport. The fixed dot is the small olive circle before "New World Warblers". Mobile/tablet (390/768/1024) render the unaffected `.sheet-fg-family` surface; the desktop `.detail-fg-family` surface (the one this fixes) shows at 1440/1920.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile — sheet) | <img width="400" alt="390 light" src="https://github.com/user-attachments/assets/a9453aa4-de8c-480a-a0a4-30536348a978" /> | <img width="400" alt="390 dark" src="https://github.com/user-attachments/assets/cc9f7c9d-b2b5-4ca9-ac7d-6fdc8531a04f" /> |
| 768×1024 (tablet — sheet) | <img width="400" alt="768 light" src="https://github.com/user-attachments/assets/ad9b57e8-3a12-4f68-81d5-174f35d5579d" /> | <img width="400" alt="768 dark" src="https://github.com/user-attachments/assets/772c7803-d4c6-4e72-b868-4dbb1a291b71" /> |
| 1024×768 (small laptop — sheet) | <img width="400" alt="1024 light" src="https://github.com/user-attachments/assets/38ab9de8-ed1f-49bb-ac0a-5cb26b7301dc" /> | <img width="400" alt="1024 dark" src="https://github.com/user-attachments/assets/0764ac8b-76ac-47a1-98d0-4955c14c199e" /> |
| 1440×900 (desktop — **detail surface, fixed**) | <img width="400" alt="1440 light" src="https://github.com/user-attachments/assets/6ff23c78-654f-42fc-abd7-d36a5ebf58cb" /> | <img width="400" alt="1440 dark" src="https://github.com/user-attachments/assets/31e5a85f-c37b-4d6f-98be-0fb33a7268f4" /> |
| 1920×1080 (wide — **detail surface, fixed**) | <img width="400" alt="1920 light" src="https://github.com/user-attachments/assets/ecb90ac5-6580-479f-96e7-778c33047a68" /> | <img width="400" alt="1920 dark" src="https://github.com/user-attachments/assets/334bb464-d0eb-4b73-9f64-c698b81b2607" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no new className (CSS-rule-only change to existing `.detail-fg-family`)
- [x] Multi-viewport design QA: 10 `user-attachments` URLs (5 viewports × 2 themes)

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` — clean (verified with the stray untracked WIP file excluded; that file is not on this branch and absent in CI). CI `build` is green.
- [x] `npm run lint` — clean (CI `lint` green; `knip` + `orphan-classname-check` green)
- [ ] New unit / integration tests — N/A, CSS-cascade fix. jsdom does not compute the cascade/layout this depends on; verified via live Playwright computed-style + rendered-box assertions instead (`.detail-fg-family` computed `display` flips `block → flex`; dot box flips `0×15 → 8×8`).
- [ ] New Playwright e2e spec — N/A (visual cascade fix; covered by the MCP smoke below)
- [x] (UI only) Playwright MCP smoke — drove `?detail=macwar&view=detail&scope=us` at all 5 canonical viewports × light/dark. Detail surface console = **0 errors**; the only warning is a pre-existing maplibre `circle-11` basemap-sprite warning that also fires on prod (`bird-maps.com`), unrelated to this change.

## Plan reference

Out of plan — regression bugfix for the desktop detail card (introduced by #919); reported live on bird-maps.com.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
