### PR TITLE
fix(frontend): collapse identity card when scope disclosure is closed (#975)

### DIFF
--- a/frontend/e2e/scope-disclosure.spec.ts
+++ b/frontend/e2e/scope-disclosure.spec.ts
@@ -166,6 +166,56 @@ test.describe('Scope disclosure (#828)', () => {
     await expect(app.scopeDisclosureTrigger).toBeFocused();
   });
 
+  test('the identity card COLLAPSES to its two-line height when the disclosure is closed (#975)', async ({ page, apiStub }) => {
+    // #975 regression guard: #958 swapped the closed scope-rows lock to
+    // `visibility:hidden`, which keeps the form IN FLOW — the card froze at its
+    // OPEN height with an empty band below the lede. The existing `toBeHidden()`
+    // asserts pass on `visibility:hidden` alone (they never measure layout), so
+    // they could NOT catch this. This test measures the CARD'S TOTAL HEIGHT
+    // (per the review amendment — NOT just `.app-header-scope-rows ≤ 1px`, which
+    // would still pass with an 8px residual flex `gap` band present): the closed
+    // card must be MATERIALLY SHORTER than the open card.
+    const app = await setup(page, apiStub);
+
+    // Read the card's rendered border-box height directly in the page so each
+    // poll re-measures a fresh frame (a Playwright Locator boundingBox snapshots
+    // once). Returns 0 if absent so `expect.poll` can retry rather than throw.
+    const cardHeight = () =>
+      page.evaluate(() => {
+        const el = document.querySelector('.app-header-identity-card');
+        return el ? el.getBoundingClientRect().height : 0;
+      });
+
+    // --- At REST (disclosure closed) ---
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'false');
+    const restingHeight = await cardHeight();
+
+    // --- OPEN the disclosure and let the grid-rows tween SETTLE ---
+    // The grid-rows + #07 tweens run for --panel-open-dur; poll the SETTLED open
+    // height rather than reading a mid-animation frame. `expect.poll` retries the
+    // measurement until the card has grown materially (the full scope form: state
+    // <select> + ZIP row + Whole US / Change scope links + divider), which only
+    // holds once the tween lands — so `openHeight` below is the settled value.
+    await app.openScopeDisclosure();
+    await expect(app.scopeControlStateSelect).toBeVisible();
+    await expect.poll(cardHeight).toBeGreaterThan(restingHeight + 40);
+    const openHeight = await cardHeight();
+
+    // --- Esc-CLOSE and assert the card COLLAPSES back to its resting height ---
+    await page.keyboard.press('Escape');
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(app.scopeControlStateSelect).toBeHidden();
+    // Poll until the collapse tween has fully settled back to ≈the resting
+    // (two-line) height — NO empty region below the lede, no residual flex `gap`
+    // band. The closed card must be ≈ wordmark + lede + padding (≤2px sub-pixel
+    // rounding slack), MATERIALLY less than its open height — which the per-row
+    // `scope-rows ≤ 1px` guard would NOT catch (it passes with the gap band
+    // present). This is the missing #975 regression guard.
+    await expect.poll(cardHeight).toBeLessThanOrEqual(restingHeight + 2);
+    const collapsedHeight = await cardHeight();
+    expect(collapsedHeight).toBeLessThan(openHeight - 40);
+  });
+
   test('clicking ✕ collapses the form', async ({ page, apiStub }) => {
     const app = await setup(page, apiStub);
 

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -312,26 +312,38 @@ export function AppHeader({
             not lose a typed ZIP). The divider only renders when open — the
             resting card is two lines. */}
         {scopeActive && (
-          <div
-            id={scopeRegionId}
-            ref={scopeRowsRef}
-            className="app-header-scope-rows t-panel-slide"
-            data-open={scopeOpen}
-          >
-            {/* Divider only renders when open — the resting card is two lines.
-                (The ScopeControl below stays mounted regardless so aria-controls
-                always resolves to a present target.) */}
-            {scopeOpen && <hr className="app-header-divider" aria-hidden="true" />}
-            <ScopeControl
-              ref={firstScopeFieldRef}
-              scope={scope as ScopedView}
-              states={states}
-              onPickState={onPickState}
-              onPickWholeUs={onPickWholeUs}
-              onExit={onExitScope}
-              onResolve={onResolveZip}
-              embedded
-            />
+          /* #975: grid 0fr↔1fr CLIP wrapper. The inner .t-panel-slide keeps the
+             UNCHANGED #07 reveal (transform/opacity/blur + visibility); this
+             wrapper is the height-collapse mechanism. Closed → 0fr track →
+             the in-flow form contributes ZERO layout height, so the identity
+             card shrinks to wordmark + lede + padding (no empty band). The
+             id/ref/aria-controls target stays on the INNER element so the a11y
+             contract + Page-Object selectors are untouched. The residual parent
+             flex `gap` band below the lede (which would survive a 0fr collapse)
+             is cancelled by a negative top-margin on the clip WHEN CLOSED — see
+             styles.css `.app-header-scope-clip[data-open='false']`. */
+          <div className="app-header-scope-clip" data-open={scopeOpen}>
+            <div
+              id={scopeRegionId}
+              ref={scopeRowsRef}
+              className="app-header-scope-rows t-panel-slide"
+              data-open={scopeOpen}
+            >
+              {/* Divider only renders when open — the resting card is two lines.
+                  (The ScopeControl below stays mounted regardless so aria-controls
+                  always resolves to a present target.) */}
+              {scopeOpen && <hr className="app-header-divider" aria-hidden="true" />}
+              <ScopeControl
+                ref={firstScopeFieldRef}
+                scope={scope as ScopedView}
+                states={states}
+                onPickState={onPickState}
+                onPickWholeUs={onPickWholeUs}
+                onExit={onExitScope}
+                onResolve={onResolveZip}
+                embedded
+              />
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -533,6 +533,56 @@ body {
   visibility: hidden;
 }
 
+/* ── #975: grid 0fr↔1fr CLIP wrapper — collapse the card height when closed ──
+   #958 swapped the closed scope-rows lock from `display:none` to
+   `visibility:hidden` so the #07 reveal stays animatable + toBeHidden() passes.
+   But `visibility:hidden` keeps the element IN FLOW: a closed in-flow flex child
+   of the vertical-column `.app-header-identity-card` still reserves the full
+   ScopeControl box, so the card froze at its OPEN height — an empty band below
+   the lede (#975). This wrapper animates `grid-template-rows: 0fr → 1fr` (the
+   catalog-only, JS-free "tween to content height" technique — the concrete
+   answer to #01's "can't tween to auto"); closed → a 0-height track, so the
+   inner form contributes ZERO layout height. The inner .t-panel-slide keeps the
+   UNCHANGED #07 transform/opacity/blur reveal on the SAME clock
+   (--panel-open-dur / --panel-ease), so both the height collapse and the visible
+   slide play together. No new per-element prefers-reduced-motion query — the
+   global motion.css guard zeroes BOTH transitions, so reduced-motion jumps the
+   track to 1fr and lands the form fully visible (rest = open). */
+.app-header-scope-clip {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows var(--panel-open-dur) var(--panel-ease);
+}
+.app-header-scope-clip[data-open='false'] {
+  grid-template-rows: 0fr;
+  /* The card's `gap: var(--space-sm)` puts an 8px band between the lede-row and
+     this wrapper. A rendered (even 0fr-track) flex item still paints that gap, so
+     a naive clip leaves a residual ~8px empty band below the lede when closed
+     (#975 review amendment). Cancel the card's gap above THIS child WHILE it is
+     collapsed with a negative top-margin equal to the gap. When OPEN the margin
+     is dropped, so the card's --space-sm gap provides the lede→divider spacing
+     (unchanged #837 rhythm): the 8px only exists when there is content to space,
+     and fully disappears when the track collapses. The inner element carries NO
+     block padding, so the `0fr` track floors at a TRUE 0 — block-axis padding on
+     a grid item is NOT subject to `min-height:0` and would otherwise hold the
+     track open ~8px, re-creating the very band this removes. Result: a closed
+     card = wordmark + lede + padding, no slack (AC #1). */
+  margin-block-start: calc(-1 * var(--space-sm));
+}
+/* min-height:0 lets the grid item shrink below its content's min-content height
+   so the 0fr track collapses to a true 0. `overflow` IS the grid-rows clip — but
+   it also clips `outline` focus rings (drawn OUTSIDE the border-box) on the
+   first/last fields, so scope it to the CLOSED state only: once open the track is
+   content-height, nothing block-axis overflows, and dropping overflow lets a
+   keyboard focus ring paint in full. (The native <select> dropdown renders in the
+   browser top layer, immune to ancestor overflow either way.) */
+.app-header-scope-clip > .app-header-scope-rows {
+  min-height: 0;
+}
+.app-header-scope-clip[data-open='false'] > .app-header-scope-rows {
+  overflow: hidden;
+}
+
 /* ── TOP-RIGHT: controls pill ───────────────────────────────────────────────
    Filters · Attribution · Theme toggle — compact content-width floating card.
    Spec §4.1. */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -575,9 +575,16 @@ body {
    first/last fields, so scope it to the CLOSED state only: once open the track is
    content-height, nothing block-axis overflows, and dropping overflow lets a
    keyboard focus ring paint in full. (The native <select> dropdown renders in the
-   browser top layer, immune to ancestor overflow either way.) */
+   browser top layer, immune to ancestor overflow either way.)
+   min-width:0 is the horizontal twin: making this a grid item gave it the default
+   `min-width:auto`, which refuses to shrink below the embedded ScopeControl's
+   min-content width (ZIP input + [Go] button row). Without it, that row spills
+   past the 360px identity-card cap at mobile 390px (#842, scope-zip-overflow).
+   This applies in BOTH disclosure states — the overflow only manifests OPEN, but
+   constraining the item unconditionally is harmless when closed and correct. */
 .app-header-scope-clip > .app-header-scope-rows {
   min-height: 0;
+  min-width: 0;
 }
 .app-header-scope-clip[data-open='false'] > .app-header-scope-rows {
   overflow: hidden;


### PR DESCRIPTION
## Diagrams

State machine — the identity card's height now tracks the disclosure state through a grid-rows clip, instead of freezing at the open height.

```mermaid
stateDiagram-v2
    [*] --> Closed: scope active, disclosure closed (rest)
    Closed --> Open: 🔍 click / openScopeDisclosure()
    Open --> Closed: ✕ click / Esc

    state Closed {
        clip_closed: .app-header-scope-clip[data-open=false]
        note right of clip_closed
            grid-template-rows: 0fr  →  track height 0
            margin-block-start: -8px →  cancels card flex gap
            inner: visibility:hidden + overflow:hidden (a11y out, clipped)
            CARD HEIGHT = wordmark + lede + padding (no empty band)
        end note
    }

    state Open {
        clip_open: .app-header-scope-clip[data-open=true]
        note right of clip_open
            grid-template-rows: 1fr  →  track = content height
            no negative margin       →  card gap = lede→divider 8px
            inner #07 reveal: translateY 14→0, opacity 0→1, blur 2→0
            CARD GROWS to fit the full scope form
        end note
    }
```

## Summary

- **Why:** #958 replaced the closed scope-rows `display:none` lock with `visibility:hidden` (so the #07 panel-reveal stays animatable and `toBeHidden()` passes). But `visibility:hidden` keeps the element **in layout flow** — the closed scope form, an in-flow flex child of the vertical-column identity card, still reserved the full ScopeControl box, so the card froze at its **open** height with a large empty white band below the lede (visible in production, e.g. Colorado scope, disclosure closed).
- **Fix:** wrap the existing `.t-panel-slide` in a `.app-header-scope-clip` grid wrapper that tweens `grid-template-rows: 0fr ↔ 1fr` (the catalog-only, JS-free "tween to content height" technique) on the same `--panel-open-dur`/`--panel-ease` clock. Closed → a 0-height track → the form contributes zero layout height. The inner element keeps its **unchanged** #07 transform/opacity/blur reveal, its `visibility:hidden` rest state, and its `id`/`ref`/`aria-controls` target.
- **Two amendment details folded in:** (1) the card's flex `gap` would still paint an ~8px band above the 0fr-track item, so a negative top-margin cancels it **when closed** (dropped when open, where the gap provides the lede→divider rhythm); the inner element carries no block padding so the `0fr` track floors at a true 0. (2) `overflow:hidden` (the clip) is scoped to the **closed** state only, so an open keyboard focus ring is never clipped. No FLIP, no motion lib, no JS height measure, no new per-element `prefers-reduced-motion` query.
- **CI-caught follow-up (`min-width:0`):** the `.app-header-scope-clip` grid wrapper makes the inner scope-rows a grid item, whose default `min-width:auto` refused to shrink below the embedded ZIP/[Go] min-content width — spilling 32px past the 360px card cap at mobile 390px (`scope-zip-overflow.spec.ts` #842 went red on first push). Added `min-width:0` to the unconditional inner rule (alongside the existing `min-height:0`) so the item is constrained on both axes in both disclosure states. Full e2e re-run: **272 passed / 0 failed**.

## Screenshots

Live-verified on the PR head (`fix/identity-card-collapse`, post-merge of `main`) against a seeded local stack (Colorado scope). **Zero console errors/warnings** at all 5 viewports × both themes. Measured: closed card **88px** (collapsed two-line — scope-rows contributes **0px** layout height) ↔ open card **213px** (#07 reveal landed at rest: opacity 1, transform identity, blur 0). After the `min-width:0` follow-up commit, the mobile-open ZIP/[Go] row sits **~139px inside** the 360px card edge (it was spilling **32px** past — the `scope-zip-overflow.spec.ts` #842 guard, now green).

### Closed — the fix: identity card collapses to its two-line height, no empty band below the lede

| Viewport | Light | Dark |
|---|---|---|
| 390×844 mobile | <img src="https://github.com/user-attachments/assets/c8b0e30e-f35a-4d20-a325-1e7931676a3a" width="300"> | <img src="https://github.com/user-attachments/assets/ae680b63-74f8-4318-8aa7-e38701c621a0" width="300"> |
| 768×1024 tablet | <img src="https://github.com/user-attachments/assets/14f4f01a-9c1e-4bd3-acf9-5cda529d759e" width="300"> | <img src="https://github.com/user-attachments/assets/2c5fbb4d-ec24-4264-b4b3-9a4b5b845ddb" width="300"> |
| 1024×768 landscape | <img src="https://github.com/user-attachments/assets/0eda1a9a-609a-4396-9935-02e86f08b03a" width="300"> | <img src="https://github.com/user-attachments/assets/3198273c-c0f3-4e0e-b867-f89efe789008" width="300"> |
| 1440×900 desktop | <img src="https://github.com/user-attachments/assets/c24a41dc-40c4-4e13-9d32-22d344ded258" width="300"> | <img src="https://github.com/user-attachments/assets/2a555745-7a06-4467-803c-cc8eda45722f" width="300"> |
| 1920×1080 wide | <img src="https://github.com/user-attachments/assets/faa65680-cdb7-40fe-bebf-5684584c6229" width="300"> | <img src="https://github.com/user-attachments/assets/dcbe4bf3-6771-4eb0-ac4d-ae56a0b91359" width="300"> |

### Open — disclosure reveal (#07) still plays + mobile [Go] stays inside the card (#842)

| State | Light | Dark |
|---|---|---|
| Desktop 1440 — scope form revealed, card grown | <img src="https://github.com/user-attachments/assets/a00be692-59d7-4985-a940-1942a4d463df" width="300"> | <img src="https://github.com/user-attachments/assets/aa7e9b8f-f7ef-4fb1-b030-699c9afe3db8" width="300"> |
| Mobile 390 — ZIP/[Go] row inside the card edge | <img src="https://github.com/user-attachments/assets/b9a54a3c-4659-4519-9d7d-69c163c2c6f2" width="300"> | <img src="https://github.com/user-attachments/assets/2094354e-1fda-4071-8824-4d446d53d6bb" width="300"> |

## Test plan

- [x] `tsc --noEmit` — green; `npm test --workspace @bird-watch/frontend` — 1291 passed
- [x] New Playwright e2e spec added: `scope-disclosure.spec.ts` asserts the identity card's **total** height collapses materially below its open height after rest AND after Esc-close (≤2px slack). Verified to **fail** on the pre-fix baseline (open−resting was only ~9px), pass with the fix, and stable across `--repeat-each=3`.
- [x] `npm run build` — clean production build
- [x] `npm run lint` (incl. forbidden-raw-token guard) — green; `npx knip` — exit 0; `scripts/check-orphan-classnames.sh` — PASS (`.app-header-scope-clip` has a matching CSS rule)
- [x] (UI) Live-verified via chrome-devtools MCP at all 5 viewports × 2 themes (closed collapse + open reveal + mobile [Go]-inside-card); 14 stills published above; zero console errors/warnings

## Plan reference

Out of plan — bug fix for the #958 regression (identity card doesn't collapse when scope disclosure is closed). Closes #975.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
