### PR TITLE
feat(frontend): controls micro-motion — theme toggle #09 icon-swap, filters badge #03 pop, legend chevron rotate

### DIFF
--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -200,8 +200,15 @@ function FamilyLegendImpl({
         }}
       >
         <span className="family-legend-title">Bird families in view</span>
-        <span className="family-legend-chevron" aria-hidden="true">
-          {effectiveExpanded ? '▾' : '▸'}
+        {/* Single glyph + rotate transition — chevron rotate only.
+            data-expanded drives the CSS rotate(90deg) on .family-legend-chevron.
+            List mount behavior is byte-identical (hard guard: no always-mount). */}
+        <span
+          className="family-legend-chevron"
+          data-expanded={effectiveExpanded ? 'true' : 'false'}
+          aria-hidden="true"
+        >
+          ▸
         </span>
       </button>
       {effectiveExpanded && entries.length > 0 && (

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -49,8 +49,6 @@ export function ThemeToggle() {
     setTheme(next);
   }, [theme]);
 
-  const icon = theme === 'light' ? '☀' : '☾';
-
   return (
     <>
       <button
@@ -58,8 +56,28 @@ export function ThemeToggle() {
         onClick={toggle}
         aria-label="Toggle color theme"
         aria-pressed={theme === 'dark'}
+        className="theme-toggle"
       >
-        {icon}
+        {/* Recipe #09 — icon-swap: two stacked glyph spans occupy one slot.
+            The visible span has data-active; the hidden span is the outgoing
+            glyph. CSS cross-fades opacity+blur+scale on [data-active] via a
+            transition — the global motion.css guard zeros the duration for
+            reduced-motion users, leaving glyphs at their end-state (visible
+            active glyph) with no sticking. */}
+        <span
+          className="theme-toggle-glyph"
+          data-active={theme === 'light' ? true : undefined}
+          aria-hidden="true"
+        >
+          ☀
+        </span>
+        <span
+          className="theme-toggle-glyph"
+          data-active={theme === 'dark' ? true : undefined}
+          aria-hidden="true"
+        >
+          ☾
+        </span>
       </button>
       {/* Visually-hidden live region — must be a SIBLING of the button,
           NOT a child. See #416. */}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -614,6 +614,27 @@ body {
   font-size: 11px;
   font-weight: var(--font-weight-semibold);
   line-height: 1;
+  /* Recipe #03 — notification-badge: one-shot @keyframes entrance on mount.
+     MUST be @keyframes + animation, NOT a transition — a CSS transition does
+     not fire on first paint of a freshly-mounted node (silent no-op).
+     animation-fill-mode: backwards ensures the start-state (scale 0.6 +
+     opacity 0) holds until the animation begins so there's no flash.
+     Digit changes stay instant hard-cuts (no animation on value change).
+     The global motion.css guard sets animation-duration: 0ms for
+     prefers-reduced-motion, resolving instantly to the end-state — no
+     stuck-hidden risk because the end-state is fully visible. */
+  animation: badge-pop 200ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes badge-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* ThemeToggle button inside the controls pill (plain <button> via ThemeToggle). */
@@ -625,6 +646,38 @@ body {
     min-height: 44px;
     min-width: 44px;
   }
+}
+
+/* Recipe #09 — icon-swap: cross-fade + blur + scale between ☀ and ☾.
+   The button positions its content as a single stack; both glyph spans
+   share the same grid cell so they overlay each other.
+
+   Resting state: opacity 0, scale 0.85, blur 4px (outgoing glyph).
+   Active state ([data-active]): opacity 1, scale 1, blur 0px (incoming glyph).
+   Transition fires in both directions on every toggle.
+
+   The global motion.css guard sets transition-duration: 0ms for
+   prefers-reduced-motion users — both glyphs then resolve instantly to
+   their end-state. The active glyph ends at opacity:1 (fully visible) so
+   reduced-motion users are never stuck-hidden. */
+.theme-toggle {
+  display: inline-grid;
+}
+.theme-toggle-glyph {
+  grid-area: 1 / 1;         /* stack both spans in the same cell */
+  opacity: 0;
+  transform: scale(0.85);
+  filter: blur(4px);
+  transition:
+    opacity   160ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    filter    160ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform, filter;
+}
+.theme-toggle-glyph[data-active] {
+  opacity: 1;
+  transform: scale(1);
+  filter: blur(0px);
 }
 
 /* Full-snap sheet: the identity card and controls pill become pointer-events:none
@@ -1093,6 +1146,18 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 .family-legend-chevron {
   font-size: var(--type-xs);
   color: var(--color-text-muted);
+  /* Chevron rotate: ▸ stays as the single glyph; data-expanded drives
+     rotate(90deg). CHEVRON ROTATE ONLY — do NOT animate the entries <ul>
+     (hard guard: always-mounted list reintroduces the #837 corner overlap,
+     breaks e2e not.toBeVisible(), drifts toward FLIP pattern).
+     The global motion.css guard zeroes transition-duration for
+     prefers-reduced-motion so the chevron snaps instantly to end-state. */
+  transform: rotate(0deg);
+  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  display: inline-block;
+}
+.family-legend-chevron[data-expanded='true'] {
+  transform: rotate(90deg);
 }
 .family-legend-entries {
   list-style: none;


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    direction LR

    state "ThemeToggle button" as T {
        state "☀ span[data-active]" as sun
        state "☾ span (resting)" as moon
        sun --> moon : toggle → dark
        moon --> sun : toggle → light
        note right of sun: recipe #09 cross-fade\nopacity+blur+scale 160ms
    }

    state "Filters badge .app-header-filter-badge" as B {
        [*] --> visible : filterCount 0→1 mount\n@keyframes badge-pop\nscale(0.6)→1 + opacity 200ms
        note right of visible: @keyframes (NOT transition)\ndigit changes stay instant
    }

    state ".family-legend-chevron" as C {
        collapsed : ▸ rotate(0deg)
        expanded  : ▸ rotate(90deg)
        collapsed --> expanded : expand
        expanded --> collapsed : collapse
        note right of collapsed: CSS transition 200ms\nlist mount byte-identical
    }
```

## Summary

- Three micro-motions on top-chrome controls batched by technique (2026-06-09 Batch 4): ThemeToggle glyph cross-fade (#09), filter badge first-appearance pop (#03 @keyframes), legend chevron rotate.
- Badge entrance is `@keyframes + animation`, not a `transition` — a transition silently no-ops on freshly-mounted nodes (bot review foot-gun); `animation-fill-mode: both` holds the from-state until paint.
- Legend list mount is byte-identical; `:has(.family-legend-entries)` selectors, `data-force-collapsed` display:none path, and e2e `not.toBeVisible()` assertions are all unaffected (hard guard honored).

## Screenshots

**Live-verified via Playwright; stills published below (5 viewports × 2 themes).** Driven against this PR's dev build on the seeded local stack (400 observations / 24 families). All three animations confirmed **firing live**: ThemeToggle #09 glyph cross-fade (`aria-pressed` flips, theme light↔dark); Filter badge #03 `@keyframes badge-pop` (scale 0.6→1, animation not transition); FamilyLegend chevron `transform 0.2s` rotate 90°↔0°. Console **0 errors / 0 warnings**; four-corner chrome intact; no horizontal overflow at 390px.

| Viewport | Light | Dark |
|---|---|---|
| **Mobile 390×844** | <img width="430" alt="mobile-light" src="https://github.com/user-attachments/assets/0b593e63-98d7-4f76-b9b8-cd1cbd577a7c"> | <img width="430" alt="mobile-dark" src="https://github.com/user-attachments/assets/1da4c36f-c2a2-4f4b-b2b7-7d99bb62a6e1"> |
| **Tablet 768×1024** | <img width="430" alt="tablet-light" src="https://github.com/user-attachments/assets/0ac42aba-5064-4e95-b671-25cdbf6850ba"> | <img width="430" alt="tablet-dark" src="https://github.com/user-attachments/assets/66f46f85-bc0c-4bfc-9ad1-07ec021b765b"> |
| **Laptop 1024×768** | <img width="430" alt="laptop-light" src="https://github.com/user-attachments/assets/e8a24248-f560-4ca7-9559-70770fdc2a63"> | <img width="430" alt="laptop-dark" src="https://github.com/user-attachments/assets/cfbce7a5-69e0-4406-89eb-f07aef3c73c7"> |
| **Desktop 1440×900** | <img width="430" alt="desktop-light" src="https://github.com/user-attachments/assets/f54e742d-5f9a-49f4-a521-2a1a652f3e8e"> | <img width="430" alt="desktop-dark" src="https://github.com/user-attachments/assets/b8176782-2489-4f43-b6bb-bb281d2bc90f"> |
| **Wide 1920×1080** | <img width="430" alt="wide-light" src="https://github.com/user-attachments/assets/643eceb4-81cf-4791-8d3a-27763893164a"> | <img width="430" alt="wide-dark" src="https://github.com/user-attachments/assets/a019737c-d611-45f9-809f-e5aec2b4b45c"> |


## Test plan

- [x] `npm run typecheck && npm run test` — green (1227 tests pass; 2 pre-existing failures in url-state.test.ts / workspace resolution unrelated to this PR, present on main)
- [x] New unit / integration tests added (if behavior changed) — N/A, CSS-only motion; aria-pressed + live-region tests in ThemeToggle.test.tsx remain byte-identical
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, enter-only animation; no behavior change, existing e2e green
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — pending orchestrator

## Plan reference

Out of plan — 2026-06-09 transitions.dev animation audit Batch 4 ride-along. Closes #952, epic #953.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

