### PR TITLE
refactor(frontend): extract silhouette sprite pipeline → silhouette-sprite.ts (U3)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -60,7 +60,7 @@ import { ObservationPopover } from './ObservationPopover.js';
 import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
 import { ClusterPill } from '../ds/ClusterPill.js';
-import { isValidSvgPathData } from './silhouette-fallback.js';
+import { registerSilhouetteSprite } from './silhouette-sprite.js';
 import {
   aggregateClusterFamilies,
   aggregateClusterSpecies,
@@ -277,79 +277,6 @@ function PresentationMarker({ longitude, latitude, anchor, children }: Presentat
 // `camera-config.ts` (epic #884, unit U2 / #886) — imported at the top of this
 // file. Behavior-preserving move; the imperative camera machinery
 // (clampBounds/padBounds/cameraForBounds/setMaxBounds) stays here for U12.
-
-/**
- * Convert a `family_silhouettes` row into a complete SVG document string
- * suitable for `<img src="data:image/svg+xml,...">`. The svgData column
- * stores a single path-`d` string (24-viewBox); we wrap it in a minimal
- * `<svg>` shell with `fill="black"` so the rendered raster is a single-
- * channel alpha mask that maplibre's SDF tinter can color-shift via the
- * symbol layer's `icon-color` paint property.
- *
- * Returns `null` when `svgData` fails the SVG path-data charset check
- * (issue #271). A literal `"`, `<`, `>`, `&`, or any other XML-breaking
- * character would either silently corrupt the surrounding `<svg>` document
- * — making `image.decode()` reject and the family fall back to `_FALLBACK`
- * with no diagnostic — or, in a worse regression, open an XSS surface if
- * the SVG ever rendered through an `innerHTML` path. The caller treats
- * `null` the same way it treats a `null` `svgData` upstream: skip the
- * sprite registration, log a warn naming the family code, fall back to
- * the `_FALLBACK` sprite via the GeoJSON join.
- */
-function silhouettePathToSvg(svgData: string, familyCode: string): string | null {
-  if (!isValidSvgPathData(svgData)) {
-    console.warn(
-      `[silhouette] invalid svgData for family ${familyCode}; falling back to _FALLBACK sprite`,
-    );
-    return null;
-  }
-  return (
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="64" height="64">` +
-    `<path d="${svgData}" fill="black"/>` +
-    `</svg>`
-  );
-}
-
-/**
- * Promise-wrap the SVG → HTMLImageElement → addImage pipeline for one
- * silhouette. Resolves once the sprite is registered; rejects on image-
- * load failure (which surfaces upstream as a Promise.all rejection).
- *
- * No-op (resolves immediately) when `svgData` fails the charset check —
- * `silhouettePathToSvg` returns `null` and we skip registration so the
- * family's observations join to the `_FALLBACK` sprite instead.
- */
-async function registerSilhouetteSprite(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  map: any,
-  id: string,
-  svgData: string,
-): Promise<void> {
-  const svgString = silhouettePathToSvg(svgData, id);
-  if (svgString === null) return;
-  const blob = new Blob([svgString], { type: 'image/svg+xml' });
-  const url = URL.createObjectURL(blob);
-  try {
-    const img = new Image();
-    img.src = url;
-    // image.decode() returns a Promise that resolves when the image is
-    // ready to render (no `onload` race). Fall back to a manual onload
-    // listener for environments (jsdom) where decode is a stub.
-    if (typeof img.decode === 'function') {
-      await img.decode().catch(() => {
-        // jsdom Image polyfill rejects decode immediately; the FakeImage
-        // shim in tests resolves. Either way we proceed — the addImage
-        // call below tolerates a half-decoded image in tests, and in
-        // production the data: URI loads synchronously.
-      });
-    }
-    if (!map.hasImage(id)) {
-      map.addImage(id, img, { sdf: true });
-    }
-  } finally {
-    URL.revokeObjectURL(url);
-  }
-}
 
 /**
  * MapLibre GL JS map instance wrapped via react-map-gl/maplibre.

--- a/frontend/src/components/map/silhouette-sprite.test.ts
+++ b/frontend/src/components/map/silhouette-sprite.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import {
+  silhouettePathToSvg,
+  registerSilhouetteSprite,
+  type SpriteMap,
+} from './silhouette-sprite.js';
+
+/* ── jsdom shims ──────────────────────────────────────────────────────────
+   jsdom ships `Blob` natively but NOT `URL.createObjectURL`/`revokeObjectURL`
+   nor a usable `HTMLImageElement.prototype.decode`. `registerSilhouetteSprite`
+   exercises all three, so stub them once for the suite. Mirrors the FakeImage /
+   createObjectURL block in MapCanvas.test.tsx so the two suites agree on the
+   environment contract (no real decode, deterministic blob: URL). */
+class FakeImage {
+  src = '';
+  width = 64;
+  height = 64;
+  decode(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+beforeAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).Image = FakeImage;
+  if (typeof URL.createObjectURL === 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (URL as any).createObjectURL = vi.fn(() => 'blob:fake-url');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (URL as any).revokeObjectURL = vi.fn();
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/* ── silhouettePathToSvg — pure data transform ───────────────────────────── */
+
+describe('silhouettePathToSvg', () => {
+  it('wraps a valid path-d string in a 24-viewBox black-fill SVG document', () => {
+    const svg = silhouettePathToSvg('M12 4 L20 20 Z', 'tyrannidae');
+    expect(svg).not.toBeNull();
+    // viewBox is the 24-unit coordinate space the migration ships.
+    expect(svg).toContain('viewBox="0 0 24 24"');
+    // fill="black" is load-bearing: it produces the single-channel alpha mask
+    // the SDF tinter recolors via the symbol layer's icon-color paint property.
+    expect(svg).toContain('fill="black"');
+    // The path-d is interpolated verbatim into the <path> element.
+    expect(svg).toContain('<path d="M12 4 L20 20 Z" fill="black"/>');
+    expect(svg).toMatch(/^<svg /);
+    expect(svg).toMatch(/<\/svg>$/);
+  });
+
+  it('returns null when svgData fails the #271 charset guard (XSS-shaped input)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A literal `"` + `<script>` would corrupt the surrounding SVG document and,
+    // worse, open an XSS surface if ever rendered through innerHTML (#271).
+    const svg = silhouettePathToSvg('M12 4 "<script>alert(1)</script>', 'badfam');
+    expect(svg).toBeNull();
+    // The caller relies on a warn naming the family code for diagnosis.
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('badfam');
+  });
+});
+
+/* ── registerSilhouetteSprite — imperative map-sync helper ────────────────── */
+
+/**
+ * A spy `SpriteMap` backed by an in-memory image registry. Mirrors the minimal
+ * structural surface `registerSilhouetteSprite` consumes (addImage / hasImage)
+ * — never maplibre's full Map, so the helper unit-tests with no WebGL.
+ */
+function makeSpriteMap(preregistered: string[] = []) {
+  const registered = new Set<string>(preregistered);
+  const addImage = vi.fn(
+    (id: string, _img: HTMLImageElement, _opts?: { sdf?: boolean }) => {
+      registered.add(id);
+    },
+  );
+  const hasImage = vi.fn((id: string) => registered.has(id));
+  const map: SpriteMap = { addImage, hasImage };
+  return { map, addImage, hasImage };
+}
+
+describe('registerSilhouetteSprite', () => {
+  it('registers the sprite via addImage with { sdf: true }', async () => {
+    const { map, addImage, hasImage } = makeSpriteMap();
+    await registerSilhouetteSprite(map, 'tyrannidae', 'M12 4 L20 20 Z');
+    expect(hasImage).toHaveBeenCalledWith('tyrannidae');
+    expect(addImage).toHaveBeenCalledOnce();
+    const [id, img, opts] = addImage.mock.calls[0];
+    expect(id).toBe('tyrannidae');
+    expect(img).toBeInstanceOf(FakeImage);
+    // sdf:true is the whole point — the sprite is a colorless alpha mask the
+    // layer tints later. Registration must never bake in a color.
+    expect(opts).toEqual({ sdf: true });
+  });
+
+  it('short-circuits (no addImage) when the sprite id is already registered', async () => {
+    const { map, addImage, hasImage } = makeSpriteMap(['tyrannidae']);
+    await registerSilhouetteSprite(map, 'tyrannidae', 'M12 4 L20 20 Z');
+    expect(hasImage).toHaveBeenCalledWith('tyrannidae');
+    expect(addImage).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op (no addImage) when svgData fails the charset guard', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { map, addImage, hasImage } = makeSpriteMap();
+    await registerSilhouetteSprite(map, 'badfam', 'M12 4 "<script>');
+    // silhouettePathToSvg returns null → we never touch the map at all.
+    expect(addImage).not.toHaveBeenCalled();
+    expect(hasImage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/silhouette-sprite.ts
+++ b/frontend/src/components/map/silhouette-sprite.ts
@@ -1,0 +1,116 @@
+import { isValidSvgPathData } from './silhouette-fallback.js';
+
+/**
+ * Silhouette sprite pipeline (extracted from MapCanvas.tsx, epic #884 · U3).
+ *
+ * Two shapes live here, mirroring the two phases of getting a `family_silhouettes`
+ * row onto the map:
+ *
+ *   1. `silhouettePathToSvg` — a PURE data transform: a single path-`d` string →
+ *      a complete `<svg>` document string (or `null` if the input fails the #271
+ *      charset guard). No side effects, no map.
+ *   2. `registerSilhouetteSprite` — the IMPERATIVE map-sync helper that runs that
+ *      SVG through `Blob` → `HTMLImageElement` → `map.addImage`. It takes a
+ *      minimal structural {@link SpriteMap}, never maplibre's full `Map`, so it
+ *      unit-tests against a tiny spy with no WebGL (exemplar: `artboard-layers.ts`).
+ *
+ * Registration is COLORLESS: `addImage(id, img, { sdf: true })` registers a
+ * single-channel alpha mask; tinting happens later via the symbol layer's
+ * `icon-color` paint property, not at sprite-register time.
+ */
+
+/**
+ * The minimal structural surface `registerSilhouetteSprite` consumes from a
+ * maplibre map — only `addImage`/`hasImage`. Deliberately NOT maplibre's full
+ * `Map` (same idiom as `artboard-layers.ts`'s `ArtboardMap`): the narrow shape
+ * keeps the helper unit-testable against a spy object and documents the exact
+ * dependency surface.
+ *
+ * `addImage`'s 3-arg overload (`id`, `image`, `options`) with `{ sdf: true }`
+ * is the maplibre-gl 5.x shape (verified against 5.x docs — the options object
+ * carries `sdf`/`pixelRatio`/`stretchX`/etc.); `HTMLImageElement` is an accepted
+ * `image` type.
+ */
+export interface SpriteMap {
+  hasImage: (id: string) => boolean;
+  addImage: (
+    id: string,
+    image: HTMLImageElement,
+    options?: { sdf?: boolean },
+  ) => void;
+}
+
+/**
+ * Convert a `family_silhouettes` row into a complete SVG document string
+ * suitable for `<img src="data:image/svg+xml,...">`. The svgData column
+ * stores a single path-`d` string (24-viewBox); we wrap it in a minimal
+ * `<svg>` shell with `fill="black"` so the rendered raster is a single-
+ * channel alpha mask that maplibre's SDF tinter can color-shift via the
+ * symbol layer's `icon-color` paint property.
+ *
+ * Returns `null` when `svgData` fails the SVG path-data charset check
+ * (issue #271). A literal `"`, `<`, `>`, `&`, or any other XML-breaking
+ * character would either silently corrupt the surrounding `<svg>` document
+ * — making `image.decode()` reject and the family fall back to `_FALLBACK`
+ * with no diagnostic — or, in a worse regression, open an XSS surface if
+ * the SVG ever rendered through an `innerHTML` path. The caller treats
+ * `null` the same way it treats a `null` `svgData` upstream: skip the
+ * sprite registration, log a warn naming the family code, fall back to
+ * the `_FALLBACK` sprite via the GeoJSON join.
+ */
+export function silhouettePathToSvg(
+  svgData: string,
+  familyCode: string,
+): string | null {
+  if (!isValidSvgPathData(svgData)) {
+    console.warn(
+      `[silhouette] invalid svgData for family ${familyCode}; falling back to _FALLBACK sprite`,
+    );
+    return null;
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="64" height="64">` +
+    `<path d="${svgData}" fill="black"/>` +
+    `</svg>`
+  );
+}
+
+/**
+ * Promise-wrap the SVG → HTMLImageElement → addImage pipeline for one
+ * silhouette. Resolves once the sprite is registered; rejects on image-
+ * load failure (which surfaces upstream as a Promise.all rejection).
+ *
+ * No-op (resolves immediately) when `svgData` fails the charset check —
+ * `silhouettePathToSvg` returns `null` and we skip registration so the
+ * family's observations join to the `_FALLBACK` sprite instead.
+ */
+export async function registerSilhouetteSprite(
+  map: SpriteMap,
+  id: string,
+  svgData: string,
+): Promise<void> {
+  const svgString = silhouettePathToSvg(svgData, id);
+  if (svgString === null) return;
+  const blob = new Blob([svgString], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    img.src = url;
+    // image.decode() returns a Promise that resolves when the image is
+    // ready to render (no `onload` race). Fall back to a manual onload
+    // listener for environments (jsdom) where decode is a stub.
+    if (typeof img.decode === 'function') {
+      await img.decode().catch(() => {
+        // jsdom Image polyfill rejects decode immediately; the FakeImage
+        // shim in tests resolves. Either way we proceed — the addImage
+        // call below tolerates a half-decoded image in tests, and in
+        // production the data: URI loads synchronously.
+      });
+    }
+    if (!map.hasImage(id)) {
+      map.addImage(id, img, { sdf: true });
+    }
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph before["MapCanvas.tsx (before)"]
        A1["silhouettePathToSvg()"]
        A2["registerSilhouetteSprite(map: any)"]
        A3["import isValidSvgPathData"]
        A4["handleLoad sprite-ready loop"]
        A4 --> A2 --> A1 --> A3
    end

    subgraph after["after — extracted module"]
        direction TB
        B4["MapCanvas.handleLoad loop"]
        subgraph mod["silhouette-sprite.ts"]
            B2["registerSilhouetteSprite(map: SpriteMap)"]
            B1["silhouettePathToSvg()"]
            B3["import isValidSvgPathData"]
            B2 --> B1 --> B3
        end
        B4 -->|"imports registerSilhouetteSprite"| B2
    end

    before ==>|"behavior-preserving move"| after
```

```mermaid
sequenceDiagram
    participant HL as MapCanvas.handleLoad
    participant RS as registerSilhouetteSprite
    participant PS as silhouettePathToSvg
    participant Map as SpriteMap (addImage/hasImage)

    HL->>RS: (map, familyCode, svgData)
    RS->>PS: svgData, id
    PS-->>RS: SVG document string | null (#271 charset guard)
    alt svgString === null
        RS-->>HL: resolve (no-op, family joins _FALLBACK)
    else valid
        RS->>RS: Blob → Image → decode()
        RS->>Map: hasImage(id)?
        Map-->>RS: false
        RS->>Map: addImage(id, img, { sdf: true })  %% colorless mask; tint via icon-color later
    end
```

## Summary

- **Why:** `silhouettePathToSvg` and `registerSilhouetteSprite` were free-standing, side-effect-scoped functions that already took the map as a parameter and never closed over component state — pure accretion around MapCanvas's load-bearing imperative core. Extracting them shrinks the 3,017-line file and lets the sprite pipeline carry its own 1:1 colocated test (no React render, no WebGL) instead of being exercised only transitively through the giant MapCanvas suite. Wave 0 leaf cut of epic #884 (unit U3).
- **What stays identical:** the moved code is character-for-character the same — same SVG string, same `addImage(id, img, { sdf: true })` colorless registration, same decode/`finally` revoke pattern. The single use-site (`handleLoad`) imports the symbol back unchanged, so rendered output is byte-identical. The only type change is narrowing the helper's `map` param from `any` to a minimal structural `SpriteMap` (`addImage`/`hasImage` only), matching the established `artboard-layers.ts` `ArtboardMap` idiom.
- **maplibre-gl 5.x:** confirmed against current 5.x docs (installed 5.24.0) that the `addImage(id, image, options)` 3-arg overload with `{ sdf: true }` is the correct 5.x shape and `HTMLImageElement` is an accepted `image` type — the call and the `SpriteMap` signature need no change from the 4.x-era code.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no CSS/className touched (pure TS extraction)`
- [x] Multi-viewport design QA — `N/A — not UI` (Wave 0 is explicitly no-Playwright per the epic plan; behavior-preserving extraction)

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (70 files / 1183 tests pass, including the new `silhouette-sprite.test.ts` and `MapCanvas.test.tsx`)
- [x] New unit tests added — `frontend/src/components/map/silhouette-sprite.test.ts` (5 tests): valid path → 24-viewBox black-fill SVG; #271 charset-fail → `null`; `registerSilhouetteSprite` against a spy `SpriteMap` asserts `addImage(id, img, { sdf: true })`, the `hasImage` short-circuit, and the null-svg no-op. Written test-first (confirmed RED on missing module, then GREEN).
- [x] No new Playwright e2e spec — behavior-preserving, no user-visible behavior change
- [x] `npm run build --workspace @bird-watch/frontend` — clean (`tsc -b` typecheck + `vite build` both exit 0)
- [x] `npx knip` — exit 0, no findings on the new module (imported back by MapCanvas, fully reachable)

## Plan reference

Out of plan — MapCanvas decomposition epic #884, unit U3 (#887). Tracked via the epic's child-issue list, not a `docs/plans/` file.

Closes #887.
Refs #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

