### PR TITLE
refactor(frontend): extract MapCanvas type declarations → MapCanvas.types.ts (#885)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -20,7 +20,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 // GeoJSON structural types come from `geojson` (@types/geojson), NOT maplibre-gl
 // (5.x does not re-export them). `import type`, erased at build — see mask.ts.
 import type { MultiPolygon } from 'geojson';
-import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
+import type { AggregatedBucket, Observation } from '@bird-watch/shared-types';
 import { BASEMAP_LIGHT, BASEMAP_DARK } from './basemap-style.js';
 import {
   CONUS_BOUNDS,
@@ -67,10 +67,8 @@ import {
   buildAdaptiveTiles,
   tilesFromAggregates,
   pickGridShape,
-  type AdaptiveTile,
   type ClusterLeafFeature,
   type FamilyAggregate,
-  type ResolvedGrid,
   type SilhouettesById,
   type SpeciesAggregate,
 } from './adaptive-grid.js';
@@ -86,6 +84,20 @@ import {
   type DeconflictInput,
 } from './deconflict.js';
 import { resolveFamilyName } from '../../derived.js';
+// Type-only declarations extracted to MapCanvas.types.ts (epic #884, U1 / #885).
+// `MapCanvasProps` is re-exported from there and back-imported here; this keeps
+// the export knip-clean (its in-file consumer at the destructuring below is
+// covered by `ignoreExportsUsedInFile`) and leaves any future external importer
+// pointing at a stable module path.
+import type {
+  MapCanvasProps,
+  ResolvedAdaptiveData,
+  SelectedObsState,
+} from './MapCanvas.types.js';
+// Preserve the prior public surface: `MapCanvasProps` was exported from this
+// module before the U1 extraction. Re-export it so any importer of
+// `./MapCanvas.js` (none today — zero importers repo-wide) keeps resolving.
+export type { MapCanvasProps } from './MapCanvas.types.js';
 
 /**
  * Adaptive-grid reconciler memoization (epic #539 spec §5.3).
@@ -120,21 +132,6 @@ import { resolveFamilyName } from '../../derived.js';
  * `__resetAdaptiveGridCacheForTesting()` export below is the test-only
  * escape hatch a `beforeEach` should call to avoid cross-test state leakage.
  */
-/**
- * Resolved per-cluster adaptive data — the unit the Concern B cache stores
- * Promises of. `kind: 'pill'` is the pill-fallback sentinel (uniqueFamilies
- * > 16 OR pointCount > 64); `kind: 'grid'` carries the shape + tiles.
- */
-type ResolvedAdaptiveData =
-  | { kind: 'pill'; uniqueFamilies: number }
-  | {
-      kind: 'grid';
-      shape: ResolvedGrid;
-      tiles: ReadonlyArray<AdaptiveTile>;
-      uniqueFamilies: number;
-      isNotablePoint: boolean;
-    };
-
 const leafCache = new Map<string, Promise<ResolvedAdaptiveData>>();
 const warnedRejections = new Set<string>();
 let cacheGeneration = 0;
@@ -286,141 +283,6 @@ function PresentationMarker({ longitude, latitude, anchor, children }: Presentat
   );
 }
 
-export interface MapCanvasProps {
-  observations: Observation[];
-  /**
-   * Aggregated low-zoom buckets (#859). Populated only in `mode === 'aggregated'`
-   * (z < 6); the map renders ONE clustered feature per bucket carrying its real
-   * families/species, instead of per-observation rows. Empty / unused in
-   * per-observation mode. Defaults to `[]` for legacy/test callers.
-   */
-  buckets?: AggregatedBucket[];
-  /**
-   * Which render path is active (#859). `'aggregated'` ⇒ feed `buckets` to the
-   * cluster source + bucket-aware popovers; `'observations'` ⇒ the unchanged
-   * per-observation path. Defaults to `'observations'`.
-   */
-  mode?: 'observations' | 'aggregated';
-  /**
-   * Species code→{comName} dictionary (#859) used to resolve the real species
-   * names carried (as codes) in aggregated buckets. Tolerates a cold/empty Map
-   * (rows fall back to the bare code, never crash). Unused in per-observation
-   * mode. Defaults to an empty Map.
-   */
-  dictionary?: SpeciesDictionary;
-  /**
-   * Family silhouettes from `/api/silhouettes`. Threaded down from App.tsx
-   * via MapSurface (see App.tsx — single mount of `useSilhouettes`, then
-   * prop-drilled per #246's strict-mount discipline). Each non-null
-   * `svgData` row gets registered as an SDF sprite via `map.addImage`
-   * during `handleLoad`. The `_FALLBACK` row backs every observation
-   * whose family has no usable silhouette.
-   *
-   * Also drives the adaptive-grid tiles for every cluster (epic #539).
-   * When the array is empty (cache miss), the reconciler short-circuits
-   * and pill markers carry the cluster signal.
-   *
-   * Optional + defaults to `[]` so legacy tests / demo harnesses still
-   * type-check; with no silhouettes the symbol layer's `icon-image`
-   * lookup misses and MapLibre logs a missing-image warning. Production
-   * App.tsx always passes the resolved array.
-   */
-  silhouettes?: FamilySilhouette[];
-  /**
-   * Issue #246: invoked when the user clicks "See species details" in
-   * the ObservationPopover. App.tsx wires this to
-   * `set({ view: 'detail', detail: code })` via `useUrlState`. Optional
-   * — when absent, the popover hides the link.
-   */
-  onSelectSpecies?: (speciesCode: string) => void;
-  /**
-   * Issue #351: invoked on every map `idle` (camera-change settle) with
-   * the current `map.getBounds()`. App.tsx threads this so the
-   * FamilyLegend's per-family counts can reflect what the user is looking
-   * at right now, not the full loaded API window.
-   *
-   * Wired inside `handleLoad` via `map.on('idle', ...)`. The choice of
-   * `idle` (over `moveend` + `zoomend`) matches the existing mosaic
-   * reconciler (`MapCanvas.tsx`'s mosaic effect) and the auto-spider
-   * hook (`use-auto-spider.ts`), which both do post-camera-change work
-   * on `idle`. `idle` is naturally throttled — fires once after the
-   * pan/zoom animation AND tile loads settle — so no debounce is
-   * necessary, and the legend updates in lockstep with the
-   * mosaic/spider reconcilers (no visible timing skew between the
-   * legend updating and the markers settling).
-   *
-   * Optional. When absent, MapCanvas registers no `idle` listener for
-   * this purpose (existing reconcilers register their own). Existing
-   * callers that don't pass it — `MapSurface` callers without the
-   * viewport-aware path, unit tests with skeletal props — keep working.
-   */
-  /**
-   * Fired on every camera-settle `idle` event with the current bounds and
-   * integer floor of the map zoom. Zoom was added in #627 so App.tsx can
-   * forward it to /api/observations and trigger server-side aggregation at
-   * low zoom (<6).
-   */
-  onViewportChange?: (bounds: import('maplibre-gl').LngLatBounds, zoom: number) => void;
-  /**
-   * Scope selector (#736 — Task C3). The `[[w,s],[e,n]]` envelope the camera
-   * should both FRAME (`fitBounds`) and CLAMP (`maxBounds`). For a state scope
-   * this is the state envelope (from `GET /api/states` `StateSummary.bbox`,
-   * converted to `[[w,s],[e,n]]` order by App.tsx); for `?scope=us` it is the
-   * CONUS envelope `[[-130,20],[-65,52]]`. When omitted (legacy callers —
-   * MapSurface without scope wiring, skeletal unit tests) the camera keeps its
-   * legacy uncontrolled CONUS `initialViewState` and clamps to `CONUS_BOUNDS`;
-   * no scope reframe fires. Owned/passed by App.tsx (#740); the prop shape
-   * mirrors the proven `ScopedMapProps` from the C0 prototype.
-   */
-  bounds?: [[number, number], [number, number]];
-  /**
-   * Changes on every scope change (e.g. the state code, or `'us'`). The single
-   * `fitBounds` re-trigger key — it drives the camera effect without re-firing
-   * on `bounds` array-reference churn. Pair with `bounds`.
-   */
-  boundsKey?: string;
-  /**
-   * Present on a ZIP scope: fly to this point at `ZIP_FLYTO_ZOOM` instead of
-   * fitting the whole-state envelope. PREFERRED over `fitBounds` when both are
-   * pending on the same (mount/ready) cycle — a ZIP is a "point inside the
-   * state" intent that must win over the whole-state framing (finding (f)).
-   * `center` is `[lng, lat]` (MapLibre order); `zoom` is `ZIP_FLYTO_ZOOM`;
-   * `key` changes per ZIP entry to re-trigger the move.
-   */
-  flyTo?: { center: [number, number]; zoom: number; key: string } | undefined;
-  /**
-   * State-artboard mask (#760/#762). The selected state's render-only
-   * MultiPolygon (from `useStatePolygon` → `/state-polygons.json`). When set,
-   * MapCanvas paints a single inverse-mask fill — flat opaque theme-aware gray
-   * everywhere EXCEPT this polygon — above the basemap and below the
-   * observation/cluster layers, so the scope reads as a Sketch-style artboard.
-   * `null`/absent (`?scope=us`, the chooser, or while the asset loads) renders
-   * no mask AND leaves `renderWorldCopies` unforced (world copies stay on).
-   */
-  maskPolygon?: MultiPolygon | null;
-  /**
-   * State-artboard clamp padding (#760/#762). When present (state scope only),
-   * the reactive `maxBounds` clamp is `padBounds(bounds, clampPad)` — the tight
-   * state envelope expanded outward by `clampPad`× per side — so the user can
-   * zoom OUT until the state shrinks on the gray field, bounded by the padded
-   * artboard margin (not an infinite void). This is the single authoritative
-   * zoom-out gate. The `fitBounds` ENTRY framing stays tight on the raw `bounds`
-   * regardless. Absent (`?scope=us`, legacy callers) ⇒ the clamp stays the raw
-   * `bounds ?? CONUS_BOUNDS` (unchanged behavior).
-   */
-  clampPad?: number;
-  /**
-   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
-   * open under an active scope (App-level `scopeActive && state.detail`).
-   * Forwarded VERBATIM to every `<AdaptiveGridMarker>` so the passive
-   * `<CellHoverPreview>` mount is suppressed while the overlay holds focus —
-   * a hover tooltip must not appear unbidden over/under a focused detail
-   * surface. The click-driven cell/cluster popovers are unaffected. Defaults
-   * to `false` (legacy/test callers keep the pre-O6 always-mount behavior).
-   */
-  detailOpen?: boolean;
-}
-
 // Camera / viewport config (CONUS framing constants, pan/zoom bounds,
 // `pickInitialZoom`, `INITIAL_VIEW`, `FIT_BOUNDS_PADDING`) was extracted to
 // `camera-config.ts` (epic #884, unit U2 / #886) — imported at the top of this
@@ -522,23 +384,6 @@ async function registerSilhouetteSprite(
  * an amber halo behind notable observations without tinting the body —
  * preserves the family-color signal in the silhouette.
  */
-/**
- * Issue #718: ObservationPopover state. Pairs the observation with the
- * projected screen position (px, relative to the .map-canvas wrapper)
- * computed at click time from the marker's lng/lat via map.project().
- *
- * The displaced-silhouette path (silhouetteOffsets.entries() render at
- * the bottom of MapCanvas) MUST pass `entry.longitude/entry.latitude`
- * (the displaced visual position) into openPopoverAt rather than the
- * obs's original survey point — otherwise the popover would project
- * from the hidden canvas-painted twin and appear offset from the
- * visible silhouette the user actually clicked.
- */
-interface SelectedObsState {
-  obs: Observation;
-  pos: { x: number; y: number };
-}
-
 const EMPTY_DICT: SpeciesDictionary = new Map();
 // Stable empty-bucket default — a fresh `[]` literal in the destructuring
 // default would change identity every render and thrash the reconciler effect

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -1,0 +1,182 @@
+// Type-only module extracted from MapCanvas.tsx (epic #884, U1 / #885).
+//
+// This holds the three top-level type declarations that have no runtime
+// footprint — they are `import type`-erased at build. The heavy doc-comments
+// are preserved verbatim: they encode the App.tsx scope/camera/artboard wiring
+// contract (#736/#740/#760/#761/#782) and the popover-projection contract
+// (#718), which the implementation in MapCanvas.tsx relies on.
+//
+// GeoJSON structural types come from `geojson` (@types/geojson), NOT maplibre-gl
+// (5.x does not re-export them). All imports below are `import type`, erased at
+// build — see mask.ts for the same idiom.
+import type { MultiPolygon } from 'geojson';
+import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
+import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
+import type { AdaptiveTile, ResolvedGrid } from './adaptive-grid.js';
+
+/**
+ * Resolved per-cluster adaptive data — the unit the Concern B cache stores
+ * Promises of. `kind: 'pill'` is the pill-fallback sentinel (uniqueFamilies
+ * > 16 OR pointCount > 64); `kind: 'grid'` carries the shape + tiles.
+ */
+export type ResolvedAdaptiveData =
+  | { kind: 'pill'; uniqueFamilies: number }
+  | {
+      kind: 'grid';
+      shape: ResolvedGrid;
+      tiles: ReadonlyArray<AdaptiveTile>;
+      uniqueFamilies: number;
+      isNotablePoint: boolean;
+    };
+
+export interface MapCanvasProps {
+  observations: Observation[];
+  /**
+   * Aggregated low-zoom buckets (#859). Populated only in `mode === 'aggregated'`
+   * (z < 6); the map renders ONE clustered feature per bucket carrying its real
+   * families/species, instead of per-observation rows. Empty / unused in
+   * per-observation mode. Defaults to `[]` for legacy/test callers.
+   */
+  buckets?: AggregatedBucket[];
+  /**
+   * Which render path is active (#859). `'aggregated'` ⇒ feed `buckets` to the
+   * cluster source + bucket-aware popovers; `'observations'` ⇒ the unchanged
+   * per-observation path. Defaults to `'observations'`.
+   */
+  mode?: 'observations' | 'aggregated';
+  /**
+   * Species code→{comName} dictionary (#859) used to resolve the real species
+   * names carried (as codes) in aggregated buckets. Tolerates a cold/empty Map
+   * (rows fall back to the bare code, never crash). Unused in per-observation
+   * mode. Defaults to an empty Map.
+   */
+  dictionary?: SpeciesDictionary;
+  /**
+   * Family silhouettes from `/api/silhouettes`. Threaded down from App.tsx
+   * via MapSurface (see App.tsx — single mount of `useSilhouettes`, then
+   * prop-drilled per #246's strict-mount discipline). Each non-null
+   * `svgData` row gets registered as an SDF sprite via `map.addImage`
+   * during `handleLoad`. The `_FALLBACK` row backs every observation
+   * whose family has no usable silhouette.
+   *
+   * Also drives the adaptive-grid tiles for every cluster (epic #539).
+   * When the array is empty (cache miss), the reconciler short-circuits
+   * and pill markers carry the cluster signal.
+   *
+   * Optional + defaults to `[]` so legacy tests / demo harnesses still
+   * type-check; with no silhouettes the symbol layer's `icon-image`
+   * lookup misses and MapLibre logs a missing-image warning. Production
+   * App.tsx always passes the resolved array.
+   */
+  silhouettes?: FamilySilhouette[];
+  /**
+   * Issue #246: invoked when the user clicks "See species details" in
+   * the ObservationPopover. App.tsx wires this to
+   * `set({ view: 'detail', detail: code })` via `useUrlState`. Optional
+   * — when absent, the popover hides the link.
+   */
+  onSelectSpecies?: (speciesCode: string) => void;
+  /**
+   * Issue #351: invoked on every map `idle` (camera-change settle) with
+   * the current `map.getBounds()`. App.tsx threads this so the
+   * FamilyLegend's per-family counts can reflect what the user is looking
+   * at right now, not the full loaded API window.
+   *
+   * Wired inside `handleLoad` via `map.on('idle', ...)`. The choice of
+   * `idle` (over `moveend` + `zoomend`) matches the existing mosaic
+   * reconciler (`MapCanvas.tsx`'s mosaic effect) and the auto-spider
+   * hook (`use-auto-spider.ts`), which both do post-camera-change work
+   * on `idle`. `idle` is naturally throttled — fires once after the
+   * pan/zoom animation AND tile loads settle — so no debounce is
+   * necessary, and the legend updates in lockstep with the
+   * mosaic/spider reconcilers (no visible timing skew between the
+   * legend updating and the markers settling).
+   *
+   * Optional. When absent, MapCanvas registers no `idle` listener for
+   * this purpose (existing reconcilers register their own). Existing
+   * callers that don't pass it — `MapSurface` callers without the
+   * viewport-aware path, unit tests with skeletal props — keep working.
+   */
+  /**
+   * Fired on every camera-settle `idle` event with the current bounds and
+   * integer floor of the map zoom. Zoom was added in #627 so App.tsx can
+   * forward it to /api/observations and trigger server-side aggregation at
+   * low zoom (<6).
+   */
+  onViewportChange?: (bounds: import('maplibre-gl').LngLatBounds, zoom: number) => void;
+  /**
+   * Scope selector (#736 — Task C3). The `[[w,s],[e,n]]` envelope the camera
+   * should both FRAME (`fitBounds`) and CLAMP (`maxBounds`). For a state scope
+   * this is the state envelope (from `GET /api/states` `StateSummary.bbox`,
+   * converted to `[[w,s],[e,n]]` order by App.tsx); for `?scope=us` it is the
+   * CONUS envelope `[[-130,20],[-65,52]]`. When omitted (legacy callers —
+   * MapSurface without scope wiring, skeletal unit tests) the camera keeps its
+   * legacy uncontrolled CONUS `initialViewState` and clamps to `CONUS_BOUNDS`;
+   * no scope reframe fires. Owned/passed by App.tsx (#740); the prop shape
+   * mirrors the proven `ScopedMapProps` from the C0 prototype.
+   */
+  bounds?: [[number, number], [number, number]];
+  /**
+   * Changes on every scope change (e.g. the state code, or `'us'`). The single
+   * `fitBounds` re-trigger key — it drives the camera effect without re-firing
+   * on `bounds` array-reference churn. Pair with `bounds`.
+   */
+  boundsKey?: string;
+  /**
+   * Present on a ZIP scope: fly to this point at `ZIP_FLYTO_ZOOM` instead of
+   * fitting the whole-state envelope. PREFERRED over `fitBounds` when both are
+   * pending on the same (mount/ready) cycle — a ZIP is a "point inside the
+   * state" intent that must win over the whole-state framing (finding (f)).
+   * `center` is `[lng, lat]` (MapLibre order); `zoom` is `ZIP_FLYTO_ZOOM`;
+   * `key` changes per ZIP entry to re-trigger the move.
+   */
+  flyTo?: { center: [number, number]; zoom: number; key: string } | undefined;
+  /**
+   * State-artboard mask (#760/#762). The selected state's render-only
+   * MultiPolygon (from `useStatePolygon` → `/state-polygons.json`). When set,
+   * MapCanvas paints a single inverse-mask fill — flat opaque theme-aware gray
+   * everywhere EXCEPT this polygon — above the basemap and below the
+   * observation/cluster layers, so the scope reads as a Sketch-style artboard.
+   * `null`/absent (`?scope=us`, the chooser, or while the asset loads) renders
+   * no mask AND leaves `renderWorldCopies` unforced (world copies stay on).
+   */
+  maskPolygon?: MultiPolygon | null;
+  /**
+   * State-artboard clamp padding (#760/#762). When present (state scope only),
+   * the reactive `maxBounds` clamp is `padBounds(bounds, clampPad)` — the tight
+   * state envelope expanded outward by `clampPad`× per side — so the user can
+   * zoom OUT until the state shrinks on the gray field, bounded by the padded
+   * artboard margin (not an infinite void). This is the single authoritative
+   * zoom-out gate. The `fitBounds` ENTRY framing stays tight on the raw `bounds`
+   * regardless. Absent (`?scope=us`, legacy callers) ⇒ the clamp stays the raw
+   * `bounds ?? CONUS_BOUNDS` (unchanged behavior).
+   */
+  clampPad?: number;
+  /**
+   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
+   * open under an active scope (App-level `scopeActive && state.detail`).
+   * Forwarded VERBATIM to every `<AdaptiveGridMarker>` so the passive
+   * `<CellHoverPreview>` mount is suppressed while the overlay holds focus —
+   * a hover tooltip must not appear unbidden over/under a focused detail
+   * surface. The click-driven cell/cluster popovers are unaffected. Defaults
+   * to `false` (legacy/test callers keep the pre-O6 always-mount behavior).
+   */
+  detailOpen?: boolean;
+}
+
+/**
+ * Issue #718: ObservationPopover state. Pairs the observation with the
+ * projected screen position (px, relative to the .map-canvas wrapper)
+ * computed at click time from the marker's lng/lat via map.project().
+ *
+ * The displaced-silhouette path (silhouetteOffsets.entries() render at
+ * the bottom of MapCanvas) MUST pass `entry.longitude/entry.latitude`
+ * (the displaced visual position) into openPopoverAt rather than the
+ * obs's original survey point — otherwise the popover would project
+ * from the hidden canvas-painted twin and appear offset from the
+ * visible silhouette the user actually clicked.
+ */
+export interface SelectedObsState {
+  obs: Observation;
+  pos: { x: number; y: number };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph before["MapCanvas.tsx (before)"]
        A1["type ResolvedAdaptiveData"]
        A2["interface MapCanvasProps (export)"]
        A3["interface SelectedObsState"]
        A4["runtime: hooks, JSX,<br/>reconciler, callbacks"]
    end

    subgraph after["after — same render, types relocated"]
        T["MapCanvas.types.ts<br/>ResolvedAdaptiveData · MapCanvasProps · SelectedObsState"]
        M["MapCanvas.tsx<br/>runtime only + import type back<br/>+ re-export MapCanvasProps"]
        M -- "import type" --> T
        M -. "export type { MapCanvasProps }" .-> T
    end

    before -->|"U1 extraction (#885)"| after
```

## Summary

- **Why:** `MapCanvasProps`, `SelectedObsState`, and `ResolvedAdaptiveData` are type-only (erased at build, zero runtime), so co-locating them with the ~2,800-line imperative core only adds noise to the very file the rest of epic #884 exists to shrink. This is the lowest-risk Wave-0 cut and gives later units a stable home for shared prop/state types.
- **What:** Move the three top-level type declarations (with their load-bearing doc-comments — the App.tsx scope/camera/artboard wiring contract #736/#740/#760/#761/#782 and the #718 popover-projection note) into `frontend/src/components/map/MapCanvas.types.ts`. `MapCanvas.tsx` back-imports all three and re-exports `MapCanvasProps`, so rendered output and the module's public surface are byte-identical. Orphaned type imports the move left behind (`FamilySilhouette`, `AdaptiveTile`, `ResolvedGrid`) are pruned from `MapCanvas.tsx` and now resolve in the new file.
- **knip stays clean:** the new file's exports are all consumed by the back-import, and the re-exported `MapCanvasProps` is covered by `ignoreExportsUsedInFile` (its in-file destructuring consumer at `}: MapCanvasProps`).

## Screenshots

N/A — behavior-preserving extraction, no visible UI change. (Type-only `.ts` move; Wave 0 is no-Playwright per the epic plan.)

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — type-only .ts file, no className changes`
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (`tsc -b && vite build`) — green; `MapCanvas` lazy chunk still emits
- [x] `npm run test --workspace @bird-watch/frontend` — **69 files, 1178 tests passed**
- [x] `npm run lint` + the forbidden-token guard from `.github/workflows/lint.yml` — green (no forbidden raw token names; type-only file has none)
- [x] `npx knip --no-progress` — exit 0; `MapCanvas.types.ts` not flagged (imported back + exports consumed)
- [x] New unit / integration tests added (if behavior changed) — N/A: type-only move, the typecheck/build IS the gate (no runtime behavior changed)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A: no user-visible change
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — N/A: type-only, no UI change

## Plan reference

Out of plan — MapCanvas consolidation epic. Closes #885 (U1, Wave 0). Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
