### PR TITLE
refactor(frontend): extract reconciler pure middle to reconcile-viewport.ts (#895)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -78,13 +78,16 @@ import {
   type HitTargetMarker,
 } from './MapMarkerHitLayer.js';
 import {
-  buildGroups,
-  displaceSilhouettes,
   hashSubId,
   SILHOUETTE_PX,
   type DeconflictGroup,
   type DeconflictInput,
 } from './deconflict.js';
+// Reconciler pure middle (deconflict → displace → unproject → feature-state
+// diff) extracted to reconcile-viewport.ts (epic #884 · U10, #895). The shell
+// in the adaptive-grid reconciler effect below assembles `inputs` (owning both
+// `map.project` calls), calls this with an injected `unproject`, then commits.
+import { reconcileToGroups } from './reconcile-viewport.js';
 import { resolveFamilyName } from '../../derived.js';
 // Pure observation derives extracted to obs-derive.ts (epic #884 · U8, #892).
 // The fresh-closure `obsLookupRef` latch below stays in the component (it's
@@ -1663,37 +1666,21 @@ export function MapCanvas({
         return;
       }
 
-      // Run deconflict (pure, sync). Output: one group per overlap component.
-      const nextGroups = buildGroups(inputs, floorZoom);
+      // Pure middle (epic #884 · U10, #895): deconflict → displace →
+      // unproject-round-trip → feature-state diff, lifted into
+      // reconcile-viewport.ts. The map dependency injected is `unproject`
+      // ONLY — the caller owns projection (both `map.project` calls above ran
+      // while assembling `inputs`, whose px/py are already projected). The
+      // pure fn returns the feature-state diff as DATA; the shell applies it
+      // and owns the `prevHiddenSubIdsRef` write-back.
+      const { groups: nextGroups, offsets: nextOffsets, featureStateDiff } =
+        reconcileToGroups(
+          inputs,
+          floorZoom,
+          (point) => map.unproject(point),
+          prevHiddenSubIdsRef.current,
+        );
       setGroups(nextGroups);
-
-      // Compute per-subId pixel offsets for silhouettes that overlap a
-      // cluster anchor, then unproject the offset to lng/lat for the
-      // render block. The unproject is a tiny per-displaced-silhouette
-      // computation — bounded by silhouette count, typically <20.
-      const pxOffsets = displaceSilhouettes(nextGroups, inputs);
-      const nextOffsets = new Map<
-        string,
-        { dx: number; dy: number; longitude: number; latitude: number }
-      >();
-      // Build a quick subId → input lookup for the projection round-trip.
-      const inputBySubId = new Map<string, DeconflictInput>();
-      for (const inp of inputs) {
-        if (inp.subId) inputBySubId.set(inp.subId, inp);
-      }
-      for (const [subId, off] of pxOffsets) {
-        const inp = inputBySubId.get(subId);
-        if (!inp || inp.longitude === undefined || inp.latitude === undefined) continue;
-        const displacedPx = inp.px + off.dx;
-        const displacedPy = inp.py + off.dy;
-        const ll = map.unproject([displacedPx, displacedPy]);
-        nextOffsets.set(subId, {
-          dx: off.dx,
-          dy: off.dy,
-          longitude: ll.lng,
-          latitude: ll.lat,
-        });
-      }
       setSilhouetteOffsets(nextOffsets);
 
       // Feature-state sync: hide the canvas-painted twin for every
@@ -1701,27 +1688,21 @@ export function MapCanvas({
       // were displaced last pass but aren't now. promoteId="subId" on
       // the Source ensures setFeatureState({id: subId}) targets the
       // right feature.
-      const nextHidden = new Set<string>(nextOffsets.keys());
-      const prevHidden = prevHiddenSubIdsRef.current;
-      // Hide newly-displaced silhouettes.
-      for (const subId of nextHidden) {
-        if (!prevHidden.has(subId)) {
-          map.setFeatureState(
-            { source: 'observations', id: subId },
-            { hidden: true },
-          );
-        }
+      for (const subId of featureStateDiff.toHide) {
+        map.setFeatureState(
+          { source: 'observations', id: subId },
+          { hidden: true },
+        );
       }
-      // Clear feature-state for silhouettes that are no longer displaced.
-      for (const subId of prevHidden) {
-        if (!nextHidden.has(subId)) {
-          map.removeFeatureState(
-            { source: 'observations', id: subId },
-            'hidden',
-          );
-        }
+      for (const subId of featureStateDiff.toClear) {
+        map.removeFeatureState(
+          { source: 'observations', id: subId },
+          'hidden',
+        );
       }
-      prevHiddenSubIdsRef.current = nextHidden;
+      // The pure fn computes the diff against the PASSED-IN hidden set but does
+      // NOT own the ref — the shell advances it after applying the diff.
+      prevHiddenSubIdsRef.current = new Set<string>(nextOffsets.keys());
 
       // End-of-idle eviction (spec §5.3 Concern B): drop cache entries
       // for clusters that no longer appear in the viewport. Bounds

--- a/frontend/src/components/map/reconcile-viewport.test.ts
+++ b/frontend/src/components/map/reconcile-viewport.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  reconcileToGroups,
+  type Unproject,
+  type LngLatLike,
+} from './reconcile-viewport.js';
+import { hashSubId, type DeconflictInput } from './deconflict.js';
+
+/**
+ * CHARACTERIZATION tests for the reconciler pure middle (epic #884 · U10, #895).
+ *
+ * These PIN today's behavior of the deconflict→displace→unproject→feature-state
+ * pipeline that was lifted out of `MapCanvas.tsx`'s reconciler effect. No map,
+ * no React: canned `DeconflictInput`s (already-projected `px`/`py`, exactly as
+ * the imperative shell assembles them) + a stub `unproject`.
+ *
+ * Scope per #895 + the issue-review IMPORTANT finding: this no-map test pins
+ *   - groups (anchor selection / member grouping)
+ *   - offsets (displaced-silhouette offsets, incl. the negative-pseudo-id
+ *     silhouette path via `-hashSubId(subId)`)
+ *   - the unproject round-trip (offset → lng/lat through the injected fn)
+ *   - the prevHidden diff (`toHide` / `toClear` vs the passed-in set)
+ *
+ * The #877 stale-id swallow and the #901/#902 `isSourceLoaded` empty-commit
+ * guard STAY in the imperative shell (they depend on the live-map
+ * `getClusterLeaves` rejection path / `map.isSourceLoaded`) and a no-map pure-fn
+ * test cannot reach them. They remain pinned by the existing
+ * `MapCanvas.test.tsx` shell suite (#901 + #875/#877), which stays green
+ * unchanged after this extraction.
+ */
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const grid4x4 = { kind: 'grid', shape: { tag: 'grid', cols: 4, rows: 4 } } as const;
+
+/** A positive-cluster_id grid cluster input (the shell already projected px/py). */
+function clusterInput(
+  id: number,
+  px: number,
+  py: number,
+  longitude = -111.9,
+  latitude = 33.45,
+): DeconflictInput {
+  return {
+    cluster_id: id,
+    px,
+    py,
+    rendered: grid4x4,
+    point_count: 32,
+    uniqueFamilies: 16,
+    longitude,
+    latitude,
+  };
+}
+
+/**
+ * A silhouette input EXACTLY as the shell assembles it (~MapCanvas.tsx:1619):
+ * negative pseudo-cluster_id `-hashSubId(subId)`, `rendered.kind = 'silhouette'`,
+ * carries the subId. px/py are already-projected.
+ */
+function silhouetteInput(
+  subId: string,
+  px: number,
+  py: number,
+  longitude = -111.9,
+  latitude = 33.45,
+): DeconflictInput {
+  return {
+    cluster_id: -hashSubId(subId),
+    px,
+    py,
+    rendered: { kind: 'silhouette' },
+    point_count: 1,
+    uniqueFamilies: 1,
+    longitude,
+    latitude,
+    subId,
+  };
+}
+
+/**
+ * Deterministic stub unproject: maps a pixel point back to a synthetic lng/lat
+ * so the round-trip is assertable. lng/lat are simple linear functions of x/y.
+ */
+const stubUnproject: Unproject = ([x, y]): LngLatLike => ({
+  lng: -110 + x / 1000,
+  lat: 40 - y / 1000,
+});
+
+// ── Characterization ─────────────────────────────────────────────────────────
+
+describe('reconcileToGroups (characterization — pinned pre-extraction behavior)', () => {
+  it('emits one group per overlap component; anchor is min(cluster_id)', () => {
+    // Two grid clusters overlapping at the same pixel neighborhood.
+    const a = clusterInput(5, 100, 100);
+    const b = clusterInput(12, 110, 100);
+    const { groups } = reconcileToGroups([a, b], 8, stubUnproject, new Set());
+    expect(groups).toHaveLength(1);
+    expect(groups[0].anchor.cluster_id).toBe(5);
+    expect(groups[0].memberIds).toEqual([5, 12]);
+  });
+
+  it('disjoint clusters → separate groups, no offsets, empty diff', () => {
+    const a = clusterInput(1, 0, 0);
+    const b = clusterInput(2, 1000, 1000);
+    const unproject = vi.fn(stubUnproject);
+    const { groups, offsets, featureStateDiff } = reconcileToGroups(
+      [a, b],
+      8,
+      unproject,
+      new Set(),
+    );
+    expect(groups).toHaveLength(2);
+    expect(offsets.size).toBe(0);
+    // No silhouettes displaced → unproject never called.
+    expect(unproject).not.toHaveBeenCalled();
+    expect(featureStateDiff).toEqual({ toHide: [], toClear: [] });
+  });
+
+  it('negative-pseudo-id silhouette overlapping a cluster anchor → displaced + unprojected', () => {
+    // Cluster anchor at (100,100); silhouette 5px east — well inside the
+    // anchor's inflated AABB → displaceSilhouettes returns a non-zero offset.
+    const anchor = clusterInput(7, 100, 100);
+    const sil = silhouetteInput('OBS-aaa', 105, 100);
+    // Anchor wins (silhouette is NEVER an anchor) regardless of the negative id.
+    const unproject = vi.fn(stubUnproject);
+    const { groups, offsets, featureStateDiff } = reconcileToGroups(
+      [anchor, sil],
+      8,
+      unproject,
+      new Set(),
+    );
+
+    // Single overlap component; the cluster (not the negative-id silhouette) is anchor.
+    expect(groups).toHaveLength(1);
+    expect(groups[0].anchor.cluster_id).toBe(7);
+    expect(groups[0].memberIds).toContain(-hashSubId('OBS-aaa'));
+
+    // The silhouette was displaced.
+    expect(offsets.has('OBS-aaa')).toBe(true);
+    const off = offsets.get('OBS-aaa')!;
+    expect(off.dx !== 0 || off.dy !== 0).toBe(true);
+
+    // unproject was called with the DISPLACED pixel (anchor px/py + dx/dy),
+    // and the returned lng/lat were stored on the offset (the round-trip).
+    const displacedPx = sil.px + off.dx;
+    const displacedPy = sil.py + off.dy;
+    expect(unproject).toHaveBeenCalledWith([displacedPx, displacedPy]);
+    expect(off.longitude).toBeCloseTo(stubUnproject([displacedPx, displacedPy]).lng, 10);
+    expect(off.latitude).toBeCloseTo(stubUnproject([displacedPx, displacedPy]).lat, 10);
+
+    // Newly displaced (prevHidden empty) → toHide carries this subId.
+    expect(featureStateDiff.toHide).toEqual(['OBS-aaa']);
+    expect(featureStateDiff.toClear).toEqual([]);
+  });
+
+  it('prevHidden diff: already-hidden displaced subId is NOT re-hidden', () => {
+    const anchor = clusterInput(7, 100, 100);
+    const sil = silhouetteInput('OBS-aaa', 105, 100);
+    const { offsets, featureStateDiff } = reconcileToGroups(
+      [anchor, sil],
+      8,
+      stubUnproject,
+      new Set(['OBS-aaa']), // already hidden last pass
+    );
+    expect(offsets.has('OBS-aaa')).toBe(true);
+    expect(featureStateDiff.toHide).toEqual([]); // not newly hidden
+    expect(featureStateDiff.toClear).toEqual([]); // still displaced → not cleared
+  });
+
+  it('prevHidden diff: a subId hidden last pass but not displaced now → toClear', () => {
+    // This pass has NO displacement (silhouette far from any anchor), but a
+    // subId was hidden last pass → it must be cleared.
+    const lonelySil = silhouetteInput('OBS-zzz', 2000, 2000);
+    const { offsets, featureStateDiff } = reconcileToGroups(
+      [lonelySil],
+      8,
+      stubUnproject,
+      new Set(['OBS-was-hidden']),
+    );
+    expect(offsets.size).toBe(0);
+    expect(featureStateDiff.toHide).toEqual([]);
+    expect(featureStateDiff.toClear).toEqual(['OBS-was-hidden']);
+  });
+
+  it('silhouette-only group (no cluster anchor) is left untouched — no displacement', () => {
+    // Two silhouettes overlapping each other; neither is a cluster, so
+    // displaceSilhouettes leaves them alone (silhouette-only group).
+    const s1 = silhouetteInput('OBS-1', 100, 100);
+    const s2 = silhouetteInput('OBS-2', 104, 100);
+    const unproject = vi.fn(stubUnproject);
+    const { groups, offsets, featureStateDiff } = reconcileToGroups(
+      [s1, s2],
+      8,
+      unproject,
+      new Set(),
+    );
+    expect(groups).toHaveLength(1); // they overlap → one component
+    expect(offsets.size).toBe(0); // silhouette-only group → no displacement
+    expect(unproject).not.toHaveBeenCalled();
+    expect(featureStateDiff).toEqual({ toHide: [], toClear: [] });
+  });
+
+  it('empty inputs → empty groups, empty offsets, empty diff', () => {
+    const { groups, offsets, featureStateDiff } = reconcileToGroups(
+      [],
+      8,
+      stubUnproject,
+      new Set(),
+    );
+    expect(groups).toEqual([]);
+    expect(offsets.size).toBe(0);
+    expect(featureStateDiff).toEqual({ toHide: [], toClear: [] });
+  });
+
+  it('idempotent: same inputs twice yield identical groups/offsets', () => {
+    const inputs = [clusterInput(7, 100, 100), silhouetteInput('OBS-aaa', 105, 100)];
+    const r1 = reconcileToGroups(inputs, 8, stubUnproject, new Set());
+    const r2 = reconcileToGroups(inputs, 8, stubUnproject, new Set());
+    expect(JSON.stringify(r1.groups)).toEqual(JSON.stringify(r2.groups));
+    expect(JSON.stringify([...r1.offsets])).toEqual(JSON.stringify([...r2.offsets]));
+  });
+});

--- a/frontend/src/components/map/reconcile-viewport.ts
+++ b/frontend/src/components/map/reconcile-viewport.ts
@@ -1,0 +1,149 @@
+import {
+  buildGroups,
+  displaceSilhouettes,
+  type DeconflictGroup,
+  type DeconflictInput,
+} from './deconflict.js';
+
+/**
+ * Pure middle of the adaptive-grid reconciler (epic #884 · U10, #895).
+ *
+ * Lifted out of `MapCanvas.tsx`'s reconciler effect. This function owns the
+ * deterministic, synchronous transformation that sits BETWEEN the imperative
+ * shell's two halves:
+ *
+ *   shell (assemble `inputs`) → reconcileToGroups(...) → shell (commit)
+ *
+ * The shell STAYS in `MapCanvas.tsx` and owns every map-touching concern:
+ *   - `queryRenderedFeatures` (cluster + unclustered-point queries)
+ *   - BOTH `map.project` calls — projection runs WHILE assembling `inputs`,
+ *     before this function is reached. "The caller owns projection." The
+ *     `inputs` crossing into here already carry projected `px`/`py`
+ *     (`DeconflictInput.px`/`py`, "already projected" — deconflict.ts).
+ *   - `getClusterLeaves` and its #877 stale-id (`isStaleClusterId`) swallow
+ *   - the #902 `isSourceLoaded` empty-commit guard
+ *   - the `cacheGeneration`/`leafCache` race-guard
+ *   - `setFeatureState`/`removeFeatureState` (driven by the returned
+ *     `featureStateDiff`)
+ *   - advancing `prevHiddenSubIdsRef.current = nextHidden` after applying the
+ *     diff (this function computes the diff against the PASSED-IN
+ *     `prevHiddenSubIds` but does NOT own the ref).
+ *
+ * The ONLY map dependency injected here is `unproject`: turning the displaced
+ * pixel offsets coming OUT of `displaceSilhouettes` back into lng/lat. `project`
+ * is deliberately NOT injected — every `map.project` call lives in the shell
+ * while `inputs` is assembled, so a `project` param would be dead (or worse,
+ * lure a caller into dragging the QRF/projection loop across this boundary and
+ * re-tangling the irreducible shell).
+ *
+ * Pure + sync: no React, no MapLibre instance, no async.
+ */
+
+/** Minimal structural type for a maplibre `LngLat` (`map.unproject` return). */
+export interface LngLatLike {
+  lng: number;
+  lat: number;
+}
+
+/**
+ * Injected pixel → lng/lat conversion (maplibre `map.unproject`). Accepts a
+ * `[x, y]` pixel pair and returns the geographic coordinate. Structurally typed
+ * so the production caller passes `map.unproject` directly and tests pass a
+ * stub.
+ */
+export type Unproject = (point: [number, number]) => LngLatLike;
+
+/** Per-displaced-silhouette render offset, keyed by subId. */
+export interface SilhouetteOffset {
+  /** Pixel-space x displacement applied at render time. */
+  dx: number;
+  /** Pixel-space y displacement applied at render time. */
+  dy: number;
+  /** Unprojected lng of the displaced position (offset round-tripped). */
+  longitude: number;
+  /** Unprojected lat of the displaced position (offset round-tripped). */
+  latitude: number;
+}
+
+/**
+ * Feature-state diff for the displaced-silhouette `hidden` flag, returned as
+ * DATA. The shell applies `toHide` via `setFeatureState({hidden:true})` and
+ * `toClear` via `removeFeatureState(...,'hidden')`, then advances the ref.
+ */
+export interface FeatureStateDiff {
+  /** subIds newly displaced this pass (were NOT hidden last pass). */
+  toHide: string[];
+  /** subIds displaced last pass but no longer displaced (clear `hidden`). */
+  toClear: string[];
+}
+
+/** Result of the pure reconcile middle. */
+export interface ReconcileResult {
+  /** Deconflicted anchor groups — fed to `setGroups`. */
+  groups: DeconflictGroup[];
+  /** Displaced-silhouette offsets (incl. unprojected lng/lat) — `setSilhouetteOffsets`. */
+  offsets: Map<string, SilhouetteOffset>;
+  /** Feature-state diff vs `prevHiddenSubIds` — applied by the shell. */
+  featureStateDiff: FeatureStateDiff;
+}
+
+/**
+ * Run the pure deconflict middle over an assembled `inputs` list.
+ *
+ * @param inputs      Deconflict inputs with ALREADY-PROJECTED `px`/`py` (the
+ *                    shell projected lng/lat while assembling these).
+ * @param floorZoom   `Math.floor(map.getZoom())` — drives the bucket key.
+ * @param unproject   Injected `map.unproject`; the sole map dependency.
+ * @param prevHiddenSubIds  The hidden set from the PRIOR pass (the shell owns
+ *                    the ref; this fn only diffs against the passed-in set).
+ */
+export function reconcileToGroups(
+  inputs: ReadonlyArray<DeconflictInput>,
+  floorZoom: number,
+  unproject: Unproject,
+  prevHiddenSubIds: ReadonlySet<string>,
+): ReconcileResult {
+  // Deconflict (pure, sync). One group per overlap component.
+  const groups = buildGroups(inputs, floorZoom);
+
+  // Compute per-subId pixel offsets for silhouettes that overlap a cluster
+  // anchor, then unproject the offset to lng/lat for the render block. The
+  // unproject is a tiny per-displaced-silhouette computation — bounded by
+  // silhouette count, typically <20.
+  const pxOffsets = displaceSilhouettes(groups, inputs);
+  const offsets = new Map<string, SilhouetteOffset>();
+  // Build a quick subId → input lookup for the projection round-trip.
+  const inputBySubId = new Map<string, DeconflictInput>();
+  for (const inp of inputs) {
+    if (inp.subId) inputBySubId.set(inp.subId, inp);
+  }
+  for (const [subId, off] of pxOffsets) {
+    const inp = inputBySubId.get(subId);
+    if (!inp || inp.longitude === undefined || inp.latitude === undefined) continue;
+    const displacedPx = inp.px + off.dx;
+    const displacedPy = inp.py + off.dy;
+    const ll = unproject([displacedPx, displacedPy]);
+    offsets.set(subId, {
+      dx: off.dx,
+      dy: off.dy,
+      longitude: ll.lng,
+      latitude: ll.lat,
+    });
+  }
+
+  // Feature-state diff: hide the canvas-painted twin for every newly-displaced
+  // silhouette; clear feature-state for silhouettes that were displaced last
+  // pass but aren't now. Returned as DATA — the shell applies it and owns the
+  // ref write-back.
+  const nextHidden = new Set<string>(offsets.keys());
+  const toHide: string[] = [];
+  const toClear: string[] = [];
+  for (const subId of nextHidden) {
+    if (!prevHiddenSubIds.has(subId)) toHide.push(subId);
+  }
+  for (const subId of prevHiddenSubIds) {
+    if (!nextHidden.has(subId)) toClear.push(subId);
+  }
+
+  return { groups, offsets, featureStateDiff: { toHide, toClear } };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph shell["MapCanvas.tsx reconciler effect (irreducible shell — STAYS)"]
        QRF["queryRenderedFeatures<br/>(clusters + unclustered)"]
        GCL["getClusterLeaves<br/>+ #877 stale-id swallow"]
        PROJ["map.project x2<br/>(caller owns projection)"]
        ASM["assemble inputs[]<br/>(px/py already projected)"]
        GEN["cacheGeneration /<br/>leafCache race-guard"]
        SRC["#902 isSourceLoaded<br/>empty-commit guard"]
        APPLY["setFeatureState /<br/>removeFeatureState"]
        REF["prevHiddenSubIdsRef<br/>write-back"]
    end
    subgraph pure["reconcile-viewport.ts — reconcileToGroups (NEW pure middle)"]
        BG["buildGroups"]
        DS["displaceSilhouettes"]
        UNP["unproject round-trip<br/>(injected unproject ONLY)"]
        DIFF["feature-state diff<br/>{ toHide, toClear }"]
    end

    QRF --> GCL --> PROJ --> ASM --> GEN --> SRC
    SRC -- "inputs, floorZoom, unproject, prevHidden" --> BG
    BG --> DS --> UNP --> DIFF
    DIFF -- "groups, offsets, featureStateDiff" --> APPLY --> REF
```

## Summary

- **Why:** The adaptive-grid reconciler effect interleaved a pure, synchronous transform (deconflict → displace → unproject-round-trip → feature-state diff) with the irreducible imperative shell. Lifting that pure middle into `reconcile-viewport.ts` makes it independently testable without a map instance and shrinks the god-component's reconciler surface, per epic #884.
- **Why inject `unproject` only:** `inputs` already carry projected `px`/`py` — the caller owns projection (both `map.project` calls run while assembling `inputs`). From `buildGroups` onward the code touches only `map.unproject`. A `project` param would be dead and would lure a future edit into dragging the QRF/projection loop across the boundary. The pure fn returns the feature-state diff as DATA (`{ toHide, toClear }`); the shell applies it via `setFeatureState`/`removeFeatureState` and owns the `prevHiddenSubIdsRef` write-back.
- **What STAYS in the caller (verified):** `queryRenderedFeatures`, `getClusterLeaves` + the #877 stale-id swallow, the #902 `isSourceLoaded` empty-commit guard, the `cacheGeneration`/`leafCache` race-guard, the feature-state mutations, and the ref write-back. Behavior-preserving — no visible UI change.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change. The pure middle was lifted verbatim from the reconciler effect; rendered output is unchanged (validated by the full incident suite + 8 new characterization tests).

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className changes (logic-only extraction)`
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (tsc -b && vite build) — clean
- [x] `npm test --workspace @bird-watch/frontend` — 81 files, **1255 tests pass**
- [x] **Characterization-test-first (HIGH-risk unit):** `reconcile-viewport.test.ts` (8 tests) written + passing BEFORE the extraction — pins groups, offsets (incl. the negative-pseudo-id silhouette path via `-hashSubId(subId)` and the `unproject` round-trip), and the `prevHidden` `toHide`/`toClear` diff. After the extraction the same 8 tests pass unchanged.
- [x] Existing `MapCanvas.test.tsx` incident suite (#901/#902 empty-commit guard, #875/#877 stale-id swallow, #718 displaced-silhouette anchoring, cacheGeneration race-drop) — green unchanged (83 tests); it exercises the shell that now calls the pure fn.
- [x] `npx knip` — no new unused files/exports/deps (new module is imported by `MapCanvas.tsx`)
- [x] New unit tests added (behavior pinned, not changed)
- [ ] New Playwright e2e spec added — N/A (no user-visible behavior change)
- [x] maplibre-gl 5.x docs pulled via context7 before touching the `unproject` signature (returns `LngLat` with `.lng`/`.lat`, matching the round-trip reads)

## Plan reference

Out of plan — epic #884 (MapCanvas consolidation), Wave 1, U10. Closes #895. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)