### PR TITLE
test(frontend): backfill use-states cache/dedup/retry unit test

### DIFF
--- a/frontend/src/data/use-states.test.tsx
+++ b/frontend/src/data/use-states.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStates, __resetStatesCache } from './use-states.js';
+import { ApiClient } from '../api/client.js';
+import type { StateSummary } from '@bird-watch/shared-types';
+
+// Build the client with `Object.assign(new ApiClient(), { getStates: vi.fn() })`
+// per the `useSilhouettes` mirror — do NOT `vi.spyOn(ApiClient.prototype, ...)`.
+// The hook's cache/inflight live at module scope; a prototype spy restored mid-
+// suite while a module-cached promise is latched is exactly where the
+// inflight-dedup assertion turns fragile.
+function makeClient(overrides: Partial<ApiClient>): ApiClient {
+  return Object.assign(new ApiClient(), overrides);
+}
+
+const AZ: StateSummary = {
+  stateCode: 'US-AZ',
+  name: 'Arizona',
+  bbox: [-114.82, 31.33, -109.04, 37.0],
+};
+const CA: StateSummary = {
+  stateCode: 'US-CA',
+  name: 'California',
+  bbox: [-124.41, 32.53, -114.13, 42.01],
+};
+
+describe('useStates', () => {
+  beforeEach(() => {
+    __resetStatesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('synchronous cache hit: a second mount fires getStates zero times', async () => {
+    const getStates = vi.fn().mockResolvedValue([AZ]);
+    const client = makeClient({ getStates } as unknown as Partial<ApiClient>);
+
+    // First mount populates the module cache.
+    const first = renderHook(() => useStates(client));
+    expect(first.result.current.loading).toBe(true);
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(getStates).toHaveBeenCalledTimes(1);
+    expect(first.result.current.states).toHaveLength(1);
+
+    // Second mount hits the cache synchronously: loading starts false and the
+    // fetcher is NOT invoked again.
+    const second = renderHook(() => useStates(client));
+    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.states).toHaveLength(1);
+    expect(second.result.current.states[0]?.stateCode).toBe('US-AZ');
+    expect(getStates).toHaveBeenCalledTimes(1);
+  });
+
+  it('inflight-dedup: two concurrent mounts share ONE in-flight promise', async () => {
+    // A deferred promise so both mounts subscribe before it resolves.
+    let resolveStates: (rows: StateSummary[]) => void = () => {};
+    const pending = new Promise<StateSummary[]>(resolve => {
+      resolveStates = resolve;
+    });
+    const getStates = vi.fn().mockReturnValue(pending);
+    const client = makeClient({ getStates } as unknown as Partial<ApiClient>);
+
+    // Two mounts before the promise resolves — both should latch onto the same
+    // inflight promise, so getStates is called exactly once.
+    const a = renderHook(() => useStates(client));
+    const b = renderHook(() => useStates(client));
+    expect(a.result.current.loading).toBe(true);
+    expect(b.result.current.loading).toBe(true);
+    expect(getStates).toHaveBeenCalledTimes(1);
+
+    resolveStates([AZ, CA]);
+    await waitFor(() => expect(a.result.current.loading).toBe(false));
+    await waitFor(() => expect(b.result.current.loading).toBe(false));
+    expect(getStates).toHaveBeenCalledTimes(1);
+    expect(a.result.current.states).toHaveLength(2);
+    expect(b.result.current.states).toHaveLength(2);
+  });
+
+  it('retry-on-reject: a rejected fetch leaves cache null + clears inflight so a later mount retries and succeeds', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('states 503'));
+    const client = makeClient({ getStates: failing } as unknown as Partial<ApiClient>);
+
+    const first = renderHook(() => useStates(client));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.states).toHaveLength(0);
+
+    // The rejected inflight promise must not be latched into the cache — a
+    // later mount with a healthy client retries and succeeds.
+    const succeeding = vi.fn().mockResolvedValue([AZ]);
+    const healthyClient = makeClient({
+      getStates: succeeding,
+    } as unknown as Partial<ApiClient>);
+    const retry = renderHook(() => useStates(healthyClient));
+    expect(retry.result.current.loading).toBe(true);
+    await waitFor(() => expect(retry.result.current.loading).toBe(false));
+    expect(succeeding).toHaveBeenCalledTimes(1);
+    expect(retry.result.current.states).toHaveLength(1);
+    expect(retry.result.current.states[0]?.stateCode).toBe('US-AZ');
+    expect(retry.result.current.error).toBeNull();
+  });
+
+  it('surfaces the error and flips loading false in finally on rejection', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('states 503'));
+    const client = makeClient({ getStates: failing } as unknown as Partial<ApiClient>);
+
+    const { result } = renderHook(() => useStates(client));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('states 503');
+    expect(result.current.states).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant M1 as Mount A
    participant M2 as Mount B
    participant Hook as useStates
    participant Cache as module cache/inflight
    participant API as ApiClient.getStates

    Note over Hook,Cache: cache=null, inflight=null
    M1->>Hook: mount
    Hook->>Cache: inflight ?? (inflight = getStates())
    Cache->>API: getStates()  (1×)
    M2->>Hook: mount (concurrent)
    Hook->>Cache: inflight already set → reuse
    Note over Cache,API: dedup — getStates NOT called again
    API-->>Cache: resolve rows → cache = rows
    Note over Hook,Cache: later mount: cache!==null → loading starts false, 0 calls

    rect rgb(255,235,235)
    Note over API: reject path
    API-->>Cache: reject → inflight = null, cache stays null
    Note over Hook: "error surfaced, loading flipped false in finally.<br/>next mount retries and succeeds"
    end
```

## Summary

- `useStates` was the one nontrivial untested hook: it owns the module-level state-table cache (name + bbox envelope) shared across every scope-chooser and state-scope-camera consumer, and its unused `__resetStatesCache` export signalled intended-but-deferred coverage. This backfills the missing sibling test, closing the "every hook has a sibling test" gap.
- Asserts the four real behaviors of the current code: synchronous cache hit (2nd mount fires `getStates` 0×), inflight-dedup (two concurrent mounts share one in-flight promise), retry-on-reject (a rejected fetch leaves cache null + clears inflight so a later mount retries and succeeds), and error surfaced with `loading` flipped false in `finally`.
- Zero extraction — pure test addition on an existing file. Mirrors `useSilhouettes` discipline; the client is built via `Object.assign(new ApiClient(), { getStates: vi.fn() })` (not a prototype spy, which would make the dedup assertion fragile against the module-cached promise). Importing `__resetStatesCache` also clears the prior knip unused-export finding.

## Screenshots

N/A — not UI

- [x] Every new/renamed `className` in this PR has a matching CSS rule (N/A — no JSX/className; test-only)
- [x] Multi-viewport design QA — N/A — not UI

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (tsc -b && vite build) — clean (213 modules)
- [x] `npm test --workspace @bird-watch/frontend` — green (74 files, 1206 tests)
- [x] New unit tests added (4 cases: cache-hit, inflight-dedup, retry-on-reject, error+finally)
- [x] Non-vacuous verification: mutating `inflight ?? (inflight = getStates())` → always-call breaks the dedup assertion; removing `inflight = null` in `.catch` breaks the retry assertion. Both restored.
- [x] knip clean (exit 0) — `__resetStatesCache` now consumed by the test
- [x] (UI only) Playwright MCP smoke — N/A — test-only, no UI change

## Plan reference

Out of plan — MapCanvas consolidation epic #884 (P1 test-backfill, risk: low, zero extraction). Closes #894. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
