### PR TITLE
fix(frontend): show cell-hover preview while a species detail is open, beneath it (#976)

### DIFF
--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -151,15 +151,17 @@ test('desktop 1440×900: keyboard skip-link → cell → Enter → popover → E
   await expect(page).not.toHaveURL(/[?&]detail=/);
 });
 
-// ─── #761 O6 (#782): detail-overlay gate — hovering a cell with a detail
-//     overlay open does NOT surface the passive hover preview ──────────────────
+// ─── #976 (reverses #761 O6 / #782): hover-to-compare with a detail open ──────
 //
-// The detail rail/sheet stays the topmost interactive surface; the unbidden
-// hover tooltip is suppressed (AdaptiveGridMarker's `detailOpen` gate, threaded
-// App → MapSurface → MapCanvas → AdaptiveGridMarker). WebGL-guarded like the
-// other live-marker scenarios. No @coarse → dev-server, 1440×900.
+// #782 SUPPRESSED the passive hover preview while a detail overlay held focus.
+// #976 reverses that product decision: hovering a cell with the detail rail open
+// now DOES surface the preview (hover-to-compare). To honor #782's anti-clutter
+// intent the tooltip is DEMOTED beneath the detail surface (the `belowDetail`
+// path adds `cell-hover-preview--under-detail`, z `--z-under-detail`), so the
+// rail stays the topmost surface and the tooltip never paints over it. WebGL-
+// guarded like the other live-marker scenarios. No @coarse → dev-server, 1440×900.
 
-test('desktop 1440×900: with the detail rail open, hovering a cell does NOT surface the hover preview', async ({ page }) => {
+test('desktop 1440×900: with the detail rail open, hovering a cell DOES surface the hover preview, beneath the rail', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   // Open a detail overlay alongside the live map (rail mounts at ≥1200px).
   await page.goto('/?scope=us&detail=vermfly&view=detail');
@@ -172,11 +174,11 @@ test('desktop 1440×900: with the detail rail open, hovering a cell does NOT sur
     return;
   }
 
-  // The detail rail/sheet must be the topmost interactive surface.
+  // The detail rail must be present (and stays the topmost interactive surface).
   const detailSurface = page.locator('aside.species-detail-rail, .species-detail-sheet');
   await expect(detailSurface.first()).toBeVisible({ timeout: 10_000 });
 
-  // Hover a cell — under the gate, the passive preview must NOT mount.
+  // Hover a cell — the passive preview must NOW mount (hover-to-compare).
   const cell = page.locator('[data-testid^="adaptive-grid-marker-cell"]').first();
   const cellVisible = await cell.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
   if (!cellVisible) {
@@ -185,11 +187,28 @@ test('desktop 1440×900: with the detail rail open, hovering a cell does NOT sur
   }
   await cell.hover();
 
-  // Give the preview the chance it would normally have to appear, then assert
-  // it never did (the gate suppresses the mount while the overlay holds focus).
-  await expect(page.locator('[data-testid="cell-hover-preview"]')).toHaveCount(0);
-  await expect(page.getByRole('tooltip')).toHaveCount(0);
-  // Detail surface still present (it remained the topmost interactive surface).
+  // The preview appears (exactly one) while the detail is open.
+  const preview = page.locator('[data-testid="cell-hover-preview"]');
+  await expect(preview).toHaveCount(1);
+  await expect(page.getByRole('tooltip')).toHaveCount(1);
+
+  // …and it carries the z-demote modifier so it cannot occlude the rail.
+  await expect(preview).toHaveClass(/cell-hover-preview--under-detail/);
+
+  // Load-bearing: the tooltip's EFFECTIVE z resolves BELOW the active detail
+  // surface (the rail). Compare computed z-index values directly so a future
+  // z bump that lifts the tooltip above the rail fails here, not just visually.
+  const tooltipZ = await preview.evaluate((el) =>
+    Number(getComputedStyle(el).zIndex),
+  );
+  const railZ = await detailSurface.first().evaluate((el) =>
+    Number(getComputedStyle(el).zIndex),
+  );
+  expect(Number.isFinite(tooltipZ)).toBe(true);
+  expect(Number.isFinite(railZ)).toBe(true);
+  expect(tooltipZ).toBeLessThan(railZ);
+
+  // Detail surface still the topmost surface (unchanged, not covered).
   await expect(detailSurface.first()).toBeVisible();
 });
 

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -75,12 +75,16 @@ export interface MapSurfaceProps {
   maskPolygon?: MultiPolygon | null;
   clampPad?: number;
   /**
-   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
-   * open under an active scope. App.tsx derives this from `scopeActive &&
-   * state.detail` — the same gate that mounts the rail/sheet. Forwarded
-   * VERBATIM to <MapCanvas> (thin pass-through) so the passive cell-hover
-   * preview is suppressed while the detail overlay holds focus. Optional;
-   * defaults to `false` for legacy/test callers.
+   * #761 O6 (#782) → reversed by #976: true when a detail overlay
+   * (SpeciesDetailRail / Sheet) is open under an active scope. App.tsx derives
+   * this from `scopeActive && state.detail` — the same gate that mounts the
+   * rail/sheet. Forwarded VERBATIM to <MapCanvas> (thin pass-through). #782
+   * originally SUPPRESSED the passive cell-hover preview in this state; #976
+   * reverses that — the preview is no longer suppressed. The flag is now
+   * forwarded down (eventually as `belowDetail` on the hover preview) so the
+   * tooltip is DEMOTED beneath the detail overlay (z `--z-under-detail` = 5)
+   * rather than suppressed, keeping hover-to-compare working with a detail
+   * open. Optional; defaults to `false` for legacy/test callers.
    */
   detailOpen?: boolean;
 }

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -727,8 +727,10 @@ button.adaptive-grid-marker__cell {
      rail's current `--z-rail` (43), so the click-driven popovers temporarily
      paint over the rail. Re-tiering the rail/sheet ABOVE the popovers (into the
      --z-modal band with the compensating #663 inert work) is O5's job (report R3);
-     O6 does NOT move the rail's z value. This tooltip at --z-modal (50) is moot to
-     that contract because its mount is gated off while the rail is open. */
+     O6 does NOT move the rail's z value. This tooltip at --z-modal (50) is the
+     RESTING tier (no detail open): the cursor tooltip can still float over an
+     open cell/cluster popover. While a detail IS open, the `--under-detail`
+     modifier below demotes it (see #976). */
   z-index: var(--z-modal);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-strong);
@@ -741,6 +743,26 @@ button.adaptive-grid-marker__cell {
   /* Smart-flip positioning is consumer-supplied via inline style; defaults
      to below-cell when not specified. Phase 1 uses CSS-only positioning
      (left/top inline); Phase 3 may add Floating-UI for collision detection. */
+}
+
+/* #976: hover-to-compare while a species detail is open. #782/#799 USED to gate
+   the passive hover preview off entirely while a detail held focus (so an
+   unbidden tooltip could not paint over the rail/sheet). Julian wants hover to
+   keep working with a detail open, so AdaptiveGridMarker now ALWAYS mounts the
+   preview and passes `belowDetail={detailOpen}`, which adds this modifier. Rather
+   than suppress the tooltip we DEMOTE it below every detail surface so it stays
+   visible on the map but is occluded wherever it overlaps the detail.
+
+   --z-under-detail (5) is below the LOWEST detail tier in play — the sheet's
+   peek detent (z-10), its half detent (z-15, the default snap), its full detent
+   (--z-modal 50) AND the desktop rail (--z-rail 43) — while staying ABOVE the
+   map canvas/markers (--z-map 0). It must NOT use --z-overlay (40): 40 > the
+   default half-sheet's 15, so a tooltip there would paint OVER the sheet on
+   narrow/mobile viewports (the rail↔sheet split is viewport-WIDTH-driven, so a
+   narrow fine-pointer desktop window shows the sheet + allows hover). The
+   t-tt-enter fade+scale enter (recipe #17) is orthogonal to z and unaffected. */
+.cell-hover-preview--under-detail {
+  z-index: var(--z-under-detail);
 }
 
 .cell-hover-preview__header {

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -717,10 +717,14 @@ button.adaptive-grid-marker__cell {
      "above the popovers it overlaps" rank — the cursor tooltip can still float
      over an open cell/cluster popover, matching the pre-O6 inline-1000 intent.
      This is safe against real --z-modal surfaces (detail sheet 50, scope-chooser
-     scrim 50) because O6 also GATES the hover-preview mount: AdaptiveGridMarker
-     suppresses it whenever a detail overlay holds focus (detailOpen), and the
-     chooser scrim only shows when there are no markers to hover. So the tooltip
-     can never coexist with a --z-modal surface despite sharing the tier value.
+     scrim 50). The base --z-modal value here only applies when NO detail is open:
+     #976 reverses O6's original suppression, so when a detail overlay holds focus
+     (detailOpen) AdaptiveGridMarker no longer suppresses the preview — it DEMOTES
+     it to --z-under-detail (5) via the `--under-detail` modifier below, far beneath
+     every detail tier (sheet peek 10 / half 15 / full 50, rail 43). The chooser
+     scrim only shows when there are no markers to hover. So the tooltip never
+     shares or contests the --z-modal (50) tier with a detail surface — the safety
+     is preserved by DEMOTION now, not suppression.
 
      ORDERING CONTRACT vs the detail rail (handoff to O5 / #783):
      P1's `--z-cell-popover`/`--z-cluster-popover` (44/45) resolve ABOVE the

--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -774,9 +774,11 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(screen.getByText(/Hummingbirds \(5\)/)).toBeInTheDocument();
   });
 
-  // --- #761 O6 (#782): detailOpen gates the passive hover preview mount -------
+  // --- #976 (reverses #761 O6 / #782): detailOpen no longer SUPPRESSES the
+  //     passive hover preview — it DEMOTES it beneath the detail surface so
+  //     hover-to-compare works with a detail open. ------------------------------
 
-  it('pointer:fine + detailOpen: mouseenter does NOT mount <CellHoverPreview> (gated by a focused detail overlay)', async () => {
+  it('pointer:fine + detailOpen: mouseenter MOUNTS <CellHoverPreview>, demoted below the detail (--under-detail)', async () => {
     const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
     render(
       <AdaptiveGridMarker
@@ -794,8 +796,16 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     );
     const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
     fireEvent.mouseEnter(cell);
-    // The passive hover preview must NOT appear while a detail overlay holds focus.
-    expect(screen.queryByRole('tooltip')).toBeNull();
+    // #976: the preview NOW appears while a detail overlay holds focus —
+    // hover-to-compare. It is not suppressed.
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(screen.getByText(/Hummingbirds \(5\)/)).toBeInTheDocument();
+    // …and it carries the z-demote modifier so it renders BENEATH the detail
+    // surface (z `--z-under-detail`, below sheet peek/half/full + rail). The
+    // load-bearing z-order resolution is asserted in
+    // CellHoverPreview.test.tsx + tokens.css.test.ts against the ACTIVE surface.
+    expect(tooltip).toHaveClass('cell-hover-preview--under-detail');
   });
 
   it('pointer:fine + detailOpen=false (default): existing hover-preview behavior is unchanged', async () => {
@@ -819,7 +829,7 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
   });
 
-  it('pointer:fine + detailOpen: the click-driven <CellPopover> is UNAFFECTED by the gate', async () => {
+  it('pointer:fine + detailOpen: the click-driven <CellPopover> is UNAFFECTED by detailOpen', async () => {
     const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
     render(
       <AdaptiveGridMarker
@@ -838,7 +848,7 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
     cell.focus();
     fireEvent.keyDown(cell, { key: 'Enter' });
-    // Only the passive preview is gated; the click-driven popover still opens.
+    // The click-driven popover has never been gated by detailOpen and still opens.
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(cell.getAttribute('aria-expanded')).toBe('true');
   });

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -101,13 +101,17 @@ export interface AdaptiveGridMarkerProps {
    */
   onDrillIn?: () => void;
   /**
-   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet)
-   * holds focus (App-level `state.detail` under an active scope). When true,
-   * the passive `<CellHoverPreview>` mount is SUPPRESSED so a hover tooltip
-   * cannot appear unbidden over/under a focused detail overlay. Only the
-   * passive hover preview is gated — the click-driven `<CellPopover>` and
-   * `<ClusterListPopover>` are intentionally UNAFFECTED (they are explicit
-   * user actions, not unbidden surfaces). Defaults to `false`.
+   * #761 O6 (#782) → reversed by #976: true when a detail overlay
+   * (SpeciesDetailRail / Sheet) holds focus (App-level `state.detail` under an
+   * active scope). #782 originally SUPPRESSED the passive `<CellHoverPreview>`
+   * mount in this state; #976 reverses that product decision (Julian wants
+   * hover-to-compare to work with a detail open). The preview now ALWAYS mounts
+   * in the preview branch and this flag is forwarded as `belowDetail`, which
+   * DEMOTES the tooltip beneath every detail surface (z `--z-under-detail` = 5,
+   * below sheet peek/half/full AND the rail) so it stays visible on the map but
+   * is occluded wherever it overlaps the detail — honoring #782's anti-clutter
+   * intent without suppression. The click-driven `<CellPopover>` /
+   * `<ClusterListPopover>` remain UNAFFECTED. Defaults to `false`.
    */
   detailOpen?: boolean;
 }
@@ -407,20 +411,21 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
       )}
       {perCellInteractive && activeCell !== null && activeTile && (
         activeCell.mode === 'preview' ? (
-          // #761 O6 (#782): suppress the passive hover preview while a detail
-          // overlay holds focus (detailOpen) so an unbidden tooltip can't appear
-          // over/under a focused SpeciesDetailRail/Sheet. The click-driven
-          // popover branch below is deliberately NOT gated.
-          detailOpen ? null : (
-            <CellHoverPreview
-              familyCode={activeTile.familyCode}
-              familyName={activeTile.displayName}
-              familyCount={activeTile.count}
-              species={activeTile.species}
-              id={previewId!}
-              cursorPos={cursorPos}
-            />
-          )
+          // #761 O6 (#782) → #976: the passive hover preview ALWAYS mounts now
+          // (hover-to-compare must work with a detail open). When a detail
+          // overlay holds focus we pass `belowDetail` so the tooltip is DEMOTED
+          // beneath every detail surface (z `--z-under-detail` 5 < sheet/rail)
+          // instead of suppressed — visible on the map, occluded over the
+          // detail. The click-driven popover branch below stays ungated.
+          <CellHoverPreview
+            familyCode={activeTile.familyCode}
+            familyName={activeTile.displayName}
+            familyCount={activeTile.count}
+            species={activeTile.species}
+            id={previewId!}
+            cursorPos={cursorPos}
+            belowDetail={detailOpen}
+          />
         ) : (
           cellRefs.current[activeCell.index] ? (
             <CellPopover

--- a/frontend/src/components/map/CellHoverPreview.tsx
+++ b/frontend/src/components/map/CellHoverPreview.tsx
@@ -34,14 +34,34 @@ export interface CellHoverPreviewProps {
    * preview falls back to its CSS-anchored position (legacy / test).
    */
   cursorPos?: { x: number; y: number } | null;
+  /**
+   * #976: true when a species detail (rail / sheet) is open. The preview is
+   * no longer suppressed in that state (hover-to-compare); instead it is
+   * DEMOTED beneath every detail surface via the
+   * `cell-hover-preview--under-detail` modifier (z `--z-under-detail` = 5,
+   * below sheet peek/half/full AND the rail, above the map). Defaults to
+   * `false` ⇒ the tooltip rides its resting `--z-modal` tier. The z change is
+   * orthogonal to the `t-tt-enter` recipe-#17 enter animation.
+   */
+  belowDetail?: boolean;
 }
 
 const PREVIEW_CAP = 3;
 
 export function CellHoverPreview(props: CellHoverPreviewProps) {
-  const { familyCode, familyName, familyCount, species, id, cursorPos } = props;
+  const { familyCode, familyName, familyCount, species, id, cursorPos, belowDetail } =
+    props;
   const visible = species.slice(0, PREVIEW_CAP);
   const hasMore = species.length > PREVIEW_CAP;
+
+  // #976: when a detail is open, append the `--under-detail` modifier so the
+  // tooltip's z drops below every detail surface (rail/sheet) — see
+  // ds-primitives.css. The base class still carries the resting --z-modal tier;
+  // the modifier overrides z only. This is purely a stacking change and does not
+  // touch the transform/opacity enter animation (recipe #17 t-tt-enter).
+  const className = belowDetail
+    ? 'cell-hover-preview cell-hover-preview--under-detail'
+    : 'cell-hover-preview';
 
   // #761 O6 (#782): the cursor-following branch keeps `position: fixed` +
   // `left`/`top`/`pointerEvents` inline (computed from `cursorPos`, cannot move
@@ -63,7 +83,7 @@ export function CellHoverPreview(props: CellHoverPreviewProps) {
     <div
       role="tooltip"
       id={id}
-      className="cell-hover-preview"
+      className={className}
       data-testid="cell-hover-preview"
       style={positionStyle}
     >

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -153,13 +153,18 @@ export interface MapCanvasProps {
    */
   clampPad?: number;
   /**
-   * #761 O6 (#782): true when a detail overlay (SpeciesDetailRail / Sheet) is
-   * open under an active scope (App-level `scopeActive && state.detail`).
-   * Forwarded VERBATIM to every `<AdaptiveGridMarker>` so the passive
-   * `<CellHoverPreview>` mount is suppressed while the overlay holds focus —
-   * a hover tooltip must not appear unbidden over/under a focused detail
-   * surface. The click-driven cell/cluster popovers are unaffected. Defaults
-   * to `false` (legacy/test callers keep the pre-O6 always-mount behavior).
+   * #761 O6 (#782) → reversed by #976: true when a detail overlay
+   * (SpeciesDetailRail / Sheet) is open under an active scope (App-level
+   * `scopeActive && state.detail`). Forwarded VERBATIM to every
+   * `<AdaptiveGridMarker>`. #782 originally SUPPRESSED the passive
+   * `<CellHoverPreview>` mount in this state; #976 reverses that product
+   * decision (hover-to-compare must work with a detail open). The preview now
+   * ALWAYS mounts and this flag is forwarded as `belowDetail`, which DEMOTES
+   * the tooltip beneath every detail surface (z `--z-under-detail`, below sheet
+   * peek/half/full AND the rail) so it stays visible on the map but is occluded
+   * wherever it overlaps the detail — honoring #782's anti-clutter intent
+   * without suppression. The click-driven cell/cluster popovers are unaffected.
+   * Defaults to `false` (legacy/test callers).
    */
   detailOpen?: boolean;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -22,6 +22,11 @@
      migrate those refs and remove this alias in a #761 follow-up.
      Added 2026-05-30 (#761 P1). */
   --z-map:             0;    /* persistent map canvas base layer                       */
+  --z-under-detail:    5;    /* #976: passive cell-hover preview while a detail is open —
+                                ABOVE the map canvas/markers (5 > 0) but BELOW every
+                                detail surface: sheet peek (10), half (15), full (50) AND
+                                the rail (43). Lets hover-to-compare work with a detail
+                                open without the tooltip painting over it. */
   --z-overlay:         40;   /* map-assist overlays: legend, scope-control             */
   --z-popover:         41;   /* on-canvas popovers above map-assist overlays           */
   --z-chrome:          42;   /* DEFINED for S2 (#775) — floating app-header chrome; NOT adopted in P1 */

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -337,6 +337,9 @@ describe('styles.css — W1 conformance', () => {
   describe('named z-index scale — #761 P1 (#778)', () => {
     it('declares every named tier with its rank-preserving value', () => {
       expect(STYLES_CSS).toMatch(/--z-map:\s*0\b/);
+      // #976: passive hover preview demoted while a detail is open — above the
+      // map (5 > 0) but below every detail tier (sheet 10/15/50, rail 43).
+      expect(STYLES_CSS).toMatch(/--z-under-detail:\s*5\b/);
       expect(STYLES_CSS).toMatch(/--z-overlay:\s*40\b/);
       expect(STYLES_CSS).toMatch(/--z-popover:\s*41\b/);
       expect(STYLES_CSS).toMatch(/--z-chrome:\s*42\b/);
@@ -354,6 +357,50 @@ describe('styles.css — W1 conformance', () => {
     });
   });
 
+  // ── #976: load-bearing z-order guard for the under-detail hover preview. ─────
+  //    When a species detail is open, the demoted cell-hover preview must resolve
+  //    BELOW whichever detail surface can be showing — the desktop RAIL (43) AND
+  //    EVERY mobile SHEET detent (peek 10, half 15 [the default], full/modal 50)
+  //    — while staying ABOVE the map canvas (0). Asserting only against the rail
+  //    (43) would pass GREEN while occluding the default half-sheet (15) on
+  //    narrow/mobile viewports, the exact gap the bot amendment flagged. A future
+  //    "bump the z-index" change that lifts --z-under-detail to/above any detail
+  //    tier fails HERE.
+  describe('under-detail hover preview z-order — #976', () => {
+    // Pull the literal --z-* values straight out of styles.css :root.
+    const z = (name: string): number => {
+      const m = STYLES_CSS.match(new RegExp(`--${name}:\\s*(\\d+)\\b`));
+      if (!m) throw new Error(`--${name} not found / not a literal in styles.css`);
+      return Number(m[1]);
+    };
+    // The sheet detents are literal z-index declarations in styles.css, NOT
+    // :root tokens — read them from their modifier rules so the guard tracks the
+    // values that actually render (styles.css:2310 / :2319).
+    const sheetDetent = (modifier: string): number => {
+      const m = STYLES_CSS.match(
+        new RegExp(`\\.species-detail-sheet--${modifier}\\s*\\{[^}]*z-index:\\s*(\\d+)\\b`, 's'),
+      );
+      if (!m) throw new Error(`.species-detail-sheet--${modifier} z-index not found`);
+      return Number(m[1]);
+    };
+
+    it('--z-under-detail sits BELOW the desktop rail (43)', () => {
+      expect(z('z-under-detail')).toBeLessThan(z('z-rail'));
+    });
+
+    it('--z-under-detail sits BELOW every mobile sheet detent (peek 10, half 15, full/modal)', () => {
+      // half (15) is the DEFAULT snap — the tier the bot amendment proved a
+      // demote to --z-overlay (40) would wrongly paint over.
+      expect(z('z-under-detail')).toBeLessThan(sheetDetent('peek'));
+      expect(z('z-under-detail')).toBeLessThan(sheetDetent('half'));
+      expect(z('z-under-detail')).toBeLessThan(z('z-modal')); // full sheet rides --z-modal
+    });
+
+    it('--z-under-detail stays ABOVE the map canvas/markers (0) so the tooltip is still visible', () => {
+      expect(z('z-under-detail')).toBeGreaterThan(z('z-map'));
+    });
+  });
+
   // ── #761 O6 (#782): the three on-canvas cell popovers consume P1's NAMED
   //    popover tokens — no `z-index: calc(var(--z-panel) + N)` arithmetic
   //    survives on any of them.
@@ -367,6 +414,12 @@ describe('styles.css — W1 conformance', () => {
     it('.cell-hover-preview consumes the named --z-modal tier (above the cell/cluster popovers it can overlap)', () => {
       expect(DS_PRIMITIVES_CSS).toMatch(
         /\.cell-hover-preview\s*\{[^}]*z-index:\s*var\(--z-modal\)/s,
+      );
+    });
+
+    it('#976: .cell-hover-preview--under-detail demotes to --z-under-detail (below every detail tier)', () => {
+      expect(DS_PRIMITIVES_CSS).toMatch(
+        /\.cell-hover-preview--under-detail\s*\{[^}]*z-index:\s*var\(--z-under-detail\)/s,
       );
     });
 

--- a/frontend/src/tokens.test.ts
+++ b/frontend/src/tokens.test.ts
@@ -39,6 +39,7 @@ describe('tokens', () => {
     it('named-tier chain is strictly monotonic', () => {
       const ranks = [
         zIndex.map,
+        zIndex.underDetail,
         zIndex.overlay,
         zIndex.popover,
         zIndex.chrome,

--- a/frontend/src/tokens.ts
+++ b/frontend/src/tokens.ts
@@ -71,6 +71,14 @@ export const iconSize = {
 export const zIndex = {
   /** Persistent map canvas base layer. */
   map: 0,
+  /**
+   * #976: passive cell-hover preview demoted while a species detail is open.
+   * Sits ABOVE the map canvas/markers (5 > map's 0) but BELOW every detail
+   * surface — sheet peek (10) / half (15) / full (modal 50) AND the rail (43)
+   * — so hover-to-compare works with a detail open without the tooltip
+   * occluding it.
+   */
+  underDetail: 5,
   /** Map-assist overlays: family legend, scope-control. */
   overlay: 40,
   /** On-canvas popovers above map-assist overlays (observation popover). */


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["AdaptiveGridMarker<br/>activeCell.mode === 'preview'"] -->|always mounts now| B["&lt;CellHoverPreview&gt;"]
    A -->|"belowDetail = detailOpen<br/>(!!(scopeActive &amp;&amp; state.detail))"| B
    B -->|belowDetail=false| C["class: cell-hover-preview<br/>z = --z-modal (50)<br/>resting tier"]
    B -->|belowDetail=true| D["class: cell-hover-preview--under-detail<br/>z = --z-under-detail (5)"]
    D --> E["BELOW every detail surface:<br/>sheet peek 10 / half 15 / full 50 · rail 43<br/>ABOVE map canvas 0"]
```

Before (#782/#799): `detailOpen ? null : <CellHoverPreview/>` suppressed the preview entirely while a detail was open. After (#976): the preview always mounts; when a detail is open it is demoted beneath the detail rather than suppressed.

## Summary

- **Why:** #782/#799 encoded "tooltip-over-detail = clutter" as a permanent gate (`detailOpen ? null :`), suppressing the cell-hover preview whenever a species detail held focus. Julian wants hover-to-compare to keep working with a detail open. This reverses that product decision without re-introducing the overlap clutter.
- **How:** Ungate the preview branch in `AdaptiveGridMarker.tsx` (it always mounts) and pass `belowDetail={detailOpen}` to `CellHoverPreview`, which adds the `cell-hover-preview--under-detail` modifier that demotes z to a new `--z-under-detail` token (5).
- **Why z = 5:** the detail surfaces are not a single z — desktop rail = `--z-rail` (43); mobile sheet detents = peek 10, half 15 (the default), full 50. `--z-overlay` (40) would still paint over the default half-sheet (40 > 15), so the demote must land below the lowest detail tier (sheet peek 10) AND the rail, while staying above the map canvas (0). The rail↔sheet split is viewport-width-driven, so this is correct on narrow fine-pointer windows too. The recipe-#17 `t-tt-enter` enter animation is orthogonal to z and unaffected.
- **Merged up to `main` (composed, not clobbered):** #960 had since added `t-tt-enter` to `CellHoverPreview`'s base className; this branch's `--under-detail` modifier was composed on top — the element now renders `cell-hover-preview t-tt-enter cell-hover-preview--under-detail` when a detail is open (verified at render), keeping **both** the #17 enter animation and the z-demote. Full e2e re-ran green post-merge (**273 passed / 0 failed**).

## Screenshots

Live-verified on the rebased PR head (`fix/hover-preview-while-detail` @ `bdd975b`, post-merge of `main`) against a seeded local stack — Colorado scope, a **Steller's Jay** detail open — driven through the canonical hover-with-detail interaction (open detail → hover a *different* cell). **Console clean** for the user flow at every viewport. At capture the preview mounted with class `cell-hover-preview t-tt-enter cell-hover-preview--under-detail`, computed **z-index 5** — measured **below** the desktop rail (`--z-rail` 43) and below the sheet half-detent (15), above the map (0). The previously-suppressed tooltip now appears alongside an open detail (hover-to-compare), demoted so it never occludes the detail surface.

### Desktop rail (≥1200px) — the preview mounts on the map next to the open Steller's Jay rail, beneath it

| Viewport | Light | Dark |
|---|---|---|
| 1440×900 desktop | <img src="https://github.com/user-attachments/assets/441bc187-43b2-431e-87be-94b3fb74c8ce" width="300"> | <img src="https://github.com/user-attachments/assets/bf7f4611-5b72-4da4-bfa8-433dd01315d6" width="300"> |
| 1920×1080 wide | <img src="https://github.com/user-attachments/assets/b8ed09a1-c807-4175-b7bb-ea7ab736efcf" width="300"> | <img src="https://github.com/user-attachments/assets/1fef3d96-de2e-4b40-8826-863899b39a06" width="300"> |

### Narrow fine-pointer (1024) — detail is a bottom **sheet**; the preview is demoted beneath it (clipped at the sheet's top edge → "beneath" made visible)

| Viewport | Light | Dark |
|---|---|---|
| 1024×768 landscape | <img src="https://github.com/user-attachments/assets/74c5b6a2-ca99-4d78-b8f6-85bc20aa05f6" width="300"> | <img src="https://github.com/user-attachments/assets/d2b07640-fdce-4401-9c0f-120829ebc1dd" width="300"> |

### Touch viewports — passive hover is `pointer:fine`-only (no hover on touch), so these show the detail **sheet** open: the `--z-under-detail` token + sheet layout are intact, no regression

| Viewport | Light | Dark |
|---|---|---|
| 390×844 mobile (iPhone 14 Pro emu, DPR 3) | <img src="https://github.com/user-attachments/assets/81945f35-e07e-46ce-9b0c-0a1b24e4a252" width="300"> | <img src="https://github.com/user-attachments/assets/8e4a9f08-3a29-4f01-88f3-dfc147a4f55f" width="300"> |
| 768×1024 tablet | <img src="https://github.com/user-attachments/assets/65b9fdd0-595d-4456-b2f9-22fbc6cb93a7" width="300"> | <img src="https://github.com/user-attachments/assets/2cf36292-3cef-438c-b8d3-b7b3f8077471" width="300"> |

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (1295 passed / 85 files)
- [x] New / inverted unit + e2e coverage (behavior changed):
  - **Inverted** `map-cell-popover.spec.ts` — rail open → hovering a cell DOES surface the preview (`toHaveCount(1)`), carries `--under-detail`, and its computed z resolves below the rail's computed z (rail stays topmost).
  - **Inverted** `AdaptiveGridMarker.test.tsx` — `detailOpen` → `mouseEnter` MOUNTS the tooltip with the `--under-detail` modifier (was `toBeNull()`). Kept the `detailOpen=false` and CellPopover-unaffected siblings.
  - **Added** the load-bearing z-order guard in `tokens.css.test.ts` — `--z-under-detail` resolves below the rail (43) AND every sheet detent (peek 10, half 15, full/modal 50) AND above the map (0), parsed from the actual CSS. Asserting against both the rail and a sheet detent is what stops a future z bump from silently re-breaking mobile.
  - **Added** the `--z-under-detail` token to the `tokens.ts` zIndex object + monotonic-chain test, and the CSS `:root` token + `tokens.css.test.ts` scale assertion.
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `tsc --noEmit` — clean · `npm run lint` — clean · `npx knip` — clean
- [x] (UI) Live-verified via chrome-devtools MCP — the transient × overlay co-occurrence (hover while a detail is open) exercised at the desktop rail (1440/1920) AND a narrow fine-pointer sheet (1024), both themes; preview computed z (5) measured below rail (43) and sheet (15); console clean; 10 stills published above.

## Plan reference

Out of plan — bug fix for #976 (`out-of-plan` label). Closes #976.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


