### PR TITLE
refactor(frontend): extract map.resize ResizeObserver → use-map-resize.ts (#893)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -62,6 +62,7 @@ import { ClusterListPopover } from './ClusterListPopover.js';
 import { ClusterPill } from '../ds/ClusterPill.js';
 import { registerSilhouetteSprite } from './silhouette-sprite.js';
 import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
+import { useMapResize } from './use-map-resize.js';
 import {
   aggregateClusterFamilies,
   aggregateClusterSpecies,
@@ -292,7 +293,9 @@ export function MapCanvas({
    * Wrapper element the `map.resize()` ResizeObserver watches (#737, S3 of
    * #761). This is the `data-testid="map-canvas"` div — the box whose containing
    * block flipped from a padded `<main>` flex child to the `position: fixed;
-   * inset: 0` `#map-layer` viewport sibling in S2. See the resize effect below.
+   * inset: 0` `#map-layer` viewport sibling in S2. The ref is consumed by the
+   * `useMapResize` hook (`use-map-resize.ts`), which owns the corrective
+   * `map.resize()` ResizeObserver effect.
    */
   const mapWrapperRef = useRef<HTMLDivElement>(null);
   /**
@@ -639,62 +642,14 @@ export function MapCanvas({
     // stable (useMemo []).
   }, [mapReady, boundsKey, flyTo?.key, prefersReducedMotion]);
 
-  /**
-   * Corrective `map.resize()` on the S2 flex→fixed container transition (#737,
-   * gap 8 of #761). Before S2 the map was a `flex: 1; min-height: 0` child of a
-   * padded `<main>`; S2 hoisted it into `#map-layer` (`position: fixed; inset: 0`)
-   * and `.map-surface` became `position: absolute; inset: 0`. That swaps the
-   * CONTAINING BLOCK (a reparent/reflow), and maplibre's built-in observer on the
-   * inner GL container does not always re-read `_containerDimensions` for the new
-   * full-viewport box on the first paint — leaving a one-frame mis-sized canvas
-   * (clipped tiles, off-by-padding marker projection). S2 demonstrated the fallout
-   * test-side: the coarse-pointer cluster-tap spec saw the marker DOM node
-   * re-created ~600ms post-tap (`sameMarkerNode === false`) because the canvas was
-   * still settling, and worked around it with an extra idle+rAF wait it deferred
-   * to this PR.
-   *
-   * Fix: a `ResizeObserver` on the `data-testid="map-canvas"` wrapper (the box
-   * whose containing block changed). It is the robust form because the box can
-   * change AGAIN after the one-time reparent (theme-toggle reflow, the detail
-   * rail/sheet opening alongside the fixed map, mobile URL-bar show/hide changing
-   * 100vh). The observer is:
-   *   - CAMERA-NEUTRAL: it only calls `map.resize()` — never `fitBounds`/`flyTo`/
-   *     a refetch — so it cannot schedule a bbox `/api/observations` (the S4
-   *     scope-gate invariant, report R1).
-   *   - IDEMPOTENT / debounced: coalesced to the next animation frame so a burst
-   *     of observer fires (including maplibre's own internal observer churn during
-   *     the same reflow) collapses to a single `resize()`; a pending frame is
-   *     guarded so we never stack rAFs.
-   *   - DISCONNECTED on cleanup (observer + any pending rAF), so a `<Map>` remount
-   *     across a scope pick leaks neither.
-   * `mapReady`-gated so `getMap()` is live. The first observe-callback fire (which
-   * ResizeObserver delivers on `observe()`) doubles as the one-shot post-`mapReady`
-   * correction for the initial reparent.
-   */
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    const wrapper = mapWrapperRef.current;
-    if (!map || !wrapper || typeof ResizeObserver === 'undefined') return;
-
-    let frame = 0;
-    const observer = new ResizeObserver(() => {
-      // Coalesce a burst of box changes (and maplibre's own internal observer
-      // churn during the same reflow) into a single rAF-batched resize. Camera-
-      // neutral: resize() recomputes the canvas/transform for the new box only.
-      if (frame !== 0) return;
-      frame = requestAnimationFrame(() => {
-        frame = 0;
-        map.resize();
-      });
-    });
-    observer.observe(wrapper);
-
-    return () => {
-      observer.disconnect();
-      if (frame !== 0) cancelAnimationFrame(frame);
-    };
-  }, [mapReady]);
+  // Corrective `map.resize()` on the S2 flex→fixed container transition (#737,
+  // gap 8 of #761). Extracted to `use-map-resize.ts` (epic #884 · U9): the
+  // `mapWrapperRef` ref + its JSX stay here, only the rAF-debounced
+  // CAMERA-NEUTRAL ResizeObserver effect moved. The hook's JSDoc carries the
+  // full rationale (containing-block reparent, the IDEMPOTENT debounce, the
+  // DISCONNECTED-on-cleanup `<Map>`-remount guard, and the S4 scope-gate
+  // invariant that the observer only ever calls `map.resize()`).
+  useMapResize(mapRef, mapWrapperRef, mapReady);
 
   // #762/#765 — `renderWorldCopies` reassertion across an IN-PLACE scope change.
   //

--- a/frontend/src/components/map/use-map-resize.test.ts
+++ b/frontend/src/components/map/use-map-resize.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMapResize } from './use-map-resize.js';
+import type { MapResizeMapRef, MapResizeTarget } from './use-map-resize.js';
+
+/**
+ * Characterization tests for the corrective `map.resize()` ResizeObserver
+ * effect extracted from MapCanvas.tsx (epic #884 · U9).
+ *
+ * The load-bearing invariants this locks (written against the pre-extraction
+ * behavior, confirmed RED→GREEN):
+ *   1. rAF-debounced `resize()` fires on `observe()` (ResizeObserver delivers
+ *      one callback synchronously on observe — the one-shot post-`mapReady`
+ *      reparent correction).
+ *   2. CAMERA-NEUTRAL — it NEVER calls `fitBounds`/`easeTo`/`flyTo`. This is the
+ *      #737 / S4 scope-gate invariant (report R1): the resize must not be able
+ *      to schedule a bbox `/api/observations` refetch.
+ *   3. Cleanup — on unmount the observer's `disconnect()` is called and a
+ *      pending rAF is cancelled, so a `<Map>` remount across a scope pick leaks
+ *      neither (the JSDoc guard against leaking across a scope-pick `<Map>`
+ *      remount).
+ */
+
+// A controllable ResizeObserver stub: capturing the callback lets the test
+// drive the observe-fire deterministically (jsdom has no layout engine, so a
+// real observer never fires).
+class StubResizeObserver {
+  static instances: StubResizeObserver[] = [];
+  callback: ResizeObserverCallback;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    StubResizeObserver.instances.push(this);
+  }
+  // Simulate the observer delivering a box-change notification.
+  fire(): void {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+// A spy maplibre map exposing the full camera surface so the negative
+// assertions are meaningful (a camera method that fired would register here).
+function makeSpyMap() {
+  return {
+    resize: vi.fn(),
+    fitBounds: vi.fn(),
+    easeTo: vi.fn(),
+    flyTo: vi.fn(),
+  };
+}
+
+describe('useMapResize', () => {
+  let rafQueue: Array<() => void>;
+  let rafIdSeq: number;
+  let cancelledRafIds: number[];
+  let originalRO: typeof globalThis.ResizeObserver | undefined;
+
+  beforeEach(() => {
+    StubResizeObserver.instances = [];
+    rafQueue = [];
+    cancelledRafIds = [];
+    rafIdSeq = 0;
+
+    // Deterministic rAF: enqueue and flush manually so the debounce is observable.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafIdSeq += 1;
+      const id = rafIdSeq;
+      rafQueue.push(() => cb(performance.now()));
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      cancelledRafIds.push(id);
+    });
+
+    originalRO = globalThis.ResizeObserver;
+    vi.stubGlobal('ResizeObserver', StubResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.ResizeObserver = originalRO as typeof globalThis.ResizeObserver;
+  });
+
+  function flushRaf(): void {
+    const pending = rafQueue;
+    rafQueue = [];
+    pending.forEach(run => run());
+  }
+
+  function makeRefs(map: ReturnType<typeof makeSpyMap>) {
+    const mapRef = {
+      current: { getMap: () => map as unknown } as MapResizeMapRef,
+    };
+    const wrapperRef = { current: document.createElement('div') as MapResizeTarget };
+    return { mapRef, wrapperRef };
+  }
+
+  it('observes the wrapper and fires a rAF-debounced resize() on observe', () => {
+    const map = makeSpyMap();
+    const { mapRef, wrapperRef } = makeRefs(map);
+
+    renderHook(() => useMapResize(mapRef, wrapperRef, true));
+
+    const observer = StubResizeObserver.instances[0];
+    expect(observer).toBeDefined();
+    expect(observer.observe).toHaveBeenCalledWith(wrapperRef.current);
+
+    // Simulate the observe-callback fire; resize is deferred to the next frame.
+    observer.fire();
+    expect(map.resize).not.toHaveBeenCalled();
+    flushRaf();
+    expect(map.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces a burst of observer fires into a single rAF resize()', () => {
+    const map = makeSpyMap();
+    const { mapRef, wrapperRef } = makeRefs(map);
+
+    renderHook(() => useMapResize(mapRef, wrapperRef, true));
+    const observer = StubResizeObserver.instances[0];
+
+    observer.fire();
+    observer.fire();
+    observer.fire();
+    flushRaf();
+
+    expect(map.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it('is CAMERA-NEUTRAL — never calls fitBounds/easeTo/flyTo', () => {
+    const map = makeSpyMap();
+    const { mapRef, wrapperRef } = makeRefs(map);
+
+    renderHook(() => useMapResize(mapRef, wrapperRef, true));
+    const observer = StubResizeObserver.instances[0];
+    observer.fire();
+    flushRaf();
+
+    expect(map.resize).toHaveBeenCalled();
+    expect(map.fitBounds).not.toHaveBeenCalled();
+    expect(map.easeTo).not.toHaveBeenCalled();
+    expect(map.flyTo).not.toHaveBeenCalled();
+  });
+
+  it('does nothing until mapReady is true', () => {
+    const map = makeSpyMap();
+    const { mapRef, wrapperRef } = makeRefs(map);
+
+    renderHook(() => useMapResize(mapRef, wrapperRef, false));
+
+    expect(StubResizeObserver.instances).toHaveLength(0);
+    expect(map.resize).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer and cancels a pending rAF on unmount', () => {
+    const map = makeSpyMap();
+    const { mapRef, wrapperRef } = makeRefs(map);
+
+    const { unmount } = renderHook(() => useMapResize(mapRef, wrapperRef, true));
+    const observer = StubResizeObserver.instances[0];
+
+    // Queue a frame but don't flush — it's pending at unmount.
+    observer.fire();
+    expect(rafQueue).toHaveLength(1);
+
+    unmount();
+
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+    expect(cancelledRafIds).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/map/use-map-resize.ts
+++ b/frontend/src/components/map/use-map-resize.ts
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Corrective `map.resize()` ResizeObserver hook (extracted from MapCanvas.tsx,
+ * epic #884 · U9). The wrapper ref + its JSX stay in `MapCanvas`; only the
+ * effect moves here.
+ *
+ * Corrective `map.resize()` on the S2 flex→fixed container transition (#737,
+ * gap 8 of #761). Before S2 the map was a `flex: 1; min-height: 0` child of a
+ * padded `<main>`; S2 hoisted it into `#map-layer` (`position: fixed; inset: 0`)
+ * and `.map-surface` became `position: absolute; inset: 0`. That swaps the
+ * CONTAINING BLOCK (a reparent/reflow), and maplibre's built-in observer on the
+ * inner GL container does not always re-read `_containerDimensions` for the new
+ * full-viewport box on the first paint — leaving a one-frame mis-sized canvas
+ * (clipped tiles, off-by-padding marker projection).
+ *
+ * Fix: a `ResizeObserver` on the `data-testid="map-canvas"` wrapper (the box
+ * whose containing block changed). It is the robust form because the box can
+ * change AGAIN after the one-time reparent (theme-toggle reflow, the detail
+ * rail/sheet opening alongside the fixed map, mobile URL-bar show/hide changing
+ * 100vh). The observer is:
+ *   - CAMERA-NEUTRAL: it only calls `map.resize()` — never `fitBounds`/`flyTo`/
+ *     a refetch — so it cannot schedule a bbox `/api/observations` (the S4
+ *     scope-gate invariant, report R1).
+ *   - IDEMPOTENT / debounced: coalesced to the next animation frame so a burst
+ *     of observer fires (including maplibre's own internal observer churn during
+ *     the same reflow) collapses to a single `resize()`; a pending frame is
+ *     guarded so we never stack rAFs.
+ *   - DISCONNECTED on cleanup (observer + any pending rAF), so a `<Map>` remount
+ *     across a scope pick leaks neither.
+ * `mapReady`-gated so `getMap()` is live. The first observe-callback fire (which
+ * ResizeObserver delivers on `observe()`) doubles as the one-shot post-`mapReady`
+ * correction for the initial reparent.
+ */
+
+/**
+ * The minimal maplibre-map surface this hook touches: only `resize()`.
+ * Deliberately NOT maplibre's full `Map` (same idiom as `silhouette-sprite.ts`'s
+ * `SpriteMap` and `artboard-layers.ts`'s `ArtboardMap`): the narrow shape keeps
+ * the hook unit-testable against a spy and documents the exact dependency
+ * surface — the camera-neutral invariant is visible in the type.
+ */
+export interface MapResizeMap {
+  resize: () => void;
+}
+
+/**
+ * The minimal react-map-gl `MapRef` surface: only `getMap()`, returning a
+ * {@link MapResizeMap}. `mapRef.current?.getMap()` is the live maplibre handle.
+ */
+export interface MapResizeMapRef {
+  getMap: () => MapResizeMap;
+}
+
+/** The wrapper element the observer watches (the `data-testid="map-canvas"` div). */
+export type MapResizeTarget = Element;
+
+/**
+ * Observe `mapWrapperRef`'s box and issue a rAF-debounced, camera-neutral
+ * `map.resize()` on every change (including the one-shot post-`mapReady`
+ * reparent correction the observer delivers on `observe()`).
+ *
+ * @param mapRef        ref to the react-map-gl `MapRef` (`getMap()` → maplibre)
+ * @param mapWrapperRef ref to the wrapper div whose containing block flips in S2
+ * @param mapReady      gate: only wire the observer once `getMap()` is live
+ */
+export function useMapResize(
+  mapRef: RefObject<MapResizeMapRef | null>,
+  mapWrapperRef: RefObject<MapResizeTarget | null>,
+  mapReady: boolean,
+): void {
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    const wrapper = mapWrapperRef.current;
+    if (!map || !wrapper || typeof ResizeObserver === 'undefined') return;
+
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      // Coalesce a burst of box changes (and maplibre's own internal observer
+      // churn during the same reflow) into a single rAF-batched resize. Camera-
+      // neutral: resize() recomputes the canvas/transform for the new box only.
+      if (frame !== 0) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        map.resize();
+      });
+    });
+    observer.observe(wrapper);
+
+    return () => {
+      observer.disconnect();
+      if (frame !== 0) cancelAnimationFrame(frame);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mapReady is the
+    // intentional gate; mapRef/mapWrapperRef are stable ref containers read
+    // imperatively inside the effect (1:1 with the pre-extraction dep array).
+  }, [mapReady]);
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph before["MapCanvas.tsx (before)"]
        W1["mapWrapperRef + JSX"]
        E1["useEffect: ResizeObserver → rAF → map.resize()"]
    end
    subgraph after["after — U9 extraction"]
        W2["mapWrapperRef + JSX<br/>(stays in MapCanvas)"]
        H["useMapResize(mapRef, mapWrapperRef, mapReady)<br/>use-map-resize.ts"]
        W2 -->|passes refs + ready gate| H
    end
    before -->|move effect, keep ref+JSX| after
```

The effect body moves verbatim; the `mapWrapperRef` ref and the `data-testid="map-canvas"` JSX stay in `MapCanvas`. Rendered output is byte-identical.

## Summary

- **Why:** MapCanvas-decomposition epic #884 (U9, Wave 0b) — isolate the corrective `map.resize()` ResizeObserver into a single-responsibility imperative hook so the effect's load-bearing invariants are testable in isolation and MapCanvas shrinks.
- Behavior-PRESERVING mechanical extraction: the rAF-debounced ResizeObserver→`map.resize()` effect moves into `useMapResize(mapRef, mapWrapperRef, mapReady)`; the wrapper ref + its JSX remain in MapCanvas. Same dep array (`[mapReady]`), same call order, no visible UI change.
- The hook types the maplibre handle as a minimal `{ resize() }` surface (same idiom as `silhouette-sprite.ts`'s `SpriteMap`), so the CAMERA-NEUTRAL invariant is visible in the type and the hook unit-tests against a spy with no WebGL. Both bot-review notes on #893 are folded in: the dangling `mapWrapperRef` JSDoc cross-reference now points at the hook, and the cleanup-leak assertion is in the test spec.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change (the hook returns `void`; JSX is untouched). Type/effect-move only under `frontend/**` — exempt per CLAUDE.md UI-verification "type-only / comment-only PRs" carve-out.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className changes`
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (74 files, 1207 tests). New `use-map-resize.test.ts` written FIRST (characterization-test-first), confirmed RED before the module existed, GREEN after.
- [x] New unit tests added: 5 cases lock rAF-debounced/coalesced `resize()` on observe, the CAMERA-NEUTRAL #737/S4 invariant (negative assertion: never `fitBounds`/`easeTo`/`flyTo`), the `mapReady` gate, and the disconnect-observer + cancel-pending-rAF cleanup (the `<Map>`-remount leak guard).
- [x] No new e2e spec — behavior-preserving, no user-visible behavior change.
- [x] `npm run build --workspace @bird-watch/frontend` — clean (`tsc -b && vite build`).
- [x] (UI only) Playwright MCP smoke — N/A, no visible UI change.
- [x] `npx knip --no-progress` — clean (no unused file/export/dep findings from the new module).

## Plan reference

Out of plan — MapCanvas-decomposition epic #884 (out-of-plan refactor; issue is `agent-ready`).

Part of #884.
Closes #893.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)