### PR TITLE
refactor(frontend): consolidate artboard machinery → useStateArtboard (U13, #898)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -10,9 +10,6 @@ import {
 } from 'react-map-gl/maplibre';
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
-// GeoJSON structural types come from `geojson` (@types/geojson), NOT maplibre-gl
-// (5.x does not re-export them). `import type`, erased at build — see mask.ts.
-import type { MultiPolygon } from 'geojson';
 import type { AggregatedBucket, Observation } from '@bird-watch/shared-types';
 import { BASEMAP_LIGHT, BASEMAP_DARK } from './basemap-style.js';
 import { INITIAL_VIEW, MIN_ZOOM } from './camera-config.js';
@@ -21,14 +18,6 @@ import {
   MASK_FILL_LIGHT,
   MASK_FILL_DARK,
 } from './mask.js';
-import {
-  applyLabelIsolation,
-  restoreLabelIsolation,
-  bufferIsolationPolygon,
-  applyArtboardFidelity,
-  removeFloatLayers,
-  MASK_LAYER_ID,
-} from './artboard-layers.js';
 import {
   observationsToGeoJson,
   bucketsToGeoJson,
@@ -52,6 +41,7 @@ import { registerSilhouetteSprite } from './silhouette-sprite.js';
 import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
 import { useMapResize } from './use-map-resize.js';
 import { useScopeCamera } from './use-scope-camera.js';
+import { useStateArtboard } from './use-state-artboard.js';
 import {
   aggregateClusterFamilies,
   aggregateClusterSpecies,
@@ -384,41 +374,16 @@ export function MapCanvas({
    * can fire before the ref is live).
    */
   const [mapReady, setMapReady] = useState(false);
-  /**
-   * Reactive theme for the state-artboard mask fill (#760/#762). Seeded from the
-   * current `[data-theme]` attribute and flipped by the SAME MutationObserver
-   * that swaps the basemap (below) — so the gray mask re-paints in lockstep with
-   * the basemap on a light/dark toggle. react-map-gl diffs the `<Layer>` `paint`
-   * prop, so updating this state re-paints the fill with no remount.
-   */
-  const [maskTheme, setMaskTheme] = useState<'light' | 'dark'>(() =>
-    typeof document !== 'undefined' &&
-    document.documentElement.getAttribute('data-theme') === 'dark'
-      ? 'dark'
-      : 'light',
-  );
-
-  // #763 — artboard FIDELITY imperative state.
-  //
-  // `savedFiltersRef` holds the basemap symbol layers' ORIGINAL filters captured
-  // when `applyLabelIsolation` ran, so `restoreLabelIsolation` can undo the
-  // `['within', …]` merge exactly when the mask unmounts (scope → us/chooser).
-  //
-  // `maskPolygonRef` mirrors the current prop so the ONCE-registered
-  // `style.load` handler (which would otherwise close over a stale value) reads
-  // the live polygon at swap time. Updated synchronously on render.
-  const savedFiltersRef = useRef<ReturnType<typeof applyLabelIsolation> | null>(
-    null,
-  );
-  const maskPolygonRef = useRef<MultiPolygon | null>(maskPolygon ?? null);
-  maskPolygonRef.current = maskPolygon ?? null;
-  // `styleEpoch` bumps once per `style.load` (i.e. per theme `setStyle` swap).
-  // It is a dep of the float/sink effect so that effect RE-RUNS after the new
-  // style finishes loading — by which time react-map-gl's reconcile has re-added
-  // `state-mask-fill`, so the guard passes and the float layers (which `setStyle`
-  // dropped) are restored. Without this, a theme swap left the artboard with NO
-  // halo/outline until the next unrelated render.
-  const [styleEpoch, setStyleEpoch] = useState(0);
+  // State-artboard machinery (#760/#762/#763/#765/#849/#850 blank-map class) is
+  // consolidated into `useStateArtboard` (`use-state-artboard.ts`, epic #884 ·
+  // U13 / #898): the four mask/label-isolation effects, the `[data-theme]`
+  // MutationObserver (basemap `setStyle` + mask-fill re-tint), and the
+  // `renderWorldCopies` reassertion — moved as ONE indivisible unit, owning ALL
+  // their cross-effect state (`maskTheme`, `savedFiltersRef`, `maskPolygonRef`,
+  // `styleEpoch`, and the MutationObserver-private `prevThemeRef` same-value
+  // guard). The hook is called below (once `maskPolygon` is in scope) and returns
+  // `{ maskTheme }` — the reactive mask-fill theme the `<Layer>` `paint` prop
+  // reads. `mapRef` + the `<Map>`/`<Source>`/`<Layer>` JSX stay here.
   /* Coarse-pointer detection (#247, mobile; also used by auto-spider hit
      targets in #277). Extracted to a generic sensor hook in #889 (epic #884);
      reactive — reads on mount and listens for `change`. */
@@ -457,190 +422,22 @@ export function MapCanvas({
   // invariant that the observer only ever calls `map.resize()`).
   useMapResize(mapRef, mapWrapperRef, mapReady);
 
-  // #762/#765 — `renderWorldCopies` reassertion across an IN-PLACE scope change.
-  //
-  // The declarative `renderWorldCopies={maskPolygon == null}` prop above is
-  // necessary (react-map-gl/maplibre does NOT reset an ABSENT setting to its
-  // default — it retains the last value, so the prop must always carry an
-  // explicit value), but it is not sufficient on the `state → us` transition.
-  // That transition also changes `boundsKey`, which re-fires the camera effect
-  // and starts a `fitBounds` animation. maplibre's animation captures a CLONE
-  // of the current transform (with the OLD `renderWorldCopies: false`) and
-  // re-`apply`s it every animation frame — clobbering the `true` that
-  // react-map-gl set declaratively. The net live result was world copies stuck
-  // OFF after leaving a state scope for `?scope=us` (PR #765 bot review,
-  // reproduced live: `getRenderWorldCopies()` stayed `false`).
-  //
-  // Reassert imperatively on `maskPolygon` change AND on `moveend` (when the
-  // clobbering animation has finished) so the explicit value wins the race.
-  // Idempotent: a no-op when the map already matches the desired value.
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    if (!map) return;
-    const desired = maskPolygon == null;
-    const apply = () => {
-      if (map.getRenderWorldCopies() !== desired) {
-        map.setRenderWorldCopies(desired);
-      }
-    };
-    apply();
-    // Win the race against an in-flight fitBounds/flyTo transform-clone replay.
-    map.on('moveend', apply);
-    return () => {
-      map.off('moveend', apply);
-    };
-  }, [mapReady, maskPolygon]);
-
-  // ───────────────────────────────────────────────────────────────────────────
-  // #763 — artboard FIDELITY: label isolation + clean exterior + float layers.
-  //
-  // ⚠ RECONCILE-SEQUENCING SPLIT (do NOT collapse this into one effect/handler).
-  //
-  // `map.setStyle()` (fired by the [data-theme] MutationObserver below) clears
-  // and asynchronously reloads ALL layers — dropping both the merged label
-  // filters AND the float layers — so everything must be re-applied after each
-  // swap. But the two halves have DIFFERENT timing requirements:
-  //
-  //   (3a) Label-filter isolation re-applies in `style.load`. Basemap symbol
-  //        layers exist immediately on style load and `applyLabelIsolation`
-  //        needs NO reference to `state-mask-fill`, so it is safe there.
-  //
-  //   (3b) The float `addLayer` + the `moveLayer` stray-sink re-apply from the
-  //        SEPARATE `maskPolygon`-watching effect below — NOT from `style.load`.
-  //        react-map-gl re-adds its managed declarative layers (including
-  //        `state-mask-fill`) on the NEXT React reconcile, which has NOT
-  //        happened yet when `style.load` fires. `moveLayer(x, 'state-mask-fill')`
-  //        or an `addLayer(..., 'state-mask-fill')` inside `style.load` therefore
-  //        throws `Cannot move layer before non-existing layer`. The effect
-  //        below re-fires on the next render (after the reconcile), so the
-  //        reference layer exists — and it still GUARDS on
-  //        `getLayer('state-mask-fill')` (warn-and-return, never call through).
-  //
-  // Collapsing (3b) back into the `style.load` handler reintroduces that throw.
-  // ───────────────────────────────────────────────────────────────────────────
-
-  // (3a-i) Label isolation re-apply on THEME SWAP. Registered ONCE after
-  // `mapReady` as a `style.load` listener (which fires after each
-  // MutationObserver `setStyle`); the handler reads the live `maskPolygon` from
-  // a ref so it needs no re-registration on prop change. Basemap symbol layers
-  // exist immediately on `style.load`, and `applyLabelIsolation` needs no
-  // reference to `state-mask-fill`, so this is safe here (unlike the float/sink
-  // half — see the sequencing comment above).
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    if (!map) return;
-
-    const onStyleLoad = () => {
-      const poly = maskPolygonRef.current;
-      // Bump the epoch unconditionally so the float/sink effect re-runs after
-      // EVERY style reload (it re-adds the floats `setStyle` dropped, once the
-      // reconcile has re-added `state-mask-fill`).
-      setStyleEpoch((n) => n + 1);
-      if (!poly) return; // no state scope → no isolation (us/chooser untouched)
-      try {
-        // The within test uses the OUTWARD-BUFFERED polygon (so near-border
-        // interior labels survive); the #762 mask FILL keeps the EXACT polygon.
-        savedFiltersRef.current = applyLabelIsolation(
-          map,
-          bufferIsolationPolygon(poly),
-        );
-      } catch {
-        /* defensive — style churn after a swap; QA detects un-isolated labels */
-      }
-    };
-
-    map.on('style.load', onStyleLoad);
-    return () => {
-      map.off('style.load', onStyleLoad);
-    };
-    // mapReady-only: the handler reads maskPolygon from a ref, so it must NOT
-    // re-register on every prop change (that would leak listeners).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapReady]);
-
-  // (3a-ii) Label isolation re-apply on MASK CHANGE (initial mount, chooser/us →
-  // state, state → state in-place). Distinct from the `style.load` listener:
-  // those transitions do NOT swap the style, so no `style.load` fires. On a
-  // state → state change the OLD isolation must be restored before the NEW one
-  // is captured+applied (else the new `applyLabelIsolation` would capture the
-  // already-merged `['all', original, within]` filter as the "original").
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    if (!map) return;
-    if (!maskPolygon) return; // us/chooser: teardown effect restores originals
-    try {
-      if (savedFiltersRef.current) {
-        restoreLabelIsolation(map, savedFiltersRef.current);
-        savedFiltersRef.current = null;
-      }
-      savedFiltersRef.current = applyLabelIsolation(
-        map,
-        bufferIsolationPolygon(maskPolygon),
-      );
-    } catch {
-      /* defensive — style churn; QA detects un-isolated labels */
-    }
-  }, [mapReady, maskPolygon]);
-
-  // (3b) Float layers + stray-sink — runs from a `maskPolygon`-watching,
-  // `mapReady`-gated effect (also keyed on `maskTheme` so the float re-tints on
-  // a theme swap). It fires AFTER react-map-gl's reconcile has (re-)added
-  // `state-mask-fill`, and `addFloatLayers` is idempotent (removes any prior
-  // instance before re-adding), so re-running it on a theme change re-tints
-  // cleanly without thrashing the LABEL filters (which are owned by the (3a)
-  // `style.load` handler and the separate teardown effect below).
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    if (!map) return;
-    if (!maskPolygon) return;
-
-    // Guard: state-mask-fill MUST exist before any moveLayer/insert anchored to
-    // it. If react-map-gl has not re-added it yet, warn and return — the effect
-    // re-fires on the next render once the reconcile lands it. Calling through
-    // is the exact `Cannot move layer before non-existing layer` throw the
-    // 3a/3b split exists to avoid.
-    if (map.getLayer(MASK_LAYER_ID) == null) {
-      console.warn(
-        '[artboard] state-mask-fill not yet reconciled; deferring float/sink',
-      );
-      return;
-    }
-    try {
-      applyArtboardFidelity(map, maskPolygon, maskTheme);
-    } catch {
-      /* defensive — layer/style churn after a swap */
-    }
-    // `styleEpoch` re-runs this AFTER a theme `setStyle`+`style.load` so the
-    // floats `setStyle` dropped are re-added once `state-mask-fill` is back.
-  }, [mapReady, maskPolygon, maskTheme, styleEpoch]);
-
-  // (3b-teardown) Restore label filters + remove float layers when the mask
-  // unmounts (scope → us/chooser) OR the component unmounts. Keyed ONLY on
-  // `maskPolygon` (NOT `maskTheme`) so a theme swap — which re-applies isolation
-  // via (3a) `style.load` against the NEW style — does not trigger a stale
-  // restore against filters the `setStyle` already cleared. Guarded against a
-  // disposed map / missing layers (the helpers wrap their MapLibre calls).
-  useEffect(() => {
-    if (!mapReady) return;
-    if (!maskPolygon) return; // only arm teardown while a mask is active
-    return () => {
-      const liveMap = mapRef.current?.getMap();
-      if (!liveMap) return;
-      try {
-        if (savedFiltersRef.current) {
-          restoreLabelIsolation(liveMap, savedFiltersRef.current);
-          savedFiltersRef.current = null;
-        }
-        removeFloatLayers(liveMap);
-      } catch {
-        /* defensive — map gone after a swap or unmount */
-      }
-    };
-  }, [mapReady, maskPolygon]);
+  // State-artboard machinery consolidated into ONE hook (`use-state-artboard.ts`,
+  // epic #884 · U13 / #898; the #760/#762/#763/#765/#849/#850 blank-map class).
+  // `useStateArtboard` owns the four mask/label-isolation effects, the
+  // `[data-theme]` MutationObserver (basemap `setStyle` + mask-fill re-tint), and
+  // the `renderWorldCopies` reassertion — moved as ONE indivisible unit with ALL
+  // their cross-effect state (`maskTheme`, `savedFiltersRef`, `maskPolygonRef`,
+  // `styleEpoch`, and the MutationObserver-private `prevThemeRef` same-value
+  // guard). The hook's JSDoc carries the full rationale (the load-bearing 3a/3b
+  // reconcile-sequencing split deferred via the `styleEpoch` re-fire, the
+  // once-registered `style.load` fresh-closure ref-mirror, the camera↔
+  // `renderWorldCopies` transform-clone race, and the no-op `data-theme` write
+  // guard). `maskTheme` is the reactive mask-fill theme consumed by the
+  // `<Layer>` `paint` prop below; `mapRef` + the `<MapView>`/`<Source>`/`<Layer>`
+  // JSX stay here. Behaviour-preserving: the effect bodies, deps, and
+  // exhaustive-deps disables are 1:1 with the pre-extraction code.
+  const { maskTheme } = useStateArtboard(mapRef, mapReady, maskPolygon);
 
   // Unmount cleanup for the `window.__birdMap` test hook (#291). The hook is
   // assigned in `handleLoad` (which fires once per mount); without an unmount
@@ -1558,61 +1355,12 @@ export function MapCanvas({
     // first resolving must re-run the reconciler so markers reflect real data.
   }, [silhouettes, silhouettesById, silhouettesVersion, mapReady, aggregated, buckets, dictionary]);
 
-  // Phase 1: [data-theme] observer — swap basemap when user toggles theme.
-  // Registered after mapReady so the map instance is guaranteed to exist.
-  // Cleaned up on unmount to prevent leaks. The observer is the single
-  // source of truth for basemap-vs-theme coupling — no prop drilling.
-  // Dark URL aliasing (G8): BASEMAP_DARK may resolve to the same
-  // visual tiles as light during the rollout window; the swap mechanism
-  // is correct regardless. See docs/design/01-spec/open-questions.md.
-  //
-  // Same-value guard: MutationRecord fires on every attribute write,
-  // including writes that set the SAME value the attribute already had
-  // (e.g. setAttribute('data-theme', 'light') when it's already 'light').
-  // Without the prevTheme ref, a no-op write would trigger setStyle and
-  // a redundant tile re-fetch.
-  const prevThemeRef = useRef<'light' | 'dark' | null>(null);
-  useEffect(() => {
-    if (!mapReady) return;
-    const map = mapRef.current?.getMap();
-    if (!map) return;
-
-    // Seed the prev ref with the current attribute value so the first
-    // observed mutation only fires setStyle when the value genuinely flips.
-    prevThemeRef.current =
-      document.documentElement.getAttribute('data-theme') === 'dark'
-        ? 'dark'
-        : 'light';
-
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (
-          mutation.type === 'attributes' &&
-          mutation.attributeName === 'data-theme'
-        ) {
-          const next: 'light' | 'dark' =
-            document.documentElement.getAttribute('data-theme') === 'dark'
-              ? 'dark'
-              : 'light';
-          if (next === prevThemeRef.current) return;
-          prevThemeRef.current = next;
-          const style = next === 'dark' ? BASEMAP_DARK : BASEMAP_LIGHT;
-          map.setStyle(style);
-          // #760/#762: re-paint the state-artboard mask fill in lockstep with
-          // the basemap swap. The mask <Layer> reads `maskTheme`; react-map-gl
-          // diffs `paint` so this re-tints the gray with no remount.
-          setMaskTheme(next);
-        }
-      }
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
-
-    return () => observer.disconnect();
-  }, [mapReady]);
+  // The [data-theme] MutationObserver (basemap `setStyle` swap + mask-fill
+  // re-tint via `setMaskTheme`, with the `prevThemeRef` no-op-write guard) was
+  // consolidated into `useStateArtboard` (`use-state-artboard.ts`, epic #884 ·
+  // U13 / #898) — it is part of the same indivisible artboard machinery and
+  // runs alongside the four mask/label-isolation effects + the world-copies
+  // reassertion. See the hook for the full rationale.
 
   /**
    * Parent-routed click for unified deconflict groups (issue #554; replaces

--- a/frontend/src/components/map/use-state-artboard.test.ts
+++ b/frontend/src/components/map/use-state-artboard.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { MultiPolygon } from 'geojson';
+import { useStateArtboard } from './use-state-artboard.js';
+import type { StateArtboardMapRef } from './use-state-artboard.js';
+import {
+  MASK_LAYER_ID,
+  ARTBOARD_HALO_ID,
+  ARTBOARD_OUTLINE_ID,
+} from './artboard-layers.js';
+
+/**
+ * P2 ordering-invariant backfill for the consolidated state-artboard hook
+ * (epic #884 · U13 / #898 — the #760/#762/#763/#765/#849/#850 nerve-center).
+ *
+ * The named incident regressions run end-to-end through `<MapCanvas>` against the
+ * stateful fake map in `MapCanvas.test.tsx` (#765 reassert-and-survive-moveend,
+ * #762 mask-first-layer, #763 within-filter + float-re-add-after-dark-swap, the
+ * `[data-theme]` MutationObserver dedup) and stay green UNCHANGED — those are NOT
+ * moved. THESE tests are the additional DIRECT `renderHook` re-assertion of the
+ * four ordering invariants by name PLUS the `prevThemeRef` same-value guard, so
+ * the load-bearing ordering of the consolidated hook is pinned at the hook
+ * boundary (not only transitively through the component):
+ *
+ *   1. (3a-ii) restore-before-capture — on a state→state mask change the OLD
+ *      isolation is restored BEFORE the new one is captured, so the new capture
+ *      records the TRUE original filter (not the already-merged one).
+ *   2. (3b) getLayer-guard defers via styleEpoch re-fire — while `state-mask-fill`
+ *      is absent the float effect warns-and-returns (no moveLayer/addLayer); a
+ *      `style.load` bumps styleEpoch, and once the mask layer is present the
+ *      float effect re-fires and applies.
+ *   3. (3b-teardown) keys on `maskPolygon` NOT `maskTheme` — a theme change does
+ *      not tear down isolation/floats; only the mask unmounting does.
+ *   4. (world-copies) re-arms on moveend — a `moveend` after an in-flight
+ *      transform-clone clobber re-asserts the desired `renderWorldCopies` value.
+ *
+ *   + prevThemeRef same-value guard — a no-op `data-theme` write must NOT re-fire
+ *     `setStyle` (the redundant-tile-refetch guard, comment-documented in the
+ *     MutationObserver effect).
+ *
+ * `e2e/state-artboard.spec.ts` is the live transform-clone-timing backstop.
+ */
+
+// Minimal isolatable basemap symbol layer (matches SYMBOL_NAME_PATTERN: 'label'
+// token) + the #762 mask fill (the z-order anchor) + a stray basemap line layer
+// painted ABOVE the mask (so the sink has something to move) + a cluster layer
+// (the float anchor that sits above the mask). Order is array-paint order.
+type StyleLayer = { id: string; type: string; source?: string };
+
+const ISOLATABLE_LAYER: StyleLayer = { id: 'label_city', type: 'symbol' };
+const MASK_LAYER: StyleLayer = { id: MASK_LAYER_ID, type: 'fill' };
+const STRAY_LINE: StyleLayer = { id: 'boundary_country', type: 'line' };
+const CLUSTER_LAYER: StyleLayer = { id: 'clusters', type: 'circle', source: 'observations' };
+
+const AZ_POLYGON: MultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [-114.8, 31.3],
+        [-109.0, 31.3],
+        [-109.0, 37.0],
+        [-114.8, 37.0],
+        [-114.8, 31.3],
+      ],
+    ],
+  ],
+};
+
+const NM_POLYGON: MultiPolygon = {
+  type: 'MultiPolygon',
+  coordinates: [
+    [
+      [
+        [-109.0, 31.3],
+        [-103.0, 31.3],
+        [-103.0, 37.0],
+        [-109.0, 37.0],
+        [-109.0, 31.3],
+      ],
+    ],
+  ],
+};
+
+/**
+ * A stateful fake maplibre map exposing the {@link StateArtboardMap} surface.
+ * Records the ordered op log so order-sensitive invariants (restore-before-
+ * capture) are assertable, backs `renderWorldCopies` with real state (#765), and
+ * exposes `__fire('moveend' | 'style.load')` so the test drives the listeners
+ * the production effects register.
+ */
+function makeFakeMap(opts: { withMask: boolean }) {
+  const layers: StyleLayer[] = opts.withMask
+    ? [ISOLATABLE_LAYER, MASK_LAYER, STRAY_LINE, CLUSTER_LAYER]
+    : [ISOLATABLE_LAYER];
+  const filters: Record<string, unknown> = {};
+  let renderWorldCopiesState = true;
+  // Listener pools per event type (production uses bare `on`/`off`).
+  const handlers: Record<string, Array<() => void>> = {};
+  // Ordered op log of the calls whose SEQUENCE matters.
+  const ops: string[] = [];
+
+  const map = {
+    // ── ArtboardMap surface ──────────────────────────────────────────────
+    getStyle: () => ({ layers: layers.slice() }),
+    getFilter: vi.fn((layerId: string) => {
+      ops.push(`getFilter:${layerId}`);
+      return filters[layerId];
+    }),
+    setFilter: vi.fn((layerId: string, filter: unknown) => {
+      ops.push(`setFilter:${layerId}`);
+      filters[layerId] = filter;
+    }),
+    getLayer: vi.fn((layerId: string) =>
+      layers.find((l) => l.id === layerId) ?? null,
+    ),
+    getSource: vi.fn(() => null),
+    addSource: vi.fn(),
+    removeSource: vi.fn(),
+    moveLayer: vi.fn((layerId: string) => {
+      ops.push(`moveLayer:${layerId}`);
+    }),
+    addLayer: vi.fn((layer: Record<string, unknown>) => {
+      ops.push(`addLayer:${String(layer.id)}`);
+      layers.push({
+        id: String(layer.id),
+        type: String(layer.type),
+        source: layer.source as string | undefined,
+      });
+    }),
+    removeLayer: vi.fn((layerId: string) => {
+      ops.push(`removeLayer:${layerId}`);
+      const i = layers.findIndex((l) => l.id === layerId);
+      if (i !== -1) layers.splice(i, 1);
+    }),
+    triggerRepaint: vi.fn(),
+    // ── world-copies / style swap / events ──────────────────────────────
+    getRenderWorldCopies: vi.fn(() => renderWorldCopiesState),
+    setRenderWorldCopies: vi.fn((v: boolean) => {
+      renderWorldCopiesState = v;
+    }),
+    setStyle: vi.fn(() => {
+      ops.push('setStyle');
+    }),
+    on: vi.fn((type: string, cb: () => void) => {
+      (handlers[type] ??= []).push(cb);
+    }),
+    off: vi.fn((type: string, cb: () => void) => {
+      handlers[type] = (handlers[type] ?? []).filter((h) => h !== cb);
+    }),
+  };
+
+  return {
+    map,
+    ops,
+    filters,
+    layers,
+    // Test affordance: fire every registered listener for a given event type.
+    fire(type: 'moveend' | 'style.load') {
+      (handlers[type] ?? []).slice().forEach((cb) => cb());
+    },
+    handlerCount(type: 'moveend' | 'style.load') {
+      return (handlers[type] ?? []).length;
+    },
+    // Test affordance: simulate react-map-gl having NOT yet re-added the mask.
+    dropMaskLayer() {
+      const i = layers.findIndex((l) => l.id === MASK_LAYER_ID);
+      if (i !== -1) layers.splice(i, 1);
+    },
+    addMaskLayer() {
+      if (!layers.find((l) => l.id === MASK_LAYER_ID)) {
+        // Re-insert just after the isolatable label layer (array paint order).
+        layers.splice(1, 0, MASK_LAYER, STRAY_LINE, CLUSTER_LAYER);
+      }
+    },
+  };
+}
+
+function makeRef(map: unknown) {
+  return { current: { getMap: () => map } as StateArtboardMapRef };
+}
+
+describe('useStateArtboard — ordering invariants (P2 backfill, #884 · U13)', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+  });
+
+  // ── Invariant 1: (3a-ii) restore-before-capture ─────────────────────────
+  it('(3a-ii) restores the OLD isolation BEFORE capturing the new one on a state→state mask change', () => {
+    const fake = makeFakeMap({ withMask: true });
+    const ref = makeRef(fake.map);
+
+    // Initial state scope (AZ): captures the TRUE original (undefined) filter and
+    // merges in the within expression.
+    const { rerender } = renderHook(
+      ({ poly }: { poly: MultiPolygon }) => useStateArtboard(ref, true, poly),
+      { initialProps: { poly: AZ_POLYGON } },
+    );
+
+    // The label layer's stored filter is now the merged ['within', …] (no original).
+    const mergedAfterAz = fake.filters['label_city'];
+    expect(mergedAfterAz).toBeDefined();
+
+    fake.ops.length = 0; // focus the log on the state→state transition only.
+
+    // State→state in-place (AZ → NM): no style swap fires, so this runs purely
+    // through the (3a-ii) mask-change effect.
+    rerender({ poly: NM_POLYGON });
+
+    // The restore (setFilter:label_city back to the TRUE original) MUST precede
+    // the re-capture (getFilter:label_city). If capture ran first it would record
+    // the already-merged filter as the "original" — the #763 double-merge bug.
+    const restoreIdx = fake.ops.indexOf('setFilter:label_city');
+    const captureIdx = fake.ops.indexOf('getFilter:label_city');
+    expect(restoreIdx).toBeGreaterThanOrEqual(0);
+    expect(captureIdx).toBeGreaterThanOrEqual(0);
+    expect(restoreIdx).toBeLessThan(captureIdx);
+
+    // And the NET stored filter after the transition is a SINGLE within-merge
+    // over the TRUE original (undefined → `['within', <NM>]`), NOT a double-merge
+    // (`['all', ['within', <AZ>], ['within', <NM>]]`). A bare 2-element ['within',…]
+    // proves the restore reset to the true original BEFORE the re-capture+merge.
+    const stored = fake.filters['label_city'] as unknown[];
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored[0]).toBe('within');
+    expect(stored).toHaveLength(2);
+  });
+
+  // ── Invariant 2: (3b) getLayer-guard defers via styleEpoch re-fire ───────
+  it('(3b) defers float/sink (warn, no moveLayer) while state-mask-fill is absent, then applies after a style.load re-fires the effect', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fake = makeFakeMap({ withMask: true });
+    const ref = makeRef(fake.map);
+
+    // Simulate react-map-gl NOT having re-added the mask at first reconcile.
+    fake.dropMaskLayer();
+
+    renderHook(() => useStateArtboard(ref, true, AZ_POLYGON));
+
+    // The float effect hit the getLayer guard: warn-and-return, NO moveLayer/addLayer.
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[artboard] state-mask-fill not yet reconciled; deferring float/sink',
+    );
+    expect(
+      fake.ops.some((o) => o.startsWith('moveLayer:') || o.startsWith('addLayer:')),
+    ).toBe(false);
+
+    // react-map-gl re-adds the mask on the reconcile; a style.load bumps
+    // styleEpoch which re-fires the float effect — now the guard passes and the
+    // floats apply (halo + outline addLayer, stray-sink moveLayer). Wrap in act:
+    // the styleEpoch state bump must flush a re-render so the float effect re-runs.
+    fake.addMaskLayer();
+    act(() => {
+      fake.fire('style.load');
+    });
+
+    expect(fake.ops).toContain(`addLayer:${ARTBOARD_HALO_ID}`);
+    expect(fake.ops).toContain(`addLayer:${ARTBOARD_OUTLINE_ID}`);
+    expect(fake.ops.some((o) => o.startsWith('moveLayer:'))).toBe(true);
+
+    warnSpy.mockRestore();
+  });
+
+  // ── Invariant 3: (3b-teardown) keys on maskPolygon NOT maskTheme ─────────
+  it('(3b-teardown) does NOT tear down on a theme change (keyed on maskPolygon, not maskTheme); tears down only on mask unmount', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const fake = makeFakeMap({ withMask: true });
+    const ref = makeRef(fake.map);
+
+    const { rerender, unmount } = renderHook(
+      ({ poly }: { poly: MultiPolygon | null }) =>
+        useStateArtboard(ref, true, poly),
+      { initialProps: { poly: AZ_POLYGON as MultiPolygon | null } },
+    );
+
+    fake.ops.length = 0;
+
+    // A theme flip drives the MutationObserver (setStyle + re-tint). It MUST NOT
+    // run the teardown cleanup; the float effect (keyed on `maskTheme`) re-tints
+    // idempotently (removeFloatLayers THEN re-addFloatLayers), so the NET result
+    // is the floats still PRESENT. MutationObserver delivers on a microtask, and
+    // the maskTheme state bump re-fires the float effect — await the re-add.
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+    await waitFor(() => expect(fake.map.setStyle).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(fake.ops).toContain(`addLayer:${ARTBOARD_HALO_ID}`),
+    );
+    // The teardown signature would be a remove with NO subsequent re-add. Net
+    // presence holds: the floats are in the live style after the theme change.
+    expect(fake.layers.some((l) => l.id === ARTBOARD_HALO_ID)).toBe(true);
+    expect(fake.layers.some((l) => l.id === ARTBOARD_OUTLINE_ID)).toBe(true);
+
+    fake.ops.length = 0;
+
+    // Now unmount the mask (scope → us): maskPolygon → null triggers the teardown
+    // cleanup — restore filters + removeFloatLayers — and the float effect does
+    // NOT re-add (its `if (!maskPolygon) return` guard fires). Net: floats GONE.
+    act(() => {
+      rerender({ poly: null });
+    });
+    expect(
+      fake.ops.some(
+        (o) =>
+          o === `removeLayer:${ARTBOARD_HALO_ID}` ||
+          o === `removeLayer:${ARTBOARD_OUTLINE_ID}`,
+      ),
+    ).toBe(true);
+    // And they are NOT re-added — the teardown removed them for good (mask gone).
+    expect(fake.ops.includes(`addLayer:${ARTBOARD_HALO_ID}`)).toBe(false);
+    expect(fake.layers.some((l) => l.id === ARTBOARD_HALO_ID)).toBe(false);
+
+    unmount();
+  });
+
+  // ── Invariant 4: (world-copies) re-arms on moveend ──────────────────────
+  it('(world-copies) re-asserts the desired renderWorldCopies value on moveend after an in-flight clobber (#762/#765)', () => {
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    // No mask → desired renderWorldCopies = true. (Fake seeds it true, so the
+    // initial idempotent apply is a no-op; the moveend reassert is what we pin.)
+    renderHook(() => useStateArtboard(ref, true, null));
+
+    // A handler is registered on moveend (the reassert listener).
+    expect(fake.handlerCount('moveend')).toBeGreaterThan(0);
+
+    // Simulate an in-flight fitBounds/flyTo transform-clone clobbering the value.
+    fake.map.setRenderWorldCopies(false);
+    expect(fake.map.getRenderWorldCopies()).toBe(false);
+
+    // moveend fires (the clobbering animation finished): the reassert wins.
+    fake.fire('moveend');
+    expect(fake.map.getRenderWorldCopies()).toBe(true);
+  });
+
+  it('(world-copies) re-asserts FALSE on moveend while a mask is active', () => {
+    const fake = makeFakeMap({ withMask: true });
+    const ref = makeRef(fake.map);
+
+    // Masked scope → desired renderWorldCopies = false. Seed it (clobbered) true.
+    fake.map.setRenderWorldCopies(true);
+    renderHook(() => useStateArtboard(ref, true, AZ_POLYGON));
+
+    // The initial apply already drove it false (desired = false, was true).
+    expect(fake.map.getRenderWorldCopies()).toBe(false);
+
+    // Clobber back to true (in-flight clone), then moveend re-asserts false.
+    fake.map.setRenderWorldCopies(true);
+    fake.fire('moveend');
+    expect(fake.map.getRenderWorldCopies()).toBe(false);
+  });
+
+  // ── prevThemeRef same-value guard ───────────────────────────────────────
+  it('prevThemeRef guard: a NO-OP same-value data-theme write does NOT re-fire setStyle', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    renderHook(() => useStateArtboard(ref, true, null));
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+    // Writing the SAME value the attribute already had: MutationRecord fires, but
+    // the prevThemeRef short-circuit must keep setStyle from running. Flush the
+    // observer microtask before asserting the negative.
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      document.documentElement.setAttribute('data-theme', 'light');
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fake.map.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('prevThemeRef guard: a GENUINE light→dark flip fires setStyle EXACTLY ONCE and re-tints the mask theme', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    const { result } = renderHook(() => useStateArtboard(ref, true, null));
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+    expect(result.current.maskTheme).toBe('light');
+
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await waitFor(() => expect(fake.map.setStyle).toHaveBeenCalledTimes(1));
+    // The returned maskTheme re-tints in lockstep (consumed by the <Layer> paint).
+    expect(result.current.maskTheme).toBe('dark');
+  });
+
+  it('returns maskTheme seeded from the current [data-theme] attribute at mount', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    const { result } = renderHook(() => useStateArtboard(ref, true, null));
+    expect(result.current.maskTheme).toBe('dark');
+  });
+});

--- a/frontend/src/components/map/use-state-artboard.ts
+++ b/frontend/src/components/map/use-state-artboard.ts
@@ -1,0 +1,393 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import type { MultiPolygon } from 'geojson';
+import { BASEMAP_LIGHT, BASEMAP_DARK } from './basemap-style.js';
+import {
+  applyLabelIsolation,
+  restoreLabelIsolation,
+  bufferIsolationPolygon,
+  applyArtboardFidelity,
+  removeFloatLayers,
+  MASK_LAYER_ID,
+} from './artboard-layers.js';
+import type { ArtboardMap } from './artboard-layers.js';
+
+/**
+ * State-artboard hook (the #884 · U13 / #898 nerve-center consolidation;
+ * extracted verbatim from `MapCanvas.tsx`). Owns the ENTIRE artboard-fidelity
+ * machinery as ONE indivisible unit — the recurrent
+ * #760/#762/#763/#765/#849/#850 blank-map class lives here:
+ *
+ *   - the `renderWorldCopies` reassertion effect (#762/#765),
+ *   - the four mask/label-isolation effects:
+ *       (3a-i)  label isolation re-apply on THEME SWAP (`style.load` listener),
+ *       (3a-ii) label isolation re-apply on MASK CHANGE,
+ *       (3b)    float layers + stray-sink (post-reconcile, `styleEpoch`-keyed),
+ *       (3b-teardown) restore filters + remove floats on mask unmount,
+ *   - the `[data-theme]` MutationObserver that swaps the basemap (`setStyle`)
+ *     and re-tints the mask fill (`setMaskTheme`).
+ *
+ * It is the SOLE owner of ALL state the moved effects own:
+ *   - `maskTheme`        — reactive mask-fill theme (the ONLY value the parent
+ *                          needs back; consumed by the `<Layer>` `paint` prop),
+ *   - `savedFiltersRef`  — captured ORIGINAL basemap filters for exact teardown,
+ *   - `maskPolygonRef`   — the live prop mirror the once-registered `style.load`
+ *                          handler reads (fresh-closure pattern, #849/#351),
+ *   - `styleEpoch`       — bumps once per `style.load`; re-fires the float effect
+ *                          AFTER react-map-gl re-adds `state-mask-fill` (the
+ *                          3a/3b reconcile-sequencing split, #763), and
+ *   - `prevThemeRef`     — the MutationObserver's PRIVATE same-value de-dup guard
+ *                          (a no-op `data-theme` write must NOT re-fire
+ *                          `setStyle`).
+ *
+ * `styleEpoch` and `prevThemeRef` are fully PRIVATE (no parent/JSX consumer);
+ * only `maskTheme` is returned. The `mapRef` + the `<Map>`/`<Source>`/`<Layer>`
+ * JSX stay in `MapCanvas`; only the state + effects move here.
+ *
+ * ⚠ EXTRACT-AS-ONE-UNIT (#884 load-bearing guardrail): the 3a/3b halves must NOT
+ * be collapsed/split. 3b's `getLayer('state-mask-fill')` guard depends on
+ * react-map-gl having RE-ADDED the mask fill, which is deferred via the
+ * `styleEpoch` re-fire from 3a-i. The camera↔`renderWorldCopies` race flows
+ * through maplibre's animation loop (see `use-scope-camera.ts` #848), not a
+ * shared React value. Effect registration ORDER is preserved 1:1 with HEAD.
+ *
+ * Behaviour-preserving: every effect body, its deps, and the exhaustive-deps
+ * disables are 1:1 with the pre-extraction code. The named incident regression
+ * tests (#765 reassert-and-survive-moveend, #762 mask-first-layer, #763
+ * within-filter + float-re-add-after-dark-swap, the `[data-theme]`
+ * MutationObserver dedup) run end-to-end through `<MapCanvas>` against the
+ * stateful fake map in `MapCanvas.test.tsx` and stay green UNCHANGED; the
+ * ordering invariants are additionally re-asserted directly in
+ * `use-state-artboard.test.ts`. `e2e/state-artboard.spec.ts` is the live
+ * transform-clone-timing backstop.
+ */
+
+/**
+ * The minimal maplibre-map surface this hook's effects touch. Extends the
+ * helper-module {@link ArtboardMap} (label-isolation / float-layer ops) with the
+ * world-copies, style-swap, and event methods the artboard effects call
+ * directly:
+ *   - `getRenderWorldCopies` / `setRenderWorldCopies` — the #762/#765 reassert,
+ *   - `setStyle` — the `[data-theme]` basemap swap,
+ *   - `on` / `off` — `style.load` (theme-swap re-isolation) + `moveend`
+ *     (world-copies reassert win against the in-flight transform-clone replay).
+ *
+ * `getLayer` is already part of {@link ArtboardMap}. Same narrow-shape idiom as
+ * `use-scope-camera.ts`'s `ScopeCameraMap`: the surface documents exactly which
+ * APIs the artboard machinery drives. The real `map` from
+ * `mapRef.current.getMap()` is structurally compatible.
+ */
+export interface StateArtboardMap extends ArtboardMap {
+  getRenderWorldCopies: () => boolean;
+  setRenderWorldCopies: (renderWorldCopies: boolean) => void;
+  setStyle: (style: unknown) => void;
+  on: (type: 'style.load' | 'moveend', listener: () => void) => void;
+  off: (type: 'style.load' | 'moveend', listener: () => void) => void;
+}
+
+/**
+ * The minimal react-map-gl `MapRef` surface: only `getMap()`, returning a
+ * {@link StateArtboardMap}. `mapRef.current?.getMap()` is the live maplibre
+ * handle.
+ */
+export interface StateArtboardMapRef {
+  getMap: () => StateArtboardMap;
+}
+
+/**
+ * Consolidated state-artboard hook (#884 · U13 / #898). Wires ALL artboard
+ * machinery — the four mask/label-isolation effects, the `[data-theme]`
+ * MutationObserver (basemap + mask-fill swap), and the `renderWorldCopies`
+ * reassertion — to the live `mapRef`, owning every piece of cross-effect state.
+ *
+ * @param mapRef       ref to the react-map-gl `MapRef` (`getMap()` → maplibre)
+ * @param mapReady     gate: only touch the map once the `load` event fired
+ * @param maskPolygon  the current state-scope mask polygon, or undefined/null
+ * @returns `{ maskTheme }` — the reactive mask-fill theme the `<Layer>` paint
+ *          prop reads. `styleEpoch` + `prevThemeRef` stay private to the hook.
+ */
+export function useStateArtboard(
+  mapRef: RefObject<StateArtboardMapRef | null>,
+  mapReady: boolean,
+  maskPolygon: MultiPolygon | null | undefined,
+): { maskTheme: 'light' | 'dark' } {
+  /**
+   * Reactive theme for the state-artboard mask fill (#760/#762). Seeded from the
+   * current `[data-theme]` attribute and flipped by the SAME MutationObserver
+   * that swaps the basemap (below) — so the gray mask re-paints in lockstep with
+   * the basemap on a light/dark toggle. react-map-gl diffs the `<Layer>` `paint`
+   * prop, so updating this state re-paints the fill with no remount.
+   */
+  const [maskTheme, setMaskTheme] = useState<'light' | 'dark'>(() =>
+    typeof document !== 'undefined' &&
+    document.documentElement.getAttribute('data-theme') === 'dark'
+      ? 'dark'
+      : 'light',
+  );
+
+  // #763 — artboard FIDELITY imperative state.
+  //
+  // `savedFiltersRef` holds the basemap symbol layers' ORIGINAL filters captured
+  // when `applyLabelIsolation` ran, so `restoreLabelIsolation` can undo the
+  // `['within', …]` merge exactly when the mask unmounts (scope → us/chooser).
+  //
+  // `maskPolygonRef` mirrors the current prop so the ONCE-registered
+  // `style.load` handler (which would otherwise close over a stale value) reads
+  // the live polygon at swap time. Updated synchronously on render.
+  const savedFiltersRef = useRef<ReturnType<typeof applyLabelIsolation> | null>(
+    null,
+  );
+  const maskPolygonRef = useRef<MultiPolygon | null>(maskPolygon ?? null);
+  maskPolygonRef.current = maskPolygon ?? null;
+  // `styleEpoch` bumps once per `style.load` (i.e. per theme `setStyle` swap).
+  // It is a dep of the float/sink effect so that effect RE-RUNS after the new
+  // style finishes loading — by which time react-map-gl's reconcile has re-added
+  // `state-mask-fill`, so the guard passes and the float layers (which `setStyle`
+  // dropped) are restored. Without this, a theme swap left the artboard with NO
+  // halo/outline until the next unrelated render.
+  const [styleEpoch, setStyleEpoch] = useState(0);
+
+  // #762/#765 — `renderWorldCopies` reassertion across an IN-PLACE scope change.
+  //
+  // The declarative `renderWorldCopies={maskPolygon == null}` prop (on the
+  // `<MapView>` in MapCanvas) is necessary (react-map-gl/maplibre does NOT reset
+  // an ABSENT setting to its default — it retains the last value, so the prop
+  // must always carry an explicit value), but it is not sufficient on the
+  // `state → us` transition. That transition also changes `boundsKey`, which
+  // re-fires the camera effect and starts a `fitBounds` animation. maplibre's
+  // animation captures a CLONE of the current transform (with the OLD
+  // `renderWorldCopies: false`) and re-`apply`s it every animation frame —
+  // clobbering the `true` that react-map-gl set declaratively. The net live
+  // result was world copies stuck OFF after leaving a state scope for
+  // `?scope=us` (PR #765 bot review, reproduced live: `getRenderWorldCopies()`
+  // stayed `false`).
+  //
+  // Reassert imperatively on `maskPolygon` change AND on `moveend` (when the
+  // clobbering animation has finished) so the explicit value wins the race.
+  // Idempotent: a no-op when the map already matches the desired value.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const desired = maskPolygon == null;
+    const apply = () => {
+      if (map.getRenderWorldCopies() !== desired) {
+        map.setRenderWorldCopies(desired);
+      }
+    };
+    apply();
+    // Win the race against an in-flight fitBounds/flyTo transform-clone replay.
+    map.on('moveend', apply);
+    return () => {
+      map.off('moveend', apply);
+    };
+  }, [mapReady, maskPolygon]);
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // #763 — artboard FIDELITY: label isolation + clean exterior + float layers.
+  //
+  // ⚠ RECONCILE-SEQUENCING SPLIT (do NOT collapse this into one effect/handler).
+  //
+  // `map.setStyle()` (fired by the [data-theme] MutationObserver below) clears
+  // and asynchronously reloads ALL layers — dropping both the merged label
+  // filters AND the float layers — so everything must be re-applied after each
+  // swap. But the two halves have DIFFERENT timing requirements:
+  //
+  //   (3a) Label-filter isolation re-applies in `style.load`. Basemap symbol
+  //        layers exist immediately on style load and `applyLabelIsolation`
+  //        needs NO reference to `state-mask-fill`, so it is safe there.
+  //
+  //   (3b) The float `addLayer` + the `moveLayer` stray-sink re-apply from the
+  //        SEPARATE `maskPolygon`-watching effect below — NOT from `style.load`.
+  //        react-map-gl re-adds its managed declarative layers (including
+  //        `state-mask-fill`) on the NEXT React reconcile, which has NOT
+  //        happened yet when `style.load` fires. `moveLayer(x, 'state-mask-fill')`
+  //        or an `addLayer(..., 'state-mask-fill')` inside `style.load` therefore
+  //        throws `Cannot move layer before non-existing layer`. The effect
+  //        below re-fires on the next render (after the reconcile), so the
+  //        reference layer exists — and it still GUARDS on
+  //        `getLayer('state-mask-fill')` (warn-and-return, never call through).
+  //
+  // Collapsing (3b) back into the `style.load` handler reintroduces that throw.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  // (3a-i) Label isolation re-apply on THEME SWAP. Registered ONCE after
+  // `mapReady` as a `style.load` listener (which fires after each
+  // MutationObserver `setStyle`); the handler reads the live `maskPolygon` from
+  // a ref so it needs no re-registration on prop change. Basemap symbol layers
+  // exist immediately on `style.load`, and `applyLabelIsolation` needs no
+  // reference to `state-mask-fill`, so this is safe here (unlike the float/sink
+  // half — see the sequencing comment above).
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    const onStyleLoad = () => {
+      const poly = maskPolygonRef.current;
+      // Bump the epoch unconditionally so the float/sink effect re-runs after
+      // EVERY style reload (it re-adds the floats `setStyle` dropped, once the
+      // reconcile has re-added `state-mask-fill`).
+      setStyleEpoch((n) => n + 1);
+      if (!poly) return; // no state scope → no isolation (us/chooser untouched)
+      try {
+        // The within test uses the OUTWARD-BUFFERED polygon (so near-border
+        // interior labels survive); the #762 mask FILL keeps the EXACT polygon.
+        savedFiltersRef.current = applyLabelIsolation(
+          map,
+          bufferIsolationPolygon(poly),
+        );
+      } catch {
+        /* defensive — style churn after a swap; QA detects un-isolated labels */
+      }
+    };
+
+    map.on('style.load', onStyleLoad);
+    return () => {
+      map.off('style.load', onStyleLoad);
+    };
+    // mapReady-only: the handler reads maskPolygon from a ref, so it must NOT
+    // re-register on every prop change (that would leak listeners).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady]);
+
+  // (3a-ii) Label isolation re-apply on MASK CHANGE (initial mount, chooser/us →
+  // state, state → state in-place). Distinct from the `style.load` listener:
+  // those transitions do NOT swap the style, so no `style.load` fires. On a
+  // state → state change the OLD isolation must be restored before the NEW one
+  // is captured+applied (else the new `applyLabelIsolation` would capture the
+  // already-merged `['all', original, within]` filter as the "original").
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    if (!maskPolygon) return; // us/chooser: teardown effect restores originals
+    try {
+      if (savedFiltersRef.current) {
+        restoreLabelIsolation(map, savedFiltersRef.current);
+        savedFiltersRef.current = null;
+      }
+      savedFiltersRef.current = applyLabelIsolation(
+        map,
+        bufferIsolationPolygon(maskPolygon),
+      );
+    } catch {
+      /* defensive — style churn; QA detects un-isolated labels */
+    }
+  }, [mapReady, maskPolygon]);
+
+  // (3b) Float layers + stray-sink — runs from a `maskPolygon`-watching,
+  // `mapReady`-gated effect (also keyed on `maskTheme` so the float re-tints on
+  // a theme swap). It fires AFTER react-map-gl's reconcile has (re-)added
+  // `state-mask-fill`, and `addFloatLayers` is idempotent (removes any prior
+  // instance before re-adding), so re-running it on a theme change re-tints
+  // cleanly without thrashing the LABEL filters (which are owned by the (3a)
+  // `style.load` handler and the separate teardown effect below).
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    if (!maskPolygon) return;
+
+    // Guard: state-mask-fill MUST exist before any moveLayer/insert anchored to
+    // it. If react-map-gl has not re-added it yet, warn and return — the effect
+    // re-fires on the next render once the reconcile lands it. Calling through
+    // is the exact `Cannot move layer before non-existing layer` throw the
+    // 3a/3b split exists to avoid.
+    if (map.getLayer(MASK_LAYER_ID) == null) {
+      console.warn(
+        '[artboard] state-mask-fill not yet reconciled; deferring float/sink',
+      );
+      return;
+    }
+    try {
+      applyArtboardFidelity(map, maskPolygon, maskTheme);
+    } catch {
+      /* defensive — layer/style churn after a swap */
+    }
+    // `styleEpoch` re-runs this AFTER a theme `setStyle`+`style.load` so the
+    // floats `setStyle` dropped are re-added once `state-mask-fill` is back.
+  }, [mapReady, maskPolygon, maskTheme, styleEpoch]);
+
+  // (3b-teardown) Restore label filters + remove float layers when the mask
+  // unmounts (scope → us/chooser) OR the component unmounts. Keyed ONLY on
+  // `maskPolygon` (NOT `maskTheme`) so a theme swap — which re-applies isolation
+  // via (3a) `style.load` against the NEW style — does not trigger a stale
+  // restore against filters the `setStyle` already cleared. Guarded against a
+  // disposed map / missing layers (the helpers wrap their MapLibre calls).
+  useEffect(() => {
+    if (!mapReady) return;
+    if (!maskPolygon) return; // only arm teardown while a mask is active
+    return () => {
+      const liveMap = mapRef.current?.getMap();
+      if (!liveMap) return;
+      try {
+        if (savedFiltersRef.current) {
+          restoreLabelIsolation(liveMap, savedFiltersRef.current);
+          savedFiltersRef.current = null;
+        }
+        removeFloatLayers(liveMap);
+      } catch {
+        /* defensive — map gone after a swap or unmount */
+      }
+    };
+  }, [mapReady, maskPolygon]);
+
+  // [data-theme] observer — swap basemap when user toggles theme.
+  // Registered after mapReady so the map instance is guaranteed to exist.
+  // Cleaned up on unmount to prevent leaks. The observer is the single
+  // source of truth for basemap-vs-theme coupling — no prop drilling.
+  // Dark URL aliasing (G8): BASEMAP_DARK may resolve to the same
+  // visual tiles as light during the rollout window; the swap mechanism
+  // is correct regardless. See docs/design/01-spec/open-questions.md.
+  //
+  // Same-value guard: MutationRecord fires on every attribute write,
+  // including writes that set the SAME value the attribute already had
+  // (e.g. setAttribute('data-theme', 'light') when it's already 'light').
+  // Without the prevTheme ref, a no-op write would trigger setStyle and
+  // a redundant tile re-fetch.
+  const prevThemeRef = useRef<'light' | 'dark' | null>(null);
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    // Seed the prev ref with the current attribute value so the first
+    // observed mutation only fires setStyle when the value genuinely flips.
+    prevThemeRef.current =
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'dark'
+        : 'light';
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-theme'
+        ) {
+          const next: 'light' | 'dark' =
+            document.documentElement.getAttribute('data-theme') === 'dark'
+              ? 'dark'
+              : 'light';
+          if (next === prevThemeRef.current) return;
+          prevThemeRef.current = next;
+          const style = next === 'dark' ? BASEMAP_DARK : BASEMAP_LIGHT;
+          map.setStyle(style);
+          // #760/#762: re-paint the state-artboard mask fill in lockstep with
+          // the basemap swap. The mask <Layer> reads `maskTheme`; react-map-gl
+          // diffs `paint` so this re-tints the gray with no remount.
+          setMaskTheme(next);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, [mapReady]);
+
+  return { maskTheme };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    MC["MapCanvas (mapRef owner, JSX)"] -->|"useStateArtboard(mapRef, mapReady, maskPolygon)"| H["useStateArtboard hook"]
    H -->|"returns { maskTheme }"| MC
    MC -->|"maskTheme → &lt;Layer&gt; paint"| L["state-mask-fill &lt;Layer&gt;"]

    subgraph H["useStateArtboard — ONE indivisible unit"]
      direction TB
      S["state owners: maskTheme · savedFiltersRef · maskPolygonRef · styleEpoch · prevThemeRef (private)"]
      E1["1 · renderWorldCopies reassert (on maskPolygon + moveend)"]
      E2["2 · 3a-i label-iso on style.load (bumps styleEpoch)"]
      E3["3 · 3a-ii label-iso on mask change (restore-before-capture)"]
      E4["4 · 3b float+stray-sink (getLayer-guard; re-fires on styleEpoch)"]
      E5["5 · 3b-teardown (keyed on maskPolygon, NOT maskTheme)"]
      E6["6 · [data-theme] MutationObserver → setStyle + setMaskTheme (prevThemeRef no-op guard)"]
      E2 -. "styleEpoch re-fire after style.load" .-> E4
      E6 -. "setStyle → style.load fires" .-> E2
    end
```

```mermaid
sequenceDiagram
    participant User
    participant Observer as "[data-theme] MutationObserver"
    participant Map as "maplibre map"
    participant E3a as "3a-i style.load handler"
    participant E3b as "3b float effect"

    User->>Observer: toggle theme (data-theme flip)
    Note over Observer: prevThemeRef guard — no-op write does NOT re-fire
    Observer->>Map: setStyle(BASEMAP_DARK) + setMaskTheme('dark')
    Map->>E3a: style.load fires
    E3a->>E3a: setStyleEpoch(n+1) + re-apply label isolation
    Note over E3b: react-map-gl reconcile re-adds state-mask-fill
    E3b->>Map: getLayer guard passes → applyArtboardFidelity (re-add floats)
```

## Summary

- **Why:** Final and highest-risk unit of the MapCanvas decomposition epic (#884). Consolidates the state-artboard "nerve-center" — the recurrent #760/#762/#763/#765/#849/#850 blank-map class — into ONE hook so its load-bearing effect ordering and cross-effect state live in a single, separately-testable place instead of scattered through a 2,400-line component.
- **What moves as ONE indivisible unit:** the four mask/label-isolation effects, the `[data-theme]` MutationObserver (basemap `setStyle` + mask-fill re-tint), and the `renderWorldCopies` reassertion — owning ALL five pieces of their state (`maskTheme`, `savedFiltersRef`, `maskPolygonRef`, `styleEpoch`, and the MutationObserver-private `prevThemeRef` same-value guard). The 3a/3b reconcile-sequencing split is preserved: 3b's `getLayer('state-mask-fill')` guard depends on the `styleEpoch` re-fire from 3a-i. Only `maskTheme` is returned; `styleEpoch`/`prevThemeRef` stay private. `mapRef` + the `<MapView>`/`<Source>`/`<Layer>` JSX stay in MapCanvas.
- **Behaviour-preserving:** every effect body, its deps, the exhaustive-deps disables, and the effect registration order are 1:1 with the pre-extraction code; the once-registered `style.load` fresh-closure ref-mirror pattern (#849/#351) is intact. MapCanvas.tsx shrinks 252 net lines. No visible UI change.

## Screenshots

N/A — behavior-preserving extraction, no visible UI change. The moved effect bodies are byte-identical to the pre-extraction code (verified against `HEAD`), and all 83 `MapCanvas.test.tsx` characterization tests (including the named #760/#762/#763/#765 incident regressions) pass UNCHANGED. The live transform-clone backstop `e2e/state-artboard.spec.ts` is unchanged and runs in the CI `e2e` gate.

- [x] N/A — class is consumed only by a primitive that ships its own CSS (no CSS / className touched — TypeScript-only move)
- [x] `N/A — not UI` (behavior-preserving extraction, no visible UI change)

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (`tsc -b && vite build`) — green
- [x] `npm test --workspace @bird-watch/frontend` — green (83 files / 1273 tests)
- [x] Characterization-test-first (mandatory for the nerve-center): confirmed the named incident regressions GREEN against the un-consolidated code, then GREEN again UNCHANGED after extraction — #765 reassert-and-survive-moveend, #762 mask-first-layer, #763 within-filter + float-re-add-after-dark-swap, #737 camera-neutral, and the `[data-theme]` MutationObserver same-value dedup
- [x] New direct `renderHook` tests added (`use-state-artboard.test.ts`, the P2 ordering-invariant backfill): 3a-ii restore-before-capture · 3b getLayer-guard defers via styleEpoch re-fire · teardown keys on `maskPolygon` not `maskTheme` · world-copies re-arms on moveend · prevThemeRef same-value guard
- [x] `npx knip --no-progress` — clean (no new dead-code finding)
- [x] root `npm run lint` + Sky-Atlas token guard — green
- [x] maplibre-gl 5.x context7 pulled for `setStyle` / `getLayer` / `setRenderWorldCopies` before touching them — signatures unchanged from the moved code
- [ ] (UI only) Playwright MCP smoke — N/A (behavior-preserving extraction, no visible UI change; `e2e/state-artboard.spec.ts` is the live backstop in CI)

## Plan reference

Out of plan — MapCanvas consolidation epic #884, unit U13 (#898). Wave 3 (LAST, ALONE). Folds the P2 `use-state-artboard.ts` ordering-invariant backfill onto this PR per the epic.

Closes #898
Part of #884

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)