### PR TITLE
feat(ingestor): iNat top-N candidate sourcer + @bird-watch/ingestor re-export (#964)

### DIFF
--- a/services/ingestor/src/inat/candidates.test.ts
+++ b/services/ingestor/src/inat/candidates.test.ts
@@ -209,3 +209,71 @@ describe('fetchInatCandidates — exclude ids', () => {
     expect(out.map((c) => c.inatId)).toEqual([1]);
   });
 });
+
+describe('fetchInatCandidates — deny-tag biasing', () => {
+  // Regression-lock (expected GREEN on first run): the no-denyContext path is
+  // identity and was already correct from Task 3. Pins that re-rank never
+  // perturbs the votes order when no deny feedback is supplied.
+  it('no denyContext preserves iNat votes order (identity)', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () =>
+        HttpResponse.json(
+          obs([
+            { id: 1, photo: 'https://ex.org/photos/1/square.jpg', attr: '(c) Ann, CC0', lic: 'cc0' },
+            { id: 2, photo: 'https://ex.org/photos/2/square.jpg', attr: '(c) Bob at the backyard feeder, CC0', lic: 'cc0' },
+            { id: 3, photo: 'https://ex.org/photos/3/square.jpg', attr: '(c) Cal, CC0', lic: 'cc0' },
+          ])
+        )
+      )
+    );
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      tiers: SINGLE_TIER,
+    });
+    expect(out.map((c) => c.inatId)).toEqual([1, 2, 3]);
+  });
+
+  it('captive-feeder deny down-ranks feeder-attributed candidates', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () =>
+        HttpResponse.json(
+          obs([
+            { id: 1, photo: 'https://ex.org/photos/1/square.jpg', attr: '(c) Bob at the backyard feeder, CC0', lic: 'cc0' },
+            { id: 2, photo: 'https://ex.org/photos/2/square.jpg', attr: '(c) Ann, CC0', lic: 'cc0' },
+            { id: 3, photo: 'https://ex.org/photos/3/square.jpg', attr: '(c) Cal, CC0', lic: 'cc0' },
+          ])
+        )
+      )
+    );
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      denyContext: { reason: 'all on a feeder', tags: ['captive-feeder'] },
+      tiers: SINGLE_TIER,
+    });
+    // The feeder-attributed candidate (id 1) sinks below the natural ones,
+    // even though iNat ranked it first by votes.
+    expect(out.map((c) => c.inatId)).toEqual([2, 3, 1]);
+  });
+
+  it('wrong-sex-morph deny de-dupes same-photographer near-duplicates to surface variety', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () =>
+        HttpResponse.json(
+          obs([
+            { id: 1, photo: 'https://ex.org/photos/1/square.jpg', attr: '(c) Ann, CC0', lic: 'cc0' },
+            { id: 2, photo: 'https://ex.org/photos/2/square.jpg', attr: '(c) Ann, CC0', lic: 'cc0' },
+            { id: 3, photo: 'https://ex.org/photos/3/square.jpg', attr: '(c) Bob, CC0', lic: 'cc0' },
+          ])
+        )
+      )
+    );
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      denyContext: { reason: 'wrong morph, want variety', tags: ['wrong-sex-morph'] },
+      tiers: SINGLE_TIER,
+    });
+    // Ann's first frame and Bob lead; Ann's duplicate is pushed to the tail so
+    // the operator sees a different photographer before a near-dup.
+    expect(out.map((c) => c.inatId)).toEqual([1, 3, 2]);
+  });
+});

--- a/services/ingestor/src/inat/candidates.test.ts
+++ b/services/ingestor/src/inat/candidates.test.ts
@@ -161,3 +161,51 @@ describe('fetchInatCandidates — license filtering', () => {
     expect(out.map((c) => c.inatId)).toEqual([9]);
   });
 });
+
+describe('fetchInatCandidates — exclude ids', () => {
+  it('sends excludeIds as not_id AND filters them client-side', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        // The exclude set is sent to iNat as a comma-joined not_id.
+        expect(url.searchParams.get('not_id')).toBe('101,102');
+        // Simulate iNat ignoring not_id (it sometimes does on place cascades):
+        // return id 101 anyway and confirm the client drops it.
+        return HttpResponse.json(
+          obs([
+            { id: 101, photo: 'https://ex.org/photos/101/square.jpg', attr: '(c) A, CC0', lic: 'cc0' },
+            { id: 103, photo: 'https://ex.org/photos/103/square.jpg', attr: '(c) C, CC0', lic: 'cc0' },
+            { id: 104, photo: 'https://ex.org/photos/104/square.jpg', attr: '(c) D, CC0', lic: 'cc0' },
+          ])
+        );
+      })
+    );
+
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      excludeIds: [101, 102],
+      tiers: SINGLE_TIER,
+    });
+
+    // 101 leaked from iNat but is dropped client-side; 102 was never returned.
+    expect(out.map((c) => c.inatId)).toEqual([103, 104]);
+  });
+
+  it('omits not_id entirely when excludeIds is empty/undefined', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.has('not_id')).toBe(false);
+        return HttpResponse.json(
+          obs([{ id: 1, photo: 'https://ex.org/photos/1/square.jpg', attr: '(c) A, CC0', lic: 'cc0' }])
+        );
+      })
+    );
+
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      tiers: SINGLE_TIER,
+    });
+    expect(out.map((c) => c.inatId)).toEqual([1]);
+  });
+});

--- a/services/ingestor/src/inat/candidates.test.ts
+++ b/services/ingestor/src/inat/candidates.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { fetchInatCandidates } from './candidates.js';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const INAT_OBSERVATIONS_URL = 'https://api.inaturalist.org/v1/observations';
+
+// Pin the cascade to a single region tier so each test makes exactly one iNat
+// call unless it is specifically exercising the cascade. `tiers` is the
+// test-only seam (see the Test-seam note in the issue body); production callers
+// never pass it.
+const SINGLE_TIER = [{ label: 'region' as const, placeId: '40' }];
+
+// Build an iNat observations payload with N photo-bearing results.
+function obs(items: Array<{ id: number; photo: string; attr: string; lic: string }>) {
+  return {
+    total_results: items.length,
+    page: 1,
+    per_page: items.length,
+    results: items.map((it) => ({
+      id: it.id,
+      photos: [{ url: it.photo, attribution: it.attr, license_code: it.lic }],
+    })),
+  };
+}
+
+describe('fetchInatCandidates — top-N parse', () => {
+  it('returns up to `limit` candidates ordered by votes, each as InatCandidate', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        // Query contract: top-N (per_page=limit), votes order, research grade,
+        // CC allowlist, photos-only — same constraints as the single-photo path
+        // except per_page is the requested N, not 1.
+        expect(url.searchParams.get('taxon_name')).toBe('Cardinalis cardinalis');
+        expect(url.searchParams.get('quality_grade')).toBe('research');
+        expect(url.searchParams.get('photo_license')).toBe('cc-by,cc-by-sa,cc0');
+        expect(url.searchParams.get('order_by')).toBe('votes');
+        expect(url.searchParams.get('per_page')).toBe('15');
+        expect(url.searchParams.get('photos')).toBe('true');
+        expect(request.headers.get('User-Agent')).toMatch(/bird-maps\.com/);
+        return HttpResponse.json(
+          obs([
+            { id: 101, photo: 'https://ex.org/photos/101/square.jpg', attr: '(c) A, CC BY', lic: 'cc-by' },
+            { id: 102, photo: 'https://ex.org/photos/102/square.jpg', attr: '(c) B, CC BY-SA', lic: 'cc-by-sa' },
+            { id: 103, photo: 'https://ex.org/photos/103/square.jpg', attr: '(c) C, CC0', lic: 'cc0' },
+          ])
+        );
+      })
+    );
+
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 15,
+      tiers: SINGLE_TIER,
+    });
+
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({
+      inatId: 101,
+      photoUrl: 'https://ex.org/photos/101/medium.jpg', // square→medium substitution
+      attribution: '(c) A, CC BY',
+      license: 'cc-by',
+    });
+    // Votes order is preserved (iNat returns ordered; we don't re-sort without a denyContext).
+    expect(out.map((c) => c.inatId)).toEqual([101, 102, 103]);
+    // No square thumbnails leak through.
+    expect(out.every((c) => c.photoUrl.includes('medium'))).toBe(true);
+  });
+
+  it('caps the returned array at `limit` even when iNat returns more', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, () =>
+        HttpResponse.json(
+          obs(
+            Array.from({ length: 20 }, (_, i) => ({
+              id: 200 + i,
+              photo: `https://ex.org/photos/${200 + i}/square.jpg`,
+              attr: `(c) P${i}, CC0`,
+              lic: 'cc0',
+            }))
+          )
+        )
+      )
+    );
+
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 12,
+      tiers: SINGLE_TIER,
+    });
+    expect(out).toHaveLength(12);
+    expect(out.map((c) => c.inatId)).toEqual(
+      Array.from({ length: 12 }, (_, i) => 200 + i)
+    );
+  });
+});

--- a/services/ingestor/src/inat/candidates.test.ts
+++ b/services/ingestor/src/inat/candidates.test.ts
@@ -98,3 +98,66 @@ describe('fetchInatCandidates — top-N parse', () => {
     );
   });
 });
+
+describe('fetchInatCandidates — license filtering', () => {
+  it('drops candidates whose license is NC/ND or missing in a malformed payload', async () => {
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        // The CC allowlist is always sent to iNat (server-side filter).
+        const url = new URL(request.url);
+        expect(url.searchParams.get('photo_license')).toBe('cc-by,cc-by-sa,cc0');
+        // iNat *should* honor it, but defend against a leaked NC/ND/null row.
+        return HttpResponse.json({
+          total_results: 4,
+          page: 1,
+          per_page: 4,
+          results: [
+            { id: 1, photos: [{ url: 'https://ex.org/photos/1/square.jpg', attribution: '(c) A, CC BY', license_code: 'cc-by' }] },
+            { id: 2, photos: [{ url: 'https://ex.org/photos/2/square.jpg', attribution: '(c) B, CC BY-NC', license_code: 'cc-by-nc' }] },
+            { id: 3, photos: [{ url: 'https://ex.org/photos/3/square.jpg', attribution: '(c) C, CC BY-ND', license_code: 'cc-by-nd' }] },
+            { id: 4, photos: [{ url: 'https://ex.org/photos/4/square.jpg', attribution: '(c) D, ARR', license_code: null }] },
+          ],
+        });
+      })
+    );
+
+    const out = await fetchInatCandidates('Cardinalis cardinalis', {
+      limit: 10,
+      tiers: SINGLE_TIER,
+    });
+
+    // Only the cc-by row survives the client-side allowlist backstop.
+    expect(out.map((c) => c.inatId)).toEqual([1]);
+    expect(out.every((c) => ['cc-by', 'cc-by-sa', 'cc0'].includes(c.license))).toBe(true);
+  });
+
+  it('cascades region → US → global, first non-empty tier wins', async () => {
+    let calls = 0;
+    const placeIds: (string | null)[] = [];
+    server.use(
+      http.get(INAT_OBSERVATIONS_URL, ({ request }) => {
+        calls++;
+        placeIds.push(new URL(request.url).searchParams.get('place_id'));
+        if (calls < 3) {
+          return HttpResponse.json({ total_results: 0, page: 1, per_page: 10, results: [] });
+        }
+        return HttpResponse.json(
+          obs([{ id: 9, photo: 'https://ex.org/photos/9/square.jpg', attr: '(c) G, CC0', lic: 'cc0' }])
+        );
+      })
+    );
+
+    const out = await fetchInatCandidates('Larus occidentalis', {
+      limit: 10,
+      tiers: [
+        { label: 'region', placeId: '40' },
+        { label: 'us', placeId: '1' },
+        { label: 'global', placeId: null },
+      ],
+    });
+
+    expect(calls).toBe(3);
+    expect(placeIds).toEqual(['40', '1', null]);
+    expect(out.map((c) => c.inatId)).toEqual([9]);
+  });
+});

--- a/services/ingestor/src/inat/candidates.ts
+++ b/services/ingestor/src/inat/candidates.ts
@@ -8,6 +8,12 @@ import {
   type Tier,
 } from './inat-shared.js';
 
+// Client-side backstop for the CC allowlist. iNat filters by photo_license
+// server-side, but a malformed/legacy payload occasionally leaks an NC/ND or
+// null code; never offer one as a candidate (the admin endpoint re-validates
+// too, but filtering here keeps it out of the review UI entirely).
+const ALLOWED_LICENSES = new Set(CC_LICENSES.split(','));
+
 /** A single sourced replacement candidate. inatId is the observation id (used
  *  to exclude already-shown candidates on re-source). */
 export interface InatCandidate {
@@ -95,13 +101,12 @@ export async function fetchInatCandidates(
       if (excludeIds.has(result.id)) continue; // client-side belt-and-suspenders
       const photo = result.photos[0];
       if (!photo) continue;
+      const license = photo.license_code ?? '';
+      if (!ALLOWED_LICENSES.has(license)) continue; // backstop: drop NC/ND/ARR/null
       candidates.push({
         inatId: result.id,
         photoUrl: toMediumUrl(photo.url),
-        // photo_license filtering at the API level guarantees a non-null
-        // code; fall back to '' on a malformed payload so a downstream NOT
-        // NULL column surfaces the schema violation loudly.
-        license: photo.license_code ?? '',
+        license,
         attribution: photo.attribution,
       });
     }

--- a/services/ingestor/src/inat/candidates.ts
+++ b/services/ingestor/src/inat/candidates.ts
@@ -1,0 +1,188 @@
+import type { InatObservationsResponse } from './types.js';
+import { getJsonWithRetry } from './client.js';
+import {
+  INAT_BASE_URL,
+  CC_LICENSES,
+  buildTiers,
+  toMediumUrl,
+  type Tier,
+} from './inat-shared.js';
+
+/** A single sourced replacement candidate. inatId is the observation id (used
+ *  to exclude already-shown candidates on re-source). */
+export interface InatCandidate {
+  inatId: number;
+  photoUrl: string; // ~800px medium JPEG (square→medium substituted)
+  attribution: string;
+  license: string; // 'cc-by' | 'cc-by-sa' | 'cc0'
+}
+
+/** Operator deny feedback that biases re-sourcing. `reason` is free text;
+ *  `tags` are the quick-chip values. Recognized tags:
+ *  'too-dark','wrong-sex-morph','still-distant','cluttered-background',
+ *  'captive-feeder','not-sharp'. Unknown tags are ignored (forward-compatible). */
+export interface DenyContext {
+  reason: string;
+  tags: string[];
+}
+
+export interface FetchInatCandidatesOptions {
+  /** Max candidates to return (top-N). Drives iNat per_page and the final slice. */
+  limit: number;
+  /** iNat observation ids to exclude (already shown / denied). */
+  excludeIds?: number[];
+  /** Deny feedback from a prior round; re-ranks/penalizes the result set. */
+  denyContext?: DenyContext;
+  baseUrl?: string;
+  maxRetries?: number;
+  retryBaseMs?: number;
+  requestTimeoutMs?: number;
+  /** Test-only override of the tier cascade (see client.ts FetchInatPhotoOptions).
+   *  Not part of the published contract signature — production callers omit it. */
+  tiers?: readonly Tier[];
+}
+
+/**
+ * Fetches up to `limit` research-grade, CC-licensed (NC/ND denied)
+ * iNaturalist candidates for a binomial name, ordered by votes, across the
+ * region → US → global geographic cascade. Unlike `fetchInatPhoto` (single
+ * top photo), this returns the deep top-N that the curation tool scores and
+ * the ingestor gate picks from.
+ *
+ * `excludeIds` is sent to iNat as `not_id` AND filtered client-side (belt and
+ * suspenders — iNat occasionally ignores `not_id` on cascaded place filters).
+ * `denyContext` re-ranks the result set (see applyDenyBias).
+ *
+ * Cascade semantics match fetchInatPhoto: the FIRST tier that returns any
+ * candidates wins (we don't merge across tiers — a region hit is more
+ * relevant than padding it with global ones). Returns [] when all tiers miss.
+ */
+export async function fetchInatCandidates(
+  sciName: string,
+  opts: FetchInatCandidatesOptions
+): Promise<InatCandidate[]> {
+  const baseUrl = opts.baseUrl ?? INAT_BASE_URL;
+  const maxRetries = opts.maxRetries ?? 1;
+  const retryBaseMs = opts.retryBaseMs ?? 250;
+  const requestTimeoutMs = opts.requestTimeoutMs ?? 30_000;
+  const excludeIds = new Set(opts.excludeIds ?? []);
+  const tiers = opts.tiers ?? buildTiers();
+
+  for (const tier of tiers) {
+    const url = new URL(`${baseUrl}/observations`);
+    url.searchParams.set('taxon_name', sciName);
+    if (tier.placeId !== null) {
+      url.searchParams.set('place_id', tier.placeId);
+    }
+    url.searchParams.set('quality_grade', 'research');
+    url.searchParams.set('photo_license', CC_LICENSES);
+    url.searchParams.set('order_by', 'votes'); // best-rated first
+    url.searchParams.set('per_page', String(opts.limit));
+    url.searchParams.set('photos', 'true');
+    if (excludeIds.size > 0) {
+      url.searchParams.set('not_id', [...excludeIds].join(','));
+    }
+
+    const body = await getJsonWithRetry<InatObservationsResponse>(
+      url,
+      maxRetries,
+      retryBaseMs,
+      requestTimeoutMs
+    );
+
+    const candidates: InatCandidate[] = [];
+    for (const result of body.results) {
+      if (excludeIds.has(result.id)) continue; // client-side belt-and-suspenders
+      const photo = result.photos[0];
+      if (!photo) continue;
+      candidates.push({
+        inatId: result.id,
+        photoUrl: toMediumUrl(photo.url),
+        // photo_license filtering at the API level guarantees a non-null
+        // code; fall back to '' on a malformed payload so a downstream NOT
+        // NULL column surfaces the schema violation loudly.
+        license: photo.license_code ?? '',
+        attribution: photo.attribution,
+      });
+    }
+
+    if (candidates.length === 0) continue; // cascade to the next tier
+
+    const ranked = applyDenyBias(candidates, opts.denyContext);
+    return ranked.slice(0, opts.limit);
+  }
+
+  return [];
+}
+
+/**
+ * Re-ranks candidates by the deny feedback from a prior round. With no
+ * denyContext this is identity (preserve iNat's votes order). Each recognized
+ * tag carries a penalty heuristic; we can't re-inspect pixels here (that's the
+ * scorer's job), so the bias works on the signals available pre-score:
+ * attribution/license text and, for variety-seeking tags, de-duplication.
+ *
+ * This is intentionally a soft re-rank (stable sort by ascending penalty), not
+ * a hard filter — the scorer downstream is authoritative; this just surfaces
+ * likely-better candidates first so the operator sees them at the top of the
+ * alternates strip.
+ */
+export function applyDenyBias(
+  candidates: InatCandidate[],
+  denyContext?: DenyContext
+): InatCandidate[] {
+  if (!denyContext || denyContext.tags.length === 0) return candidates;
+  const tags = new Set(denyContext.tags);
+
+  const penalty = (c: InatCandidate): number => {
+    let p = 0;
+    const attr = c.attribution.toLowerCase();
+    // captive/feeder deny → down-rank candidates whose attribution hints at a
+    // feeder/captive/zoo/aviary setting (the only pre-score signal we have).
+    if (tags.has('captive-feeder') && /feeder|captive|zoo|aviary|rehab/.test(attr)) {
+      p += 10;
+    }
+    // wrong-sex/morph deny → bias toward variety: penalize same-photographer
+    // near-duplicates is handled by the de-dup pass below, so this tag mostly
+    // relaxes ordering. A small constant nudge keeps the original top from
+    // dominating after a wrong-morph deny.
+    if (tags.has('wrong-sex-morph')) {
+      p += 1;
+    }
+    return p;
+  };
+
+  let ranked = [...candidates]
+    .map((c, i) => ({ c, i, p: penalty(c) }))
+    // stable sort: ascending penalty, then original (votes) order.
+    .sort((a, b) => a.p - b.p || a.i - b.i)
+    .map((x) => x.c);
+
+  // For variety-seeking denials, drop adjacent same-photographer duplicates so
+  // the operator isn't shown five near-identical frames by one contributor.
+  if (tags.has('wrong-sex-morph') || tags.has('cluttered-background')) {
+    ranked = dedupeByPhotographer(ranked);
+  }
+  return ranked;
+}
+
+/** Keep the first candidate per photographer (parsed from the "(c) Name, ..."
+ *  attribution prefix), preserving order. Returns the deduped list followed by
+ *  the dropped duplicates appended at the end (so we never shrink below what
+ *  the caller's `limit` could fill). */
+function dedupeByPhotographer(candidates: InatCandidate[]): InatCandidate[] {
+  const seen = new Set<string>();
+  const primary: InatCandidate[] = [];
+  const dupes: InatCandidate[] = [];
+  for (const c of candidates) {
+    const m = c.attribution.match(/^\(c\)\s*([^,]+)/i);
+    const who = (m?.[1] ?? c.attribution).trim().toLowerCase();
+    if (seen.has(who)) {
+      dupes.push(c);
+    } else {
+      seen.add(who);
+      primary.push(c);
+    }
+  }
+  return [...primary, ...dupes];
+}

--- a/services/ingestor/src/inat/client.ts
+++ b/services/ingestor/src/inat/client.ts
@@ -2,67 +2,20 @@ import type {
   InatObservationsResponse,
   InatPhoto,
 } from './types.js';
+import {
+  INAT_USER_AGENT,
+  INAT_BASE_URL,
+  CC_LICENSES,
+  buildTiers,
+  toMediumUrl,
+  type Tier,
+} from './inat-shared.js';
 
-// User-Agent header value identifying the app to iNaturalist's API. iNat's
-// API recommended-practices doc (https://www.inaturalist.org/pages/api+recommended+practices)
-// asks for meaningful UA strings so they can contact the app maintainer if a
-// problem is observed. Anonymous UAs may be throttled or blocked outright.
-// Exported so sibling iNat clients (taxon-client.ts) can present the same
-// identity — iNat's per-UA throttle bucketing depends on it.
-export const INAT_USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
-
-// Tier 1 place_id defaults to '40' (iNaturalist's canonical "Arizona" Place,
-// confirmed via `GET https://api.inaturalist.org/v1/places/40` →
-// `name='Arizona'`, `place_type=8`, `admin_level=10`). This default preserves
-// AZ-launch production behavior — changing it without re-verifying other
-// AZ-shaped places (county, NWR, etc.) would silently narrow or skew the
-// photo pool.
-//
-// `INAT_PLACE_ID` env var overrides Tier 1 for non-AZ deployments. Set to a
-// different iNat Place ID (e.g. '14' for California) to narrow Tier 1 to a
-// different region. Set to empty string (`INAT_PLACE_ID=`) to drop Tier 1
-// entirely — the cascade then starts at Tier 2 (US). National expansion
-// (umbrella plan Phase 2) sets this to '' so we don't penalize species
-// photographed outside AZ.
-const DEFAULT_TIER1_PLACE_ID = '40';
-
-// place_id=1 is iNaturalist's canonical "United States" Place. Confirmed via
-// `GET https://api.inaturalist.org/v1/places/1` returning `name='United States'`,
-// `place_type=12` (country), `admin_level=0`. Used as Tier 2 in the photo
-// fallback cascade for region-rare/vagrant species (e.g. Cave Swallow,
-// Glossy Ibis) that have plenty of US research-grade observations elsewhere
-// but no Tier-1 hits.
-const UNITED_STATES_PLACE_ID = '1';
-
-// Tier cascade for the photo lookup. Tier 1 is the region-narrowed filter
-// (configurable via INAT_PLACE_ID); Tier 2 widens to the US; Tier 3 drops the
-// place filter entirely. Each tier keeps the same
-// quality_grade/license/order_by constraints — only the geographic filter
-// relaxes.
-export type Tier = { label: 'region' | 'us' | 'global'; placeId: string | null };
-
-function buildTiers(): readonly Tier[] {
-  // env read at module init time is correct here: ingestor process lifetime
-  // is short (single backfill / cron tick), and tests opt-in via the
-  // `opts.tiers` override below rather than mutating process.env mid-run.
-  const envVal = process.env.INAT_PLACE_ID;
-  const tier1 = envVal === undefined ? DEFAULT_TIER1_PLACE_ID : envVal;
-  const tiers: Tier[] = [];
-  if (tier1 !== '') {
-    tiers.push({ label: 'region', placeId: tier1 });
-  }
-  tiers.push({ label: 'us', placeId: UNITED_STATES_PLACE_ID });
-  tiers.push({ label: 'global', placeId: null });
-  return tiers;
-}
-
-// CC license codes accepted by `photo_license`. CC-BY-NC* variants are
-// excluded because they forbid commercial use; while bird-maps.com is
-// non-commercial today, a future donations/grants tier could change that
-// classification, and re-licensing every backfilled photo would be painful.
-const CC_LICENSES = 'cc-by,cc-by-sa,cc0';
-
-const INAT_BASE_URL = 'https://api.inaturalist.org/v1';
+// Re-exported for backward compatibility: taxon-client.ts and the existing
+// client.test.ts import these from './client.js'. The definitions now live in
+// inat-shared.ts (Slice 3 extraction); re-exporting keeps every existing
+// import path valid.
+export { INAT_USER_AGENT, type Tier };
 
 export interface FetchInatPhotoOptions {
   baseUrl?: string;
@@ -124,13 +77,10 @@ export async function fetchInatPhoto(
     const firstPhoto = firstResult.photos[0];
     if (!firstPhoto) continue;
 
-    // iNat's `photo.url` returns a 75px square thumbnail by convention. The
-    // URL contains the literal segment 'square' (e.g.
-    // .../photos/12345/square.jpg); substituting 'medium' yields the
-    // ~500-800px variant suitable for a detail panel. iNat publishes the size
-    // token convention at https://www.inaturalist.org/pages/help#photos —
-    // supported values are square, small, medium, large, original.
-    const mediumUrl = firstPhoto.url.replace('square', 'medium');
+    // iNat's `photo.url` returns a 75px square thumbnail by convention; the
+    // shared toMediumUrl helper substitutes 'medium' to get the ~500-800px
+    // variant suitable for a detail panel (see inat-shared.ts).
+    const mediumUrl = toMediumUrl(firstPhoto.url);
 
     // photo_license filtering at the API level guarantees a non-null code,
     // but defend against a malformed payload by falling back to an empty

--- a/services/ingestor/src/inat/inat-shared.ts
+++ b/services/ingestor/src/inat/inat-shared.ts
@@ -1,0 +1,53 @@
+// Shared iNaturalist building blocks used by both the single-photo client
+// (client.ts) and the top-N candidate sourcer (candidates.ts). Extracted in
+// Slice 3 so the two paths share one license allowlist, one tier cascade, and
+// one square→medium substitution — no drift between "fetch the best one" and
+// "fetch the top N".
+
+// User-Agent header value identifying the app to iNaturalist's API. iNat's
+// API recommended-practices doc asks for a meaningful UA so they can contact
+// the maintainer. Anonymous UAs may be throttled or blocked.
+export const INAT_USER_AGENT = 'bird-maps.com/1.0 (https://bird-maps.com)';
+
+export const INAT_BASE_URL = 'https://api.inaturalist.org/v1';
+
+// CC license codes accepted by `photo_license`. CC-BY-NC* (non-commercial)
+// and CC-*-ND (no-derivatives) variants are excluded: NC forbids commercial
+// use (a future donations/grants tier could reclassify bird-maps.com, and
+// re-licensing backfilled photos would be painful), ND forbids the cropping /
+// resizing the pipeline performs. cc-by, cc-by-sa, cc0 are the only safe set.
+export const CC_LICENSES = 'cc-by,cc-by-sa,cc0';
+
+// Tier 1 place_id defaults to '40' (iNaturalist's canonical "Arizona" Place).
+// Preserves AZ-launch behavior. `INAT_PLACE_ID` env overrides; '' drops Tier 1.
+const DEFAULT_TIER1_PLACE_ID = '40';
+// place_id=1 is iNaturalist's canonical "United States" Place (Tier 2).
+const UNITED_STATES_PLACE_ID = '1';
+
+// Tier cascade for photo lookup. Tier 1 is region-narrowed (configurable via
+// INAT_PLACE_ID); Tier 2 widens to the US; Tier 3 drops the place filter.
+export type Tier = { label: 'region' | 'us' | 'global'; placeId: string | null };
+
+export function buildTiers(): readonly Tier[] {
+  // env read at module-init time is correct: ingestor process lifetime is
+  // short (single backfill / cron tick); tests opt-in via the `tiers` option
+  // rather than mutating process.env mid-run.
+  const envVal = process.env.INAT_PLACE_ID;
+  const tier1 = envVal === undefined ? DEFAULT_TIER1_PLACE_ID : envVal;
+  const tiers: Tier[] = [];
+  if (tier1 !== '') {
+    tiers.push({ label: 'region', placeId: tier1 });
+  }
+  tiers.push({ label: 'us', placeId: UNITED_STATES_PLACE_ID });
+  tiers.push({ label: 'global', placeId: null });
+  return tiers;
+}
+
+// iNat's `photo.url` returns a 75px square thumbnail by convention (the URL
+// contains the literal segment 'square', e.g. .../photos/12345/square.jpg).
+// Substituting 'medium' yields the ~500-800px variant suitable for a detail
+// panel. iNat documents the size tokens at
+// https://www.inaturalist.org/pages/help#photos (square|small|medium|large|original).
+export function toMediumUrl(squareUrl: string): string {
+  return squareUrl.replace('square', 'medium');
+}

--- a/services/ingestor/src/inat/types.ts
+++ b/services/ingestor/src/inat/types.ts
@@ -18,6 +18,7 @@ export interface InatObservationPhoto {
 }
 
 export interface InatObservation {
+  id: number; // iNat observation id; projected to InatCandidate.inatId for exclude/re-source bookkeeping
   photos: InatObservationPhoto[];
 }
 

--- a/services/ingestor/src/index.test.ts
+++ b/services/ingestor/src/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+// Import from the package barrel — the same surface Slices 4 & 5 consume as
+// `@bird-watch/ingestor`. If candidates.ts is not re-exported here, this import
+// is undefined and the test fails.
+import { fetchInatCandidates, type DenyContext, type InatCandidate } from './index.js';
+
+describe('@bird-watch/ingestor barrel — candidate sourcer surface', () => {
+  it('re-exports fetchInatCandidates as a callable', () => {
+    expect(typeof fetchInatCandidates).toBe('function');
+  });
+
+  it('re-exports the DenyContext / InatCandidate types (compile-time lock)', () => {
+    // Type-only assertions: these object literals must satisfy the re-exported
+    // type names, or `tsc` (npm run build) fails. No runtime behavior.
+    const deny: DenyContext = { reason: 'all on a feeder', tags: ['captive-feeder'] };
+    const cand: InatCandidate = {
+      inatId: 1,
+      photoUrl: 'https://ex.org/photos/1/medium.jpg',
+      attribution: '(c) A, CC0',
+      license: 'cc0',
+    };
+    expect(deny.tags).toContain('captive-feeder');
+    expect(cand.inatId).toBe(1);
+  });
+});

--- a/services/ingestor/src/index.ts
+++ b/services/ingestor/src/index.ts
@@ -3,3 +3,4 @@ export { runIngest, type RunSummary } from './run-ingest.js';
 export { runHotspotIngest, type RunHotspotSummary } from './run-hotspots.js';
 export { runBackfill, type RunBackfillSummary } from './run-backfill.js';
 export { runPhotos, type RunPhotosSummary, type RunPhotosArgs } from './run-photos.js';
+export { fetchInatCandidates, type InatCandidate, type DenyContext } from './inat/candidates.js';


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Caller as Slice4/Slice9 caller
    participant Sourcer as fetchInatCandidates
    participant Shared as inat-shared
    participant iNat as iNaturalist API

    Caller->>Sourcer: sciName plus limit excludeIds denyContext
    Sourcer->>Shared: buildTiers region US global
    loop until first non-empty tier
        Sourcer->>iNat: GET observations votes research CC not_id
        iNat-->>Sourcer: results array
    end
    Sourcer->>Sourcer: drop excludeIds and NC ND null licenses
    Sourcer->>Sourcer: applyDenyBias re-rank then slice to limit
    Sourcer-->>Caller: InatCandidate array
```

```mermaid
graph LR
    client[client.ts fetchInatPhoto] --> shared[inat-shared.ts]
    candidates[candidates.ts fetchInatCandidates] --> shared
    shared -.- bits[CC_LICENSES buildTiers toMediumUrl UA base-url]
    candidates --> barrel[index.ts @bird-watch/ingestor]
```

## Summary

- **Why:** Slices 4 (curation CLI) and 9 (ingestor gate) need a top-N candidate sourcer with deny-reason re-sourcing, sharing the single-photo path's license allowlist and geographic cascade without drift. This adds it and surfaces it on the package barrel so consumers import from the `@bird-watch/ingestor` boundary, never a deep relative path.
- **What:** Extracts the shared iNat building blocks (`CC_LICENSES`, `buildTiers`/`Tier`, `toMediumUrl`, UA/base-url) from `client.ts` into a new `inat-shared.ts` (pure refactor — `fetchInatPhoto` and its 8 tests unchanged), then adds `fetchInatCandidates` returning up to `limit` research-grade CC candidates ordered by votes across the region → US → global cascade, with a client-side license backstop, `excludeIds` → `not_id` + client-side drop, and `DenyContext` re-rank biasing (captive-feeder down-rank, wrong-sex-morph de-dup).
- **Boundary:** No `@bird-watch/photo-quality` import here — this slice only produces `InatCandidate[]`; candidate *scoring* is the later Claude Code workflow. `exifHints` deliberately deferred to the Slice 4 scorer (see issue §5.2 divergence note).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/ingestor` — green (242 tests, 25 files; `candidates.test.ts` 9, `client.test.ts` unchanged at 8, `index.test.ts` 2)
- [x] New unit tests added — 4 msw v2 groups (top-N parse, license filtering, exclude ids, deny-tag biasing) + barrel re-export test
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior
- [x] `npm run build` — clean production build (root chain, all 5 workspaces)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

Also verified: `npx knip` exits 0 (clean); no `package-lock.json` drift.

## Plan reference

Part of epic #974. Implements #964 ([photo-curation 3/10] iNat top-N candidate sourcer + `@bird-watch/ingestor` re-export). Spec: `docs/specs/2026-06-10-photo-quality-curation-design.md` §5.2.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
