### PR TITLE
feat(frontend): complete Photo skeleton→image reveal — #14 skeleton-reveal, image fade-in only

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -313,6 +313,7 @@
   height: 100%;
   object-fit: cover;
   border-radius: var(--photo-radius);
+  transition: opacity var(--dur-base) ease;
 }
 
 .photo__img--pending {


### PR DESCRIPTION
## Diagrams

N/A — single CSS property addition; no data-flow, state machine, or component structure change.

## Summary

- Completes catalog recipe #14 skeleton-reveal on `<Photo>`: the shimmer pulse half was already shipped (#419), but the image was snapping from `opacity:0→1` in the same frame the skeleton unmounted — a hard cut.
- Adds `transition: opacity var(--dur-base) ease` (`--dur-base` = 250ms) to `.photo__img` so the image fades in over 250ms after `onLoad` fires.
- Position is deliberately excluded from the transition list: the `--pending→loaded` swap also flips `position: absolute→static` (ds-primitives.css:322/329) and that must snap, not ease, to avoid layout jank. Reduced-motion is covered by the existing global `motion.css` guard — no per-element query added.

Closes #949. Part of epic #953.

## Screenshots

**Functional verification (live-verify N/A for this change — maintainer-approved, like #948).** The only change is `transition: opacity var(--dur-base) ease;` on `.photo__img` — completing recipe #14's reveal half (image fades in on load). This is **not live-verifiable with the dev seed**: the masthead `<Photo>` requires a species with a real photo URL, which the synthetic `devseed-*` species do not have; and a 250ms opacity fade is not demonstrable in a static screenshot regardless. Verified by: the one-line diff (opacity-only, position excluded so it snaps; skeleton untouched — it conditionally unmounts), CI green (test/lint/build/e2e/knip), and the bot review of the diff.


## Test plan

- [x] `npm run typecheck && npm run test` — typecheck clean; unit tests: 1227 passed (2 pre-existing failures on `origin/main` unrelated to this change: `App.seed.test.ts` + `url-state.test.ts`, verified by stash-test)
- [x] New unit / integration tests added — N/A (CSS-only change; no new behavior to unit-test beyond what existing Photo tests cover)
- [x] New Playwright e2e spec added — N/A (CSS-only transition; no new interactive behavior)
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — pending orchestrator live-verification

## Plan reference

Out of plan — transitions.dev animation audit Batch 2 (2026-06-09), adversarially verified per issue #949.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
