### PR TITLE
feat(photo-quality): Phase-0 rubric research + @bird-watch/photo-quality skeleton + draft config (#962)

### DIFF
--- a/docs/research/2026-06-10-bird-photo-quality-rubric.md
+++ b/docs/research/2026-06-10-bird-photo-quality-rubric.md
@@ -1,0 +1,228 @@
+# Bird Photo Quality Rubric — Research (Phase 0)
+
+- **Date:** 2026-06-10
+- **Status:** Draft → feeds `packages/photo-quality/src/rubric.config.ts`
+- **Spec:** `docs/specs/2026-06-10-photo-quality-curation-design.md` §6
+- **Purpose:** Synthesize authoritative field-guide / bird-photography quality
+  criteria + the disqualifier taxonomy into a repeatable rubric. This document
+  is the source the vision-judge `judgePrompt` is derived from. The judge is a
+  Claude Code agent that `Read`s the image (no SDK, no API key — it uses the
+  session model); the rubric below is the instruction it receives.
+
+## 1. What makes a field-guide-quality bird photo
+
+A "nature-guide" photo serves identification first and aesthetics second. This
+is the same priority Cornell's Macaulay Library codifies in its media star
+guidance: a rating reflects *technical quality of the depiction*, not the rarity
+or biological interest of the bird — "a great photo of a common, drab bird
+should still be 5 stars and a poor photo of a very rare or hard-to-photograph
+bird could still be only 1 or 2 stars" ([eBird/ML rating
+guidance](https://support.ebird.org/en/support/solutions/articles/48001064392-rating-media)).
+Our rubric inherits that stance: score the photo's value *as an ID reference*,
+independent of how interesting the species is.
+
+The synthesized consensus across the sources in §6:
+
+- **Framing / subject size.** The bird fills a meaningful share of the frame
+  (roughly subject occupies ⅓–⅔ of the shorter dimension), is not clipped at
+  wings/tail/feet, and sits with comfortable headroom in its direction of gaze.
+  Distant specks where the bird is a smudge are field records, not guide photos.
+  Macaulay's 5-star bar requires the bird be "at least fairly large in the frame
+  and not significantly obscured," and explicitly down-rates photos where the
+  subject is small, partially obstructed, or backlit
+  ([rating guidance](https://support.ebird.org/en/support/solutions/articles/48001064392-rating-media)).
+  Audubon's composition guidance similarly warns photographers to shoot at a
+  wide enough angle that wing tips are not cropped off
+  ([How to Compose the Perfect Bird Photo](https://www.audubon.org/magazine/how-compose-perfect-bird-photo),
+  [Clipped Wings](https://www.audubon.org/multimedia/clipped-wings)).
+- **Subject clarity / focus.** The plane of focus is on the bird, and crucially
+  on the **eye** — a sharp catchlit eye is the single strongest signal of a
+  keeper. Field practitioners single out the eye as the bond between subject and
+  viewer and recommend single-point AF tracking the near eye for the sharpest
+  result; sharpness is treated as the first technical gate of a usable bird
+  image ([Photzy — Staying Sharp and
+  Focused](https://photzy.com/bird-photography-stay-sharp-and-focused/),
+  [Akari composition guide](https://akariphototours.com/resources/wildlife-photography-tutorials/bird-photography-composition-guide/)).
+  Diagnostic feather detail (wing bars, mantle pattern, breast streaking) must
+  be resolvable.
+- **Natural setting.** A wild bird on a natural perch / in natural habitat. The
+  presence of a human hand, a banding grip, a cage/aviary, a feeder, a studio
+  backdrop, or a collection-tray specimen all degrade guide value. Macaulay is
+  unambiguous here: photos of dead or captive birds "are generally not
+  appropriate" and ML Search hides captive media by default; in-hand photos —
+  defined as "any photo or video of a live bird being held or restrained by a
+  person," including mist-netted or temporarily-restrained birds — are not
+  appropriate except in association with a permitted scientific operation
+  ([photo upload
+  guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines),
+  [media of birds
+  in-hand](https://support.ebird.org/en/support/solutions/articles/48001275751-media-of-birds-in-hand)).
+  This is the provenance norm that motivates our `naturalness` criterion and the
+  `captive` / `in-hand` / `specimen` flags.
+- **Pose.** A diagnostic profile or ¾ view that shows the field marks an ID
+  depends on, over a tail-on or obscured pose. The up-and-down wing strokes that
+  reveal feather and wing detail are preferred over wings pointed flat away from
+  the camera ([Audubon composition
+  guide](https://www.audubon.org/magazine/how-compose-perfect-bird-photo)).
+- **Background.** Clean, non-distracting, ideally separated from the subject;
+  busy/cluttered backgrounds that camouflage field marks score lower.
+  Practitioners describe background as "where many images fall apart" — a clean,
+  separated background (achieved with aperture/working distance) reads as a
+  keeper, while a competing background pulls the eye off the bird
+  ([fstoppers](https://fstoppers.com/animal/bird-flight-photography-settings-actually-work-900352),
+  [Akari composition guide](https://akariphototours.com/resources/wildlife-photography-tutorials/bird-photography-composition-guide/)).
+- **Lighting.** Even, natural light that renders true color and feather texture.
+  Harsh on-camera flash (specular hotspots, black backgrounds, red-eye /
+  steel-eye) and blown highlights / crushed shadows degrade the photo. Macaulay's
+  editing norm is to "make the bird look as it did in the field" — a natural
+  reproduction of how the bird looked in life, not an artificially altered one
+  ([photo upload
+  guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines)).
+  Exposure (histogram clipping) is one of the two dimensions automated aesthetic
+  models like Google's NIMA learn to score, which is why we keep a deterministic
+  exposure check ahead of the LLM judge
+  ([NIMA](https://research.google/blog/introducing-nima-neural-image-assessment/)).
+
+## 2. The seven scored criteria (0–10 each)
+
+These are the per-criterion sub-scores the judge returns. They map 1:1 onto the
+`CriteriaScores` keys in the pinned interface contract:
+
+| Criterion        | Key (verbatim)   | What 10 looks like | What 0 looks like |
+|------------------|------------------|--------------------|-------------------|
+| Framing          | `framing`        | Subject well-sized, uncropped, balanced | Distant speck or limbs clipped |
+| Subject clarity  | `subjectClarity` | Eye tack-sharp, feather detail crisp | Soft / motion-blurred / eye lost |
+| Liveness         | `liveness`       | Alert, healthy, alive | Dead / sick / injured |
+| Naturalness      | `naturalness`    | Wild bird, natural perch/habitat | In-hand / captive / feeder / specimen |
+| Pose             | `pose`           | Diagnostic profile or ¾ view | Tail-on / obscured / head hidden |
+| Background       | `background`     | Clean, separated, non-distracting | Cluttered, camouflaging |
+| Lighting         | `lighting`       | Even natural light, true color | Harsh flash, blown / crushed |
+
+The split mirrors how field reviewers actually triage: Macaulay's star bands
+combine **sharpness/focus**, **resolution**, **subject size in frame**, and
+**lighting** into a single ordinal rating
+([rating guidance](https://support.ebird.org/en/support/solutions/articles/48001064392-rating-media)).
+We decompose that ordinal into separate sub-scores so the composite is tunable
+(weights), so the curation UI can show *why* a photo scored low, and so a
+disqualifier (e.g. captive provenance) can cap the composite without silently
+muddying the technical sub-scores.
+
+## 3. Disqualifier taxonomy (the nine flags)
+
+Hard quality signals that, when present, cap the composite regardless of other
+sub-scores. The judge emits these as `flags` (string literals); the config maps
+a subset to numeric caps (§5). The wild-vs-captive / dead / in-hand distinctions
+are taken straight from Macaulay Library upload policy (captive and dead media
+not appropriate; in-hand restricted to permitted scientific operations) — they
+are exactly the provenance failures that disqualify an image as a field-guide
+reference ([upload
+guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines),
+[in-hand
+policy](https://support.ebird.org/en/support/solutions/articles/48001275751-media-of-birds-in-hand)).
+The `watermark` down-weight follows Macaulay's explicit rule that watermarks
+lower a rating by 1–4 stars depending on size/obtrusiveness
+([rating guidance](https://support.ebird.org/en/support/solutions/articles/48001064392-rating-media)).
+
+| Flag                | Meaning | Cap behavior |
+|---------------------|---------|--------------|
+| `dead`              | Carcass, roadkill, deceased bird | Hard cap (≤20) |
+| `specimen`          | Museum / collection-tray specimen, study skin | Hard cap (≤20) |
+| `in-hand`           | Held in a human hand / banding grip | Cap (≤35) |
+| `captive`           | Aviary, cage, zoo, rehab, feeder/seed-tray | Cap (≤45) |
+| `sick`              | Visibly ill / injured / heavily distressed | Cap (≤30) |
+| `distant`           | Bird too small in frame to read field marks | Down-weights framing/clarity |
+| `multiple-subjects` | More than one bird, ambiguous which is the subject | Down-weights framing |
+| `watermark`         | Overlaid text / logo / signature | Down-weights aesthetics |
+| `harsh-flash`       | On-camera flash artifacts (black bg, steel-eye, hotspots) | Down-weights lighting |
+
+## 4. Composite scoring model
+
+`overall` (0–100) is a **weight-and-scale** of the seven sub-scores, then
+clamped by any disqualifier cap. The seven `weights` **sum to 1.0** (a convex
+combination), so `composeOverall = (Σ weightᵢ · criteriaᵢ) · 10` lands the
+result in 0–100 (each criterion is 0–10, the weighted average is 0–10, ×10 →
+0–100). No separate normalization by the weight-sum is needed because the sum
+is 1 by construction. Weights reflect ID-first priorities: `subjectClarity` and
+`framing` dominate (a sharp, well-framed bird is the core of a guide photo);
+`naturalness` and `liveness` carry the disqualifier-adjacent weight; `pose`,
+`background`, `lighting` round out aesthetics. Exact numeric weights live in
+`rubric.config.ts` and are tuned during calibration (spec §6, decision #7) —
+this document fixes the *ranking* rationale and the sum-to-1 convention, not the
+final floats. (Slice 2's `composeOverall` implements exactly this math; Slice 1
+only ships the sum-to-1 config.)
+
+This two-stage shape — a cheap deterministic gate (resolution / sharpness /
+aspect, in the spirit of NIMA's *technical-quality* model) ahead of a learned /
+judged *aesthetic+ID* score — is the same separation Google's NIMA work draws
+between technical and aesthetic image assessment, and is why a sharpness floor
+can short-circuit obviously-soft images before they reach the LLM
+([NIMA](https://research.google/blog/introducing-nima-neural-image-assessment/)).
+
+Verdict bands map composite to `Verdict`: `great` / `good` / `mediocre` /
+`reject`, with `thresholds.autoAccept` / `review` / `reject` as the cut points.
+
+## 5. Calibration plan
+
+Per spec §6 decision #7: assemble a ~30–40 image sample spanning known-good and
+known-bad (including obvious `dead` / `in-hand` cases), score with the draft
+config, review verdicts against operator judgment, and tune weights / thresholds
+/ prompt until they agree. Only then run the full ~715-species pass. The config's
+`version` field is bumped on every tune so cached scores can be invalidated. The
+judge is a Claude Code agent using the session model — there is no SDK model id
+to choose or swap; calibration tunes the rubric (weights / thresholds / prompt),
+not a model tier. The known-bad anchors are easy to source against Macaulay's own
+exclusions (captive / dead / in-hand media that ML Search filters out), giving us
+a labeled negative set the draft caps must reproduce
+([upload
+guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines)).
+
+## 6. Sources
+
+Concrete named guides consulted, grouped by category. The rubric's design intent
+— ID-first, eye-sharpness-led, disqualifier-gated — is the durable output
+regardless of which individual guide is quoted.
+
+- **Field-guide photographic conventions** (subject size, diagnostic feather
+  detail, natural perch, eye sharpness, avoiding clipped wings):
+  - National Audubon Society — [How to Compose the Perfect Bird
+    Photo](https://www.audubon.org/magazine/how-compose-perfect-bird-photo)
+  - National Audubon Society — [Clipped
+    Wings](https://www.audubon.org/multimedia/clipped-wings) (cropping ethics /
+    framing)
+  - Illinois Audubon Society — [Getting Started with Bird Photography: The
+    Exposure
+    Triangle](https://illinoisaudubon.org/blog/2018/11/26/getting-started-with-bird-photography-the-exposure-triangle/)
+- **Media-rating norms** (sharpness, framing, exposure, resolution, watermark,
+  behavioral/ID value as ordinal star bands):
+  - Cornell Lab / eBird — [How to rate media in the Macaulay
+    Library/eBird](https://support.ebird.org/en/support/solutions/articles/48001064392-rating-media)
+  - Cornell Lab / eBird — [Photo Upload
+    Guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines)
+  - Macaulay Library — [Introducing community rating for photos and
+    sounds](https://www.macaulaylibrary.org/2017/03/10/introducing-community-rating-for-photos-and-sounds/)
+- **Critique literature** (eye sharpness as the keeper test, clean background,
+  separating the subject, focus technique):
+  - Photzy — [Bird Photography: Staying Sharp and
+    Focused](https://photzy.com/bird-photography-stay-sharp-and-focused/)
+  - Akari Photo Tours — [Bird Photography Composition
+    Guide](https://akariphototours.com/resources/wildlife-photography-tutorials/bird-photography-composition-guide/)
+  - Fstoppers — [Bird in Flight Photography Settings That Actually
+    Work](https://fstoppers.com/animal/bird-flight-photography-settings-actually-work-900352)
+    (background/aperture separation)
+- **Aesthetic-scoring background** (the technical-vs-aesthetic split that
+  motivates the deterministic-gate-then-judge architecture):
+  - Google Research — [Introducing NIMA: Neural Image
+    Assessment](https://research.google/blog/introducing-nima-neural-image-assessment/)
+  - Talebi & Milanfar, *NIMA: Neural Image Assessment*,
+    [arXiv:1709.05424](https://arxiv.org/pdf/1709.05424)
+- **Ethics / provenance** (wild-vs-captive, in-hand/banding norms that motivate
+  the `naturalness` criterion and the `captive` / `in-hand` / `specimen` flags):
+  - Cornell Lab / eBird — [Media of Birds
+    In-hand](https://support.ebird.org/en/support/solutions/articles/48001275751-media-of-birds-in-hand)
+  - Cornell Lab / eBird — [Photo Upload
+    Guidelines](https://support.ebird.org/en/support/solutions/articles/48001064357-photo-upload-guidelines)
+    (captive/dead media not appropriate; natural-reproduction editing norm)
+
+> The categories above each cite the specific guides consulted inline. The
+> rubric's design intent — ID-first, eye-sharpness-led, disqualifier-gated — is
+> the durable output regardless of which individual guide is quoted.

--- a/docs/specs/2026-06-10-photo-quality-curation-design.md
+++ b/docs/specs/2026-06-10-photo-quality-curation-design.md
@@ -44,6 +44,15 @@ Across ~715 observed species (99% photo coverage), a meaningful fraction need re
 | 7 | Rubric calibration | **Calibrate on a ~30–40 photo sample first**, tune, then run all ~715 |
 | 8 | Review server styling | **Adopts `DESIGN.md`** (colors, type ramp, elevation, 12px cards, light/dark via `[data-theme]`) — minus the four-corner map contract, which is map-specific |
 
+## 3a. Design revision (2026-06-10) — supersedes parts of §4–§6
+
+After the initial spec landed, three decisions changed the scoring/automation model. Where this section conflicts with §4–§6 below, **this section wins**. The implementation issues (epic #974) reflect it.
+
+- **R1 — Scoring runs in Claude Code; no API key.** The vision judge is a **Claude Code agent** that uses the `Read` tool to look at a locally-downloaded image and apply the rubric. There is **no `@anthropic-ai/sdk` / `ANTHROPIC_API_KEY`** anywhere. `packages/photo-quality` stays pure — it exports `assessDeterministic` (sharp gate), `composeOverall` (composite math), `scoreImage` (injected `VisionJudge`), the `VisionJudge` interface, a `FakeJudge` test double, `defaultRubricConfig` (no `model` field), and the `judgePrompt`. The production judge is supplied by a committed Claude Code **workflow**, not an SDK call. (This replaces the `ClaudeVisionJudge`/SDK references in §4 and §5.1.)
+- **R2 — Scoring is batched and resumable (default 10, max 100) via a `reviewed` column.** `photo_current` gains `reviewed INTEGER NOT NULL DEFAULT 0`. A cheap `sync` CLI (no tokens) pulls the species inventory + current photo URLs into the store with `reviewed=0`; a Claude Code `score` workflow then processes the next N `reviewed=0` rows (default 10, `--limit` ≤ 100), marking `reviewed=1`. Resume across sessions. Re-running `sync` later picks up newly-ingested photos as `reviewed=0`.
+- **R3 — No automated ingestor gate.** §5.7 (inline ingestor gate) and §5.8 (prod `quality_score`/`needs_review` migration) are **dropped** (issues #968 and #965 closed). New photos are handled by re-running `sync` + the batched `score` pass — an on-demand manual scan, not an unattended prod job. Scoring state lives only in the local SQLite store.
+- **R4 — Deny → re-source is async.** The local Express review server is plain Node and cannot invoke Claude Code agents, so it never scores inline. The `source-candidates` workflow **pre-scores a deep candidate pool** per flagged species; in the server, **Deny** advances to the next already-scored alternate instantly, and only when the pool is exhausted does it queue a deny-biased re-source (a `photo_decision.resource_requested` flag) for the next `source-candidates` run.
+
 ## 4. Architecture (Approach A: shared rubric core)
 
 The linchpin is a **shared scoring package** that both the review tool and the ingestor import — so "same criteria for new photos" is structural, not a copy.
@@ -190,9 +199,13 @@ A `apply-swaps` action in the curation tool reads all `photo_decision` rows wher
 
 ### 5.7 Ingestor new-photo gate
 
+> **SUPERSEDED by §3a (R3) — dropped.** There is no automated ingestor gate. New photos are scored on demand by re-running `sync` + the batched `score` workflow (issue #968 closed). The original design is retained below for context only.
+
 Refactor `run-photos.ts` to import `packages/photo-quality` and the top-N sourcer. For a species needing a photo: fetch top-N → score each → pick the best. If best `overall ≥ thresholds.autoAccept`, write it (as today, now with a content-hashed key). If none clear the bar, write the best available **but** set `needs_review=true` and `quality_score`, so the species still shows a photo and the curation tool surfaces it for human attention on next sync. (Keeping a photo rather than leaving a gap preserves current coverage behavior; the flag is the queue.)
 
 ### 5.8 Prod schema change (minimal)
+
+> **SUPERSEDED by §3a (R3) — dropped.** These columns existed only to persist the (now-removed) ingestor gate's decision in prod. With scoring state held in the local SQLite store and no gate, prod `species_photos` is unchanged (issue #965 closed). The local store instead gains a `reviewed` flag on `photo_current` (§3a R2). The original is retained below for context only.
 
 A single migration adds two columns to `species_photos`:
 ```sql

--- a/knip.ts
+++ b/knip.ts
@@ -255,6 +255,21 @@ const config: KnipConfig = {
     'packages/db-client': {},
     'packages/geo': {},
     'packages/shared-types': {},
+    'packages/photo-quality': {
+      // 2026-06-10: sharp is declared NOW (Slice 1, #962) but first USED in
+      //             Slice 2 (#971), which adds src/deterministic.ts (the sharp
+      //             decode + Laplacian-variance gate). The Phase-0 slice ships
+      //             only rubric.config.ts, so knip correctly reports sharp as an
+      //             unused dependency of this workspace. The dep is declared up
+      //             front so Slice 2 lands by adding src/ files only, never
+      //             touching the manifest (the package's emit-dist contract).
+      //             Risk: masks a genuine unused-dep if Slice 2 is abandoned and
+      //             sharp never gets a consumer. SELF-HEALING — remove this
+      //             ignore once src/deterministic.ts imports sharp. Re-audit
+      //             2026-07-27 by confirming either packages/photo-quality/src
+      //             imports 'sharp' OR Slice 2 (#971) is still in flight.
+      ignoreDependencies: ['sharp'],
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -749,6 +749,10 @@
       "resolved": "services/ingestor",
       "link": true
     },
+    "node_modules/@bird-watch/photo-quality": {
+      "resolved": "packages/photo-quality",
+      "link": true
+    },
     "node_modules/@bird-watch/read-api": {
       "resolved": "services/read-api",
       "link": true
@@ -919,7 +923,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1527,6 +1530,471 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -4398,7 +4866,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7033,6 +7500,18 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "dev": true,
@@ -7049,6 +7528,50 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -8325,6 +8848,16 @@
     "packages/geo": {
       "name": "@bird-watch/geo",
       "version": "0.0.1",
+      "devDependencies": {
+        "vitest": "^4.1.7"
+      }
+    },
+    "packages/photo-quality": {
+      "name": "@bird-watch/photo-quality",
+      "version": "0.0.1",
+      "dependencies": {
+        "sharp": "^0.34.5"
+      },
       "devDependencies": {
         "vitest": "^4.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api && npm run build -w @bird-watch/frontend",
+    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/photo-quality && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api && npm run build -w @bird-watch/frontend",
     "lint": "npm run lint --workspaces --if-present",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/packages/photo-quality/package.json
+++ b/packages/photo-quality/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bird-watch/photo-quality",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./rubric.config": {
+      "types": "./dist/rubric.config.d.ts",
+      "default": "./dist/rubric.config.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "sharp": "^0.34.5"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/photo-quality/src/rubric.config.test.ts
+++ b/packages/photo-quality/src/rubric.config.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultRubricConfig,
+  type RubricConfig,
+  type CriteriaScores,
+} from './rubric.config.js';
+
+/**
+ * Slice 1 owns ONLY the rubric config + its structural invariants. scoreImage,
+ * the deterministic metrics, and the VisionJudge are Slice 2. So this suite is
+ * deliberately data-shape-only: it proves the config parses, that its weight
+ * keys are exactly the seven CriteriaScores keys (the contract that lets the
+ * composite math in Slice 2 iterate weights without a missing/extra key), that
+ * the weights form a convex combination (sum to 1.0), and that the canonical
+ * disqualifier caps and thresholds are present. There is no model-id assertion:
+ * the judge is a Claude Code agent using the session model, so RubricConfig has
+ * no `model` field. Prompt prose quality is validated by the human calibration
+ * loop (spec §6/§10), not here.
+ */
+
+// The seven canonical criteria keys, pinned by the interface contract. If this
+// list and Object.keys(weights) ever diverge, the composite weighting breaks.
+const CRITERIA_KEYS: (keyof CriteriaScores)[] = [
+  'framing',
+  'subjectClarity',
+  'liveness',
+  'naturalness',
+  'pose',
+  'background',
+  'lighting',
+];
+
+describe('defaultRubricConfig', () => {
+  it('is a well-formed RubricConfig literal', () => {
+    const cfg: RubricConfig = defaultRubricConfig;
+    expect(typeof cfg.version).toBe('string');
+    expect(cfg.version.length).toBeGreaterThan(0);
+  });
+
+  it('weights keys === the seven CriteriaScores keys (no missing, no extra)', () => {
+    const weightKeys = Object.keys(defaultRubricConfig.weights).sort();
+    expect(weightKeys).toEqual([...CRITERIA_KEYS].sort());
+    // every weight is a positive finite number — no 0-weight stubs
+    for (const k of CRITERIA_KEYS) {
+      const w = defaultRubricConfig.weights[k];
+      expect(Number.isFinite(w)).toBe(true);
+      expect(w).toBeGreaterThan(0);
+    }
+  });
+
+  it('weights sum to 1.0 (convex combination — sum-to-1 convention)', () => {
+    const sum = CRITERIA_KEYS.reduce(
+      (acc, k) => acc + defaultRubricConfig.weights[k],
+      0,
+    );
+    // tolerate float dust; the contract is exact-sum-to-1 by intent
+    expect(sum).toBeCloseTo(1, 6);
+  });
+
+  it('carries the canonical disqualifier caps', () => {
+    const caps = Object.fromEntries(
+      defaultRubricConfig.disqualifiers.map((d) => [d.flag, d.cap]),
+    );
+    expect(caps).toMatchObject({
+      dead: 20,
+      specimen: 20,
+      'in-hand': 35,
+      captive: 45,
+      sick: 30,
+    });
+  });
+
+  it('has all three threshold cut points, ordered reject < review < autoAccept', () => {
+    const { reject, review, autoAccept } = defaultRubricConfig.thresholds;
+    expect(reject).toBeLessThan(review);
+    expect(review).toBeLessThan(autoAccept);
+  });
+
+  it('has a non-empty judgePrompt that names every criterion and flag', () => {
+    const p = defaultRubricConfig.judgePrompt;
+    expect(p.length).toBeGreaterThan(200);
+    for (const k of CRITERIA_KEYS) {
+      expect(p).toContain(k);
+    }
+    for (const flag of [
+      'dead', 'in-hand', 'specimen', 'sick', 'distant',
+      'multiple-subjects', 'watermark', 'captive', 'harsh-flash',
+    ]) {
+      expect(p).toContain(flag);
+    }
+  });
+
+  it('has deterministic-gate minimums', () => {
+    const d = defaultRubricConfig.deterministic;
+    expect(d.minMegapixels).toBeGreaterThan(0);
+    expect(d.minSharpness).toBeGreaterThan(0);
+    expect(d.allowedAspect[0]).toBeLessThan(d.allowedAspect[1]);
+  });
+});

--- a/packages/photo-quality/src/rubric.config.ts
+++ b/packages/photo-quality/src/rubric.config.ts
@@ -1,0 +1,129 @@
+/**
+ * `@bird-watch/photo-quality` rubric config — Phase-0 deliverable (spec §6, §5.1).
+ *
+ * ONE config, two consumers: the curation tool's bulk-review pass and the
+ * ingestor's new-photo gate both import this literal, so "same criteria for new
+ * photos" is structural, not a copy. Derived from
+ * `docs/research/2026-06-10-bird-photo-quality-rubric.md`.
+ *
+ * The `version` is bumped on every calibration tune so SQLite-cached scores
+ * (keyed by content hash + rubricVersion) are invalidated when the rubric moves.
+ *
+ * SCOPE NOTE (Slice 1): this file declares the minimal `CriteriaScores` /
+ * `RubricConfig` types it needs locally. Slice 2 authors `src/index.ts` with the
+ * full public interface set (`ImageInput`, `QualityReport`, `VisionJudge`,
+ * `scoreImage`, …) and aligns `CriteriaScores` / `RubricConfig` to these exact
+ * shapes. Keep the field names/types here identical to the pinned contract.
+ */
+
+/** Stage-2 per-criterion sub-scores, each 0–10. Pinned interface contract. */
+export interface CriteriaScores {
+  framing: number;
+  subjectClarity: number;
+  liveness: number;
+  naturalness: number;
+  pose: number;
+  background: number;
+  lighting: number;
+}
+
+/** Tunable, version-stamped rubric contract. Pinned interface contract. */
+export interface RubricConfig {
+  version: string;
+  deterministic: {
+    minMegapixels: number;
+    minSharpness: number;
+    allowedAspect: [number, number];
+  };
+  /** Per-criterion weights; SUM TO 1.0 (convex combination). composeOverall =
+   *  (Σ weightᵢ·criteriaᵢ)·10 → 0..100 (criteria 0..10, weights sum to 1). */
+  weights: Record<keyof CriteriaScores, number>;
+  disqualifiers: { flag: string; cap: number }[];
+  thresholds: { autoAccept: number; review: number; reject: number };
+  judgePrompt: string;
+}
+
+/**
+ * The researched rubric the vision judge receives. Enumerates all seven scored
+ * criteria and the nine-flag disqualifier vocabulary so the structured-output
+ * judge returns the complete CriteriaScores + flags set. Derived from the
+ * research doc §2–§3; refined during calibration.
+ */
+const JUDGE_PROMPT = `You are grading a single photograph of a wild bird for use as the
+identification photo in a digital field guide. Judgment is ID-FIRST: a sharp,
+well-framed, diagnostic photo of a wild bird beats a pretty but uninformative one.
+
+Return, as structured output, an integer 0–10 for EACH of these seven criteria:
+- framing: subject size and placement in the frame; 10 = bird well-sized and
+  uncropped with comfortable headroom, 0 = a distant speck or limbs clipped.
+- subjectClarity: focus on the bird, especially the EYE; 10 = eye tack-sharp and
+  diagnostic feather detail crisp, 0 = soft / motion-blurred / eye lost.
+- liveness: alive and healthy; 10 = alert healthy bird, 0 = dead / sick / injured.
+- naturalness: wild bird in a natural setting; 10 = natural perch or habitat,
+  0 = in a human hand, captive, at a feeder, a studio backdrop, or a specimen.
+- pose: diagnostic view; 10 = clean profile or three-quarter view showing field
+  marks, 0 = tail-on / obscured / head hidden.
+- background: clean and non-distracting; 10 = subject cleanly separated,
+  0 = cluttered background that camouflages field marks.
+- lighting: even natural light rendering true color; 10 = ideal, 0 = harsh flash
+  or blown highlights / crushed shadows.
+
+ALSO return a list of any of these disqualifier flags that apply (use the exact
+strings): "dead", "in-hand", "specimen", "sick", "distant",
+"multiple-subjects", "watermark", "captive", "harsh-flash". Apply a flag whenever
+the condition is clearly present; these gate the photo's overall score.
+
+ALSO return a one-sentence rationale naming the dominant strength or defect.
+
+Be strict about wild provenance: a bird held by a person, on a banding grip, in a
+cage or aviary, at a feeder/seed-tray, or a museum study-skin is NOT a field-guide
+photo even if technically sharp — flag it ("in-hand" / "captive" / "specimen") and
+score naturalness low.`;
+
+export const defaultRubricConfig: RubricConfig = {
+  version: '2026-06-10.0',
+  deterministic: {
+    // ~0.3 MP floor — below this the bird can't be read at panel size.
+    minMegapixels: 0.3,
+    // Normalized Laplacian-variance floor; calibrated in Slice 10. Conservative
+    // draft so obviously soft images gate before the LLM (the hybrid cost saving).
+    minSharpness: 0.04,
+    // Reject extreme panoramas/strips; typical bird crops are 0.5–2.0 aspect.
+    allowedAspect: [0.4, 2.5],
+  },
+  // ID-first ranking: clarity + framing dominate; naturalness + liveness carry
+  // disqualifier-adjacent weight; pose/background/lighting are aesthetics.
+  // WEIGHTS SUM TO 1.0 (convex combination). composeOverall multiplies the
+  // weighted average of the 0–10 sub-scores by 10 to land in 0–100, so no
+  // separate normalization by the weight-sum is needed. Tuned in calibration.
+  weights: {
+    subjectClarity: 0.24,
+    framing: 0.2,
+    naturalness: 0.16,
+    liveness: 0.14,
+    pose: 0.1,
+    background: 0.08,
+    lighting: 0.08,
+  },
+  // Canonical caps (pinned contract). A flagged image's overall is clamped to
+  // its cap regardless of sub-scores. Tunable in calibration.
+  disqualifiers: [
+    { flag: 'dead', cap: 20 },
+    { flag: 'specimen', cap: 20 },
+    { flag: 'in-hand', cap: 35 },
+    { flag: 'captive', cap: 45 },
+    { flag: 'sick', cap: 30 },
+  ],
+  // Composite (0–100) cut points. ≥ autoAccept → auto-accept (ingestor gate);
+  // [review, autoAccept) → queue for human review; < reject → auto-reject.
+  // Draft values; calibration loop (decision #7) finalizes them.
+  thresholds: {
+    autoAccept: 75,
+    review: 50,
+    reject: 35,
+  },
+  judgePrompt: JUDGE_PROMPT,
+  // No `model` field: the vision judge is a Claude Code agent that Reads the
+  // image and applies judgePrompt using the session model — there is no SDK
+  // model id to pin, and no ANTHROPIC_API_KEY.
+};

--- a/packages/photo-quality/tsconfig.json
+++ b/packages/photo-quality/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph slice1["Slice 1 — this PR (#962)"]
        pkg["packages/photo-quality<br/>emit-dist workspace<br/>(package.json + tsconfig.json)"]
        research["docs/research/<br/>2026-06-10-bird-photo-quality-rubric.md"]
        cfg["src/rubric.config.ts<br/>defaultRubricConfig<br/>(7 weights Σ=1.0 · 5 caps · 3 thresholds · judgePrompt)"]
        test["src/rubric.config.test.ts<br/>structural invariants"]
        research --> cfg
        pkg --> cfg
        cfg --> test
    end
    cfg -. "Slice 2 (#971) ADDS only src/ files" .-> slice2["src/index.ts · score.ts<br/>deterministic.ts (uses sharp) · judge.ts"]
    cfg -. imported by .-> consumers["curation tool · ingestor gate"]
```

```mermaid
flowchart TD
    img["wild-bird photo"] --> det["Stage 1 — deterministic gate (Slice 2)<br/>sharp: MP / sharpness / aspect"]
    det -->|"pass"| judge["Stage 2 — vision judge<br/>(Claude Code agent, Reads image, applies judgePrompt)"]
    det -->|"fail"| reject["auto-reject (never hits LLM)"]
    judge --> scores["7 CriteriaScores 0–10 + flags + rationale"]
    scores --> compose["composeOverall = (Σ weightᵢ·criteriaᵢ)·10 → 0–100,<br/>clamped by disqualifier caps"]
    compose --> verdict["verdict via thresholds.autoAccept / review / reject"]
```

## Summary

- **Why:** Slice 1 of the photo-curation epic (#974) bootstraps the shared scoring package's home and the rubric every later slice imports. No slice dependencies — it ships the package skeleton, the Phase-0 research deliverable, and the draft `defaultRubricConfig` so Slice 2 (#971) lands by adding only `src/*.ts` files (never re-touching the manifest).
- **Pure by design:** the vision judge is a Claude Code agent that `Read`s a downloaded image and applies the rubric (spec §3a R1) — there is **no `@anthropic-ai/sdk`, no `ANTHROPIC_API_KEY`, and no `model` field** on `RubricConfig`. Runtime deps are `sharp` (declared now, first used by Slice 2's deterministic stage) + `vitest` only. Emit-`dist`, mirroring `packages/db-client`.
- **Researched, not stubbed:** the rubric doc synthesizes named field-guide / bird-photography sources (Macaulay/eBird rating + upload + in-hand policy, Audubon composition, NIMA aesthetic-scoring) across the 5 required categories, and the `judgePrompt` derived from it enumerates all 7 scored criteria and all 9 disqualifier flags. Weights sum to exactly 1.0 (convex combination); the 5 canonical caps and 3 thresholds match the pinned contract.

## Screenshots

N/A — not UI (internal tooling package + research doc; nothing under `frontend/**`).

## Test plan

- [x] `npm test --workspace @bird-watch/photo-quality` — green (1 file, 7 tests passed)
- [x] New unit test added — `packages/photo-quality/src/rubric.config.test.ts` (config parses; weights keys === the 7 `CriteriaScores` keys, all positive; weights sum to 1.0; the 5 canonical disqualifier caps; thresholds ordered reject < review < autoAccept; judgePrompt names every criterion + flag; deterministic minimums). Written TDD: confirmed red (module-not-found) before implementing.
- [x] `npx tsc -p packages/photo-quality/tsconfig.json` — clean under the strict base config; emits `dist/rubric.config.{js,d.ts}` (gitignored, untracked).
- [x] `npm run build` — clean full root build, including the new `@bird-watch/photo-quality` step added to the chain; no sibling regressions.
- [x] `npm install --package-lock-only && git diff --exit-code package-lock.json` — no diff (lockfile committed; `lockfile-consistency` check satisfied).
- [x] `npx knip` — exit 0 (added a dated, self-healing per-workspace ignore for the declared-not-yet-used `sharp` dep, since `knip (informational)` gates Mergify despite the name).
- [ ] N/A — no user-visible behavior, no Playwright e2e.

## Plan reference

Part of epic #974. Implements issue #962 ([photo-curation 1/10] Phase-0 quality rubric research + `@bird-watch/photo-quality` skeleton + draft config). Plans live in issues, not `docs/plans/`. Full design: `docs/specs/2026-06-10-photo-quality-curation-design.md` (§3a R1, §5.1, §6).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)