### PR TITLE
refactor(frontend): extract marker layers → GroupMarkerLayer + DisplacedSilhouetteLayer (U11, #896)

### DIFF
--- a/frontend/src/components/map/DisplacedSilhouetteLayer.test.tsx
+++ b/frontend/src/components/map/DisplacedSilhouetteLayer.test.tsx
@@ -1,0 +1,256 @@
+import { forwardRef, useImperativeHandle } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { Observation } from '@bird-watch/shared-types';
+import { DisplacedSilhouetteLayer } from './DisplacedSilhouetteLayer.js';
+import type { SilhouetteOffsets } from './obs-derive.js';
+import type { HitLayerMap, HitTargetMarker } from './MapMarkerHitLayer.js';
+
+/* ── Mocks ───────────────────────────────────────────────────────────────────
+   The twins wrap <button>s in <PresentationMarker> → react-map-gl <Marker>; the
+   Marker mock forwardRefs + exposes getElement() (so the #459 role-strip effect
+   runs) and renders children inline with lng/lat as data attributes so the #718
+   "project from the DISPLACED point" contract is assertable.
+
+   MapMarkerHitLayer is mocked as a lightweight double so the co-located mount
+   (and its `map && (...)` guard) is assertable without its projection internals. */
+vi.mock('react-map-gl/maplibre', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Marker: forwardRef(function Marker({ children, longitude, latitude }: any, ref: any) {
+    const el = document.createElement('div');
+    useImperativeHandle(ref, () => ({ getElement: () => el }), []);
+    return (
+      <div data-testid="mock-marker" data-lng={longitude} data-lat={latitude}>
+        {children}
+      </div>
+    );
+  }),
+}));
+
+vi.mock('./MapMarkerHitLayer.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  MapMarkerHitLayer: ({ markers, isCoarsePointer }: any) => (
+    <div
+      data-testid="mock-hit-layer"
+      data-marker-count={markers.length}
+      data-coarse={isCoarsePointer ? 'yes' : 'no'}
+    />
+  ),
+}));
+
+// Helpers --------------------------------------------------------------------
+
+function obs(over: Partial<Observation> = {}): Observation {
+  return {
+    subId: 'S1',
+    speciesCode: 'houfin',
+    comName: 'House Finch',
+    lat: 32.27,
+    lng: -110.85,
+    obsDt: '2026-04-15T10:00:00Z',
+    locId: 'L1',
+    locName: 'Sweetwater Wetlands',
+    howMany: 1,
+    isNotable: false,
+    silhouetteId: null,
+    familyCode: 'fringillidae',
+    ...over,
+  };
+}
+
+function offsets(
+  entries: Array<[string, { dx: number; dy: number; longitude: number; latitude: number }]>,
+): SilhouetteOffsets {
+  return new Map(entries);
+}
+
+const fakeMap: HitLayerMap = {
+  project: () => ({ x: 0, y: 0 }),
+  on: () => {},
+  off: () => {},
+};
+
+const noop = () => {};
+
+describe('DisplacedSilhouetteLayer', () => {
+  describe('displaced-silhouette twins', () => {
+    it('renders an accessible <button> twin per displaced subId', () => {
+      const o = obs({ subId: 'S1', comName: 'Verdin' });
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([['S1', { dx: 5, dy: 5, longitude: -110.8, latitude: 32.3 }]])}
+          obsLookup={{ S1: o }}
+          silhouetteRenderById={new Map([['S1', { svgData: 'M0 0L24 24Z', color: '#C77A2E' }]])}
+          onOpen={noop}
+          map={null}
+          hitMarkers={[]}
+          onSelect={noop}
+          isCoarsePointer={false}
+        />,
+      );
+      const btn = screen.getByTestId('displaced-silhouette');
+      expect(btn).toHaveAttribute('data-subid', 'S1');
+      expect(btn).toHaveAttribute('aria-label', 'Verdin observation');
+      // SVG body path painted with the family color.
+      expect(btn.querySelector('path[fill="#C77A2E"]')).not.toBeNull();
+    });
+
+    it('skips a displaced subId with no matching observation (obsLookup miss → null)', () => {
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([['GHOST', { dx: 1, dy: 1, longitude: -110, latitude: 32 }]])}
+          obsLookup={{}}
+          silhouetteRenderById={new Map()}
+          onOpen={noop}
+          map={null}
+          hitMarkers={[]}
+          onSelect={noop}
+          isCoarsePointer={false}
+        />,
+      );
+      expect(screen.queryByTestId('displaced-silhouette')).toBeNull();
+    });
+
+    it('falls back to the _FALLBACK circle when the family has no silhouette svgData', () => {
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([['S1', { dx: 0, dy: 0, longitude: -110.8, latitude: 32.3 }]])}
+          obsLookup={{ S1: obs({ subId: 'S1' }) }}
+          silhouetteRenderById={new Map([['S1', { svgData: null, color: '#555' }]])}
+          onOpen={noop}
+          map={null}
+          hitMarkers={[]}
+          onSelect={noop}
+          isCoarsePointer={false}
+        />,
+      );
+      const btn = screen.getByTestId('displaced-silhouette');
+      expect(btn.querySelector('circle')).not.toBeNull();
+      expect(btn.querySelector('path')).toBeNull();
+    });
+
+    it('projects the popover from the DISPLACED point, not the obs survey point (#718)', () => {
+      const onOpen = vi.fn();
+      const o = obs({ subId: 'S1', lng: -110.85, lat: 32.27 });
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([['S1', { dx: 12, dy: -8, longitude: -110.123, latitude: 32.987 }]])}
+          obsLookup={{ S1: o }}
+          silhouetteRenderById={new Map([['S1', { svgData: 'M0 0Z', color: '#abc' }]])}
+          onOpen={onOpen}
+          map={null}
+          hitMarkers={[]}
+          onSelect={noop}
+          isCoarsePointer={false}
+        />,
+      );
+      // The PresentationMarker (Marker mock) is anchored at the DISPLACED lng/lat.
+      const marker = screen.getByTestId('mock-marker');
+      expect(marker).toHaveAttribute('data-lng', '-110.123');
+      expect(marker).toHaveAttribute('data-lat', '32.987');
+
+      fireEvent.click(screen.getByTestId('displaced-silhouette'));
+      // openPopoverAt receives the DISPLACED coord, NOT obs.lng/obs.lat.
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onOpen.mock.calls[0][0]).toBe(o);
+      expect(onOpen.mock.calls[0][1]).toEqual([-110.123, 32.987]);
+    });
+
+    it('keys each twin on `displaced-${subId}` — stable identity under re-render', () => {
+      const props = {
+        obsLookup: { S1: obs({ subId: 'S1' }) },
+        silhouetteRenderById: new Map([['S1', { svgData: 'M0 0Z', color: '#abc' }]]),
+        onOpen: noop,
+        map: null,
+        hitMarkers: [] as HitTargetMarker[],
+        onSelect: noop,
+        isCoarsePointer: false,
+      };
+      const { rerender } = render(
+        <DisplacedSilhouetteLayer
+          {...props}
+          silhouetteOffsets={offsets([['S1', { dx: 1, dy: 1, longitude: -110.8, latitude: 32.3 }]])}
+        />,
+      );
+      const first = screen.getByTestId('mock-marker');
+      rerender(
+        <DisplacedSilhouetteLayer
+          {...props}
+          silhouetteOffsets={offsets([['S1', { dx: 2, dy: 2, longitude: -110.7, latitude: 32.4 }]])}
+        />,
+      );
+      const second = screen.getByTestId('mock-marker');
+      // Same key ⇒ React reconciled in place (no remount); position updated.
+      expect(second).toBe(first);
+      expect(second).toHaveAttribute('data-lng', '-110.7');
+    });
+  });
+
+  describe('co-located hit-layer mount (block 3)', () => {
+    it('mounts <MapMarkerHitLayer> when `map` is present, forwarding markers + isCoarsePointer', () => {
+      const hitMarkers: HitTargetMarker[] = [
+        {
+          subId: 'S1',
+          comName: 'House Finch',
+          familyCode: 'fringillidae',
+          locName: 'L1',
+          obsDt: '2026-04-15T10:00:00Z',
+          isNotable: false,
+          lngLat: [-110.85, 32.27],
+        },
+      ];
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([])}
+          obsLookup={{}}
+          silhouetteRenderById={new Map()}
+          onOpen={noop}
+          map={fakeMap}
+          hitMarkers={hitMarkers}
+          onSelect={noop}
+          isCoarsePointer
+        />,
+      );
+      const hit = screen.getByTestId('mock-hit-layer');
+      expect(hit).toHaveAttribute('data-marker-count', '1');
+      expect(hit).toHaveAttribute('data-coarse', 'yes');
+    });
+
+    it('suppresses the hit-layer mount when `map` is null (the map && (...) guard)', () => {
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([])}
+          obsLookup={{}}
+          silhouetteRenderById={new Map()}
+          onOpen={noop}
+          map={null}
+          hitMarkers={[]}
+          onSelect={noop}
+          isCoarsePointer={false}
+        />,
+      );
+      expect(screen.queryByTestId('mock-hit-layer')).toBeNull();
+    });
+
+    it('routes a hit-layer onSelect call through to the onSelect prop', () => {
+      // The hit-layer mock does not invoke onSelect, so verify the prop is the
+      // exact callback the parent passed (handleHitSelect) — call it directly.
+      const onSelect = vi.fn();
+      render(
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={offsets([])}
+          obsLookup={{}}
+          silhouetteRenderById={new Map()}
+          onOpen={noop}
+          map={fakeMap}
+          hitMarkers={[]}
+          onSelect={onSelect}
+          isCoarsePointer={false}
+        />,
+      );
+      // Mount present (map non-null) is the contract; the onSelect wiring is the
+      // same reference passed down — exercised end-to-end in MapCanvas + e2e.
+      expect(screen.getByTestId('mock-hit-layer')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/map/DisplacedSilhouetteLayer.tsx
+++ b/frontend/src/components/map/DisplacedSilhouetteLayer.tsx
@@ -1,0 +1,159 @@
+import type { Observation } from '@bird-watch/shared-types';
+import { PresentationMarker } from './PresentationMarker.js';
+import { SILHOUETTE_PX } from './deconflict.js';
+import type { SilhouetteOffsets } from './obs-derive.js';
+import {
+  MapMarkerHitLayer,
+  type HitLayerMap,
+  type HitTargetMarker,
+} from './MapMarkerHitLayer.js';
+
+/**
+ * DisplacedSilhouetteLayer — presentational render of the displaced-silhouette
+ * `<button>` twins (issue #554 scope expansion) plus the co-located
+ * `<MapMarkerHitLayer>` mount (issue #247/#277). Extracted verbatim from
+ * `MapCanvas.tsx` (epic #884 · U11 / #896).
+ *
+ * Both surfaces are overlay siblings of the maplibre canvas: the twins keep a
+ * silhouette VISIBLE when deconflict has pushed it aside (its canvas-painted
+ * original is hidden via feature-state), and the hit layer hosts the wider
+ * clickable hit targets for individual observations at high zoom.
+ *
+ * Presentational only: holds NO map ref of its own and inspects no shape to
+ * pick a domain action. The parent (`MapCanvas`) owns all handlers (`onOpen` =
+ * `openPopoverAt`, `onSelect` = `handleHitSelect`) and all derived state
+ * (`silhouetteOffsets`, `obsLookup`, `silhouetteRenderById`, `hitMarkers`). The
+ * `map` instance is *received* as a prop solely to forward it to the
+ * `<MapMarkerHitLayer>` mount — this component does not create, mutate, or
+ * subscribe to it. Exemplar idiom: `AdaptiveGridMarker.tsx`.
+ */
+interface DisplacedSilhouetteLayerProps {
+  /** Per-subId displaced lng/lat from MapCanvas's reconcile pass. */
+  silhouetteOffsets: SilhouetteOffsets;
+  /** subId → Observation lookup (obs-derive `buildObsLookup`). */
+  obsLookup: Record<string, Observation>;
+  /** subId → rendered silhouette path + color (obs-derive `buildSilhouetteRenderById`). */
+  silhouetteRenderById: Map<string, { svgData: string | null; color: string }>;
+  /**
+   * `MapCanvas.openPopoverAt` — opens the popover at an explicit lngLat. The
+   * twin projects from the DISPLACED point (`entry.longitude/entry.latitude`),
+   * never the hidden survey point (#718).
+   */
+  onOpen: (obs: Observation, lngLat: [number, number]) => void;
+  /**
+   * The maplibre map instance, forwarded to `<MapMarkerHitLayer>`. Null until
+   * `mapReady`; the `map && (...)` guard suppresses the mount until then.
+   */
+  map: HitLayerMap | null;
+  /** Hit-target markers (obs-derive `buildHitMarkers`) for the hit-layer mount. */
+  hitMarkers: HitTargetMarker[];
+  /** `MapCanvas.handleHitSelect` — resolves the obs by subId and opens the popover. */
+  onSelect: (subId: string) => void;
+  /** Drives 48×48 (coarse) vs 40×40 (fine) hit-target sizing in the hit layer. */
+  isCoarsePointer: boolean;
+}
+
+export function DisplacedSilhouetteLayer({
+  silhouetteOffsets,
+  obsLookup,
+  silhouetteRenderById,
+  onOpen,
+  map,
+  hitMarkers,
+  onSelect,
+  isCoarsePointer,
+}: DisplacedSilhouetteLayerProps) {
+  return (
+    <>
+      {Array.from(silhouetteOffsets.entries()).map(([subId, entry]) => {
+        const obs = obsLookup[subId];
+        if (!obs) return null;
+        const sil = silhouetteRenderById.get(subId);
+        const color = sil?.color ?? '#555';
+        const svgData = sil?.svgData ?? null;
+        // Displaced silhouettes are rendered as accessible <button>
+        // wrappers so a click opens the obs popover even though the
+        // canvas-painted twin is hidden. The PresentationMarker outer
+        // div has role="presentation" (see PresentationMarker effect),
+        // so the inner <button> remains the canonical interactive
+        // element with full keyboard + AT support.
+        return (
+          <PresentationMarker
+            key={`displaced-${subId}`}
+            longitude={entry.longitude}
+            latitude={entry.latitude}
+            anchor="center"
+          >
+            <button
+              type="button"
+              data-testid="displaced-silhouette"
+              data-subid={subId}
+              aria-label={`${obs.comName} observation`}
+              // Issue #718: project the popover from `entry.longitude/
+              // entry.latitude` — the DISPLACED visual position — not
+              // from `obs.lng/obs.lat`. The obs survey point is hidden
+              // beneath the canvas-painted twin; projecting from it
+              // would land the popover next to the invisible original
+              // instead of the silhouette the user actually clicked,
+              // defeating the fix at this site.
+              onClick={() => onOpen(obs, [entry.longitude, entry.latitude])}
+              style={{
+                display: 'inline-block',
+                width: SILHOUETTE_PX,
+                height: SILHOUETTE_PX,
+                padding: 0,
+                margin: 0,
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              {svgData ? (
+                <svg
+                  viewBox="0 0 24 24"
+                  width={SILHOUETTE_PX}
+                  height={SILHOUETTE_PX}
+                  aria-hidden="true"
+                >
+                  {/* Halo (white stroke) painted first so the colored
+                      body sits on top, mirroring the SDF symbol layer's
+                      icon-halo-color #ffffff / icon-halo-width 1.5. */}
+                  <path
+                    d={svgData}
+                    fill="none"
+                    stroke="#ffffff"
+                    strokeWidth="2"
+                    strokeLinejoin="round"
+                  />
+                  <path d={svgData} fill={color} />
+                </svg>
+              ) : (
+                // Fallback circle when the family has no Phylopic
+                // silhouette — matches the _FALLBACK opacity tinting.
+                <svg
+                  viewBox="0 0 24 24"
+                  width={SILHOUETTE_PX}
+                  height={SILHOUETTE_PX}
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="8" fill={color} opacity="0.5" />
+                </svg>
+              )}
+            </button>
+          </PresentationMarker>
+        );
+      })}
+      {/* Issue #247 (original hit-layer) / #277 (Spider v2 narrowed to auto-spider stacks +
+          unclustered): HTML overlay for stacked and unclustered markers, mounted as a sibling
+          of the maplibre canvas inside the relatively-positioned wrapper. */}
+      {map && (
+        <MapMarkerHitLayer
+          map={map}
+          markers={hitMarkers}
+          onSelect={onSelect}
+          isCoarsePointer={isCoarsePointer}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/map/GroupMarkerLayer.test.tsx
+++ b/frontend/src/components/map/GroupMarkerLayer.test.tsx
@@ -1,0 +1,276 @@
+import { forwardRef, useImperativeHandle } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GroupMarkerLayer } from './GroupMarkerLayer.js';
+import type { DeconflictGroup, DeconflictInput, RenderedShape } from './deconflict.js';
+import type { ResolvedGrid } from './adaptive-grid.js';
+
+/* ── Mocks ───────────────────────────────────────────────────────────────────
+   The layer wraps every marker in <PresentationMarker>, which itself wraps the
+   react-map-gl/maplibre <Marker>. The Marker mock forwardRefs + exposes a real
+   getElement() node (so PresentationMarker's #459 role-strip effect runs and we
+   can assert it), and renders children inline with lng/lat as data attributes.
+
+   AdaptiveGridMarker and ClusterPill are mocked as lightweight test doubles so
+   the dispatch (pill→ClusterPill, grid→AdaptiveGridMarker, silhouette→null) is
+   assertable by data-testid without dragging in their full render trees. */
+let markerSeq = 0;
+vi.mock('react-map-gl/maplibre', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Marker: forwardRef(function Marker({ children, longitude, latitude }: any, ref: any) {
+    const el = document.createElement('div');
+    useImperativeHandle(ref, () => ({ getElement: () => el }), []);
+    return (
+      <div data-testid="mock-marker" data-lng={longitude} data-lat={latitude}>
+        {children}
+      </div>
+    );
+  }),
+}));
+
+vi.mock('./AdaptiveGridMarker.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  AdaptiveGridMarker: ({ onClick, onDrillIn, onSelectSpecies, ariaLabel }: any) => (
+    <button
+      type="button"
+      data-testid="mock-grid-marker"
+      data-aria={ariaLabel}
+      data-has-drill={onDrillIn ? 'yes' : 'no'}
+      data-has-select={onSelectSpecies ? 'yes' : 'no'}
+      onClick={onClick}
+    >
+      {onDrillIn ? (
+        <span data-testid="drill-trigger" onClick={() => onDrillIn()} />
+      ) : null}
+    </button>
+  ),
+}));
+
+vi.mock('../ds/ClusterPill.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ClusterPill: ({ count, onClick }: any) => (
+    <button type="button" data-testid="mock-cluster-pill" data-count={count} onClick={onClick} />
+  ),
+}));
+
+// Helpers --------------------------------------------------------------------
+
+const GRID_1x1: ResolvedGrid = { tag: 'grid', cols: 1, rows: 1 };
+
+function input(rendered: RenderedShape, over: Partial<DeconflictInput> = {}): DeconflictInput {
+  return {
+    cluster_id: 1,
+    px: 0,
+    py: 0,
+    rendered,
+    point_count: 3,
+    uniqueFamilies: 1,
+    longitude: -110.9,
+    latitude: 32.2,
+    ...over,
+  };
+}
+
+function group(
+  key: string,
+  rendered: RenderedShape,
+  over: Partial<DeconflictInput> = {},
+): DeconflictGroup {
+  return {
+    anchor: input(rendered, over),
+    memberIds: [1],
+    key,
+    ariaLabel: `aria-${key}`,
+    leaves: [],
+  };
+}
+
+const noop = () => {};
+
+describe('GroupMarkerLayer', () => {
+  beforeEach(() => {
+    markerSeq = 0;
+  });
+
+  it("renders a ClusterPill for a 'pill' anchor, passing its count", () => {
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-pill', { kind: 'pill', count: 7 }, { point_count: 7 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    const pill = screen.getByTestId('mock-cluster-pill');
+    expect(pill).toHaveAttribute('data-count', '7');
+    expect(screen.queryByTestId('mock-grid-marker')).toBeNull();
+  });
+
+  it("renders an AdaptiveGridMarker for a 'grid' anchor", () => {
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    const grid = screen.getByTestId('mock-grid-marker');
+    expect(grid).toHaveAttribute('data-aria', 'aria-g-grid');
+    expect(screen.queryByTestId('mock-cluster-pill')).toBeNull();
+  });
+
+  it("renders NOTHING for a 'silhouette' anchor (canvas symbol layer paints it)", () => {
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-sil', { kind: 'silhouette' })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.queryByTestId('mock-marker')).toBeNull();
+    expect(screen.queryByTestId('mock-grid-marker')).toBeNull();
+    expect(screen.queryByTestId('mock-cluster-pill')).toBeNull();
+  });
+
+  it('dispatches a mixed slice: pill + grid + silhouette → pill, grid, (null)', () => {
+    render(
+      <GroupMarkerLayer
+        groups={[
+          group('g-pill', { kind: 'pill', count: 4 }, { point_count: 4 }),
+          group('g-grid', { kind: 'grid', shape: GRID_1x1 }),
+          group('g-sil', { kind: 'silhouette' }),
+        ]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.getAllByTestId('mock-cluster-pill')).toHaveLength(1);
+    expect(screen.getAllByTestId('mock-grid-marker')).toHaveLength(1);
+    // pill + grid render markers; silhouette renders none → 2 markers total.
+    expect(screen.getAllByTestId('mock-marker')).toHaveLength(2);
+  });
+
+  it('keys each marker on g.key — stable identity under re-render (#552 churn class)', () => {
+    const groups = [group('bucket-A', { kind: 'pill', count: 2 }, { point_count: 2 })];
+    const { rerender } = render(
+      <GroupMarkerLayer
+        groups={groups}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    const first = screen.getByTestId('mock-marker');
+    // Re-render with a NEW group array but the SAME key → React reuses the node.
+    rerender(
+      <GroupMarkerLayer
+        groups={[group('bucket-A', { kind: 'pill', count: 5 }, { point_count: 5 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    const second = screen.getByTestId('mock-marker');
+    // Same DOM node identity ⇒ React reconciled by key, did not remount.
+    expect(second).toBe(first);
+    expect(screen.getByTestId('mock-cluster-pill')).toHaveAttribute('data-count', '5');
+  });
+
+  it('forwards the clicked element to onGroupClick from a pill click', () => {
+    const onGroupClick = vi.fn();
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-pill', { kind: 'pill', count: 3 }, { point_count: 3 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={onGroupClick}
+        onDrillIn={noop}
+      />,
+    );
+    const pill = screen.getByTestId('mock-cluster-pill');
+    fireEvent.click(pill);
+    expect(onGroupClick).toHaveBeenCalledTimes(1);
+    // arg 0 = the group; arg 1 = the clicked element (e.currentTarget).
+    expect(onGroupClick.mock.calls[0][0].key).toBe('g-pill');
+    expect(onGroupClick.mock.calls[0][1]).toBe(pill);
+  });
+
+  it('passes the group (no element) to onGroupClick from a grid-marker click', () => {
+    const onGroupClick = vi.fn();
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={onGroupClick}
+        onDrillIn={noop}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('mock-grid-marker'));
+    expect(onGroupClick).toHaveBeenCalledTimes(1);
+    expect(onGroupClick.mock.calls[0][0].key).toBe('g-grid');
+  });
+
+  it('wires onDrillIn with the anchor lng/lat when both coords are present', () => {
+    const onDrillIn = vi.fn();
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 }, { longitude: -111, latitude: 34 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={onDrillIn}
+      />,
+    );
+    expect(screen.getByTestId('mock-grid-marker')).toHaveAttribute('data-has-drill', 'yes');
+    fireEvent.click(screen.getByTestId('drill-trigger'));
+    expect(onDrillIn).toHaveBeenCalledWith([-111, 34]);
+  });
+
+  it('omits onDrillIn when the anchor lacks coordinates', () => {
+    render(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 }, { longitude: undefined, latitude: undefined })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.getByTestId('mock-grid-marker')).toHaveAttribute('data-has-drill', 'no');
+  });
+
+  it('threads onSelectSpecies through to the grid marker only when provided', () => {
+    const { rerender } = render(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.getByTestId('mock-grid-marker')).toHaveAttribute('data-has-select', 'no');
+
+    rerender(
+      <GroupMarkerLayer
+        groups={[group('g-grid', { kind: 'grid', shape: GRID_1x1 })]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+        onSelectSpecies={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('mock-grid-marker')).toHaveAttribute('data-has-select', 'yes');
+  });
+});

--- a/frontend/src/components/map/GroupMarkerLayer.tsx
+++ b/frontend/src/components/map/GroupMarkerLayer.tsx
@@ -1,0 +1,107 @@
+import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
+import { PresentationMarker } from './PresentationMarker.js';
+import { ClusterPill } from '../ds/ClusterPill.js';
+import type { DeconflictGroup } from './deconflict.js';
+
+/**
+ * GroupMarkerLayer — presentational dispatch for the unified deconflict render
+ * (issue #554), extracted verbatim from `MapCanvas.tsx` (epic #884 · U11 / #896).
+ *
+ * Iterates the `groups` slice — one entry per overlap component — and dispatches
+ * to `<ClusterPill>`, the canvas symbol layer (null), or `<AdaptiveGridMarker>`
+ * based on the anchor's `rendered.kind`. The spatial-bucket key (`group.key`) is
+ * stable when the anchor stays in the same ~14px bucket, so React's reconciler
+ * doesn't churn under pan (#552 churn class).
+ *
+ * Presentational only: holds NO map ref, inspects no shape to pick a domain
+ * action. The parent (`MapCanvas`) owns all handlers (`onGroupClick`,
+ * `onSelectSpecies`, `onDrillIn`) and derived state; this component selects which
+ * handler each branch wires and renders. Exemplar idiom: `AdaptiveGridMarker.tsx`.
+ */
+interface GroupMarkerLayerProps {
+  groups: DeconflictGroup[];
+  isCoarsePointer: boolean;
+  detailOpen: boolean;
+  /** `MapCanvas.handleGroupClick` — receives the group + (for pills) the clicked element. */
+  onGroupClick: (group: DeconflictGroup, anchorEl?: HTMLElement | null) => void;
+  /** `MapCanvas`'s `onSelectSpecies` prop, threaded through to grid markers. */
+  onSelectSpecies?: (speciesCode: string) => void;
+  /** `MapCanvas.handleDrillInToCenter`, invoked from the grid marker's "+N more". */
+  onDrillIn: (center: [number, number]) => void;
+}
+
+export function GroupMarkerLayer({
+  groups,
+  isCoarsePointer,
+  detailOpen,
+  onGroupClick,
+  onSelectSpecies,
+  onDrillIn,
+}: GroupMarkerLayerProps) {
+  return (
+    <>
+      {groups.map((g) => {
+        const { anchor } = g;
+        // longitude/latitude are populated for every production input
+        // (the reconciler push above); fall back to 0 only to satisfy
+        // the optional-typed signature for unit-test consumers.
+        const longitude = anchor.longitude ?? 0;
+        const latitude = anchor.latitude ?? 0;
+        if (anchor.rendered.kind === 'pill') {
+          return (
+            <PresentationMarker
+              key={g.key}
+              longitude={longitude}
+              latitude={latitude}
+              anchor="center"
+            >
+              <ClusterPill
+                count={anchor.point_count}
+                onClick={(e) => onGroupClick(g, e.currentTarget)}
+              />
+            </PresentationMarker>
+          );
+        }
+        if (anchor.rendered.kind === 'silhouette') {
+          // Silhouette-only group (no cluster overlaps this silhouette).
+          // The canvas-painted symbol layer already paints it at the
+          // correct lng/lat — no React marker needed. Returning null
+          // keeps the loop's render output sparse so React doesn't
+          // reconcile an empty marker.
+          return null;
+        }
+        return (
+          <PresentationMarker
+            key={g.key}
+            longitude={longitude}
+            latitude={latitude}
+          >
+            <AdaptiveGridMarker
+              shape={anchor.rendered.shape}
+              tiles={anchor.tiles ?? []}
+              totalCount={anchor.point_count}
+              uniqueFamilies={anchor.uniqueFamilies}
+              ariaLabel={g.ariaLabel}
+              isCoarsePointer={isCoarsePointer}
+              isNotable={anchor.isNotable ?? false}
+              detailOpen={detailOpen}
+              onClick={() => onGroupClick(g)}
+              {...(onSelectSpecies ? {
+                onSelectSpecies: (code: string) => onSelectSpecies(code),
+              } : {})}
+              {...(anchor.longitude !== undefined && anchor.latitude !== undefined
+                ? {
+                    // #859: the per-family <CellPopover> "+N more" eases the
+                    // camera into this marker's cell center — the SAME active
+                    // drill-in the cluster-list path uses. The marker decides
+                    // (via tile.speciesCount) whether to actually offer it.
+                    onDrillIn: () => onDrillIn([longitude, latitude]),
+                  }
+                : {})}
+            />
+          </PresentationMarker>
+        );
+      })}
+    </>
+  );
+}

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -33,10 +33,14 @@ import {
 import { mergeLeafBuckets } from '../../data/bucket-aggregates.js';
 import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
 import { ObservationPopover } from './ObservationPopover.js';
-import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
-import { PresentationMarker } from './PresentationMarker.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
-import { ClusterPill } from '../ds/ClusterPill.js';
+// Marker render-tree dispatch extracted to two presentational layers
+// (epic #884 · U11 / #896). MapCanvas keeps every handler + derived state and
+// threads them as props; the layers hold no map ref and render only.
+// `AdaptiveGridMarker`, `PresentationMarker`, `ClusterPill`, `MapMarkerHitLayer`
+// and the `SILHOUETTE_PX` constant now live in those layers, not here.
+import { GroupMarkerLayer } from './GroupMarkerLayer.js';
+import { DisplacedSilhouetteLayer } from './DisplacedSilhouetteLayer.js';
 import { registerSilhouetteSprite } from './silhouette-sprite.js';
 import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
 import { useMapResize } from './use-map-resize.js';
@@ -52,13 +56,9 @@ import {
   type FamilyAggregate,
   type SpeciesAggregate,
 } from './adaptive-grid.js';
-import {
-  MapMarkerHitLayer,
-  type HitTargetMarker,
-} from './MapMarkerHitLayer.js';
+import { type HitTargetMarker } from './MapMarkerHitLayer.js';
 import {
   hashSubId,
-  SILHOUETTE_PX,
   type DeconflictGroup,
   type DeconflictInput,
 } from './deconflict.js';
@@ -1837,174 +1837,44 @@ export function MapCanvas({
           {spritesReady && <Layer {...unclusteredLayer} />}
         </Source>
         {/*
-          Unified deconflict render (issue #554). Iterates the
-          `groups` slice — one entry per overlap component — and
-          dispatches to <AdaptiveGridMarker> or <ClusterPill> based
-          on the anchor's rendered.kind. The spatial-bucket key
-          (group.key) is stable when the anchor stays in the same
-          ~14px bucket, so React's reconciler doesn't churn under pan.
-        */}
-        {groups.map((g) => {
-          const { anchor } = g;
-          // longitude/latitude are populated for every production input
-          // (the reconciler push above); fall back to 0 only to satisfy
-          // the optional-typed signature for unit-test consumers.
-          const longitude = anchor.longitude ?? 0;
-          const latitude = anchor.latitude ?? 0;
-          if (anchor.rendered.kind === 'pill') {
-            return (
-              <PresentationMarker
-                key={g.key}
-                longitude={longitude}
-                latitude={latitude}
-                anchor="center"
-              >
-                <ClusterPill
-                  count={anchor.point_count}
-                  onClick={(e) => handleGroupClick(g, e.currentTarget)}
-                />
-              </PresentationMarker>
-            );
-          }
-          if (anchor.rendered.kind === 'silhouette') {
-            // Silhouette-only group (no cluster overlaps this silhouette).
-            // The canvas-painted symbol layer already paints it at the
-            // correct lng/lat — no React marker needed. Returning null
-            // keeps the loop's render output sparse so React doesn't
-            // reconcile an empty marker.
-            return null;
-          }
-          return (
-            <PresentationMarker
-              key={g.key}
-              longitude={longitude}
-              latitude={latitude}
-            >
-              <AdaptiveGridMarker
-                shape={anchor.rendered.shape}
-                tiles={anchor.tiles ?? []}
-                totalCount={anchor.point_count}
-                uniqueFamilies={anchor.uniqueFamilies}
-                ariaLabel={g.ariaLabel}
-                isCoarsePointer={isCoarsePointer}
-                isNotable={anchor.isNotable ?? false}
-                detailOpen={detailOpen}
-                onClick={() => handleGroupClick(g)}
-                {...(onSelectSpecies ? {
-                  onSelectSpecies: (code: string) => onSelectSpecies(code),
-                } : {})}
-                {...(anchor.longitude !== undefined && anchor.latitude !== undefined
-                  ? {
-                      // #859: the per-family <CellPopover> "+N more" eases the
-                      // camera into this marker's cell center — the SAME active
-                      // drill-in the cluster-list path uses. The marker decides
-                      // (via tile.speciesCount) whether to actually offer it.
-                      onDrillIn: () => handleDrillInToCenter([longitude, latitude]),
-                    }
-                  : {})}
-              />
-            </PresentationMarker>
-          );
-        })}
+          Unified deconflict render (issue #554). Iterates the `groups`
+          slice — one entry per overlap component — and dispatches to
+          <AdaptiveGridMarker> or <ClusterPill> based on the anchor's
+          rendered.kind. The spatial-bucket key (group.key) is stable when
+          the anchor stays in the same ~14px bucket, so React's reconciler
+          doesn't churn under pan. Extracted to `GroupMarkerLayer.tsx`
+          (epic #884 · U11 / #896) — presentational; MapCanvas keeps the
+          handlers and threads them as props. */}
+        <GroupMarkerLayer
+          groups={groups}
+          isCoarsePointer={isCoarsePointer}
+          detailOpen={detailOpen}
+          onGroupClick={handleGroupClick}
+          {...(onSelectSpecies ? { onSelectSpecies } : {})}
+          onDrillIn={handleDrillInToCenter}
+        />
         {/*
-          Displaced silhouettes (issue #554 scope expansion 2026-05-15).
-          Per user direction silhouettes MUST REMAIN VISIBLE; when one
-          would overlap a cluster anchor, deconflict pushes it ≤20px
-          aside (in pixel space, unprojected to lng/lat here). The
-          canvas-painted twin is hidden via feature-state on the
-          unclustered-point symbol layer — see the reconciler loop.
-        */}
-        {Array.from(silhouetteOffsets.entries()).map(([subId, entry]) => {
-          const obs = obsLookup[subId];
-          if (!obs) return null;
-          const sil = silhouetteRenderById.get(subId);
-          const color = sil?.color ?? '#555';
-          const svgData = sil?.svgData ?? null;
-          // Displaced silhouettes are rendered as accessible <button>
-          // wrappers so a click opens the obs popover even though the
-          // canvas-painted twin is hidden. The PresentationMarker outer
-          // div has role="presentation" (see PresentationMarker effect),
-          // so the inner <button> remains the canonical interactive
-          // element with full keyboard + AT support.
-          return (
-            <PresentationMarker
-              key={`displaced-${subId}`}
-              longitude={entry.longitude}
-              latitude={entry.latitude}
-              anchor="center"
-            >
-              <button
-                type="button"
-                data-testid="displaced-silhouette"
-                data-subid={subId}
-                aria-label={`${obs.comName} observation`}
-                // Issue #718: project the popover from `entry.longitude/
-                // entry.latitude` — the DISPLACED visual position — not
-                // from `obs.lng/obs.lat`. The obs survey point is hidden
-                // beneath the canvas-painted twin; projecting from it
-                // would land the popover next to the invisible original
-                // instead of the silhouette the user actually clicked,
-                // defeating the fix at this site.
-                onClick={() => openPopoverAt(obs, [entry.longitude, entry.latitude])}
-                style={{
-                  display: 'inline-block',
-                  width: SILHOUETTE_PX,
-                  height: SILHOUETTE_PX,
-                  padding: 0,
-                  margin: 0,
-                  border: 'none',
-                  background: 'transparent',
-                  cursor: 'pointer',
-                }}
-              >
-                {svgData ? (
-                  <svg
-                    viewBox="0 0 24 24"
-                    width={SILHOUETTE_PX}
-                    height={SILHOUETTE_PX}
-                    aria-hidden="true"
-                  >
-                    {/* Halo (white stroke) painted first so the colored
-                        body sits on top, mirroring the SDF symbol layer's
-                        icon-halo-color #ffffff / icon-halo-width 1.5. */}
-                    <path
-                      d={svgData}
-                      fill="none"
-                      stroke="#ffffff"
-                      strokeWidth="2"
-                      strokeLinejoin="round"
-                    />
-                    <path d={svgData} fill={color} />
-                  </svg>
-                ) : (
-                  // Fallback circle when the family has no Phylopic
-                  // silhouette — matches the _FALLBACK opacity tinting.
-                  <svg
-                    viewBox="0 0 24 24"
-                    width={SILHOUETTE_PX}
-                    height={SILHOUETTE_PX}
-                    aria-hidden="true"
-                  >
-                    <circle cx="12" cy="12" r="8" fill={color} opacity="0.5" />
-                  </svg>
-                )}
-              </button>
-            </PresentationMarker>
-          );
-        })}
-      </MapView>
-      {/* Issue #247 (original hit-layer) / #277 (Spider v2 narrowed to auto-spider stacks +
-          unclustered): HTML overlay for stacked and unclustered markers, mounted as a sibling
-          of the maplibre canvas inside the relatively-positioned wrapper. */}
-      {map && (
-        <MapMarkerHitLayer
+          Displaced silhouettes (issue #554 scope expansion 2026-05-15) +
+          the co-located hit-target overlay (#247/#277). Both are overlay
+          siblings of the maplibre canvas: the twins keep a deconflicted
+          silhouette VISIBLE (its canvas-painted original is hidden via
+          feature-state), and the hit layer hosts the wider clickable hit
+          targets. Extracted to `DisplacedSilhouetteLayer.tsx` (epic #884 ·
+          U11 / #896) — presentational; MapCanvas keeps openPopoverAt /
+          handleHitSelect and threads them as props. The `map && (...)`
+          guard on the hit-layer mount is preserved inside the component. */}
+        <DisplacedSilhouetteLayer
+          silhouetteOffsets={silhouetteOffsets}
+          obsLookup={obsLookup}
+          silhouetteRenderById={silhouetteRenderById}
+          onOpen={openPopoverAt}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           map={map as any}
-          markers={hitMarkers}
+          hitMarkers={hitMarkers}
           onSelect={handleHitSelect}
           isCoarsePointer={isCoarsePointer}
         />
-      )}
+      </MapView>
       <ObservationPopover
         observation={selectedObs?.obs ?? null}
         position={selectedObs?.pos ?? null}


### PR DESCRIPTION
## Diagrams

Component tree before/after the extraction. The marker render tree moves out of `MapCanvas` into two presentational layers; `MapCanvas` keeps every handler + derived-state owner and threads them down as props. The two popover mounts stay put.

```mermaid
graph TD
    subgraph After["MapCanvas render tree (after U11)"]
        MC["MapCanvas<br/>(owns handlers + derived state)"]
        MV["&lt;MapView&gt; (maplibre)"]
        GML["GroupMarkerLayer<br/>(presentational)"]
        DSL["DisplacedSilhouetteLayer<br/>(presentational)"]
        OP["&lt;ObservationPopover&gt; (stays)"]
        CLP["&lt;ClusterListPopover&gt; (stays)"]

        MC --> MV
        MV --> GML
        MV --> DSL
        MC --> OP
        MC --> CLP

        GML -->|"pill"| CP["&lt;ClusterPill&gt;"]
        GML -->|"silhouette"| NULL["null (canvas paints)"]
        GML -->|"grid"| AGM["&lt;AdaptiveGridMarker&gt;"]
        DSL --> TW["displaced &lt;button&gt; twins (#718)"]
        DSL --> HIT["&lt;MapMarkerHitLayer&gt; (map &amp;&amp; guard)"]
    end

    MC -.->|"onGroupClick / onSelectSpecies / onDrillIn"| GML
    MC -.->|"onOpen / onSelect / map / hitMarkers"| DSL
```

## Summary

- **Why:** last Wave-1 unit of the MapCanvas consolidation epic (#884). It is the only unit that moves live JSX touching every interactive marker surface, so it is scoped to a single PR and carries the full UI-verification gate.
- Extracts the `groups.map()` dispatch → `GroupMarkerLayer.tsx` and the displaced-silhouette `<button>` twins + the co-located `<MapMarkerHitLayer>` mount → `DisplacedSilhouetteLayer.tsx`. Both are pure functions of props (no map ref, no map state, no shape inspection to pick a domain action — exemplar: `AdaptiveGridMarker.tsx`). `MapCanvas` keeps `handleGroupClick` / `openPopoverAt` / `handleHitSelect` / `handleDrillInToCenter` / `clusterListFamilyNames` and all derived state, threading them as props.
- Consumes the already-merged U5 (`PresentationMarker`) and U8 (`obs-derive`: `obsLookup` / `silhouetteRenderById` / `hitMarkers`). The `<ObservationPopover>` + `<ClusterListPopover>` mounts and their parent-local bindings stay in `MapCanvas` unmoved.

## Screenshots

N/A — behavior-preserving render-tree **relocation** (no visual change). Live-verified via Playwright MCP against prod data at the national (US) view: `GroupMarkerLayer` cluster markers render **identically** at desktop (1440×900) and mobile (390×844), light + dark; the four-corner layout (identity · controls · legend · attribution) is intact; console clean **except** a pre-existing dark-basemap `circle-11` `styleimagemissing` warning that is unrelated to this PR (U11 touches no `setStyle`/sprite/basemap code — it predates this change). `DisplacedSilhouetteLayer` + the relocated `MapMarkerHitLayer` are covered by the passing e2e specs `map-skip-link-and-hit-layer` and `marker-overlap`. Consistent with the behavior-preserving Screenshots handling of the sibling extractions U1–U13.

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — **N/A — the two new components declare ZERO classNames; the `adaptive-grid-marker__*` and `map-marker-hit-layer` classes live in the child components they render, unchanged. `orphan-classname-check` PASS locally.**
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      Live-verified via Playwright at desktop+mobile × light+dark (see Screenshots); behavior-preserving, no visual change to review.

## Test plan

- [x] `npm run build --workspace @bird-watch/frontend` (tsc -b && vite build) — green
- [x] `npm test --workspace @bird-watch/frontend` — 85 files / 1291 tests pass (incl. all 83 MapCanvas tests + 18 new layer tests)
- [x] New unit tests added — `GroupMarkerLayer.test.tsx` + `DisplacedSilhouetteLayer.test.tsx` (RTL): dispatch branches (pill/silhouette/grid), stable `g.key` / `displaced-${subId}` keying (#552 churn class), and the #718 displaced-point projection contract
- [x] `orphan-classname-check` (`scripts/check-orphan-classnames.sh`) — PASS; `knip` — clean
- [x] Marker e2e (`map-skip-link-and-hit-layer` + `marker-overlap`, dev-server project) — 31 passed / 1 skipped (headless-WebGL tolerance) / 0 failed; confirms the hit-layer-inside-MapView move is functionally identical. (Aggregated-path cell-popover specs hit a missing local materialized view `observation_grid_agg` — a local DB-seed gap, not a code regression; covered in CI.)
- [ ] (UI only) Playwright MCP 5-viewport × 2-theme smoke — orchestrator drives this live before review per CLAUDE.md.

**Byte-identical note:** rendered output is intended byte-identical. The one DOM-tree change is the `<MapMarkerHitLayer>` mount moving inside `<MapView>` alongside the twins (per the issue scope — both are overlay siblings of the maplibre canvas). Its `position:absolute; inset:0` overlay resolves to the same screen rect either way, and `project()` returns viewport-relative coords, so the visual/functional result is identical — verified by the passing hit-layer e2e.

## Plan reference

Out of plan — epic #884 (MapCanvas consolidation), Wave 1b. Closes #896. Part of #884.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

