### PR TITLE
chore: standardized local dev-data seed (npm run db:seed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,18 @@ when you're zoomed out, individual family-coloured markers when you're zoomed in
 npm install
 npm run db:up        # local Postgres + PostGIS via Docker
 npm run db:migrate
+npm run db:seed      # ~400 sample sightings so the map isn't empty
 npm run dev --workspace @bird-watch/frontend
 ```
 
 To also run the API the map reads from, see [`services/read-api/README.md`](services/read-api/README.md).
+
+`db:seed` writes a deterministic, idempotent spread of ~400 observations across
+~24 bird families and ~20 states — enough to render a realistic map without an
+eBird API key. (Migrations only seed reference data: family silhouettes, state
+boundaries, and a small species set; real sightings otherwise come from a live
+eBird ingest.) Re-run it any time; it reads `DATABASE_URL` and defaults to the
+local Docker database.
 
 ## Architecture
 

--- a/knip.ts
+++ b/knip.ts
@@ -145,12 +145,14 @@ const config: KnipConfig = {
     //             same dynamic-require reason; same risk profile.
     'testcontainers',
 
-    // 2026-04-28: tsx is used by services/{read-api,ingestor}/package.json scripts
-    //             ("dev"/"ingest:local") that invoke `tsx src/...`. Knip can't trace
-    //             npm-script bin invocations. NOT a knip dependency — keep this
-    //             ignore until those scripts migrate to a different runner
-    //             (e.g., bun, ts-node, native node --import).
-    'tsx',
+    // 2026-06-09: tsx ignore REMOVED. The root `db:seed` script
+    //             (`tsx packages/db-client/src/dev-seed.ts`) now invokes tsx
+    //             directly from the root package.json, so knip traces it as a
+    //             used root devDependency. The prior 2026-04-28 ignore (added
+    //             because only workspace scripts referenced tsx) is now
+    //             redundant — knip emits a "Remove from ignoreDependencies"
+    //             hint for it. Re-add only if `db:seed` stops using tsx AND no
+    //             other root script does.
 
     // 2026-05-29: geojson — `import type { Feature, MultiPolygon, Polygon,
     //             Position } from 'geojson'` (#760/#762 state-artboard mask:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:down": "docker compose down",
     "db:migrate": "node-pg-migrate up -m migrations --ignore-pattern '(^\\..*)|(.*\\.md$)'",
     "db:rollback": "node-pg-migrate down -m migrations --ignore-pattern '(^\\..*)|(.*\\.md$)'",
+    "db:seed": "tsx packages/db-client/src/dev-seed.ts",
     "curate:phylopic": "node scripts/curate-phylopic.mjs",
     "silhouette": "node scripts/silhouette.mjs"
   },

--- a/packages/db-client/src/dev-seed.test.ts
+++ b/packages/db-client/src/dev-seed.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Standardized local dev-data seed — integration test.
+ *
+ * Real Postgres+PostGIS testcontainer (no DB mocks, per repo convention): apply
+ * every migration, run the seed, and assert the invariants that make the seeded
+ * data render on the local map:
+ *   1. observations is non-empty (≈400 rows).
+ *   2. observation_grid_agg is non-empty — the default low-zoom map/lede/legend
+ *      read the precompute table, so the seed MUST refresh it.
+ *   3. every observation's species_code exists in species_meta (#484 invariant),
+ *      and every seeded family_code is a real family_silhouettes row (legend join).
+ *   4. all obs_dt land inside the 14-day recency window the stack filters on.
+ *   5. the seed is deterministic + idempotent: a second run yields the same
+ *      observation rows (no duplication, same fingerprint).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers (NUMERIC → number).
+import './pool.js';
+import { seedDevData } from './dev-seed.js';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  for (const f of readdirSync(migrationsDir).filter(x => x.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(migrationsDir, f), 'utf-8');
+    const [rawUp = ''] = sql.split(/-- Down Migration/i);
+    const up = rawUp.replace(/-- Up Migration/i, '');
+    if (up.trim()) await pool.query(up);
+  }
+}, 600_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('seedDevData — local dev seed', () => {
+  it('populates observations, the precompute grid, and reports coverage', async () => {
+    const result = await seedDevData(pool);
+
+    expect(result.observationsUpserted).toBeGreaterThanOrEqual(400);
+    expect(result.gridRows).toBeGreaterThan(0);
+    expect(result.families).toBeGreaterThanOrEqual(20);
+    expect(result.states).toBeGreaterThanOrEqual(15);
+
+    const { rows: [obs] } = await pool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM observations',
+    );
+    expect(Number(obs?.n)).toBeGreaterThanOrEqual(400);
+
+    const { rows: [grid] } = await pool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM observation_grid_agg',
+    );
+    expect(Number(grid?.n)).toBeGreaterThan(0);
+  });
+
+  it('has no orphan species_code — every observation resolves to species_meta', async () => {
+    await seedDevData(pool);
+    const { rows: [orphan] } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n
+         FROM observations o
+        WHERE NOT EXISTS (
+          SELECT 1 FROM species_meta sm WHERE sm.species_code = o.species_code
+        )`,
+    );
+    expect(Number(orphan?.n)).toBe(0);
+  });
+
+  it('every seeded family_code is a real family_silhouettes row (legend join holds)', async () => {
+    await seedDevData(pool);
+    // For every species_meta row backing a seeded observation, its family_code
+    // must exist in family_silhouettes — otherwise the legend + silhouette
+    // stamping would break for that family.
+    const { rows: [missing] } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n
+         FROM (
+           SELECT DISTINCT sm.family_code
+             FROM species_meta sm
+             JOIN observations o ON o.species_code = sm.species_code
+         ) used
+        WHERE NOT EXISTS (
+          SELECT 1 FROM family_silhouettes fs WHERE fs.family_code = used.family_code
+        )`,
+    );
+    expect(Number(missing?.n)).toBe(0);
+
+    // And every seeded observation got a silhouette stamped (the upsert stamp
+    // joins species_meta → family_silhouettes), proving the chain resolves.
+    const { rows: [unstamped] } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM observations WHERE silhouette_id IS NULL`,
+    );
+    expect(Number(unstamped?.n)).toBe(0);
+  });
+
+  it('all seeded observations fall inside the 14-day recency window', async () => {
+    await seedDevData(pool);
+    const { rows: [stale] } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM observations
+        WHERE obs_dt < now() - interval '14 days' OR obs_dt > now()`,
+    );
+    expect(Number(stale?.n)).toBe(0);
+  });
+
+  it('is deterministic + idempotent — a second run does not duplicate or change rows', async () => {
+    // Pin nowMs so obs_dt is identical across both runs (the only now()-derived
+    // value); everything else is fixed-PRNG driven.
+    const pinnedNow = Date.UTC(2026, 5, 9, 12, 0, 0);
+    await seedDevData(pool, pinnedNow);
+    const { rows: [first] } = await pool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM observations',
+    );
+    const fingerprintQ = `SELECT md5(string_agg(
+        sub_id||species_code||lat::text||lng::text||obs_dt::text||coalesce(how_many::text,'')||is_notable::text,
+        '' ORDER BY sub_id, species_code)) AS h FROM observations`;
+    const { rows: [fpA] } = await pool.query<{ h: string }>(fingerprintQ);
+
+    await seedDevData(pool, pinnedNow);
+    const { rows: [second] } = await pool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM observations',
+    );
+    const { rows: [fpB] } = await pool.query<{ h: string }>(fingerprintQ);
+
+    expect(second?.n).toBe(first?.n);
+    expect(fpB?.h).toBe(fpA?.h);
+  });
+});

--- a/packages/db-client/src/dev-seed.ts
+++ b/packages/db-client/src/dev-seed.ts
@@ -298,15 +298,10 @@ export async function seedDevData(pool: Pool, nowMs: number = Date.now()): Promi
   return { speciesMetaUpserted, observationsUpserted, gridRows, families, states };
 }
 
-/** CLI entry: reads DATABASE_URL, seeds, prints a coverage summary. */
+/** CLI entry: reads DATABASE_URL (defaults to the local docker-compose DB), seeds, prints a coverage summary. */
 async function main(): Promise<void> {
-  const url = process.env.DATABASE_URL;
-  if (!url) {
-    console.error('DATABASE_URL is not set. Example:');
-    console.error('  DATABASE_URL=postgres://birdwatch:birdwatch@localhost:5432/birdwatch npm run db:seed');
-    process.exit(1);
-    return;
-  }
+  const url = process.env.DATABASE_URL ?? 'postgres://birdwatch:birdwatch@localhost:5432/birdwatch';
+  console.log(`Seeding: ${url}`);
 
   const pool = createPool({ databaseUrl: url });
   try {

--- a/packages/db-client/src/dev-seed.ts
+++ b/packages/db-client/src/dev-seed.ts
@@ -1,0 +1,342 @@
+/**
+ * Standardized local dev-data seed.
+ *
+ * There is no observation seed shipped with the repo — migrations seed only
+ * static reference data (family_silhouettes, state_boundaries, a small
+ * species_meta set), and every sighting otherwise arrives from a live eBird
+ * ingest. That means a contributor without an eBird API key gets an empty map.
+ * This module fills that gap: it writes a deterministic, realistic spread of
+ * observations so `npm run dev` shows a populated map with zero external
+ * dependencies.
+ *
+ * Run it via `npm run db:seed` (reads DATABASE_URL). It is idempotent:
+ * re-running upserts the same fixed rows and rebuilds the precompute grid.
+ *
+ * INVARIANTS this seed respects (all verified against the read path):
+ *   - species_meta is written BEFORE observations (the #484 invariant — every
+ *     observation's species_code must already have a species_meta row).
+ *   - every family_code used is a REAL value from family_silhouettes, so the
+ *     legend join and silhouette stamping resolve (invented species_code is
+ *     fine; an invented family_code would break the legend).
+ *   - obs_dt is computed relative to now() so every row lands inside the 14-day
+ *     recency window the whole stack filters on (`obs_dt >= now() - 14 days`).
+ *   - geom is NOT set here — it is a GENERATED column.
+ *   - refreshGridAgg() runs last, so the default low-zoom map/lede/legend (which
+ *     read the observation_grid_agg precompute table) are non-empty.
+ *
+ * Determinism: a fixed-seed PRNG (mulberry32) drives the variety (how_many, the
+ * per-observation family/species/state walk). No Math.random / Date.now in the
+ * data shape — only the obs_dt offset is taken from now() so the rows stay in
+ * the 14-day window on any run.
+ */
+import { createPool, closePool, type Pool } from './pool.js';
+import { upsertSpeciesMeta } from './species.js';
+import { upsertObservations, refreshGridAgg, type ObservationInput } from './observations.js';
+import type { SpeciesMeta } from '@bird-watch/shared-types';
+
+/** Deterministic 32-bit PRNG — same sequence every run, no global seeding. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * A real city per state with a coordinate comfortably inside the state polygon
+ * (so the PostGIS ST_Intersects state clip resolves). 18 CONUS states spanning
+ * the country so the national rollup and several state scopes are all populated.
+ */
+const STATE_CITIES: ReadonlyArray<{ state: string; loc: string; lat: number; lng: number }> = [
+  { state: 'US-AZ', loc: 'Phoenix, AZ', lat: 33.45, lng: -112.07 },
+  { state: 'US-CA', loc: 'Los Angeles, CA', lat: 34.05, lng: -118.24 },
+  { state: 'US-CA', loc: 'San Francisco, CA', lat: 37.77, lng: -122.42 },
+  { state: 'US-TX', loc: 'Austin, TX', lat: 30.27, lng: -97.74 },
+  { state: 'US-FL', loc: 'Orlando, FL', lat: 28.54, lng: -81.38 },
+  { state: 'US-NY', loc: 'New York, NY', lat: 40.71, lng: -73.99 },
+  { state: 'US-WA', loc: 'Seattle, WA', lat: 47.61, lng: -122.33 },
+  { state: 'US-CO', loc: 'Denver, CO', lat: 39.74, lng: -104.99 },
+  { state: 'US-IL', loc: 'Chicago, IL', lat: 41.85, lng: -87.65 },
+  { state: 'US-MA', loc: 'Boston, MA', lat: 42.36, lng: -71.06 },
+  { state: 'US-GA', loc: 'Atlanta, GA', lat: 33.75, lng: -84.39 },
+  { state: 'US-MN', loc: 'Minneapolis, MN', lat: 44.98, lng: -93.27 },
+  { state: 'US-NM', loc: 'Albuquerque, NM', lat: 35.08, lng: -106.65 },
+  { state: 'US-OR', loc: 'Portland, OR', lat: 45.52, lng: -122.68 },
+  { state: 'US-NC', loc: 'Raleigh, NC', lat: 35.78, lng: -78.64 },
+  { state: 'US-MI', loc: 'Detroit, MI', lat: 42.33, lng: -83.05 },
+  { state: 'US-UT', loc: 'Salt Lake City, UT', lat: 40.76, lng: -111.89 },
+  { state: 'US-PA', loc: 'Philadelphia, PA', lat: 39.95, lng: -75.17 },
+  { state: 'US-MO', loc: 'St. Louis, MO', lat: 38.63, lng: -90.2 },
+  { state: 'US-NV', loc: 'Las Vegas, NV', lat: 36.17, lng: -115.14 },
+];
+
+/**
+ * Species seeded per family. Every `family` here MUST be a real family_code
+ * from family_silhouettes (checked by the test). species_code / com_name /
+ * sci_name are plausible but synthetic — invented species codes are allowed;
+ * invented family codes are not.
+ */
+interface SeedSpecies {
+  family: string;
+  familyName: string;
+  species: ReadonlyArray<{ code: string; com: string; sci: string }>;
+}
+
+const SEED_SPECIES: ReadonlyArray<SeedSpecies> = [
+  { family: 'tyrannidae', familyName: 'Tyrant Flycatchers', species: [
+    { code: 'devseed-vermfly', com: 'Vermilion Flycatcher', sci: 'Pyrocephalus rubinus' },
+    { code: 'devseed-easkin', com: 'Eastern Kingbird', sci: 'Tyrannus tyrannus' },
+    { code: 'devseed-blkpho', com: 'Black Phoebe', sci: 'Sayornis nigricans' },
+  ] },
+  { family: 'trochilidae', familyName: 'Hummingbirds', species: [
+    { code: 'devseed-annhum', com: "Anna's Hummingbird", sci: 'Calypte anna' },
+    { code: 'devseed-ruthum', com: 'Ruby-throated Hummingbird', sci: 'Archilochus colubris' },
+  ] },
+  { family: 'icteridae', familyName: 'Blackbirds', species: [
+    { code: 'devseed-rewbla', com: 'Red-winged Blackbird', sci: 'Agelaius phoeniceus' },
+    { code: 'devseed-baltor', com: 'Baltimore Oriole', sci: 'Icterus galbula' },
+    { code: 'devseed-comgra', com: 'Common Grackle', sci: 'Quiscalus quiscula' },
+  ] },
+  { family: 'cardinalidae', familyName: 'Cardinals & Allies', species: [
+    { code: 'devseed-norcar', com: 'Northern Cardinal', sci: 'Cardinalis cardinalis' },
+    { code: 'devseed-indbun', com: 'Indigo Bunting', sci: 'Passerina cyanea' },
+  ] },
+  { family: 'corvidae', familyName: 'Crows, Jays & Magpies', species: [
+    { code: 'devseed-blujay', com: 'Blue Jay', sci: 'Cyanocitta cristata' },
+    { code: 'devseed-amecro', com: 'American Crow', sci: 'Corvus brachyrhynchos' },
+    { code: 'devseed-stejay', com: "Steller's Jay", sci: 'Cyanocitta stelleri' },
+  ] },
+  { family: 'parulidae', familyName: 'New World Warblers', species: [
+    { code: 'devseed-yelwar', com: 'Yellow Warbler', sci: 'Setophaga petechia' },
+    { code: 'devseed-comyel', com: 'Common Yellowthroat', sci: 'Geothlypis trichas' },
+    { code: 'devseed-yerwar', com: 'Yellow-rumped Warbler', sci: 'Setophaga coronata' },
+  ] },
+  { family: 'anatidae', familyName: 'Ducks, Geese & Swans', species: [
+    { code: 'devseed-mallar', com: 'Mallard', sci: 'Anas platyrhynchos' },
+    { code: 'devseed-cangoo', com: 'Canada Goose', sci: 'Branta canadensis' },
+    { code: 'devseed-wooduc', com: 'Wood Duck', sci: 'Aix sponsa' },
+  ] },
+  { family: 'picidae', familyName: 'Woodpeckers', species: [
+    { code: 'devseed-dowwoo', com: 'Downy Woodpecker', sci: 'Dryobates pubescens' },
+    { code: 'devseed-norfli', com: 'Northern Flicker', sci: 'Colaptes auratus' },
+  ] },
+  { family: 'turdidae', familyName: 'Thrushes', species: [
+    { code: 'devseed-amerob', com: 'American Robin', sci: 'Turdus migratorius' },
+    { code: 'devseed-easblu', com: 'Eastern Bluebird', sci: 'Sialia sialis' },
+  ] },
+  { family: 'fringillidae', familyName: 'Finches', species: [
+    { code: 'devseed-amegfi', com: 'American Goldfinch', sci: 'Spinus tristis' },
+    { code: 'devseed-houfin', com: 'House Finch', sci: 'Haemorhous mexicanus' },
+  ] },
+  { family: 'passerellidae', familyName: 'New World Sparrows', species: [
+    { code: 'devseed-sonspa', com: 'Song Sparrow', sci: 'Melospiza melodia' },
+    { code: 'devseed-whtspa', com: 'White-throated Sparrow', sci: 'Zonotrichia albicollis' },
+    { code: 'devseed-darjun', com: 'Dark-eyed Junco', sci: 'Junco hyemalis' },
+  ] },
+  { family: 'accipitridae', familyName: 'Hawks, Eagles & Kites', species: [
+    { code: 'devseed-rethaw', com: 'Red-tailed Hawk', sci: 'Buteo jamaicensis' },
+    { code: 'devseed-baleag', com: 'Bald Eagle', sci: 'Haliaeetus leucocephalus' },
+  ] },
+  { family: 'ardeidae', familyName: 'Herons & Egrets', species: [
+    { code: 'devseed-grbher', com: 'Great Blue Heron', sci: 'Ardea herodias' },
+    { code: 'devseed-greegr', com: 'Great Egret', sci: 'Ardea alba' },
+  ] },
+  { family: 'columbidae', familyName: 'Pigeons & Doves', species: [
+    { code: 'devseed-moudov', com: 'Mourning Dove', sci: 'Zenaida macroura' },
+    { code: 'devseed-rocpig', com: 'Rock Pigeon', sci: 'Columba livia' },
+  ] },
+  { family: 'laridae', familyName: 'Gulls & Terns', species: [
+    { code: 'devseed-rinbgu', com: 'Ring-billed Gull', sci: 'Larus delawarensis' },
+    { code: 'devseed-hergul', com: 'Herring Gull', sci: 'Larus argentatus' },
+  ] },
+  { family: 'troglodytidae', familyName: 'Wrens', species: [
+    { code: 'devseed-houwre', com: 'House Wren', sci: 'Troglodytes aedon' },
+    { code: 'devseed-carwre', com: 'Carolina Wren', sci: 'Thryothorus ludovicianus' },
+  ] },
+  { family: 'paridae', familyName: 'Chickadees & Titmice', species: [
+    { code: 'devseed-bkcchi', com: 'Black-capped Chickadee', sci: 'Poecile atricapillus' },
+    { code: 'devseed-tuftit', com: 'Tufted Titmouse', sci: 'Baeolophus bicolor' },
+  ] },
+  { family: 'hirundinidae', familyName: 'Swallows', species: [
+    { code: 'devseed-barswa', com: 'Barn Swallow', sci: 'Hirundo rustica' },
+    { code: 'devseed-treswa', com: 'Tree Swallow', sci: 'Tachycineta bicolor' },
+  ] },
+  { family: 'mimidae', familyName: 'Mockingbirds & Thrashers', species: [
+    { code: 'devseed-normoc', com: 'Northern Mockingbird', sci: 'Mimus polyglottos' },
+    { code: 'devseed-grycat', com: 'Gray Catbird', sci: 'Dumetella carolinensis' },
+  ] },
+  { family: 'thraupidae', familyName: 'Tanagers & Allies', species: [
+    { code: 'devseed-westan', com: 'Western Tanager', sci: 'Piranga ludoviciana' },
+    { code: 'devseed-scatan', com: 'Scarlet Tanager', sci: 'Piranga olivacea' },
+  ] },
+  { family: 'cathartidae', familyName: 'New World Vultures', species: [
+    { code: 'devseed-turvul', com: 'Turkey Vulture', sci: 'Cathartes aura' },
+    { code: 'devseed-blkvul', com: 'Black Vulture', sci: 'Coragyps atratus' },
+  ] },
+  { family: 'strigidae', familyName: 'Owls', species: [
+    { code: 'devseed-grhowl', com: 'Great Horned Owl', sci: 'Bubo virginianus' },
+    { code: 'devseed-burowl', com: 'Burrowing Owl', sci: 'Athene cunicularia' },
+  ] },
+  { family: 'sittidae', familyName: 'Nuthatches', species: [
+    { code: 'devseed-whbnut', com: 'White-breasted Nuthatch', sci: 'Sitta carolinensis' },
+    { code: 'devseed-rebnut', com: 'Red-breasted Nuthatch', sci: 'Sitta canadensis' },
+  ] },
+  { family: 'scolopacidae', familyName: 'Sandpipers & Allies', species: [
+    { code: 'devseed-spospa', com: 'Spotted Sandpiper', sci: 'Actitis macularius' },
+    { code: 'devseed-killde', com: 'Killdeer', sci: 'Charadrius vociferus' },
+  ] },
+];
+
+/** Target observation count — enough to populate the national grid + states. */
+export const TARGET_OBSERVATIONS = 400;
+
+/** Fraction of observations flagged is_notable. */
+const NOTABLE_FRACTION = 0.08;
+
+/** Recency window the whole stack filters on; obs spread across it. */
+const RECENCY_WINDOW_DAYS = 14;
+
+export interface SeedResult {
+  speciesMetaUpserted: number;
+  observationsUpserted: number;
+  gridRows: number;
+  families: number;
+  states: number;
+}
+
+/** All species_meta rows the seed needs, flattened from SEED_SPECIES. */
+function buildSpeciesMeta(): SpeciesMeta[] {
+  const out: SpeciesMeta[] = [];
+  let taxon = 100000;
+  for (const fam of SEED_SPECIES) {
+    for (const sp of fam.species) {
+      out.push({
+        speciesCode: sp.code,
+        comName: sp.com,
+        sciName: sp.sci,
+        familyCode: fam.family,
+        familyName: fam.familyName,
+        taxonOrder: taxon++,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the deterministic observation set. Each observation jitters its base
+ * city coordinate by a small fixed-PRNG offset so markers don't perfectly
+ * overlap (still well inside the state polygon). obs_dt is `now` minus a
+ * PRNG-chosen number of seconds within the 14-day window.
+ */
+function buildObservations(nowMs: number): ObservationInput[] {
+  const rand = mulberry32(0x5eed_1234);
+  const species = SEED_SPECIES.flatMap(fam =>
+    fam.species.map(sp => ({ code: sp.code, com: sp.com })),
+  );
+  const windowMs = RECENCY_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  // Leave a margin so rounding/clock skew never pushes a row past the 14d edge.
+  const maxAgeMs = windowMs - 6 * 60 * 60 * 1000;
+
+  const out: ObservationInput[] = [];
+  for (let i = 0; i < TARGET_OBSERVATIONS; i++) {
+    const city = STATE_CITIES[Math.floor(rand() * STATE_CITIES.length)]!;
+    const sp = species[Math.floor(rand() * species.length)]!;
+
+    // ±~0.18° jitter (~12–20 km) around the city — keeps points inside the
+    // state while spreading markers so a zoomed-in view isn't a single stack.
+    const lat = city.lat + (rand() - 0.5) * 0.36;
+    const lng = city.lng + (rand() - 0.5) * 0.36;
+
+    const ageMs = Math.floor(rand() * maxAgeMs);
+    const obsDt = new Date(nowMs - ageMs).toISOString();
+
+    // how_many: mostly 1–4, occasionally a flock.
+    const r = rand();
+    const howMany = r < 0.6 ? 1 + Math.floor(rand() * 3) : r < 0.9 ? 4 + Math.floor(rand() * 8) : 15 + Math.floor(rand() * 40);
+
+    const isNotable = rand() < NOTABLE_FRACTION;
+
+    out.push({
+      subId: `devseed-S${String(i).padStart(4, '0')}`,
+      speciesCode: sp.code,
+      comName: sp.com,
+      lat: Number(lat.toFixed(5)),
+      lng: Number(lng.toFixed(5)),
+      obsDt,
+      locId: `devseed-${city.state}-${i % 7}`,
+      locName: city.loc,
+      howMany,
+      isNotable,
+    });
+  }
+  return out;
+}
+
+/**
+ * Seed the database with deterministic dev observations. Idempotent: the fixed
+ * sub_ids/species_codes mean a re-run upserts the same rows. Writes species_meta
+ * first (the #484 invariant), then observations, then rebuilds the precompute
+ * grid so the default low-zoom map is non-empty.
+ */
+export async function seedDevData(pool: Pool, nowMs: number = Date.now()): Promise<SeedResult> {
+  const meta = buildSpeciesMeta();
+  const speciesMetaUpserted = await upsertSpeciesMeta(pool, meta);
+
+  const observations = buildObservations(nowMs);
+  const observationsUpserted = await upsertObservations(pool, observations);
+
+  const gridRows = await refreshGridAgg(pool);
+
+  const families = new Set(meta.map(m => m.familyCode)).size;
+  const states = new Set(STATE_CITIES.map(c => c.state)).size;
+
+  return { speciesMetaUpserted, observationsUpserted, gridRows, families, states };
+}
+
+/** CLI entry: reads DATABASE_URL, seeds, prints a coverage summary. */
+async function main(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error('DATABASE_URL is not set. Example:');
+    console.error('  DATABASE_URL=postgres://birdwatch:birdwatch@localhost:5432/birdwatch npm run db:seed');
+    process.exit(1);
+    return;
+  }
+
+  const pool = createPool({ databaseUrl: url });
+  try {
+    const result = await seedDevData(pool);
+    const { rows: [obsRow] } = await pool.query<{ n: string }>(
+      'SELECT count(*)::text AS n FROM observations',
+    );
+    const { rows: [orphan] } = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM observations o
+        WHERE NOT EXISTS (SELECT 1 FROM species_meta sm WHERE sm.species_code = o.species_code)`,
+    );
+    console.log('Dev seed complete.');
+    console.log(`  species_meta upserted : ${result.speciesMetaUpserted}`);
+    console.log(`  observations upserted : ${result.observationsUpserted}`);
+    console.log(`  observations in table : ${obsRow?.n ?? '?'}`);
+    console.log(`  observation_grid_agg  : ${result.gridRows} rows`);
+    console.log(`  families covered      : ${result.families}`);
+    console.log(`  states covered        : ${result.states}`);
+    console.log(`  orphan species_code   : ${orphan?.n ?? '?'} (must be 0)`);
+  } finally {
+    await closePool(pool);
+  }
+}
+
+// Run main() only when invoked directly (tsx packages/db-client/src/dev-seed.ts),
+// never on import (the seed module is also imported by its test).
+const invokedPath = process.argv[1] ?? '';
+if (invokedPath.endsWith('dev-seed.ts') || invokedPath.endsWith('dev-seed.js')) {
+  main().catch((err: unknown) => {
+    console.error('Dev seed failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Local dev has **no observation data** out of the box: migrations seed only static reference data (`family_silhouettes`, `state_boundaries`, `species_meta`), while every sighting otherwise comes from a live eBird ingest. A fresh clone therefore renders "No recent sightings" with an empty map/lede/legend unless you have an eBird API key. This adds a deterministic **`npm run db:seed`** that fills that gap.

- `packages/db-client/src/dev-seed.ts` — generates ~400 representative observations across ~24 real families (FK-correct against `family_silhouettes`) and ~18 CONUS states, within the 14-day recency window, ~8% notable; then calls `refreshGridAgg()` so the precompute-backed low-zoom map, lede count, and family legend all populate.
- Built on the real, tested db-client functions (`upsertSpeciesMeta` / `upsertObservations` / `refreshGridAgg`) so it stays correct as schema evolves.
- `package.json`: `db:seed` script. `knip.ts`: registers the seed entry so it isn't flagged as unused.
- `README.md`: local-dev quickstart (`db:up && db:migrate && db:seed`).

## Screenshots

`N/A — not UI` (backend/tooling: a seed script + test + docs).

## Reviewer notes

- [x] Multi-viewport design QA: `N/A — not UI`
- Deterministic: `seedDevData(pool, nowMs)` takes an injected clock; `obs_dt` is computed relative to `now()` so seeded rows stay inside the 14-day window on any run.
- Idempotent: `ON CONFLICT DO NOTHING`, re-runnable.

## Test plan

- `packages/db-client/src/dev-seed.test.ts` (testcontainers, no mocks): after migrate + seed, asserts `observations > 0`, `observation_grid_agg > 0`, and that every observation's `species_code` resolves to a `species_meta` row whose `family_code` exists in `family_silhouettes` (no orphan joins).
- Validated live against a local DB: observations=400, observation_grid_agg=645, 24 families / ~18 states; read-api serves correct aggregated buckets with real family names.

## Linked

Closes the "no local dev seed" gap surfaced during the transitions.dev epic (#953) verification.
