### PR TITLE
refactor(frontend): extract observation derives → obs-derive.ts (#892)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -85,6 +85,14 @@ import {
   type DeconflictInput,
 } from './deconflict.js';
 import { resolveFamilyName } from '../../derived.js';
+// Pure observation derives extracted to obs-derive.ts (epic #884 · U8, #892).
+// The fresh-closure `obsLookupRef` latch below stays in the component (it's
+// the indirection, not the memo).
+import {
+  buildObsLookup,
+  buildSilhouetteRenderById,
+  buildHitMarkers,
+} from './obs-derive.js';
 // Type-only declarations extracted to MapCanvas.types.ts (epic #884, U1 / #885).
 // `MapCanvasProps` is re-exported from there and back-imported here; this keeps
 // the export knip-clean (its in-file consumer at the destructuring below is
@@ -1035,12 +1043,9 @@ export function MapCanvas({
   const notableRingLayer = useMemo(() => buildNotableRingLayerSpec(), []);
   const unclusteredLayer = useMemo(() => buildUnclusteredPointLayerSpec(), []);
 
-  // Observation lookup by subId for click handler.
-  const obsLookup = useMemo(() => {
-    const lookup: Record<string, Observation> = Object.create(null);
-    for (const o of observations) lookup[o.subId] = o;
-    return lookup;
-  }, [observations]);
+  // Observation lookup by subId for click handler. Pure derive extracted to
+  // obs-derive.ts (#892); prototype-free record built there.
+  const obsLookup = useMemo(() => buildObsLookup(observations), [observations]);
 
   /**
    * Per-subId silhouette-render lookup (issue #554 scope expansion 2026-05-15).
@@ -1049,21 +1054,13 @@ export function MapCanvas({
    * visually matches the symbol-layer rendering it replaces.
    * `svgData === null` means the family has no usable Phylopic silhouette —
    * the displaced marker falls through to the _FALLBACK shape.
+   * Pure derive extracted to obs-derive.ts (#892).
    */
-  const silhouetteRenderById = useMemo(() => {
-    const lookup = new Map<string, { svgData: string | null; color: string }>();
-    for (const o of observations) {
-      const key = o.familyCode?.toLowerCase();
-      const sil = key ? silhouettesById.get(key) : undefined;
-      lookup.set(o.subId, {
-        svgData: sil?.svgData ?? null,
-        color: sil?.color ?? '#555',
-      });
-    }
-    return lookup;
-  // silhouettesById captures the silhouettes prop transitively (see
-  // useSilhouetteCatalogue — keyed on [silhouettes]).
-  }, [observations, silhouettesById]);
+  const silhouetteRenderById = useMemo(
+    () => buildSilhouetteRenderById(observations, silhouettesById),
+    // silhouettesById captures the silhouettes prop transitively (see its useMemo above).
+    [observations, silhouettesById],
+  );
 
   // Ref keeps the click handler's closure fresh when observations change.
   // `onLoad` only fires once, so a plain closure over `obsLookup` would go
@@ -2166,44 +2163,14 @@ export function MapCanvas({
      hit layer is the wider clickable surface that survives small marker
      sizes. Below CLUSTER_MAX_ZOOM, observations are clustered, so the
      overlay is suppressed and cluster-marker clicks (AdaptiveGridMarker /
-     ClusterPill) drive the interaction. */
-  const hitMarkers: HitTargetMarker[] = useMemo(() => {
-    if (mapZoom < CLUSTER_MAX_ZOOM) {
-      return [];
-    }
-    return observations.map((o) => {
-      // If this subId is currently displaced (silhouette deconflict),
-      // anchor the hit target at the displaced lng/lat so clicks land on
-      // where the user actually sees the silhouette, not the canvas-
-      // hidden original position.
-      const displaced = silhouetteOffsets.get(o.subId);
-      const lngLat: [number, number] = displaced
-        ? [displaced.longitude, displaced.latitude]
-        : [o.lng, o.lat];
-      // #921: resolve the colloquial family name UPSTREAM, where the silhouette
-      // catalogue (`silhouettesById`) is in scope. The leaf `MapMarkerHitLayer`
-      // gets no catalogue, so without this it fell back to the RAW lowercase
-      // `familyCode` in the screen-reader aria-label (`…, tyrannidae, …`). The
-      // resolver chain stays `name ?? commonName ?? prettyFamily`; `name`
-      // (AggregatedFamily.name) has no per-observation analogue, so only the
-      // silhouette `commonName` participates here.
-      const familyName = o.familyCode
-        ? resolveFamilyName(o.familyCode, {
-            commonName: silhouettesById.get(o.familyCode.toLowerCase())?.commonName,
-          })
-        : undefined;
-      return {
-        subId: o.subId,
-        comName: o.comName,
-        familyCode: o.familyCode,
-        familyName,
-        locName: o.locName,
-        obsDt: o.obsDt,
-        isNotable: o.isNotable,
-        lngLat,
-      };
-    });
-  }, [observations, mapZoom, silhouetteOffsets, silhouettesById]);
+     ClusterPill) drive the interaction.
+     Pure derive extracted to obs-derive.ts (#892); the #921 upstream
+     colloquial-family-name resolution + #247/#277 displaced re-anchoring
+     live in buildHitMarkers. */
+  const hitMarkers: HitTargetMarker[] = useMemo(
+    () => buildHitMarkers(observations, mapZoom, silhouetteOffsets, silhouettesById),
+    [observations, mapZoom, silhouetteOffsets, silhouettesById],
+  );
 
   const handleHitSelect = useCallback(
     (subId: string) => {

--- a/frontend/src/components/map/obs-derive.test.ts
+++ b/frontend/src/components/map/obs-derive.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import type { Observation } from '@bird-watch/shared-types';
+import {
+  buildObsLookup,
+  buildSilhouetteRenderById,
+  buildHitMarkers,
+  type SilhouetteOffsets,
+} from './obs-derive.js';
+import type { SilhouettesById } from './adaptive-grid.js';
+import { CLUSTER_MAX_ZOOM } from './observation-layers.js';
+
+// Minimal Observation factory — only the fields the derives read are
+// meaningful; the rest are filled with structurally-valid placeholders.
+function obs(overrides: Partial<Observation> = {}): Observation {
+  return {
+    subId: 'S1',
+    speciesCode: 'amerob',
+    comName: 'American Robin',
+    lat: 33.45,
+    lng: -112.07,
+    obsDt: '2026-06-08 07:00',
+    locId: 'L1',
+    locName: 'Papago Park',
+    howMany: 1,
+    isNotable: false,
+    silhouetteId: null,
+    familyCode: 'tyrannidae',
+    ...overrides,
+  };
+}
+
+// SilhouettesById is keyed by LOWERCASE familyCode (mirrors MapCanvas's
+// `silhouettesById` memo, which lowercases on insert). The catalogue carries
+// the curated colloquial `commonName` the resolver consumes (#920/#921).
+const catalogue: SilhouettesById = new Map([
+  ['tyrannidae', { svgData: 'M0 0h24v24H0z', color: '#aa0000', colorDark: '#ff6666', commonName: 'Tyrant Flycatchers' }],
+]);
+
+describe('buildObsLookup', () => {
+  it('keys observations by subId', () => {
+    const a = obs({ subId: 'A' });
+    const b = obs({ subId: 'B' });
+    const lookup = buildObsLookup([a, b]);
+    expect(lookup['A']).toBe(a);
+    expect(lookup['B']).toBe(b);
+  });
+
+  it('produces a prototype-free record (Object.create(null))', () => {
+    const lookup = buildObsLookup([obs({ subId: 'A' })]);
+    expect(Object.getPrototypeOf(lookup)).toBeNull();
+    // A would-be prototype pollution key resolves to undefined, not Object.prototype.
+    expect(lookup['toString']).toBeUndefined();
+    expect((lookup as Record<string, unknown>)['__proto__']).toBeUndefined();
+  });
+
+  it('last write wins for duplicate subIds', () => {
+    const first = obs({ subId: 'DUP', comName: 'first' });
+    const second = obs({ subId: 'DUP', comName: 'second' });
+    const lookup = buildObsLookup([first, second]);
+    expect(lookup['DUP']).toBe(second);
+  });
+});
+
+describe('buildSilhouetteRenderById', () => {
+  it('resolves svgData + color from the lowercased familyCode key', () => {
+    const lookup = buildSilhouetteRenderById([obs({ subId: 'A', familyCode: 'Tyrannidae' })], catalogue);
+    expect(lookup.get('A')).toEqual({ svgData: 'M0 0h24v24H0z', color: '#aa0000' });
+  });
+
+  it('falls back to null svgData + neutral color when the family is absent', () => {
+    const lookup = buildSilhouetteRenderById([obs({ subId: 'A', familyCode: 'unknownidae' })], catalogue);
+    expect(lookup.get('A')).toEqual({ svgData: null, color: '#555' });
+  });
+
+  it('handles a null familyCode without throwing', () => {
+    const lookup = buildSilhouetteRenderById([obs({ subId: 'A', familyCode: null })], catalogue);
+    expect(lookup.get('A')).toEqual({ svgData: null, color: '#555' });
+  });
+});
+
+describe('buildHitMarkers', () => {
+  const offsets: SilhouetteOffsets = new Map();
+
+  it('returns [] below CLUSTER_MAX_ZOOM (suppress so cluster clicks win)', () => {
+    const markers = buildHitMarkers(
+      [obs()],
+      CLUSTER_MAX_ZOOM - 1,
+      offsets,
+      catalogue,
+    );
+    expect(markers).toEqual([]);
+  });
+
+  it('anchors at the observation lng/lat when not displaced', () => {
+    const markers = buildHitMarkers(
+      [obs({ subId: 'A', lng: -112.07, lat: 33.45 })],
+      CLUSTER_MAX_ZOOM,
+      offsets,
+      catalogue,
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0]!.lngLat).toEqual([-112.07, 33.45]);
+  });
+
+  it('re-anchors at the displaced lng/lat when silhouetteOffsets has an entry (#247/#277)', () => {
+    const displaced: SilhouetteOffsets = new Map([
+      ['A', { dx: 5, dy: 5, longitude: -111.0, latitude: 34.0 }],
+    ]);
+    const markers = buildHitMarkers(
+      [obs({ subId: 'A', lng: -112.07, lat: 33.45 })],
+      CLUSTER_MAX_ZOOM,
+      displaced,
+      catalogue,
+    );
+    expect(markers[0]!.lngLat).toEqual([-111.0, 34.0]);
+  });
+
+  it('resolves familyName via resolveFamilyName from the catalogue commonName (#921 — raw code must NOT leak)', () => {
+    const markers = buildHitMarkers(
+      [obs({ subId: 'A', familyCode: 'tyrannidae' })],
+      CLUSTER_MAX_ZOOM,
+      offsets,
+      catalogue,
+    );
+    expect(markers[0]!.familyName).toBe('Tyrant Flycatchers');
+    // The raw lowercase code must never be the resolved name.
+    expect(markers[0]!.familyName).not.toBe('tyrannidae');
+  });
+
+  it('lowercases familyCode when keying the catalogue', () => {
+    const markers = buildHitMarkers(
+      [obs({ subId: 'A', familyCode: 'Tyrannidae' })],
+      CLUSTER_MAX_ZOOM,
+      offsets,
+      catalogue,
+    );
+    expect(markers[0]!.familyName).toBe('Tyrant Flycatchers');
+  });
+
+  it('leaves familyName undefined when familyCode is null', () => {
+    const markers = buildHitMarkers(
+      [obs({ subId: 'A', familyCode: null })],
+      CLUSTER_MAX_ZOOM,
+      offsets,
+      catalogue,
+    );
+    expect(markers[0]!.familyName).toBeUndefined();
+    expect(markers[0]!.familyCode).toBeNull();
+  });
+
+  it('carries through subId/comName/familyCode/locName/obsDt/isNotable verbatim', () => {
+    const o = obs({
+      subId: 'A',
+      comName: 'American Robin',
+      familyCode: 'tyrannidae',
+      locName: 'Papago Park',
+      obsDt: '2026-06-08 07:00',
+      isNotable: true,
+    });
+    const markers = buildHitMarkers([o], CLUSTER_MAX_ZOOM, offsets, catalogue);
+    expect(markers[0]).toMatchObject({
+      subId: 'A',
+      comName: 'American Robin',
+      familyCode: 'tyrannidae',
+      locName: 'Papago Park',
+      obsDt: '2026-06-08 07:00',
+      isNotable: true,
+    });
+  });
+});

--- a/frontend/src/components/map/obs-derive.ts
+++ b/frontend/src/components/map/obs-derive.ts
@@ -1,0 +1,116 @@
+import type { Observation } from '@bird-watch/shared-types';
+import type { SilhouettesById } from './adaptive-grid.js';
+import type { HitTargetMarker } from './MapMarkerHitLayer.js';
+import { CLUSTER_MAX_ZOOM } from './observation-layers.js';
+import { resolveFamilyName } from '../../derived.js';
+
+/**
+ * Pure observation derives extracted from MapCanvas.tsx (epic #884 · U8).
+ *
+ * Three behavior-preserving data transforms — no map API, no React, no refs.
+ * The caller (MapCanvas) wraps each in a `useMemo` and holds the fresh-closure
+ * `obsLookupRef` latch itself (the latch is the indirection, not the memo, so
+ * it stays in the component). Rendered output is byte-identical to the inline
+ * versions these replaced.
+ */
+
+/**
+ * The displaced-silhouette offset map MapCanvas threads from its reconcile
+ * pass: per-subId visible (shifted) lng/lat used to re-anchor hit targets so a
+ * click lands where the user actually sees the silhouette, not the canvas-
+ * hidden original survey point (#247/#277). Only `longitude`/`latitude` are
+ * read here; `dx`/`dy` are carried for the renderer.
+ */
+export type SilhouetteOffsets = ReadonlyMap<
+  string,
+  { dx: number; dy: number; longitude: number; latitude: number }
+>;
+
+/**
+ * Observation lookup by subId for the click handler. Prototype-free
+ * (`Object.create(null)`) so a `subId` colliding with an `Object.prototype`
+ * key (e.g. `toString`, `__proto__`) can never resolve to an inherited method.
+ */
+export function buildObsLookup(
+  observations: readonly Observation[],
+): Record<string, Observation> {
+  const lookup: Record<string, Observation> = Object.create(null);
+  for (const o of observations) lookup[o.subId] = o;
+  return lookup;
+}
+
+/**
+ * Per-subId silhouette-render lookup (issue #554 scope expansion 2026-05-15).
+ * Maps each observation's subId → its rendered silhouette path + color, so
+ * the displaced-silhouette render block can paint an inline SVG that
+ * visually matches the symbol-layer rendering it replaces.
+ * `svgData === null` means the family has no usable Phylopic silhouette —
+ * the displaced marker falls through to the _FALLBACK shape.
+ */
+export function buildSilhouetteRenderById(
+  observations: readonly Observation[],
+  silhouettesById: SilhouettesById,
+): Map<string, { svgData: string | null; color: string }> {
+  const lookup = new Map<string, { svgData: string | null; color: string }>();
+  for (const o of observations) {
+    const key = o.familyCode?.toLowerCase();
+    const sil = key ? silhouettesById.get(key) : undefined;
+    lookup.set(o.subId, {
+      svgData: sil?.svgData ?? null,
+      color: sil?.color ?? '#555',
+    });
+  }
+  return lookup;
+}
+
+/**
+ * Hit-target layer markers: render hit targets at zoom >= CLUSTER_MAX_ZOOM
+ * (now 22, post-cutover) for individual observations. The adaptive-grid
+ * reconciler renders 1×1 grid markers for singletons at this zoom; the
+ * hit layer is the wider clickable surface that survives small marker
+ * sizes. Below CLUSTER_MAX_ZOOM, observations are clustered, so the
+ * overlay is suppressed (returns `[]`) and cluster-marker clicks
+ * (AdaptiveGridMarker / ClusterPill) drive the interaction.
+ */
+export function buildHitMarkers(
+  observations: readonly Observation[],
+  mapZoom: number,
+  silhouetteOffsets: SilhouetteOffsets,
+  silhouettesById: SilhouettesById,
+): HitTargetMarker[] {
+  if (mapZoom < CLUSTER_MAX_ZOOM) {
+    return [];
+  }
+  return observations.map((o) => {
+    // If this subId is currently displaced (silhouette deconflict),
+    // anchor the hit target at the displaced lng/lat so clicks land on
+    // where the user actually sees the silhouette, not the canvas-
+    // hidden original position.
+    const displaced = silhouetteOffsets.get(o.subId);
+    const lngLat: [number, number] = displaced
+      ? [displaced.longitude, displaced.latitude]
+      : [o.lng, o.lat];
+    // #921: resolve the colloquial family name UPSTREAM, where the silhouette
+    // catalogue (`silhouettesById`) is in scope. The leaf `MapMarkerHitLayer`
+    // gets no catalogue, so without this it fell back to the RAW lowercase
+    // `familyCode` in the screen-reader aria-label (`…, tyrannidae, …`). The
+    // resolver chain stays `name ?? commonName ?? prettyFamily`; `name`
+    // (AggregatedFamily.name) has no per-observation analogue, so only the
+    // silhouette `commonName` participates here.
+    const familyName = o.familyCode
+      ? resolveFamilyName(o.familyCode, {
+          commonName: silhouettesById.get(o.familyCode.toLowerCase())?.commonName,
+        })
+      : undefined;
+    return {
+      subId: o.subId,
+      comName: o.comName,
+      familyCode: o.familyCode,
+      familyName,
+      locName: o.locName,
+      obsDt: o.obsDt,
+      isNotable: o.isNotable,
+      lngLat,
+    };
+  });
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph MapCanvas.tsx
        O[observations] --> M1["useMemo obsLookup"]
        O --> M2["useMemo silhouetteRenderById"]
        O --> M3["useMemo hitMarkers"]
        S[silhouettesById] --> M2
        S --> M3
        Z[mapZoom] --> M3
        OF[silhouetteOffsets] --> M3
    end
    subgraph "obs-derive.ts (pure, NEW)"
        F1[buildObsLookup]
        F2[buildSilhouetteRenderById]
        F3["buildHitMarkers · resolveFamilyName"]
    end
    M1 -.delegates.-> F1
    M2 -.delegates.-> F2
    M3 -.delegates.-> F3
    M1 --> R["obsLookupRef latch · STAYS in component"]
```

## Summary

- **Why:** the MapCanvas consolidation epic (#884, Wave 0b) pulls pure data transforms out of the god-component into unit-testable `.ts` modules. These three derives touch no map API, no React, no refs — ideal extraction candidates. The memo bodies become one-liners and behavior is pinned by a colocated `obs-derive.test.ts`.
- **What moved:** `buildObsLookup` (prototype-free `subId→Observation` record), `buildSilhouetteRenderById` (per-subId render path+color, lowercased family key), `buildHitMarkers` (hit-target markers — `[]` below `CLUSTER_MAX_ZOOM` so cluster clicks win, #247/#277 displaced re-anchoring, #921 upstream colloquial-family-name resolution via `resolveFamilyName` + `silhouettesById` `commonName`). Logic and dep arrays are byte-identical to the inline versions; rendered output is unchanged.
- **What deliberately stayed:** the fresh-closure `obsLookupRef` latch (the indirection, not the memo) stays in the component. The optional `buildClusterListFamilyNames` fold was **not** taken — `clusterListFamilyNames` keys `silhouettesById` un-lowercased (#926) whereas these derives lowercase, so folding risks a silent casing change (bot SUGGESTION #2 on the issue).

## Screenshots

N/A — not UI. Behavior-preserving extraction, no visible UI change.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no className changes (`.ts` extraction only)
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm run typecheck && npm run test` — green (`tsc -b` clean; 74 files / 1215 tests pass, incl. new `obs-derive.test.ts` 13 tests)
- [x] New unit tests added — `obs-derive.test.ts` pins the high-blast behaviors: prototype-free lookup, `[]` below `CLUSTER_MAX_ZOOM`, displaced re-anchoring (#247/#277), `familyName` resolved via `resolveFamilyName` so the raw lowercase code does not leak (#921)
- [x] New Playwright e2e spec — N/A, behavior-preserving, no user-visible behavior change
- [x] `npm run build` — clean production build (`tsc -b && vite build`)
- [x] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — epic #884 (MapCanvas consolidation), Wave 0b unit U8. Closes #892. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)