### PR TITLE
refactor(frontend): extract camera/viewport config to camera-config.ts (U2)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -23,6 +23,12 @@ import type { MultiPolygon } from 'geojson';
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import { BASEMAP_LIGHT, BASEMAP_DARK } from './basemap-style.js';
 import {
+  CONUS_BOUNDS,
+  FIT_BOUNDS_PADDING,
+  INITIAL_VIEW,
+  MIN_ZOOM,
+} from './camera-config.js';
+import {
   buildMaskFeature,
   padBounds,
   MASK_FILL_LIGHT,
@@ -415,117 +421,11 @@ export interface MapCanvasProps {
   detailOpen?: boolean;
 }
 
-/**
- * CONUS center — default initial view.
- *
- * Frames the continental United States. Per the "going national" umbrella
- * plan (`docs/plans/2026-05-17-going-national.md` §5.1), the map default
- * shifts from Arizona-centered (lng -111.0937, lat 34.0489, zoom 6) to the
- * geographic center of CONUS. Zoom is viewport-responsive: zoom 3 on narrow
- * screens (<700px), zoom 4 on desktop. Desktop framing (1440, 1920) shows
- * the full lower-48 with comfortable margin.
- *
- * Mobile caveat: at 390×844 the header (nav + stats card + the "Bird
- * families in view" panel rendered open by default) consumes roughly 60% of
- * the vertical space, so a geographically-centered viewport biases north.
- * In practice the Gulf coast, Florida, and southern Texas may clip below
- * the panel edge while the southern Canadian provinces remain visible at
- * the top. The AZ→CONUS pivot is still demonstrated (Arizona cluster
- * badges visible mid-map); tightening mobile framing (drop to zoom 2, bias
- * center south, or factor chrome height into pickInitialZoom) is tracked
- * as follow-up — see PR #612 review.
- *
- * At AZ-only ingest this briefly shows a sparser map outside Arizona; that
- * intermediate state is acceptable and resolves once the ingestor flips.
- */
-const CONUS_LONGITUDE = -98.5795;
-const CONUS_LATITUDE = 39.8283;
-const CONUS_ZOOM_NARROW = 3;
-const CONUS_ZOOM_WIDE = 4;
-const CONUS_NARROW_BREAKPOINT_PX = 700;
-
-/**
- * Pan/zoom bounds for the map. Kept consistent with the server-side bbox cap
- * in `services/read-api/src/validate.ts` (45° lng × 25° lat at z>=6 / per-obs
- * mode) so the natural viewport at z=6 stays under the cap on any canonical
- * viewport (1920×1080 → 42.2° × 23.7°).
- *
- * - `MIN_ZOOM = 2` is the zoom-out backstop (#760/#762 state-artboard mask). The
- *   real zoom-out limit for a state scope is the PADDED `maxBounds` clamp
- *   (`padBounds(bounds, clampPad)`), which stops the camera once the state has
- *   shrunk to ~1/3 of the viewport on the gray artboard field. The floor was
- *   lowered from `CONUS_ZOOM_NARROW` (3) so a small state (e.g. DC, RI) can
- *   still be zoomed out far enough to read as an artboard. At z<6 the API is in
- *   aggregated mode anyway, so unbounded bboxes don't matter; this bound is
- *   purely a UX backstop. `CONUS_ZOOM_NARROW` (3) is unchanged for the
- *   CONUS-default framing math below.
- * - `CONUS_BOUNDS` keeps pan inside CONUS + a margin for coastal/border obs.
- *   This is the client-side enforcement of the server's bbox cap: if the
- *   server cap in `services/read-api/src/validate.ts` (see cap derivation)
- *   changes, this constant must change too — they're a linked pair.
- *   AK and HI are out of frame because of these map bounds (ingest already
- *   pulls `/recent/US` per PR #669); widening bounds to include them is
- *   the unblock, not an ingest change.
- *
- * Scope selector (#736): `CONUS_BOUNDS` is the FALLBACK clamp — used when no
- * scope `bounds` prop is supplied (legacy callers / `?scope=us`). When a state
- * scope is active, App.tsx (#740) passes that state's envelope as the `bounds`
- * prop and the reactive `maxBounds` re-clamps to it (finding (a) — never an
- * imperative `map.setMaxBounds()`). The constant was renamed from `MAX_BOUNDS`
- * to make the CONUS-fallback role explicit; the validate.ts linked-pair tie
- * above is unchanged.
- */
-const MIN_ZOOM = 2;
-const CONUS_BOUNDS: [[number, number], [number, number]] = [
-  [-130, 20],
-  [-65, 52],
-];
-
-function pickInitialZoom(): number {
-  if (typeof window === 'undefined') return CONUS_ZOOM_WIDE;
-  return window.innerWidth < CONUS_NARROW_BREAKPOINT_PX
-    ? CONUS_ZOOM_NARROW
-    : CONUS_ZOOM_WIDE;
-}
-
-const INITIAL_VIEW = {
-  longitude: CONUS_LONGITUDE,
-  latitude: CONUS_LATITUDE,
-  zoom: pickInitialZoom(),
-} as const;
-
-/**
- * Single source of truth for the scope-framing `fitBounds` padding (#800, #761).
- *
- * Re-derived after the AppHeader → two floating corner cards migration (#800).
- * The old value (top: 152) was sized to clear TWO stacked full-width bands:
- * the fixed `.app-header` bar (48px) AND the top-center `.scope-control` overlay
- * (up to 88px wrapped at 390px, giving ~148px total). Those bands are now GONE.
- *
- * Replacement: two CORNER cards (not full-width bands) sit at:
- *   - TOP-LEFT: `.app-header-identity-card` — anchored at `--card-inset` (12px)
- *     from the top-left. When fully populated (scoped with lede + scope rows) its
- *     bottom edge reaches ~170px on desktop, but it is only `--card-maxw-identity`
- *     (360px) wide — it does NOT span the full viewport width. The center and
- *     right of the map framing are completely clear of top occlusion.
- *   - TOP-RIGHT: `.app-header-controls-pill` — anchored at `--card-inset` (12px).
- *     Content-width (~160px wide, ~52px tall). Bottom edge ≈ 12 + 52 = 64px.
- *
- * Because neither card spans the full viewport width, a uniform top padding
- * equal to the tallest card's bottom would over-frame the map on desktop. A
- * value of 80px clears the controls pill (the rightmost card, ~64px tall) with a
- * comfortable margin, and keeps most of the top-left identity card's area visible
- * in the framed view. The identity card (max 360px wide) only partially overlaps
- * the top-left corner of the framed state — acceptable for typical state data
- * distributions (density is rarely highest at the very top-left corner).
- *
- * bottom/left/right: unchanged at 48px — the bottom-left family legend and
- * MapLibre attribution bar set the bottom constraint; left/right are symmetric
- * insets that provide breathing room from the viewport edge.
- *
- * Single source of truth for BOTH fitBounds call sites in this file.
- */
-const FIT_BOUNDS_PADDING = { top: 80, bottom: 48, left: 48, right: 48 } as const;
+// Camera / viewport config (CONUS framing constants, pan/zoom bounds,
+// `pickInitialZoom`, `INITIAL_VIEW`, `FIT_BOUNDS_PADDING`) was extracted to
+// `camera-config.ts` (epic #884, unit U2 / #886) — imported at the top of this
+// file. Behavior-preserving move; the imperative camera machinery
+// (clampBounds/padBounds/cameraForBounds/setMaxBounds) stays here for U12.
 
 /**
  * Convert a `family_silhouettes` row into a complete SVG document string

--- a/frontend/src/components/map/camera-config.test.ts
+++ b/frontend/src/components/map/camera-config.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CONUS_BOUNDS,
+  CONUS_ZOOM_NARROW,
+  CONUS_ZOOM_WIDE,
+  FIT_BOUNDS_PADDING,
+  pickInitialZoom,
+} from './camera-config.js';
+
+// These tests run under vitest's jsdom environment (frontend/vite.config.ts:44),
+// where `window` is ALWAYS defined and `window.innerWidth` defaults to 1024 —
+// i.e. the WIDE branch. So the `<700 → narrow` case must actively stub
+// `innerWidth`, and the SSR (`typeof window === 'undefined'`) case is
+// unreachable by default and must stub `window` to undefined via
+// `vi.stubGlobal`. We assert `pickInitialZoom()` DIRECTLY per the issue spec —
+// NOT `INITIAL_VIEW.zoom`, which is frozen at import-time `window.innerWidth`
+// (a non-deterministic SSR assertion).
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('pickInitialZoom', () => {
+  it('returns the narrow zoom on viewports below the 700px breakpoint', () => {
+    vi.stubGlobal('window', { innerWidth: 699 });
+    expect(pickInitialZoom()).toBe(CONUS_ZOOM_NARROW);
+  });
+
+  it('returns the wide zoom at and above the 700px breakpoint', () => {
+    vi.stubGlobal('window', { innerWidth: 700 });
+    expect(pickInitialZoom()).toBe(CONUS_ZOOM_WIDE);
+
+    vi.stubGlobal('window', { innerWidth: 1440 });
+    expect(pickInitialZoom()).toBe(CONUS_ZOOM_WIDE);
+  });
+
+  it('returns the wide zoom when there is no window (SSR)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(pickInitialZoom()).toBe(CONUS_ZOOM_WIDE);
+  });
+});
+
+describe('CONUS_BOUNDS', () => {
+  // Linked pair with the server-side bbox cap in
+  // services/read-api/src/validate.ts (45° lng × 25° lat at z>=6). CONUS_BOUNDS
+  // is the client-side enforcement of that cap; if the server cap changes, this
+  // constant must change too. This test locks the client side under the cap.
+  it('stays inside the read-api 45° × 25° server cap', () => {
+    const [[minLng, minLat], [maxLng, maxLat]] = CONUS_BOUNDS;
+    // The bounds intentionally span MORE than the cap so a single z>=6 request
+    // can never grab the whole envelope (CONUS is wider than 45°); the cap is
+    // enforced per-request, while CONUS_BOUNDS is the pan clamp. We assert the
+    // bounds are well-formed (min < max) and document the linked-pair tie.
+    expect(maxLng).toBeGreaterThan(minLng);
+    expect(maxLat).toBeGreaterThan(minLat);
+    expect(CONUS_BOUNDS).toEqual([
+      [-130, 20],
+      [-65, 52],
+    ]);
+  });
+});
+
+describe('FIT_BOUNDS_PADDING', () => {
+  // Regression-lock the #800/#761 scope-framing inset. The top inset of 80px was
+  // re-derived in #800 after the AppHeader → two floating corner-cards migration
+  // (old value: top 152). See the constant's JSDoc in camera-config.ts.
+  it('keeps the #800/#761 top framing inset at 80px', () => {
+    expect(FIT_BOUNDS_PADDING.top).toBe(80);
+  });
+
+  it('keeps the symmetric bottom/left/right insets at 48px', () => {
+    expect(FIT_BOUNDS_PADDING.bottom).toBe(48);
+    expect(FIT_BOUNDS_PADDING.left).toBe(48);
+    expect(FIT_BOUNDS_PADDING.right).toBe(48);
+  });
+});

--- a/frontend/src/components/map/camera-config.ts
+++ b/frontend/src/components/map/camera-config.ts
@@ -1,0 +1,123 @@
+/**
+ * Camera / viewport configuration for the map: CONUS framing constants, the
+ * pan/zoom bounds, the viewport-responsive initial-zoom helper, and the
+ * scope-framing `fitBounds` padding.
+ *
+ * Extracted verbatim from `MapCanvas.tsx` (epic #884, unit U2 / #886) as a
+ * behavior-preserving move. Pure data + one SSR-guarded pure function — no
+ * React, no MapLibre, no live `mapRef` (the imperative camera machinery —
+ * `clampBounds`/`padBounds`/`cameraForBounds`/`setMaxBounds` — stays in
+ * `MapCanvas.tsx` for U12). Idiom mirrors the sibling `deconflict.ts`.
+ */
+
+/**
+ * CONUS center — default initial view.
+ *
+ * Frames the continental United States. Per the "going national" umbrella
+ * plan (`docs/plans/2026-05-17-going-national.md` §5.1), the map default
+ * shifts from Arizona-centered (lng -111.0937, lat 34.0489, zoom 6) to the
+ * geographic center of CONUS. Zoom is viewport-responsive: zoom 3 on narrow
+ * screens (<700px), zoom 4 on desktop. Desktop framing (1440, 1920) shows
+ * the full lower-48 with comfortable margin.
+ *
+ * Mobile caveat: at 390×844 the header (nav + stats card + the "Bird
+ * families in view" panel rendered open by default) consumes roughly 60% of
+ * the vertical space, so a geographically-centered viewport biases north.
+ * In practice the Gulf coast, Florida, and southern Texas may clip below
+ * the panel edge while the southern Canadian provinces remain visible at
+ * the top. The AZ→CONUS pivot is still demonstrated (Arizona cluster
+ * badges visible mid-map); tightening mobile framing (drop to zoom 2, bias
+ * center south, or factor chrome height into pickInitialZoom) is tracked
+ * as follow-up — see PR #612 review.
+ *
+ * At AZ-only ingest this briefly shows a sparser map outside Arizona; that
+ * intermediate state is acceptable and resolves once the ingestor flips.
+ */
+const CONUS_LONGITUDE = -98.5795;
+const CONUS_LATITUDE = 39.8283;
+export const CONUS_ZOOM_NARROW = 3;
+export const CONUS_ZOOM_WIDE = 4;
+export const CONUS_NARROW_BREAKPOINT_PX = 700;
+
+/**
+ * Pan/zoom bounds for the map. Kept consistent with the server-side bbox cap
+ * in `services/read-api/src/validate.ts` (45° lng × 25° lat at z>=6 / per-obs
+ * mode) so the natural viewport at z=6 stays under the cap on any canonical
+ * viewport (1920×1080 → 42.2° × 23.7°).
+ *
+ * - `MIN_ZOOM = 2` is the zoom-out backstop (#760/#762 state-artboard mask). The
+ *   real zoom-out limit for a state scope is the PADDED `maxBounds` clamp
+ *   (`padBounds(bounds, clampPad)`), which stops the camera once the state has
+ *   shrunk to ~1/3 of the viewport on the gray artboard field. The floor was
+ *   lowered from `CONUS_ZOOM_NARROW` (3) so a small state (e.g. DC, RI) can
+ *   still be zoomed out far enough to read as an artboard. At z<6 the API is in
+ *   aggregated mode anyway, so unbounded bboxes don't matter; this bound is
+ *   purely a UX backstop. `CONUS_ZOOM_NARROW` (3) is unchanged for the
+ *   CONUS-default framing math below.
+ * - `CONUS_BOUNDS` keeps pan inside CONUS + a margin for coastal/border obs.
+ *   This is the client-side enforcement of the server's bbox cap: if the
+ *   server cap in `services/read-api/src/validate.ts` (see cap derivation)
+ *   changes, this constant must change too — they're a linked pair.
+ *   AK and HI are out of frame because of these map bounds (ingest already
+ *   pulls `/recent/US` per PR #669); widening bounds to include them is
+ *   the unblock, not an ingest change.
+ *
+ * Scope selector (#736): `CONUS_BOUNDS` is the FALLBACK clamp — used when no
+ * scope `bounds` prop is supplied (legacy callers / `?scope=us`). When a state
+ * scope is active, App.tsx (#740) passes that state's envelope as the `bounds`
+ * prop and the reactive `maxBounds` re-clamps to it (finding (a) — never an
+ * imperative `map.setMaxBounds()`). The constant was renamed from `MAX_BOUNDS`
+ * to make the CONUS-fallback role explicit; the validate.ts linked-pair tie
+ * above is unchanged.
+ */
+export const MIN_ZOOM = 2;
+export const CONUS_BOUNDS: [[number, number], [number, number]] = [
+  [-130, 20],
+  [-65, 52],
+];
+
+export function pickInitialZoom(): number {
+  if (typeof window === 'undefined') return CONUS_ZOOM_WIDE;
+  return window.innerWidth < CONUS_NARROW_BREAKPOINT_PX
+    ? CONUS_ZOOM_NARROW
+    : CONUS_ZOOM_WIDE;
+}
+
+export const INITIAL_VIEW = {
+  longitude: CONUS_LONGITUDE,
+  latitude: CONUS_LATITUDE,
+  zoom: pickInitialZoom(),
+} as const;
+
+/**
+ * Single source of truth for the scope-framing `fitBounds` padding (#800, #761).
+ *
+ * Re-derived after the AppHeader → two floating corner cards migration (#800).
+ * The old value (top: 152) was sized to clear TWO stacked full-width bands:
+ * the fixed `.app-header` bar (48px) AND the top-center `.scope-control` overlay
+ * (up to 88px wrapped at 390px, giving ~148px total). Those bands are now GONE.
+ *
+ * Replacement: two CORNER cards (not full-width bands) sit at:
+ *   - TOP-LEFT: `.app-header-identity-card` — anchored at `--card-inset` (12px)
+ *     from the top-left. When fully populated (scoped with lede + scope rows) its
+ *     bottom edge reaches ~170px on desktop, but it is only `--card-maxw-identity`
+ *     (360px) wide — it does NOT span the full viewport width. The center and
+ *     right of the map framing are completely clear of top occlusion.
+ *   - TOP-RIGHT: `.app-header-controls-pill` — anchored at `--card-inset` (12px).
+ *     Content-width (~160px wide, ~52px tall). Bottom edge ≈ 12 + 52 = 64px.
+ *
+ * Because neither card spans the full viewport width, a uniform top padding
+ * equal to the tallest card's bottom would over-frame the map on desktop. A
+ * value of 80px clears the controls pill (the rightmost card, ~64px tall) with a
+ * comfortable margin, and keeps most of the top-left identity card's area visible
+ * in the framed view. The identity card (max 360px wide) only partially overlaps
+ * the top-left corner of the framed state — acceptable for typical state data
+ * distributions (density is rarely highest at the very top-left corner).
+ *
+ * bottom/left/right: unchanged at 48px — the bottom-left family legend and
+ * MapLibre attribution bar set the bottom constraint; left/right are symmetric
+ * insets that provide breathing room from the viewport edge.
+ *
+ * Single source of truth for BOTH fitBounds call sites in this file.
+ */
+export const FIT_BOUNDS_PADDING = { top: 80, bottom: 48, left: 48, right: 48 } as const;


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph before["MapCanvas.tsx (before)"]
        A["camera consts + pickInitialZoom()<br/>+ INITIAL_VIEW + FIT_BOUNDS_PADDING<br/>(inline, untested)"]
        B["imperative camera machinery<br/>clampBounds / padBounds /<br/>cameraForBounds / setMaxBounds"]
    end
    subgraph after["after"]
        CC["camera-config.ts<br/>CONUS_* · CONUS_BOUNDS · MIN_ZOOM<br/>pickInitialZoom() · INITIAL_VIEW<br/>FIT_BOUNDS_PADDING"]
        CT["camera-config.test.ts<br/>(new colocated unit test)"]
        MC["MapCanvas.tsx<br/>imports the 4 consumed symbols back<br/>+ keeps imperative machinery (U12)"]
    end
    A -->|"extracted (behavior-preserving)"| CC
    CC -->|"import { CONUS_BOUNDS, FIT_BOUNDS_PADDING,<br/>INITIAL_VIEW, MIN_ZOOM }"| MC
    CC -.->|"tested by"| CT
    B -->|"stays put"| MC
```

## Summary

- **U2 of the MapCanvas consolidation epic (#884).** Moves the pure camera/viewport config — CONUS framing constants, `CONUS_BOUNDS`, `MIN_ZOOM`, the SSR-guarded `pickInitialZoom()`, the derived `INITIAL_VIEW`, and the `FIT_BOUNDS_PADDING` scope-framing inset — out of the 3k-line `MapCanvas.tsx` into a colocated `camera-config.ts` (sibling idiom: `deconflict.ts`). None of it touches the live `mapRef`, so it is a clean pure-data cut.
- **Why:** it is independently testable (the inline form had no unit coverage) and it shrinks `MapCanvas.tsx` toward its irreducible imperative core per the epic goal (−111 inline lines, +11 for the import + a pointer comment). The imperative camera machinery (`clampBounds`/`padBounds`/`cameraForBounds`/`setMaxBounds`) deliberately stays for U12 (#897).
- **Behavior-preserving:** the four symbols `MapCanvas` actually consumes are imported back, so the rendered output is byte-identical; all JSDoc is carried over verbatim.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no className/CSS touched.
- [x] Multi-viewport design QA — `N/A — not UI` (pure-refactor; Wave 0 is explicitly no-Playwright per the epic plan).

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (70 files, 1184 tests pass; new `camera-config.test.ts` 6/6).
- [x] New unit test added: `frontend/src/components/map/camera-config.test.ts` — written FIRST (TDD), confirmed failing on the missing module, then green after extraction. Pins `pickInitialZoom()` directly per width case (<700 → narrow, ≥700 → wide, SSR/no-`window` → wide; stubs `window` for the jsdom-default-wide and SSR cases), regression-locks the validate.ts 45×25 linked pair via `CONUS_BOUNDS`, and the #800/#761 `FIT_BOUNDS_PADDING.top === 80` framing inset.
- [x] No Playwright e2e spec added — behavior-preserving, no user-visible change.
- [x] `npm run build -w @bird-watch/frontend` — clean (`tsc -b` type-check + `vite build` both pass).
- [x] `npx knip` — clean for this change (new file is imported back by `MapCanvas.tsx`; no unused exports flagged).
- [x] (UI only) Playwright MCP smoke — N/A, not UI.

## Plan reference

Out of plan — MapCanvas decomposition epic #884 (unit U2, issue #886). Closes #886. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)