### PR TITLE
chore(frontend): motion hygiene — lede tabular-nums, 300ms→240ms comments, shared --ds-shimmer-dur token

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -93,7 +93,7 @@
     var(--color-bg-skeleton)           100%
   );
   background-size: 200% 100%;
-  animation: ds-shimmer 1.6s ease-in-out infinite;
+  animation: ds-shimmer var(--ds-shimmer-dur) ease-in-out infinite;
 }
 
 /* Title — primary text */
@@ -302,7 +302,7 @@
     var(--color-bg-skeleton)           100%
   );
   background-size: 200% 100%;
-  animation: ds-shimmer 1.6s ease-in-out infinite;
+  animation: ds-shimmer var(--ds-shimmer-dur) ease-in-out infinite;
   border-radius: var(--photo-radius);
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -452,6 +452,7 @@ body {
   font-size: var(--type-sm);
   color: var(--color-text-body);
   line-height: 1.4;
+  font-variant-numeric: tabular-nums;
 }
 
 /* #828: the in-card `.app-header-freshness` line (and its `a` link recipe that
@@ -2042,8 +2043,8 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
 }
 
 /* ── Field-guide motion ────────────────────────────────────────────────────
-   ONE clock for every leg: --sheet-settle-dur (300ms) / --sheet-settle-ease.
-   recipe #08 (page cross-dissolve) reads --page-* (retuned to 300ms in
+   ONE clock for every leg: --sheet-settle-dur (240ms) / --sheet-settle-ease.
+   recipe #08 (page cross-dissolve) reads --page-* (retuned to 240ms in
    tokens.css); recipe #01 (photo card-resize + the container height tween) and
    recipe #07 (card-page reveals) read --sheet-settle-*. All start+finish on one
    frame → no two-stage. Reduced-motion is owned globally by motion.css

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -145,7 +145,7 @@
 
   /* recipe-08 (page-side-by-side) — drives the mid↔full cross-dissolve between
      the two stable sheet pages (.sheet-page--card ↔ .sheet-page--entry). The
-     catalog default is 200ms; the sheet retunes to the single 300ms settle
+     catalog default is 200ms; the sheet retunes to the single 240ms settle
      clock (--sheet-settle-dur/-ease) so the page cross-fade, the in-page
      reveals (#07), and the container-height tween (#01) all start+finish on one
      frame (no two-stage desync). --page-slide-distance is kept SMALL (8px) so
@@ -161,6 +161,12 @@
   --page-blur:           14px;
   --page-slide-ease:     cubic-bezier(0.22, 1, 0.36, 1);
   --page-fade-ease:      cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* ds-shimmer duration — shared by .status-block__skeleton + .photo__skeleton
+     (both use the same ds-shimmer keyframe; #948). adaptive-grid-pending-shimmer
+     (1.4s, reverse-direction) and skeleton-shimmer (opacity-pulse technique) are
+     intentionally excluded — different techniques, different tempos. */
+  --ds-shimmer-dur: 1.6s;
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */


### PR DESCRIPTION
## Diagrams

N/A — CSS-only comment corrections and property additions; no structural change to data flow, state, or component tree.

## Summary

- **Why:** Three motion-hygiene fixes from the 2026-06-09 transitions.dev animation audit (Batch 1, #948). Digit-width jitter, stale inline documentation, and a duplicated magic number are the issues; all three are zero-risk CSS changes with no new animation.
- `font-variant-numeric: tabular-nums` on `.app-header-lede` locks digit widths so the count re-words cleanly on camera settle without layout jitter. No transition added — the hard-cut is intentional (see #948 for audit rationale).
- Stale `300ms` settle-clock comments corrected to `240ms` (live value since transitions.dev tuning); `--ds-shimmer-dur: 1.6s` token introduced in tokens.css `:root` so the two identical `ds-shimmer` consumers reference one source of truth.

## Screenshots

**Functional verification (in lieu of stills — agreed with maintainer).** This PR's only *visible* change is `font-variant-numeric: tabular-nums` on `.app-header-lede`; the remaining edits are comment-only and a CSS-token rename (non-visual). A typographic feature like tabular-nums is not meaningfully demonstrable in a static screenshot, so it was verified live instead, against a local dev build + a seeded local DB (400 observations, 24 families):

- `getComputedStyle(document.querySelector('.app-header-lede')).fontVariantNumeric === 'tabular-nums'` ✅ (confirmed in the running build)
- Lede renders `"400 sightings"` correctly in the map view; legend + markers render normally.
- Console clean — only the pre-existing form-field `id`/`name` issue (unrelated to this PR).
- `grep -n "300ms"` over the three CSS files returns zero stale settle-clock comments; the 1.4s adaptive-grid shimmer and the opacity-pulse skeleton-shimmer are byte-identical (excluded from the `--ds-shimmer-dur` token, by design).


## Test plan

- [x] `npm run typecheck && npm run test` — green (85/85 test files pass)
- [x] New unit / integration tests added (if behavior changed) — N/A, CSS-only
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A, CSS property only
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — pending orchestrator live-verification before bot review

## Plan reference

Out of plan — motion-hygiene cleanup from 2026-06-09 transitions.dev animation audit. Closes #948. Part of epic #953.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
