### PR TITLE
refactor(frontend): extract silhouette-catalogue derives → use-silhouette-catalogue.ts (#891)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -61,6 +61,7 @@ import { PresentationMarker } from './PresentationMarker.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
 import { ClusterPill } from '../ds/ClusterPill.js';
 import { registerSilhouetteSprite } from './silhouette-sprite.js';
+import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
 import {
   aggregateClusterFamilies,
   aggregateClusterSpecies,
@@ -69,7 +70,6 @@ import {
   pickGridShape,
   type ClusterLeafFeature,
   type FamilyAggregate,
-  type SilhouettesById,
   type SpeciesAggregate,
 } from './adaptive-grid.js';
 import {
@@ -892,24 +892,18 @@ export function MapCanvas({
   }, []);
 
   /**
-   * Monotonic `silhouettesVersion` (spec §5.3 Concern C, point 2). This is
-   * a strict integer counter, NOT `silhouettes.length` — a length-only
-   * proxy misses in-place row replacement (same count, different svgData
-   * — Phylopic refreshes, low-res→hi-res swaps). The counter increments
-   * each time the silhouettes prop changes by reference, which is the same
-   * point where the supercluster catalogue is rebuilt.
-   *
-   * Carried into the per-grid memo key + the cache-generation effect so
-   * an in-place catalogue refresh invalidates render-pass identity and the
-   * Concern B promise cache together.
+   * Silhouette catalogue derives (epic #884, U7 / #891). The monotonic
+   * `silhouettesVersion` render-phase counter + the `silhouettesById` lookup
+   * memo (keyed `[silhouettes]`, referentially stable) are extracted into
+   * `use-silhouette-catalogue.ts` — behavior-preserving. The version counter
+   * is NOT `silhouettes.length` (a length-only proxy misses in-place row
+   * replacement — Phylopic refreshes, low-res→hi-res swaps); it bumps on a
+   * silhouettes-prop reference change, which is where the supercluster
+   * catalogue is rebuilt. Carried into the per-grid memo key + the
+   * cache-generation effect; `silhouettesById` (an empty map signals
+   * "catalogue not loaded yet") threads into `buildAdaptiveTiles`.
    */
-  const silhouettesVersionRef = useRef(0);
-  const prevSilhouettesRef = useRef<typeof silhouettes>(silhouettes);
-  if (prevSilhouettesRef.current !== silhouettes) {
-    silhouettesVersionRef.current += 1;
-    prevSilhouettesRef.current = silhouettes;
-  }
-  const silhouettesVersion = silhouettesVersionRef.current;
+  const { silhouettesById, silhouettesVersion } = useSilhouetteCatalogue(silhouettes);
 
   /**
    * #872 — synchronous DOM-marker invalidation on SCOPE change. The
@@ -950,32 +944,6 @@ export function MapCanvas({
     setSilhouetteOffsets(new Map());
     prevHiddenSubIdsRef.current = new Set();
   }
-
-  /**
-   * Pure per-family lookup used by `buildAdaptiveTiles` (spec §5.3 Concern
-   * C, point 3). Resolved once per reconcile from the silhouettes prop —
-   * the tile-builder MUST NOT read from a ref, so we thread this
-   * explicitly. An empty map signals "catalogue not loaded yet" and
-   * produces all-`pending` tiles.
-   */
-  const silhouettesById = useMemo<SilhouettesById>(() => {
-    const map = new Map<
-      string,
-      { svgData: string | null; color: string; colorDark: string; commonName: string | null }
-    >();
-    for (const s of silhouettes) {
-      map.set(s.familyCode.toLowerCase(), {
-        svgData: s.svgData,
-        color: s.color,
-        colorDark: s.colorDark,
-        // #920: carry the curated colloquial name so the tile builders can
-        // resolve each tile's `displayName` and the popovers show
-        // "Tyrant Flycatchers" instead of the scientific "Tyrannidae".
-        commonName: s.commonName,
-      });
-    }
-    return map;
-  }, [silhouettes]);
 
   /**
    * #920: resolved colloquial display name per family for the standalone
@@ -1093,7 +1061,8 @@ export function MapCanvas({
       });
     }
     return lookup;
-  // silhouettesById captures the silhouettes prop transitively (see its useMemo above).
+  // silhouettesById captures the silhouettes prop transitively (see
+  // useSilhouetteCatalogue — keyed on [silhouettes]).
   }, [observations, silhouettesById]);
 
   // Ref keeps the click handler's closure fresh when observations change.

--- a/frontend/src/components/map/use-silhouette-catalogue.test.ts
+++ b/frontend/src/components/map/use-silhouette-catalogue.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
+import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
+
+// 1:1 colocated characterization test for U7 (#891 / epic #884). This is a
+// behavior-PRESERVING extraction of the `silhouettesVersion` monotonic
+// render-phase ref + the `silhouettesById` memo out of MapCanvas.tsx. The
+// invariants under test are EXACTLY the ones the inline code held:
+//
+//   1. `silhouettesById` is referentially STABLE keyed on `[silhouettes]`
+//      (re-render with the SAME array reference returns the SAME Map). This is
+//      load-bearing: instability re-registers the adaptive-grid reconciler →
+//      bumps `cacheGeneration` → clears `leafCache` (the #872–875-adjacent
+//      churn the memo exists to prevent).
+//   2. `commonName: string | null` is carried through verbatim (PR #926,
+//      #920 colloquial family names + screen-reader labels).
+//   3. `silhouettesVersion` is a monotonic integer counter that bumps on a
+//      silhouettes prop REFERENCE change. The inline code seeds
+//      `prevSilhouettesRef` with the FIRST `silhouettes` value, so the FIRST
+//      render does NOT bump (counter stays 0). A fresh same-length array with
+//      swapped svgData bumps it (the case `silhouettes.length` as a proxy would
+//      miss); a true same-reference render does NOT bump.
+
+const SILHOUETTES: FamilySilhouette[] = [
+  {
+    familyCode: 'tyrannidae',
+    color: '#c3772d',
+    colorDark: '#C77A2E',
+    svgData: 'M0 0L1 1Z',
+    svgUrl: null,
+    source: 'placeholder',
+    license: 'CC0',
+    commonName: 'Tyrant Flycatchers',
+    creator: null,
+  },
+  {
+    familyCode: 'trochilidae',
+    color: '#9637ad',
+    colorDark: '#9637ad',
+    svgData: 'M2 2L3 3Z',
+    svgUrl: null,
+    source: 'placeholder',
+    license: 'CC0',
+    commonName: 'Hummingbirds',
+    creator: null,
+  },
+  {
+    familyCode: 'uncurated',
+    color: '#888888',
+    colorDark: '#888888',
+    svgData: null,
+    svgUrl: null,
+    source: null,
+    license: null,
+    commonName: null,
+    creator: null,
+  },
+];
+
+describe('useSilhouetteCatalogue', () => {
+  it('builds silhouettesById keyed by lowercased familyCode', () => {
+    const { result } = renderHook(
+      ({ silhouettes }) => useSilhouetteCatalogue(silhouettes),
+      { initialProps: { silhouettes: SILHOUETTES } },
+    );
+    const map = result.current.silhouettesById;
+    expect(map.get('tyrannidae')).toEqual({
+      svgData: 'M0 0L1 1Z',
+      color: '#c3772d',
+      colorDark: '#C77A2E',
+      commonName: 'Tyrant Flycatchers',
+    });
+    expect(map.get('trochilidae')?.svgData).toBe('M2 2L3 3Z');
+    // familyCode is lowercased on insert; an upper-case lookup misses.
+    expect(map.get('TYRANNIDAE')).toBeUndefined();
+  });
+
+  it('carries commonName (string | null) verbatim — #920/#926 load-bearing', () => {
+    const { result } = renderHook(
+      ({ silhouettes }) => useSilhouetteCatalogue(silhouettes),
+      { initialProps: { silhouettes: SILHOUETTES } },
+    );
+    const map = result.current.silhouettesById;
+    // Curated colloquial name preserved exactly.
+    expect(map.get('tyrannidae')?.commonName).toBe('Tyrant Flycatchers');
+    expect(map.get('trochilidae')?.commonName).toBe('Hummingbirds');
+    // null preserved as null (NOT undefined) — the field is present-and-null
+    // for unseeded/uncurated families; consumers fall back to prettyFamily().
+    expect(map.get('uncurated')?.commonName).toBeNull();
+    expect(map.get('uncurated')).toHaveProperty('commonName');
+  });
+
+  it('CRITICAL — silhouettesById is referentially STABLE keyed on [silhouettes]', () => {
+    const { result, rerender } = renderHook(
+      ({ silhouettes }) => useSilhouetteCatalogue(silhouettes),
+      { initialProps: { silhouettes: SILHOUETTES } },
+    );
+    const first = result.current.silhouettesById;
+    // Re-render with the SAME array reference — the memo must NOT recompute.
+    // Instability here would re-register the reconciler, bump cacheGeneration,
+    // and clear leafCache (the churn the memo exists to prevent).
+    rerender({ silhouettes: SILHOUETTES });
+    expect(result.current.silhouettesById).toBe(first);
+
+    // A new array identity (even with identical contents) DOES recompute —
+    // that's the correct memo behavior on a [silhouettes]-keyed dep.
+    const cloned: FamilySilhouette[] = SILHOUETTES.map((s) => ({ ...s }));
+    rerender({ silhouettes: cloned });
+    expect(result.current.silhouettesById).not.toBe(first);
+  });
+
+  it('silhouettesVersion does NOT bump on the first render or on a same-reference re-render', () => {
+    const { result, rerender } = renderHook(
+      ({ silhouettes }) => useSilhouetteCatalogue(silhouettes),
+      { initialProps: { silhouettes: SILHOUETTES } },
+    );
+    // The inline ref seeds prevSilhouettesRef with the FIRST prop, so the
+    // initial compare is equal — the counter stays 0 on first render.
+    expect(result.current.silhouettesVersion).toBe(0);
+
+    // Same reference: NO bump.
+    rerender({ silhouettes: SILHOUETTES });
+    expect(result.current.silhouettesVersion).toBe(0);
+  });
+
+  it('silhouettesVersion bumps on a fresh same-length array with swapped svgData (not on length)', () => {
+    const { result, rerender } = renderHook(
+      ({ silhouettes }) => useSilhouetteCatalogue(silhouettes),
+      { initialProps: { silhouettes: SILHOUETTES } },
+    );
+    const v0 = result.current.silhouettesVersion;
+    expect(v0).toBe(0);
+
+    // Fresh array, SAME length, swapped svgData (a Phylopic refresh /
+    // low-res→hi-res swap). The trigger is array IDENTITY, not length — this
+    // is the exact case `silhouettes.length` as a proxy would miss.
+    const swapped: FamilySilhouette[] = SILHOUETTES.map((s) => ({
+      ...s,
+      svgData: s.svgData === null ? null : `${s.svgData} `,
+    }));
+    expect(swapped.length).toBe(SILHOUETTES.length);
+    rerender({ silhouettes: swapped });
+    expect(result.current.silhouettesVersion).toBe(1);
+
+    // Same reference again: NO further bump.
+    rerender({ silhouettes: swapped });
+    expect(result.current.silhouettesVersion).toBe(1);
+
+    // Another fresh array → another bump (monotonic).
+    rerender({ silhouettes: SILHOUETTES.map((s) => ({ ...s })) });
+    expect(result.current.silhouettesVersion).toBe(2);
+  });
+});

--- a/frontend/src/components/map/use-silhouette-catalogue.ts
+++ b/frontend/src/components/map/use-silhouette-catalogue.ts
@@ -1,0 +1,77 @@
+// Extracted from MapCanvas.tsx for epic #884 (U7 / #891) — a behavior-
+// PRESERVING move of the silhouette-catalogue derives out of the god
+// component. Two pieces travel together because they share the one input
+// (the `silhouettes` prop) and are consumed as a pair downstream:
+//
+//   1. The monotonic `silhouettesVersion` render-phase ref-counter.
+//   2. The `silhouettesById` lookup memo keyed on `[silhouettes]`.
+//
+// NOTHING about the runtime contract changes: the version counter still seeds
+// from the FIRST `silhouettes` value and bumps only on a reference change; the
+// memo is still referentially STABLE on `[silhouettes]` (load-bearing — see
+// below); the `commonName: string | null` field (#920/#926) is carried
+// verbatim. `silhouetteRenderById` is keyed on `[observations, …]` and stays in
+// MapCanvas (U8). The render-phase `prevBoundsKeyRef` scope-change block (#872)
+// also stays — it is unrelated to the silhouette catalogue.
+import { useMemo, useRef } from 'react';
+import type { FamilySilhouette } from '@bird-watch/shared-types';
+import type { SilhouettesById } from './adaptive-grid.js';
+
+/**
+ * Silhouette-catalogue derives extracted from MapCanvas. Returns the per-family
+ * `silhouettesById` lookup plus the monotonic `silhouettesVersion` counter that
+ * surfaces in-place catalogue refreshes the memo's `[silhouettes]` key already
+ * captures.
+ */
+export function useSilhouetteCatalogue(silhouettes: FamilySilhouette[]): {
+  silhouettesById: SilhouettesById;
+  silhouettesVersion: number;
+} {
+  /**
+   * Monotonic `silhouettesVersion` (spec §5.3 Concern C, point 2). This is
+   * a strict integer counter, NOT `silhouettes.length` — a length-only
+   * proxy misses in-place row replacement (same count, different svgData
+   * — Phylopic refreshes, low-res→hi-res swaps). The counter increments
+   * each time the silhouettes prop changes by reference, which is the same
+   * point where the supercluster catalogue is rebuilt.
+   *
+   * Carried into the per-grid memo key + the cache-generation effect so
+   * an in-place catalogue refresh invalidates render-pass identity and the
+   * Concern B promise cache together.
+   */
+  const silhouettesVersionRef = useRef(0);
+  const prevSilhouettesRef = useRef<typeof silhouettes>(silhouettes);
+  if (prevSilhouettesRef.current !== silhouettes) {
+    silhouettesVersionRef.current += 1;
+    prevSilhouettesRef.current = silhouettes;
+  }
+  const silhouettesVersion = silhouettesVersionRef.current;
+
+  /**
+   * Pure per-family lookup used by `buildAdaptiveTiles` (spec §5.3 Concern
+   * C, point 3). Resolved once per reconcile from the silhouettes prop —
+   * the tile-builder MUST NOT read from a ref, so we thread this
+   * explicitly. An empty map signals "catalogue not loaded yet" and
+   * produces all-`pending` tiles.
+   */
+  const silhouettesById = useMemo<SilhouettesById>(() => {
+    const map = new Map<
+      string,
+      { svgData: string | null; color: string; colorDark: string; commonName: string | null }
+    >();
+    for (const s of silhouettes) {
+      map.set(s.familyCode.toLowerCase(), {
+        svgData: s.svgData,
+        color: s.color,
+        colorDark: s.colorDark,
+        // #920: carry the curated colloquial name so the tile builders can
+        // resolve each tile's `displayName` and the popovers show
+        // "Tyrant Flycatchers" instead of the scientific "Tyrannidae".
+        commonName: s.commonName,
+      });
+    }
+    return map;
+  }, [silhouettes]);
+
+  return { silhouettesById, silhouettesVersion };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph before["MapCanvas.tsx (before)"]
        P1[silhouettes prop] --> V1["silhouettesVersionRef\n(render-phase counter)"]
        P1 --> M1["silhouettesById useMemo\nkeyed [silhouettes]"]
    end

    subgraph after["MapCanvas.tsx (after)"]
        P2[silhouettes prop] --> H["useSilhouetteCatalogue(silhouettes)"]
        H --> R["{ silhouettesById, silhouettesVersion }"]
    end

    R --> C1["buildAdaptiveTiles / reconciler effect"]
    R --> C2["clusterListFamilyNames (STAYS — component state)"]
    R --> C3["silhouetteRenderById (STAYS — U8, [observations]-keyed)"]
```

## Summary

- **Why:** U7 of the MapCanvas consolidation epic (#884) — the silhouette-catalogue derives are a self-contained, single-input (`silhouettes` prop) pair that lifts cleanly out of the god component, shrinking MapCanvas without touching runtime behavior.
- **What moves:** the monotonic `silhouettesVersion` render-phase ref-counter (bumps on a `silhouettes` *reference* change — not `.length` — to catch in-place Phylopic / low-res→hi-res swaps) **and** the `silhouettesById` lookup memo (keyed `[silhouettes]`, referentially **stable** — instability would re-register the reconciler → bump `cacheGeneration` → clear `leafCache`, the #872–875-adjacent churn the memo exists to prevent). The load-bearing `commonName: string | null` field (#920/#926 colloquial family names + a11y labels) is carried through verbatim.
- **What deliberately STAYS:** `silhouetteRenderById` (keyed `[observations, …]` → U8) and the render-phase `prevBoundsKeyRef` scope-change marker-clear block (#872) remain in MapCanvas; `clusterListFamilyNames` stays (it depends on component-owned `clusterList` state) and becomes a consumer of the extracted `silhouettesById`. Rendered output is byte-identical.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change. Type/behavior-preserving move under `frontend/**`; no `className` added or renamed.

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (`tsc -b && vite build`) — clean
- [x] `npm test --workspace @bird-watch/frontend` — green (74 files / 1207 tests), incl. the `silhouettesVersion bump` prior-art test in `MapCanvas.test.tsx`
- [x] New 1:1 colocated `use-silhouette-catalogue.test.ts` (renderHook) — written first (RED), confirmed GREEN after extraction; pins referential stability on a same-reference re-render, `commonName` preservation (string AND null), and the identity-not-length version-bump semantics
- [x] `npx knip` — clean (new file imported by MapCanvas; no dead-code finding)
- [x] No Playwright MCP smoke — exempt per CLAUDE.md (behavior-preserving, no visible UI change)

## Plan reference

Out of plan — epic #884 (MapCanvas consolidation), unit U7.

Closes #891
Part of #884

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
