### PR TITLE
feat(photo-curation): apply-swaps — batched, confirm-gated push of approved swaps (#967)

### DIFF
--- a/tools/photo-curation/src/apply-swaps.test.ts
+++ b/tools/photo-curation/src/apply-swaps.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import Database from 'better-sqlite3';
+import { runApplySwaps, type ApplyDeps } from './apply-swaps.js';
+
+const ADMIN_BASE = 'https://admin.example';
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+/**
+ * An in-memory SQLite matching the Slice-4 schema for the three tables
+ * apply-swaps touches. Real better-sqlite3 (no DB mock — repo rule), just
+ * `:memory:` so the test is hermetic and fast.
+ */
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE photo_current (
+      species_code TEXT PRIMARY KEY, com_name TEXT, sci_name TEXT, family TEXT,
+      url TEXT, attribution TEXT, license TEXT, content_hash TEXT
+    );
+    CREATE TABLE photo_candidate (
+      id INTEGER PRIMARY KEY, species_code TEXT, inat_id INTEGER, photo_url TEXT,
+      thumb_path TEXT, attribution TEXT, license TEXT,
+      excluded INTEGER DEFAULT 0, source_round INTEGER
+    );
+    CREATE TABLE photo_decision (
+      species_code TEXT PRIMARY KEY, action TEXT, chosen_candidate_id INTEGER,
+      deny_reason TEXT, deny_tags_json TEXT, decided_at TEXT,
+      applied INTEGER DEFAULT 0, applied_at TEXT
+    );
+  `);
+  return db;
+}
+
+/** Seed one species with a current photo, one candidate, and an approve decision. */
+function seedApproved(
+  db: Database.Database,
+  opts: { code: string; candidateId: number; newUrl: string; license?: string; applied?: 0 | 1 },
+): void {
+  db.prepare(
+    `INSERT INTO photo_current (species_code, com_name, sci_name, family, url, attribution, license, content_hash)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(opts.code, 'Common Name', 'Genus species', 'familyidae',
+        `https://photos.bird-maps.com/species/${opts.code}.oldhash1.jpg`,
+        '(c) Old Photographer, CC BY', 'cc-by', 'oldhash1');
+  db.prepare(
+    `INSERT INTO photo_candidate (id, species_code, inat_id, photo_url, thumb_path, attribution, license, excluded, source_round)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 0, 1)`,
+  ).run(opts.candidateId, opts.code, 9000 + opts.candidateId, opts.newUrl,
+        `./thumb-cache/${opts.candidateId}.jpg`, '(c) New Photographer, CC BY-SA', opts.license ?? 'cc-by-sa');
+  db.prepare(
+    `INSERT INTO photo_decision (species_code, action, chosen_candidate_id, decided_at, applied, applied_at)
+     VALUES (?, 'approve', ?, ?, ?, NULL)`,
+  ).run(opts.code, opts.candidateId, '2026-06-10T00:00:00.000Z', opts.applied ?? 0);
+}
+
+function makeDeps(db: Database.Database, overrides: Partial<ApplyDeps> = {}): ApplyDeps {
+  return {
+    db,
+    adminBase: ADMIN_BASE,
+    adminToken: 'tok',
+    fetch: globalThis.fetch,
+    log: () => {},          // silence summary output in tests
+    confirm: async () => true,
+    now: () => '2026-06-10T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('runApplySwaps', () => {
+  it('PUTs each approved swap and marks it applied on 2xx', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'norcar', candidateId: 1, newUrl: 'https://inat.example/photos/1/original.jpg' });
+
+    const seen: { url: string; auth: string | null; body: unknown }[] = [];
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, async ({ request, params }) => {
+        seen.push({
+          url: `/admin/species-photos/${params.code}`,
+          auth: request.headers.get('Authorization'),
+          body: await request.json(),
+        });
+        return HttpResponse.json({ url: 'https://photos.bird-maps.com/species/norcar.newhash.jpg', key: 'species/norcar.newhash.jpg' });
+      }),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+
+    expect(result.applied).toEqual(['norcar']);
+    expect(result.failed).toEqual([]);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.url).toBe('/admin/species-photos/norcar');
+    expect(seen[0]!.auth).toBe('Bearer tok');
+    expect(seen[0]!.body).toEqual({
+      sourceUrl: 'https://inat.example/photos/1/original.jpg',
+      attribution: '(c) New Photographer, CC BY-SA',
+      license: 'cc-by-sa',
+    });
+
+    const row = db.prepare(`SELECT applied, applied_at FROM photo_decision WHERE species_code = 'norcar'`).get() as { applied: number; applied_at: string };
+    expect(row.applied).toBe(1);
+    expect(row.applied_at).toBe('2026-06-10T12:00:00.000Z');
+  });
+
+  it('leaves a row un-applied and reports it when the admin endpoint returns non-2xx', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'baleag', candidateId: 2, newUrl: 'https://inat.example/photos/2/original.jpg' });
+
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, () =>
+        HttpResponse.json({ error: 'license rejected by server-side allowlist' }, { status: 422 }),
+      ),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+
+    expect(result.applied).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.speciesCode).toBe('baleag');
+    expect(result.failed[0]!.reason).toContain('422');
+
+    const row = db.prepare(`SELECT applied FROM photo_decision WHERE species_code = 'baleag'`).get() as { applied: number };
+    expect(row.applied).toBe(0);
+  });
+
+  it('isolates failures per species — one failure does not abort the rest', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'aaa', candidateId: 1, newUrl: 'https://inat.example/photos/a/original.jpg' });
+    seedApproved(db, { code: 'bbb', candidateId: 2, newUrl: 'https://inat.example/photos/b/original.jpg' });
+    seedApproved(db, { code: 'ccc', candidateId: 3, newUrl: 'https://inat.example/photos/c/original.jpg' });
+
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, ({ params }) => {
+        if (params.code === 'bbb') return HttpResponse.json({ error: 'boom' }, { status: 500 });
+        return HttpResponse.json({ url: `https://photos.bird-maps.com/species/${params.code}.h.jpg`, key: 'k' });
+      }),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+
+    expect(result.applied.sort()).toEqual(['aaa', 'ccc']);
+    expect(result.failed.map(f => f.speciesCode)).toEqual(['bbb']);
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='bbb'`).get() as { applied: number }).applied).toBe(0);
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='aaa'`).get() as { applied: number }).applied).toBe(1);
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='ccc'`).get() as { applied: number }).applied).toBe(1);
+  });
+
+  it('is idempotent — already-applied rows are skipped (no admin call)', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'done', candidateId: 1, newUrl: 'https://inat.example/photos/d/original.jpg', applied: 1 });
+    seedApproved(db, { code: 'todo', candidateId: 2, newUrl: 'https://inat.example/photos/t/original.jpg', applied: 0 });
+
+    const calls: string[] = [];
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, ({ params }) => {
+        calls.push(params.code as string);
+        return HttpResponse.json({ url: 'https://photos.bird-maps.com/species/todo.h.jpg', key: 'k' });
+      }),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+
+    expect(calls).toEqual(['todo']);            // 'done' is never called
+    expect(result.applied).toEqual(['todo']);
+    expect(result.alreadyAppliedTotal).toBe(1);
+  });
+
+  it('ignores non-approve decisions (keep / deny / pending)', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'approveme', candidateId: 1, newUrl: 'https://inat.example/photos/1/original.jpg' });
+    // A kept decision must never be pushed.
+    db.prepare(
+      `INSERT INTO photo_decision (species_code, action, chosen_candidate_id, decided_at, applied)
+       VALUES ('keepme', 'keep', NULL, '2026-06-10T00:00:00.000Z', 0)`,
+    ).run();
+
+    const calls: string[] = [];
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, ({ params }) => {
+        calls.push(params.code as string);
+        return HttpResponse.json({ url: 'x', key: 'k' });
+      }),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+    expect(calls).toEqual(['approveme']);
+    expect(result.applied).toEqual(['approveme']);
+  });
+
+  it('aborts with zero admin calls when the operator declines confirmation', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'norcar', candidateId: 1, newUrl: 'https://inat.example/photos/1/original.jpg' });
+
+    let calls = 0;
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, () => {
+        calls++;
+        return HttpResponse.json({ url: 'x', key: 'k' });
+      }),
+    );
+
+    const result = await runApplySwaps(makeDeps(db, { confirm: async () => false }));
+
+    expect(calls).toBe(0);
+    expect(result.aborted).toBe(true);
+    expect(result.applied).toEqual([]);
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='norcar'`).get() as { applied: number }).applied).toBe(0);
+  });
+
+  it('marks a species failed (un-applied) when fetch throws a network error', async () => {
+    const db = makeDb();
+    seedApproved(db, { code: 'neterr', candidateId: 1, newUrl: 'https://inat.example/photos/1/original.jpg' });
+
+    const result = await runApplySwaps(
+      makeDeps(db, { fetch: async () => { throw new Error('ECONNRESET'); } }),
+    );
+
+    expect(result.applied).toEqual([]);
+    expect(result.failed[0]!.speciesCode).toBe('neterr');
+    expect(result.failed[0]!.reason).toContain('ECONNRESET');
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='neterr'`).get() as { applied: number }).applied).toBe(0);
+  });
+});
+
+import { resolveAdminEnv } from './apply-swaps.js';
+
+describe('resolveAdminEnv', () => {
+  it('returns base+token when both env vars are present', () => {
+    const r = resolveAdminEnv({ ADMIN_API_URL: 'https://admin.bird-maps.com', ADMIN_API_TOKEN: 'tok' });
+    expect(r).toEqual({ ok: true, adminBase: 'https://admin.bird-maps.com', adminToken: 'tok' });
+  });
+
+  it('reports an error when ADMIN_API_URL is missing', () => {
+    const r = resolveAdminEnv({ ADMIN_API_TOKEN: 'tok' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/ADMIN_API_URL/);
+  });
+
+  it('reports an error when ADMIN_API_TOKEN is missing', () => {
+    const r = resolveAdminEnv({ ADMIN_API_URL: 'https://admin.bird-maps.com' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/ADMIN_API_TOKEN/);
+  });
+});

--- a/tools/photo-curation/src/apply-swaps.ts
+++ b/tools/photo-curation/src/apply-swaps.ts
@@ -1,0 +1,177 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * Staged apply (spec §5.6). Reads `photo_decision` rows where
+ * action='approve' AND applied=0, joins the chosen candidate + current photo,
+ * prints a confirm summary, and on confirmation PUTs each swap to the prod
+ * admin endpoint `PUT /admin/species-photos/:speciesCode`. A 2xx marks the row
+ * applied=1; any non-2xx / network error leaves it applied=0 and reports it for
+ * retry. Per-species isolation: one failure does not abort the batch.
+ *
+ * Everything external (the SQLite handle, fetch, confirmation prompt, clock,
+ * logger) is injected so the path is unit-testable without real network/IO —
+ * the same DI idiom as services/ingestor/src/cli.ts (runCli(kind, deps)).
+ */
+export interface ApplyDeps {
+  db: Database.Database;
+  adminBase: string;                 // ADMIN_API_URL, e.g. https://admin.bird-maps.com
+  adminToken: string;                // ADMIN_API_TOKEN bearer
+  fetch: typeof globalThis.fetch;
+  log: (line: string) => void;       // summary output; production = console.log
+  confirm: () => Promise<boolean>;   // operator y/N gate; production = stdin prompt
+  now: () => string;                 // ISO timestamp; injectable for deterministic tests
+}
+
+export interface PendingSwap {
+  speciesCode: string;
+  comName: string;
+  oldUrl: string;                    // photo_current.url (display only)
+  newUrl: string;                    // chosen candidate's photo_url → admin `sourceUrl`
+  attribution: string;
+  license: string;
+}
+
+export interface ApplyFailure {
+  speciesCode: string;
+  reason: string;
+}
+
+export interface ApplyResult {
+  applied: string[];                 // species codes successfully pushed + marked
+  failed: ApplyFailure[];            // species codes that errored (left un-applied)
+  alreadyAppliedTotal: number;       // count of ALL action='approve' rows already applied=1 (cumulative, informational)
+  aborted: boolean;                  // true when the operator declined the confirm
+}
+
+/**
+ * Selects approvable swaps. INNER JOIN on photo_candidate guarantees the chosen
+ * candidate still exists; LEFT JOIN on photo_current so a brand-new species
+ * (no prior live photo) still applies (oldUrl falls back to '(none)'). The
+ * `cand.excluded = 0` guard defends against a future flow that re-excludes a
+ * candidate after it was approved — an excluded candidate must never be pushed.
+ */
+function selectPendingSwaps(db: Database.Database): PendingSwap[] {
+  const rows = db
+    .prepare(
+      `SELECT d.species_code   AS speciesCode,
+              COALESCE(cur.com_name, d.species_code) AS comName,
+              COALESCE(cur.url, '(none)')            AS oldUrl,
+              cand.photo_url    AS newUrl,
+              cand.attribution  AS attribution,
+              cand.license      AS license
+         FROM photo_decision d
+         JOIN photo_candidate cand ON cand.id = d.chosen_candidate_id
+         LEFT JOIN photo_current cur ON cur.species_code = d.species_code
+        WHERE d.action = 'approve' AND d.applied = 0 AND cand.excluded = 0
+        ORDER BY d.species_code`,
+    )
+    .all() as PendingSwap[];
+  return rows;
+}
+
+function countAlreadyApplied(db: Database.Database): number {
+  const row = db
+    .prepare(`SELECT COUNT(*) AS n FROM photo_decision WHERE action = 'approve' AND applied = 1`)
+    .get() as { n: number };
+  return row.n;
+}
+
+async function pushOne(deps: ApplyDeps, swap: PendingSwap): Promise<void> {
+  const url = `${deps.adminBase.replace(/\/$/, '')}/admin/species-photos/${swap.speciesCode}`;
+  const res = await deps.fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${deps.adminToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      sourceUrl: swap.newUrl,
+      attribution: swap.attribution,
+      license: swap.license,
+    }),
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = (await res.text()).slice(0, 200);
+    } catch {
+      // body unreadable — status alone is enough context for retry triage
+    }
+    throw new Error(`HTTP ${res.status}${detail ? `: ${detail}` : ''}`);
+  }
+}
+
+export async function runApplySwaps(deps: ApplyDeps): Promise<ApplyResult> {
+  const swaps = selectPendingSwaps(deps.db);
+  const alreadyAppliedTotal = countAlreadyApplied(deps.db);
+
+  if (swaps.length === 0) {
+    deps.log(
+      alreadyAppliedTotal > 0
+        ? `Nothing to apply — ${alreadyAppliedTotal} approved swap(s) already applied.`
+        : 'Nothing to apply — no approved swaps staged.',
+    );
+    return { applied: [], failed: [], alreadyAppliedTotal, aborted: false };
+  }
+
+  // Confirm summary: N species, old→new, license. Mutates prod only on "yes".
+  deps.log(`About to apply ${swaps.length} approved photo swap(s):`);
+  for (const s of swaps) {
+    deps.log(`  ${s.speciesCode} (${s.comName})`);
+    deps.log(`    from: ${s.oldUrl}`);
+    deps.log(`    to:   ${s.newUrl}  [${s.license}]`);
+  }
+  const ok = await deps.confirm();
+  if (!ok) {
+    deps.log('Aborted — no changes pushed.');
+    return { applied: [], failed: [], alreadyAppliedTotal, aborted: true };
+  }
+
+  const markApplied = deps.db.prepare(
+    `UPDATE photo_decision SET applied = 1, applied_at = ? WHERE species_code = ?`,
+  );
+
+  const applied: string[] = [];
+  const failed: ApplyFailure[] = [];
+
+  // Per-species isolation: one bad apply must not abort the batch. Failures
+  // stay applied=0 for retry — R2-before-DB ordering inside the admin endpoint
+  // means a failed apply never leaves a dangling live URL (spec §8).
+  for (const swap of swaps) {
+    try {
+      await pushOne(deps, swap);
+      markApplied.run(deps.now(), swap.speciesCode);
+      applied.push(swap.speciesCode);
+      deps.log(`  OK  ${swap.speciesCode}`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      failed.push({ speciesCode: swap.speciesCode, reason });
+      deps.log(`  ERR ${swap.speciesCode}: ${reason}`);
+    }
+  }
+
+  deps.log(`Applied ${applied.length}, failed ${failed.length}.`);
+  if (failed.length > 0) {
+    deps.log('Failures left un-applied for retry:');
+    for (const f of failed) deps.log(`  ${f.speciesCode}: ${f.reason}`);
+  }
+  return { applied, failed, alreadyAppliedTotal, aborted: false };
+}
+
+export type AdminEnv =
+  | { ok: true; adminBase: string; adminToken: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolves the admin endpoint env, mirroring scripts/silhouette.mjs's contract:
+ * both ADMIN_API_URL and ADMIN_API_TOKEN must be present. Returned as a result
+ * object (not a throw) so the CLI maps a missing-env to exit code 2 — the same
+ * code silhouette.mjs returns for missing env.
+ */
+export function resolveAdminEnv(env: NodeJS.ProcessEnv): AdminEnv {
+  const adminBase = env.ADMIN_API_URL;
+  const adminToken = env.ADMIN_API_TOKEN;
+  if (!adminBase) return { ok: false, error: 'ADMIN_API_URL must be set in env' };
+  if (!adminToken) return { ok: false, error: 'ADMIN_API_TOKEN must be set in env' };
+  return { ok: true, adminBase, adminToken };
+}

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
 import { Command } from 'commander';
 import { openDb, DEFAULT_DB_PATH } from './db.js';
 import { sync } from './sources.js';
 import { startServer } from './server/serve.js';
+import { resolveAdminEnv, runApplySwaps } from './apply-swaps.js';
 
 const API_BASE = process.env.READ_API_BASE ?? 'https://api.bird-maps.com';
 
@@ -43,10 +46,39 @@ program
 
 program
   .command('apply-swaps')
-  .description('Push approved photo_decision rows to the admin endpoint')
-  .action(() => {
-    console.error('[apply-swaps] not implemented in Slice 4 — the batched apply ships in Slice 8.');
-    process.exit(0);
+  .description('Push approved photo_decision rows to the admin endpoint (confirm-gated)')
+  .action(async () => {
+    const env = resolveAdminEnv(process.env);
+    if (!env.ok) {
+      console.error(env.error);
+      process.exit(2); // mirrors scripts/silhouette.mjs missing-env exit code
+    }
+    const db = openDb(DEFAULT_DB_PATH); // opens ./review.sqlite (Slice 4 helper)
+    try {
+      const result = await runApplySwaps({
+        db,
+        adminBase: env.adminBase,
+        adminToken: env.adminToken,
+        fetch: globalThis.fetch,
+        log: line => console.log(line),
+        confirm: async () => {
+          const rl = createInterface({ input, output });
+          try {
+            const answer = await rl.question('Apply these swaps to PROD? [y/N] ');
+            return /^y(es)?$/i.test(answer.trim());
+          } finally {
+            rl.close();
+          }
+        },
+        now: () => new Date().toISOString(),
+      });
+      // Non-zero exit when any species failed, so a wrapping shell script / CI
+      // step can detect partial failure and re-run (idempotent — applied rows
+      // are skipped on the retry).
+      process.exit(result.failed.length > 0 ? 1 : 0);
+    } finally {
+      db.close();
+    }
   });
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant CLI as photo-curate apply-swaps
    participant SQLite as review.sqlite
    participant Operator
    participant Admin as PUT /admin/species-photos/:code

    CLI->>SQLite: SELECT approve rows where applied=0 (join candidate + current)
    SQLite-->>CLI: pending swaps (oldUrl old, newUrl, license)
    CLI->>Operator: print confirm summary (N species, old to new, license)
    Operator-->>CLI: y/N
    Note over CLI: declined aborts with zero admin calls
    loop per approved species (isolated)
        CLI->>Admin: PUT Bearer token, body sourceUrl attribution license
        alt 2xx
            Admin-->>CLI: 200 url key
            CLI->>SQLite: UPDATE applied=1, applied_at=now
        else non-2xx or network error
            Admin-->>CLI: error
            Note over CLI: leave applied=0, add to failures
        end
    end
    CLI->>Operator: applied N, failed M (exit 1 if any failed)
```

## Summary

- Slice 8 of the photo-curation epic: replaces the Slice-4 `apply-swaps` stub with the real staged-apply path. It reads `photo_decision` rows where `action='approve' AND applied=0`, resolves each chosen `photo_candidate` (its `photo_url`/`attribution`/`license`), prints a confirm summary, and on confirmation PUTs each swap to the prod admin endpoint — the one step in the epic that mutates prod, gated behind operator confirmation.
- Correctness is enforced where it matters: a 2xx marks exactly that one row `applied=1, applied_at=<iso>`; non-2xx or a thrown network error leaves it `applied=0` and reports it for retry; per-species isolation means one failure never aborts the batch; a re-run skips already-applied rows (idempotent); an `excluded=1` candidate is never pushed. Missing `ADMIN_API_URL`/`ADMIN_API_TOKEN` exits 2 (silhouette.mjs precedent); a partial-failure run exits 1 as a retry signal.
- DI-shaped (`runApplySwaps(deps)` with store, fetch, confirm, clock, log injected), so tests drive the full path with an msw v2-stubbed admin endpoint and real `better-sqlite3` (`:memory:`) — no DB mock, per repo rule.

## Screenshots

N/A — not UI (changes are confined to `tools/photo-curation/`; no `frontend/**` files touched).

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (90 tests, 11 files; 10 new in `apply-swaps.test.ts`)
- [x] New unit tests added: 7 `runApplySwaps` cases (2xx apply, non-2xx report, per-species isolation, idempotent skip, ignore non-approve, confirm-decline abort, network-error fail) + 3 `resolveAdminEnv` cases
- [x] `npm run build` (root) — clean across all workspaces
- [x] `npx knip` — clean (exit 0)
- [x] `npm install --package-lock-only && git diff --exit-code package-lock.json` — no lockfile drift
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — agent-ready issue #967 ("[photo-curation 8/10] photo-curate apply-swaps"). Part of epic #974; spec `docs/specs/2026-06-10-photo-quality-curation-design.md` §5.6. Depends on #970 (Slice 4 scaffold) and #982 (Slice 7 admin endpoint), both merged on `main`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
