### PR TITLE
refactor(frontend): move hashSubId into deconflict.ts (U4, #888)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -79,6 +79,7 @@ import {
 import {
   buildGroups,
   displaceSilhouettes,
+  hashSubId,
   SILHOUETTE_PX,
   type DeconflictGroup,
   type DeconflictInput,
@@ -221,20 +222,6 @@ export function handleMapError(e: MapErrorEvent): void {
     return;
   }
   console.error(e.error);
-}
-
-/**
- * Stable string hash for observation subIds (issue #554 silhouette
- * deconflict). Used to derive a NEGATIVE pseudo-cluster_id so silhouette
- * inputs can be carried through `buildGroups` alongside real clusters
- * without collision. djb2-style — same algorithm as the unit tests'
- * `hashForTest`. The return value is wrapped through `Math.abs` so
- * negation in the caller produces a deterministic negative id.
- */
-function hashSubId(s: string): number {
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
-  return Math.abs(h);
 }
 
 /**

--- a/frontend/src/components/map/deconflict.test.ts
+++ b/frontend/src/components/map/deconflict.test.ts
@@ -6,6 +6,7 @@ import {
   bucketKey,
   buildGroups,
   displaceSilhouettes,
+  hashSubId,
   SILHOUETTE_PX,
   type DeconflictInput,
 } from './deconflict.js';
@@ -221,7 +222,7 @@ describe('deconflict', () => {
     py: number,
   ): DeconflictInput {
     return {
-      cluster_id: -hashForTest(subId),
+      cluster_id: -hashSubId(subId),
       px,
       py,
       rendered: { kind: 'silhouette' },
@@ -230,12 +231,47 @@ describe('deconflict', () => {
       subId,
     };
   }
-  function hashForTest(s: string): number {
-    // Stable test-only hash; matches the production djb2-style helper.
-    let h = 5381;
-    for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
-    return Math.abs(h);
-  }
+
+  // ---- hashSubId (U4 extraction from MapCanvas.tsx, #888) ----
+  //
+  // djb2-style string hash → positive int. Callers negate the result to derive
+  // a NEGATIVE pseudo-cluster_id (e.g. `-hashSubId(subId)`) so silhouette inputs
+  // can ride through `buildGroups` alongside real (positive) supercluster ids
+  // without collision. Previously mirrored as a test-only `hashForTest`; this
+  // unit moved the helper to `deconflict.ts` so its contract lives next to the
+  // negative-pseudo-id consumers, and the duplicate was deleted.
+  describe('hashSubId', () => {
+    it('is deterministic — same input yields the same hash', () => {
+      expect(hashSubId('OBS1')).toBe(hashSubId('OBS1'));
+      expect(hashSubId('S12345678')).toBe(hashSubId('S12345678'));
+    });
+
+    it('returns a positive integer (caller negates for the pseudo-id)', () => {
+      for (const subId of ['OBS1', 'OBS2', 'S12345678', 'L9876543', 'a', '']) {
+        const h = hashSubId(subId);
+        expect(Number.isInteger(h)).toBe(true);
+        expect(h).toBeGreaterThanOrEqual(0);
+        // Negated form is the value actually fed into DeconflictInput.cluster_id.
+        expect(-h).toBeLessThanOrEqual(0);
+      }
+    });
+
+    it('distinguishes distinct subIds (no trivial collision on common eBird ids)', () => {
+      expect(hashSubId('OBS1')).not.toBe(hashSubId('OBS2'));
+      expect(hashSubId('S12345678')).not.toBe(hashSubId('S12345679'));
+    });
+
+    it('matches the djb2 reference (5381 seed, h<<5 + h + c, |0, Math.abs)', () => {
+      const ref = (s: string): number => {
+        let h = 5381;
+        for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+        return Math.abs(h);
+      };
+      for (const subId of ['OBS1', 'OBS_E', 'OBS_W', 'S12345678', '']) {
+        expect(hashSubId(subId)).toBe(ref(subId));
+      }
+    });
+  });
 
   it('aabbForShape({kind:"silhouette"}) at (100,100) → 28×28 box centered there', () => {
     expect(aabbForShape({ kind: 'silhouette' }, 100, 100)).toEqual({

--- a/frontend/src/components/map/deconflict.ts
+++ b/frontend/src/components/map/deconflict.ts
@@ -413,3 +413,21 @@ export function displaceSilhouettes(
 
   return offsets;
 }
+
+/**
+ * Stable string hash for observation subIds (issue #554 silhouette
+ * deconflict). Used to derive a NEGATIVE pseudo-`cluster_id` (callers negate
+ * the result, e.g. `-hashSubId(subId)`) so silhouette inputs can be carried
+ * through `buildGroups` alongside real (positive) supercluster `cluster_id`s
+ * without collision. djb2-style. The return value is wrapped through
+ * `Math.abs` so negation in the caller produces a deterministic negative id.
+ *
+ * Extracted from `MapCanvas.tsx` (#888, U4): its negative-pseudo-id contract
+ * lives here next to `DeconflictInput.cluster_id` and `buildGroups`, which is
+ * where the sign convention is enforced.
+ */
+export function hashSubId(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph before["Before"]
        MC1["MapCanvas.tsx<br/>function hashSubId (local)"]
        DT1["deconflict.test.ts<br/>function hashForTest (mirror dup)"]
        MC1 -. "-hashSubId(subId)" .-> CID1["DeconflictInput.cluster_id<br/>(negative pseudo-id)"]
    end
    subgraph after["After"]
        DC2["deconflict.ts<br/>export function hashSubId (appended)"]
        MC2["MapCanvas.tsx<br/>import { hashSubId }"]
        DT2["deconflict.test.ts<br/>import { hashSubId } + direct tests"]
        DC2 --> MC2
        DC2 --> DT2
        MC2 -. "-hashSubId(subId)<br/>(unchanged call site)" .-> CID2["DeconflictInput.cluster_id<br/>(negative pseudo-id)"]
    end
    before ==> after
```

## Summary

- **Why:** `hashSubId`'s only purpose is the deconflict layer's negative-pseudo-id contract — callers negate its always-positive djb2 result to mint a NEGATIVE `DeconflictInput.cluster_id` so silhouette inputs ride through `buildGroups` alongside real (positive) supercluster ids without collision. That sign convention is enforced in `deconflict.ts`, so the helper belongs next to it, not in the `MapCanvas.tsx` god-component (U4 of the consolidation epic #884, Wave 0).
- **What:** Append-only extraction — `hashSubId` moved to `deconflict.ts` (no edits to existing exports, so U10/#895 inherits a clean append), imported back into `MapCanvas.tsx` (the `cluster_id: -hashSubId(subId)` call site is unchanged → rendered output byte-identical), and the mirrored test-only `hashForTest` duplicate deleted from `deconflict.test.ts`.
- **Net test delta:** +4 — direct `hashSubId` coverage (determinism, positivity, distinctness, djb2-reference match) replaces the deleted duplicate.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, no className changes
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445) — N/A — not UI (no rendered-output change; call site unchanged, Wave 0 is explicitly no-Playwright per the epic)

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (69 files, 1182 tests; includes 4 new `hashSubId` tests)
- [x] New unit tests added — `describe('hashSubId')` in `deconflict.test.ts` (determinism, positivity, distinctness, djb2-reference match); TDD: confirmed RED (`hashSubId is not a function`) before the move, GREEN after
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior change
- [x] `npm run build -w @bird-watch/frontend` (`tsc -b && vite build`) — clean production build
- [x] `npx knip --no-progress` — clean (new export is imported by `MapCanvas.tsx` + the test)
- [x] (UI only) Playwright MCP smoke — N/A — not UI (behavior-preserving extraction; the only caller, `cluster_id: -hashSubId(subId)`, is unchanged)

## Plan reference

Part of #884 (MapCanvas consolidation epic), U4 / Wave 0. Closes #888.
Ordering: this MUST land before U10 (#895), which imports `hashSubId` from `deconflict.ts`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)