### PR TITLE
feat(photo-curation): review server — Express API + serve CLI + overview/swap screens (Slice 5b, #973)

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -282,7 +282,24 @@ const config: KnipConfig = {
       //             workflow if one is deleted from the runbook but left on
       //             disk. Re-audit 2026-07-27 — confirm both are still
       //             referenced by the photo-curation runbook / epic #974.
-      ignore: ['workflows/score-current.mjs', 'workflows/source-candidates.mjs'],
+      //
+      // 2026-06-10 (Slice 5b, #973): the three public/*.js files are browser ES
+      //             modules served verbatim by the review server's
+      //             express.static (Screen 1 = overview.js, Screen 2 = swap.js,
+      //             both `import` theme.js). They are loaded at runtime via the
+      //             HTML `<script type="module" src="/overview.js">` /
+      //             `/swap.js` tags + a bare `/theme.js` specifier resolved by
+      //             the browser, never imported by any TS/JS module knip can
+      //             trace, so static analysis flags all three as unused files.
+      //             Risk: masks a genuinely orphaned public asset if a screen is
+      //             deleted but its script left on disk. Re-audit 2026-07-27 —
+      //             confirm public/index.html + public/swap.html still reference
+      //             these three scripts (grep `src="/overview.js"`, `/swap.js`,
+      //             and an `import .* '/theme.js'` in the two client modules).
+      ignore: [
+        'workflows/score-current.mjs', 'workflows/source-candidates.mjs',
+        'public/overview.js', 'public/swap.js', 'public/theme.js',
+      ],
     },
   },
 };

--- a/knip.ts
+++ b/knip.ts
@@ -296,6 +296,15 @@ const config: KnipConfig = {
       //             confirm public/index.html + public/swap.html still reference
       //             these three scripts (grep `src="/overview.js"`, `/swap.js`,
       //             and an `import .* '/theme.js'` in the two client modules).
+      //
+      // 2026-06-10 (#973 security addendum): public/safe.js — the shared
+      //             XSS-hardening helper (esc + safeImg) imported by overview.js
+      //             + swap.js — is deliberately NOT ignored here: its sibling
+      //             public/safe.test.ts is a real vitest target that imports it,
+      //             so knip already traces safe.js as used (an ignore entry is
+      //             flagged redundant). If that test is ever removed, knip will
+      //             report safe.js as unused — re-add it to this ignore list
+      //             (with the overview/swap import rationale above) at that time.
       ignore: [
         'workflows/score-current.mjs', 'workflows/source-candidates.mjs',
         'public/overview.js', 'public/swap.js', 'public/theme.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2188,6 +2188,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -2853,6 +2866,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3638,6 +3661,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
@@ -3654,6 +3688,23 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -3688,10 +3739,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3715,6 +3805,20 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3745,6 +3849,27 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/set-cookie-parser": {
@@ -3805,6 +3930,47 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/superagent/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -3997,6 +4163,44 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/agent-base": {
@@ -4256,6 +4460,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -4540,6 +4751,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -4612,6 +4847,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bytewise": {
       "version": "1.1.0",
       "license": "MIT",
@@ -4638,6 +4882,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -4712,6 +4972,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compress-commons": {
       "version": "6.0.2",
       "dev": true,
@@ -4725,6 +4995,28 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -4745,6 +5037,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4918,6 +5226,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "dev": true,
@@ -4933,6 +5250,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -5108,10 +5436,25 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5234,6 +5577,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5242,6 +5591,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -5286,6 +5644,83 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5304,6 +5739,13 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5399,6 +5841,27 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "dev": true,
@@ -5445,6 +5908,42 @@
       },
       "engines": {
         "node": ">=18.3.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -5780,6 +6279,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5804,6 +6323,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -5889,6 +6424,12 @@
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -6531,6 +7072,37 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -6718,6 +7290,15 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nise": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
@@ -6846,6 +7427,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -6856,6 +7449,18 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6994,6 +7599,15 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -7427,6 +8041,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "license": "MIT",
@@ -7444,9 +8080,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quickselect": {
       "version": "3.0.0",
       "license": "ISC"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -7675,6 +8350,32 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "license": "BSD-3-Clause"
@@ -7699,7 +8400,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -7731,6 +8431,76 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "dev": true,
@@ -7748,6 +8518,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7810,6 +8586,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -8031,7 +8879,6 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8172,6 +9019,72 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8426,6 +9339,15 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -8516,6 +9438,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -8581,6 +9559,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "dev": true,
@@ -8610,6 +9597,15 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
       "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.14",
@@ -9485,6 +10481,7 @@
         "@bird-watch/shared-types": "*",
         "better-sqlite3": "^11.8.1",
         "commander": "^13.1.0",
+        "express": "^5.2.1",
         "sharp": "^0.34.1"
       },
       "bin": {
@@ -9492,8 +10489,11 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
+        "@types/express": "^5.0.6",
         "@types/node": "^24.12.4",
+        "@types/supertest": "^6.0.3",
         "msw": "^2.14.6",
+        "supertest": "^7.2.2",
         "tsx": "^4.22.3",
         "vitest": "^4.1.7"
       }

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "bin": { "photo-curate": "dist/cli.js" },
+  "bin": {
+    "photo-curate": "dist/cli.js"
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
@@ -15,12 +17,16 @@
     "@bird-watch/shared-types": "*",
     "better-sqlite3": "^11.8.1",
     "commander": "^13.1.0",
+    "express": "^5.2.1",
     "sharp": "^0.34.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
+    "@types/express": "^5.0.6",
     "@types/node": "^24.12.4",
+    "@types/supertest": "^6.0.3",
     "msw": "^2.14.6",
+    "supertest": "^7.2.2",
     "tsx": "^4.22.3",
     "vitest": "^4.1.7"
   }

--- a/tools/photo-curation/public/app.css
+++ b/tools/photo-curation/public/app.css
@@ -1,0 +1,79 @@
+/* ── DESIGN.md-aligned tokens (light/dark via [data-theme]) ── */
+:root {
+  --type-xs: 11px; --type-sm: 13px; --type-base: 15px; --type-md: 17px; --type-lg: 22px; --type-hero: 34px;
+  --font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI Variable", "Helvetica Neue", "Inter", sans-serif;
+  --radius-lg: 12px;
+  /* Status colors chosen for this tool. deep-ember is a DESIGN.md token; the
+     green + amber are picked to pass light-mode contrast (not token-named). */
+  --status-great: #1f7a3d;   /* green (chosen) */
+  --status-good:  #984012;   /* amber (passes light contrast; = --c-amber-700) */
+  --status-bad:   #c43a1a;   /* deep-ember (DESIGN.md) */
+}
+:root[data-theme="light"] {
+  --bg: #fafaf6; --surface: #ffffff; --surface-2: #f0ece4; --text: #1a1a1a; --text-dim: #5b5750;
+  --border: #d8d3c3; --card-elevation: 0 1px 3px rgba(0,0,0,.08), 0 4px 12px rgba(0,0,0,.04);
+}
+:root[data-theme="dark"] {
+  --bg: #0d1424; --surface: #131c30; --surface-2: #1b2742; --text: #f5f7fb; --text-dim: #9aa6bd;
+  --border: #2a3a5c; --card-elevation: 0 1px 3px rgba(0,0,0,.4), 0 4px 16px rgba(0,0,0,.3);
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); background: var(--bg); color: var(--text); }
+.app-header { display: flex; align-items: center; gap: 16px; padding: 16px 24px; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg); z-index: 2; }
+.app-title { font-size: var(--type-lg); font-weight: 600; margin: 0; }
+.staged-indicator { margin-left: auto; font-size: var(--type-sm); color: var(--text-dim); padding: 6px 12px; border: 1px solid var(--border); border-radius: var(--radius-lg); }
+.toolbar { display: flex; gap: 12px; flex-wrap: wrap; padding: 12px 24px; }
+.toolbar label { font-size: var(--type-sm); color: var(--text-dim); display: flex; align-items: center; gap: 6px; }
+.toolbar select { font: inherit; padding: 6px 8px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px; padding: 24px; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); overflow: hidden; position: relative; }
+.card.below-threshold { box-shadow: inset 4px 0 0 var(--status-bad), var(--card-elevation); }
+.card-photo { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; display: block; background: var(--surface-2); }
+.card-body { padding: 12px 14px; }
+.card-name { font-size: var(--type-md); font-weight: 600; margin: 0 0 2px; }
+.card-sci { font-size: var(--type-sm); color: var(--text-dim); font-style: italic; margin: 0 0 8px; }
+.score-badge { display: inline-block; font-weight: 700; font-size: var(--type-sm); padding: 2px 8px; border-radius: 999px; color: #fff; }
+.score-badge.great { background: var(--status-great); }
+.score-badge.good  { background: var(--status-good); }
+.score-badge.bad   { background: var(--status-bad); }
+.flag-chips { display: flex; flex-wrap: wrap; gap: 4px; margin: 8px 0; }
+.flag-chip { font-size: var(--type-xs); padding: 2px 6px; border-radius: 6px; background: var(--surface-2); color: var(--status-bad); border: 1px solid var(--status-bad); }
+.subscores { display: grid; grid-template-columns: repeat(2, 1fr); gap: 2px 12px; font-size: var(--type-xs); color: var(--text-dim); margin: 8px 0; }
+.subscore { display: flex; justify-content: space-between; }
+.card-actions { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+.mark-swap { font-size: var(--type-sm); display: flex; align-items: center; gap: 6px; }
+.mark-cb { accent-color: var(--status-great); }
+.swap-link { margin-left: auto; font-size: var(--type-sm); color: var(--status-good); text-decoration: none; }
+.theme-toggle { background: var(--surface); border: 1px solid var(--border); color: var(--text); border-radius: 8px; padding: 6px 10px; cursor: pointer; font: inherit; }
+.empty { padding: 48px; text-align: center; color: var(--text-dim); }
+
+/* ── Screen 2: swap review ── */
+.swap-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
+.swap-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 16px; }
+.swap-head .com { font-size: var(--type-hero); font-weight: 700; }
+.swap-head .sci { font-size: var(--type-md); color: var(--text-dim); font-style: italic; }
+.compare { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.pane { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); overflow: hidden; }
+.pane-label { font-size: var(--type-sm); font-weight: 600; padding: 8px 14px; border-bottom: 1px solid var(--border); }
+.pane-photo { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; background: var(--surface-2); display: block; }
+.pane-body { padding: 12px 14px; }
+.attribution { font-size: var(--type-xs); color: var(--text-dim); margin-top: 8px; }
+.license-note { font-size: var(--type-xs); color: var(--status-good); margin-top: 4px; }
+.alternates { display: flex; gap: 8px; overflow-x: auto; padding: 16px 0; }
+.alt { flex: 0 0 auto; width: 96px; cursor: pointer; border: 2px solid transparent; border-radius: 8px; overflow: hidden; background: var(--surface-2); }
+.alt.selected { border-color: var(--status-good); }
+.alt img { width: 96px; height: 72px; object-fit: cover; display: block; }
+.alt .alt-score { font-size: var(--type-xs); text-align: center; padding: 2px; }
+.action-bar { display: flex; gap: 12px; margin-top: 20px; flex-wrap: wrap; align-items: center; }
+.btn { font: inherit; padding: 10px 18px; border-radius: var(--radius-lg); border: 1px solid var(--border); cursor: pointer; background: var(--surface); color: var(--text); }
+.btn.approve { background: var(--status-great); color: #fff; border-color: var(--status-great); }
+.btn.keep { background: var(--surface); }
+.btn.deny { background: var(--status-bad); color: #fff; border-color: var(--status-bad); }
+.deny-panel { margin-top: 16px; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); display: none; }
+.deny-panel.open { display: block; }
+.deny-panel textarea { width: 100%; min-height: 64px; font: inherit; padding: 8px; border-radius: 8px; border: 1px solid var(--border); background: var(--bg); color: var(--text); }
+.quick-chips { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0; }
+.quick-chip { font-size: var(--type-sm); padding: 4px 10px; border-radius: 999px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text); cursor: pointer; }
+.quick-chip.active { background: var(--status-bad); color: #fff; border-color: var(--status-bad); }
+.back-link { font-size: var(--type-sm); color: var(--status-good); text-decoration: none; }
+.toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); background: var(--surface); border: 1px solid var(--border); box-shadow: var(--card-elevation); border-radius: var(--radius-lg); padding: 12px 20px; font-size: var(--type-sm); }

--- a/tools/photo-curation/public/index.html
+++ b/tools/photo-curation/public/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Photo Curation — Overview</title>
+  <link rel="stylesheet" href="/app.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1 class="app-title">Photo Curation</h1>
+    <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
+    <span class="staged-indicator" id="staged">staged: 0 approved</span>
+  </header>
+  <div class="toolbar">
+    <label>Sort
+      <select id="sort">
+        <option value="worst-first">Worst first</option>
+        <option value="best-first">Best first</option>
+        <option value="has-better-candidate">Has better candidate</option>
+        <option value="recently-scored">Recently scored</option>
+      </select>
+    </label>
+    <label>Filter
+      <select id="filter">
+        <option value="all">All</option>
+        <option value="flagged">Flagged</option>
+        <option value="dead-sick">Dead / sick</option>
+        <option value="distant">Distant</option>
+        <option value="in-hand">In-hand</option>
+        <option value="soft">Soft</option>
+        <option value="marked-for-swap">Marked for swap</option>
+      </select>
+    </label>
+  </div>
+  <main class="grid" id="grid"></main>
+  <script type="module" src="/overview.js"></script>
+</body>
+</html>

--- a/tools/photo-curation/public/overview.js
+++ b/tools/photo-curation/public/overview.js
@@ -1,0 +1,56 @@
+import { initTheme, toggleTheme } from '/theme.js';
+initTheme();
+document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+const SUBSCORE_KEYS = ['framing', 'subjectClarity', 'liveness', 'naturalness', 'pose', 'background', 'lighting'];
+
+function scoreClass(overall) {
+  if (overall === null) return 'bad';
+  if (overall >= 75) return 'great';
+  if (overall >= 50) return 'good';
+  return 'bad';
+}
+
+function card(row) {
+  const el = document.createElement('article');
+  el.className = 'card' + (row.overall !== null && row.overall < 50 ? ' below-threshold' : '');
+  const flags = row.flags.map(f => `<span class="flag-chip">${f}</span>`).join('');
+  const subs = SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${k}</span><span>${row.criteria[k]}</span></span>`).join('');
+  el.innerHTML = `
+    <img class="card-photo" src="${row.url}" alt="${row.comName}" loading="lazy" />
+    <div class="card-body">
+      <p class="card-name">${row.comName}</p>
+      <p class="card-sci">${row.sciName}</p>
+      <span class="score-badge ${scoreClass(row.overall)}">${row.overall ?? '—'}</span>
+      <div class="flag-chips">${flags}</div>
+      <div class="subscores">${subs}</div>
+      <div class="card-actions">
+        <label class="mark-swap"><input type="checkbox" class="mark-cb" ${row.markedForSwap ? 'checked' : ''}/> Mark for swap</label>
+        <a class="swap-link" href="/swap/${row.speciesCode}">Review →</a>
+      </div>
+    </div>`;
+  el.querySelector('.mark-cb').addEventListener('change', async (e) => {
+    await fetch('/api/decision', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ speciesCode: row.speciesCode, action: e.target.checked ? 'pending' : 'keep' }),
+    });
+    load();
+  });
+  return el;
+}
+
+async function load() {
+  const sort = document.getElementById('sort').value;
+  const filter = document.getElementById('filter').value;
+  const res = await fetch(`/api/overview?sort=${sort}&filter=${filter}`);
+  const data = await res.json();
+  document.getElementById('staged').textContent = `staged: ${data.stagedApproved} approved`;
+  const grid = document.getElementById('grid');
+  grid.innerHTML = '';
+  if (data.rows.length === 0) { grid.innerHTML = '<p class="empty">No species match this filter.</p>'; return; }
+  for (const row of data.rows) grid.appendChild(card(row));
+}
+
+document.getElementById('sort').addEventListener('change', load);
+document.getElementById('filter').addEventListener('change', load);
+load();

--- a/tools/photo-curation/public/overview.js
+++ b/tools/photo-curation/public/overview.js
@@ -1,4 +1,5 @@
 import { initTheme, toggleTheme } from '/theme.js';
+import { esc, safeImg } from './safe.js';
 initTheme();
 document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
 
@@ -14,19 +15,19 @@ function scoreClass(overall) {
 function card(row) {
   const el = document.createElement('article');
   el.className = 'card' + (row.overall !== null && row.overall < 50 ? ' below-threshold' : '');
-  const flags = row.flags.map(f => `<span class="flag-chip">${f}</span>`).join('');
-  const subs = SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${k}</span><span>${row.criteria[k]}</span></span>`).join('');
+  const flags = row.flags.map(f => `<span class="flag-chip">${esc(f)}</span>`).join('');
+  const subs = SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${esc(k)}</span><span>${esc(row.criteria[k])}</span></span>`).join('');
   el.innerHTML = `
-    <img class="card-photo" src="${row.url}" alt="${row.comName}" loading="lazy" />
+    <img class="card-photo" src="${safeImg(row.url)}" alt="${esc(row.comName)}" loading="lazy" />
     <div class="card-body">
-      <p class="card-name">${row.comName}</p>
-      <p class="card-sci">${row.sciName}</p>
-      <span class="score-badge ${scoreClass(row.overall)}">${row.overall ?? '—'}</span>
+      <p class="card-name">${esc(row.comName)}</p>
+      <p class="card-sci">${esc(row.sciName)}</p>
+      <span class="score-badge ${scoreClass(row.overall)}">${esc(row.overall ?? '—')}</span>
       <div class="flag-chips">${flags}</div>
       <div class="subscores">${subs}</div>
       <div class="card-actions">
         <label class="mark-swap"><input type="checkbox" class="mark-cb" ${row.markedForSwap ? 'checked' : ''}/> Mark for swap</label>
-        <a class="swap-link" href="/swap/${row.speciesCode}">Review →</a>
+        <a class="swap-link" href="/swap/${esc(row.speciesCode)}">Review →</a>
       </div>
     </div>`;
   el.querySelector('.mark-cb').addEventListener('change', async (e) => {

--- a/tools/photo-curation/public/safe.js
+++ b/tools/photo-curation/public/safe.js
@@ -1,0 +1,53 @@
+// Shared browser-safety helpers for the photo-curation review screens.
+//
+// Both review screens (overview.js + swap.js) build their DOM with `innerHTML`
+// template strings that interpolate EXTERNAL, UNTRUSTED data: species
+// comName/sciName (eBird taxonomy), free-text `attribution` ("© Photographer …"
+// from iNaturalist / Wikimedia user content), and image url/photoUrl. The review
+// server exposes write routes (POST /api/decision, POST /api/deny), so an
+// unescaped payload like `"><img src=x onerror=alert(1)>` is a real XSS that can
+// drive those routes. These helpers neutralize that:
+//   - `esc(s)`     HTML-escapes & < > " ' so a payload renders as inert text.
+//   - `safeImg(u)` returns the URL only when it is an https URL on the photo-host
+//                  allowlist; otherwise a transparent 1×1 placeholder.
+//
+// Plain ESM with named exports so it is importable both by the browser
+// (served verbatim by the review server's express.static) and by vitest in node.
+
+const ESCAPES = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+
+/** HTML-escape `& < > " '` so an interpolated value renders as inert text. */
+export function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ESCAPES[c]);
+}
+
+// 1×1 transparent PNG — the fallback when a candidate/current image URL is not a
+// trusted https photo-host URL. Inert: a data: URI can't run JS in <img src>.
+const PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+// Only these hosts may appear in an <img src>. Everything else (other hosts,
+// non-https schemes, `javascript:`, unparseable strings) → the placeholder.
+const ALLOWED_HOSTS = new Set([
+  'photos.bird-maps.com',
+  'static.inaturalist.org',
+  'inaturalist-open-data.s3.amazonaws.com',
+  'upload.wikimedia.org',
+]);
+
+/**
+ * Validate an image URL before it reaches `<img src>`. Returns `u` unchanged
+ * only when it parses, is https, and its host is on the allowlist; otherwise a
+ * transparent 1×1 data-URI placeholder.
+ */
+export function safeImg(u) {
+  let parsed;
+  try {
+    parsed = new URL(u);
+  } catch {
+    return PLACEHOLDER;
+  }
+  if (parsed.protocol !== 'https:') return PLACEHOLDER;
+  if (!ALLOWED_HOSTS.has(parsed.host.toLowerCase())) return PLACEHOLDER;
+  return u;
+}

--- a/tools/photo-curation/public/safe.test.ts
+++ b/tools/photo-curation/public/safe.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+// safe.js is plain ESM with named exports, served verbatim to the browser by the
+// review server's express.static AND importable here in node.
+import { esc, safeImg } from './safe.js';
+
+const PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+describe('esc', () => {
+  it('neutralizes an injected <img onerror> payload — no raw < > "', () => {
+    const out = esc('"><img src=x onerror=alert(1)>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).not.toContain('"');
+    // The dangerous characters survive only in their escaped form.
+    expect(out).toContain('&lt;');
+    expect(out).toContain('&gt;');
+    expect(out).toContain('&quot;');
+  });
+
+  it('escapes & < > " and single quote', () => {
+    expect(esc('Tom & Jerry')).toBe('Tom &amp; Jerry');
+    expect(esc("O'Brien")).toBe('O&#39;Brien');
+  });
+
+  it('leaves benign text untouched and coerces non-strings', () => {
+    expect(esc('© Jane Photographer')).toBe('© Jane Photographer');
+    expect(esc(42)).toBe('42');
+    expect(esc(null)).toBe('null');
+  });
+});
+
+describe('safeImg', () => {
+  it('returns an allowlisted https photo-host URL unchanged', () => {
+    const url = 'https://photos.bird-maps.com/x.webp';
+    expect(safeImg(url)).toBe(url);
+  });
+
+  it('accepts every allowlisted host', () => {
+    for (const host of [
+      'photos.bird-maps.com',
+      'static.inaturalist.org',
+      'inaturalist-open-data.s3.amazonaws.com',
+      'upload.wikimedia.org',
+    ]) {
+      const url = `https://${host}/photo.jpg`;
+      expect(safeImg(url)).toBe(url);
+    }
+  });
+
+  it('rejects a javascript: URL → placeholder', () => {
+    expect(safeImg('javascript:alert(1)')).toBe(PLACEHOLDER);
+  });
+
+  it('rejects a non-https (http:) URL → placeholder', () => {
+    expect(safeImg('http://evil/x.jpg')).toBe(PLACEHOLDER);
+  });
+
+  it('rejects an https URL on a non-allowlisted host → placeholder', () => {
+    expect(safeImg('https://evil.example.com/x.jpg')).toBe(PLACEHOLDER);
+  });
+
+  it('rejects an unparseable / empty value → placeholder', () => {
+    expect(safeImg('not a url')).toBe(PLACEHOLDER);
+    expect(safeImg('')).toBe(PLACEHOLDER);
+    expect(safeImg(undefined)).toBe(PLACEHOLDER);
+  });
+});

--- a/tools/photo-curation/public/swap.html
+++ b/tools/photo-curation/public/swap.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Photo Curation — Swap Review</title>
+  <link rel="stylesheet" href="/app.css" />
+</head>
+<body>
+  <header class="app-header">
+    <a class="back-link" href="/">← Overview</a>
+    <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
+  </header>
+  <div class="swap-wrap" id="root"></div>
+  <script type="module" src="/swap.js"></script>
+</body>
+</html>

--- a/tools/photo-curation/public/swap.js
+++ b/tools/photo-curation/public/swap.js
@@ -1,4 +1,5 @@
 import { initTheme, toggleTheme } from '/theme.js';
+import { esc, safeImg } from './safe.js';
 initTheme();
 document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
 
@@ -8,10 +9,10 @@ const code = location.pathname.split('/').pop();
 let featured = null; // candidateId
 
 function subscoresHtml(criteria) {
-  return `<div class="subscores">${SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${k}</span><span>${criteria[k]}</span></span>`).join('')}</div>`;
+  return `<div class="subscores">${SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${esc(k)}</span><span>${esc(criteria[k])}</span></span>`).join('')}</div>`;
 }
 function flagsHtml(flags) {
-  return `<div class="flag-chips">${flags.map(f => `<span class="flag-chip">${f}</span>`).join('')}</div>`;
+  return `<div class="flag-chips">${flags.map(f => `<span class="flag-chip">${esc(f)}</span>`).join('')}</div>`;
 }
 
 function toast(msg) {
@@ -29,31 +30,31 @@ async function render() {
 
   const proposedPane = v.proposed ? `
     <div class="pane">
-      <div class="pane-label">Proposed replacement · ${v.proposed.overall ?? '—'}</div>
-      <img class="pane-photo" src="${v.proposed.photoUrl}" alt="proposed" />
+      <div class="pane-label">Proposed replacement · ${esc(v.proposed.overall ?? '—')}</div>
+      <img class="pane-photo" src="${safeImg(v.proposed.photoUrl)}" alt="proposed" />
       <div class="pane-body">
         ${flagsHtml(v.proposed.flags)}${subscoresHtml(v.proposed.criteria)}
-        <p class="attribution">${v.proposed.attribution} · ${v.proposed.license}</p>
+        <p class="attribution">${esc(v.proposed.attribution)} · ${esc(v.proposed.license)}</p>
       </div>
     </div>` : `<div class="pane"><div class="pane-label">Proposed replacement</div><p class="empty">No scored candidate left — re-source queued; run <code>source-candidates</code> then refresh.</p></div>`;
 
   const alts = v.alternates.map(a => `
-    <div class="alt ${a.candidateId === featured ? 'selected' : ''}" data-id="${a.candidateId}">
-      <img src="${a.photoUrl}" alt="alt" />
-      <div class="alt-score">${a.overall ?? '—'}</div>
+    <div class="alt ${a.candidateId === featured ? 'selected' : ''}" data-id="${esc(a.candidateId)}">
+      <img src="${safeImg(a.photoUrl)}" alt="alt" />
+      <div class="alt-score">${esc(a.overall ?? '—')}</div>
     </div>`).join('');
 
-  const chips = QUICK_CHIPS.map(c => `<button type="button" class="quick-chip" data-tag="${c}">${c}</button>`).join('');
+  const chips = QUICK_CHIPS.map(c => `<button type="button" class="quick-chip" data-tag="${esc(c)}">${esc(c)}</button>`).join('');
 
   document.getElementById('root').innerHTML = `
-    <div class="swap-head"><span class="com">${v.comName}</span><span class="sci">${v.sciName}</span></div>
+    <div class="swap-head"><span class="com">${esc(v.comName)}</span><span class="sci">${esc(v.sciName)}</span></div>
     <div class="compare">
       <div class="pane">
-        <div class="pane-label">Current (live) · ${v.current.overall ?? '—'}</div>
-        <img class="pane-photo" src="${v.current.url}" alt="current" />
+        <div class="pane-label">Current (live) · ${esc(v.current.overall ?? '—')}</div>
+        <img class="pane-photo" src="${safeImg(v.current.url)}" alt="current" />
         <div class="pane-body">
           ${flagsHtml(v.current.flags)}${subscoresHtml(v.current.criteria)}
-          <p class="attribution">${v.current.attribution} · ${v.current.license}</p>
+          <p class="attribution">${esc(v.current.attribution)} · ${esc(v.current.license)}</p>
         </div>
       </div>
       ${proposedPane}

--- a/tools/photo-curation/public/swap.js
+++ b/tools/photo-curation/public/swap.js
@@ -1,0 +1,125 @@
+import { initTheme, toggleTheme } from '/theme.js';
+initTheme();
+document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+const QUICK_CHIPS = ['too-dark', 'wrong-sex-morph', 'still-distant', 'cluttered-background', 'captive-feeder', 'not-sharp'];
+const SUBSCORE_KEYS = ['framing', 'subjectClarity', 'liveness', 'naturalness', 'pose', 'background', 'lighting'];
+const code = location.pathname.split('/').pop();
+let featured = null; // candidateId
+
+function subscoresHtml(criteria) {
+  return `<div class="subscores">${SUBSCORE_KEYS.map(k => `<span class="subscore"><span>${k}</span><span>${criteria[k]}</span></span>`).join('')}</div>`;
+}
+function flagsHtml(flags) {
+  return `<div class="flag-chips">${flags.map(f => `<span class="flag-chip">${f}</span>`).join('')}</div>`;
+}
+
+function toast(msg) {
+  const t = document.createElement('div');
+  t.className = 'toast'; t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), 2500);
+}
+
+async function render() {
+  const res = await fetch(`/api/swap/${code}`);
+  if (res.status === 404) { document.getElementById('root').innerHTML = '<p class="empty">Unknown species.</p>'; return; }
+  const v = await res.json();
+  featured = v.proposed ? v.proposed.candidateId : null;
+
+  const proposedPane = v.proposed ? `
+    <div class="pane">
+      <div class="pane-label">Proposed replacement · ${v.proposed.overall ?? '—'}</div>
+      <img class="pane-photo" src="${v.proposed.photoUrl}" alt="proposed" />
+      <div class="pane-body">
+        ${flagsHtml(v.proposed.flags)}${subscoresHtml(v.proposed.criteria)}
+        <p class="attribution">${v.proposed.attribution} · ${v.proposed.license}</p>
+      </div>
+    </div>` : `<div class="pane"><div class="pane-label">Proposed replacement</div><p class="empty">No scored candidate left — re-source queued; run <code>source-candidates</code> then refresh.</p></div>`;
+
+  const alts = v.alternates.map(a => `
+    <div class="alt ${a.candidateId === featured ? 'selected' : ''}" data-id="${a.candidateId}">
+      <img src="${a.photoUrl}" alt="alt" />
+      <div class="alt-score">${a.overall ?? '—'}</div>
+    </div>`).join('');
+
+  const chips = QUICK_CHIPS.map(c => `<button type="button" class="quick-chip" data-tag="${c}">${c}</button>`).join('');
+
+  document.getElementById('root').innerHTML = `
+    <div class="swap-head"><span class="com">${v.comName}</span><span class="sci">${v.sciName}</span></div>
+    <div class="compare">
+      <div class="pane">
+        <div class="pane-label">Current (live) · ${v.current.overall ?? '—'}</div>
+        <img class="pane-photo" src="${v.current.url}" alt="current" />
+        <div class="pane-body">
+          ${flagsHtml(v.current.flags)}${subscoresHtml(v.current.criteria)}
+          <p class="attribution">${v.current.attribution} · ${v.current.license}</p>
+        </div>
+      </div>
+      ${proposedPane}
+    </div>
+    <div class="alternates" id="alternates">${alts}</div>
+    <div class="action-bar">
+      <button class="btn approve" id="approve" ${featured === null ? 'disabled' : ''}>Approve</button>
+      <button class="btn keep" id="keep">Keep original</button>
+      <button class="btn deny" id="deny-toggle">Deny…</button>
+    </div>
+    <div class="deny-panel" id="deny-panel">
+      <textarea id="deny-reason" placeholder="Why is every candidate wrong? (feeds re-sourcing)"></textarea>
+      <div class="quick-chips" id="quick-chips">${chips}</div>
+      <button class="btn deny" id="deny-submit">Deny & re-source</button>
+    </div>`;
+
+  // feature an alternate
+  document.querySelectorAll('.alt').forEach(el => el.addEventListener('click', () => {
+    featured = Number(el.dataset.id);
+    document.querySelectorAll('.alt').forEach(x => x.classList.toggle('selected', Number(x.dataset.id) === featured));
+    document.getElementById('approve').disabled = false;
+  }));
+
+  document.getElementById('approve').addEventListener('click', async () => {
+    const chosenCandidateId = alternateInatId(v, featured);
+    if (chosenCandidateId === null) { toast('Pick a replacement candidate before approving'); return; }
+    await fetch('/api/decision', { method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ speciesCode: code, action: 'approve', chosenCandidateId }) });
+    toast('Approved (staged — nothing live until apply-swaps)');
+  });
+  document.getElementById('keep').addEventListener('click', async () => {
+    await fetch('/api/decision', { method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ speciesCode: code, action: 'keep' }) });
+    toast('Kept original (staged)');
+  });
+  document.getElementById('deny-toggle').addEventListener('click', () => {
+    document.getElementById('deny-panel').classList.toggle('open');
+  });
+  document.querySelectorAll('.quick-chip').forEach(c => c.addEventListener('click', () => c.classList.toggle('active')));
+  document.getElementById('deny-submit').addEventListener('click', async () => {
+    const reason = document.getElementById('deny-reason').value;
+    const tags = [...document.querySelectorAll('.quick-chip.active')].map(c => c.dataset.tag);
+    // Exclude the shown candidate(s): the proposed one currently on screen.
+    const excludeIds = v.proposed ? [v.proposed.inatId] : [];
+    const r = await fetch('/api/deny', { method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ speciesCode: code, reason, tags, excludeIds }) }).then(x => x.json());
+    // Server never scores. Common case: denyAndAdvance returned the next already-
+    // scored alternate as result.next (resourceQueued:false) — re-render shows it
+    // instantly. Pool exhausted (resourceQueued:true): no proposed; re-source.
+    if (r.resourceQueued) {
+      toast('Re-source queued — run `source-candidates` then refresh');
+    } else {
+      toast('Denied — advanced to next pre-scored candidate');
+    }
+    render(); // re-render: either the next pre-scored alternate, or the empty/queued state
+  });
+}
+
+// chosen_candidate_id in the contract stores the candidate's inat id.
+// The default approve path features the *proposed* candidate, which lives in
+// its own pane — not the alternates strip — so search proposed first, then the
+// ranked alternates. Returns null only if nothing matches (server then 400s the
+// approve rather than persisting a null swap).
+function alternateInatId(view, candidateId) {
+  const hit = [view.proposed, ...view.alternates].find(x => x && x.candidateId === candidateId);
+  return hit ? hit.inatId : null;
+}
+
+render();

--- a/tools/photo-curation/public/theme.js
+++ b/tools/photo-curation/public/theme.js
@@ -1,0 +1,10 @@
+const KEY = 'photo-curate-theme';
+export function initTheme() {
+  const saved = localStorage.getItem(KEY) || 'light';
+  document.documentElement.setAttribute('data-theme', saved);
+}
+export function toggleTheme() {
+  const cur = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', cur);
+  localStorage.setItem(KEY, cur);
+}

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -2,6 +2,7 @@
 import { Command } from 'commander';
 import { openDb, DEFAULT_DB_PATH } from './db.js';
 import { sync } from './sources.js';
+import { startServer } from './server/serve.js';
 
 const API_BASE = process.env.READ_API_BASE ?? 'https://api.bird-maps.com';
 
@@ -32,9 +33,12 @@ program
 program
   .command('serve')
   .description('Start the local review server (default http://localhost:5180)')
-  .action(() => {
-    console.error('[serve] not implemented in Slice 4 — the review server ships in Slice 5.');
-    process.exit(0);
+  .option('--port <port>', 'port to bind', '5180')
+  .option('--db <path>', 'review store path', DEFAULT_DB_PATH)
+  .action((opts: { port: string; db: string }) => {
+    // startServer opens the store via openDb and starts Express; the http server
+    // holds the event loop open, so the process stays alive until Ctrl-C.
+    startServer({ dbPath: opts.db, port: Number(opts.port) });
   });
 
 program

--- a/tools/photo-curation/src/server/index.test.ts
+++ b/tools/photo-curation/src/server/index.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import Database from 'better-sqlite3';
+import { createServer } from './index.js';
+
+function seedDb(): Database.Database {
+  const db = new Database(':memory:');
+  // Canonical schema (matches src/db.ts openDb): photo_current carries `reviewed`
+  // and photo_decision carries `resource_requested` — denyAndAdvance writes the
+  // latter when the pre-scored pool is exhausted, so the column must exist here.
+  db.exec(`
+    CREATE TABLE photo_current(species_code TEXT PRIMARY KEY, com_name TEXT, sci_name TEXT, family TEXT, url TEXT, attribution TEXT, license TEXT, content_hash TEXT, reviewed INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE photo_score(id INTEGER PRIMARY KEY, species_code TEXT, role TEXT, candidate_inat_id INTEGER, content_hash TEXT, overall REAL, verdict TEXT, criteria_json TEXT, flags_json TEXT, rationale TEXT, rubric_version TEXT, scored_at TEXT);
+    CREATE TABLE photo_candidate(id INTEGER PRIMARY KEY, species_code TEXT, inat_id INTEGER, photo_url TEXT, thumb_path TEXT, attribution TEXT, license TEXT, excluded INTEGER DEFAULT 0, source_round INTEGER);
+    CREATE TABLE photo_decision(species_code TEXT PRIMARY KEY, action TEXT, chosen_candidate_id INTEGER, deny_reason TEXT, deny_tags_json TEXT, resource_requested INTEGER NOT NULL DEFAULT 0, decided_at TEXT, applied INTEGER DEFAULT 0, applied_at TEXT);
+  `);
+  const crit = JSON.stringify({ framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 6, lighting: 8 });
+  db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('houspa','House Sparrow','Passer domesticus','passeridae','https://photos/houspa.jpg','(c) B','cc0','hashB',1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','current',NULL,'hashB',18,'reject',?, '["dead","distant"]','dead','v1','2026-06-11T00:00:00Z')`).run(crit);
+  // Pre-scored candidate pool (source-candidates already scored these). 5001 is the
+  // top-ranked (shown as `proposed`); 5002 is the next-best already-scored alternate.
+  db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5001,'https://inat/5001.jpg','thumb-cache/5001.jpg','(c) C','cc-by',0,1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','candidate',5001,'hashC',79,'good',?, '[]','clean','v1','2026-06-11T00:00:00Z')`).run(crit);
+  db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5002,'https://inat/5002.jpg','thumb-cache/5002.jpg','(c) D','cc0',0,1)`).run();
+  db.prepare(`INSERT INTO photo_score (species_code,role,candidate_inat_id,content_hash,overall,verdict,criteria_json,flags_json,rationale,rubric_version,scored_at) VALUES ('houspa','candidate',5002,'hashD',64,'good',?, '[]','clean','v1','2026-06-11T00:00:00Z')`).run(crit);
+  return db;
+}
+
+describe('review-server API', () => {
+  let db: Database.Database;
+  afterEach(() => db.close());
+  beforeEach(() => { db = seedDb(); });
+
+  it('GET /api/overview returns rows honoring sort/filter', async () => {
+    const app = createServer(db);
+    const res = await request(app).get('/api/overview?sort=worst-first&filter=flagged');
+    expect(res.status).toBe(200);
+    expect(res.body.rows).toHaveLength(1);
+    expect(res.body.rows[0].speciesCode).toBe('houspa');
+    expect(res.body.stagedApproved).toBe(0);
+  });
+
+  it('GET /api/swap/:code returns the swap view', async () => {
+    const app = createServer(db);
+    const res = await request(app).get('/api/swap/houspa');
+    expect(res.status).toBe(200);
+    expect(res.body.current.overall).toBe(18);
+    expect(res.body.proposed.inatId).toBe(5001);
+  });
+
+  it('GET /api/swap/:code 404s unknown species', async () => {
+    const app = createServer(db);
+    const res = await request(app).get('/api/swap/nope');
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api/decision approve persists a staged decision', async () => {
+    const app = createServer(db);
+    const res = await request(app).post('/api/decision')
+      .send({ speciesCode: 'houspa', action: 'approve', chosenCandidateId: 5001 });
+    expect(res.status).toBe(200);
+    const row = db.prepare(`SELECT action, chosen_candidate_id FROM photo_decision WHERE species_code='houspa'`).get() as { action: string; chosen_candidate_id: number | null };
+    expect(row.action).toBe('approve');
+    expect(row.chosen_candidate_id).toBe(5001);
+  });
+
+  it('POST /api/decision approve without a chosenCandidateId is rejected 400', async () => {
+    const app = createServer(db);
+    const res = await request(app).post('/api/decision').send({ speciesCode: 'houspa', action: 'approve' });
+    expect(res.status).toBe(400);
+    // nothing persisted: a null approve would defeat the swap
+    const row = db.prepare(`SELECT action FROM photo_decision WHERE species_code='houspa'`).get() as { action: string } | undefined;
+    expect(row).toBeUndefined();
+  });
+
+  it('POST /api/deny records the deny, excludes the shown candidate, and advances to the next pre-scored alternate', async () => {
+    // Common case: the pre-scored pool still has an alternate (5002). Deny the
+    // shown candidate (5001) via excludeIds; denyAndAdvance excludes it and
+    // returns the next already-scored alternate as `result.next` — instant, NO
+    // scoring. The route surfaces it as `proposed`.
+    const app = createServer(db);
+    const res = await request(app).post('/api/deny')
+      .send({ speciesCode: 'houspa', reason: 'still distant', tags: ['still-distant'], excludeIds: [5001] });
+    expect(res.status).toBe(200);
+    expect(res.body.resourceQueued).toBe(false);
+    // denyAndAdvance returned the next pre-scored alternate as `result.next`,
+    // which the route forwards as `proposed` (instant advance — no agent, no scoring)
+    expect(res.body.proposed.inatId).toBe(5002);
+
+    // deny recorded
+    const dec = db.prepare(`SELECT action, deny_reason, deny_tags_json, resource_requested FROM photo_decision WHERE species_code='houspa'`).get() as { action: string; deny_reason: string; deny_tags_json: string; resource_requested: number };
+    expect(dec.action).toBe('deny');
+    expect(dec.deny_reason).toBe('still distant');
+    expect(JSON.parse(dec.deny_tags_json)).toEqual(['still-distant']);
+    // pool not exhausted → no re-source queued
+    expect(dec.resource_requested).toBe(0);
+    // shown candidate excluded
+    const ex = db.prepare(`SELECT excluded FROM photo_candidate WHERE inat_id=5001`).get() as { excluded: number };
+    expect(ex.excluded).toBe(1);
+    // and a follow-up swap fetch agrees: the next pre-scored alternate is now proposed
+    const view = await request(app).get('/api/swap/houspa');
+    expect(view.body.proposed.inatId).toBe(5002);
+  });
+
+  it('POST /api/deny queues a re-source when the pre-scored pool is exhausted', async () => {
+    // Deny everything in the pool. Exclude 5002 up front and pass 5001 via
+    // excludeIds so denyAndAdvance has no scored alternate left to advance to.
+    db.prepare(`UPDATE photo_candidate SET excluded=1 WHERE inat_id=5002`).run();
+    const app = createServer(db);
+    const res = await request(app).post('/api/deny')
+      .send({ speciesCode: 'houspa', reason: 'all wrong sex/morph', tags: ['wrong-sex-morph'], excludeIds: [5001] });
+    expect(res.status).toBe(200);
+    // pool exhausted → result.next is null, resourceRequested true; route forwards
+    // as proposed:null, resourceQueued:true (UI shows "run source-candidates")
+    expect(res.body.proposed).toBeNull();
+    expect(res.body.resourceQueued).toBe(true);
+    // the re-source-requested flag is persisted for the next source-candidates run
+    const dec = db.prepare(`SELECT action, resource_requested, deny_tags_json FROM photo_decision WHERE species_code='houspa'`).get() as { action: string; resource_requested: number; deny_tags_json: string };
+    expect(dec.action).toBe('deny');
+    expect(dec.resource_requested).toBe(1);
+    expect(JSON.parse(dec.deny_tags_json)).toEqual(['wrong-sex-morph']);
+    // shown candidate still excluded
+    const ex = db.prepare(`SELECT excluded FROM photo_candidate WHERE inat_id=5001`).get() as { excluded: number };
+    expect(ex.excluded).toBe(1);
+  });
+
+  it('POST /api/decision rejects an unknown action with 400', async () => {
+    const app = createServer(db);
+    const res = await request(app).post('/api/decision').send({ speciesCode: 'houspa', action: 'bogus' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tools/photo-curation/src/server/index.ts
+++ b/tools/photo-curation/src/server/index.ts
@@ -24,8 +24,10 @@ export function createServer(db: Database.Database): Express {
   const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'public');
   app.use(express.static(publicDir));
   // Screen 2 is one HTML file; the :code is read client-side from the path.
+  // Use sendFile's { root } option (relative filename) — the canonical Express 5
+  // form; passing a bare absolute path trips `send`'s NotFoundError on some paths.
   app.get('/swap/:code', (_req: Request, res: Response) => {
-    res.sendFile(join(publicDir, 'swap.html'));
+    res.sendFile('swap.html', { root: publicDir });
   });
 
   // ── JSON API ──

--- a/tools/photo-curation/src/server/index.ts
+++ b/tools/photo-curation/src/server/index.ts
@@ -1,0 +1,94 @@
+import express, { type Express, type Request, type Response } from 'express';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type Database from 'better-sqlite3';
+import {
+  listOverview, getSwapView, writeDecision, denyAndAdvance,
+  type SortMode, type FilterMode,
+} from './queries.js';
+
+// NOTE: the Express server is plain Node — it CANNOT dispatch a Claude Code
+// agent, so it never scores a photo. All scoring lives in the `source-candidates`
+// workflow, which pre-scores a DEEP candidate pool ahead of the review session.
+// Deny advances to the next already-scored alternate from that pool, or — when
+// the pool is exhausted — queues a re-source for the next `source-candidates` run.
+
+const VALID_SORTS: SortMode[] = ['worst-first', 'best-first', 'has-better-candidate', 'recently-scored'];
+const VALID_FILTERS: FilterMode[] = ['all', 'flagged', 'dead-sick', 'distant', 'in-hand', 'soft', 'marked-for-swap', 'unscored'];
+
+export function createServer(db: Database.Database): Express {
+  const app = express();
+  app.use(express.json());
+
+  // ── Static screens ──
+  const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'public');
+  app.use(express.static(publicDir));
+  // Screen 2 is one HTML file; the :code is read client-side from the path.
+  app.get('/swap/:code', (_req: Request, res: Response) => {
+    res.sendFile(join(publicDir, 'swap.html'));
+  });
+
+  // ── JSON API ──
+  app.get('/api/overview', (req: Request, res: Response) => {
+    const sort = (req.query.sort as SortMode) ?? 'worst-first';
+    const filter = (req.query.filter as FilterMode) ?? 'all';
+    if (!VALID_SORTS.includes(sort)) return res.status(400).json({ error: `bad sort: ${sort}` });
+    if (!VALID_FILTERS.includes(filter)) return res.status(400).json({ error: `bad filter: ${filter}` });
+    const rows = listOverview(db, { sort, filter });
+    const staged = db.prepare(`SELECT COUNT(*) AS c FROM photo_decision WHERE action='approve' AND applied=0`).get() as { c: number };
+    return res.json({ rows, stagedApproved: staged.c, sort, filter });
+  });
+
+  app.get('/api/swap/:code', (req: Request, res: Response) => {
+    // Express 5 types params values as `string | string[] | undefined`; a single
+    // named segment is always a string at runtime, but narrow it for strict TS.
+    const code = req.params.code;
+    if (typeof code !== 'string' || !code) return res.status(400).json({ error: 'species code required' });
+    const view = getSwapView(db, code);
+    if (!view) return res.status(404).json({ error: `unknown species: ${code}` });
+    return res.json(view);
+  });
+
+  app.post('/api/decision', (req: Request, res: Response) => {
+    const { speciesCode, action, chosenCandidateId } = req.body ?? {};
+    if (typeof speciesCode !== 'string' || !speciesCode) return res.status(400).json({ error: 'speciesCode required' });
+    if (action !== 'approve' && action !== 'keep' && action !== 'pending') {
+      return res.status(400).json({ error: `bad action: ${action}` }); // deny goes to /api/deny
+    }
+    // An approve MUST carry a chosen candidate's inat id. Enforce server-side so
+    // a missing/null chosenCandidateId is rejected (400) independent of whether
+    // the UI disabled the Approve button — a null approve would silently store
+    // chosen_candidate_id = NULL and defeat the swap.
+    if (action === 'approve' && typeof chosenCandidateId !== 'number') {
+      return res.status(400).json({ error: 'approve requires chosenCandidateId' });
+    }
+    writeDecision(db, {
+      speciesCode, action,
+      ...(typeof chosenCandidateId === 'number' ? { chosenCandidateId } : {}),
+    });
+    return res.json({ ok: true });
+  });
+
+  app.post('/api/deny', (req: Request, res: Response) => {
+    const { speciesCode, reason, tags, excludeIds } = req.body ?? {};
+    if (typeof speciesCode !== 'string' || !speciesCode) return res.status(400).json({ error: 'speciesCode required' });
+    if (typeof reason !== 'string') return res.status(400).json({ error: 'reason required' });
+
+    // Part 5a's denyAndAdvance does it all in one call: records the deny
+    // (photo_decision action='deny' + deny_reason + deny_tags_json), excludes the
+    // shown candidate(s) (excludeIds → photo_candidate.excluded=1), and returns the
+    // next ALREADY-SCORED alternate from the pre-scored pool as `next`. The server
+    // does NOT score — when no scored alternate remains, denyAndAdvance sets
+    // photo_decision.resource_requested=1 and returns resourceRequested=true so the
+    // UI shows "re-source queued — run `source-candidates` then refresh."
+    const result = denyAndAdvance(db, {
+      speciesCode,
+      reason,
+      tags: Array.isArray(tags) ? (tags as string[]) : [],
+      excludeIds: Array.isArray(excludeIds) ? (excludeIds as number[]) : [],
+    });
+    return res.json({ proposed: result.next, resourceQueued: result.resourceRequested });
+  });
+
+  return app;
+}

--- a/tools/photo-curation/src/server/queries.test.ts
+++ b/tools/photo-curation/src/server/queries.test.ts
@@ -156,6 +156,21 @@ describe('getSwapView', () => {
   it('returns null for unknown species', () => {
     expect(getSwapView(db, 'nope')).toBeNull();
   });
+
+  it('proposes only a SCORED candidate — an unscored-only pool yields proposed:null', () => {
+    // Consistency with denyAndAdvance (advances only to scored alternates):
+    // the proposed candidate the UI shows must have a non-null score. Replace
+    // houspa's scored candidate (5001) with an unscored one — proposed must be
+    // null until `source-candidates` scores it, even though a non-excluded
+    // candidate row exists.
+    db.prepare(`UPDATE photo_candidate SET excluded = 1 WHERE inat_id = 5001`).run();
+    db.prepare(`INSERT INTO photo_candidate (species_code,inat_id,photo_url,thumb_path,attribution,license,excluded,source_round) VALUES ('houspa',5009,'https://inat/5009.jpg','thumb-cache/5009.jpg','(c) U','cc0',0,2)`).run();
+    const view = getSwapView(db, 'houspa');
+    expect(view!.proposed).toBeNull();
+    // the unscored candidate still appears in the alternates strip (overall null)
+    expect(view!.alternates.map(a => a.inatId)).toEqual([5009]);
+    expect(view!.alternates[0]!.overall).toBeNull();
+  });
 });
 
 describe('writeDecision', () => {

--- a/tools/photo-curation/src/server/queries.ts
+++ b/tools/photo-curation/src/server/queries.ts
@@ -197,6 +197,16 @@ export function getSwapView(db: Database.Database, speciesCode: string): SwapVie
     rationale: r.rationale, sourceRound: r.source_round,
   }));
 
+  // `proposed` must be a SCORED candidate so the UI's proposed pick agrees with
+  // denyAndAdvance, which only ever advances to an already-scored alternate
+  // (overall NOT NULL). alternates[0] could be an unscored candidate (overall
+  // null) — surfacing it as `proposed` would let the UI offer a replacement the
+  // deny path would never advance to. Pick the top-ranked scored alternate; if
+  // the pool is unscored-only, propose nothing until `source-candidates` scores
+  // it. alternates is already ORDER BY cs.overall DESC, so the first one with a
+  // non-null overall is the top scored candidate.
+  const proposed = alternates.find(a => a.overall !== null) ?? null;
+
   return {
     speciesCode, comName: cur.com_name, sciName: cur.sci_name, family: cur.family,
     current: {
@@ -205,7 +215,7 @@ export function getSwapView(db: Database.Database, speciesCode: string): SwapVie
       flags: parseFlags(cur.flags_json), criteria: parseCriteria(cur.criteria_json),
       rationale: cur.rationale,
     },
-    proposed: alternates[0] ?? null,
+    proposed,
     alternates,
   };
 }

--- a/tools/photo-curation/src/server/serve.ts
+++ b/tools/photo-curation/src/server/serve.ts
@@ -1,0 +1,14 @@
+import { openDb } from '../db.js';
+import { createServer } from './index.js';
+
+export interface ServeOptions { dbPath: string; port: number }
+
+export function startServer(opts: ServeOptions): { close: () => void } {
+  const db = openDb(opts.dbPath);   // Slice 4's opener; opens ./review.sqlite by default
+  const app = createServer(db);
+  const server = app.listen(opts.port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`review server on http://localhost:${opts.port}  (db: ${opts.dbPath})`);
+  });
+  return { close: () => { server.close(); db.close(); } };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant UI as Review UI (browser)
    participant Server as Express server (plain Node)
    participant Queries as queries.ts (5a data layer)
    participant DB as review.sqlite

    UI->>Server: GET /api/overview?sort&filter
    Server->>Queries: listOverview(db, opts)
    Queries->>DB: SELECT current + scored candidates
    DB-->>UI: rows + stagedApproved

    UI->>Server: POST /api/deny excludeIds
    Server->>Queries: denyAndAdvance(db, input)
    Queries->>DB: record deny, exclude shown, next scored alternate
    alt pre-scored alternate remains
        DB-->>UI: proposed next, resourceQueued false
    else pool exhausted
        Queries->>DB: set resource_requested 1
        DB-->>UI: proposed null, resourceQueued true
    end
```

## Summary

- Wires the Part 5a data layer into a runnable `photo-curate serve` review server: an Express 5 app (`createServer(db)`) exposing `GET /api/overview`, `GET /api/swap/:code`, `POST /api/decision`, `POST /api/deny` plus two static screens, replacing Slice 4's `serve` stub. The server is **plain Node and never scores** — `/api/deny` is a thin wrapper over 5a's `denyAndAdvance`, which records the deny, excludes the shown candidate(s), and advances to the next already-scored alternate from the pre-scored pool, or sets `resource_requested=1` when the pool is exhausted. Approve has a server-side 400 guard when `chosenCandidateId` is missing.
- **Consistency fix (review note carried from #972):** `getSwapView`'s `proposed` was `alternates[0]`, which could surface an *unscored* candidate while `denyAndAdvance` only advances to *scored* alternates — so the UI's proposed pick and deny-advance behavior could disagree. `proposed` now filters to the top-ranked candidate with a non-null score; an unscored-only pool yields `proposed: null`. Added a test asserting this.
- Two screens under `public/` adopting DESIGN.md tokens (light/dark via `[data-theme]` + a localStorage-persisted toggle), status colors deep-ember / dark-amber / forest-green (NOT the `--color-decision-point`/density tokens DESIGN.md flags as failing light contrast). This slice OWNS adding `express` 5.x + `supertest` (+ `@types/*`) to the workspace.

## Screenshots

N/A — not UI (under `tools/`, not `frontend/**`; the #445 CSS gate and 5-viewport design-review gate do not apply). A light + dark local smoke check was still run — both screens render, the deny path advances to the next pre-scored alternate live, and the console is clean (zero errors / zero warnings) in both themes.

- [x] N/A — not UI (every CSS class used has a matching rule in `tools/photo-curation/public/app.css`, verified by a by-hand orphan-className scan)
- [x] N/A — not UI (no #445 multi-viewport requirement for `tools/`)

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (9 files, 71 tests; new `src/server/index.test.ts` covers all 4 routes via supertest against a temp sqlite, incl. deny-advance / pool-exhausted-queued / approve-400-guard, plus the proposed-only-scored consistency test in `queries.test.ts`)
- [x] New unit tests added (8 server-API cases + 1 `getSwapView` consistency case)
- [x] N/A — no Playwright e2e spec (this is a local CLI tool under `tools/`, not the `frontend/**` e2e surface)
- [x] `npm run build` (root) — clean; `npm run build --workspace @bird-watch/photo-curation` — clean `tsc`
- [x] `npx knip` — clean (added a dated ignore rule for the three `public/*.js` browser modules served by `express.static`, same convention as the `workflows/*.mjs` entry)
- [x] `npm install --package-lock-only && git diff --exit-code package-lock.json` — clean
- [x] Light + dark smoke check via Playwright MCP — both screens, both themes, zero console errors/warnings; deny advance verified live (denied proposed 5001, re-rendered with 5002 as the new proposed)

## Plan reference

Part of epic #974. Implements issue #973 (photo-curation Slice 5b). Depends on #970 (store + `openDb`), #972 (5a data layer), #971 (Slice 4 `serve` stub this replaces) — all merged on `main`. Plans live in issues, not `docs/plans/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)