### PR TITLE
fix(db): correct inverted silky-flycatcher dedupe migration 52000 (#922)

### DIFF
--- a/migrations/1700000052000_dedupe_ptiliogonatidae_silhouette.sql
+++ b/migrations/1700000052000_dedupe_ptiliogonatidae_silhouette.sql
@@ -1,48 +1,67 @@
 -- Up Migration
--- Issue #922 (family-name hygiene). Dedupe the spelling-variant duplicate in
--- family_silhouettes for the silky-flycatcher family.
+-- Issue #922 (family-name hygiene) — CORRECTED (inverted-spelling fix).
+-- Dedupe the spelling-variant duplicate in family_silhouettes for the
+-- silky-flycatcher family, keeping the spelling production actually resolves
+-- against.
 --
--- The table carries BOTH spellings of the Ptilogonatidae family:
---   * `ptilogonatidae`  — the PROJECT CANONICAL key, which is
---     `lower(familySciName)` (the same shape every other family_code uses,
---     and the key observations.family_code / species_meta.family_code resolve
---     against). Seeded in migration 15000, named 'Silky-Flycatchers' in 19500,
---     dual-palette colored in 46000.
---   * `ptiliogonatidae` — an extra-`i` variant matching eBird's own family
---     scientific-name spelling (`Ptiliogonatidae`). Inserted as a separate row
---     in migration 34000 (issue #495 AZ backfill) with common_name
---     'Silky-flycatchers' (note the lowercase `f` — a casing inconsistency too).
+-- The table carries BOTH spellings of the silky-flycatcher family:
+--   * `ptiliogonatidae` — eBird's family scientific-name spelling
+--     ("Ptiliogonatidae", extra `i`). Because family_code is
+--     `lower(familySciName)`, this is what species_meta.family_code holds for
+--     Phainopepla, so the silhouette-stamp join (db-client observations.ts)
+--     writes observations.silhouette_id = 'ptiliogonatidae'. THE LOAD-BEARING
+--     ROW. Inserted by migration 34000, palette set in 46000 (#73596a).
+--   * `ptilogonatidae` — a no-`i` spelling seeded in migration 15000 before the
+--     eBird-derived family_code convention existed. NOTHING joins to it: it is
+--     an orphan. Named 'Silky-Flycatchers' in 19500, palette set in 46000
+--     (#5b5b9c).
 --
--- Both rows currently carry a common_name, so rendering is fine TODAY. But two
--- rows for one family is latent taxonomy drift, and once a `family_silhouettes`
--- join is added on the read path (PR4 / issue #925), a `LEFT JOIN` on
--- family_code could match two rows for this family. Removing the variant now
--- keeps that join single-row-per-family.
+-- WHY THE ORIGINAL 52000 FAILED: it deleted `ptiliogonatidae` (the load-bearing
+-- row) on the inverted belief that `ptilogonatidae` was canonical. In
+-- production that DELETE hit observations_silhouette_id_fkey (real observation
+-- rows reference 'ptiliogonatidae'), so it errored on every deploy
+-- (deploy-migrations red since 2026-06-07) — yet passed CI, because
+-- testcontainers run against an empty observations table where the FK check
+-- never fires. The premise in the old comment ("no observation references the
+-- extra-`i` spelling") was the exact inversion of prod reality.
 --
--- We keep `ptilogonatidae` (the project canonical) and delete the
--- `ptiliogonatidae` variant. No observation or species_meta row references the
--- extra-`i` spelling (family_code is `lower(familySciName)` = `ptilogonatidae`),
--- so nothing is orphaned. The surviving canonical row keeps its non-null
--- common_name ('Silky-Flycatchers') unchanged.
---
--- eBird-join normalization note (scoped to a comment, NOT live code): the
--- project's family_code is `lower(familySciName)`, while eBird's taxonomy
--- spells this family `Ptiliogonatidae` (extra `i`) — so a future
--- `lower(familySciName)` join against eBird's `familyComName` would need the
--- alias `ptiliogonatidae -> ptilogonatidae`. No eBird name-refresh consumer
--- ships in this work, so the alias stays documented-only until one exists; see
--- docs/analyses/2026-06-07-family-colloquial-names/report.md (Authoritative
--- source) for the full normalization gotcha.
-DELETE FROM family_silhouettes WHERE family_code = 'ptiliogonatidae';
+-- FIX: keep `ptiliogonatidae` (eBird-canonical, prod-referenced), transfer the
+-- orphan's maintained palette + title-case common_name onto it, then delete the
+-- orphan `ptilogonatidae`. No ingest alias is ever needed because the surviving
+-- spelling already matches what eBird ingest produces — the alias the old
+-- comment worried about was an artifact of keeping the wrong row.
+
+-- 1. FK safety: repoint any observation stamped with the orphan spelling onto
+--    the survivor before deleting it. In prod this matches zero rows (the orphan
+--    is unreferenced), but it makes the migration correct under any data state
+--    and lets the DELETE below never violate the FK.
+UPDATE observations SET silhouette_id = 'ptiliogonatidae' WHERE silhouette_id = 'ptilogonatidae';
+
+-- 2. Transfer the orphan's maintained palette (migration 46000) and title-case
+--    common_name (migration 19500) onto the survivor, so the surviving row
+--    keeps the WCAG-calibrated colors and the 'Silky-Flycatchers' casing.
+--    UPDATE...FROM becomes a no-op once the orphan is gone (idempotent re-run).
+UPDATE family_silhouettes AS keep
+   SET color = src.color, color_dark = src.color_dark, common_name = src.common_name
+  FROM family_silhouettes AS src
+ WHERE keep.family_code = 'ptiliogonatidae' AND src.family_code = 'ptilogonatidae';
+
+-- 3. Drop the orphan spelling. Idempotent (no-op if already absent).
+DELETE FROM family_silhouettes WHERE family_code = 'ptilogonatidae';
 
 -- Down Migration
--- Re-insert the `ptiliogonatidae` variant exactly as it stood in the
--- fully-migrated forward state: NULL svg_data/source/license/creator (it was a
--- skip-family row in 34000), common_name 'Silky-flycatchers', and the
--- dual-palette colors set by migration 46000 (color/color_dark = #73596a).
--- ON CONFLICT keeps this idempotent if the row somehow already exists.
+-- Restore the two-row pre-migration state: re-insert the `ptilogonatidae` orphan
+-- with its pre-Up values (NULL svg_data/source/license/creator, migration 19500
+-- title-case 'Silky-Flycatchers', migration 46000 dual palette #5b5b9c), and
+-- revert the survivor `ptiliogonatidae` to its own pre-Up values (#73596a,
+-- migration 34000 'Silky-flycatchers' lowercase `f`). ON CONFLICT keeps the
+-- INSERT idempotent.
 INSERT INTO family_silhouettes
   (id, family_code, svg_data, color, color_dark, source, license, creator, common_name)
 VALUES
-  ('ptiliogonatidae', 'ptiliogonatidae', NULL, '#73596a', '#73596a', NULL, NULL, NULL, 'Silky-flycatchers')
+  ('ptilogonatidae', 'ptilogonatidae', NULL, '#5b5b9c', '#5b5b9c', NULL, NULL, NULL, 'Silky-Flycatchers')
 ON CONFLICT (id) DO NOTHING;
+
+UPDATE family_silhouettes
+   SET color = '#73596a', color_dark = '#73596a', common_name = 'Silky-flycatchers'
+ WHERE family_code = 'ptiliogonatidae';

--- a/packages/db-client/src/family-silhouettes-contrast.test.ts
+++ b/packages/db-client/src/family-silhouettes-contrast.test.ts
@@ -147,9 +147,10 @@ describe('family palette WCAG 1.4.11 (3:1 non-text contrast) — dual-palette co
   // (#51665e, 2.76), podicipedidae (#406a65, 2.80), ptiliogonatidae (#73596a, 2.72),
   // ptilogonatidae (#5b5b9c, 2.77), rallidae (#63605a, 2.71), strigidae (#725e35, 2.72),
   // sturnidae (#6b5885, 2.72), trochilidae (#9637ad, 2.79), troglodytidae (#86582c, 2.79).
-  // (Historical snapshot from #570; migration 52000 (#922) since removed the
-  // spelling-variant `ptiliogonatidae` row, so only the canonical
-  // `ptilogonatidae` remains of that pair.)
+  // (Historical snapshot from #570; migration 52000 (#922, inverted-spelling
+  // fix) since removed the no-`i` orphan `ptilogonatidae`, so only the
+  // eBird-canonical `ptiliogonatidae` remains of that pair — carrying the
+  // transferred #5b5b9c palette.)
   //
   // Re-enable to `it(...)` once migration 1700000047000 lands. See #583.
   it.todo('every family_silhouettes.color_dark is ≥ 3:1 against the dark legend card surface (#131C30) — pending migration 1700000047000 (tracked in #583)');

--- a/packages/db-client/src/migrations-down-chain.test.ts
+++ b/packages/db-client/src/migrations-down-chain.test.ts
@@ -66,11 +66,11 @@ describe('Down(14000→17000) rollback chain', () => {
     const migrationsDir = resolve(process.cwd(), '../../migrations');
 
     // Roll down from 52000 → 14000 in reverse numeric order.
-    // Migration 52000 (#922 family-name hygiene) DELETEs the spelling-variant
-    // `ptiliogonatidae` row (one of the svg_data=NULL skip-family rows from
-    // 34000). Its Up runs in beforeAll, so it must be rolled down FIRST or the
-    // deleted NULL row would deflate test 1's NULL count (6 not 7) and test 2's
-    // total count (53 not 54). Down(52000) re-inserts it, restoring the
+    // Migration 52000 (#922 family-name hygiene, inverted-spelling fix) DELETEs
+    // the no-`i` orphan `ptilogonatidae` row (a svg_data=NULL row; the seed
+    // 15000 spelling). Its Up runs in beforeAll, so it must be rolled down FIRST
+    // or the deleted NULL row would deflate test 1's NULL count (6 not 7) and
+    // test 2's total count (53 not 54). Down(52000) re-inserts it, restoring the
     // historical invariants. (Mirrors `node-pg-migrate down`: latest first.)
     // Migration 48000 (Phase 3a national-coverage flip) inserts 32 rows,
     // 15 of them with svg_data=NULL — must be rolled down first or its

--- a/packages/db-client/src/ptiliogonatidae-dedupe-migration.test.ts
+++ b/packages/db-client/src/ptiliogonatidae-dedupe-migration.test.ts
@@ -3,19 +3,27 @@
  * dedupe the spelling-variant duplicate in family_silhouettes for the
  * silky-flycatcher family (`ptilogonatidae` vs `ptiliogonatidae`).
  *
- * Issue #922 (family-name hygiene). The table historically carried two rows for
- * one family: the project-canonical `ptilogonatidae` (`lower(familySciName)`,
- * the key observations/species_meta resolve against) and an extra-`i`
- * `ptiliogonatidae` variant (matching eBird's own spelling), inserted by
- * migration 34000. Both have a common_name so rendering is fine today, but the
- * duplicate is latent taxonomy drift and would let PR4's `family_silhouettes`
- * LEFT JOIN match two rows for the family.
+ * Issue #922 (family-name hygiene), CORRECTED. The table historically carried
+ * two rows for one family. The ORIGINAL migration deleted `ptiliogonatidae`
+ * believing `ptilogonatidae` (no `i`) was the canonical `lower(familySciName)`
+ * key. Production proved that inverted: eBird's familySciName is
+ * "Ptiliogonatidae" (extra `i`), so species_meta.family_code =
+ * 'ptiliogonatidae', the silhouette-stamp join writes
+ * observations.silhouette_id = 'ptiliogonatidae', and deleting that row
+ * violated observations_silhouette_id_fkey — failing every prod deploy while
+ * passing CI (testcontainers have an empty observations table). The no-`i`
+ * `ptilogonatidae` row is the orphaned seed (migration 15000) that nothing
+ * joins to.
+ *
+ * The corrected migration KEEPS `ptiliogonatidae` (eBird-canonical,
+ * prod-referenced), transfers the orphan's maintained palette + title-case
+ * common_name onto it, and deletes the orphan `ptilogonatidae`.
  *
  * Invariants exercised here:
- *   - Up leaves exactly ONE silky-flycatcher row, the canonical
- *     `ptilogonatidae`, and it still has a non-null common_name.
- *   - Up does not touch the canonical row's common_name.
- *   - Down re-inserts the `ptiliogonatidae` variant (rollback restores the
+ *   - Up leaves exactly ONE silky-flycatcher row, the eBird-canonical
+ *     `ptiliogonatidae`, with the title-case common_name 'Silky-Flycatchers'.
+ *   - Up removes the orphan `ptilogonatidae` row entirely.
+ *   - Down re-inserts the `ptilogonatidae` orphan (rollback restores the
  *     pre-migration two-row state).
  *
  * No DB mocks — runs against a real PostGIS testcontainer per the project-wide
@@ -37,9 +45,9 @@ let pool: pg.Pool;
 
 const MIGRATION_FILE = '1700000052000_dedupe_ptiliogonatidae_silhouette.sql';
 
-// The two spellings of the Ptilogonatidae (silky-flycatcher) family.
-const CANONICAL = 'ptilogonatidae'; // lower(familySciName) — kept
-const VARIANT = 'ptiliogonatidae'; // extra `i`, eBird spelling — removed
+// The two spellings of the Ptiliogonatidae (silky-flycatcher) family.
+const CANONICAL = 'ptiliogonatidae'; // eBird familySciName / lower() — kept (prod-referenced)
+const VARIANT = 'ptilogonatidae'; // no-`i` orphaned seed row — removed
 
 function parseMigration(filePath: string): { up: string; down: string } {
   const sql = readFileSync(filePath, 'utf-8');
@@ -87,7 +95,7 @@ describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Up', () 
     expect(rows[0]?.common_name).not.toBeNull();
   });
 
-  it('removes the extra-`i` variant row entirely', async () => {
+  it('removes the no-`i` orphan row entirely', async () => {
     const { rows } = await pool.query<{ count: string }>(
       `SELECT COUNT(*) AS count FROM family_silhouettes WHERE family_code = $1`,
       [VARIANT]
@@ -108,7 +116,7 @@ describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Up', () 
 });
 
 describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Down', () => {
-  it('re-inserts the variant row (restores the two-row pre-migration state)', async () => {
+  it('re-inserts the orphan row (restores the two-row pre-migration state)', async () => {
     const migrationsDir = resolve(process.cwd(), '../../migrations');
     const { down, up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
     expect(down).toBeTruthy();
@@ -127,9 +135,11 @@ describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Down', (
       [VARIANT]
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.common_name).toBe('Silky-flycatchers');
-    expect(rows[0]?.color).toBe('#73596a');
-    expect(rows[0]?.color_dark).toBe('#73596a');
+    // Down restores the no-`i` orphan with its pre-Up values (migration 19500
+    // title-case name, migration 46000 dual palette #5b5b9c).
+    expect(rows[0]?.common_name).toBe('Silky-Flycatchers');
+    expect(rows[0]?.color).toBe('#5b5b9c');
+    expect(rows[0]?.color_dark).toBe('#5b5b9c');
     expect(rows[0]?.svg_data).toBeNull();
 
     // Both spellings present again after Down.
@@ -141,5 +151,49 @@ describe('migration 1700000052000_dedupe_ptiliogonatidae_silhouette — Down', (
 
     // Re-apply Up so the container is left in forward state for any shared run.
     await pool.query(up);
+  });
+});
+
+describe('migration 1700000052000 — FK safety (regression for the prod failure)', () => {
+  // The ORIGINAL migration failed every prod deploy with
+  // observations_silhouette_id_fkey because it deleted a family_silhouettes row
+  // that observations referenced. CI never caught it: testcontainers run against
+  // an empty observations table, so the FK check never fired. This test closes
+  // that gap by stamping a real observation onto the row the migration deletes,
+  // then asserting Up succeeds (repoints, not FK-errors).
+  it('Up succeeds and repoints observations when a row references the orphan spelling', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { down, up } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+
+    // Restore the two-row state so the orphan `ptilogonatidae` exists to be
+    // referenced (mirrors prod, where both rows were present pre-dedupe).
+    await pool.query(down);
+
+    // Stamp an observation onto the orphan row — the exact FK hazard. (region_id
+    // was dropped in migration 43000; geom is generated from lat/lng.)
+    await pool.query(
+      `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, silhouette_id)
+       VALUES ('FKTEST_SUB', 'phaino', 33.45, -112.07, now(), 'FKTEST_LOC', $1)`,
+      [VARIANT]
+    );
+
+    // The corrected Up must NOT throw an FK violation here.
+    await expect(pool.query(up)).resolves.toBeDefined();
+
+    // The observation was repointed onto the surviving canonical spelling…
+    const obs = await pool.query<{ silhouette_id: string }>(
+      `SELECT silhouette_id FROM observations WHERE sub_id = 'FKTEST_SUB' AND species_code = 'phaino'`
+    );
+    expect(obs.rows[0]?.silhouette_id).toBe(CANONICAL);
+
+    // …and the orphan row is gone.
+    const orphan = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM family_silhouettes WHERE family_code = $1`,
+      [VARIANT]
+    );
+    expect(Number(orphan.rows[0]?.count)).toBe(0);
+
+    // Cleanup the test observation so it doesn't leak into a shared container.
+    await pool.query(`DELETE FROM observations WHERE sub_id = 'FKTEST_SUB'`);
   });
 });

--- a/packages/db-client/src/silhouettes.test.ts
+++ b/packages/db-client/src/silhouettes.test.ts
@@ -13,8 +13,9 @@ describe('getSilhouettes', () => {
     // from migration 33000 (#482) + 38 observed-family backfill from
     // migration 34000 (#495) + 32 national-coverage rows from migration
     // 48000 (Phase 3a US-wide flip) − 1 spelling-variant dedupe from
-    // migration 52000 (#922: dropped the extra-`i` `ptiliogonatidae`, leaving
-    // the canonical `ptilogonatidae`). The _FALLBACK row backs the SDF symbol
+    // migration 52000 (#922, inverted-spelling fix: dropped the no-`i` orphan
+    // `ptilogonatidae`, kept eBird-canonical `ptiliogonatidae`). The _FALLBACK
+    // row backs the SDF symbol
     // layer's fallback rendering for observations whose family has no
     // usable Phylopic silhouette.
     const rows = await getSilhouettes(db.pool);
@@ -151,7 +152,6 @@ describe('getSilhouettes', () => {
       mimidae: '#8E7B5A',       // unchanged (passes both)
       paridae: '#4A6FA5',       // unchanged (passes both)
       parulidae: '#958b23',     // was #D4C84A (light-failing, darkened)
-      ptilogonatidae: '#5b5b9c', // was #1F1F35
       remizidae: '#789166',     // was #9AAE8C (light-failing, darkened)
       threskiornithidae: '#C56B9D', // unchanged (passes both)
       // --- migration 18000 (issue #246 fallback) ---
@@ -187,8 +187,10 @@ describe('getSilhouettes', () => {
       polioptilidae: '#788ca0', // was #A8B5C2 (light-failing, darkened)
       psittacidae: '#3b9d4b',   // was #3FA850 (light-failing, darkened)
       psittaculidae: '#3d9790', // was #4FB8B0 (light-failing, darkened)
-      // ptiliogonatidae removed by migration 52000 (#922 dedupe) — the
-      // canonical `ptilogonatidae` (#5b5b9c, above) is the surviving row.
+      // ptiliogonatidae is the silky-flycatcher survivor of migration 52000
+      // (#922 dedupe, inverted-spelling fix): the no-`i` `ptilogonatidae`
+      // orphan was deleted and its #5b5b9c palette transferred onto this row.
+      ptiliogonatidae: '#5b5b9c',
       rallidae: '#63605a',      // was #403E3A
       recurvirostridae: '#c47484', // was #E1B8C0 (light-failing, darkened)
       regulidae: '#68964b',     // was #6FA050 (light-failing, darkened)
@@ -280,7 +282,6 @@ describe('getSilhouettes', () => {
       mimidae: 'Mockingbirds & Thrashers',
       columbidae: 'Pigeons & Doves',
       parulidae: 'New World Warblers',
-      ptilogonatidae: 'Silky-Flycatchers',
       paridae: 'Tits, Chickadees & Titmice',
       fringillidae: 'Finches',
       caprimulgidae: 'Nightjars',
@@ -322,8 +323,10 @@ describe('getSilhouettes', () => {
       polioptilidae: 'Gnatcatchers',
       psittacidae: 'African & New World Parrots',
       psittaculidae: 'Old World Parrots',
-      // ptiliogonatidae removed by migration 52000 (#922 dedupe); the
-      // canonical `ptilogonatidae: 'Silky-Flycatchers'` (above) survives.
+      // ptiliogonatidae is the silky-flycatcher survivor of migration 52000
+      // (#922 dedupe, inverted-spelling fix); the no-`i` `ptilogonatidae`
+      // orphan was deleted and its title-case common_name transferred here.
+      ptiliogonatidae: 'Silky-Flycatchers',
       rallidae: 'Rails, Gallinules & Coots',
       recurvirostridae: 'Stilts & Avocets',
       regulidae: 'Kinglets',

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -966,8 +966,9 @@ describe('GET /api/silhouettes', () => {
     // + 38 observed-family backfill rows from migration 34000 (issue #495)
     // + 32 national-coverage rows from migration 48000 (Phase 3a US-wide
     // flip — 17 with svg_data, 15 with NULL svg_data) − 1 spelling-variant
-    // dedupe from migration 52000 (#922: dropped the extra-`i`
-    // `ptiliogonatidae`) → 96 total.
+    // dedupe from migration 52000 (#922, inverted-spelling fix: dropped the
+    // no-`i` orphan `ptilogonatidae`, kept eBird-canonical `ptiliogonatidae`)
+    // → 96 total.
     expect(body).toHaveLength(96);
     // Spot-check the _FALLBACK row round-trips through the Hono response
     // so the frontend's symbol-layer fallback path can rely on it.


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    sm["species_meta.family_code<br/>= 'ptiliogonatidae'<br/>(lower of eBird 'Ptiliogonatidae')"] --> stamp["silhouette-stamp join"]
    stamp --> obs["observations.silhouette_id<br/>= 'ptiliogonatidae'"]
    obs -. observations_silhouette_id_fkey .-> keep["family_silhouettes<br/>'ptiliogonatidae' (load-bearing)"]
    orphan["family_silhouettes<br/>'ptilogonatidae' (orphan seed, nothing joins)"]

    subgraph OLD["OLD 52000 — deletes the referenced row → prod deploy FAILS"]
        delA["DELETE 'ptiliogonatidae'"] -. FK VIOLATION .-> keep
    end

    subgraph NEW["NEW 52000 — FK-safe, keeps the canonical row"]
        repoint["1. repoint any obs 'ptilogonatidae' → 'ptiliogonatidae'"] --> transfer["2. transfer orphan palette + title-case name onto survivor"] --> delB["3. DELETE 'ptilogonatidae' (orphan, unreferenced)"]
    end
```

## Summary

- **Why:** migration 52000 deleted `ptiliogonatidae` — the eBird-canonical spelling that `species_meta`/`observations` actually reference — believing the no-`i` `ptilogonatidae` seed row was canonical. That DELETE hit `observations_silhouette_id_fkey` on **every prod deploy** (`deploy-migrations` red since 2026-06-07), yet passed CI because testcontainers run against an empty `observations` table where the FK never fires.
- **Fix:** keep `ptiliogonatidae`; transfer the orphan's WCAG-vetted palette (`#5b5b9c`) and title-case `common_name` ('Silky-Flycatchers') onto it; repoint any observation referencing the orphan; then delete `ptilogonatidae`. Idempotent and FK-safe by construction (the only FK into `family_silhouettes` is `observations.silhouette_id`, handled by the repoint). No ingest alias needed — the surviving spelling already matches what eBird ingest produces.
- Adds an **FK-path regression test** that stamps an observation onto the deleted row before running Up — the exact coverage gap that let the original bug ship green. Snapshot/down-chain/count tests updated for the flipped survivor (still 96 families).

## Screenshots

N/A — not UI

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A — not UI
- [x] Multi-viewport design QA — N/A — not UI

## Test plan

- [x] Affected integration tests green vs real Postgres (testcontainers): `ptiliogonatidae-dedupe-migration.test.ts` (5, incl. new FK regression), `silhouettes.test.ts`, `migrations-down-chain.test.ts`, `family-silhouettes-contrast.test.ts`, read-api `app.test.ts` silhouettes — 18 passed, 1 todo. Full suite + e2e run in CI.
- [x] New unit / integration tests added — FK-path regression in `ptiliogonatidae-dedupe-migration.test.ts`
- [x] New Playwright e2e spec — N/A — data migration, no user-visible behavior change (legend rendering unchanged)
- [x] `npm run build` — clean for `@bird-watch/db-client` and `@bird-watch/read-api` (tsc)
- [x] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Out of plan — fixes a prod-blocking migration regression from #922 / PR #925 (`deploy-migrations` red since 2026-06-07). Unblocks the migration pipeline on merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)