### PR TITLE
feat(photo-curation): review server data layer — overview query + swap/decision writes + deny→advance (#972)

### DIFF
--- a/tools/photo-curation/src/server/queries.test.ts
+++ b/tools/photo-curation/src/server/queries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
+import { listOverview, type OverviewRow } from './queries.js';
 
 /** Open an in-memory db with the canonical schema and a tiny seed. */
 function seedDb(): Database.Database {
@@ -24,13 +25,105 @@ function seedDb(): Database.Database {
   return db;
 }
 
-describe('seedDb helper', () => {
+describe('listOverview', () => {
   let db: Database.Database;
   beforeEach(() => { db = seedDb(); });
   afterEach(() => db.close());
 
-  it('seeds the canonical schema with the two current photos', () => {
-    const n = db.prepare(`SELECT COUNT(*) AS c FROM photo_current`).get() as { c: number };
-    expect(n.c).toBe(2);
+  it('worst-first sorts ascending by overall', () => {
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'all' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa', 'amerob']);
+    expect(rows[0]!.overall).toBe(18);
+  });
+
+  it('best-first sorts descending by overall', () => {
+    const rows = listOverview(db, { sort: 'best-first', filter: 'all' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['amerob', 'houspa']);
+  });
+
+  it('parses flags and criteria from json', () => {
+    const houspa = listOverview(db, { sort: 'worst-first', filter: 'all' })[0]!;
+    expect(houspa.flags).toEqual(['dead', 'distant']);
+    expect(houspa.criteria.liveness).toBe(1);
+  });
+
+  it('filter=flagged returns only rows with >=1 flag', () => {
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'flagged' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa']);
+  });
+
+  it('filter=dead-sick matches the dead flag', () => {
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'dead-sick' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa']);
+  });
+
+  it('has-better-candidate sorts species with a higher-scoring candidate first', () => {
+    const rows = listOverview(db, { sort: 'has-better-candidate', filter: 'all' });
+    expect(rows[0]!.speciesCode).toBe('houspa'); // candidate 79 > current 18
+    expect(rows[0]!.bestCandidateOverall).toBe(79);
+    expect(rows.find(r => r.speciesCode === 'amerob')!.bestCandidateOverall).toBeNull();
+  });
+
+  it('recently-scored sorts by scored_at descending', () => {
+    // houspa scored 2026-06-11, amerob scored 2026-06-10
+    const rows = listOverview(db, { sort: 'recently-scored', filter: 'all' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa', 'amerob']);
+  });
+
+  it('filter=distant matches the distant flag', () => {
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'distant' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa']); // flags ['dead','distant']
+  });
+
+  it('filter=in-hand matches the in-hand flag', () => {
+    // amerob has no in-hand flag; flip its flags_json to include it
+    db.prepare(`UPDATE photo_score SET flags_json='["in-hand"]' WHERE species_code='amerob' AND role='current'`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'in-hand' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['amerob']);
+  });
+
+  it('filter=soft matches rows with subjectClarity in (0, SOFT_CLARITY_MAX]', () => {
+    // houspa's critBad has subjectClarity=3 (soft); amerob's is 9 (sharp)
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'soft' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['houspa']);
+  });
+
+  it('filter=marked-for-swap returns only species with a pending/approve decision', () => {
+    db.prepare(`INSERT INTO photo_decision (species_code, action, decided_at) VALUES ('amerob','pending','2026-06-11T00:00:00Z')`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'marked-for-swap' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['amerob']);
+  });
+
+  it('markedForSwap is true for a pending decision, false with no decision', () => {
+    db.prepare(`INSERT INTO photo_decision (species_code, action, decided_at) VALUES ('amerob','pending','2026-06-11T00:00:00Z')`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'all' });
+    expect(rows.find(r => r.speciesCode === 'amerob')!.markedForSwap).toBe(true);
+    expect(rows.find(r => r.speciesCode === 'houspa')!.markedForSwap).toBe(false); // no decision row
+  });
+
+  it('markedForSwap is true for an approve decision (intended mapping; see note)', () => {
+    db.prepare(`INSERT INTO photo_decision (species_code, action, decided_at) VALUES ('amerob','approve','2026-06-11T00:00:00Z')`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'all' });
+    expect(rows.find(r => r.speciesCode === 'amerob')!.markedForSwap).toBe(true);
+  });
+
+  it('markedForSwap is false for a keep/deny decision', () => {
+    db.prepare(`INSERT INTO photo_decision (species_code, action, decided_at) VALUES ('amerob','keep','2026-06-11T00:00:00Z')`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'all' });
+    expect(rows.find(r => r.speciesCode === 'amerob')!.markedForSwap).toBe(false);
+  });
+
+  it('exposes reviewed status; seeded rows are reviewed=1', () => {
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'all' });
+    expect(rows.every(r => r.reviewed === true)).toBe(true);
+  });
+
+  it('filter=unscored returns only rows with reviewed=0 (no current score yet)', () => {
+    // newly-synced species: reviewed=0, no photo_score(role='current')
+    db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('bewwre','Bewick''s Wren','Thryomanes bewickii','troglodytidae','https://photos/bewwre.jpg','(c) E','cc0','hashE',0)`).run();
+    const rows = listOverview(db, { sort: 'worst-first', filter: 'unscored' });
+    expect(rows.map(r => r.speciesCode)).toEqual(['bewwre']);
+    expect(rows[0]!.reviewed).toBe(false);
+    expect(rows[0]!.overall).toBeNull();
   });
 });

--- a/tools/photo-curation/src/server/queries.test.ts
+++ b/tools/photo-curation/src/server/queries.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { listOverview, type OverviewRow } from './queries.js';
+import { getSwapView, writeDecision, denyAndAdvance, selectUnreviewed, markReviewed, type DenyInput } from './queries.js';
 
 /** Open an in-memory db with the canonical schema and a tiny seed. */
 function seedDb(): Database.Database {
@@ -125,5 +126,153 @@ describe('listOverview', () => {
     expect(rows.map(r => r.speciesCode)).toEqual(['bewwre']);
     expect(rows[0]!.reviewed).toBe(false);
     expect(rows[0]!.overall).toBeNull();
+  });
+});
+
+describe('getSwapView', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = seedDb(); });
+  afterEach(() => db.close());
+
+  it('returns current + top candidate + ranked alternates', () => {
+    // add a second, lower-scoring candidate
+    db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5002,'https://inat/5002.jpg','thumb-cache/5002.jpg','(c) D','cc0',0,1)`).run();
+    db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','candidate',5002,'hashD',61,'mediocre','{"framing":5,"subjectClarity":6,"liveness":7,"naturalness":6,"pose":5,"background":5,"lighting":6}','[]','ok','v1','2026-06-11T00:00:00Z')`).run();
+
+    const view = getSwapView(db, 'houspa');
+    expect(view).not.toBeNull();
+    expect(view!.current.overall).toBe(18);
+    expect(view!.proposed!.inatId).toBe(5001);       // 79 is top
+    expect(view!.alternates.map(a => a.inatId)).toEqual([5001, 5002]); // votes desc
+  });
+
+  it('excludes excluded candidates from proposed + alternates', () => {
+    db.prepare(`UPDATE photo_candidate SET excluded = 1 WHERE inat_id = 5001`).run();
+    const view = getSwapView(db, 'houspa');
+    expect(view!.proposed).toBeNull();
+    expect(view!.alternates).toEqual([]);
+  });
+
+  it('returns null for unknown species', () => {
+    expect(getSwapView(db, 'nope')).toBeNull();
+  });
+});
+
+describe('writeDecision', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = seedDb(); });
+  afterEach(() => db.close());
+
+  it('approve records the chosen candidate', () => {
+    writeDecision(db, { speciesCode: 'houspa', action: 'approve', chosenCandidateId: 5001 });
+    const row = db.prepare(`SELECT action, chosen_candidate_id, applied FROM photo_decision WHERE species_code='houspa'`).get() as { action: string; chosen_candidate_id: number; applied: number };
+    expect(row.action).toBe('approve');
+    expect(row.chosen_candidate_id).toBe(5001);
+    expect(row.applied).toBe(0); // staged, not applied
+  });
+
+  it('keep records action=keep with no candidate', () => {
+    writeDecision(db, { speciesCode: 'amerob', action: 'keep' });
+    const row = db.prepare(`SELECT action, chosen_candidate_id FROM photo_decision WHERE species_code='amerob'`).get() as { action: string; chosen_candidate_id: number | null };
+    expect(row.action).toBe('keep');
+    expect(row.chosen_candidate_id).toBeNull();
+  });
+
+  it('re-deciding upserts on species_code (PK)', () => {
+    writeDecision(db, { speciesCode: 'amerob', action: 'keep' });
+    writeDecision(db, { speciesCode: 'amerob', action: 'approve', chosenCandidateId: 9 });
+    const n = db.prepare(`SELECT COUNT(*) AS c FROM photo_decision WHERE species_code='amerob'`).get() as { c: number };
+    expect(n.c).toBe(1);
+  });
+});
+
+describe('denyAndAdvance', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = seedDb(); });
+  afterEach(() => db.close());
+
+  it('advances to the next pre-scored alternate when one remains (no re-source)', () => {
+    // second candidate, scored 61 — denying the top (5001) should advance to it
+    db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5002,'https://inat/5002.jpg','thumb-cache/5002.jpg','(c) D','cc0',0,1)`).run();
+    db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','candidate',5002,'hashD',61,'mediocre','{"framing":5,"subjectClarity":6,"liveness":7,"naturalness":6,"pose":5,"background":5,"lighting":6}','[]','ok','v1','2026-06-11T00:00:00Z')`).run();
+
+    const input: DenyInput = {
+      speciesCode: 'houspa',
+      reason: 'top pick still too far',
+      tags: ['still-distant'],
+      excludeIds: [5001], // the shown candidate(s) the reviewer rejected
+    };
+    const out = denyAndAdvance(db, input);
+
+    const dec = db.prepare(`SELECT action, deny_reason, deny_tags_json FROM photo_decision WHERE species_code='houspa'`).get() as { action: string; deny_reason: string; deny_tags_json: string };
+    expect(dec.action).toBe('deny');
+    expect(dec.deny_reason).toBe('top pick still too far');
+    expect(JSON.parse(dec.deny_tags_json)).toEqual(['still-distant']);
+
+    // 5001 is hidden; 5002 stays in the pool
+    const excluded = db.prepare(`SELECT inat_id FROM photo_candidate WHERE species_code='houspa' AND excluded=1`).all() as { inat_id: number }[];
+    expect(excluded.map(e => e.inat_id)).toEqual([5001]);
+
+    // instant advance to the next already-scored alternate; no re-source queued
+    expect(out.next!.inatId).toBe(5002);
+    expect(out.next!.overall).toBe(61);
+    expect(out.resourceRequested).toBe(false);
+    const flag = db.prepare(`SELECT resource_requested FROM photo_decision WHERE species_code='houspa'`).get() as { resource_requested: number };
+    expect(flag.resource_requested).toBe(0);
+
+    // DenyContext is still surfaced for the route to log / future source-candidates run
+    expect(out.denyContext).toEqual({ reason: 'top pick still too far', tags: ['still-distant'] });
+  });
+
+  it('sets resource_requested when the pre-scored pool is exhausted', () => {
+    // seed has only candidate 5001 for houspa; denying it empties the pool
+    const input: DenyInput = {
+      speciesCode: 'houspa',
+      reason: 'still too far and dim',
+      tags: ['still-distant', 'too-dark'],
+      excludeIds: [5001],
+    };
+    const out = denyAndAdvance(db, input);
+
+    const excluded = db.prepare(`SELECT inat_id FROM photo_candidate WHERE species_code='houspa' AND excluded=1`).all() as { inat_id: number }[];
+    expect(excluded.map(e => e.inat_id)).toEqual([5001]);
+
+    // no scored alternate left → advance is null and the re-source flag is set
+    expect(out.next).toBeNull();
+    expect(out.resourceRequested).toBe(true);
+    const flag = db.prepare(`SELECT resource_requested FROM photo_decision WHERE species_code='houspa'`).get() as { resource_requested: number };
+    expect(flag.resource_requested).toBe(1);
+
+    expect(out.denyContext).toEqual({ reason: 'still too far and dim', tags: ['still-distant', 'too-dark'] });
+  });
+
+  it('treats an unscored candidate as not a valid advance (pool effectively exhausted)', () => {
+    // a non-excluded candidate exists but has NO photo_score row → not yet scored
+    db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5003,'https://inat/5003.jpg','thumb-cache/5003.jpg','(c) E','cc0',0,1)`).run();
+    const out = denyAndAdvance(db, { speciesCode: 'houspa', reason: 'nope', tags: [], excludeIds: [5001] });
+    expect(out.next).toBeNull();           // 5003 is unscored, so it can't be the instant advance
+    expect(out.resourceRequested).toBe(true);
+  });
+});
+
+describe('selectUnreviewed / markReviewed (scoring-pass cursor)', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = seedDb(); });
+  afterEach(() => db.close());
+
+  it('selectUnreviewed returns up to `limit` reviewed=0 species', () => {
+    db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('bewwre','Bewick''s Wren','Thryomanes bewickii','troglodytidae','https://photos/bewwre.jpg','(c) E','cc0','hashE',0)`).run();
+    db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('bushti','Bushtit','Psaltriparus minimus','aegithalidae','https://photos/bushti.jpg','(c) F','cc0','hashF',0)`).run();
+    // seeded amerob/houspa are reviewed=1, so only the two new rows qualify
+    expect(selectUnreviewed(db, 10).map(r => r.speciesCode).sort()).toEqual(['bewwre', 'bushti']);
+    expect(selectUnreviewed(db, 1).length).toBe(1); // limit is honored
+  });
+
+  it('markReviewed flips a row to reviewed=1 and drops it from the next select', () => {
+    db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('bewwre','Bewick''s Wren','Thryomanes bewickii','troglodytidae','https://photos/bewwre.jpg','(c) E','cc0','hashE',0)`).run();
+    markReviewed(db, 'bewwre');
+    const row = db.prepare(`SELECT reviewed FROM photo_current WHERE species_code='bewwre'`).get() as { reviewed: number };
+    expect(row.reviewed).toBe(1);
+    expect(selectUnreviewed(db, 10).map(r => r.speciesCode)).toEqual([]);
   });
 });

--- a/tools/photo-curation/src/server/queries.test.ts
+++ b/tools/photo-curation/src/server/queries.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+
+/** Open an in-memory db with the canonical schema and a tiny seed. */
+function seedDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE photo_current(species_code TEXT PRIMARY KEY, com_name TEXT, sci_name TEXT, family TEXT, url TEXT, attribution TEXT, license TEXT, content_hash TEXT, reviewed INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE photo_score(id INTEGER PRIMARY KEY, species_code TEXT, role TEXT, candidate_inat_id INTEGER, content_hash TEXT, overall REAL, verdict TEXT, criteria_json TEXT, flags_json TEXT, rationale TEXT, rubric_version TEXT, scored_at TEXT);
+    CREATE TABLE photo_candidate(id INTEGER PRIMARY KEY, species_code TEXT, inat_id INTEGER, photo_url TEXT, thumb_path TEXT, attribution TEXT, license TEXT, excluded INTEGER DEFAULT 0, source_round INTEGER);
+    CREATE TABLE photo_decision(species_code TEXT PRIMARY KEY, action TEXT, chosen_candidate_id INTEGER, deny_reason TEXT, deny_tags_json TEXT, resource_requested INTEGER NOT NULL DEFAULT 0, decided_at TEXT, applied INTEGER DEFAULT 0, applied_at TEXT);
+  `);
+  const crit = JSON.stringify({ framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 6, lighting: 8 });
+  const critBad = JSON.stringify({ framing: 2, subjectClarity: 3, liveness: 1, naturalness: 2, pose: 2, background: 2, lighting: 3 });
+  // good current photo (AI-scored → reviewed=1)
+  db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('amerob','American Robin','Turdus migratorius','turdidae','https://photos/amerob.jpg','(c) A','cc-by','hashA',1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('amerob','current',NULL,'hashA',86,'great',?, '[]','sharp wild bird','v1','2026-06-10T00:00:00Z')`).run(crit);
+  // bad current photo (dead + distant; AI-scored → reviewed=1)
+  db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('houspa','House Sparrow','Passer domesticus','passeridae','https://photos/houspa.jpg','(c) B','cc0','hashB',1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','current',NULL,'hashB',18,'reject',?, '["dead","distant"]','dead specimen, distant','v1','2026-06-11T00:00:00Z')`).run(critBad);
+  // candidate for houspa (round 1)
+  db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5001,'https://inat/5001.jpg','thumb-cache/5001.jpg','(c) C','cc-by',0,1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','candidate',5001,'hashC',79,'good',?, '[]','clean wild perch','v1','2026-06-11T00:00:00Z')`).run(crit);
+  return db;
+}
+
+describe('seedDb helper', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = seedDb(); });
+  afterEach(() => db.close());
+
+  it('seeds the canonical schema with the two current photos', () => {
+    const n = db.prepare(`SELECT COUNT(*) AS c FROM photo_current`).get() as { c: number };
+    expect(n.c).toBe(2);
+  });
+});

--- a/tools/photo-curation/src/server/queries.ts
+++ b/tools/photo-curation/src/server/queries.ts
@@ -1,0 +1,123 @@
+import type Database from 'better-sqlite3';
+
+export type SortMode = 'worst-first' | 'best-first' | 'has-better-candidate' | 'recently-scored';
+export type FilterMode = 'all' | 'flagged' | 'dead-sick' | 'distant' | 'in-hand' | 'soft' | 'marked-for-swap' | 'unscored';
+
+export interface Criteria {
+  framing: number; subjectClarity: number; liveness: number;
+  naturalness: number; pose: number; background: number; lighting: number;
+}
+
+export interface OverviewRow {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  url: string;
+  attribution: string;
+  license: string;
+  overall: number | null;
+  verdict: string | null;
+  flags: string[];
+  criteria: Criteria;
+  rationale: string | null;
+  scoredAt: string | null;
+  bestCandidateOverall: number | null;
+  markedForSwap: boolean;
+  decisionAction: string | null;
+  reviewed: boolean;   // photo_current.reviewed — false = awaiting the AI scoring pass
+}
+
+const ZERO_CRITERIA: Criteria = {
+  framing: 0, subjectClarity: 0, liveness: 0, naturalness: 0, pose: 0, background: 0, lighting: 0,
+};
+
+interface RawRow {
+  species_code: string; com_name: string; sci_name: string; family: string;
+  url: string; attribution: string; license: string;
+  overall: number | null; verdict: string | null; criteria_json: string | null;
+  flags_json: string | null; rationale: string | null; scored_at: string | null;
+  best_candidate_overall: number | null;
+  decision_action: string | null;
+  reviewed: number;
+}
+
+// 'soft' = low subjectClarity (blur). Threshold mirrors the rubric's
+// subjectClarity floor; tuned during calibration (Slice 10), 5 is a safe default.
+const SOFT_CLARITY_MAX = 5;
+
+function mapRow(r: RawRow): OverviewRow {
+  let flags: string[] = [];
+  if (r.flags_json) { try { flags = JSON.parse(r.flags_json) as string[]; } catch { flags = []; } }
+  let criteria = ZERO_CRITERIA;
+  if (r.criteria_json) { try { criteria = JSON.parse(r.criteria_json) as Criteria; } catch { /* keep zeros */ } }
+  return {
+    speciesCode: r.species_code, comName: r.com_name, sciName: r.sci_name, family: r.family,
+    url: r.url, attribution: r.attribution, license: r.license,
+    overall: r.overall, verdict: r.verdict, flags, criteria,
+    rationale: r.rationale, scoredAt: r.scored_at,
+    bestCandidateOverall: r.best_candidate_overall,
+    markedForSwap: r.decision_action === 'approve' || r.decision_action === 'pending',
+    decisionAction: r.decision_action,
+    reviewed: r.reviewed === 1,
+  };
+}
+
+export function listOverview(
+  db: Database.Database,
+  opts: { sort: SortMode; filter: FilterMode },
+): OverviewRow[] {
+  const raw = db.prepare(`
+    SELECT pc.species_code, pc.com_name, pc.sci_name, pc.family,
+           pc.url, pc.attribution, pc.license, pc.reviewed,
+           ps.overall, ps.verdict, ps.criteria_json, ps.flags_json, ps.rationale, ps.scored_at,
+           (SELECT MAX(cs.overall)
+              FROM photo_score cs
+              JOIN photo_candidate cand
+                ON cand.species_code = cs.species_code
+               AND cand.inat_id = cs.candidate_inat_id
+               AND cand.excluded = 0
+             WHERE cs.species_code = pc.species_code AND cs.role = 'candidate') AS best_candidate_overall,
+           pd.action AS decision_action
+      FROM photo_current pc
+      LEFT JOIN photo_score ps
+        ON ps.species_code = pc.species_code AND ps.role = 'current'
+      LEFT JOIN photo_decision pd
+        ON pd.species_code = pc.species_code
+  `).all() as RawRow[];
+
+  let rows = raw.map(mapRow);
+
+  // Filter
+  rows = rows.filter(row => {
+    switch (opts.filter) {
+      case 'all': return true;
+      case 'flagged': return row.flags.length > 0;
+      case 'dead-sick': return row.flags.includes('dead') || row.flags.includes('sick');
+      case 'distant': return row.flags.includes('distant');
+      case 'in-hand': return row.flags.includes('in-hand');
+      case 'soft': return row.criteria.subjectClarity > 0 && row.criteria.subjectClarity <= SOFT_CLARITY_MAX;
+      case 'marked-for-swap': return row.markedForSwap;
+      case 'unscored': return !row.reviewed;
+    }
+  });
+
+  // Sort (stable; null overall sorts last on score-based modes)
+  const byOverallAsc = (a: OverviewRow, b: OverviewRow) => (a.overall ?? Infinity) - (b.overall ?? Infinity);
+  const byOverallDesc = (a: OverviewRow, b: OverviewRow) => (b.overall ?? -Infinity) - (a.overall ?? -Infinity);
+  switch (opts.sort) {
+    case 'worst-first': rows.sort(byOverallAsc); break;
+    case 'best-first': rows.sort(byOverallDesc); break;
+    case 'recently-scored':
+      rows.sort((a, b) => (b.scoredAt ?? '').localeCompare(a.scoredAt ?? ''));
+      break;
+    case 'has-better-candidate':
+      rows.sort((a, b) => {
+        const ga = a.bestCandidateOverall !== null && a.overall !== null ? a.bestCandidateOverall - a.overall : -Infinity;
+        const gb = b.bestCandidateOverall !== null && b.overall !== null ? b.bestCandidateOverall - b.overall : -Infinity;
+        return gb - ga;
+      });
+      break;
+  }
+  return rows;
+}

--- a/tools/photo-curation/src/server/queries.ts
+++ b/tools/photo-curation/src/server/queries.ts
@@ -1,4 +1,5 @@
 import type Database from 'better-sqlite3';
+import type { DenyContext } from '@bird-watch/ingestor';
 
 export type SortMode = 'worst-first' | 'best-first' | 'has-better-candidate' | 'recently-scored';
 export type FilterMode = 'all' | 'flagged' | 'dead-sick' | 'distant' | 'in-hand' | 'soft' | 'marked-for-swap' | 'unscored';
@@ -120,4 +121,224 @@ export function listOverview(
       break;
   }
   return rows;
+}
+
+export interface CandidateView {
+  candidateId: number;     // photo_candidate.id
+  inatId: number;
+  photoUrl: string;
+  thumbPath: string;
+  attribution: string;
+  license: string;
+  overall: number | null;
+  verdict: string | null;
+  flags: string[];
+  criteria: Criteria;
+  rationale: string | null;
+  sourceRound: number;
+}
+
+export interface CurrentView {
+  url: string; attribution: string; license: string;
+  overall: number | null; verdict: string | null;
+  flags: string[]; criteria: Criteria; rationale: string | null;
+}
+
+export interface SwapView {
+  speciesCode: string; comName: string; sciName: string; family: string;
+  current: CurrentView;
+  proposed: CandidateView | null;     // top-scored non-excluded candidate
+  alternates: CandidateView[];        // all non-excluded candidates, votes/score desc
+}
+
+function parseFlags(s: string | null): string[] {
+  if (!s) return [];
+  try { return JSON.parse(s) as string[]; } catch { return []; }
+}
+function parseCriteria(s: string | null): Criteria {
+  if (!s) return { ...ZERO_CRITERIA };
+  try { return JSON.parse(s) as Criteria; } catch { return { ...ZERO_CRITERIA }; }
+}
+
+export function getSwapView(db: Database.Database, speciesCode: string): SwapView | null {
+  const cur = db.prepare(`
+    SELECT pc.com_name, pc.sci_name, pc.family, pc.url, pc.attribution, pc.license,
+           ps.overall, ps.verdict, ps.criteria_json, ps.flags_json, ps.rationale
+      FROM photo_current pc
+      LEFT JOIN photo_score ps ON ps.species_code = pc.species_code AND ps.role = 'current'
+     WHERE pc.species_code = ?
+  `).get(speciesCode) as
+    | { com_name: string; sci_name: string; family: string; url: string; attribution: string; license: string;
+        overall: number | null; verdict: string | null; criteria_json: string | null; flags_json: string | null; rationale: string | null }
+    | undefined;
+  if (!cur) return null;
+
+  const candRows = db.prepare(`
+    SELECT cand.id AS candidate_id, cand.inat_id, cand.photo_url, cand.thumb_path,
+           cand.attribution, cand.license, cand.source_round,
+           cs.overall, cs.verdict, cs.criteria_json, cs.flags_json, cs.rationale
+      FROM photo_candidate cand
+      LEFT JOIN photo_score cs
+        ON cs.species_code = cand.species_code
+       AND cs.role = 'candidate'
+       AND cs.candidate_inat_id = cand.inat_id
+     WHERE cand.species_code = ? AND cand.excluded = 0
+     ORDER BY cs.overall DESC, cand.inat_id ASC
+  `).all(speciesCode) as {
+    candidate_id: number; inat_id: number; photo_url: string; thumb_path: string;
+    attribution: string; license: string; source_round: number;
+    overall: number | null; verdict: string | null; criteria_json: string | null; flags_json: string | null; rationale: string | null;
+  }[];
+
+  const alternates: CandidateView[] = candRows.map(r => ({
+    candidateId: r.candidate_id, inatId: r.inat_id, photoUrl: r.photo_url, thumbPath: r.thumb_path,
+    attribution: r.attribution, license: r.license, overall: r.overall, verdict: r.verdict,
+    flags: parseFlags(r.flags_json), criteria: parseCriteria(r.criteria_json),
+    rationale: r.rationale, sourceRound: r.source_round,
+  }));
+
+  return {
+    speciesCode, comName: cur.com_name, sciName: cur.sci_name, family: cur.family,
+    current: {
+      url: cur.url, attribution: cur.attribution, license: cur.license,
+      overall: cur.overall, verdict: cur.verdict,
+      flags: parseFlags(cur.flags_json), criteria: parseCriteria(cur.criteria_json),
+      rationale: cur.rationale,
+    },
+    proposed: alternates[0] ?? null,
+    alternates,
+  };
+}
+
+export interface DecisionInput {
+  speciesCode: string;
+  action: 'approve' | 'keep' | 'deny' | 'pending';
+  chosenCandidateId?: number;
+  denyReason?: string;
+  denyTags?: string[];
+}
+
+export function writeDecision(db: Database.Database, input: DecisionInput): void {
+  db.prepare(`
+    INSERT INTO photo_decision (species_code, action, chosen_candidate_id, deny_reason, deny_tags_json, decided_at, applied, applied_at)
+    VALUES (@species_code, @action, @chosen_candidate_id, @deny_reason, @deny_tags_json, @decided_at, 0, NULL)
+    ON CONFLICT(species_code) DO UPDATE SET
+      action = excluded.action,
+      chosen_candidate_id = excluded.chosen_candidate_id,
+      deny_reason = excluded.deny_reason,
+      deny_tags_json = excluded.deny_tags_json,
+      decided_at = excluded.decided_at
+  `).run({
+    species_code: input.speciesCode,
+    action: input.action,
+    chosen_candidate_id: input.chosenCandidateId ?? null,
+    deny_reason: input.denyReason ?? null,
+    deny_tags_json: input.denyTags ? JSON.stringify(input.denyTags) : null,
+    decided_at: new Date().toISOString(),
+  });
+}
+
+export interface DenyInput {
+  speciesCode: string;
+  reason: string;
+  tags: string[];        // quick-chip values: 'too-dark','wrong-sex-morph','still-distant','cluttered-background','captive-feeder','not-sharp'
+  excludeIds: number[];  // iNat ids of the candidate(s) the reviewer just rejected (hide these)
+}
+
+export interface DenyResult {
+  denyContext: DenyContext;            // reason/tags — the route logs it; the next source-candidates run consumes it
+  next: CandidateView | null;          // next ALREADY-SCORED alternate from the pre-scored pool (instant advance)
+  resourceRequested: boolean;          // true iff the pool was exhausted and resource_requested was set
+}
+
+/**
+ * Deny → advance (R4, §5.4). The serve server can't score (plain Node, no
+ * Claude Code agent); the candidate pool is pre-scored ahead of the session by
+ * the `source-candidates` workflow. So Deny:
+ *   1. records action='deny' + reason/tags,
+ *   2. marks the shown candidate(s) (input.excludeIds) excluded=1,
+ *   3. returns the next already-scored, non-excluded alternate (the common,
+ *      instant case) — picked by the same ORDER BY getSwapView uses,
+ *   4. only when NO scored alternate remains, sets photo_decision.resource_requested=1
+ *      so a later `source-candidates` run fetches+scores a fresh deny-biased batch.
+ * This function never sources or scores — no scoreAndCacheCandidates call here.
+ * "Scored" means a matching photo_score(role='candidate') row exists (overall NOT NULL).
+ */
+export function denyAndAdvance(db: Database.Database, input: DenyInput): DenyResult {
+  let next: CandidateView | null = null;
+  let resourceRequested = false;
+
+  const tx = db.transaction(() => {
+    writeDecision(db, {
+      speciesCode: input.speciesCode, action: 'deny',
+      denyReason: input.reason, denyTags: input.tags,
+    });
+    if (input.excludeIds.length > 0) {
+      const placeholders = input.excludeIds.map(() => '?').join(',');
+      db.prepare(`UPDATE photo_candidate SET excluded = 1 WHERE species_code = ? AND inat_id IN (${placeholders})`)
+        .run(input.speciesCode, ...input.excludeIds);
+    }
+
+    // Next already-scored, non-excluded alternate (INNER JOIN drops unscored candidates).
+    const row = db.prepare(`
+      SELECT cand.id AS candidate_id, cand.inat_id, cand.photo_url, cand.thumb_path,
+             cand.attribution, cand.license, cand.source_round,
+             cs.overall, cs.verdict, cs.criteria_json, cs.flags_json, cs.rationale
+        FROM photo_candidate cand
+        JOIN photo_score cs
+          ON cs.species_code = cand.species_code
+         AND cs.role = 'candidate'
+         AND cs.candidate_inat_id = cand.inat_id
+       WHERE cand.species_code = ? AND cand.excluded = 0 AND cs.overall IS NOT NULL
+       ORDER BY cs.overall DESC, cand.inat_id ASC
+       LIMIT 1
+    `).get(input.speciesCode) as {
+      candidate_id: number; inat_id: number; photo_url: string; thumb_path: string;
+      attribution: string; license: string; source_round: number;
+      overall: number | null; verdict: string | null; criteria_json: string | null; flags_json: string | null; rationale: string | null;
+    } | undefined;
+
+    if (row) {
+      next = {
+        candidateId: row.candidate_id, inatId: row.inat_id, photoUrl: row.photo_url, thumbPath: row.thumb_path,
+        attribution: row.attribution, license: row.license, overall: row.overall, verdict: row.verdict,
+        flags: parseFlags(row.flags_json), criteria: parseCriteria(row.criteria_json),
+        rationale: row.rationale, sourceRound: row.source_round,
+      };
+    } else {
+      // pool exhausted → queue a re-source for the next source-candidates run
+      db.prepare(`UPDATE photo_decision SET resource_requested = 1 WHERE species_code = ?`).run(input.speciesCode);
+      resourceRequested = true;
+    }
+  });
+  tx();
+
+  return { denyContext: { reason: input.reason, tags: input.tags }, next, resourceRequested };
+}
+
+export interface UnreviewedRow {
+  speciesCode: string;
+  comName: string;
+  url: string;
+}
+
+/**
+ * Batched-scoring cursor (R2): the next `limit` species awaiting the AI scoring
+ * pass (photo_current.reviewed = 0). The `score` workflow scores these, then
+ * calls markReviewed() per row. Deterministic order so re-runs are resumable.
+ */
+export function selectUnreviewed(db: Database.Database, limit: number): UnreviewedRow[] {
+  const rows = db.prepare(`
+    SELECT species_code, com_name, url
+      FROM photo_current
+     WHERE reviewed = 0
+     ORDER BY species_code ASC
+     LIMIT ?
+  `).all(limit) as { species_code: string; com_name: string; url: string }[];
+  return rows.map(r => ({ speciesCode: r.species_code, comName: r.com_name, url: r.url }));
+}
+
+/** Mark a species AI-scored (reviewed = 1) after the score workflow writes its row. */
+export function markReviewed(db: Database.Database, speciesCode: string): void {
+  db.prepare(`UPDATE photo_current SET reviewed = 1 WHERE species_code = ?`).run(speciesCode);
 }


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Route as serve route (5b)
    participant Q as queries.ts (5a)
    participant DB as review.sqlite

    Note over Q,DB: Screen 1 — overview
    Route->>Q: listOverview(db, sort, filter)
    Q->>DB: SELECT photo_current JOIN photo_score + best-candidate subquery
    DB-->>Q: rows (overall, flags, criteria, reviewed, markedForSwap)
    Q-->>Route: OverviewRow[] sorted and filtered

    Note over Q,DB: Screen 2 — swap and decide
    Route->>Q: getSwapView(db, speciesCode)
    Q->>DB: current + non-excluded candidates ordered by score
    DB-->>Q: current, proposed, alternates
    Q-->>Route: SwapView or null

    Route->>Q: denyAndAdvance(db, input)
    Q->>DB: write deny decision, exclude shown ids
    Q->>DB: SELECT next already-scored alternate
    alt scored alternate remains
        DB-->>Q: next candidate row
        Q-->>Route: next CandidateView, resourceRequested false
    else pool exhausted
        Q->>DB: SET resource_requested = 1
        Q-->>Route: next null, resourceRequested true
    end
```

## Summary

- **Why:** Slice 5 of the photo-quality curation epic needs a pure, testable data layer before the Express API + HTML screens (Part 5b) can be wired. This is Part 5a — the `better-sqlite3` query module over `review.sqlite` only; no server, no scoring, no new deps.
- **What lands:** `src/server/queries.ts` exposing `listOverview` (4 sort modes + 8 filters incl. the new `unscored`/`reviewed=0` filter, with `markedForSwap` and per-row `reviewed` status), `getSwapView` (current + pre-scored proposed/alternates), `writeDecision` (PK upsert), `denyAndAdvance` (record deny → exclude shown ids → advance to next already-scored alternate, else set `photo_decision.resource_requested=1`), and the batched score-pass cursor `selectUnreviewed`/`markReviewed`.
- **Deliberately deferred to 5b:** `express`/`supertest`/`@types/*` and the `dev` script — adding them here would leave four unused packages and trip the knip gate. `denyAndAdvance` never scores and never calls `scoreAndCacheCandidates`; scoring is a separate Claude-Code workflow. `DenyContext` is imported from the `@bird-watch/ingestor` package boundary (built `dist/`), not a deep relative path.

## Screenshots

N/A — not UI. All changes are under `tools/photo-curation/` (a non-deployed Node tool), not `frontend/**`.

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (6 files, 51 tests; `queries.test.ts` is 27 of them, against a `:memory:` better-sqlite3 store — the real store, no mocks)
- [x] New unit tests added: every sort + every filter (incl. `unscored`), `markedForSwap`/`reviewed` semantics, `getSwapView`, `writeDecision` (incl. PK upsert), `denyAndAdvance` (advance + pool-exhausted re-source + unscored-candidate cases), `selectUnreviewed`/`markReviewed`
- [x] `npm run build` (root) — clean across all workspaces (photo-quality + ingestor built first per the issue)
- [x] `npx knip` — clean (no unused deps/exports; no server deps added)
- [x] Lockfile unchanged (no deps added)
- [x] N/A — not UI (Playwright MCP smoke not applicable; tool has no HTML/CSS)

## Plan reference

Part of epic #974. Implements #972 (Slice 5, Part 5a). Continued by Part 5b (#973), which wires these functions into the Express API + serve CLI and builds the two HTML screens. Depends on #970 (the `tools/photo-curation` workspace + `openDb` store with `photo_current.reviewed` + `photo_decision.resource_requested`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
