### PR TITLE
feat(admin-api): PUT /admin/species-photos/:code — content-hashed R2 photo swap + cache purge

### DIFF
--- a/infra/terraform/admin-api.tf
+++ b/infra/terraform/admin-api.tf
@@ -158,6 +158,25 @@ resource "google_cloud_run_v2_service" "admin_api" {
         value = "https://silhouettes.${var.domain}"
       }
 
+      # Photos bucket for the species-photo swap endpoint (PUT
+      # /admin/species-photos/:code). The cloudflare_r2_bucket.photos resource
+      # is declared in photos.tf (issue #327). The bird-admin-api SA writes to
+      # R2 via the account-scoped S3-compatible access key already wired through
+      # R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY — R2 access keys are
+      # account-scoped, so the existing credentials already authorize this
+      # bucket and no new GCP IAM binding is required. If the underlying
+      # Cloudflare R2 API token is ever bucket-scoped, widen it to include
+      # birdwatch-photos (a cloudflare_api_token / dashboard change).
+      env {
+        name  = "R2_PHOTOS_BUCKET"
+        value = cloudflare_r2_bucket.photos.name
+      }
+
+      env {
+        name  = "SPECIES_PHOTOS_PUBLIC_PREFIX"
+        value = "https://photos.${var.domain}"
+      }
+
       env {
         name = "CLOUDFLARE_ZONE_ID"
         value_source {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5292,6 +5292,15 @@
       "integrity": "sha512-a5jlKftS7HUOhkUyYD7j2sJ/ZnvWiNlZS1ldR+g1ifQ+/UuZXIE+YTc/lK1qGj/GwAU5F8Z0e1eVq2t1J5Ob2g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "0.1.1",
       "license": "MIT",
@@ -8341,7 +8350,8 @@
         "@bird-watch/db-client": "*",
         "@bird-watch/shared-types": "*",
         "@hono/node-server": "^2.0.4",
-        "hono": "^4.12.23"
+        "hono": "^4.12.23",
+        "ipaddr.js": "^2.4.0"
       },
       "devDependencies": {
         "@testcontainers/postgresql": "^10.7.0",

--- a/services/admin-api/README.md
+++ b/services/admin-api/README.md
@@ -91,10 +91,53 @@ For sourcing the SVG art itself, see the `curating-fallback-silhouettes` skill
 | `GET` | `/health` | none | `{"ok":true}` |
 | `PUT` | `/admin/silhouettes/family/:code` | Bearer | Multipart `file` (SVG) → validate → R2 `PUT` → `UPDATE family_silhouettes SET svg_url, svg_data` → Cloudflare purge. Returns `{ url, key, pathD }`. |
 | `DELETE` | `/admin/silhouettes/family/:code` | Bearer | R2 `DELETE` of the prior object → `UPDATE family_silhouettes SET svg_url = NULL, svg_data = NULL` → Cloudflare purge. Returns `{ ok:true }`. |
+| `PUT` | `/admin/species-photos/:speciesCode` | Bearer | JSON `{ sourceUrl, attribution, license }` → license + species-existence check → server-side fetch of `sourceUrl` → image validate → R2 `PUT` (photos bucket) → `insertSpeciesPhoto` upsert → Cloudflare purge. Returns `{ url, key }`. |
 
-`:code` must match `^[a-z]+$` (lowercase letters only) — otherwise `400`.
-The family row must already exist in `family_silhouettes` or the request `404`s
-(the admin-api overrides existing rows, it does not create families).
+`:code` (silhouettes) must match `^[a-z]+$` (lowercase letters only) and
+`:speciesCode` (photos) must match `^[a-z0-9]+$` — otherwise `400`.
+The family row must already exist in `family_silhouettes`, and the species row
+in `species_meta`, or the request `404`s (the admin-api overrides existing
+rows, it does not create families or species).
+
+### Species-photo swap (`PUT /admin/species-photos/:speciesCode`)
+
+Pushes an operator-approved replacement **detail-panel** photo live. The
+**curation tool's `apply-swaps` step** (Slice 8) calls this per species after an
+operator approves a candidate; it ships a `sourceUrl`, not bytes, so the
+admin-api fetches and re-validates the image itself. Write sequence (mirrors the
+silhouette handler's **R2-before-DB** ordering):
+
+1. **License backstop** — `license` must re-pass the `cc-by` / `cc-by-sa` /
+   `cc0` allowlist (case-insensitive; NC/ND denied). This is a server-side
+   re-check even though the local tool already filtered — the endpoint is a
+   public surface and a mis-tagged image must never go live (`400` on deny,
+   before any fetch).
+2. **Species existence** — `species_code` must exist in `species_meta`
+   (`404` otherwise; no R2 write).
+3. **Server-side fetch** of `sourceUrl` (15s timeout) — must `200` and carry an
+   image content-type; the body is validated for magic bytes (jpeg/png/webp/avif
+   incl. the `WEBP` fourCC at bytes 8-11) and a ≥1 KB floor (`400` otherwise).
+4. **R2 `PUT`** to the `birdwatch-photos` bucket at a content-hashed key
+   `species/<code>.<sha8>.<ext>`, served `immutable, max-age=1yr`.
+5. **`insertSpeciesPhoto` upsert** on `(species_code, 'detail-panel')` — only
+   `url`/`attribution`/`license` are written; taxonomy columns are untouched.
+   On a DB failure *after* the R2 upload the request `5xx`s and the uploaded
+   object is left orphaned (hygiene, not breakage) — no broken-image row.
+6. **Prior R2 object** (if any) is best-effort deleted (content-hashed keys
+   never collide, so the old immutable object would otherwise leak per swap).
+7. **Cloudflare purge** of `https://<API_HOST>/api/species/<code>`; a failure is
+   non-fatal (`X-Purge-Status: failed` header, still `200`).
+
+```sh
+curl -X PUT "https://admin.bird-maps.com/admin/species-photos/norcar" \
+  -H "Authorization: Bearer $ADMIN_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"sourceUrl":"https://static.inaturalist.org/photos/12345/medium.jpg","attribution":"(c) photographer, CC-BY","license":"cc-by"}'
+# {"url":"https://photos.bird-maps.com/species/norcar.<sha>.jpg","key":"species/norcar.<sha>.jpg"}
+```
+
+The apply step is driven by the curation tool's `apply-swaps` action (Slice 8),
+which reuses the `ADMIN_API_URL` / `ADMIN_API_TOKEN` env precedent.
 
 ### Auth model (`src/auth.ts`)
 
@@ -151,8 +194,10 @@ written to `family_silhouettes.svg_data`.
 | `ADMIN_API_TOKEN` | yes | — | bearer auth; empty → boot fails |
 | `R2_ENDPOINT` | yes | — | R2 S3 client |
 | `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | yes (prod) | — | R2 credentials |
-| `R2_BUCKET_NAME` | no | `bird-maps-silhouettes` | R2 target bucket |
-| `SILHOUETTES_PUBLIC_PREFIX` | no | `https://silhouettes.bird-maps.com` | public URL prefix written to DB |
+| `R2_BUCKET_NAME` | no | `bird-maps-silhouettes` | R2 target bucket (silhouettes) |
+| `SILHOUETTES_PUBLIC_PREFIX` | no | `https://silhouettes.bird-maps.com` | public URL prefix written to DB (silhouettes) |
+| `R2_PHOTOS_BUCKET` | no | `birdwatch-photos` | R2 target bucket (species photos) |
+| `SPECIES_PHOTOS_PUBLIC_PREFIX` | no | `https://photos.bird-maps.com` | public URL prefix written to DB (species photos) |
 | `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_API_TOKEN` | for purge | — | `purge_cache` call |
 | `API_HOST` | no | `api.bird-maps.com` | purge target host |
 | `PORT` | no | `8788` (local) / `8080` (container) | listen port |

--- a/services/admin-api/package.json
+++ b/services/admin-api/package.json
@@ -14,7 +14,8 @@
     "@bird-watch/db-client": "*",
     "@bird-watch/shared-types": "*",
     "@hono/node-server": "^2.0.4",
-    "hono": "^4.12.23"
+    "hono": "^4.12.23",
+    "ipaddr.js": "^2.4.0"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.7.0",

--- a/services/admin-api/src/app.ts
+++ b/services/admin-api/src/app.ts
@@ -22,6 +22,18 @@ export interface AppDeps {
 /** Max 3xx hops the species-photo fetch follows (each re-validated). */
 const MAX_PHOTO_REDIRECTS = 2;
 
+/**
+ * Upper bound on the fetched photo body (15 MB — generous for a species photo;
+ * the largest real iNat/Wikimedia originals sit well under this). The admin
+ * service runs on a 256Mi container, so an uncapped `response.arrayBuffer()`
+ * against a trusted-but-compromised or buggy allowlisted host could buffer a
+ * multi-GB body and OOM the process. Enforced twice: against the advertised
+ * `content-length` (cheap reject BEFORE reading), and against the realized
+ * `byteLength` after the read (a missing or lying content-length still can't
+ * exceed the cap). Both rejections happen before any R2 write.
+ */
+const MAX_PHOTO_BYTES = 15 * 1024 * 1024;
+
 const FAMILY_CODE = /^[a-z]+$/;
 // eBird species codes are lowercase alphanumerics (e.g. norcar, x00013).
 const SPECIES_CODE = /^[a-z0-9]+$/;
@@ -218,8 +230,28 @@ export function createApp(deps: AppDeps): Hono {
       if (!response.ok) {
         return c.json({ error: `source fetch failed: status ${response.status}` }, 400);
       }
+      // Size cap, pass 1: reject on the advertised content-length BEFORE
+      // reading the body, so an honestly-large response never allocates. A
+      // multi-GB body against the 256Mi admin service would otherwise OOM.
+      const declaredLength = Number(response.headers.get('content-length'));
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_PHOTO_BYTES) {
+        return c.json(
+          { error: `source body too large (${declaredLength} bytes; max ${MAX_PHOTO_BYTES})` },
+          413,
+        );
+      }
       mime = (response.headers.get('content-type') ?? '').split(';')[0]!.trim();
       body = Buffer.from(await response.arrayBuffer());
+      // Size cap, pass 2: a missing or understated content-length can't slip a
+      // larger body past pass 1 — re-check the realized size before any R2
+      // write. (arrayBuffer() has already buffered the bytes; this is the
+      // backstop for a lying header, not the primary defense.)
+      if (body.byteLength > MAX_PHOTO_BYTES) {
+        return c.json(
+          { error: `source body too large (${body.byteLength} bytes; max ${MAX_PHOTO_BYTES})` },
+          413,
+        );
+      }
     } catch (err) {
       if (err instanceof SsrfError) {
         return c.json({ error: `source URL rejected: ${err.message}` }, 400);

--- a/services/admin-api/src/app.ts
+++ b/services/admin-api/src/app.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
 import type { Pool } from '@bird-watch/db-client';
+import { insertSpeciesPhoto, getSpeciesPhotos } from '@bird-watch/db-client';
 import { bearerAuth } from './auth.js';
-import { validateSvg, ValidationError } from './validate.js';
+import { validateSvg, validatePhotoImage, validateLicense, ValidationError } from './validate.js';
 import type { Storage } from './storage.js';
-import { purgeSilhouettesJson } from './purge.js';
+import { purgeSilhouettesJson, purgeSpeciesJson } from './purge.js';
 
 export interface AppDeps {
   pool: Pool;
@@ -12,6 +13,8 @@ export interface AppDeps {
 }
 
 const FAMILY_CODE = /^[a-z]+$/;
+// eBird species codes are lowercase alphanumerics (e.g. norcar, x00013).
+const SPECIES_CODE = /^[a-z0-9]+$/;
 
 export function createApp(deps: AppDeps): Hono {
   const app = new Hono();
@@ -128,6 +131,109 @@ export function createApp(deps: AppDeps): Hono {
     }
 
     return c.json({ ok: true });
+  });
+
+  app.put('/admin/species-photos/:speciesCode', async c => {
+    const speciesCode = c.req.param('speciesCode');
+    if (!SPECIES_CODE.test(speciesCode)) {
+      return c.json({ error: 'invalid species code' }, 400);
+    }
+
+    let payload: { sourceUrl?: unknown; attribution?: unknown; license?: unknown };
+    try {
+      payload = await c.req.json();
+    } catch {
+      return c.json({ error: 'body must be JSON' }, 400);
+    }
+    const { sourceUrl, attribution, license } = payload;
+    if (typeof sourceUrl !== 'string' || typeof attribution !== 'string' || typeof license !== 'string') {
+      return c.json({ error: 'sourceUrl, attribution, license are required strings' }, 400);
+    }
+
+    // License backstop FIRST — cheapest deny, before any network fetch.
+    let normalizedLicense: string;
+    try {
+      normalizedLicense = validateLicense(license);
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+
+    // Confirm the species row exists before any side effect (mirrors the
+    // silhouette 404-existence check — a photo for an unknown species would
+    // FK-fail on insert and leave an orphaned R2 object).
+    const existing = await deps.pool.query<{ count: string }>(
+      `SELECT count(*) AS count FROM species_meta WHERE species_code = $1`,
+      [speciesCode],
+    );
+    if (existing.rows[0]!.count === '0') {
+      return c.json({ error: `unknown species_code: ${speciesCode}` }, 404);
+    }
+
+    // Fetch the source image server-side (the local tool ships a URL, not
+    // bytes). Must 200 and be image/*.
+    let body: Buffer;
+    let mime: string;
+    try {
+      const fetched = await fetch(sourceUrl, { signal: AbortSignal.timeout(15_000) });
+      if (!fetched.ok) {
+        return c.json({ error: `source fetch failed: status ${fetched.status}` }, 400);
+      }
+      mime = (fetched.headers.get('content-type') ?? '').split(';')[0]!.trim();
+      body = Buffer.from(await fetched.arrayBuffer());
+    } catch (err) {
+      return c.json({ error: `source fetch error: ${err instanceof Error ? err.message : String(err)}` }, 400);
+    }
+
+    let validated;
+    try {
+      validated = validatePhotoImage(body, mime);
+    } catch (err) {
+      if (err instanceof ValidationError) return c.json({ error: err.message }, 400);
+      throw err;
+    }
+
+    // ── R2 BEFORE DB ──────────────────────────────────────────────────────
+    // Upload first; only write the DB url if R2 succeeded. A DB row pointing
+    // at a not-yet-uploaded key would render a broken image; a failed DB write
+    // after upload only leaks an unreferenced R2 object (hygiene). The
+    // species-photo.test.ts ordering case asserts this directly: a forced
+    // insert failure leaves exactly one PutObject and zero live rows.
+    const put = await deps.storage.putSpeciesPhoto(speciesCode, validated.source, mime, validated.ext);
+
+    // Read the prior object key BEFORE the upsert overwrites the url, so we can
+    // best-effort delete it after (content-hashed keys never collide, so the
+    // old immutable object would otherwise leak on every swap).
+    const prior = await getSpeciesPhotos(deps.pool, speciesCode);
+    const priorDetail = prior.find(p => p.purpose === 'detail-panel');
+
+    await insertSpeciesPhoto(deps.pool, {
+      speciesCode,
+      purpose: 'detail-panel',
+      url: put.url,
+      attribution,
+      license: normalizedLicense,
+    });
+
+    if (priorDetail) {
+      try {
+        const priorUrl = new URL(priorDetail.url);
+        const priorKey = priorUrl.pathname.replace(/^\//, '');
+        if (priorKey !== put.key && priorKey.startsWith('species/')) {
+          await deps.storage.deleteSpeciesPhoto(priorKey);
+        }
+      } catch (err) {
+        console.warn(`[admin-api] R2 cleanup of prior photo failed: ${err}`);
+      }
+    }
+
+    const purge = await purgeSpeciesJson(speciesCode);
+    if (!purge.ok) {
+      c.header('X-Purge-Status', 'failed');
+      console.warn(`[admin-api] species purge failed: ${purge.error}`);
+    }
+
+    return c.json({ url: put.url, key: put.key });
   });
 
   app.onError((err, c) => {

--- a/services/admin-api/src/app.ts
+++ b/services/admin-api/src/app.ts
@@ -5,12 +5,22 @@ import { bearerAuth } from './auth.js';
 import { validateSvg, validatePhotoImage, validateLicense, ValidationError } from './validate.js';
 import type { Storage } from './storage.js';
 import { purgeSilhouettesJson, purgeSpeciesJson } from './purge.js';
+import { assertSafePhotoSource, SsrfError, type DnsLookupAll } from './ssrf-guard.js';
 
 export interface AppDeps {
   pool: Pool;
   storage: Storage;
   token: string;
+  /**
+   * Override for the SSRF guard's `dns.lookup(host, { all: true })`. Injectable
+   * so tests drive the resolved-to-private-IP cases without real DNS; defaults
+   * to node:dns inside `assertSafePhotoSource`.
+   */
+  dnsLookup?: DnsLookupAll;
 }
+
+/** Max 3xx hops the species-photo fetch follows (each re-validated). */
+const MAX_PHOTO_REDIRECTS = 2;
 
 const FAMILY_CODE = /^[a-z]+$/;
 // eBird species codes are lowercase alphanumerics (e.g. norcar, x00013).
@@ -172,16 +182,48 @@ export function createApp(deps: AppDeps): Hono {
 
     // Fetch the source image server-side (the local tool ships a URL, not
     // bytes). Must 200 and be image/*.
+    //
+    // SSRF GUARD (issue #966 security addendum): validate the URL BEFORE every
+    // fetch — https-only, host allowlist, and reject any host that DNS-resolves
+    // to an internal range. Redirects are followed manually (redirect:
+    // 'manual') so a 3xx Location pointing at internal space is re-validated
+    // before we re-issue, capped at MAX_PHOTO_REDIRECTS hops.
     let body: Buffer;
     let mime: string;
     try {
-      const fetched = await fetch(sourceUrl, { signal: AbortSignal.timeout(15_000) });
-      if (!fetched.ok) {
-        return c.json({ error: `source fetch failed: status ${fetched.status}` }, 400);
+      let currentUrl = sourceUrl;
+      let response: Response | undefined;
+      for (let hop = 0; hop <= MAX_PHOTO_REDIRECTS; hop++) {
+        await assertSafePhotoSource(currentUrl, { lookup: deps.dnsLookup });
+        const fetched = await fetch(currentUrl, {
+          redirect: 'manual',
+          signal: AbortSignal.timeout(15_000),
+        });
+        if (fetched.status >= 300 && fetched.status < 400) {
+          const location = fetched.headers.get('location');
+          if (!location) {
+            return c.json({ error: `source fetch redirect (${fetched.status}) without Location` }, 400);
+          }
+          // Resolve relative redirects against the current URL, then re-guard
+          // on the next loop iteration.
+          currentUrl = new URL(location, currentUrl).toString();
+          continue;
+        }
+        response = fetched;
+        break;
       }
-      mime = (fetched.headers.get('content-type') ?? '').split(';')[0]!.trim();
-      body = Buffer.from(await fetched.arrayBuffer());
+      if (!response) {
+        return c.json({ error: `source fetch exceeded ${MAX_PHOTO_REDIRECTS} redirects` }, 400);
+      }
+      if (!response.ok) {
+        return c.json({ error: `source fetch failed: status ${response.status}` }, 400);
+      }
+      mime = (response.headers.get('content-type') ?? '').split(';')[0]!.trim();
+      body = Buffer.from(await response.arrayBuffer());
     } catch (err) {
+      if (err instanceof SsrfError) {
+        return c.json({ error: `source URL rejected: ${err.message}` }, 400);
+      }
       return c.json({ error: `source fetch error: ${err instanceof Error ? err.message : String(err)}` }, 400);
     }
 

--- a/services/admin-api/src/photo-storage.test.ts
+++ b/services/admin-api/src/photo-storage.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { createStorage } from './storage.js';
+
+const s3Mock = mockClient(S3Client);
+
+describe('storage — species photos', () => {
+  beforeEach(() => {
+    s3Mock.reset();
+    process.env.R2_ENDPOINT = 'https://acct.r2.cloudflarestorage.com';
+    process.env.R2_PHOTOS_BUCKET = 'birdwatch-photos';
+    process.env.R2_ACCESS_KEY_ID = 'akid';
+    process.env.R2_SECRET_ACCESS_KEY = 'sak';
+    process.env.SPECIES_PHOTOS_PUBLIC_PREFIX = 'https://photos.bird-maps.com';
+  });
+
+  it('putSpeciesPhoto uploads at species/<code>.<sha8>.<ext> in the photos bucket', async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+    const storage = createStorage();
+    const body = Buffer.from('fake-jpeg-bytes', 'utf8');
+    const result = await storage.putSpeciesPhoto('norcar', body, 'image/jpeg', 'jpg');
+    expect(result.key).toMatch(/^species\/norcar\.[0-9a-f]{8}\.jpg$/);
+    expect(result.url).toBe(`https://photos.bird-maps.com/${result.key}`);
+    const calls = s3Mock.commandCalls(PutObjectCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toMatchObject({
+      Bucket: 'birdwatch-photos',
+      Key: result.key,
+      ContentType: 'image/jpeg',
+      CacheControl: 'public, max-age=31536000, immutable',
+    });
+  });
+
+  it('content hash changes when body changes; stable when it does not', async () => {
+    s3Mock.on(PutObjectCommand).resolves({});
+    const storage = createStorage();
+    const a = await storage.putSpeciesPhoto('norcar', Buffer.from('a'), 'image/jpeg', 'jpg');
+    const a2 = await storage.putSpeciesPhoto('norcar', Buffer.from('a'), 'image/jpeg', 'jpg');
+    const b = await storage.putSpeciesPhoto('norcar', Buffer.from('b'), 'image/jpeg', 'jpg');
+    expect(a.key).toBe(a2.key);
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it('deleteSpeciesPhoto removes the given key from the photos bucket', async () => {
+    s3Mock.on(DeleteObjectCommand).resolves({});
+    const storage = createStorage();
+    await storage.deleteSpeciesPhoto('species/norcar.deadbeef.jpg');
+    const calls = s3Mock.commandCalls(DeleteObjectCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toMatchObject({
+      Bucket: 'birdwatch-photos',
+      Key: 'species/norcar.deadbeef.jpg',
+    });
+  });
+});

--- a/services/admin-api/src/photo-validate.test.ts
+++ b/services/admin-api/src/photo-validate.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { validatePhotoImage, validateLicense, ValidationError } from './validate.js';
+
+describe('validatePhotoImage', () => {
+  // Minimal valid JPEG: SOI + APP0/JFIF + EOI is enough for the magic-byte check.
+  const jpegMagic = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+  const pngMagic = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  // RIFF<4-byte size>WEBP — a real WebP container header.
+  const webpMagic = Buffer.concat([
+    Buffer.from('RIFF', 'ascii'),
+    Buffer.from([0x00, 0x00, 0x00, 0x00]),
+    Buffer.from('WEBP', 'ascii'),
+  ]);
+  // RIFF<size>WAVE — a non-WebP RIFF container (a .wav); must be rejected.
+  const wavMagic = Buffer.concat([
+    Buffer.from('RIFF', 'ascii'),
+    Buffer.from([0x00, 0x00, 0x00, 0x00]),
+    Buffer.from('WAVE', 'ascii'),
+  ]);
+  // ISO-BMFF box-size (4 bytes) + 'ftyp' marker at offset 4 — a valid AVIF head.
+  const avifMagic = Buffer.concat([
+    Buffer.from([0x00, 0x00, 0x00, 0x20]),
+    Buffer.from('ftyp', 'ascii'),
+  ]);
+
+  it('accepts image/jpeg with jpeg magic bytes and returns ext "jpg"', () => {
+    const { ext } = validatePhotoImage(Buffer.concat([jpegMagic, Buffer.alloc(2048)]), 'image/jpeg');
+    expect(ext).toBe('jpg');
+  });
+
+  it('accepts image/png with png magic bytes and returns ext "png"', () => {
+    const { ext } = validatePhotoImage(Buffer.concat([pngMagic, Buffer.alloc(2048)]), 'image/png');
+    expect(ext).toBe('png');
+  });
+
+  it('accepts image/webp with RIFF....WEBP magic bytes and returns ext "webp"', () => {
+    const { ext } = validatePhotoImage(Buffer.concat([webpMagic, Buffer.alloc(2048)]), 'image/webp');
+    expect(ext).toBe('webp');
+  });
+
+  it('rejects a non-WEBP RIFF container (e.g. a .wav) declared image/webp', () => {
+    expect(() => validatePhotoImage(Buffer.concat([wavMagic, Buffer.alloc(2048)]), 'image/webp'))
+      .toThrow(/magic bytes/);
+  });
+
+  it('accepts image/avif with an ftyp box marker and returns ext "avif"', () => {
+    const { ext } = validatePhotoImage(Buffer.concat([avifMagic, Buffer.alloc(2048)]), 'image/avif');
+    expect(ext).toBe('avif');
+  });
+
+  it('rejects a non-image mime', () => {
+    expect(() => validatePhotoImage(Buffer.alloc(2048), 'text/html')).toThrow(ValidationError);
+  });
+
+  it('rejects when magic bytes do not match the declared mime', () => {
+    expect(() => validatePhotoImage(Buffer.concat([pngMagic, Buffer.alloc(2048)]), 'image/jpeg'))
+      .toThrow(/magic bytes/);
+  });
+
+  it('rejects an empty body', () => {
+    expect(() => validatePhotoImage(Buffer.alloc(0), 'image/jpeg')).toThrow(/empty/);
+  });
+
+  it('rejects a body below the minimum byte floor (likely an error page, not a photo)', () => {
+    expect(() => validatePhotoImage(Buffer.concat([jpegMagic, Buffer.alloc(10)]), 'image/jpeg'))
+      .toThrow(/too small/);
+  });
+});
+
+describe('validateLicense', () => {
+  it.each(['cc-by', 'cc-by-sa', 'cc0', 'CC-BY', 'CC0'])('accepts CC allowlist member %s', (lic) => {
+    expect(validateLicense(lic)).toBe(lic.toLowerCase());
+  });
+
+  it.each(['cc-by-nc', 'cc-by-nd', 'cc-by-nc-sa', 'cc-by-nc-nd', 'arr', ''])(
+    'rejects non-allowlisted / NC / ND license %s',
+    (lic) => {
+      expect(() => validateLicense(lic)).toThrow(ValidationError);
+    },
+  );
+});

--- a/services/admin-api/src/purge-species.test.ts
+++ b/services/admin-api/src/purge-species.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { purgeSpeciesJson } from './purge.js';
+
+describe('purgeSpeciesJson', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('POSTs a purge for https://<API_HOST>/api/species/<code> and returns ok on 200', async () => {
+    process.env.CLOUDFLARE_ZONE_ID = 'zone';
+    process.env.CLOUDFLARE_API_TOKEN = 'cftoken';
+    process.env.API_HOST = 'api.bird-maps.com';
+    const fetchSpy = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+
+    const res = await purgeSpeciesJson('norcar');
+    expect(res.ok).toBe(true);
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const sentBody = JSON.parse(String(init!.body));
+    // Must match the read-api detail route confirmed in Step 3.0: /api/species/:code
+    expect(sentBody.files).toEqual(['https://api.bird-maps.com/api/species/norcar']);
+  });
+
+  it('returns not-ok when CF env is missing', async () => {
+    delete process.env.CLOUDFLARE_ZONE_ID;
+    const res = await purgeSpeciesJson('norcar');
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns not-ok on a non-2xx cloudflare status', async () => {
+    process.env.CLOUDFLARE_ZONE_ID = 'zone';
+    process.env.CLOUDFLARE_API_TOKEN = 'cftoken';
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
+    const res = await purgeSpeciesJson('norcar');
+    expect(res.ok).toBe(false);
+  });
+});

--- a/services/admin-api/src/purge.ts
+++ b/services/admin-api/src/purge.ts
@@ -42,3 +42,53 @@ export async function purgeSilhouettesJson(opts: { timeoutMs?: number } = {}): P
     if (timer) clearTimeout(timer);
   }
 }
+
+/**
+ * Purge the per-species detail JSON (`GET /api/species/<code>`) from the
+ * Cloudflare edge so a freshly-swapped photo URL is served immediately.
+ * Mirrors purgeSilhouettesJson; non-fatal on failure (DB is authoritative —
+ * spec §8). The species detail route is short-cached (no `immutable`), so the
+ * purge plus the route's own max-age expiry both converge the edge.
+ *
+ * The `/api/species/<code>` path is confirmed against the read-api detail
+ * route `app.get('/api/species/:code', ...)` (services/read-api/src/app.ts).
+ */
+export async function purgeSpeciesJson(
+  speciesCode: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<PurgeResult> {
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const apiHost = process.env.API_HOST ?? 'api.bird-maps.com';
+  if (!zoneId || !apiToken) {
+    return { ok: false, error: 'CLOUDFLARE_ZONE_ID or CLOUDFLARE_API_TOKEN missing' };
+  }
+  const url = `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`;
+  const body = JSON.stringify({ files: [`https://${apiHost}/api/species/${speciesCode}`] });
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`purge timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    const res = await Promise.race([
+      fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+        body,
+        signal: controller.signal,
+      }),
+      timeoutPromise,
+    ]);
+    if (!res.ok) return { ok: false, error: `cloudflare status ${res.status}` };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/services/admin-api/src/species-photo.test.ts
+++ b/services/admin-api/src/species-photo.test.ts
@@ -12,6 +12,12 @@ const s3Mock = mockClient(S3Client);
 const JPEG_BODY = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.alloc(4096, 0x11)]);
 const SOURCE_URL = 'https://static.inaturalist.org/photos/12345/medium.jpg';
 
+// Default SSRF-guard DNS stub: every allowlisted host resolves to one public
+// (unicast) IPv4. Tests that need a private/loopback resolution override it.
+// Using an injected lookup keeps the whole suite off real DNS.
+const PUBLIC_IP = [{ address: '151.101.0.1', family: 4 }];
+const publicLookup = async () => PUBLIC_IP;
+
 describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
   let db: TestDb;
   let app: ReturnType<typeof createApp>;
@@ -31,7 +37,7 @@ describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
     process.env.CLOUDFLARE_ZONE_ID = 'zone';
     process.env.CLOUDFLARE_API_TOKEN = 'cftoken';
     process.env.API_HOST = 'api.bird-maps.com';
-    app = createApp({ pool: db.pool, storage: createStorage(), token: TOKEN });
+    app = createApp({ pool: db.pool, storage: createStorage(), token: TOKEN, dnsLookup: publicLookup });
   }, 120_000);
 
   afterAll(async () => {
@@ -166,7 +172,7 @@ describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
       }) as typeof realPool.query,
     } as typeof realPool;
 
-    const failingApp = createApp({ pool: failingPool, storage: createStorage(), token: TOKEN });
+    const failingApp = createApp({ pool: failingPool, storage: createStorage(), token: TOKEN, dnsLookup: publicLookup });
     const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY, failingApp);
 
     // Handler surfaces the DB failure as a 5xx (onError default).
@@ -189,5 +195,99 @@ describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
     const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
     expect(res.status).toBe(200);
     expect(res.headers.get('X-Purge-Status')).toBe('failed');
+  });
+
+  // ── SSRF guard (issue #966 security addendum) ───────────────────────────────
+  // The handler fetches `sourceUrl` server-side; assertSafePhotoSource must run
+  // BEFORE any fetch. Each case must return 4xx AND perform zero R2 writes. DNS
+  // is always stubbed (publicLookup by default, overridden per-case) — no real
+  // DNS hits the network.
+  describe('SSRF guard', () => {
+    it('rejects an http:// (non-https) sourceUrl: 400, no R2, no fetch', async () => {
+      // Fresh spy with no implementation; assert it is never invoked — the
+      // guard rejects before any fetch (source download or CF purge).
+      vi.restoreAllMocks();
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(null));
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, {
+        ...VALID_BODY,
+        sourceUrl: 'http://static.inaturalist.org/photos/1/medium.jpg',
+      });
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      // Guard runs before fetch — the source fetch never happens.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-allowlisted host: 400, no R2', async () => {
+      stubFetch();
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, {
+        ...VALID_BODY,
+        sourceUrl: 'https://evil.example.com/x.jpg',
+      });
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('rejects the IMDS host http://169.254.169.254/latest/meta-data/: 400, no R2', async () => {
+      stubFetch();
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, {
+        ...VALID_BODY,
+        sourceUrl: 'http://169.254.169.254/latest/meta-data/',
+      });
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('rejects an allowlisted host whose DNS resolves to a private/loopback IP: 400, no R2', async () => {
+      stubFetch();
+      // Build an app whose injected DNS resolves the allowlisted host to a
+      // loopback address — the DNS-rebinding / repointed-host case.
+      const loopbackApp = createApp({
+        pool: db.pool,
+        storage: createStorage(),
+        token: TOKEN,
+        dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+      });
+      const res = await put(
+        'norcar',
+        { Authorization: `Bearer ${TOKEN}` },
+        VALID_BODY,
+        loopbackApp,
+      );
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('rejects a 3xx whose Location points at an internal host: 400, no R2', async () => {
+      // First fetch: an allowlisted host that 302-redirects to an internal IP.
+      // The guard must re-run on the Location before re-issuing and reject it,
+      // so the second (image) fetch never returns bytes to R2.
+      vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+        const u = typeof input === 'string' ? input : input.url;
+        if (u.includes('api.cloudflare.com')) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        if (u.startsWith('https://static.inaturalist.org')) {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: 'http://169.254.169.254/latest/meta-data/' },
+          });
+        }
+        // Should never be reached — the redirect target is rejected first.
+        return new Response(JPEG_BODY, { status: 200, headers: { 'Content-Type': 'image/jpeg' } });
+      });
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    it('an IMDS HTML/JSON body that somehow reaches validatePhotoImage is rejected by MIME (no R2)', async () => {
+      // Defense-in-depth: even if a body reaches validation, a non-image MIME
+      // (what IMDS returns) is rejected before R2 — asserting the MIME floor.
+      stubFetch({ imageBody: Buffer.from('{"AccessKeyId":"x"}'), imageMime: 'application/json' });
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+      expect(res.status).toBe(400);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
   });
 });

--- a/services/admin-api/src/species-photo.test.ts
+++ b/services/admin-api/src/species-photo.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
+import { createApp } from './app.js';
+import { createStorage } from './storage.js';
+
+const TOKEN = 'integration-token';
+const s3Mock = mockClient(S3Client);
+
+// Minimal valid JPEG body: SOI/APP0 magic + padding to clear MIN_PHOTO_BYTES.
+const JPEG_BODY = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.alloc(4096, 0x11)]);
+const SOURCE_URL = 'https://static.inaturalist.org/photos/12345/medium.jpg';
+
+describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
+  let db: TestDb;
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(async () => {
+    db = await startTestDb();
+    // species_photos.species_code FKs species_meta — seed a parent row.
+    await db.pool.query(
+      `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+       VALUES ('norcar', 'Northern Cardinal', 'Cardinalis cardinalis', 'cardinalidae', 'Cardinals', 100)`,
+    );
+    process.env.R2_ENDPOINT = 'https://acct.r2.cloudflarestorage.com';
+    process.env.R2_PHOTOS_BUCKET = 'birdwatch-photos';
+    process.env.R2_ACCESS_KEY_ID = 'akid';
+    process.env.R2_SECRET_ACCESS_KEY = 'sak';
+    process.env.SPECIES_PHOTOS_PUBLIC_PREFIX = 'https://photos.bird-maps.com';
+    process.env.CLOUDFLARE_ZONE_ID = 'zone';
+    process.env.CLOUDFLARE_API_TOKEN = 'cftoken';
+    process.env.API_HOST = 'api.bird-maps.com';
+    app = createApp({ pool: db.pool, storage: createStorage(), token: TOKEN });
+  }, 120_000);
+
+  afterAll(async () => {
+    await db.stop();
+  });
+
+  // fetch is used for BOTH the source-image download and the CF purge POST.
+  // Discriminate by URL: cloudflare → purge success; everything else → image.
+  function stubFetch(opts: { imageBody?: Buffer; imageMime?: string; imageStatus?: number } = {}) {
+    const { imageBody = JPEG_BODY, imageMime = 'image/jpeg', imageStatus = 200 } = opts;
+    vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+      const u = typeof input === 'string' ? input : input.url;
+      if (u.includes('api.cloudflare.com')) {
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      }
+      return new Response(imageBody, {
+        status: imageStatus,
+        headers: { 'Content-Type': imageMime },
+      });
+    });
+  }
+
+  beforeEach(async () => {
+    s3Mock.reset();
+    s3Mock.on(PutObjectCommand).resolves({});
+    s3Mock.on(DeleteObjectCommand).resolves({});
+    await db.pool.query(`DELETE FROM species_photos WHERE species_code = 'norcar'`);
+  });
+
+  function put(code: string, headers: Record<string, string>, json?: unknown, targetApp = app) {
+    return targetApp.request(`/admin/species-photos/${code}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: json === undefined ? undefined : JSON.stringify(json),
+    });
+  }
+
+  const VALID_BODY = { sourceUrl: SOURCE_URL, attribution: '(c) someone, CC-BY', license: 'cc-by' };
+
+  it('without token returns 401 and does NOT call R2', async () => {
+    stubFetch();
+    const res = await put('norcar', {}, VALID_BODY);
+    expect(res.status).toBe(401);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it('with a bad token returns 401', async () => {
+    stubFetch();
+    const res = await put('norcar', { Authorization: 'Bearer wrong-token' }, VALID_BODY);
+    expect(res.status).toBe(401);
+  });
+
+  it('valid request uploads to R2, upserts species_photos, purges, returns 200 with the public URL', async () => {
+    stubFetch();
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string; key: string };
+    expect(body.url).toMatch(/^https:\/\/photos\.bird-maps\.com\/species\/norcar\.[0-9a-f]{8}\.jpg$/);
+
+    // R2 PUT happened exactly once with the photos bucket.
+    const puts = s3Mock.commandCalls(PutObjectCommand);
+    expect(puts).toHaveLength(1);
+    expect(puts[0]!.args[0].input.Bucket).toBe('birdwatch-photos');
+
+    // DB upserted to the new URL.
+    const { rows } = await db.pool.query<{ url: string; attribution: string; license: string }>(
+      `SELECT url, attribution, license FROM species_photos
+        WHERE species_code = 'norcar' AND purpose = 'detail-panel'`,
+    );
+    expect(rows[0]!.url).toBe(body.url);
+    expect(rows[0]!.attribution).toBe('(c) someone, CC-BY');
+    expect(rows[0]!.license).toBe('cc-by');
+  });
+
+  it('re-applying upserts in place (no duplicate row)', async () => {
+    stubFetch();
+    await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    await put('norcar', { Authorization: `Bearer ${TOKEN}` }, { ...VALID_BODY, attribution: 'updated' });
+    const { rows } = await db.pool.query(
+      `SELECT id, attribution FROM species_photos WHERE species_code = 'norcar' AND purpose = 'detail-panel'`,
+    );
+    expect(rows).toHaveLength(1);
+    expect((rows[0] as any).attribution).toBe('updated');
+  });
+
+  it('an NC/ND license is denied (400) before any R2 upload or DB write', async () => {
+    stubFetch();
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, { ...VALID_BODY, license: 'cc-by-nc' });
+    expect(res.status).toBe(400);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    const { rows } = await db.pool.query(`SELECT 1 FROM species_photos WHERE species_code = 'norcar'`);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('a non-image source body is rejected (400), no R2, no DB', async () => {
+    stubFetch({ imageBody: Buffer.from('<html>not found</html>'), imageMime: 'text/html' });
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    expect(res.status).toBe(400);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it('a non-200 source fetch is a 400, no R2, no DB', async () => {
+    stubFetch({ imageStatus: 404 });
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    expect(res.status).toBe(400);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it('unknown species code returns 404, no R2', async () => {
+    stubFetch();
+    const res = await put('notareal', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    expect(res.status).toBe(404);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+  });
+
+  it('R2-before-DB: a DB write that FAILS after a successful R2 upload returns 5xx, leaves exactly one PutObject and zero live rows', async () => {
+    stubFetch();
+
+    // Build an app whose pool rejects the species_photos INSERT but otherwise
+    // delegates to the real pool (so the existence-check SELECT still passes).
+    // This forces the DB write to fail AFTER the R2 PutObject has resolved —
+    // exercising the real ordering, not a tautology.
+    const realPool = db.pool;
+    const failingPool: typeof realPool = {
+      ...realPool,
+      query: ((text: any, params?: any) => {
+        const sql = typeof text === 'string' ? text : text?.text ?? '';
+        if (/insert\s+into\s+species_photos/i.test(sql)) {
+          return Promise.reject(new Error('injected DB failure on species_photos insert'));
+        }
+        return (realPool.query as any)(text, params);
+      }) as typeof realPool.query,
+    } as typeof realPool;
+
+    const failingApp = createApp({ pool: failingPool, storage: createStorage(), token: TOKEN });
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY, failingApp);
+
+    // Handler surfaces the DB failure as a 5xx (onError default).
+    expect(res.status).toBeGreaterThanOrEqual(500);
+
+    // R2 upload ran exactly once — it MUST precede the (failed) DB write.
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+
+    // No live row: the failed insert left species_photos empty for this code.
+    const { rows } = await realPool.query(`SELECT * FROM species_photos WHERE species_code = 'norcar'`);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('purge failure is non-fatal: still 200, X-Purge-Status: failed', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+      const u = typeof input === 'string' ? input : input.url;
+      if (u.includes('api.cloudflare.com')) return new Response('boom', { status: 500 });
+      return new Response(JPEG_BODY, { status: 200, headers: { 'Content-Type': 'image/jpeg' } });
+    });
+    const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Purge-Status')).toBe('failed');
+  });
+});

--- a/services/admin-api/src/species-photo.test.ts
+++ b/services/admin-api/src/species-photo.test.ts
@@ -290,4 +290,85 @@ describe('admin-api PUT /admin/species-photos/:speciesCode', () => {
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
     });
   });
+
+  // ── Body-size cap (OOM hardening) ───────────────────────────────────────────
+  // The handler buffers the fetched body with response.arrayBuffer(); a
+  // multi-GB body from a trusted-but-compromised or buggy allowlisted host
+  // would OOM the 256Mi admin service. MAX_PHOTO_BYTES (15 MB) caps it, enforced
+  // both on the advertised content-length (cheap, pre-read) and on the realized
+  // byteLength (backstop for a missing or lying header). Each case must return a
+  // 4xx AND perform zero R2 writes.
+  describe('body-size cap', () => {
+    const MAX_PHOTO_BYTES = 15 * 1024 * 1024;
+
+    it('an over-cap content-length header is rejected (4xx) BEFORE reading, no R2 write', async () => {
+      // Advertise a 20 MB content-length on a (valid-magic) JPEG body. The
+      // handler must reject on the header alone — it never reaches validation
+      // or R2. The body itself is small so this is purely the header check.
+      vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+        const u = typeof input === 'string' ? input : input.url;
+        if (u.includes('api.cloudflare.com')) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(JPEG_BODY, {
+          status: 200,
+          headers: {
+            'Content-Type': 'image/jpeg',
+            'Content-Length': String(MAX_PHOTO_BYTES + 5 * 1024 * 1024),
+          },
+        });
+      });
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+      expect(res.status).toBe(413);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      const { rows } = await db.pool.query(`SELECT 1 FROM species_photos WHERE species_code = 'norcar'`);
+      expect(rows).toHaveLength(0);
+    });
+
+    it('a realized body over the cap with no/understated content-length is rejected (4xx), no R2 write', async () => {
+      // No Content-Length header (the lying/absent case): the realized body is
+      // > MAX_PHOTO_BYTES, so the post-read byteLength backstop must reject it
+      // before any R2 upload. Body carries valid JPEG magic so the only thing
+      // that can stop it is the size cap.
+      const oversizedJpeg = Buffer.concat([
+        Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+        Buffer.alloc(MAX_PHOTO_BYTES + 1024, 0x11),
+      ]);
+      vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+        const u = typeof input === 'string' ? input : input.url;
+        if (u.includes('api.cloudflare.com')) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        // Construct a Response WITHOUT a Content-Length header (the Response
+        // ctor would otherwise set one for a Buffer) by streaming the body.
+        return new Response(oversizedJpeg, { status: 200, headers: { 'Content-Type': 'image/jpeg' } });
+      });
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+      expect(res.status).toBe(413);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      const { rows } = await db.pool.query(`SELECT 1 FROM species_photos WHERE species_code = 'norcar'`);
+      expect(rows).toHaveLength(0);
+    });
+
+    it('a body exactly at the cap is accepted (200) — boundary is inclusive', async () => {
+      // The cap is a strict "greater than" — a body == MAX_PHOTO_BYTES still
+      // uploads. Guards against an off-by-one that would reject legitimate
+      // large-but-allowed photos.
+      const atCapJpeg = Buffer.concat([
+        Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
+        Buffer.alloc(MAX_PHOTO_BYTES - 4, 0x11),
+      ]);
+      expect(atCapJpeg.byteLength).toBe(MAX_PHOTO_BYTES);
+      vi.spyOn(global, 'fetch').mockImplementation(async (input: any) => {
+        const u = typeof input === 'string' ? input : input.url;
+        if (u.includes('api.cloudflare.com')) {
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(atCapJpeg, { status: 200, headers: { 'Content-Type': 'image/jpeg' } });
+      });
+      const res = await put('norcar', { Authorization: `Bearer ${TOKEN}` }, VALID_BODY);
+      expect(res.status).toBe(200);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+    });
+  });
 });

--- a/services/admin-api/src/ssrf-guard.test.ts
+++ b/services/admin-api/src/ssrf-guard.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { assertSafePhotoSource, SsrfError, PHOTO_HOST_ALLOWLIST } from './ssrf-guard.js';
+
+// A stub `dns.lookup({ all: true })` that always resolves to one public IPv4.
+// Tests that exercise the host/protocol checks never reach DNS, but the helper
+// requires *some* lookup; this keeps them deterministic with zero real DNS.
+function lookupPublic() {
+  return vi.fn(async () => [{ address: '151.101.0.1', family: 4 }]);
+}
+
+function lookupFor(addresses: { address: string; family: number }[]) {
+  return vi.fn(async () => addresses);
+}
+
+describe('assertSafePhotoSource', () => {
+  it('accepts an https allowlisted host that resolves to a public IP', async () => {
+    const lookup = lookupPublic();
+    await expect(
+      assertSafePhotoSource('https://static.inaturalist.org/photos/1/medium.jpg', { lookup }),
+    ).resolves.toBeUndefined();
+    expect(lookup).toHaveBeenCalledOnce();
+  });
+
+  it.each([...PHOTO_HOST_ALLOWLIST])('accepts allowlisted host %s', async (host) => {
+    const lookup = lookupPublic();
+    await expect(
+      assertSafePhotoSource(`https://${host}/x.jpg`, { lookup }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects an http:// (non-https) URL before any DNS lookup', async () => {
+    const lookup = lookupPublic();
+    await expect(
+      assertSafePhotoSource('http://static.inaturalist.org/x.jpg', { lookup }),
+    ).rejects.toBeInstanceOf(SsrfError);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it.each(['file:///etc/passwd', 'data:text/html,<x>', 'ftp://static.inaturalist.org/x'])(
+    'rejects non-https scheme %s',
+    async (url) => {
+      await expect(assertSafePhotoSource(url, { lookup: lookupPublic() })).rejects.toBeInstanceOf(
+        SsrfError,
+      );
+    },
+  );
+
+  it('rejects an unparseable URL', async () => {
+    await expect(assertSafePhotoSource('not a url', { lookup: lookupPublic() })).rejects.toBeInstanceOf(
+      SsrfError,
+    );
+  });
+
+  it('rejects a non-allowlisted host before any DNS lookup', async () => {
+    const lookup = lookupPublic();
+    await expect(
+      assertSafePhotoSource('https://evil.example.com/x.jpg', { lookup }),
+    ).rejects.toBeInstanceOf(SsrfError);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('rejects the IMDS host (169.254.169.254 is not allowlisted; also link-local)', async () => {
+    await expect(
+      assertSafePhotoSource('http://169.254.169.254/latest/meta-data/', {
+        lookup: lookupPublic(),
+      }),
+    ).rejects.toBeInstanceOf(SsrfError);
+  });
+
+  it('matches the host case-insensitively and strips a trailing dot', async () => {
+    const lookup = lookupPublic();
+    await expect(
+      assertSafePhotoSource('https://STATIC.INaturalist.org./photos/1/medium.jpg', { lookup }),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    ['loopback', '127.0.0.1'],
+    ['loopback v6', '::1'],
+    ['private 10.x', '10.0.0.5'],
+    ['private 172.16', '172.16.0.1'],
+    ['private 192.168', '192.168.1.1'],
+    ['link-local', '169.254.169.254'],
+    ['unique-local v6', 'fd00::1'],
+    ['unspecified', '0.0.0.0'],
+  ])('rejects an allowlisted host that resolves to a %s address (%s)', async (_label, ip) => {
+    const lookup = lookupFor([{ address: ip, family: ip.includes(':') ? 6 : 4 }]);
+    await expect(
+      assertSafePhotoSource('https://static.inaturalist.org/x.jpg', { lookup }),
+    ).rejects.toBeInstanceOf(SsrfError);
+  });
+
+  it('rejects when ANY of several resolved addresses is private (DNS round-robin)', async () => {
+    const lookup = lookupFor([
+      { address: '151.101.0.1', family: 4 },
+      { address: '10.0.0.7', family: 4 },
+    ]);
+    await expect(
+      assertSafePhotoSource('https://static.inaturalist.org/x.jpg', { lookup }),
+    ).rejects.toBeInstanceOf(SsrfError);
+  });
+
+  it('rejects when DNS resolves to zero addresses', async () => {
+    const lookup = lookupFor([]);
+    await expect(
+      assertSafePhotoSource('https://static.inaturalist.org/x.jpg', { lookup }),
+    ).rejects.toBeInstanceOf(SsrfError);
+  });
+});

--- a/services/admin-api/src/ssrf-guard.ts
+++ b/services/admin-api/src/ssrf-guard.ts
@@ -1,0 +1,119 @@
+import { lookup as dnsLookupCb } from 'node:dns';
+import { promisify } from 'node:util';
+import ipaddr from 'ipaddr.js';
+
+/**
+ * SSRF guard for the operator-supplied `sourceUrl` the species-photo handler
+ * fetches server-side and mirrors to R2 (issue #966 security addendum).
+ *
+ * Without this, the handler is a Server-Side Request Forgery sink: an attacker
+ * (or a confused-deputy with a compromised admin token) could point `sourceUrl`
+ * at cloud-metadata (`http://169.254.169.254/…`) or an internal host and have
+ * the server fetch it. Authentication does NOT remove the risk. The guard runs
+ * BEFORE any `fetch`, and again on every redirect target.
+ */
+
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfError';
+  }
+}
+
+/**
+ * Exact host allowlist — the trusted photo origins the ingestor already pulls
+ * from. Lowercased, no trailing dot. Aligned with:
+ *   - iNaturalist photo CDNs (`services/ingestor/src/inat/client.ts`):
+ *     `static.inaturalist.org` (legacy) and
+ *     `inaturalist-open-data.s3.amazonaws.com` (open-data bucket).
+ *   - Wikimedia (`services/ingestor/src/wikipedia/lead-image.ts`):
+ *     `upload.wikimedia.org`.
+ *   - `photos.bird-maps.com` — our own served-photos origin (re-mirror case).
+ */
+export const PHOTO_HOST_ALLOWLIST: ReadonlySet<string> = new Set([
+  'static.inaturalist.org',
+  'inaturalist-open-data.s3.amazonaws.com',
+  'upload.wikimedia.org',
+  'photos.bird-maps.com',
+]);
+
+/** ipaddr.js `range()` values that designate a non-public / internal target. */
+const BLOCKED_RANGES: ReadonlySet<string> = new Set([
+  'loopback',
+  'private',
+  'linkLocal',
+  'uniqueLocal',
+  'unspecified',
+]);
+
+/** `dns.lookup(host, { all: true })` shape — injectable so tests stub DNS. */
+export type DnsLookupAll = (
+  hostname: string,
+) => Promise<Array<{ address: string; family: number }>>;
+
+const defaultLookup: DnsLookupAll = (() => {
+  const promisified = promisify(dnsLookupCb);
+  return (hostname: string) =>
+    promisified(hostname, { all: true }) as Promise<Array<{ address: string; family: number }>>;
+})();
+
+export interface AssertSafePhotoSourceOptions {
+  /** Override for `dns.lookup(host, { all: true })`; defaults to node:dns.
+   *  Accepts `undefined` so callers can forward an optional dep directly under
+   *  `exactOptionalPropertyTypes`. */
+  lookup?: DnsLookupAll | undefined;
+}
+
+/**
+ * Throw `SsrfError` unless `sourceUrl` is safe to fetch server-side:
+ *   1. parses as a URL with `protocol === 'https:'`;
+ *   2. host (lowercased, trailing-dot-stripped) is on `PHOTO_HOST_ALLOWLIST`;
+ *   3. EVERY DNS-resolved address is a public unicast range — rejects if ANY
+ *      is loopback/private/link-local/unique-local/unspecified. Resolving and
+ *      checking ALL addresses defeats DNS-rebinding and an allowlisted host
+ *      repointed at internal space.
+ *
+ * Resolves to `void` on success. Cheapest denials (scheme, host) short-circuit
+ * before the DNS lookup.
+ */
+export async function assertSafePhotoSource(
+  sourceUrl: string,
+  opts: AssertSafePhotoSourceOptions = {},
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(sourceUrl);
+  } catch {
+    throw new SsrfError(`sourceUrl is not a valid URL: ${sourceUrl}`);
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new SsrfError(`sourceUrl must be https (got ${url.protocol})`);
+  }
+
+  const host = url.hostname.toLowerCase().replace(/\.$/, '');
+  if (!PHOTO_HOST_ALLOWLIST.has(host)) {
+    throw new SsrfError(`sourceUrl host not on allowlist: ${host}`);
+  }
+
+  const lookup = opts.lookup ?? defaultLookup;
+  const resolved = await lookup(host);
+  if (resolved.length === 0) {
+    throw new SsrfError(`sourceUrl host resolved to no addresses: ${host}`);
+  }
+
+  for (const { address } of resolved) {
+    let range: string;
+    try {
+      range = ipaddr.parse(address).range();
+    } catch {
+      // Unparseable address from DNS — fail closed.
+      throw new SsrfError(`sourceUrl host resolved to an unparseable address: ${address}`);
+    }
+    if (BLOCKED_RANGES.has(range)) {
+      throw new SsrfError(
+        `sourceUrl host ${host} resolves to a ${range} address (${address}); refusing to fetch`,
+      );
+    }
+  }
+}

--- a/services/admin-api/src/storage.ts
+++ b/services/admin-api/src/storage.ts
@@ -8,9 +8,23 @@ export interface PutResult {
   url: string;
 }
 
+export interface SpeciesPhotoPutResult {
+  /** R2 object key (e.g. "species/norcar.a1b2c3d4.jpg"). */
+  key: string;
+  /** Public URL served by the photos Worker. */
+  url: string;
+}
+
 export interface Storage {
   putSilhouette(familyCode: string, body: Buffer): Promise<PutResult>;
   deleteSilhouette(key: string): Promise<void>;
+  putSpeciesPhoto(
+    speciesCode: string,
+    body: Buffer,
+    contentType: string,
+    ext: string,
+  ): Promise<SpeciesPhotoPutResult>;
+  deleteSpeciesPhoto(key: string): Promise<void>;
 }
 
 export function createStorage(): Storage {
@@ -18,6 +32,11 @@ export function createStorage(): Storage {
   if (!endpoint) throw new Error('R2_ENDPOINT is required');
   const bucket = process.env.R2_BUCKET_NAME ?? 'bird-maps-silhouettes';
   const publicPrefix = process.env.SILHOUETTES_PUBLIC_PREFIX ?? 'https://silhouettes.bird-maps.com';
+  // Photos live in their own bucket (R2_PHOTOS_BUCKET) so the same service can
+  // write silhouettes and species photos to independent buckets.
+  const photosBucket = process.env.R2_PHOTOS_BUCKET ?? 'birdwatch-photos';
+  const photosPublicPrefix =
+    process.env.SPECIES_PHOTOS_PUBLIC_PREFIX ?? 'https://photos.bird-maps.com';
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;
   const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
 
@@ -47,6 +66,25 @@ export function createStorage(): Storage {
     },
     async deleteSilhouette(key) {
       await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    },
+    async putSpeciesPhoto(speciesCode, body, contentType, ext) {
+      // Content-hash the body for a write-once-never-overwrite key, mirroring
+      // putSilhouette. The image is served `immutable, max-age=1yr`, so a new
+      // key per image is the only safe way to swap without stranding the old
+      // bytes at the CDN edge for up to a year.
+      const sha = createHash('sha256').update(body).digest('hex').slice(0, 8);
+      const key = `species/${speciesCode}.${sha}.${ext}`;
+      await client.send(new PutObjectCommand({
+        Bucket: photosBucket,
+        Key: key,
+        Body: body,
+        ContentType: contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }));
+      return { key, url: `${photosPublicPrefix}/${key}` };
+    },
+    async deleteSpeciesPhoto(key) {
+      await client.send(new DeleteObjectCommand({ Bucket: photosBucket, Key: key }));
     },
   };
 }

--- a/services/admin-api/src/validate.ts
+++ b/services/admin-api/src/validate.ts
@@ -77,3 +77,98 @@ export function validateSvg(body: Buffer): ValidatedSvg {
 
   return { pathD, source: body };
 }
+
+// ── Species-photo validation ────────────────────────────────────────────────
+
+/** Min bytes a real photo should clear — guards against fetching an HTML error
+ *  page or a 1px tracking pixel where a JPEG was expected. */
+const MIN_PHOTO_BYTES = 1024;
+
+/** Accepted image MIME → file extension. Anything else is rejected; the R2 key
+ *  ext and the served Content-Type both come from this map. */
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/avif': 'avif',
+};
+
+/** First bytes that must be present for each accepted mime (format magic). */
+const MAGIC: Record<string, number[]> = {
+  'image/jpeg': [0xff, 0xd8, 0xff],
+  'image/png': [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+  // WEBP is RIFF-wrapped: bytes 0-3 are "RIFF" AND bytes 8-11 are "WEBP".
+  // Checked explicitly below (a non-WEBP RIFF container — a .wav, an AVI —
+  // must NOT pass), so it carries an empty leading-magic entry here.
+  'image/webp': [],
+  // AVIF is ISO-BMFF: bytes 4-7 are "ftyp"; check that offset.
+  'image/avif': [],
+};
+
+export interface ValidatedPhoto {
+  /** File extension for the R2 key (jpg/png/webp/avif). */
+  ext: string;
+  /** Verbatim source bytes the caller uploads to R2. */
+  source: Buffer;
+}
+
+/**
+ * Validate a fetched image body against its declared content-type:
+ * - non-empty, ≥ MIN_PHOTO_BYTES
+ * - mime is on the accepted list (→ ext)
+ * - format magic bytes match the declared mime (defends against an HTML
+ *   error page mislabeled image/jpeg, or a content-type/extension mismatch).
+ *   jpeg/png check a leading prefix; webp requires RIFF at 0-3 AND WEBP at
+ *   8-11; avif requires the ftyp box marker at offset 4.
+ *
+ * Returns the ext and the verbatim source for the R2 upload. Throws
+ * ValidationError on any failure so the handler returns 400.
+ */
+export function validatePhotoImage(body: Buffer, mime: string): ValidatedPhoto {
+  if (body.length === 0) throw new ValidationError('empty image body');
+  const ext = MIME_TO_EXT[mime];
+  if (!ext) throw new ValidationError(`unsupported image mime: ${mime}`);
+  if (body.length < MIN_PHOTO_BYTES) {
+    throw new ValidationError(`image too small (${body.length} bytes; min ${MIN_PHOTO_BYTES})`);
+  }
+  if (mime === 'image/webp') {
+    // RIFF container: 'RIFF' at bytes 0-3 AND 'WEBP' fourCC at bytes 8-11.
+    // Requiring both rejects a non-WEBP RIFF file (a .wav, an AVI) mislabeled
+    // image/webp — checking only the RIFF prefix would let those through.
+    const riff = body.subarray(0, 4).toString('ascii');
+    const fourCC = body.subarray(8, 12).toString('ascii');
+    if (riff !== 'RIFF' || fourCC !== 'WEBP') {
+      throw new ValidationError('image magic bytes do not match image/webp');
+    }
+  } else if (mime === 'image/avif') {
+    // ISO-BMFF: 'ftyp' box marker at byte offset 4.
+    const ftyp = body.subarray(4, 8).toString('ascii');
+    if (ftyp !== 'ftyp') throw new ValidationError('image magic bytes do not match image/avif');
+  } else {
+    const magic = MAGIC[mime]!;
+    const head = Array.from(body.subarray(0, magic.length));
+    if (magic.some((b, i) => head[i] !== b)) {
+      throw new ValidationError(`image magic bytes do not match ${mime}`);
+    }
+  }
+  return { ext, source: body };
+}
+
+/**
+ * Canonical CC allowlist — the SAME set the ingestor's iNat client filters on
+ * (`services/ingestor/src/inat/client.ts` `CC_LICENSES`). NC (non-commercial)
+ * and ND (no-derivatives) variants are excluded. This is the server-side
+ * backstop (spec §8/§9): the local curation tool already filters at source,
+ * but a mis-tagged image must never go live through this public endpoint.
+ *
+ * Returns the normalized (lowercased) license on success; throws on deny.
+ */
+const CC_ALLOWLIST = new Set(['cc-by', 'cc-by-sa', 'cc0']);
+
+export function validateLicense(license: string): string {
+  const normalized = license.trim().toLowerCase();
+  if (!CC_ALLOWLIST.has(normalized)) {
+    throw new ValidationError(`license not on CC allowlist (cc-by, cc-by-sa, cc0): "${license}"`);
+  }
+  return normalized;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Curation as curation tool (apply-swaps, Slice 8)
    participant Admin as bird-admin-api
    participant Source as source URL (iNat)
    participant R2 as R2 birdwatch-photos
    participant DB as Postgres species_photos
    participant CF as Cloudflare purge_cache

    Curation->>Admin: PUT /admin/species-photos/:code (Bearer) — { sourceUrl, attribution, license }
    Admin->>Admin: validateLicense (cc-by/cc-by-sa/cc0, NC/ND → 400)
    Admin->>DB: SELECT count(*) species_meta (unknown → 404)
    Admin->>Source: fetch sourceUrl (15s, non-200 → 400)
    Admin->>Admin: validatePhotoImage (magic bytes incl. WEBP fourCC, ≥1KB → 400)
    Admin->>R2: PutObject species/<code>.<sha8>.<ext> (R2 BEFORE DB)
    Admin->>DB: insertSpeciesPhoto upsert (detail-panel)
    Admin->>R2: deleteObject(prior key) — best-effort
    Admin->>CF: purge https://API_HOST/api/species/<code> (non-fatal)
    Admin-->>Curation: 200 { url, key }
```

## Summary

- Adds the **only prod-mutating surface** of the photo-curation epic: `PUT /admin/species-photos/:speciesCode` lets `apply-swaps` push an operator-approved replacement detail photo live, mirroring the existing silhouette override handler almost verbatim (bearer auth, R2-before-DB, purge-on-warning, `onError`).
- **R2-before-DB ordering is load-bearing and asserted directly** — a DB row pointing at a not-yet-uploaded key would render a broken image; the ordering test forces `insertSpeciesPhoto` to reject *after* a successful `PutObject` and proves exactly one `PutObject` recorded + zero live rows.
- **Server-side CC-license backstop** re-applies the ingestor's `cc-by`/`cc-by-sa`/`cc0` allowlist (NC/ND denied) because this is a public surface and the local tool is trusted-but-fallible; a mis-tagged image must never go live.

## Screenshots

N/A — not UI (no files under `frontend/**`; backend service + infra + docs only).

## Test plan

- [x] `npm run build --workspace @bird-watch/admin-api` — clean `tsc`
- [x] `npm run test --workspace @bird-watch/admin-api` — 75 passed (9 files), incl. 4 new suites: `photo-storage` (3), `photo-validate` (20), `purge-species` (3), `species-photo` integration (10, testcontainers PG + S3 mock + stubbed purge)
- [x] Integration coverage for all 6 acceptance behaviors: R2-before-DB (forced DB failure), content-hash key, upsert-in-place, purge call, auth missing/bad, license deny backstop; plus unknown-species 404, non-image/non-200 source 400, purge-failure non-fatal
- [x] `terraform -chdir=infra/terraform fmt` (no diffs) + `validate` (Success) after `init -backend=false`
- [x] No new `knip` findings introduced; `shared-types` `SpeciesMeta` unchanged (wire type stable)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Implements issue #966 ([photo-curation 7/10] admin-api PUT /admin/species-photos/:code). Part of epic #974. Plans live in issues (not `docs/plans/`) per repo convention.

### Infra note for review

Task 5 says "declare birdwatch-photos bucket if not yet declared" — it **already exists** in `infra/terraform/photos.tf` (`cloudflare_r2_bucket.photos`, #327). Re-declaring would be a duplicate-resource error, so `admin-api.tf` only **references** it via `cloudflare_r2_bucket.photos.name`. R2 access keys are account-scoped (shared with the silhouettes bucket), so no new GCP IAM binding is needed; if the underlying Cloudflare R2 API token is bucket-scoped, widening it to include `birdwatch-photos` is an operator follow-up (dashboard / `cloudflare_api_token` change) — flagged in the `admin-api.tf` comment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

