### PR TITLE
test(frontend): backfill use-theme + use-breakpoint sibling unit tests (#899)

### DIFF
--- a/frontend/src/hooks/use-breakpoint.test.ts
+++ b/frontend/src/hooks/use-breakpoint.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBreakpoint } from './use-breakpoint.js';
+import { setMatchMedia, getMockMediaQuery } from '../test-setup.js';
+
+/**
+ * useBreakpoint maps two `window.matchMedia` queries onto three named tiers:
+ *
+ *   (max-width: 479px)  matches  → 'compact'
+ *   (max-width: 1023px) matches  → 'roomy'   (and compact did NOT match)
+ *   neither matches              → 'wide'
+ *
+ * The token pixel values are BP_COMPACT=480 / BP_WIDE=1024, so the queries
+ * are `${480 - 1}` and `${1024 - 1}` px. test-setup mocks `matchMedia` and
+ * lets a test flip `matches` via `dispatchChange` to simulate a resize without
+ * a real layout engine (mirrors use-media-query.test.ts).
+ */
+
+const Q_COMPACT = '(max-width: 479px)';
+const Q_ROOMY = '(max-width: 1023px)';
+
+/** Build a matcher for a given viewport width against the two breakpoint queries. */
+function matcherForWidth(width: number) {
+  return (query: string): boolean => {
+    if (query === Q_COMPACT) return width <= 479;
+    if (query === Q_ROOMY) return width <= 1023;
+    return false;
+  };
+}
+
+describe('useBreakpoint', () => {
+  it("returns 'compact' below 480px (both queries match)", () => {
+    setMatchMedia(matcherForWidth(390));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('compact');
+  });
+
+  it("returns 'roomy' between 480px and 1023px (only the wide query matches)", () => {
+    setMatchMedia(matcherForWidth(768));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('roomy');
+  });
+
+  it("returns 'wide' at 1024px and up (neither query matches)", () => {
+    setMatchMedia(matcherForWidth(1440));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('wide');
+  });
+
+  it("treats the 480px boundary as 'roomy' (compact is < 480, not ≤)", () => {
+    setMatchMedia(matcherForWidth(480));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('roomy');
+  });
+
+  it("treats the 1024px boundary as 'wide' (roomy is < 1024, not ≤)", () => {
+    setMatchMedia(matcherForWidth(1024));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('wide');
+  });
+
+  it("re-evaluates compact → roomy when the compact query transitions to false", () => {
+    setMatchMedia(matcherForWidth(390));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('compact');
+
+    // Simulate resizing past 480px. The hook's onchange handler re-reads via
+    // readBreakpoint(), which re-queries window.matchMedia — so we must move the
+    // installed matcher to the new viewport before firing the change event
+    // (re-querying with a stale matcher would overwrite our manual .matches).
+    act(() => {
+      setMatchMedia(matcherForWidth(768));
+      getMockMediaQuery(Q_COMPACT)!.dispatchChange(false);
+    });
+
+    expect(result.current).toBe('roomy');
+  });
+
+  it("re-evaluates roomy → wide when the roomy query transitions to false", () => {
+    setMatchMedia(matcherForWidth(768));
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('roomy');
+
+    act(() => {
+      setMatchMedia(matcherForWidth(1440));
+      getMockMediaQuery(Q_ROOMY)!.dispatchChange(false);
+    });
+
+    expect(result.current).toBe('wide');
+  });
+
+  it("falls back to 'wide' when window.matchMedia is unavailable", () => {
+    // Defensive SSR / jsdom-without-matchMedia path: the hook must not crash
+    // and should report the desktop fallback.
+    // @ts-expect-error — deliberately removing the stub for this test.
+    delete window.matchMedia;
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('wide');
+  });
+
+  it('removes its resize listeners on unmount without throwing', () => {
+    setMatchMedia(matcherForWidth(390));
+    const { result, unmount } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('compact');
+    unmount();
+    // Dispatching a change after unmount must not throw or update state.
+    expect(() => {
+      getMockMediaQuery(Q_ROOMY)!.dispatchChange(false);
+    }).not.toThrow();
+  });
+});

--- a/frontend/src/hooks/use-theme.test.ts
+++ b/frontend/src/hooks/use-theme.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme } from './use-theme.js';
+
+/**
+ * useTheme reads `document.documentElement`'s `[data-theme]` attribute and
+ * re-renders on changes via a real `MutationObserver`. The repo's test-setup
+ * mocks `window.matchMedia` but NOT `MutationObserver` — jsdom ships a working
+ * observer that fires its callback on `setAttribute`, so these tests drive the
+ * attribute directly and wait one microtask-ish tick for the observer + React
+ * re-render (mirrors AdaptiveGridMarker.test.tsx / MapCanvas.test.tsx).
+ */
+
+const originalTheme = document.documentElement.getAttribute('data-theme');
+
+afterEach(() => {
+  // Restore the <html> attribute so theme state never leaks between tests.
+  if (originalTheme === null) {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', originalTheme);
+  }
+});
+
+// Let a queued MutationObserver callback flush, then React re-render.
+const flushObserver = () => new Promise(r => setTimeout(r, 50));
+
+describe('useTheme', () => {
+  it("returns 'dark' when [data-theme] is 'dark' on mount", () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('dark');
+  });
+
+  it("returns 'light' when [data-theme] is 'light' on mount", () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('light');
+  });
+
+  it("treats a missing [data-theme] attribute as 'light'", () => {
+    document.documentElement.removeAttribute('data-theme');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('light');
+  });
+
+  it("treats any non-'dark' value as 'light' (e.g. 'sepia')", () => {
+    document.documentElement.setAttribute('data-theme', 'sepia');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('light');
+  });
+
+  it('reacts to a light → dark attribute mutation', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('light');
+
+    await act(async () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      await flushObserver();
+    });
+
+    expect(result.current).toBe('dark');
+  });
+
+  it('reacts to a dark → light attribute mutation', async () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current).toBe('dark');
+
+    await act(async () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      await flushObserver();
+    });
+
+    expect(result.current).toBe('light');
+  });
+
+  it('stops reacting after unmount (observer disconnected)', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result, unmount } = renderHook(() => useTheme());
+    expect(result.current).toBe('light');
+
+    unmount();
+
+    // After unmount the observer is disconnected: flipping the attribute must
+    // neither throw nor warn about a state update on an unmounted component.
+    await act(async () => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      await flushObserver();
+    });
+
+    // The last value renderHook captured stays 'light' — no post-unmount update.
+    expect(result.current).toBe('light');
+  });
+});


### PR DESCRIPTION
## Diagrams

N/A — test-only backfill (two new colocated unit-test files, zero production code change, nothing to diagram).

## Summary

- **Why:** Completeness — make "every hook has a colocated sibling test" literally true for the two remaining test-less hooks (`use-theme`, `use-breakpoint`). Pure hygiene; **zero extraction**, no risk moved (P2, blast = cosmetic).
- The behaviors were already mirror-tested elsewhere (`MapCanvas.test.tsx` theme-swap suite + `AdaptiveGridMarker.test.tsx` for the `useTheme` MutationObserver; `use-media-query.test.ts` for the matchMedia pattern); this colocates equivalent coverage on the hooks themselves.
- `use-theme.test.ts` drives `[data-theme]` through jsdom's real `MutationObserver` (test-setup mocks `matchMedia` but NOT `MutationObserver`, so the observer fires for real on `setAttribute`); `use-breakpoint.test.ts` uses the shared `setMatchMedia`/`getMockMediaQuery` harness, covering all three tiers, both boundary edges, live resize transitions, the SSR fallback, and listener cleanup.

## Screenshots

N/A — not UI

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css` (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, no CSS/className touched
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — N/A — not UI

## Test plan

- [x] `npm run typecheck && npm run test` — green (full frontend build `tsc -b && vite build` clean; `npm test` → 75 files / 1218 tests pass)
- [x] New unit / integration tests added (if behavior changed) — two new colocated hook tests (16 cases); the two resize-transition cases were RED before the matcher fix, confirming meaningful assertions
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior change
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Out of plan — P2 test-backfill for the MapCanvas consolidation epic. Closes #899. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)