### PR TITLE
feat(frontend): scope disclosure open → #07 panel-reveal (remove the double display:none lock)

### DIFF
--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -295,19 +295,28 @@ export function AppHeader({
           </div>
         )}
 
-        {/* Scope disclosure body (§4.2 / #828) — MOUNTED whenever scope is active
-            (so aria-controls has a valid target) but CSS-collapsed until the 🔍
-            trigger opens it. `data-open` drives the reveal; the Esc handler lives
-            here so a press from any field (or the trigger) collapses + restores
-            focus. NO click-outside (a stray map click must not lose a typed ZIP).
-            The divider only renders when open — the resting card is two lines. */}
+        {/* Scope disclosure body (§4.2 / #828 / #951) — MOUNTED whenever scope is
+            active (so aria-controls has a valid target) but CSS-collapsed until
+            the 🔍 trigger opens it. `data-open` drives the catalog #07
+            panel-reveal (.t-panel-slide, styles.css): the rows REST at the
+            VISIBLE open end-state and are only offset (translate/opacity/blur +
+            visibility:hidden) while closed, so the global reduced-motion guard —
+            which zeroes the interpolation, not the start value — lands them
+            fully visible on open. The element is always painted (visibility,
+            not display:none), so the synchronous data-open flip tweens without a
+            post-paint rAF. visibility:hidden at rest keeps the closed form out of
+            the a11y tree + tab order AND satisfies Playwright toBeHidden() (an
+            `inert`-only rest would still occupy layout and fail those #951 asserts).
+            The Esc handler lives here so a press from any field (or the trigger)
+            collapses + restores focus. NO click-outside (a stray map click must
+            not lose a typed ZIP). The divider only renders when open — the
+            resting card is two lines. */}
         {scopeActive && (
           <div
             id={scopeRegionId}
             ref={scopeRowsRef}
-            className="app-header-scope-rows"
+            className="app-header-scope-rows t-panel-slide"
             data-open={scopeOpen}
-            hidden={!scopeOpen}
           >
             {/* Divider only renders when open — the resting card is two lines.
                 (The ScopeControl below stays mounted regardless so aria-controls

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -473,11 +473,15 @@ body {
   border-top: 1px solid var(--color-border-ui);
 }
 
-/* Scope rows container (§4.2 / #828) — the scope form, collapsed behind the 🔍
-   disclosure. The `hidden` attribute (display:none) handles the collapsed state;
-   when open it is a stacked flex column flush within the card padding. The
-   `[data-open]` hooks document the state for the orphan-className gate and allow
-   future open/close transitions without a JS class toggle. */
+/* Scope rows container (§4.2 / #828 / #951) — the scope form, collapsed behind
+   the 🔍 disclosure. Opening it plays catalog recipe #07 (panel-reveal): the
+   form slides a short distance into the card with transform/opacity/blur,
+   compositing cleanly (the identity card is position:absolute, so its growth
+   does not reflow the map canvas — #01 height-tween rejected, see #951). The
+   `[data-open]` hook drives the reveal with no JS class toggle. The container
+   itself is always `display:flex` — the open/close gating now lives on the
+   .t-panel-slide rules below (the old `hidden` prop + `display:none` rule are
+   removed; either left in force would clip the start frame and kill the tween). */
 .app-header-scope-rows {
   display: flex;
   flex-direction: column;
@@ -486,10 +490,47 @@ body {
      as every other row in the card (#837). */
   gap: var(--space-sm);
 }
-/* Defensive: `hidden` already collapses it, but assert display:none on the
-   closed state so a stray `display` from a future flex rule can't reveal it. */
-.app-header-scope-rows[data-open='false'] {
-  display: none;
+
+/* ── #951: scope disclosure open → recipe #07 (panel-reveal) ────────────────
+   Catalog snippet (~/.claude/skills/transitions-dev/07-panel-reveal.md) pasted
+   with the enumerated properties, will-change, and the same in-card overrides
+   the SpeciesDetailRail precedent uses (styles.css §#918): --panel-translate-y
+   shortened to a small in-card travel (this is a brief reveal of two/three
+   rows, not a full-height panel), --panel-open-dur / --panel-ease / --panel-blur
+   reused from tokens.css.
+
+   REST = the VISIBLE open end-state (translateY(0)/opacity:1/blur(0)). The rows
+   are only offset while CLOSED ([data-open='false']) — that ordering is what
+   makes the GLOBAL reduced-motion guard (motion.css zeroes the INTERPOLATION,
+   not the start value) land the form fully visible on open instead of stuck
+   off-screen. No per-element prefers-reduced-motion query here (house policy).
+
+   Closed-state visibility:hidden (NOT inert alone, NOT opacity:0 alone): pulls
+   the collapsed form out of the a11y tree + tab order AND satisfies the e2e
+   `toBeHidden()` asserts (scope-disclosure.spec.ts :96/:97/:164/:178) — an
+   inert element still occupies layout and would fail toBeHidden(). visibility is
+   discrete (no tween), so the form's interactive surface flips on/off cleanly at
+   the open/close edges while transform/opacity/filter carry the visible motion.
+   The element is always painted (visibility, not display:none), so the
+   synchronous data-open flip tweens without a post-paint rAF. */
+.app-header-scope-rows.t-panel-slide {
+  /* A short in-card travel — a few rows revealing, not a full panel. */
+  --panel-translate-y: 14px;
+  transform: translateY(0);
+  opacity: 1;
+  filter: blur(0);
+  visibility: visible;
+  transition:
+    transform var(--panel-open-dur) var(--panel-ease),
+    opacity   var(--panel-open-dur) var(--panel-ease),
+    filter    var(--panel-open-dur) var(--panel-ease);
+  will-change: transform, opacity, filter;
+}
+.app-header-scope-rows.t-panel-slide[data-open='false'] {
+  transform: translateY(var(--panel-translate-y));
+  opacity: 0;
+  filter: blur(var(--panel-blur));
+  visibility: hidden;
 }
 
 /* ── TOP-RIGHT: controls pill ───────────────────────────────────────────────


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    [*] --> Closed: scope active, rows MOUNTED
    Closed --> Open: click 🔍 (data-open=true)
    Open --> Closed: ✕ / Esc (data-open=false)

    state Closed {
        [*] --> offset
        offset: translateY(14px) · opacity 0 · blur 2px<br/>visibility hidden (out of a11y tree + tab order)
    }
    state Open {
        [*] --> rest
        rest: translateY(0) · opacity 1 · blur 0<br/>visibility visible — recipe #07 enter tween
    }

    note right of Open
        REST state = the VISIBLE end-state.
        Only CLOSED is offset, so the GLOBAL
        reduced-motion guard (motion.css zeroes
        the interpolation, not the start value)
        lands the form fully visible on open.
    end note
```

## Summary

- **Why #07, not #01:** the scope disclosure (🔍 → state/ZIP form in the top-left identity card) now opens with transitions.dev recipe **#07 panel-reveal** (transform/opacity/blur, composites cleanly) instead of the rejected **#01 card-resize** (per-frame height reflow, can't tween to `height:auto` without JS measurement — the FLIP-adjacent trap). The identity card is `position:absolute`, so its growth never reflows the map canvas.
- **The double `display:none` lock is gone.** The collapse was locked twice — the React `hidden` prop on `.app-header-scope-rows` AND a CSS `[data-open='false'] { display:none }` rule. Both are removed; either left in force clips the start frame and the transition never fires.
- **Rest-at-visible + reduced-motion + a11y.** The rows REST at the visible open end-state and are only offset while closed, so the global reduced-motion guard (`motion.css`, which zeroes the interpolation not the start value) lands the form fully visible on open. Closed-state uses `visibility: hidden` — not `inert` alone — which keeps the form out of the a11y tree + tab order AND satisfies the e2e `toBeHidden()` asserts (an `inert` element still occupies layout and would fail them). The element stays painted (`visibility`, not `display:none`), so the synchronous `data-open` flip tweens without a post-paint rAF. The open-edge focus move (first `<select>`) is unchanged.

## Screenshots

**Live-verified via Playwright; stills published below (5 viewports × 2 themes, scope form revealed).** Driven against this PR's dev build on the seeded local stack (400 observations / 24 families). The **#07 panel-reveal** confirmed live: at rest `.app-header-scope-rows` is `display:flex` + **`visibility:hidden`** (the double `display:none` lock removed; the foot-gun honored — `visibility:hidden`, NOT `inert`-alone — keeps it out of the a11y tree/tab order AND satisfies the e2e `toBeHidden()` asserts); clicking 🔍 "Change region" flips `data-open=true` → `visibility:visible`/`opacity:1`, the `t-panel-slide` (transform/opacity/filter) reveal settles, and the form controls become reachable. Console **0 errors / 0 warnings**. The stills show the revealed form.

| Viewport | Light | Dark |
|---|---|---|
| **Mobile 390×844** | <img width="430" alt="mobile-light" src="https://github.com/user-attachments/assets/f6c0a649-a8c1-458f-b24c-d452fb89b94b"> | <img width="430" alt="mobile-dark" src="https://github.com/user-attachments/assets/3d4807db-e2ac-4902-b4e6-3ac715df8500"> |
| **Tablet 768×1024** | <img width="430" alt="tablet-light" src="https://github.com/user-attachments/assets/cfb746a0-31fe-4dcb-b9b2-4af24bcf4cea"> | <img width="430" alt="tablet-dark" src="https://github.com/user-attachments/assets/91a6b4ca-e592-41d3-823c-895e9c41eecb"> |
| **Laptop 1024×768** | <img width="430" alt="laptop-light" src="https://github.com/user-attachments/assets/2cb28a15-e518-4031-a463-0d1e1de44505"> | <img width="430" alt="laptop-dark" src="https://github.com/user-attachments/assets/ea720759-aaa6-4629-bd32-e32880862cc4"> |
| **Desktop 1440×900** | <img width="430" alt="desktop-light" src="https://github.com/user-attachments/assets/d66169c1-d4a1-4f4a-93b0-8dddf103c6b2"> | <img width="430" alt="desktop-dark" src="https://github.com/user-attachments/assets/4e77c23c-c34d-408a-8b56-eb7499ff8b66"> |
| **Wide 1920×1080** | <img width="430" alt="wide-light" src="https://github.com/user-attachments/assets/e589b4a3-a5cb-4a80-aa13-4e596dcdbf44"> | <img width="430" alt="wide-dark" src="https://github.com/user-attachments/assets/f9efe030-1574-4a01-82bf-3894d1cabc9b"> |


## Test plan

- [x] `tsc --noEmit` (typecheck) + `npm test --workspace @bird-watch/frontend` — green (1291 unit tests pass)
- [x] No new unit tests needed — the existing `AppHeader.test.tsx` disclosure suite (`data-open` toggles, focus-on-open, Esc-restore, no-click-outside) and `frontend/e2e/scope-disclosure.spec.ts` (`toBeHidden()` at rest, `toBeVisible()` on open) already cover the contract and stay green under the new CSS mechanism.
- [x] No new Playwright e2e spec — the open/close + a11y behavior is unchanged; only the rest-closed mechanism moved from `display:none` to recipe-#07 `visibility:hidden` + transform/opacity/blur.
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — pending orchestrator live-verification across the 5 canonical viewports × 2 themes.

## Plan reference

Out of plan — transitions.dev animation audit (Batch 4; verdict REVISE #01→#07). Closes #951; part of epic #953.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

