### PR TITLE
refactor(frontend): extract PresentationMarker → PresentationMarker.tsx (U5)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -13,7 +13,6 @@ import {
   Map as MapView,
   Source,
   Layer,
-  Marker,
 } from 'react-map-gl/maplibre';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -58,6 +57,7 @@ import { mergeLeafBuckets } from '../../data/bucket-aggregates.js';
 import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
 import { ObservationPopover } from './ObservationPopover.js';
 import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
+import { PresentationMarker } from './PresentationMarker.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
 import { ClusterPill } from '../ds/ClusterPill.js';
 import { registerSilhouetteSprite } from './silhouette-sprite.js';
@@ -224,53 +224,10 @@ export function handleMapError(e: MapErrorEvent): void {
   console.error(e.error);
 }
 
-/**
- * PresentationMarker — a <Marker> wrapper that removes `role="button"` from
- * the maplibre-gl marker container div after mount.
- *
- * Why this is needed (WCAG 4.1.2 / #459 W4-C):
- *   maplibre-gl's Marker.addTo() calls `setAttribute('role', 'button')` on
- *   its container element unless a role is already present. When the Marker
- *   children are themselves interactive elements (<button>: AdaptiveGridMarker,
- *   ClusterPill), the result is a `<div role="button">`
- *   wrapping a `<button>` — a nested-interactive WCAG 4.1.2 violation that
- *   axe-core flags on every visible marker (47 violations in the 2026-05-11
- *   audit).
- *
- * Fix: react-map-gl's Marker component exposes the MapLibre MarkerInstance
- * via forwardRef. After mount we set role="presentation" on the wrapper
- * element. This overrides maplibre's role="button" and removes the
- * interactive semantics from the container; the child <button> remains the
- * canonical interactive element with full keyboard + AT support.
- *
- * We do NOT use aria-hidden="true" — that propagates to children and hides
- * the inner <button> from assistive technologies (silent AT regression).
- */
-interface PresentationMarkerProps {
-  longitude: number;
-  latitude: number;
-  anchor?: 'center' | 'top' | 'bottom' | 'left' | 'right' |
-    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-  children: React.ReactNode;
-}
-
-function PresentationMarker({ longitude, latitude, anchor, children }: PresentationMarkerProps) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const markerRef = useRef<any>(null);
-
-  useEffect(() => {
-    const mk = markerRef.current;
-    if (mk && typeof mk.getElement === 'function') {
-      mk.getElement().setAttribute('role', 'presentation');
-    }
-  }, []);
-
-  return (
-    <Marker ref={markerRef} longitude={longitude} latitude={latitude} anchor={anchor}>
-      {children}
-    </Marker>
-  );
-}
+// PresentationMarker — the WCAG role-strip <Marker> wrapper (#459 W4-C) was
+// extracted to `PresentationMarker.tsx` (epic #884, unit U5 / #890) and is
+// imported at the top of this file. Behavior-preserving move; the three call
+// sites below are unchanged.
 
 // Camera / viewport config (CONUS framing constants, pan/zoom bounds,
 // `pickInitialZoom`, `INITIAL_VIEW`, `FIT_BOUNDS_PADDING`) was extracted to

--- a/frontend/src/components/map/PresentationMarker.test.tsx
+++ b/frontend/src/components/map/PresentationMarker.test.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, useImperativeHandle } from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PresentationMarker } from './PresentationMarker.js';
+
+/* ── Purpose-built react-map-gl/maplibre Marker mock ─────────────────────────
+   The PresentationMarker post-mount effect is guarded by
+   `if (mk && typeof mk.getElement === 'function')` — so to exercise the
+   #459 role-strip set-path (rather than the no-op short-circuit), the mock
+   MUST forwardRef and expose a real `getElement()` DOM node via
+   useImperativeHandle. (The plain non-ref `<div>` Marker mock in
+   MapCanvas.test.tsx can only ever assert the no-op branch — do not copy it.)
+
+   `markerEl` is created fresh per Marker mount inside the forwardRef body, so
+   assertion #2 ("re-fires per remount") proves a genuinely fresh element
+   carries the role, not a hand-reset shared node. A module-level registry
+   records each mount's element keyed by `data-key` so the test can target the
+   freshly-mounted marker. */
+const mounts: Record<string, HTMLDivElement> = {};
+
+vi.mock('react-map-gl/maplibre', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Marker: forwardRef(function Marker({ children, anchor }: any, ref: any) {
+    const markerEl = document.createElement('div'); // fresh real DOM node per mount
+    useImperativeHandle(ref, () => ({ getElement: () => markerEl }), []);
+    const key = typeof anchor === 'string' ? anchor : '__default__';
+    mounts[key] = markerEl;
+    return <div data-testid="mock-marker">{children}</div>;
+  }),
+}));
+
+describe('PresentationMarker', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(mounts)) delete mounts[k];
+  });
+
+  it('sets role="presentation" on the marker container element after mount (#459)', () => {
+    render(
+      <PresentationMarker longitude={-111} latitude={34}>
+        <button>child</button>
+      </PresentationMarker>,
+    );
+
+    expect(mounts['__default__'].getAttribute('role')).toBe('presentation');
+  });
+
+  it('re-fires the role-strip effect on each fresh remount (keyed by g.key)', () => {
+    // Render markers inside a parent map() keyed so changing the keyed item
+    // unmounts the old marker and mounts a brand-new one. The effect has `[]`
+    // deps, so only a new MOUNT (not a re-render) re-runs it.
+    function Parent({ groups }: { groups: { key: string; anchor: 'top' | 'bottom' }[] }) {
+      return (
+        <>
+          {groups.map((g) => (
+            <PresentationMarker key={g.key} longitude={-111} latitude={34} anchor={g.anchor}>
+              <button>{g.key}</button>
+            </PresentationMarker>
+          ))}
+        </>
+      );
+    }
+
+    const { rerender } = render(<Parent groups={[{ key: 'a', anchor: 'top' }]} />);
+    expect(mounts['top'].getAttribute('role')).toBe('presentation');
+
+    // Swap the keyed item: React unmounts marker 'a' and mounts a fresh 'b'.
+    rerender(<Parent groups={[{ key: 'b', anchor: 'bottom' }]} />);
+    // The freshly-mounted marker carries the role — a genuinely new element
+    // (created inside the forwardRef body), not a residue from the prior mount.
+    expect(mounts['bottom'].getAttribute('role')).toBe('presentation');
+  });
+});

--- a/frontend/src/components/map/PresentationMarker.tsx
+++ b/frontend/src/components/map/PresentationMarker.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef } from 'react';
+import { Marker } from 'react-map-gl/maplibre';
+
+/**
+ * PresentationMarker — a <Marker> wrapper that removes `role="button"` from
+ * the maplibre-gl marker container div after mount.
+ *
+ * Why this is needed (WCAG 4.1.2 / #459 W4-C):
+ *   maplibre-gl's Marker.addTo() calls `setAttribute('role', 'button')` on
+ *   its container element unless a role is already present. When the Marker
+ *   children are themselves interactive elements (<button>: AdaptiveGridMarker,
+ *   ClusterPill), the result is a `<div role="button">`
+ *   wrapping a `<button>` — a nested-interactive WCAG 4.1.2 violation that
+ *   axe-core flags on every visible marker (47 violations in the 2026-05-11
+ *   audit).
+ *
+ * Fix: react-map-gl's Marker component exposes the MapLibre MarkerInstance
+ * via forwardRef. After mount we set role="presentation" on the wrapper
+ * element. This overrides maplibre's role="button" and removes the
+ * interactive semantics from the container; the child <button> remains the
+ * canonical interactive element with full keyboard + AT support.
+ *
+ * We do NOT use aria-hidden="true" — that propagates to children and hides
+ * the inner <button> from assistive technologies (silent AT regression).
+ */
+interface PresentationMarkerProps {
+  longitude: number;
+  latitude: number;
+  anchor?: 'center' | 'top' | 'bottom' | 'left' | 'right' |
+    'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  children: React.ReactNode;
+}
+
+export function PresentationMarker({ longitude, latitude, anchor, children }: PresentationMarkerProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const markerRef = useRef<any>(null);
+
+  useEffect(() => {
+    const mk = markerRef.current;
+    if (mk && typeof mk.getElement === 'function') {
+      mk.getElement().setAttribute('role', 'presentation');
+    }
+  }, []);
+
+  return (
+    <Marker ref={markerRef} longitude={longitude} latitude={latitude} anchor={anchor}>
+      {children}
+    </Marker>
+  );
+}


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph Before
        MC1[MapCanvas.tsx]
        MC1 -->|defines + renders| PM1[PresentationMarker<br/>WCAG role-strip wrapper]
    end
    subgraph After
        PM2[PresentationMarker.tsx<br/>presentational module]
        MC2[MapCanvas.tsx] -->|imports| PM2
        MC2 -->|renders ×3 call sites| PM2
        U11[U11 future consumer] -.->|will import| PM2
    end
    Before ==>|location-only move<br/>byte-identical render| After
```

## Summary

- **Why:** `PresentationMarker` is presentational with zero coupling to MapCanvas state/refs — it takes already-derived `longitude`/`latitude`/`anchor` props and only strips maplibre's auto `role="button"` after mount (#459 W4-C nested-interactive WCAG 4.1.2 fix). Extracting it shrinks MapCanvas and lets U11 consume the wrapper directly (epic #884, Wave 0b).
- **What moved:** the 24-line JSDoc + `PresentationMarkerProps` interface + `PresentationMarker` function → new `frontend/src/components/map/PresentationMarker.tsx`. MapCanvas now imports it; the three existing call sites are unchanged. `Marker` dropped from MapCanvas's `react-map-gl/maplibre` import (now used only inside the extracted module).
- **Behavior-preserving:** same Marker import source, same props, same `[]`-dep post-mount effect, same rendered JSX → byte-identical output.

## Screenshots

N/A — not UI. Behavior-preserving extraction (location-only move); no visible UI change. Per the testing protocol, a Playwright sanity drive was still run: the app boots clean, chrome + Map region + scope-picker render, `browser_console_messages` returns **0 warnings**. The only 3 console errors are upstream `502 Bad Gateway` from the dev `/api/*` proxy (no backend reachable in the isolated worktree) — environmental, not from this change; the app degrades gracefully ("Couldn't load the state list" path). No React render error, no `.error-screen`, no uncaught exception.

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A, `PresentationMarker` has no `className` (verified); orphan-classname-check does not apply.
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). — `N/A — not UI` (behavior-preserving extraction, no visible UI change).

## Test plan

- [x] `npm run typecheck && npm run test` — green (frontend build = `tsc -b && vite build` clean; **1204 tests passed across 74 files**, including the new colocated spec).
- [x] New unit / integration tests added — `PresentationMarker.test.tsx` (RTL). TDD: wrote the spec first, confirmed RED (module absent → import fails), then GREEN. Authors a purpose-built `forwardRef` Marker mock exposing `getElement()` via `useImperativeHandle` (the repo's only existing Marker mock is a plain non-ref `<div>` that can assert only the effect's no-op short-circuit). Asserts (1) `role="presentation"` is set after mount (#459 set-path), and (2) the effect re-fires on each fresh remount (keyed by `g.key`, `[]`-dep effect).
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior change.
- [x] `npm run build` — clean production build.
- [x] (UI only) Playwright MCP smoke — ran `npm run dev --workspace @bird-watch/frontend`, drove the app; `browser_console_messages` returns 0 warnings (3 errors are environmental `/api/*` 502s, not from this change). Markers require live observation data unavailable in the sandbox; the move is verified byte-identical via the unit suite + diff review.

## Plan reference

Out of plan — MapCanvas consolidation epic #884, unit U5 (#890), Wave 0b. Tracked in GitHub issues (no `docs/plans/` file; plans live in issues for this epic).

Closes #890
Part of #884

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)