### PR TITLE
feat(photo-curation): scaffold tools/photo-curation + SQLite store + data layer (#970)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,14 @@ terraform.tfstate.backup
 
 # Throwaway directory for Phase 0 prototype gating — deleted in Task 0.4.
 prototype/
+
+# Local photo-curation tool workspace (photo-quality epic, Slice 4).
+# review.sqlite holds scored reports + staged decisions; thumb-cache/ holds
+# downloaded candidate thumbnails. Operator-local and regenerable — never
+# commit. dist/ is the tsc build output.
+tools/photo-curation/review.sqlite
+tools/photo-curation/review.sqlite-journal
+tools/photo-curation/review.sqlite-wal
+tools/photo-curation/review.sqlite-shm
+tools/photo-curation/thumb-cache/
+tools/photo-curation/dist/

--- a/knip.ts
+++ b/knip.ts
@@ -256,6 +256,38 @@ const config: KnipConfig = {
     'packages/geo': {},
     'packages/shared-types': {},
     'packages/photo-quality': {},
+
+    'tools/photo-curation': {
+      // 2026-06-10: Part A (#970) scaffolds this workspace + its SQLite store /
+      //             data layer / decision machine / FakeJudge. Several declared
+      //             deps and one store helper are not CONSUMED until Part B
+      //             (#971) lands sources.ts / score-current / cli.ts. They are
+      //             pinned in Part A's package.json on purpose (Part A is the
+      //             sole scaffolder), so knip flags them as unused until Part B
+      //             imports them. These are intentionally self-healing: each
+      //             entry should drop out of this list once #971 wires it.
+      //             Re-audit 2026-07-27 — if any entry is still here AND #971
+      //             has merged, it is a genuine orphan; delete the dep instead.
+      ignoreDependencies: [
+        // CLI flag parser for cli.ts (Part B, #971 — four subcommands).
+        'commander',
+        // Image decode/thumbnail in sources.ts download path (Part B, #971);
+        // Part A's data layer never decodes an image.
+        'sharp',
+        // Shared DB/API DTOs imported by Part B's sources.ts + cli.ts wiring;
+        // mirrors the services/admin-api shared-types Dockerfile-only ignore.
+        '@bird-watch/shared-types',
+        // MSW network mocks for Part B's sources.ts iNat-fetch unit tests; no
+        // network in Part A's :memory: SQLite tests.
+        'msw',
+      ],
+      // 2026-06-10: maxSourceRound (store.ts) is the re-source round counter
+      //             Part B's denyAndAdvance / sources.ts read to land new
+      //             candidates in a higher source_round. Exported in Part A so
+      //             Part B imports it without re-touching store.ts. Self-healing:
+      //             remove once #971 imports it. Re-audit 2026-07-27.
+      ignore: ['src/store.ts'],
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "packages/*",
         "services/*",
+        "tools/*",
         "frontend"
       ],
       "devDependencies": {
@@ -747,6 +748,10 @@
     },
     "node_modules/@bird-watch/ingestor": {
       "resolved": "services/ingestor",
+      "link": true
+    },
+    "node_modules/@bird-watch/photo-curation": {
+      "resolved": "tools/photo-curation",
       "link": true
     },
     "node_modules/@bird-watch/photo-quality": {
@@ -3623,6 +3628,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -4444,6 +4459,17 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -4462,9 +4488,17 @@
         "node": "*"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4474,7 +4508,6 @@
     },
     "node_modules/bl/node_modules/buffer": {
       "version": "5.7.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4497,7 +4530,6 @@
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -4620,7 +4652,6 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/cli-width": {
@@ -4670,6 +4701,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/compress-commons": {
@@ -4844,6 +4884,30 @@
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5203,6 +5267,15 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5320,6 +5393,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "dev": true,
@@ -5370,7 +5449,6 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fsevents": {
@@ -5511,6 +5589,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -5724,7 +5808,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5751,6 +5834,12 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/int53": {
@@ -6475,6 +6564,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "dev": true,
@@ -6527,7 +6628,6 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -6612,6 +6712,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/nise": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
@@ -6644,6 +6750,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -7148,6 +7266,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "dev": true,
@@ -7242,7 +7429,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -7261,6 +7447,30 @@
     "node_modules/quickselect": {
       "version": "3.0.0",
       "license": "ISC"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -7616,6 +7826,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/sinon": {
@@ -8218,6 +8473,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tweetnacl": {
@@ -9207,6 +9474,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "tools/photo-curation": {
+      "name": "@bird-watch/photo-curation",
+      "version": "0.0.1",
+      "dependencies": {
+        "@bird-watch/ingestor": "*",
+        "@bird-watch/photo-quality": "*",
+        "@bird-watch/shared-types": "*",
+        "better-sqlite3": "^11.8.1",
+        "commander": "^13.1.0",
+        "sharp": "^0.34.1"
+      },
+      "bin": {
+        "photo-curate": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^24.12.4",
+        "msw": "^2.14.6",
+        "tsx": "^4.22.3",
+        "vitest": "^4.1.7"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "workspaces": [
     "packages/*",
     "services/*",
+    "tools/*",
     "frontend"
   ],
   "scripts": {

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bird-watch/photo-curation",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "bin": { "photo-curate": "dist/cli.js" },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "curate": "tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@bird-watch/ingestor": "*",
+    "@bird-watch/photo-quality": "*",
+    "@bird-watch/shared-types": "*",
+    "better-sqlite3": "^11.8.1",
+    "commander": "^13.1.0",
+    "sharp": "^0.34.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^24.12.4",
+    "msw": "^2.14.6",
+    "tsx": "^4.22.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/tools/photo-curation/src/db.test.ts
+++ b/tools/photo-curation/src/db.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { openDb } from './db.js';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database | undefined;
+afterEach(() => { db?.close(); db = undefined; });
+
+function columns(d: Database.Database, table: string): string[] {
+  return (d.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[])
+    .map(r => r.name);
+}
+
+describe('openDb', () => {
+  it('creates the four contract tables', () => {
+    db = openDb(':memory:');
+    const tables = (db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`
+    ).all() as { name: string }[]).map(r => r.name);
+    expect(tables).toEqual(
+      expect.arrayContaining([
+        'photo_candidate', 'photo_current', 'photo_decision', 'photo_score',
+      ]),
+    );
+  });
+
+  it('photo_current has the exact contract columns', () => {
+    db = openDb(':memory:');
+    expect(columns(db, 'photo_current')).toEqual([
+      'species_code', 'com_name', 'sci_name', 'family',
+      'url', 'attribution', 'license', 'content_hash', 'reviewed',
+    ]);
+  });
+
+  it('photo_decision has the exact contract columns (incl. resource_requested)', () => {
+    db = openDb(':memory:');
+    expect(columns(db, 'photo_decision')).toEqual([
+      'species_code', 'action', 'chosen_candidate_id', 'deny_reason',
+      'deny_tags_json', 'decided_at', 'applied', 'applied_at', 'resource_requested',
+    ]);
+  });
+
+  it('photo_current.reviewed defaults to 0 (not-yet-AI-scored)', () => {
+    db = openDb(':memory:');
+    db.prepare(
+      `INSERT INTO photo_current (species_code) VALUES (?)`
+    ).run('amerob');
+    const row = db.prepare(
+      `SELECT reviewed FROM photo_current WHERE species_code = ?`
+    ).get('amerob') as { reviewed: number };
+    expect(row.reviewed).toBe(0);
+  });
+
+  it('photo_decision defaults applied=0 and exposes the four-action shape', () => {
+    db = openDb(':memory:');
+    db.prepare(
+      `INSERT INTO photo_decision (species_code, action) VALUES (?, ?)`
+    ).run('amerob', 'pending');
+    const row = db.prepare(
+      `SELECT action, applied FROM photo_decision WHERE species_code = ?`
+    ).get('amerob') as { action: string; applied: number };
+    expect(row.action).toBe('pending');
+    expect(row.applied).toBe(0);
+  });
+
+  it('is idempotent — re-opening the SAME store re-runs the schema without throwing', () => {
+    const p = path.join(os.tmpdir(), `idem-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+    try {
+      db = openDb(p);
+      const count = (d: Database.Database) => (d.prepare(
+        `SELECT COUNT(*) c FROM sqlite_master WHERE type='table'`,
+      ).get() as { c: number }).c;
+      const before = count(db);
+      db.close();
+      // Second open hits CREATE TABLE IF NOT EXISTS against the EXISTING schema.
+      db = undefined;
+      let db2: Database.Database | undefined;
+      expect(() => { db2 = openDb(p); }).not.toThrow();
+      expect(count(db2!)).toBe(before);
+      db2!.close();
+    } finally {
+      for (const ext of ['', '-journal', '-wal', '-shm']) {
+        try { fs.rmSync(p + ext); } catch { /* ignore */ }
+      }
+    }
+  });
+});

--- a/tools/photo-curation/src/db.ts
+++ b/tools/photo-curation/src/db.ts
@@ -1,0 +1,90 @@
+import Database from 'better-sqlite3';
+
+/** Default on-disk path for the review store (gitignored). */
+export const DEFAULT_DB_PATH = './review.sqlite';
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS photo_current (
+  species_code TEXT PRIMARY KEY,
+  com_name     TEXT,
+  sci_name     TEXT,
+  family       TEXT,
+  url          TEXT,
+  attribution  TEXT,
+  license      TEXT,
+  content_hash TEXT,
+  -- AI-scoring-pass flag: 0 = not yet AI-scored, 1 = scored. Tracks the token
+  -- cost of the \`score\` workflow (Part B); the human approve/deny decision
+  -- still lives in photo_decision. \`sync\` (re)inserts rows with reviewed=0;
+  -- re-running \`sync\` after new photos land re-surfaces them as reviewed=0.
+  reviewed     INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS photo_score (
+  id                INTEGER PRIMARY KEY,
+  species_code      TEXT,
+  role              TEXT,           -- 'current' | 'candidate'
+  candidate_inat_id INTEGER,
+  content_hash      TEXT,
+  overall           REAL,
+  verdict           TEXT,
+  criteria_json     TEXT,
+  flags_json        TEXT,
+  rationale         TEXT,
+  rubric_version    TEXT,
+  scored_at         TEXT
+);
+
+CREATE TABLE IF NOT EXISTS photo_candidate (
+  id           INTEGER PRIMARY KEY,
+  species_code TEXT,
+  inat_id      INTEGER,
+  photo_url    TEXT,
+  thumb_path   TEXT,
+  attribution  TEXT,
+  license      TEXT,
+  excluded     INTEGER DEFAULT 0,
+  source_round INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS photo_decision (
+  species_code        TEXT PRIMARY KEY,
+  action              TEXT,         -- 'approve' | 'keep' | 'deny' | 'pending'
+  chosen_candidate_id INTEGER,
+  deny_reason         TEXT,
+  deny_tags_json      TEXT,
+  decided_at          TEXT,
+  applied             INTEGER DEFAULT 0,
+  applied_at          TEXT,
+  -- Re-source queue flag: 0 = no alternate needed, 1 = a deny exhausted the
+  -- pre-scored alternate pool and an additional source/score round is queued.
+  -- denyAndAdvance (Slice 4b data layer) sets this when no scored alternate
+  -- remains; POST /api/deny surfaces it as resourceQueued. Per-species deny
+  -- state — lives here alongside deny_reason/deny_tags_json/action, NOT on
+  -- photo_current.
+  resource_requested  INTEGER NOT NULL DEFAULT 0
+);
+
+-- One report per (subject, content_hash): re-scoring an unchanged image is a
+-- no-op the orchestrator can detect before calling the judge.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_photo_score_subject
+  ON photo_score (species_code, role, content_hash);
+
+-- Dedupe candidates per species + round.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_photo_candidate_unique
+  ON photo_candidate (species_code, inat_id, source_round);
+`;
+
+/**
+ * Open (or create) the review store at `path` and ensure the schema exists.
+ * Pass ':memory:' in tests. WAL is enabled for the on-disk case so the Slice-5
+ * review server can read while the CLI writes; no-op on :memory:. THE store
+ * opener — Slices 5 and 8 import `openDb` from here.
+ */
+export function openDb(path: string = DEFAULT_DB_PATH): Database.Database {
+  const db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(SCHEMA);
+  return db;
+}

--- a/tools/photo-curation/src/decision.test.ts
+++ b/tools/photo-curation/src/decision.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDb } from './db.js';
+import { insertCandidate, listCandidates } from './store.js';
+import {
+  getDecision, stageApprove, stageKeep, stageDeny,
+  listPendingApplies, markApplied,
+} from './decision.js';
+
+let db: Database.Database;
+beforeEach(() => {
+  db = openDb(':memory:');
+  insertCandidate(db, { speciesCode: 'amerob', inatId: 111, photoUrl: 'u1', thumbPath: 't1', attribution: 'a1', license: 'cc-by', sourceRound: 0 });
+  insertCandidate(db, { speciesCode: 'amerob', inatId: 222, photoUrl: 'u2', thumbPath: 't2', attribution: 'a2', license: 'cc0', sourceRound: 0 });
+});
+afterEach(() => { db.close(); });
+
+describe('decision state machine', () => {
+  it('defaults to pending for an untouched species', () => {
+    expect(getDecision(db, 'amerob').action).toBe('pending');
+  });
+
+  it('approve records the chosen candidate and stays unapplied', () => {
+    stageApprove(db, 'amerob', 222);
+    const d = getDecision(db, 'amerob');
+    expect(d.action).toBe('approve');
+    expect(d.chosenCandidateId).toBe(222);
+    expect(d.applied).toBe(false);
+  });
+
+  it('keep-original records keep with no candidate', () => {
+    stageKeep(db, 'amerob');
+    const d = getDecision(db, 'amerob');
+    expect(d.action).toBe('keep');
+    expect(d.chosenCandidateId).toBeNull();
+  });
+
+  it('deny stores reason+tags, excludes the shown candidates, and returns the DenyContext', () => {
+    const shown = listCandidates(db, 'amerob').map(c => c.inatId); // [111, 222]
+    const ctx = stageDeny(db, 'amerob', {
+      reason: 'all captive feeder shots, still too distant',
+      tags: ['captive-feeder', 'still-distant'],
+      shownInatIds: shown,
+    });
+    const d = getDecision(db, 'amerob');
+    expect(d.action).toBe('deny');
+    expect(d.denyReason).toContain('captive feeder');
+    expect(d.denyTags).toEqual(['captive-feeder', 'still-distant']);
+    // shown candidates are now excluded → off the next swap screen
+    expect(listCandidates(db, 'amerob')).toEqual([]);
+    // the returned DenyContext biases the re-source and excludes shown ids
+    expect(ctx.reason).toContain('captive feeder');
+    expect(ctx.tags).toEqual(['captive-feeder', 'still-distant']);
+  });
+
+  it('re-deciding overwrites the staged decision (PK species_code)', () => {
+    stageApprove(db, 'amerob', 222);
+    stageKeep(db, 'amerob');
+    expect(getDecision(db, 'amerob').action).toBe('keep');
+  });
+
+  it('listPendingApplies returns only approved+unapplied; markApplied flips it', () => {
+    stageApprove(db, 'amerob', 222);
+    stageKeep(db, 'btbwar'); // keep is not an apply
+    expect(listPendingApplies(db).map(d => d.speciesCode)).toEqual(['amerob']);
+    markApplied(db, 'amerob');
+    expect(listPendingApplies(db)).toEqual([]);
+    expect(getDecision(db, 'amerob').applied).toBe(true);
+  });
+});

--- a/tools/photo-curation/src/decision.ts
+++ b/tools/photo-curation/src/decision.ts
@@ -1,0 +1,135 @@
+import type Database from 'better-sqlite3';
+import { markCandidatesExcluded } from './store.js';
+// DenyContext is the Slice-3 sourcer's bias input — imported across the
+// workspace boundary from the ingestor package (re-exported from its index).
+import type { DenyContext } from '@bird-watch/ingestor';
+
+export type DecisionAction = 'approve' | 'keep' | 'deny' | 'pending';
+
+export interface Decision {
+  speciesCode: string;
+  action: DecisionAction;
+  chosenCandidateId: number | null;
+  denyReason: string | null;
+  denyTags: string[];
+  decidedAt: string | null;
+  applied: boolean;
+  appliedAt: string | null;
+}
+
+interface DecisionRow {
+  species_code: string;
+  action: DecisionAction;
+  chosen_candidate_id: number | null;
+  deny_reason: string | null;
+  deny_tags_json: string | null;
+  decided_at: string | null;
+  applied: number;
+  applied_at: string | null;
+}
+
+function rowToDecision(r: DecisionRow): Decision {
+  return {
+    speciesCode: r.species_code,
+    action: r.action,
+    chosenCandidateId: r.chosen_candidate_id,
+    denyReason: r.deny_reason,
+    denyTags: r.deny_tags_json ? (JSON.parse(r.deny_tags_json) as string[]) : [],
+    decidedAt: r.decided_at,
+    applied: r.applied === 1,
+    appliedAt: r.applied_at,
+  };
+}
+
+/** Read the staged decision; an untouched species reads as `pending`/unapplied. */
+export function getDecision(db: Database.Database, speciesCode: string): Decision {
+  const row = db.prepare(
+    `SELECT * FROM photo_decision WHERE species_code=?`,
+  ).get(speciesCode) as DecisionRow | undefined;
+  if (!row) {
+    return {
+      speciesCode, action: 'pending', chosenCandidateId: null,
+      denyReason: null, denyTags: [], decidedAt: null, applied: false, appliedAt: null,
+    };
+  }
+  return rowToDecision(row);
+}
+
+/**
+ * Upsert a decision row (PK species_code — re-deciding overwrites). Always
+ * resets `applied=0`: a fresh decision must be re-applied. Only markApplied
+ * sets `applied_at`.
+ */
+function upsertDecision(
+  db: Database.Database,
+  d: Pick<Decision, 'speciesCode' | 'action' | 'chosenCandidateId' | 'denyReason'> & { denyTags: string[] },
+): void {
+  db.prepare(
+    `INSERT INTO photo_decision
+       (species_code, action, chosen_candidate_id, deny_reason, deny_tags_json, decided_at, applied, applied_at)
+     VALUES (@species_code, @action, @chosen_candidate_id, @deny_reason, @deny_tags_json, @decided_at, 0, NULL)
+     ON CONFLICT(species_code) DO UPDATE SET
+       action=excluded.action, chosen_candidate_id=excluded.chosen_candidate_id,
+       deny_reason=excluded.deny_reason, deny_tags_json=excluded.deny_tags_json,
+       decided_at=excluded.decided_at, applied=0, applied_at=NULL`,
+  ).run({
+    species_code: d.speciesCode,
+    action: d.action,
+    chosen_candidate_id: d.chosenCandidateId,
+    deny_reason: d.denyReason,
+    deny_tags_json: JSON.stringify(d.denyTags),
+    decided_at: new Date().toISOString(),
+  });
+}
+
+/** Stage an approval featuring `candidateInatId`. Nothing mutates prod until Slice-8 apply. */
+export function stageApprove(db: Database.Database, speciesCode: string, candidateInatId: number): void {
+  upsertDecision(db, {
+    speciesCode, action: 'approve', chosenCandidateId: candidateInatId,
+    denyReason: null, denyTags: [],
+  });
+}
+
+/** Stage "keep the original" — no swap will be applied for this species. */
+export function stageKeep(db: Database.Database, speciesCode: string): void {
+  upsertDecision(db, {
+    speciesCode, action: 'keep', chosenCandidateId: null, denyReason: null, denyTags: [],
+  });
+}
+
+export interface DenyArgs {
+  reason: string;
+  tags: string[]; // quick-chips: 'too-dark','wrong-sex-morph','still-distant','cluttered-background','captive-feeder','not-sharp'
+  shownInatIds: number[];
+}
+
+/**
+ * Deny: record reason+tags, exclude the shown candidates so they never
+ * re-appear, and return a DenyContext for the caller to feed into
+ * fetchInatCandidates (Slice 3). The re-source itself (sources.ts →
+ * scoreAndCacheCandidates) lands new candidates in a higher source_round; the
+ * Slice-5 swap screen then refreshes.
+ */
+export function stageDeny(db: Database.Database, speciesCode: string, args: DenyArgs): DenyContext {
+  upsertDecision(db, {
+    speciesCode, action: 'deny', chosenCandidateId: null,
+    denyReason: args.reason, denyTags: args.tags,
+  });
+  markCandidatesExcluded(db, speciesCode, args.shownInatIds);
+  return { reason: args.reason, tags: args.tags };
+}
+
+/** Decisions ready to push: approved and not yet applied (consumed by Slice-8 apply-swaps). */
+export function listPendingApplies(db: Database.Database): Decision[] {
+  const rows = db.prepare(
+    `SELECT * FROM photo_decision WHERE action='approve' AND applied=0 ORDER BY species_code`,
+  ).all() as DecisionRow[];
+  return rows.map(rowToDecision);
+}
+
+/** Mark a decision applied after a successful admin-endpoint call (Slice 8). */
+export function markApplied(db: Database.Database, speciesCode: string): void {
+  db.prepare(
+    `UPDATE photo_decision SET applied=1, applied_at=? WHERE species_code=?`,
+  ).run(new Date().toISOString(), speciesCode);
+}

--- a/tools/photo-curation/src/hash.test.ts
+++ b/tools/photo-curation/src/hash.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { sha256hex, sha8 } from './hash.js';
+
+describe('hash', () => {
+  it('sha256hex is deterministic and 64 hex chars', () => {
+    const a = sha256hex(Buffer.from('bird'));
+    const b = sha256hex(Buffer.from('bird'));
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('sha8 is the first 8 hex chars of sha256', () => {
+    const buf = Buffer.from('bird');
+    expect(sha8(buf)).toBe(sha256hex(buf).slice(0, 8));
+    expect(sha8(buf)).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('different bytes hash differently', () => {
+    expect(sha8(Buffer.from('a'))).not.toBe(sha8(Buffer.from('b')));
+  });
+});

--- a/tools/photo-curation/src/hash.ts
+++ b/tools/photo-curation/src/hash.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+
+/** Full lowercase hex SHA-256 of the given bytes. */
+export function sha256hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * First 8 hex chars of the SHA-256 — the content-hash cache key here and
+ * (Slice 7) the R2 object-key suffix `species/<code>.<sha8>.<ext>`. 32 bits;
+ * key is always scoped per species, so a global collision is harmless.
+ */
+export function sha8(bytes: Buffer): string {
+  return sha256hex(bytes).slice(0, 8);
+}

--- a/tools/photo-curation/src/judge.test.ts
+++ b/tools/photo-curation/src/judge.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { FakeJudge } from './judge.js';
+import type { ImageInput, SpeciesContext } from '@bird-watch/photo-quality';
+
+const img: ImageInput = { buffer: Buffer.from('x'), mime: 'image/jpeg' };
+const ctx: SpeciesContext = { speciesCode: 'amerob', comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' };
+
+describe('FakeJudge', () => {
+  it('returns the canned criteria/flags/rationale for a registered key', async () => {
+    const judge = new FakeJudge({
+      'image/jpeg': {
+        criteria: { framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 8, lighting: 8 },
+        flags: [],
+        rationale: 'canned good',
+      },
+    });
+    const out = await judge.judge(img, ctx, 'prompt');
+    expect(out.criteria.subjectClarity).toBe(9);
+    expect(out.flags).toEqual([]);
+    expect(out.rationale).toBe('canned good');
+  });
+
+  it('falls back to a neutral mid response for an unregistered key', async () => {
+    const judge = new FakeJudge({});
+    const out = await judge.judge(img, ctx, 'prompt');
+    expect(out.criteria.framing).toBe(5);
+    expect(out.flags).toEqual([]);
+  });
+});

--- a/tools/photo-curation/src/judge.ts
+++ b/tools/photo-curation/src/judge.ts
@@ -1,0 +1,25 @@
+import type { ImageInput, SpeciesContext, VisionJudge, CriteriaScores } from '@bird-watch/photo-quality';
+
+type JudgeOutput = { criteria: CriteriaScores; flags: string[]; rationale: string };
+
+const NEUTRAL: JudgeOutput = {
+  criteria: { framing: 5, subjectClarity: 5, liveness: 5, naturalness: 5, pose: 5, background: 5, lighting: 5 },
+  flags: [],
+  rationale: 'neutral (unregistered fake key)',
+};
+
+/**
+ * Deterministic test double for VisionJudge. Keyed by image `mime` for the
+ * simple tests here. No network. The PRODUCTION judge is NOT defined here and is
+ * NOT an SDK call — it is a Claude Code agent the Part B `score` workflow
+ * supplies (Part B, Task 8): per image it `Read`s the downloaded file, applies
+ * defaultRubricConfig.judgePrompt, and returns {criteria, flags, rationale} as
+ * StructuredOutput. No @anthropic-ai/sdk, no ANTHROPIC_API_KEY. Adding an SDK
+ * judge here is a contract violation — do not.
+ */
+export class FakeJudge implements VisionJudge {
+  constructor(private readonly canned: Record<string, JudgeOutput>) {}
+  async judge(img: ImageInput, _ctx: SpeciesContext, _prompt: string): Promise<JudgeOutput> {
+    return this.canned[img.mime] ?? NEUTRAL;
+  }
+}

--- a/tools/photo-curation/src/store.test.ts
+++ b/tools/photo-curation/src/store.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDb } from './db.js';
+import {
+  upsertCurrentPhoto, upsertScore, getScoreByHash,
+  insertCandidate, listCandidates, markCandidatesExcluded,
+  selectUnreviewed, markReviewed,
+} from './store.js';
+import type { QualityReport } from '@bird-watch/photo-quality';
+
+let db: Database.Database;
+beforeEach(() => { db = openDb(':memory:'); });
+afterEach(() => { db.close(); });
+
+const report: QualityReport = {
+  overall: 82,
+  verdict: 'good',
+  deterministic: {
+    width: 1200, height: 900, megapixels: 1.08, sharpness: 140,
+    exposure: 0.9, aspectRatio: 1.333, passedGate: true, failReasons: [],
+  },
+  criteria: {
+    framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9,
+    pose: 7, background: 8, lighting: 8,
+  },
+  flags: [],
+  rationale: 'Sharp perched adult, natural perch, good light.',
+  rubricVersion: '1.0.0',
+};
+
+describe('store', () => {
+  it('upserts and reads back the current photo', () => {
+    upsertCurrentPhoto(db, {
+      speciesCode: 'amerob', comName: 'American Robin', sciName: 'Turdus migratorius',
+      family: 'Turdidae', url: 'https://photos.bird-maps.com/species/amerob.aaaaaaaa.jpg',
+      attribution: '(c) X (CC BY)', license: 'cc-by', contentHash: 'deadbeef',
+    });
+    const row = db.prepare(`SELECT * FROM photo_current WHERE species_code=?`).get('amerob') as any;
+    expect(row.com_name).toBe('American Robin');
+    expect(row.content_hash).toBe('deadbeef');
+  });
+
+  it('upsertScore round-trips JSON columns and getScoreByHash finds it (the cache check)', () => {
+    upsertScore(db, {
+      speciesCode: 'amerob', role: 'current', candidateInatId: null,
+      contentHash: 'deadbeef', report,
+    });
+    const found = getScoreByHash(db, 'amerob', 'current', 'deadbeef');
+    expect(found).not.toBeNull();
+    expect(found!.overall).toBe(82);
+    expect(found!.verdict).toBe('good');
+    expect(found!.criteria.subjectClarity).toBe(9);
+    expect(found!.flags).toEqual([]);
+    expect(found!.rubricVersion).toBe('1.0.0');
+  });
+
+  it('getScoreByHash returns null for an unscored hash (drives the cache miss path)', () => {
+    expect(getScoreByHash(db, 'amerob', 'current', 'nope')).toBeNull();
+  });
+
+  it('upsertScore is idempotent on (species_code, role, content_hash)', () => {
+    const args = {
+      speciesCode: 'amerob' as const, role: 'current' as const,
+      candidateInatId: null, contentHash: 'deadbeef', report,
+    };
+    upsertScore(db, args);
+    upsertScore(db, { ...args, report: { ...report, overall: 99 } });
+    const n = (db.prepare(`SELECT COUNT(*) c FROM photo_score`).get() as { c: number }).c;
+    expect(n).toBe(1);
+    expect(getScoreByHash(db, 'amerob', 'current', 'deadbeef')!.overall).toBe(99);
+  });
+
+  it('insert/list/exclude candidates round-trip with excluded filtering', () => {
+    insertCandidate(db, {
+      speciesCode: 'amerob', inatId: 111, photoUrl: 'https://inat/111/medium.jpg',
+      thumbPath: './thumb-cache/amerob-111.jpg', attribution: '(c) A (CC BY)',
+      license: 'cc-by', sourceRound: 0,
+    });
+    insertCandidate(db, {
+      speciesCode: 'amerob', inatId: 222, photoUrl: 'https://inat/222/medium.jpg',
+      thumbPath: './thumb-cache/amerob-222.jpg', attribution: '(c) B (CC0)',
+      license: 'cc0', sourceRound: 0,
+    });
+    expect(listCandidates(db, 'amerob').length).toBe(2);
+    markCandidatesExcluded(db, 'amerob', [111]);
+    expect(listCandidates(db, 'amerob').map(c => c.inatId)).toEqual([222]);
+    expect(listCandidates(db, 'amerob', { includeExcluded: true }).length).toBe(2);
+  });
+
+  it('selectUnreviewed returns up to `limit` reviewed=0 rows; markReviewed flips one (the batched-score loop)', () => {
+    const mk = (code: string) => upsertCurrentPhoto(db, {
+      speciesCode: code, comName: code, sciName: code, family: 'Turdidae',
+      url: `https://photos.bird-maps.com/species/${code}.aaaaaaaa.jpg`,
+      attribution: '(c) X (CC BY)', license: 'cc-by', contentHash: 'deadbeef',
+    });
+    mk('amerob'); mk('btbwar'); mk('wlswar');
+    // all three start reviewed=0 (column default); limit caps the batch
+    expect(selectUnreviewed(db, 2).length).toBe(2);
+    expect(selectUnreviewed(db, 10).map(r => r.speciesCode).sort())
+      .toEqual(['amerob', 'btbwar', 'wlswar']);
+    // scoring amerob removes it from the unreviewed backlog
+    markReviewed(db, 'amerob');
+    expect(selectUnreviewed(db, 10).map(r => r.speciesCode).sort())
+      .toEqual(['btbwar', 'wlswar']);
+  });
+
+  it('markReviewed is idempotent (calling it twice leaves the row scored)', () => {
+    upsertCurrentPhoto(db, {
+      speciesCode: 'amerob', comName: 'American Robin', sciName: 'Turdus migratorius',
+      family: 'Turdidae', url: 'https://photos.bird-maps.com/species/amerob.aaaaaaaa.jpg',
+      attribution: '(c) X (CC BY)', license: 'cc-by', contentHash: 'deadbeef',
+    });
+    markReviewed(db, 'amerob');
+    markReviewed(db, 'amerob'); // idempotent
+    expect(selectUnreviewed(db, 10)).toEqual([]);
+  });
+});

--- a/tools/photo-curation/src/store.ts
+++ b/tools/photo-curation/src/store.ts
@@ -1,0 +1,259 @@
+import type Database from 'better-sqlite3';
+import type { QualityReport, CriteriaScores, Verdict } from '@bird-watch/photo-quality';
+
+export interface CurrentPhotoInput {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  url: string;
+  attribution: string;
+  license: string;
+  contentHash: string;
+}
+
+export type ScoreRole = 'current' | 'candidate';
+
+export interface ScoreInput {
+  speciesCode: string;
+  role: ScoreRole;
+  candidateInatId: number | null;
+  contentHash: string;
+  report: QualityReport;
+}
+
+export interface StoredScore {
+  speciesCode: string;
+  role: ScoreRole;
+  candidateInatId: number | null;
+  contentHash: string;
+  overall: number;
+  verdict: Verdict;
+  criteria: CriteriaScores;
+  flags: string[];
+  rationale: string;
+  rubricVersion: string;
+  scoredAt: string;
+}
+
+export interface CandidateInput {
+  speciesCode: string;
+  inatId: number;
+  photoUrl: string;
+  thumbPath: string;
+  attribution: string;
+  license: string;
+  sourceRound: number;
+}
+
+export interface StoredCandidate extends CandidateInput {
+  id: number;
+  excluded: boolean;
+}
+
+/** Upsert the snapshot of a species' live photo (PK species_code). */
+export function upsertCurrentPhoto(db: Database.Database, p: CurrentPhotoInput): void {
+  db.prepare(
+    `INSERT INTO photo_current
+       (species_code, com_name, sci_name, family, url, attribution, license, content_hash)
+     VALUES (@speciesCode, @comName, @sciName, @family, @url, @attribution, @license, @contentHash)
+     ON CONFLICT(species_code) DO UPDATE SET
+       com_name=excluded.com_name, sci_name=excluded.sci_name, family=excluded.family,
+       url=excluded.url, attribution=excluded.attribution, license=excluded.license,
+       content_hash=excluded.content_hash`,
+  ).run(p);
+}
+
+export interface UnreviewedPhoto {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  url: string;
+  attribution: string;
+  license: string;
+  contentHash: string;
+}
+
+interface CurrentPhotoRow {
+  species_code: string;
+  com_name: string;
+  sci_name: string;
+  family: string;
+  url: string;
+  attribution: string;
+  license: string;
+  content_hash: string;
+}
+
+/**
+ * The batched-`score` backlog query: up to `limit` photo_current rows with
+ * reviewed=0 (not yet AI-scored), oldest-first by species_code. Part B's
+ * `score` workflow pulls a batch (default 10, max 100), agent-scores each, and
+ * calls markReviewed to clear it from the backlog — resumable across sessions.
+ * `limit` is clamped to [1,100] by the caller (the CLI `--limit` flag).
+ */
+export function selectUnreviewed(db: Database.Database, limit: number): UnreviewedPhoto[] {
+  const rows = db.prepare(
+    `SELECT species_code, com_name, sci_name, family, url, attribution, license, content_hash
+       FROM photo_current WHERE reviewed=0 ORDER BY species_code ASC LIMIT ?`,
+  ).all(limit) as CurrentPhotoRow[];
+  return rows.map(r => ({
+    speciesCode: r.species_code,
+    comName: r.com_name,
+    sciName: r.sci_name,
+    family: r.family,
+    url: r.url,
+    attribution: r.attribution,
+    license: r.license,
+    contentHash: r.content_hash,
+  }));
+}
+
+/** Mark a species' current photo AI-scored (reviewed=1) — clears it from selectUnreviewed. Idempotent. */
+export function markReviewed(db: Database.Database, speciesCode: string): void {
+  db.prepare(`UPDATE photo_current SET reviewed=1 WHERE species_code=?`).run(speciesCode);
+}
+
+/**
+ * Upsert a scoring report keyed by (species_code, role, content_hash). The
+ * unique index makes this the idempotent cache row: a re-score of the same
+ * image overwrites in place. JSON columns hold criteria + flags.
+ */
+export function upsertScore(db: Database.Database, s: ScoreInput): void {
+  db.prepare(
+    `INSERT INTO photo_score
+       (species_code, role, candidate_inat_id, content_hash, overall, verdict,
+        criteria_json, flags_json, rationale, rubric_version, scored_at)
+     VALUES (@species_code, @role, @candidate_inat_id, @content_hash, @overall, @verdict,
+        @criteria_json, @flags_json, @rationale, @rubric_version, @scored_at)
+     ON CONFLICT(species_code, role, content_hash) DO UPDATE SET
+       candidate_inat_id=excluded.candidate_inat_id, overall=excluded.overall,
+       verdict=excluded.verdict, criteria_json=excluded.criteria_json,
+       flags_json=excluded.flags_json, rationale=excluded.rationale,
+       rubric_version=excluded.rubric_version, scored_at=excluded.scored_at`,
+  ).run({
+    species_code: s.speciesCode,
+    role: s.role,
+    candidate_inat_id: s.candidateInatId,
+    content_hash: s.contentHash,
+    overall: s.report.overall,
+    verdict: s.report.verdict,
+    criteria_json: JSON.stringify(s.report.criteria),
+    flags_json: JSON.stringify(s.report.flags),
+    rationale: s.report.rationale,
+    rubric_version: s.report.rubricVersion,
+    scored_at: new Date().toISOString(),
+  });
+}
+
+interface ScoreRow {
+  species_code: string;
+  role: ScoreRole;
+  candidate_inat_id: number | null;
+  content_hash: string;
+  overall: number;
+  verdict: Verdict;
+  criteria_json: string;
+  flags_json: string;
+  rationale: string;
+  rubric_version: string;
+  scored_at: string;
+}
+
+/**
+ * The cache check: return the stored report for this image content hash, or
+ * null when unscored. The orchestrator calls this BEFORE scoreImage to avoid a
+ * redundant (paid) judge call.
+ */
+export function getScoreByHash(
+  db: Database.Database, speciesCode: string, role: ScoreRole, contentHash: string,
+): StoredScore | null {
+  const row = db.prepare(
+    `SELECT * FROM photo_score WHERE species_code=? AND role=? AND content_hash=?`,
+  ).get(speciesCode, role, contentHash) as ScoreRow | undefined;
+  if (!row) return null;
+  return {
+    speciesCode: row.species_code,
+    role: row.role,
+    candidateInatId: row.candidate_inat_id,
+    contentHash: row.content_hash,
+    overall: row.overall,
+    verdict: row.verdict,
+    criteria: JSON.parse(row.criteria_json) as CriteriaScores,
+    flags: JSON.parse(row.flags_json) as string[],
+    rationale: row.rationale,
+    rubricVersion: row.rubric_version,
+    scoredAt: row.scored_at,
+  };
+}
+
+/** Insert a sourced candidate. Ignores a duplicate (species, inat_id, round). */
+export function insertCandidate(db: Database.Database, c: CandidateInput): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO photo_candidate
+       (species_code, inat_id, photo_url, thumb_path, attribution, license, source_round)
+     VALUES (@speciesCode, @inatId, @photoUrl, @thumbPath, @attribution, @license, @sourceRound)`,
+  ).run(c);
+}
+
+interface CandidateRow {
+  id: number;
+  species_code: string;
+  inat_id: number;
+  photo_url: string;
+  thumb_path: string;
+  attribution: string;
+  license: string;
+  excluded: number;
+  source_round: number;
+}
+
+/** List candidates for a species, newest round first; excludes `excluded=1` by default. */
+export function listCandidates(
+  db: Database.Database, speciesCode: string, opts: { includeExcluded?: boolean } = {},
+): StoredCandidate[] {
+  const where = opts.includeExcluded
+    ? `species_code=?`
+    : `species_code=? AND excluded=0`;
+  const rows = db.prepare(
+    `SELECT * FROM photo_candidate WHERE ${where} ORDER BY source_round DESC, id ASC`,
+  ).all(speciesCode) as CandidateRow[];
+  return rows.map(r => ({
+    id: r.id,
+    speciesCode: r.species_code,
+    inatId: r.inat_id,
+    photoUrl: r.photo_url,
+    thumbPath: r.thumb_path,
+    attribution: r.attribution,
+    license: r.license,
+    excluded: r.excluded === 1,
+    sourceRound: r.source_round,
+  }));
+}
+
+/**
+ * Mark the given iNat ids excluded for a species (deny → remove from the next
+ * swap screen). Scoped by species_code because the candidate uniqueness key is
+ * (species_code, inat_id, source_round) — inat_id is NOT unique on its own, so
+ * an unscoped `WHERE inat_id=?` could over-exclude a same-id row under another
+ * species.
+ */
+export function markCandidatesExcluded(
+  db: Database.Database, speciesCode: string, inatIds: number[],
+): void {
+  if (inatIds.length === 0) return;
+  const stmt = db.prepare(
+    `UPDATE photo_candidate SET excluded=1 WHERE species_code=? AND inat_id=?`,
+  );
+  const tx = db.transaction((ids: number[]) => { for (const id of ids) stmt.run(speciesCode, id); });
+  tx(inatIds);
+}
+
+/** Highest source_round seen for a species (-1 when none) — the re-source counter. */
+export function maxSourceRound(db: Database.Database, speciesCode: string): number {
+  const row = db.prepare(
+    `SELECT COALESCE(MAX(source_round), -1) AS r FROM photo_candidate WHERE species_code=?`,
+  ).get(speciesCode) as { r: number };
+  return row.r;
+}

--- a/tools/photo-curation/tsconfig.json
+++ b/tools/photo-curation/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/tools/photo-curation/vitest.config.ts
+++ b/tools/photo-curation/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant CLI as photo-curate (Part B)
    participant Store as store.ts / decision.ts
    participant DB as review.sqlite (openDb)
    participant Judge as FakeJudge / agent (Part B)

    CLI->>Store: selectUnreviewed(db, limit)
    Store->>DB: SELECT reviewed=0 oldest-first
    DB-->>Store: unreviewed photos
    CLI->>Judge: judge(image, ctx, prompt)
    Judge-->>CLI: criteria, flags, rationale
    CLI->>Store: upsertScore + markReviewed
    Store->>DB: INSERT photo_score, reviewed=1
    CLI->>Store: stageDeny(reason, tags, shownIds)
    Store->>DB: mark candidates excluded
    Store-->>CLI: DenyContext for re-source
```

## Summary

- Stands up the new local `tools/photo-curation` workspace (`@bird-watch/photo-curation`, bin `photo-curate`) — Part A of the photo-curation epic. This slice is the **sole** owner of adding `"tools/*"` to the root `package.json` `workspaces`, and lays the SQLite foundation Part B (#971) and Slices 5/8 build on.
- Foundation layer: `sha8` content-hash helper; `openDb` (in `src/db.ts`) creating the four contract tables verbatim — `photo_current` carries `reviewed INTEGER NOT NULL DEFAULT 0` (AI-scoring-pass flag) and `photo_decision` carries `resource_requested INTEGER NOT NULL DEFAULT 0` (the Slice-4b re-source queue flag); the typed data layer (`store.ts`, incl. `selectUnreviewed`/`markReviewed` batch helpers); the decision/staging/deny→exclude state machine (`decision.ts`, returning a `DenyContext` from `@bird-watch/ingestor`); and a local `FakeJudge` test double.
- No SDK judge anywhere (no `@anthropic-ai/sdk`, no `ANTHROPIC_API_KEY`) — the production `VisionJudge` is a Claude Code agent supplied by Part B's `score` workflow. The ingestor `DenyContext` re-export already landed on `main` via #964, so it is not re-added here. All tests run against a real `:memory:` better-sqlite3 store (no DB mocks).

## Screenshots

N/A — not UI (internal tooling under `tools/`, no `frontend/**` changes).

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (5 files, 24 tests: hash 3, db 6, store 7, decision 6, judge 2)
- [x] New unit tests added (TDD per task — failing test confirmed before each implementation)
- [ ] New Playwright e2e spec added (N/A — not UI)
- [x] `npm run build` — clean production build (root chain green); `npm run build -w @bird-watch/photo-curation` green (Node types resolve via `@types/node` + `"types": ["node"]`)
- [x] `npx knip` clean (dated self-healing ignore entries added for Part-B-consumed deps per CLAUDE.md knip false-positive workflow); `npm install --package-lock-only && git diff --exit-code package-lock.json` clean

## Plan reference

Part of epic #974. Implements #970 ([photo-curation 4a] tools/photo-curation scaffold + SQLite store + data layer). Out of `docs/plans/` — this epic's plans live in issues.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)