### PR TITLE
feat(frontend): transient-popover enter family — #05/#06/#07/#12/#17 across popovers, filters panel, scope chooser, ZIP error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1271,7 +1271,7 @@ export function App() {
           />
           <div
             ref={filtersPanelRef}
-            className="filters-panel"
+            className="filters-panel t-filters-enter"
             role="region"
             aria-label="Filters"
           >

--- a/frontend/src/components/ScopeChooser.tsx
+++ b/frontend/src/components/ScopeChooser.tsx
@@ -87,7 +87,7 @@ export function ScopeChooser({
 
   return (
     <div className="scope-chooser" role="region" aria-label="Choose where to look at birds">
-      <div className="scope-chooser__card">
+      <div className="scope-chooser__card t-modal-grow">
         <h1 className="scope-chooser__title">Where do you want to look at birds?</h1>
         <p className="scope-chooser__subtitle">
           Enter a ZIP code or pick a state to see recent sightings near you.

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -784,12 +784,30 @@ button.adaptive-grid-marker__cell {
   }
 }
 
-/* Reduced-motion: no fade animation. The default render is instant;
-   no JS animation lib in use. This block documents the contract for
-   future authors. */
-@media (prefers-reduced-motion: reduce) {
-  .cell-hover-preview {
-    /* No-op currently; reserved for future fade-in. */
+/* #950 — recipe-17 (tooltip) delayed fade+scale IN. The preview mounts on
+   hover (desktop-only surface) and unmounts on leave, so the exit is instant
+   (free via unmount) and only the enter is animated. The tooltip RESTS at the
+   visible end-state (opacity 1, scale 1); @starting-style supplies the
+   opacity:0 + scale(0.96) offset for the enter pass — the global reduced-motion
+   guard (motion.css) then leaves the tooltip fully visible immediately (never
+   stuck hidden). The transition lists transform/opacity ONLY: the cursor-follow
+   left/top (inline, from cursorPos) MUST stay out of the transition or the
+   tooltip would lag the pointer. The --tt-delay makes it a *delayed* appear so a
+   quick mouse-over doesn't flash a tooltip. transform-origin: top left keeps the
+   scale anchored toward the cursor (the preview sits down-right of the pointer). */
+.cell-hover-preview.t-tt-enter {
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: top left;
+  transition:
+    opacity   var(--tt-in-dur) var(--tt-in-ease) var(--tt-delay),
+    transform var(--tt-in-dur) var(--tt-in-ease) var(--tt-delay);
+  will-change: transform, opacity;
+}
+@starting-style {
+  .cell-hover-preview.t-tt-enter {
+    opacity: 0;
+    transform: scale(var(--tt-scale));
   }
 }
 
@@ -941,11 +959,28 @@ button.adaptive-grid-marker__cell {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .cell-popover {
-    /* No animation in v1; reserved for future scale-in/fade-in. */
-  }
+/* #950 — recipe-05 (menu-dropdown) enter. The shared `.t-popover-grow` rule
+   (styles.css) carries the transition + the scale(1)/opacity(1) visible REST
+   state; this block supplies CellPopover's data-placed GATE and the
+   transform-origin that tracks the flip. The card mounts parked off-screen
+   (left:-9999; visibility:hidden) for one pre-paint pass while CellPopover.tsx
+   measures the anchor rect, so it CANNOT use @starting-style (the enter would
+   play against the off-screen park and surface as a hard cut). Instead the
+   offset lives on the UN-placed state and the visible end-state is reached when
+   `data-placed="true"` flips on — set in the SAME useLayoutEffect as the
+   position. Resting at the visible end-state once placed keeps the global
+   reduced-motion guard (motion.css) from leaving the card stuck hidden. The
+   card unmounts on dismiss (pan/zoom/ESC/click-out), so the exit stays instant. */
+.cell-popover.t-popover-grow:not([data-placed]) {
+  transform: scale(var(--dropdown-pre-scale));
+  opacity: 0;
 }
+.cell-popover.t-popover-grow[data-placed='true'] {
+  transform: scale(1);
+  opacity: 1;
+}
+.cell-popover.t-popover-grow[data-placement='above'] { transform-origin: bottom left; }
+.cell-popover.t-popover-grow[data-placement='below'] { transform-origin: top left; }
 
 /* ─────────────────────────────────────────────────────────────────────────────
    <ClusterListPopover> — Phase 2 (#559)
@@ -955,9 +990,14 @@ button.adaptive-grid-marker__cell {
 
 .cluster-list-popover {
   position: fixed;
-  /* Slide up from the bottom of the viewport on mobile. On tablet portrait
-     (768×1024), the popover sizes to its content and centers within the
-     bottom 60% of the viewport. */
+  /* Anchored to the bottom strip of the viewport (left/right/bottom =
+     --space-md); on tablet portrait (768×1024) it sizes to its content within
+     that strip. NOTE (#950): there is NO slide-up enter animation here — the
+     prior comment documented motion that never shipped. The recipe-07 slide-up
+     is DEFERRED: it collides with map-cell-popover.spec.ts:265,307 and is the
+     most acute rest-state-hidden trap (a popover resting at translateY(100%)
+     would be stuck off-screen for reduced-motion users). Only the per-family
+     caret animates (rotate, above). */
   left: var(--space-md);
   right: var(--space-md);
   bottom: var(--space-md);
@@ -1033,16 +1073,26 @@ button.adaptive-grid-marker__cell {
   border-radius: 2px;
 }
 
+/* #950 — caret is ONE glyph (▶) that rotates 90° to point down on expand,
+   replacing the prior ▶/▼ content swap so the open/close reads as a smooth
+   rotate instead of a hard glyph cut. transform: rotate ONLY (no layout
+   property animates); the global reduced-motion guard (motion.css) zeroes the
+   duration so reduced-motion users still get the correct ▶/▼ direction with no
+   motion. The #07 slide-up for the whole popover stays DEFERRED (#950): it
+   collides with map-cell-popover.spec.ts:265,307 and is the most acute rest-
+   state-hidden trap; only the caret animates here. */
 .cluster-list-popover__family-toggle::before {
   content: "▶ ";
   font-size: 10px;
   display: inline-block;
   width: 12px;
   color: var(--color-text-muted);
+  transform-origin: 40% 50%;
+  transition: transform var(--dropdown-open-dur) var(--dropdown-ease);
 }
 
 .cluster-list-popover__family--expanded > .cluster-list-popover__family-toggle::before {
-  content: "▼ ";
+  transform: rotate(90deg);
 }
 
 .cluster-list-popover__rows {

--- a/frontend/src/components/map/CellHoverPreview.tsx
+++ b/frontend/src/components/map/CellHoverPreview.tsx
@@ -63,7 +63,7 @@ export function CellHoverPreview(props: CellHoverPreviewProps) {
     <div
       role="tooltip"
       id={id}
-      className="cell-hover-preview"
+      className="cell-hover-preview t-tt-enter"
       data-testid="cell-hover-preview"
       style={positionStyle}
     >

--- a/frontend/src/components/map/CellPopover.tsx
+++ b/frontend/src/components/map/CellPopover.tsx
@@ -61,7 +61,7 @@ function computePopoverPosition(
   cardHeight: number,
   viewportWidth: number,
   viewportHeight: number,
-): { left: number; top: number } {
+): { left: number; top: number; placement: 'above' | 'below' } {
   // Horizontal: left-align to the cell, then clamp into the viewport so the
   // card never overflows the right (flips effectively become a right-shift) or
   // left edge.
@@ -73,11 +73,15 @@ function computePopoverPosition(
   const belowTop = anchorRect.bottom + ANCHOR_GAP;
   const aboveTop = anchorRect.top - ANCHOR_GAP - cardHeight;
   const overflowsBottom = belowTop + cardHeight > viewportHeight - VIEWPORT_MARGIN;
-  let top = overflowsBottom && aboveTop >= VIEWPORT_MARGIN ? aboveTop : belowTop;
+  const placedAbove = overflowsBottom && aboveTop >= VIEWPORT_MARGIN;
+  let top = placedAbove ? aboveTop : belowTop;
   const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - cardHeight - VIEWPORT_MARGIN);
   top = Math.min(Math.max(top, VIEWPORT_MARGIN), maxTop);
 
-  return { left, top };
+  // #950: surface the flip decision so the recipe-05 transform-origin tracks
+  // it — a card placed below the cell grows from its top edge, one placed above
+  // grows from its bottom edge.
+  return { left, top, placement: placedAbove ? 'above' : 'below' };
 }
 export interface CellPopoverProps {
   familyCode: string;
@@ -119,7 +123,11 @@ export function CellPopover(props: CellPopoverProps) {
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   // #863: the portaled card's fixed-position placement, computed from the
   // anchor rect on mount. `null` until the layout effect runs (one paint).
-  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+  // #950: `placement` ('above'|'below') drives the recipe-05 transform-origin
+  // so the scale-in grows from the cell-facing edge.
+  const [position, setPosition] = useState<
+    { left: number; top: number; placement: 'above' | 'below' } | null
+  >(null);
 
   const visible = species.slice(0, POPOVER_CAP);
   // Overflow is the EXACT distinct-species remainder when the caller supplies
@@ -197,8 +205,15 @@ export function CellPopover(props: CellPopoverProps) {
       ref={rootRef}
       role="dialog"
       aria-labelledby={headingId}
-      className="cell-popover"
+      className="cell-popover t-popover-grow"
       data-testid="cell-popover"
+      // #950: gate the recipe-05 scale-in on data-placed — it flips to "true"
+      // in the SAME useLayoutEffect that sets `position`, so the enter never
+      // plays while the card is parked off-screen at left:-9999/visibility:hidden
+      // (which would surface as a hard cut on first paint). data-placement
+      // ('above'|'below') sets the transform-origin to the cell-facing edge.
+      data-placed={position ? 'true' : undefined}
+      data-placement={position?.placement}
       style={positionStyle}
     >
       <header className="cell-popover__header">

--- a/frontend/src/components/map/ClusterListPopover.tsx
+++ b/frontend/src/components/map/ClusterListPopover.tsx
@@ -210,9 +210,10 @@ export function ClusterListPopover(props: ClusterListPopoverProps) {
                 aria-expanded={isExpanded ? 'true' : 'false'}
                 onClick={() => toggleFamily(fam.familyCode)}
               >
-                {/* The collapsed/expanded caret (▶ / ▼) is a CSS ::before
-                    pseudo-element driven by the `--expanded` modifier on the
-                    parent `.cluster-list-popover__family` (ds-primitives.css). */}
+                {/* #950: the caret is a single ▶ CSS ::before glyph that rotates
+                    90° (transform) to point down when the `--expanded` modifier
+                    is set on the parent `.cluster-list-popover__family`
+                    (ds-primitives.css) — a smooth rotate, not a ▶/▼ content swap. */}
                 {familyNames?.get(fam.familyCode) ?? prettyFamily(fam.familyCode)} ({fam.count})
               </button>
               {isExpanded && (

--- a/frontend/src/components/map/ObservationPopover.tsx
+++ b/frontend/src/components/map/ObservationPopover.tsx
@@ -92,6 +92,12 @@ export function ObservationPopover({
   });
 
   let style: CSSProperties = {};
+  // #950: recipe-05 transform-origin tracks the flip decision so the scale-in
+  // grows from the corner nearest the click. Default (below-right of click) →
+  // the click sits at the popover's top-left corner; flipX/flipY move the
+  // origin to the corner the popover grew toward. Defaults to 'top left' for
+  // the legacy no-anchor path (position === null).
+  let origin = 'top left';
   if (position) {
     const vw = typeof window !== 'undefined' ? window.innerWidth : 1440;
     const vh = typeof window !== 'undefined' ? window.innerHeight : 900;
@@ -106,12 +112,14 @@ export function ObservationPopover({
         ? `${Math.max(8, position.y - OFFSET - measuredH)}px`
         : `${position.y + OFFSET}px`,
     };
+    origin = `${flipY ? 'bottom' : 'top'} ${flipX ? 'right' : 'left'}`;
   }
 
   return (
     <div
       ref={rootRef}
-      className="observation-popover"
+      className="observation-popover t-popover-grow"
+      data-origin={origin}
       role="dialog"
       aria-label={`Details for ${observation.comName}`}
       style={style}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1346,6 +1346,36 @@ body:has(.species-detail-sheet--peek) .family-legend {
   color: var(--color-text-strong);
   max-width: 280px;
 }
+
+/* #950 — recipe-05 (menu-dropdown) origin-aware enter. Shared by the transient
+   popovers that grow from a click point: ObservationPopover here, CellPopover
+   in ds-primitives.css (which gates the enter behind data-placed). The element
+   RESTS at the visible end-state (scale 1, opacity 1); the scale(0.96)+opacity:0
+   offset lives in @starting-style so it plays only on the enter pass — the
+   global reduced-motion guard (motion.css) then leaves the surface fully visible
+   (never stuck hidden). transform/opacity ONLY — the inline top/left placement
+   is NEVER transitioned (animating it would fight the flip math). data-origin
+   sets the transform-origin to the corner nearest the click (derived from the
+   flipX/flipY decision). The popover unmounts on close (movestart for
+   ObservationPopover) so the exit stays instant. */
+.t-popover-grow {
+  transform: scale(1);
+  opacity: 1;
+  transform-origin: top left;
+  transition:
+    transform var(--dropdown-open-dur) var(--dropdown-ease),
+    opacity   var(--dropdown-open-dur) var(--dropdown-ease);
+  will-change: transform, opacity;
+}
+.t-popover-grow[data-origin='top right']    { transform-origin: top right; }
+.t-popover-grow[data-origin='bottom left']  { transform-origin: bottom left; }
+.t-popover-grow[data-origin='bottom right'] { transform-origin: bottom right; }
+@starting-style {
+  .t-popover-grow {
+    transform: scale(var(--dropdown-pre-scale));
+    opacity: 0;
+  }
+}
 .observation-popover-header {
   display: flex;
   align-items: center;
@@ -2466,6 +2496,53 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   }
 }
 
+/* #950 — Filters panel enter. The panel is conditionally mounted (App.tsx:
+   `{filtersOpen && …}`) so it RESTS at the visible end-state and the enter
+   offset lives in @starting-style — the global reduced-motion guard (motion.css)
+   then leaves it fully visible on open (never stuck hidden). No exit tween: the
+   panel unmounts on close (the inert/focus-restore useLayoutEffect stays keyed
+   on [filtersOpen] and is untouched — @starting-style needs no deferred unmount).
+
+   Desktop default: recipe-05 (menu-dropdown) — scale(0.96→1) + opacity, grown
+   from the top-right under the Filters trigger (transform-origin: top right).
+   transform/opacity ONLY — the fixed top/right anchor is never transitioned. */
+.filters-panel.t-filters-enter {
+  transform: scale(1);
+  opacity: 1;
+  transform-origin: top right;
+  transition:
+    transform var(--dropdown-open-dur) var(--dropdown-ease),
+    opacity   var(--dropdown-open-dur) var(--dropdown-ease);
+  will-change: transform, opacity;
+}
+@starting-style {
+  .filters-panel.t-filters-enter {
+    transform: scale(var(--dropdown-pre-scale));
+    opacity: 0;
+  }
+}
+
+/* Mobile ≤639px: recipe-07 (panel-reveal) bottom-sheet — a short translateY
+   slide-up + opacity + cross-blur (the sheet's own height supplies the rest of
+   the open distance, so a 24px travel reads as a full open). transform-origin
+   resets to the sheet's own box; transform/opacity/filter ONLY. */
+@media (max-width: 639px) {
+  .filters-panel.t-filters-enter {
+    transform-origin: bottom center;
+    transition:
+      transform var(--panel-open-dur) var(--panel-ease),
+      opacity   var(--panel-open-dur) var(--panel-ease),
+      filter    var(--panel-open-dur) var(--panel-ease);
+  }
+  @starting-style {
+    .filters-panel.t-filters-enter {
+      transform: translateY(var(--panel-translate-y-filters));
+      opacity: 0;
+      filter: blur(var(--panel-blur));
+    }
+  }
+}
+
 /* ── O4 (#780): .filters-backdrop — transparent click-catch ─────────────────
    The backdrop covers the full viewport so clicking outside the filters panel
    dismisses it (see App.tsx — onClick handler). It carries no role/label
@@ -2625,6 +2702,25 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border: 1px solid var(--color-error-border);
   border-radius: 4px;
   line-height: 1.3;
+  /* #950 — recipe-12 (error-state-shake) on the ERROR BOX only (never the input
+     field, never the role=status "not recognized" path). The box is
+     conditionally mounted by ZipInput.tsx (malformed / fetchError), so the
+     shake fires once on mount via `animation:` (NOT a transition, and no JS
+     reflow needed — a fresh element mounts each time the error appears). The
+     box rests at its normal painted position; the keyframe is a self-contained
+     translateX oscillation that returns to 0, so reduced-motion users (global
+     guard zeroes animation-duration) see the static error box, never a stuck
+     offset. Per-segment ease per the catalog (each leg follows its own bezier). */
+  animation: zip-input-shake calc(
+      var(--shake-dur-a) * 2 + var(--shake-dur-b) * 2
+    ) linear;
+}
+@keyframes zip-input-shake {
+  0%     { transform: translateX(0);                                animation-timing-function: var(--shake-ease); }
+  28.57% { transform: translateX(var(--shake-distance));            animation-timing-function: var(--shake-ease); }
+  57.14% { transform: translateX(calc(var(--shake-distance) * -1)); animation-timing-function: var(--shake-ease); }
+  78.57% { transform: translateX(var(--shake-overshoot));           animation-timing-function: var(--shake-ease); }
+  100%   { transform: translateX(0); }
 }
 
 /* ── ScopeChooser scrim (#761 S1) ─────────────────────────────────────────
@@ -2691,6 +2787,30 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border: 1px solid var(--color-border-ui);
   border-radius: var(--radius-lg, 12px);
   box-shadow: var(--shadow-listbox);
+}
+
+/* #950 — recipe-06 (modal) enter on the landing card ONLY (never the scrim
+   wash, never the native <select>: transform on a native select is a no-op
+   trap). The card RESTS at the visible end-state (scale 1, opacity 1); the
+   scale(0.96)+opacity:0 offset lives in @starting-style, so it plays only on
+   the enter pass. Reduced-motion is satisfied for free: the global guard
+   (motion.css) zeroes the duration and the card is already at its visible end-
+   state — never stuck hidden. The card unmounts when scope resolves, so the
+   exit stays instant (no close tween). transform-origin: center (modal). */
+.scope-chooser__card.t-modal-grow {
+  transform: scale(1);
+  opacity: 1;
+  transform-origin: center;
+  transition:
+    transform var(--modal-open-dur) var(--modal-ease),
+    opacity   var(--modal-open-dur) var(--modal-ease);
+  will-change: transform, opacity;
+}
+@starting-style {
+  .scope-chooser__card.t-modal-grow {
+    transform: scale(var(--modal-scale));
+    opacity: 0;
+  }
 }
 .scope-chooser__title {
   margin: 0;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -167,6 +167,40 @@
      (1.4s, reverse-direction) and skeleton-shimmer (opacity-pulse technique) are
      intentionally excluded — different techniques, different tempos. */
   --ds-shimmer-dur: 1.6s;
+
+  /* ── transient-popover enter family (#950) ──────────────────────────────
+   * Catalog tunings consumed by the transient-layer entrances:
+   *   recipe-05 (menu-dropdown) — ObservationPopover, CellPopover, Filters
+   *     panel (desktop). Origin-aware scale(0.96→1) + opacity.
+   *   recipe-06 (modal)         — ScopeChooser landing card scale-up.
+   *   recipe-12 (error-state-shake) — ZipInput error box.
+   *   recipe-17 (tooltip)       — CellHoverPreview delayed fade+scale in.
+   * Every surface here is ENTER-ONLY (instant exit via React unmount) and
+   * rests at the VISIBLE end-state — the offset lives in @starting-style or a
+   * post-paint data-open flip, NOT the resting rule, so the global reduced-
+   * motion guard (motion.css zeroes only the duration) never leaves a surface
+   * stuck hidden. No per-recipe reduced-motion guard here. */
+  --dropdown-open-dur:   180ms;
+  --dropdown-pre-scale:  0.96;
+  --dropdown-ease:       cubic-bezier(0.22, 1, 0.36, 1);
+  --modal-open-dur:      180ms;
+  --modal-scale:         0.96;
+  --modal-ease:          cubic-bezier(0.22, 1, 0.36, 1);
+  --shake-distance:      6px;
+  --shake-overshoot:     4px;
+  --shake-dur-a:         80ms;
+  --shake-dur-b:         60ms;
+  --shake-ease:          cubic-bezier(0.22, 1, 0.36, 1);
+  --tt-in-dur:           140ms;
+  --tt-scale:            0.96;
+  --tt-delay:            120ms;
+  --tt-in-ease:          ease-out;
+  /* Mobile (≤639px) Filters bottom-sheet travel for the recipe-07 slide-up;
+     the sheet's own height supplies the rest of the open distance so a short
+     translate reads as a full open (recipe-07 note). Named -filters so it
+     doesn't collide with the canonical --panel-translate-y (100px) or the
+     field-guide sheet's --panel-translate-y-sheet (32px). */
+  --panel-translate-y-filters: 24px;
 }
 
 /* ── Layer 2: Semantic — light mode ─────────────────────────────────── */


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    subgraph "transient-popover enter family (#950) — 7 surfaces, one authoring discipline"
        direction TB
        REST["Every surface RESTS at the visible end-state<br/>(scale 1 / opacity 1 / translateY 0)"]
        OFFSET["Enter offset lives ONLY in @starting-style<br/>or a post-paint data-* flip"]
        RM["motion.css zeroes the DURATION, not the start value<br/>→ reduced-motion users see the surface immediately"]
        EXIT["Exit = React unmount (instant) — no exit tween, no deferred unmount"]
        REST --> RM
        OFFSET --> RM
        REST --> EXIT
    end

    subgraph "Recipe assignment"
        P05["#05 menu-dropdown<br/>scale(0.96→1)+opacity, origin-aware"]
        P06["#06 modal<br/>scale(0.96→1)+opacity, center"]
        P07["#07 panel-reveal<br/>translateY slide-up + cross-blur"]
        P12["#12 error-state-shake<br/>translateX keyframe"]
        P17["#17 tooltip<br/>delayed fade+scale in"]
    end

    P05 --> ObsPop["ObservationPopover<br/>data-origin ← flipX/flipY"]
    P05 --> CellPop["CellPopover<br/>enter GATED on data-placed"]
    P05 --> FiltersD["Filters panel (desktop, grow top-right)"]
    P07 --> FiltersM["Filters panel (mobile ≤639px slide-up)"]
    P06 --> Scope[".scope-chooser__card only"]
    P12 --> Zip[".zip-input__error box only"]
    P17 --> Hover["CellHoverPreview (cursor left/top OUT of transition)"]
    Caret["ClusterListPopover caret: ▶ glyph rotate 90°<br/>(#07 slide-up DEFERRED — e2e collision)"]
```

## Summary

- The transient layer (popovers, filters panel, landing card, ZIP error, hover preview) had no catalog entrances. This lands all seven in one PR so the two load-bearing guards — *rest at the visible end-state* (reduced-motion safety under the global `motion.css` duration-only guard) and *enter-only / instant-unmount-exit* — are implemented once, correctly, instead of seven chances to get them wrong.
- transitions.dev catalog only (no FLIP, no motion libs). transform/opacity (+ `filter: blur` on the #07 mobile sheet) only — nothing transitions `top/left/width/height`. `CellPopover`'s scale-in is gated on a `data-placed` attr flipped in the same `useLayoutEffect` as `setPosition`, so it never plays while the card is parked off-screen.
- Also deletes the two stale "reserved for future" reduced-motion no-op comments (cell-popover, cell-hover-preview) and the stale "Slide up from the bottom" cluster-list comment that documented motion that never shipped. The `ClusterListPopover` caret becomes one `▶` glyph that rotates 90° on expand; the #07 cluster slide-up is DEFERRED (collides with `map-cell-popover.spec.ts:265,307` + is the most acute rest-state-hidden trap).

## Screenshots

**Live-verified via Playwright; stills published below (5 viewports × 2 themes).** Driven against this PR's dev build on the seeded local stack (400 observations / 24 families). All **7 transient-popover recipes are wired** (CSS confirms `t-popover-grow` #05, `t-filters-enter`, `t-modal-grow` #06, the `zip-input-shake` `@keyframes` #12, `@starting-style` enter, plus the cell-popover / cell-hover-preview rules). The **Filters panel #05 enter** was driven live: opens anchored top-right (`transform-origin: 420px 0`) and **settles to `opacity:1`** — it rests at the visible end-state (no stuck-hidden under the global reduced-motion guard). Console **0 errors / 0 warnings** across viewports. The stills below confirm the resting chrome renders cleanly at every viewport × both themes — the popover / chooser / tooltip / ZIP-shake surfaces are **transient** (they appear on click/hover, not in a resting still).

| Viewport | Light | Dark |
|---|---|---|
| **Mobile 390×844** | <img width="430" alt="mobile-light" src="https://github.com/user-attachments/assets/9c876289-fe29-4126-9afb-b69f22424159"> | <img width="430" alt="mobile-dark" src="https://github.com/user-attachments/assets/044896a4-cbd0-41a9-8863-df10c961b3c0"> |
| **Tablet 768×1024** | <img width="430" alt="tablet-light" src="https://github.com/user-attachments/assets/62e62a2e-e848-47a8-a06d-0dce55eafab9"> | <img width="430" alt="tablet-dark" src="https://github.com/user-attachments/assets/6e501204-ef6b-491d-8263-c5e34869ddfc"> |
| **Laptop 1024×768** | <img width="430" alt="laptop-light" src="https://github.com/user-attachments/assets/93ac3324-7009-4447-836b-8d381c832a11"> | <img width="430" alt="laptop-dark" src="https://github.com/user-attachments/assets/892ab42c-5d01-4978-a051-217ce28fa7be"> |
| **Desktop 1440×900** | <img width="430" alt="desktop-light" src="https://github.com/user-attachments/assets/d62b8bf3-f8ba-4456-9537-f38d71098f16"> | <img width="430" alt="desktop-dark" src="https://github.com/user-attachments/assets/d63ecb33-70a7-47bb-92ba-a44b02a265f0"> |
| **Wide 1920×1080** | <img width="430" alt="wide-light" src="https://github.com/user-attachments/assets/57148a30-8588-4a43-a328-ba1e40478ba1"> | <img width="430" alt="wide-dark" src="https://github.com/user-attachments/assets/fbb56a91-e8a3-44e5-843d-6791ee7381b9"> |


## Test plan

- [x] `tsc --noEmit` + `npm test --workspace @bird-watch/frontend` — green (1291 unit tests pass)
- [x] No behavior change to component logic; existing unit tests cover the touched components (ObservationPopover, CellPopover, CellHoverPreview, ClusterListPopover, ScopeChooser, ZipInput)
- [ ] New Playwright e2e spec — N/A (enter-only CSS; existing specs assert via `aria-expanded` / class modifiers, not the `::before` glyph; the deferred cluster slide-up keeps `map-cell-popover.spec.ts` green)
- [x] `npm run build` — clean production build
- [ ] (UI only) Playwright MCP smoke — pending orchestrator live-verification at all 5 canonical viewports × 2 themes (this PR touches 7 surfaces)

## Plan reference

Out of plan — 2026-06-09 transitions.dev animation audit (Batch 3). Part of epic #953. Closes #950.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
