### PR TITLE
fix(photo-curation): runnable scoring split + bulk with-photos sync (#992)

### DIFF
--- a/docs/runbooks/photo-curation-scoring.md
+++ b/docs/runbooks/photo-curation-scoring.md
@@ -1,0 +1,135 @@
+# Photo-curation scoring runbook
+
+## Purpose
+
+Score the live detail-panel photos on bird-maps.com against the
+`@bird-watch/photo-quality` rubric so an operator can spot weak photos and
+queue better alternates. The vision judge is a **Claude Code agent** that
+`Read`s each downloaded image — there is **no `@anthropic-ai/sdk` and no
+`ANTHROPIC_API_KEY`**. Scoring is therefore orchestrator-driven: the runnable
+Node halves do all filesystem + SQLite work, and a Claude Code **Workflow-tool
+script** dispatches the agents between them (issue #992, epic #974).
+
+This split exists because the judge can only run inside Claude Code (not plain
+Node), while the SQLite store + photo download can only run in plain Node (not
+the Workflow sandbox). A single hybrid `.mjs` that imports `better-sqlite3`
+**and** calls `agent()` runs in neither environment — that was the original
+bug.
+
+## Prerequisites
+
+```bash
+npm install && npm run build            # builds @bird-watch/photo-curation → dist/
+cd tools/photo-curation
+# Optional overrides:
+export READ_API_BASE="https://api.bird-maps.com"   # default; the prod read-api
+export THUMB_DIR="./thumb-cache"                    # default; downloaded images
+```
+
+The review store is `./review.sqlite` (gitignored, WAL). All commands below run
+from `tools/photo-curation/`.
+
+## Step 1 — sync (cheap, NO tokens)
+
+Snapshot the live detail-panel photos into `photo_current` with `reviewed=0`.
+The no-`--species` path calls `GET /api/species/with-photos` **once** — the
+read-api endpoint that returns the ~715 observed-with-photos species in a
+single response — and upserts them all. It does **not** walk the full 17.8k-code
+taxonomy with a per-species detail call (the #992 fix).
+
+```bash
+npx photo-curate sync                 # all observed-with-photos species (~715)
+npx photo-curate sync --species amerob  # one species via /api/species/:code
+```
+
+Re-running `sync` after new photos land re-surfaces the changed rows as
+`reviewed=0` — this is the "scan for new photos" mechanism. It writes no score
+rows; scoring is the separate token-spending pass below.
+
+## Step 2 — score the backlog
+
+Scoring runs in **batches of 10** (`--limit`, clamped to `[1,100]`) and is
+**resumable**: each committed species is marked `reviewed=1` and drops out of
+the next batch, so you re-run until the backlog clears. Two ways to drive it:
+
+### Option A — the score-current Workflow (recommended)
+
+Run `tools/photo-curation/workflows/score-current.mjs` via the **Workflow
+tool** (never `node`). It performs the three-phase flow for you:
+
+1. a **prepare agent** shells out to `score-prepare` (Bash);
+2. **parallel score agents** each `Read` one image and apply the rubric;
+3. a **commit agent** writes `results.json` and shells out to `score-commit`.
+
+```bash
+LIMIT=10   # batch size; re-run the Workflow until the backlog is empty
+```
+
+### Option B — the 3 steps by hand (prepare → dispatch agents → commit)
+
+1. **Prepare** — select the next N `reviewed=0` photos, download each to
+   `./thumb-cache/<code>.<ext>`, and emit a manifest. The last stdout line is
+   the manifest path.
+
+   ```bash
+   npx photo-curate score-prepare --limit 10
+   # → ./thumb-cache/manifest.json
+   #   [{ speciesCode, comName, sciName, family, imagePath, contentHash }, …]
+   ```
+
+2. **Dispatch agents** — for each manifest entry, have a Claude Code agent
+   `Read` the `imagePath`, apply `defaultRubricConfig.judgePrompt`, and return
+   `{ speciesCode, criteria, flags, rationale }`. Collect all results into a
+   `results.json` array.
+
+3. **Commit** — `composeReport` each result and persist it as `role='current'`
+   (keyed by the content hash `score-prepare` stamped), then mark each species
+   reviewed.
+
+   ```bash
+   npx photo-curate score-commit results.json
+   # exits non-zero if any result failed → safe to re-run (idempotent)
+   ```
+
+Repeat steps 1–3 (or re-run the Workflow) in batches of 10 until
+`score-prepare` returns an empty manifest.
+
+## Step 3 — source alternates for flagged species (optional)
+
+`source-candidates` pre-scores a deep iNat pool for every **flagged** species (a
+current score below the rubric review threshold) so the review server's deny
+route can advance to an already-scored alternate instantly. Same prepare →
+agents → commit shape:
+
+- **Workflow:** run `workflows/source-candidates.mjs` via the Workflow tool
+  (`POOL=15`).
+- **By hand:**
+  ```bash
+  npx photo-curate source-prepare --pool 15     # → ./thumb-cache/candidates-manifest.json
+  # dispatch one Read-agent per candidate → candidate-results.json
+  #   [{ speciesCode, inatId, contentHash, criteria, flags, rationale }, …]
+  npx photo-curate source-commit candidate-results.json
+  ```
+
+## Step 4 — review + apply
+
+Start the local review server and apply approved swaps to prod:
+
+```bash
+npx photo-curate serve                  # http://localhost:5180
+npx photo-curate apply-swaps            # confirm-gated push to the admin-api
+```
+
+## Notes
+
+- **Resumability** is the load-bearing property: `reviewed=1` is set only after
+  a successful commit, so an interrupted run loses no progress — just re-run the
+  next batch.
+- The Node halves (`score-prepare` / `score-commit` /
+  `source-prepare` / `source-commit`) are unit-tested in
+  `src/score-orchestration.test.ts` with a temp sqlite + a stubbed download.
+  The `.mjs` Workflow scripts are intentionally **not** vitest targets — they
+  wire the real `agent()` judge and are validated structurally (no `fs` /
+  `better-sqlite3` imports, valid JS).
+- The read-api `GET /api/species/with-photos` endpoint deploys on merge via the
+  `deploy-read-api` workflow.

--- a/knip.ts
+++ b/knip.ts
@@ -272,16 +272,21 @@ const config: KnipConfig = {
       //             2026-07-27 — drop this if sharp gains a direct import or is
       //             removed from package.json.
       ignoreDependencies: ['sharp'],
-      // 2026-06-10: the two committed workflows under workflows/*.mjs are
-      //             Claude Code Workflow-tool entries — run via the Workflow
-      //             tool against ../dist, never imported by any TS/JS module, so
+      // 2026-06-10 (rewired #992): the two committed workflows under
+      //             workflows/*.mjs are Claude Code Workflow-tool entries — run
+      //             via the Workflow tool, never imported by any TS/JS module, so
       //             static analysis can't see a reference and flags them as
-      //             unused files. They wire the real agent() judge + live fetch
-      //             and are intentionally NOT vitest targets (the testable
-      //             surface is sources.ts). Risk: masks a genuinely orphaned
-      //             workflow if one is deleted from the runbook but left on
-      //             disk. Re-audit 2026-07-27 — confirm both are still
-      //             referenced by the photo-curation runbook / epic #974.
+      //             unused files. After #992 their bodies use the Workflow
+      //             primitives (agent()/parallel()) ONLY and import just
+      //             defaultRubricConfig — the filesystem/SQLite/iNat work moved
+      //             to the runnable Node CLI halves (score-prepare/score-commit,
+      //             source-prepare/source-commit in src/score-orchestration.ts,
+      //             which ARE vitest targets). The .mjs scripts stay intentionally
+      //             NOT vitest targets (they wire the real agent() judge). Risk:
+      //             masks a genuinely orphaned workflow if one is deleted from the
+      //             runbook but left on disk. Re-audit 2026-07-27 — confirm both
+      //             are still referenced by docs/runbooks/photo-curation-scoring.md
+      //             / epic #974.
       //
       // 2026-06-10 (Slice 5b, #973): the three public/*.js files are browser ES
       //             modules served verbatim by the review server's

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -12,6 +12,7 @@ export {
 export {
   getSpeciesMeta,
   getSpeciesDictionary,
+  getSpeciesWithPhotos,
   upsertSpeciesMeta,
   findMissingSpeciesMeta,
   insertSpeciesPhoto,

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -7,6 +7,7 @@ import {
   findMissingSpeciesMeta,
   insertSpeciesPhoto,
   getSpeciesPhotos,
+  getSpeciesWithPhotos,
   getSpeciesPhenology,
   insertSpeciesDescription,
 } from './species.js';
@@ -731,5 +732,93 @@ describe('species descriptions', () => {
     expect(rows[0]?.source).toBe('inat');
     expect(rows[0]?.body).toBe(body);
     expect(rows[0]?.attribution_url).toBe('https://www.inaturalist.org/taxa/9083');
+  });
+});
+
+describe('getSpeciesWithPhotos (#992)', () => {
+  it('returns ONLY species with a detail-panel photo, INNER JOINed, sorted by code', async () => {
+    // Three species in species_meta; only two have a detail-panel photo row.
+    // The INNER JOIN must drop the photo-less one (annhum) entirely — the
+    // photo-curation `sync` tool relies on this to enumerate the ~715
+    // observed-with-photos species without walking the full taxonomy.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+      { speciesCode: 'mallar3', comName: 'Mallard',
+        sciName: 'Anas platyrhynchos', familyCode: 'anatidae',
+        familyName: 'Ducks, Geese, and Waterfowl', taxonOrder: 261 },
+    ]);
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'vermfly', purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/species/vermfly.jpg',
+      attribution: '(c) A (CC BY)', license: 'cc-by',
+    });
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'mallar3', purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/species/mallar3.jpg',
+      attribution: '(c) B (CC BY-NC)', license: 'cc-by-nc',
+    });
+    // annhum gets NO photo row → must be absent from the result.
+
+    const rows = await getSpeciesWithPhotos(db.pool);
+    // Sorted by species_code asc: mallar3, vermfly (annhum dropped).
+    expect(rows.map(r => r.code)).toEqual(['mallar3', 'vermfly']);
+
+    const verm = rows.find(r => r.code === 'vermfly')!;
+    expect(verm.comName).toBe('Vermilion Flycatcher');
+    expect(verm.sciName).toBe('Pyrocephalus rubinus');
+    expect(verm.family).toBe('Tyrant Flycatchers');
+    expect(verm.photoUrl).toBe('https://photos.bird-maps.com/species/vermfly.jpg');
+    expect(verm.photoAttribution).toBe('(c) A (CC BY)');
+    expect(verm.photoLicense).toBe('cc-by');
+    // Exactly the seven wire fields — no taxon_order / family_code leak.
+    expect(Object.keys(verm).sort())
+      .toEqual(['code', 'comName', 'family', 'photoAttribution', 'photoLicense', 'photoUrl', 'sciName']);
+  });
+
+  it('ignores non-detail-panel photo purposes (only detail-panel counts)', async () => {
+    // A photo row exists for the species, but with a non-detail-panel purpose.
+    // The (species_code, purpose) UNIQUE means a species can carry other
+    // purposes in future; this endpoint is detail-panel-scoped, so a species
+    // whose ONLY photo is a different purpose must NOT appear.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'galleryonly', comName: 'Gallery Only',
+        sciName: 'Solus galleria', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 99100 },
+    ]);
+    // Drop the purpose CHECK so we can seed a non-detail-panel row directly
+    // (insertSpeciesPhoto only writes detail-panel via its caller contract).
+    await db.pool.query(`ALTER TABLE species_photos DROP CONSTRAINT species_photos_purpose_check`);
+    try {
+      await db.pool.query(
+        `INSERT INTO species_photos (species_code, purpose, url, attribution, license)
+         VALUES ('galleryonly', 'gallery', 'https://x/g.jpg', '(c) G', 'cc-by')`
+      );
+      const rows = await getSpeciesWithPhotos(db.pool);
+      expect(rows.map(r => r.code)).not.toContain('galleryonly');
+    } finally {
+      await db.pool.query(`DELETE FROM species_photos WHERE purpose = 'gallery'`);
+      await db.pool.query(
+        `ALTER TABLE species_photos
+         ADD CONSTRAINT species_photos_purpose_check
+         CHECK (purpose IN ('detail-panel'))`
+      );
+    }
+  });
+
+  it('returns an empty array when no species has a detail-panel photo', async () => {
+    // beforeEach truncates species_meta CASCADE (drops photos too) — seed a
+    // photo-less species so the JOIN produces zero rows.
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'nophoto', comName: 'No Photo',
+        sciName: 'Nullus avis', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 99200 },
+    ]);
+    const rows = await getSpeciesWithPhotos(db.pool);
+    expect(rows).toEqual([]);
   });
 });

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -1,5 +1,5 @@
 import type { Pool } from './pool.js';
-import type { SpeciesMeta, SpeciesDictEntry } from '@bird-watch/shared-types';
+import type { SpeciesMeta, SpeciesDictEntry, SpeciesWithPhoto } from '@bird-watch/shared-types';
 
 /**
  * One row of `species_photos`. Mirrors the column shape verbatim — used by
@@ -262,6 +262,57 @@ export async function getSpeciesDictionary(
     code: r.code,
     comName: r.com_name,
     familyCode: r.family_code,
+  }));
+}
+
+/**
+ * Every species that currently has a detail-panel photo, returned in ONE
+ * response (#992). An INNER JOIN against `species_photos (purpose='detail-panel')`
+ * drops every species WITHOUT such a photo, so the result is the ~715
+ * observed-with-photos set — not the full 17.8k taxonomy. The
+ * `tools/photo-curation` `sync` tool calls this once to enumerate the curation
+ * backlog instead of walking `/api/species` then issuing a per-species
+ * `/api/species/:code` detail call (~17.8k requests, almost all `noPhoto`).
+ *
+ * `family` projects `family_name` (the human-readable family, mirroring what
+ * `sync` stored from `meta.familyName`), NOT `family_code`. The three photo
+ * fields are non-NULL by construction (the INNER JOIN guarantees a matching
+ * `species_photos` row), so unlike `getSpeciesMeta`'s LEFT-JOIN projection they
+ * are always present. Sorted by `species_code` for a stable wire order.
+ */
+export async function getSpeciesWithPhotos(
+  pool: Pool
+): Promise<SpeciesWithPhoto[]> {
+  const { rows } = await pool.query<{
+    code: string;
+    com_name: string;
+    sci_name: string;
+    family_name: string;
+    photo_url: string;
+    photo_attribution: string;
+    photo_license: string;
+  }>(
+    `SELECT sm.species_code AS code,
+            sm.com_name      AS com_name,
+            sm.sci_name      AS sci_name,
+            sm.family_name   AS family_name,
+            sp.url           AS photo_url,
+            sp.attribution   AS photo_attribution,
+            sp.license       AS photo_license
+       FROM species_meta sm
+       JOIN species_photos sp
+         ON sp.species_code = sm.species_code
+        AND sp.purpose = 'detail-panel'
+      ORDER BY sm.species_code`
+  );
+  return rows.map(r => ({
+    code: r.code,
+    comName: r.com_name,
+    sciName: r.sci_name,
+    family: r.family_name,
+    photoUrl: r.photo_url,
+    photoAttribution: r.photo_attribution,
+    photoLicense: r.photo_license,
   }));
 }
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -311,6 +311,26 @@ export interface SpeciesDictEntry {
 }
 
 /**
+ * One row of `GET /api/species/with-photos` (#992). The complete set of
+ * species that currently have a `species_photos(purpose='detail-panel')` row,
+ * returned in ONE response so the photo-curation `sync` tool can enumerate the
+ * ~715 observed-with-photos species without walking the full 17.8k taxonomy and
+ * issuing a per-species detail call. An INNER JOIN against `species_photos`
+ * guarantees `photoUrl`/`photoAttribution`/`photoLicense` are always present
+ * (unlike the optional projection on `SpeciesMeta`), so these are required
+ * (non-optional) fields here.
+ */
+export interface SpeciesWithPhoto {
+  code: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  photoUrl: string;
+  photoAttribution: string;
+  photoLicense: string;
+}
+
+/**
  * Discriminated-union response from GET /api/observations.
  *
  * - `mode === 'observations'` (default; also when zoom >= 6 with bbox):

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1087,6 +1087,74 @@ describe('GET /api/species (dictionary, #859)', () => {
   });
 });
 
+describe('GET /api/species/with-photos (#992)', () => {
+  it('returns ONLY species with a detail-panel photo in one response with the species cache header', async () => {
+    // Seed three species; give two a detail-panel photo. The INNER JOIN must
+    // drop the photo-less one so the photo-curation `sync` tool enumerates the
+    // observed-with-photos set in ONE call (no per-species detail walk).
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'wpvermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'wpannhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+      { speciesCode: 'wpmallar', comName: 'Mallard',
+        sciName: 'Anas platyrhynchos', familyCode: 'anatidae',
+        familyName: 'Ducks, Geese, and Waterfowl', taxonOrder: 261 },
+    ]);
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'wpvermfly', purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/species/wpvermfly.jpg',
+      attribution: '(c) A (CC BY)', license: 'cc-by',
+    });
+    await insertSpeciesPhoto(db.pool, {
+      speciesCode: 'wpmallar', purpose: 'detail-panel',
+      url: 'https://photos.bird-maps.com/species/wpmallar.jpg',
+      attribution: '(c) B (CC BY-NC)', license: 'cc-by-nc',
+    });
+    // wpannhum has NO photo row → absent from the response.
+
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/with-photos');
+    expect(res.status).toBe(200);
+    // Rides the per-species 'species' cache tier (photo_url is a
+    // monthly-refreshed field — see cache-headers.ts).
+    expect(res.headers.get('cache-control')).toBe('public, max-age=604800');
+
+    const body = await res.json() as Array<{
+      code: string; comName: string; sciName: string; family: string;
+      photoUrl: string; photoAttribution: string; photoLicense: string;
+    }>;
+    const codes = body.map(r => r.code);
+    expect(codes).toContain('wpvermfly');
+    expect(codes).toContain('wpmallar');
+    expect(codes).not.toContain('wpannhum');
+
+    const verm = body.find(r => r.code === 'wpvermfly')!;
+    expect(verm.comName).toBe('Vermilion Flycatcher');
+    expect(verm.sciName).toBe('Pyrocephalus rubinus');
+    expect(verm.family).toBe('Tyrant Flycatchers');
+    expect(verm.photoUrl).toBe('https://photos.bird-maps.com/species/wpvermfly.jpg');
+    expect(verm.photoAttribution).toBe('(c) A (CC BY)');
+    expect(verm.photoLicense).toBe('cc-by');
+    // Exactly the seven wire fields.
+    expect(Object.keys(verm).sort())
+      .toEqual(['code', 'comName', 'family', 'photoAttribution', 'photoLicense', 'photoUrl', 'sciName']);
+  });
+
+  it('is NOT shadowed by the /api/species/:code detail route', async () => {
+    // Route-ordering guard: /api/species/with-photos must resolve to the
+    // with-photos endpoint (an ARRAY), not the :code detail route treating
+    // 'with-photos' as a species code (a 404 object).
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species/with-photos');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+});
+
 describe('GET /api/species/:code', () => {
   it('returns species meta for a known code', async () => {
     const app = createApp({ pool: db.pool });

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -5,7 +5,7 @@ import type { Pool } from '@bird-watch/db-client';
 import {
   getHotspots, getObservations, getObservationsAggregated,
   getFreshestObservationAt,
-  getSpeciesMeta, getSpeciesDictionary, getSilhouettes,
+  getSpeciesMeta, getSpeciesDictionary, getSpeciesWithPhotos, getSilhouettes,
   getSpeciesPhenology,
   listStatesWithBbox,
   // #878 — precomputed per-scope aggregation grid.
@@ -389,6 +389,23 @@ export function createApp(deps: AppDeps): Hono {
     const dict = await getSpeciesDictionary(deps.pool);
     c.header('Cache-Control', cacheControlFor('species-dict'));
     return c.json(dict);
+  });
+
+  // #992 — every species with a detail-panel photo, in ONE response. The
+  // `tools/photo-curation` `sync` tool calls this once to enumerate the ~715
+  // observed-with-photos species instead of walking /api/species (full 17.8k
+  // taxonomy) then issuing a per-species /api/species/:code detail call.
+  // Registered BEFORE the `/api/species/:code` detail route: Hono's trie
+  // prefers a static segment over `:code`, but declaring the static route first
+  // keeps the precedence explicit and order-independent of any future router
+  // change (mirrors the /api/species dictionary precedence comment above).
+  // Rides the per-species 'species' cache tier — photo_url is a
+  // monthly-refreshed field (see cache-headers.ts), so the same 7-day max-age
+  // and re-validate-at-expiry semantics apply to this projection.
+  app.get('/api/species/with-photos', async c => {
+    const rows = await getSpeciesWithPhotos(deps.pool);
+    c.header('Cache-Control', cacheControlFor('species'));
+    return c.json(rows);
   });
 
   app.get('/api/species/:code', async c => {

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -1,13 +1,26 @@
 #!/usr/bin/env node
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
+import { readFile } from 'node:fs/promises';
 import { Command } from 'commander';
 import { openDb, DEFAULT_DB_PATH } from './db.js';
-import { sync } from './sources.js';
+import { sync, syncAll, scoreBatch } from './sources.js';
+import {
+  scorePrepare, scoreCommit, sourcePrepare, sourceCommit,
+  type ScoreResult, type SourceResult,
+} from './score-orchestration.js';
 import { startServer } from './server/serve.js';
 import { resolveAdminEnv, runApplySwaps } from './apply-swaps.js';
 
 const API_BASE = process.env.READ_API_BASE ?? 'https://api.bird-maps.com';
+const THUMB_DIR = process.env.THUMB_DIR ?? './thumb-cache';
+
+/** Live thumbnail download for the prepare CLI (unit tests inject a stub). */
+async function downloadBytes(url: string): Promise<Buffer> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!res.ok) throw new Error(`download ${res.status} for ${url}`);
+  return Buffer.from(await res.arrayBuffer());
+}
 
 const program = new Command();
 program.name('photo-curate').description('Local bird-photo quality curation tool');
@@ -18,19 +31,84 @@ program
   .option('--species <code>', 'sync a single species code instead of the whole dictionary')
   .action(async (opts: { species?: string }) => {
     const db = openDb(DEFAULT_DB_PATH);
-    let codes: string[];
-    if (opts.species) {
-      codes = [opts.species];
-    } else {
-      const res = await fetch(`${API_BASE}/api/species`, { headers: { accept: 'application/json' } });
-      if (!res.ok) throw new Error(`read-api ${res.status} for /api/species`);
-      const dict = (await res.json()) as Array<{ code: string }>;
-      codes = dict.map(d => d.code);
-    }
-    const summary = await sync(db, codes, { apiBase: API_BASE });
+    // No `--species`: ONE call to /api/species/with-photos (#992), which returns
+    // the ~715 observed-with-photos species in a single body — no per-species
+    // detail walk. `--species <code>`: the single-species path via
+    // /api/species/:code (unchanged).
+    const summary = opts.species
+      ? await sync(db, [opts.species], { apiBase: API_BASE })
+      : await syncAll(db, { apiBase: API_BASE });
     console.log(`[sync] ${JSON.stringify(summary, null, 2)}`);
     console.log('[sync] Next: run the score-current workflow to AI-score the reviewed=0 rows (default 10, --limit up to 100).');
     db.close();
+  });
+
+program
+  .command('score-prepare')
+  .description('Select the next N reviewed=0 photos, download each, and write a manifest the score agents Read (Node half of the score Workflow — Bug 1, #992).')
+  .option('--limit <n>', 'how many photos to prepare (clamped to [1,100])', '10')
+  .action(async (opts: { limit: string }) => {
+    const db = openDb(DEFAULT_DB_PATH);
+    try {
+      const limit = scoreBatch.clampLimit(Number(opts.limit));
+      const result = await scorePrepare(db, limit, { download: downloadBytes, thumbDir: THUMB_DIR });
+      console.log(`[score-prepare] picked ${result.picked} photo(s); manifest at ${result.manifestPath}`);
+      // The manifest path on its own line so the Workflow's prepare agent can
+      // grep it out of stdout and hand it to the parallel score agents.
+      console.log(result.manifestPath);
+    } finally {
+      db.close();
+    }
+  });
+
+program
+  .command('score-commit')
+  .description('Commit agent scoring results (composeReport → upsertScore + markReviewed) — Node half of the score Workflow (Bug 1, #992).')
+  .argument('<results.json>', 'path to the agent results JSON: [{ speciesCode, criteria, flags, rationale }]')
+  .action(async (resultsPath: string) => {
+    const db = openDb(DEFAULT_DB_PATH);
+    try {
+      const results = JSON.parse(await readFile(resultsPath, 'utf8')) as ScoreResult[];
+      const summary = await scoreCommit(db, results);
+      console.log(`[score-commit] ${JSON.stringify(summary, null, 2)}`);
+      // Non-zero exit when any result failed so a wrapping shell/Workflow step
+      // can detect partial failure and re-run (idempotent — committed rows are
+      // reviewed=1 and drop out of the next prepare).
+      process.exit(summary.failed > 0 ? 1 : 0);
+    } finally {
+      db.close();
+    }
+  });
+
+program
+  .command('source-prepare')
+  .description('Fetch + download a deep iNat candidate pool for FLAGGED species and write a manifest the source agents Read (Node half of the source-candidates Workflow — Bug 1, #992).')
+  .option('--pool <n>', 'iNat candidates per flagged species', '15')
+  .action(async (opts: { pool: string }) => {
+    const db = openDb(DEFAULT_DB_PATH);
+    try {
+      const result = await sourcePrepare(db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR });
+      console.log(`[source-prepare] sourced ${result.picked} candidate(s); manifest at ${result.manifestPath}`);
+      console.log(result.manifestPath);
+    } finally {
+      db.close();
+    }
+  });
+
+program
+  .command('source-commit')
+  .description('Commit agent candidate scores (composeReport → upsertScore role=candidate) — Node half of the source-candidates Workflow (Bug 1, #992).')
+  .argument('<results.json>', 'path to the agent results JSON: [{ speciesCode, inatId, contentHash, criteria, flags, rationale }]')
+  .action(async (resultsPath: string) => {
+    const db = openDb(DEFAULT_DB_PATH);
+    try {
+      const results = JSON.parse(await readFile(resultsPath, 'utf8')) as SourceResult[];
+      const summary = await sourceCommit(db, results);
+      console.log(`[source-commit] ${JSON.stringify(summary, null, 2)}`);
+      process.exit(summary.failed > 0 ? 1 : 0);
+    } finally {
+      db.close();
+    }
   });
 
 program

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -52,7 +52,7 @@ program
     try {
       const limit = scoreBatch.clampLimit(Number(opts.limit));
       const result = await scorePrepare(db, limit, { download: downloadBytes, thumbDir: THUMB_DIR });
-      console.log(`[score-prepare] picked ${result.picked} photo(s); manifest at ${result.manifestPath}`);
+      console.log(`[score-prepare] picked ${result.picked} photo(s) — ${result.downloads} edge download(s), ${result.skipped} already-scored skipped; manifest at ${result.manifestPath}`);
       // The manifest path on its own line so the Workflow's prepare agent can
       // grep it out of stdout and hand it to the parallel score agents.
       console.log(result.manifestPath);
@@ -88,7 +88,7 @@ program
     const db = openDb(DEFAULT_DB_PATH);
     try {
       const result = await sourcePrepare(db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR });
-      console.log(`[source-prepare] sourced ${result.picked} candidate(s); manifest at ${result.manifestPath}`);
+      console.log(`[source-prepare] sourced ${result.picked} candidate(s) — ${result.inatFetches} iNat fetch(es) + ${result.downloads} edge download(s); manifest at ${result.manifestPath}`);
       console.log(result.manifestPath);
     } finally {
       db.close();

--- a/tools/photo-curation/src/pacing.test.ts
+++ b/tools/photo-curation/src/pacing.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Pacer, withBackoff, isTransient, clampPool, CANDIDATE_POOL_CAP,
+  INAT_PACE_MS, EDGE_PACE_MS,
+} from './pacing.js';
+import { makeFakeClock } from './test-clock.js';
+
+describe('Pacer', () => {
+  it('does NOT wait before the first call', async () => {
+    const clock = makeFakeClock();
+    const pacer = new Pacer(1100, clock);
+    await pacer.gate();
+    expect(clock.sleeps).toEqual([]); // no sleep before the first call
+  });
+
+  it('spaces successive calls by ≥ the min interval (asserted via the fake clock)', async () => {
+    const clock = makeFakeClock();
+    const pacer = new Pacer(1100, clock);
+
+    const starts: number[] = [];
+    // Three back-to-back gates with NO simulated work between them: the pacer
+    // must sleep 1100 ms before calls 2 and 3.
+    await pacer.gate(); starts.push(clock.now());
+    await pacer.gate(); starts.push(clock.now());
+    await pacer.gate(); starts.push(clock.now());
+
+    expect(clock.sleeps).toEqual([1100, 1100]); // exactly two pacing waits
+    // Each consecutive call begins ≥1100 ms after the previous.
+    expect(starts[1]! - starts[0]!).toBeGreaterThanOrEqual(1100);
+    expect(starts[2]! - starts[1]!).toBeGreaterThanOrEqual(1100);
+  });
+
+  it('only waits the REMAINDER when the call did real work in between', async () => {
+    const clock = makeFakeClock();
+    const pacer = new Pacer(1100, clock);
+    await pacer.gate();
+    // Simulate 400 ms of work (e.g. a slow download) before the next gate.
+    clock.current += 400;
+    await pacer.gate();
+    // Only the remaining 700 ms is slept — not a full 1100.
+    expect(clock.sleeps).toEqual([700]);
+  });
+});
+
+describe('withBackoff', () => {
+  it('retries transient (429/5xx) failures with jittered exponential backoff, then succeeds', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw Object.assign(new Error('429'), { status: 429 });
+      return 'ok';
+    };
+    // random()=1 → full ceiling each attempt: base*2^0=500, base*2^1=1000.
+    const out = await withBackoff(fn, { clock, baseMs: 500, random: () => 1 });
+    expect(out).toBe('ok');
+    expect(calls).toBe(3);
+    expect(clock.sleeps).toEqual([500, 1000]); // two backoff waits before success
+  });
+
+  it('does NOT retry a non-transient (4xx) error — surfaces immediately', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      throw Object.assign(new Error('404'), { status: 404 });
+    };
+    await expect(withBackoff(fn, { clock })).rejects.toThrow(/404/);
+    expect(calls).toBe(1); // no retry
+    expect(clock.sleeps).toEqual([]);
+  });
+
+  it('gives up after maxRetries transient failures (so the caller can abort the species)', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      throw Object.assign(new Error('503'), { status: 503 });
+    };
+    await expect(withBackoff(fn, { clock, maxRetries: 2, random: () => 0 })).rejects.toThrow(/503/);
+    expect(calls).toBe(3); // initial + 2 retries
+  });
+});
+
+describe('isTransient', () => {
+  it('classifies 429 and 5xx as transient, 4xx and others as not', () => {
+    expect(isTransient({ status: 429 })).toBe(true);
+    expect(isTransient({ status: 503 })).toBe(true);
+    expect(isTransient({ status: 404 })).toBe(false);
+    expect(isTransient(new Error('download 429 for https://x'))).toBe(true);
+    expect(isTransient(new Error('read-api 502 for amerob'))).toBe(true);
+    expect(isTransient(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('clampPool', () => {
+  it('caps the candidate pool to ~12 (and floors at 1)', () => {
+    expect(clampPool(100)).toBe(CANDIDATE_POOL_CAP);
+    expect(clampPool(12)).toBe(12);
+    expect(clampPool(5)).toBe(5);
+    expect(clampPool(0)).toBe(1);
+    expect(clampPool(-3)).toBe(1);
+  });
+});
+
+describe('pacing constants', () => {
+  it('pace iNat + edge at ≥1000 ms (≤1 req/sec), with margin', () => {
+    expect(INAT_PACE_MS).toBeGreaterThanOrEqual(1000);
+    expect(EDGE_PACE_MS).toBeGreaterThanOrEqual(1100); // Cloudflare 60/min/IP
+  });
+});

--- a/tools/photo-curation/src/pacing.ts
+++ b/tools/photo-curation/src/pacing.ts
@@ -1,0 +1,132 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Conservative external-API pacing (ADDENDUM, #992).
+//
+// Every external call the curation tool makes must be deliberately gentle:
+//
+//   • iNaturalist (third-party)        — ≤ 1 req/sec sustained (pace ≥ 1100 ms).
+//   • bird-maps.com edge (Cloudflare)  — ≥ 1.1 s between image downloads, serial,
+//                                         because CF rate-limits 60 req/min/IP.
+//
+// The pacing is injectable so the fast unit tests assert spacing deterministically
+// via a fake clock — they NEVER incur a real wall-clock wait. Production callers
+// default to `realClock`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Canonical inter-call pacing constants (ms). */
+export const INAT_PACE_MS = 1_100; // ≤1 req/sec to iNat, with margin (≥1000).
+export const EDGE_PACE_MS = 1_100; // ≥1.1 s between bird-maps.com edge requests.
+
+/**
+ * Injected clock seam. `now()` returns monotonic-ish ms (Date.now in prod);
+ * `sleep(ms)` resolves after `ms`. Tests pass a fake clock that advances a
+ * virtual `now` and records every requested sleep WITHOUT a real timer, so a
+ * suite asserting ≥1.1 s spacing runs in microseconds.
+ */
+export interface Clock {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+}
+
+/** The production clock: real `Date.now` + a real `setTimeout`-backed sleep. */
+export const realClock: Clock = {
+  now: () => Date.now(),
+  sleep: (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)),
+};
+
+/**
+ * Enforces a minimum interval between successive external calls. Call `gate()`
+ * immediately BEFORE each request: the first call returns without waiting, and
+ * every later call sleeps just enough that consecutive calls are ≥ `minIntervalMs`
+ * apart (measured from the prior call's start). This gives a steady ≤ 1/interval
+ * request rate without sitting idle for `interval * N` on an N-item run.
+ */
+export class Pacer {
+  private lastStart: number | null = null;
+  constructor(
+    private readonly minIntervalMs: number,
+    private readonly clock: Clock = realClock,
+  ) {}
+
+  /** Wait (if needed) so this call starts ≥ minIntervalMs after the previous one. */
+  async gate(): Promise<void> {
+    const now = this.clock.now();
+    if (this.lastStart !== null) {
+      const elapsed = now - this.lastStart;
+      const wait = this.minIntervalMs - elapsed;
+      if (wait > 0) {
+        await this.clock.sleep(wait);
+      }
+    }
+    // Stamp the *post-wait* time so back-to-back gates chain correctly.
+    this.lastStart = this.clock.now();
+  }
+}
+
+/** A transient (retryable) upstream failure — 429 or 5xx. */
+export interface RetryableError {
+  status?: number;
+}
+
+/** Whether an error is a transient upstream failure worth retrying (429 / 5xx). */
+export function isTransient(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const status = (err as RetryableError).status;
+  if (typeof status === 'number') {
+    return status === 429 || status >= 500;
+  }
+  // Plain Error from `download` helpers carries the status in its message
+  // (`download 429 for …`, `read-api 503 for …`). Treat 429/5xx text as transient.
+  if (err instanceof Error) {
+    return /\b(429|5\d\d)\b/.test(err.message);
+  }
+  return false;
+}
+
+export interface BackoffOptions {
+  /** Bounded retry count on transient failures (default 3 → 4 attempts total). */
+  maxRetries?: number;
+  /** Base backoff in ms; doubles each attempt, full-jitter applied (default 500). */
+  baseMs?: number;
+  clock?: Clock;
+  /** Injectable randomness for the jitter (default Math.random) — test seam. */
+  random?: () => number;
+}
+
+/**
+ * Run `fn` with jittered exponential backoff on transient (429/5xx) failures.
+ * Non-transient errors throw immediately (a 404 is a bug, not flakiness). After
+ * `maxRetries` transient failures the last error is rethrown so the CALLER can
+ * abort the species (not the whole batch). Full-jitter variant (AWS write-up):
+ * `sleep(random() * base * 2^attempt)`.
+ */
+export async function withBackoff<T>(
+  fn: () => Promise<T>,
+  opts: BackoffOptions = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? 3;
+  const baseMs = opts.baseMs ?? 500;
+  const clock = opts.clock ?? realClock;
+  const random = opts.random ?? Math.random;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!isTransient(err) || attempt === maxRetries) break;
+      const ceiling = baseMs * Math.pow(2, attempt);
+      const withJitter = Math.floor(random() * ceiling);
+      await clock.sleep(withJitter);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/** The candidate-pool cap per species (top-N) — bound the iNat fetch + downloads. */
+export const CANDIDATE_POOL_CAP = 12;
+
+/** Clamp a requested candidate pool into [1, CANDIDATE_POOL_CAP]. */
+export function clampPool(n: number): number {
+  return Math.max(1, Math.min(CANDIDATE_POOL_CAP, Math.trunc(n) || 1));
+}

--- a/tools/photo-curation/src/score-orchestration.test.ts
+++ b/tools/photo-curation/src/score-orchestration.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
+import { openDb } from './db.js';
+import { upsertCurrentPhoto, upsertScore, getScoreByHash, selectUnreviewed, listCandidates } from './store.js';
+import {
+  scorePrepare, scoreCommit, sourcePrepare, sourceCommit,
+} from './score-orchestration.js';
+import type { ScoreResult, SourceResult } from './score-orchestration.js';
+import type { QualityReport } from '@bird-watch/photo-quality';
+
+let db: Database.Database;
+let workDir: string;
+beforeEach(() => {
+  db = openDb(':memory:');
+  workDir = mkdtempSync(join(tmpdir(), 'photo-curate-'));
+});
+afterEach(() => {
+  db.close();
+  rmSync(workDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function seedCurrent(code: string, url: string): void {
+  upsertCurrentPhoto(db, {
+    speciesCode: code, comName: code.toUpperCase(), sciName: `Sci ${code}`,
+    family: `Fam ${code}`, url,
+    attribution: '(c) Jane Doe (CC BY)', license: 'cc-by', contentHash: '',
+  });
+}
+
+describe('scorePrepare (Node, testable — Bug 1)', () => {
+  it('selects the next N reviewed=0 rows, downloads each, writes a manifest, and clamps the limit', async () => {
+    seedCurrent('aaa', 'https://photos.example/aaa.jpg');
+    seedCurrent('bbb', 'https://photos.example/bbb.png');
+    seedCurrent('ccc', 'https://photos.example/ccc.jpg');
+
+    // Stub download: distinct bytes per url so contentHashes differ.
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    // limit 0 clamps up to 1 → only the oldest-by-code row (aaa).
+    const result = await scorePrepare(db, 0, { download, thumbDir: workDir });
+    expect(result.picked).toBe(1);
+    expect(existsSync(result.manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{
+      speciesCode: string; comName: string; sciName: string; family: string;
+      imagePath: string; contentHash: string;
+    }>;
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0]!.speciesCode).toBe('aaa');
+    expect(manifest[0]!.comName).toBe('AAA');
+    expect(manifest[0]!.sciName).toBe('Sci aaa');
+    expect(manifest[0]!.family).toBe('Fam aaa');
+    // The image was written to disk at the manifest path, extension from the url.
+    expect(manifest[0]!.imagePath).toBe(join(workDir, 'aaa.jpg'));
+    expect(existsSync(manifest[0]!.imagePath)).toBe(true);
+    expect(manifest[0]!.contentHash).toMatch(/^[0-9a-f]{8}$/);
+
+    // download was called exactly once (one row picked).
+    expect(download).toHaveBeenCalledTimes(1);
+
+    // The content hash was stamped into photo_current so score-commit can read it.
+    const row = db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('aaa') as { content_hash: string };
+    expect(row.content_hash).toBe(manifest[0]!.contentHash);
+    // The row is NOT yet reviewed — score-commit marks it.
+    expect(selectUnreviewed(db, 10).map(r => r.species_code)).toContain('aaa');
+  });
+
+  it('uses the correct file extension from the photo url (png/webp/jpg)', async () => {
+    seedCurrent('pngsp', 'https://photos.example/pngsp.png');
+    const download = vi.fn(async () => Buffer.from('png-bytes'));
+    const result = await scorePrepare(db, 1, { download, thumbDir: workDir });
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ imagePath: string }>;
+    expect(manifest[0]!.imagePath).toBe(join(workDir, 'pngsp.png'));
+  });
+});
+
+describe('scoreCommit (Node, testable — Bug 1)', () => {
+  it('composes the report, upserts the score (role=current), and marks the species reviewed', async () => {
+    seedCurrent('aaa', 'https://photos.example/aaa.jpg');
+    // Simulate a prepare pass having stamped the content hash.
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+    await scorePrepare(db, 1, { download, thumbDir: workDir });
+    const hash = (db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('aaa') as { content_hash: string }).content_hash;
+
+    // A strong photo → 'great'/'good'; a flagged one → capped reject.
+    const results: ScoreResult[] = [
+      {
+        speciesCode: 'aaa',
+        criteria: { framing: 9, subjectClarity: 10, liveness: 10, naturalness: 9, pose: 8, background: 8, lighting: 9 },
+        flags: [],
+        rationale: 'Tack-sharp wild adult on a natural perch.',
+      },
+    ];
+    const summary = await scoreCommit(db, results);
+    expect(summary.committed).toBe(1);
+    expect(summary.failed).toBe(0);
+
+    // Score row written with role=current, keyed by the stamped content hash.
+    const stored = getScoreByHash(db, 'aaa', 'current', hash);
+    expect(stored).not.toBeNull();
+    expect(stored!.overall).toBeGreaterThan(0);
+    expect(['great', 'good']).toContain(stored!.verdict);
+    expect(stored!.rationale).toBe('Tack-sharp wild adult on a natural perch.');
+
+    // The species is now reviewed (cleared from the backlog).
+    expect(selectUnreviewed(db, 10)).toEqual([]);
+  });
+
+  it('applies disqualifier caps via composeReport (a flagged photo is capped low)', async () => {
+    seedCurrent('inhand', 'https://photos.example/inhand.jpg');
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+    await scorePrepare(db, 1, { download, thumbDir: workDir });
+    const hash = (db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('inhand') as { content_hash: string }).content_hash;
+
+    // High sub-scores but an 'in-hand' flag → capped to a reject-ish overall.
+    const results: ScoreResult[] = [
+      {
+        speciesCode: 'inhand',
+        criteria: { framing: 9, subjectClarity: 10, liveness: 10, naturalness: 2, pose: 9, background: 9, lighting: 9 },
+        flags: ['in-hand'],
+        rationale: 'Sharp but held in a banding grip — not a field-guide photo.',
+      },
+    ];
+    await scoreCommit(db, results);
+    const stored = getScoreByHash(db, 'inhand', 'current', hash);
+    expect(stored).not.toBeNull();
+    // in-hand caps overall at 35 (defaultRubricConfig disqualifiers).
+    expect(stored!.overall).toBeLessThanOrEqual(35);
+    expect(stored!.flags).toContain('in-hand');
+  });
+
+  it('records a failure for a result whose species has no photo_current row', async () => {
+    const results: ScoreResult[] = [
+      {
+        speciesCode: 'ghost',
+        criteria: { framing: 5, subjectClarity: 5, liveness: 5, naturalness: 5, pose: 5, background: 5, lighting: 5 },
+        flags: [],
+        rationale: 'n/a',
+      },
+    ];
+    const summary = await scoreCommit(db, results);
+    expect(summary.committed).toBe(0);
+    expect(summary.failed).toBe(1);
+    expect(summary.errors[0]!.speciesCode).toBe('ghost');
+  });
+});
+
+/** A flagged (below-review) current score so source-prepare picks the species. */
+function seedFlaggedScore(code: string): void {
+  const report: QualityReport = {
+    overall: 30, verdict: 'reject',
+    deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+    criteria: { framing: 3, subjectClarity: 3, liveness: 5, naturalness: 4, pose: 3, background: 3, lighting: 3 },
+    flags: [], rationale: 'soft + cluttered', rubricVersion: '0.1.0',
+  };
+  upsertScore(db, { speciesCode: code, role: 'current', candidateInatId: null, contentHash: 'cur00000', report });
+}
+
+describe('sourcePrepare (Node, testable — Bug 1 source-candidates split)', () => {
+  it('fetches iNat candidates for FLAGGED species, downloads each, inserts candidate rows, and writes a manifest', async () => {
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1');
+    // A second species that is NOT flagged (no below-review score) must be skipped.
+    seedCurrent('good1', 'https://photos.example/good1.jpg');
+
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P (CC BY)', license: 'cc-by' },
+      { inatId: 12, photoUrl: 'https://inat.example/12.png', attribution: '(c) Q (CC0)', license: 'cc0' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir });
+    // Only the flagged species was sourced.
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(1);
+    expect(result.picked).toBe(2); // two candidates for flag1
+    expect(existsSync(result.manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{
+      speciesCode: string; inatId: number; imagePath: string; contentHash: string;
+      attribution: string; license: string;
+    }>;
+    expect(manifest).toHaveLength(2);
+    expect(manifest.map(m => m.inatId).sort()).toEqual([11, 12]);
+    expect(manifest.every(m => m.speciesCode === 'flag1')).toBe(true);
+    expect(manifest.every(m => existsSync(m.imagePath))).toBe(true);
+    expect(manifest.find(m => m.inatId === 12)!.imagePath).toBe(join(workDir, 'flag1-12.png'));
+
+    // Candidate rows were persisted (so the deny-loop can advance to them).
+    const cands = listCandidates(db, 'flag1');
+    expect(cands.map(c => c.inatId).sort()).toEqual([11, 12]);
+  });
+});
+
+describe('sourceCommit (Node, testable — Bug 1 source-candidates split)', () => {
+  it('composes + upserts a candidate score (role=candidate) keyed by inat id', async () => {
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1');
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P (CC BY)', license: 'cc-by' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+    const prep = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir });
+    const hash = prep.manifest[0]!.contentHash;
+
+    const results: SourceResult[] = [
+      {
+        speciesCode: 'flag1', inatId: 11, contentHash: hash,
+        criteria: { framing: 9, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 8, background: 8, lighting: 9 },
+        flags: [],
+        rationale: 'A much sharper wild alternate.',
+      },
+    ];
+    const summary = await sourceCommit(db, results);
+    expect(summary.committed).toBe(1);
+    expect(summary.failed).toBe(0);
+
+    const stored = getScoreByHash(db, 'flag1', 'candidate', hash);
+    expect(stored).not.toBeNull();
+    expect(stored!.candidateInatId).toBe(11);
+    expect(['great', 'good']).toContain(stored!.verdict);
+  });
+});

--- a/tools/photo-curation/src/score-orchestration.test.ts
+++ b/tools/photo-curation/src/score-orchestration.test.ts
@@ -9,7 +9,13 @@ import {
   scorePrepare, scoreCommit, sourcePrepare, sourceCommit,
 } from './score-orchestration.js';
 import type { ScoreResult, SourceResult } from './score-orchestration.js';
+import { makeFakeClock } from './test-clock.js';
 import type { QualityReport } from '@bird-watch/photo-quality';
+
+// Instant clock so the prepare paths never incur a real ≥1.1 s pacing wait in
+// the fast unit suite (the spacing itself is asserted in the dedicated pacing
+// tests with a recording fake clock).
+const instant = () => makeFakeClock();
 
 let db: Database.Database;
 let workDir: string;
@@ -41,7 +47,7 @@ describe('scorePrepare (Node, testable — Bug 1)', () => {
     const download = vi.fn(async (url: string) => Buffer.from(url));
 
     // limit 0 clamps up to 1 → only the oldest-by-code row (aaa).
-    const result = await scorePrepare(db, 0, { download, thumbDir: workDir });
+    const result = await scorePrepare(db, 0, { download, thumbDir: workDir, clock: instant() });
     expect(result.picked).toBe(1);
     expect(existsSync(result.manifestPath)).toBe(true);
 
@@ -72,7 +78,7 @@ describe('scorePrepare (Node, testable — Bug 1)', () => {
   it('uses the correct file extension from the photo url (png/webp/jpg)', async () => {
     seedCurrent('pngsp', 'https://photos.example/pngsp.png');
     const download = vi.fn(async () => Buffer.from('png-bytes'));
-    const result = await scorePrepare(db, 1, { download, thumbDir: workDir });
+    const result = await scorePrepare(db, 1, { download, thumbDir: workDir, clock: instant() });
     const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ imagePath: string }>;
     expect(manifest[0]!.imagePath).toBe(join(workDir, 'pngsp.png'));
   });
@@ -83,7 +89,7 @@ describe('scoreCommit (Node, testable — Bug 1)', () => {
     seedCurrent('aaa', 'https://photos.example/aaa.jpg');
     // Simulate a prepare pass having stamped the content hash.
     const download = vi.fn(async (url: string) => Buffer.from(url));
-    await scorePrepare(db, 1, { download, thumbDir: workDir });
+    await scorePrepare(db, 1, { download, thumbDir: workDir, clock: instant() });
     const hash = (db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('aaa') as { content_hash: string }).content_hash;
 
     // A strong photo → 'great'/'good'; a flagged one → capped reject.
@@ -113,7 +119,7 @@ describe('scoreCommit (Node, testable — Bug 1)', () => {
   it('applies disqualifier caps via composeReport (a flagged photo is capped low)', async () => {
     seedCurrent('inhand', 'https://photos.example/inhand.jpg');
     const download = vi.fn(async (url: string) => Buffer.from(url));
-    await scorePrepare(db, 1, { download, thumbDir: workDir });
+    await scorePrepare(db, 1, { download, thumbDir: workDir, clock: instant() });
     const hash = (db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('inhand') as { content_hash: string }).content_hash;
 
     // High sub-scores but an 'in-hand' flag → capped to a reject-ish overall.
@@ -173,7 +179,7 @@ describe('sourcePrepare (Node, testable — Bug 1 source-candidates split)', () 
     ]);
     const download = vi.fn(async (url: string) => Buffer.from(url));
 
-    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir });
+    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
     // Only the flagged species was sourced.
     expect(fetchInatCandidates).toHaveBeenCalledTimes(1);
     expect(result.picked).toBe(2); // two candidates for flag1
@@ -203,7 +209,7 @@ describe('sourceCommit (Node, testable — Bug 1 source-candidates split)', () =
       { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P (CC BY)', license: 'cc-by' },
     ]);
     const download = vi.fn(async (url: string) => Buffer.from(url));
-    const prep = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir });
+    const prep = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
     const hash = prep.manifest[0]!.contentHash;
 
     const results: SourceResult[] = [
@@ -222,5 +228,146 @@ describe('sourceCommit (Node, testable — Bug 1 source-candidates split)', () =
     expect(stored).not.toBeNull();
     expect(stored!.candidateInatId).toBe(11);
     expect(['great', 'good']).toContain(stored!.verdict);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conservative external-API usage (#992 addendum). Spacing is asserted via an
+// injected fake clock that advances virtual time only — NO real wait.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scorePrepare — conservative edge usage (#992)', () => {
+  it('(b) downloads are SERIAL and paced ≥1.1 s apart (asserted via the fake clock)', async () => {
+    seedCurrent('aaa', 'https://photos.example/aaa.jpg');
+    seedCurrent('bbb', 'https://photos.example/bbb.jpg');
+    seedCurrent('ccc', 'https://photos.example/ccc.jpg');
+
+    const clock = makeFakeClock();
+    // Record the virtual time at the moment each download STARTS.
+    const downloadStarts: number[] = [];
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const download = vi.fn(async (url: string) => {
+      downloadStarts.push(clock.now());
+      inFlight++;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      inFlight--;
+      return Buffer.from(url);
+    });
+
+    const result = await scorePrepare(db, 3, { download, thumbDir: workDir, clock });
+    expect(result.picked).toBe(3);
+    expect(result.downloads).toBe(3);
+    // Serial: never more than one download in flight.
+    expect(maxConcurrent).toBe(1);
+    // First download starts immediately; each later one ≥1100 ms after the prior.
+    expect(downloadStarts).toHaveLength(3);
+    expect(downloadStarts[1]! - downloadStarts[0]!).toBeGreaterThanOrEqual(1100);
+    expect(downloadStarts[2]! - downloadStarts[1]!).toBeGreaterThanOrEqual(1100);
+    // Exactly two pacing waits for three downloads.
+    expect(clock.sleeps.filter(s => s >= 1100)).toHaveLength(2);
+  });
+
+  it('(c) SKIPS a species whose current content-hash is already scored — no re-download', async () => {
+    seedCurrent('done', 'https://photos.example/done.jpg');
+    seedCurrent('todo', 'https://photos.example/todo.jpg');
+
+    // First pass: download + score 'done' so its content-hash lands in photo_score.
+    const download1 = vi.fn(async (url: string) => Buffer.from(url));
+    const first = await scorePrepare(db, 10, { download: download1, thumbDir: workDir, clock: instant() });
+    expect(first.downloads).toBe(2);
+    // Commit a score for 'done' (its stamped current hash), leave 'todo' unscored.
+    const doneHash = (db.prepare(`SELECT content_hash FROM photo_current WHERE species_code=?`).get('done') as { content_hash: string }).content_hash;
+    upsertScore(db, {
+      speciesCode: 'done', role: 'current', candidateInatId: null, contentHash: doneHash,
+      report: {
+        overall: 80, verdict: 'good',
+        deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+        criteria: { framing: 8, subjectClarity: 8, liveness: 8, naturalness: 8, pose: 8, background: 8, lighting: 8 },
+        flags: [], rationale: 'already scored', rubricVersion: '0.1.0',
+      },
+    });
+
+    // Second pass: 'done' already has a scored content-hash → skipped, no download.
+    const download2 = vi.fn(async (url: string) => Buffer.from(url));
+    const second = await scorePrepare(db, 10, { download: download2, thumbDir: workDir, clock: instant() });
+    expect(second.skipped).toBe(1);
+    expect(second.picked).toBe(1); // only 'todo' was prepared
+    // 'done' was never re-downloaded.
+    const downloadedUrls = download2.mock.calls.map(c => c[0]);
+    expect(downloadedUrls).not.toContain('https://photos.example/done.jpg');
+    expect(downloadedUrls).toContain('https://photos.example/todo.jpg');
+    expect(second.manifest.map(m => m.speciesCode)).toEqual(['todo']);
+  });
+});
+
+describe('sourcePrepare — conservative iNat usage (#992)', () => {
+  it('(a) paces iNat fetches ≥1 s between species (asserted via the fake clock)', async () => {
+    seedCurrent('f1', 'https://photos.example/f1.jpg');
+    seedFlaggedScore('f1');
+    seedCurrent('f2', 'https://photos.example/f2.jpg');
+    seedFlaggedScore('f2');
+
+    const clock = makeFakeClock();
+    // Record the virtual time at each iNat fetch (one per flagged species).
+    const fetchStarts: number[] = [];
+    const fetchInatCandidates = vi.fn(async (sci: string) => {
+      fetchStarts.push(clock.now());
+      const id = sci.includes('f1') ? 11 : 21;
+      return [{ inatId: id, photoUrl: `https://inat.example/${id}.jpg`, attribution: '(c) P (CC BY)', license: 'cc-by' }];
+    });
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    const result = await sourcePrepare(db, 12, { fetchInatCandidates, download, thumbDir: workDir, clock });
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(2);
+    expect(result.inatFetches).toBe(2);
+    expect(fetchStarts).toHaveLength(2);
+    // The second species' iNat fetch begins ≥1100 ms after the first's.
+    expect(fetchStarts[1]! - fetchStarts[0]!).toBeGreaterThanOrEqual(1100);
+  });
+
+  it('(d) caps the candidate pool to ~12 per species even when more are returned, and when a larger pool is requested', async () => {
+    seedCurrent('big', 'https://photos.example/big.jpg');
+    seedFlaggedScore('big');
+
+    // iNat (stubbed) returns 30; the cap must hold both on the requested limit
+    // AND on the post-fetch slice.
+    const fetchInatCandidates = vi.fn(async (_sci: string, opts: { limit: number }) => {
+      // The tool must request a bounded limit (≤12), not 30.
+      expect(opts.limit).toBeLessThanOrEqual(12);
+      return Array.from({ length: 30 }, (_v, i) => ({
+        inatId: 1000 + i, photoUrl: `https://inat.example/${1000 + i}.jpg`,
+        attribution: '(c) P (CC BY)', license: 'cc-by',
+      }));
+    });
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    const result = await sourcePrepare(db, 30, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
+    // No more than 12 candidates sourced + downloaded.
+    expect(result.picked).toBeLessThanOrEqual(12);
+    expect(result.picked).toBe(12);
+    expect(result.downloads).toBe(12);
+    expect(download).toHaveBeenCalledTimes(12);
+  });
+
+  it('aborts a species (not the batch) when its iNat fetch fails persistently', async () => {
+    seedCurrent('bad', 'https://photos.example/bad.jpg');
+    seedFlaggedScore('bad');
+    seedCurrent('ok', 'https://photos.example/ok.jpg');
+    seedFlaggedScore('ok');
+
+    const fetchInatCandidates = vi.fn(async (sci: string) => {
+      if (sci.includes('bad')) throw Object.assign(new Error('429'), { status: 429 });
+      return [{ inatId: 77, photoUrl: 'https://inat.example/77.jpg', attribution: '(c) P (CC BY)', license: 'cc-by' }];
+    });
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    const result = await sourcePrepare(db, 12, {
+      fetchInatCandidates, download, thumbDir: workDir, clock: instant(),
+    });
+    // The bad species was aborted; the good one still produced a candidate.
+    expect(result.manifest.map(m => m.speciesCode)).toEqual(['ok']);
+    expect(listCandidates(db, 'bad')).toEqual([]);
+    expect(listCandidates(db, 'ok').map(c => c.inatId)).toEqual([77]);
   });
 });

--- a/tools/photo-curation/src/score-orchestration.ts
+++ b/tools/photo-curation/src/score-orchestration.ts
@@ -1,0 +1,314 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
+import type { CriteriaScores, QualityReport, DeterministicReport } from '@bird-watch/photo-quality';
+import { composeReport, defaultRubricConfig } from '@bird-watch/photo-quality';
+import type { InatCandidate, DenyContext } from '@bird-watch/ingestor';
+import { fetchInatCandidates as realFetchInatCandidates } from '@bird-watch/ingestor';
+import { sha8 } from './hash.js';
+import {
+  selectUnreviewed, updateCurrentPhotoHash, upsertScore, markReviewed,
+  insertCandidate, maxSourceRound,
+} from './store.js';
+import { scoreBatch, mimeFromUrl, extFromMime } from './sources.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bug 1 (#992) — orchestrator-driven scoring, split into two runnable Node
+// halves that the score-current Workflow drives:
+//
+//   score-prepare  → select reviewed=0, download each photo to disk, emit a
+//                    manifest JSON the dispatched Read-agents consume.
+//   <agents>       → each Reads an imagePath, applies the judge prompt, returns
+//                    {criteria,flags,rationale}. (NOT here — the Workflow script.)
+//   score-commit   → composeReport → upsertScore(role='current') +
+//                    updateCurrentPhotoHash + markReviewed.
+//
+// Both halves are plain Node (no `agent()`), so they unit-test with a temp
+// sqlite + a stubbed download. The agent dispatch lives ONLY in the .mjs
+// Workflow script, which is unrunnable in plain Node and unrunnable in the
+// Workflow sandbox if it touched the filesystem/DB — so the two concerns are
+// kept in separate runtimes (the bug the old hybrid .mjs runner had).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One row of the prepare manifest — the agent-facing scoring input. */
+export interface ManifestEntry {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  /** Local path to the downloaded photo the score-agent `Read`s. */
+  imagePath: string;
+  /** sha8 of the photo bytes — stamped into photo_current so commit can re-key. */
+  contentHash: string;
+}
+
+export interface PrepareDeps {
+  /** Injected so unit tests never hit the network. */
+  download: (url: string) => Promise<Buffer>;
+  /** Cache dir for downloaded thumbs + the manifest. */
+  thumbDir: string;
+}
+
+export interface PrepareResult {
+  picked: number;
+  /** Absolute path to the manifest JSON the operator hands to the score agents. */
+  manifestPath: string;
+  manifest: ManifestEntry[];
+}
+
+/**
+ * score-prepare: select the next `limit` reviewed=0 rows (clamp [1,100], shared
+ * with scoreBatch), download each photo into `<thumbDir>/<code>.<ext>`, stamp
+ * the real content hash into photo_current (so score-commit can re-key the
+ * score row by hash WITHOUT clobbering the attribution/license sync stored),
+ * and write a manifest JSON to `<thumbDir>/manifest.json`. Returns the manifest
+ * + its path. Per-row download failures abort the prepare (a bad URL is an
+ * operator-visible signal — unlike a single bad candidate in the deny loop).
+ */
+export async function scorePrepare(
+  db: Database.Database, limit: number, deps: PrepareDeps,
+): Promise<PrepareResult> {
+  const rows = selectUnreviewed(db, scoreBatch.clampLimit(limit));
+  await mkdir(deps.thumbDir, { recursive: true });
+
+  const manifest: ManifestEntry[] = [];
+  for (const row of rows) {
+    const bytes = await deps.download(row.url);
+    const mime = mimeFromUrl(row.url);
+    const hash = sha8(bytes);
+    const imagePath = join(deps.thumbDir, `${row.species_code}.${extFromMime(mime)}`);
+    await writeFile(imagePath, bytes);
+    // Record the real content_hash now (hash-only update — preserves the
+    // attribution/license sync populated). score-commit keys the score row by it.
+    updateCurrentPhotoHash(db, row.species_code, hash);
+    manifest.push({
+      speciesCode: row.species_code,
+      comName: row.com_name,
+      sciName: row.sci_name,
+      family: row.family,
+      imagePath,
+      contentHash: hash,
+    });
+  }
+
+  const manifestPath = join(deps.thumbDir, 'manifest.json');
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return { picked: rows.length, manifestPath, manifest };
+}
+
+/** One agent scoring result — the score-commit input shape. */
+export interface ScoreResult {
+  speciesCode: string;
+  criteria: CriteriaScores;
+  flags: string[];
+  rationale: string;
+}
+
+export interface CommitSummary {
+  committed: number;
+  failed: number;
+  errors: Array<{ speciesCode: string; reason: string }>;
+}
+
+interface CurrentHashRow { content_hash: string | null }
+
+/** A neutral deterministic report — the agent path skips the sharp decode gate. */
+function neutralDeterministic(): DeterministicReport {
+  return {
+    width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0,
+    passedGate: true, failReasons: [],
+  };
+}
+
+/**
+ * score-commit: for each agent result, composeReport(criteria, flags,
+ * defaultRubricConfig) → {overall, verdict}, build a QualityReport, and persist
+ * it via upsertScore(role='current') keyed by the content_hash score-prepare
+ * stamped into photo_current. Then markReviewed clears the species from the
+ * backlog. A result whose species has no photo_current row (or no stamped hash —
+ * never prepared) is recorded as a failure, not thrown, so one stray result
+ * never aborts a batch commit.
+ */
+export async function scoreCommit(
+  db: Database.Database, results: ScoreResult[],
+): Promise<CommitSummary> {
+  const summary: CommitSummary = { committed: 0, failed: 0, errors: [] };
+  for (const r of results) {
+    try {
+      const row = db.prepare(
+        `SELECT content_hash FROM photo_current WHERE species_code=?`,
+      ).get(r.speciesCode) as CurrentHashRow | undefined;
+      const hash = row?.content_hash;
+      if (!hash) {
+        throw new Error(`no prepared photo_current row (content_hash) for ${r.speciesCode} — run score-prepare first`);
+      }
+
+      const { overall, verdict } = composeReport(r.criteria, r.flags, defaultRubricConfig);
+      const report: QualityReport = {
+        overall, verdict,
+        deterministic: neutralDeterministic(),
+        criteria: r.criteria,
+        flags: r.flags,
+        rationale: r.rationale,
+        rubricVersion: defaultRubricConfig.version,
+      };
+      upsertScore(db, {
+        speciesCode: r.speciesCode, role: 'current', candidateInatId: null,
+        contentHash: hash, report,
+      });
+      // re-stamp the (already-stamped) hash defensively + clear the backlog flag.
+      updateCurrentPhotoHash(db, r.speciesCode, hash);
+      markReviewed(db, r.speciesCode);
+      summary.committed++;
+    } catch (err) {
+      summary.failed++;
+      summary.errors.push({ speciesCode: r.speciesCode, reason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return summary;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// source-candidates split (analogous to score-prepare / score-commit). The
+// prepare half fetches a DEEP iNat pool per FLAGGED species (current overall <
+// thresholds.review), downloads + inserts each candidate, and emits a manifest
+// the parallel score agents Read; the commit half persists the agent scores as
+// role='candidate' so Slice 5's deny route can advance to an already-scored
+// alternate. Same no-`agent()`-in-Node discipline as the score halves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** One row of the source-prepare manifest — one iNat candidate per entry. */
+export interface SourceManifestEntry {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  inatId: number;
+  imagePath: string;
+  contentHash: string;
+  attribution: string;
+  license: string;
+}
+
+export interface SourcePrepareDeps {
+  fetchInatCandidates?: (
+    sciName: string,
+    opts: { limit: number; excludeIds?: number[]; denyContext?: DenyContext },
+  ) => Promise<InatCandidate[]>;
+  download: (url: string) => Promise<Buffer>;
+  thumbDir: string;
+}
+
+export interface SourcePrepareResult {
+  /** number of candidates sourced across all flagged species */
+  picked: number;
+  manifestPath: string;
+  manifest: SourceManifestEntry[];
+}
+
+interface FlaggedRow {
+  species_code: string; com_name: string | null; sci_name: string | null; family: string | null;
+}
+
+/**
+ * source-prepare: find every FLAGGED species (a scored current photo below the
+ * rubric review threshold), fetch up to `pool` fresh iNat candidates for each,
+ * download + write each thumb to `<thumbDir>/<code>-<inatId>.<ext>`, persist a
+ * `photo_candidate` row (next source_round), and write a manifest the score
+ * agents Read. NO judge call here — scoring is the agent + commit step.
+ */
+export async function sourcePrepare(
+  db: Database.Database, pool: number, deps: SourcePrepareDeps,
+): Promise<SourcePrepareResult> {
+  const fetchInat = deps.fetchInatCandidates ?? realFetchInatCandidates;
+  await mkdir(deps.thumbDir, { recursive: true });
+
+  const flagged = db.prepare(
+    `SELECT c.species_code, c.com_name, c.sci_name, c.family
+       FROM photo_score s
+       JOIN photo_current c ON c.species_code = s.species_code
+      WHERE s.role = 'current' AND s.overall < ?
+      ORDER BY s.overall ASC`,
+  ).all(defaultRubricConfig.thresholds.review) as FlaggedRow[];
+
+  const manifest: SourceManifestEntry[] = [];
+  for (const sp of flagged) {
+    if (!sp.sci_name) continue; // can't source without a scientific name
+    const round = maxSourceRound(db, sp.species_code) + 1;
+    const candidates = await fetchInat(sp.sci_name, { limit: pool });
+    for (const cand of candidates) {
+      const bytes = await deps.download(cand.photoUrl);
+      const mime = mimeFromUrl(cand.photoUrl);
+      const hash = sha8(bytes);
+      const imagePath = join(deps.thumbDir, `${sp.species_code}-${cand.inatId}.${extFromMime(mime)}`);
+      await writeFile(imagePath, bytes);
+      insertCandidate(db, {
+        speciesCode: sp.species_code, inatId: cand.inatId, photoUrl: cand.photoUrl,
+        thumbPath: imagePath, attribution: cand.attribution, license: cand.license,
+        sourceRound: round,
+      });
+      manifest.push({
+        speciesCode: sp.species_code,
+        comName: sp.com_name ?? '',
+        sciName: sp.sci_name,
+        family: sp.family ?? '',
+        inatId: cand.inatId,
+        imagePath,
+        contentHash: hash,
+        attribution: cand.attribution,
+        license: cand.license,
+      });
+    }
+  }
+
+  const manifestPath = join(deps.thumbDir, 'candidates-manifest.json');
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return { picked: manifest.length, manifestPath, manifest };
+}
+
+/** One agent candidate-scoring result. Carries the inat id + content hash. */
+export interface SourceResult {
+  speciesCode: string;
+  inatId: number;
+  contentHash: string;
+  criteria: CriteriaScores;
+  flags: string[];
+  rationale: string;
+}
+
+/**
+ * source-commit: composeReport each agent candidate result and persist it as
+ * role='candidate' keyed by (species_code, content_hash) with the inat id, so
+ * the review server's deny route can advance to a scored alternate. A missing
+ * content hash is recorded as a failure, not thrown.
+ */
+export async function sourceCommit(
+  db: Database.Database, results: SourceResult[],
+): Promise<CommitSummary> {
+  const summary: CommitSummary = { committed: 0, failed: 0, errors: [] };
+  for (const r of results) {
+    try {
+      if (!r.contentHash) {
+        throw new Error(`missing contentHash for ${r.speciesCode} candidate ${r.inatId} — re-run source-prepare`);
+      }
+      const { overall, verdict } = composeReport(r.criteria, r.flags, defaultRubricConfig);
+      const report: QualityReport = {
+        overall, verdict,
+        deterministic: neutralDeterministic(),
+        criteria: r.criteria,
+        flags: r.flags,
+        rationale: r.rationale,
+        rubricVersion: defaultRubricConfig.version,
+      };
+      upsertScore(db, {
+        speciesCode: r.speciesCode, role: 'candidate', candidateInatId: r.inatId,
+        contentHash: r.contentHash, report,
+      });
+      summary.committed++;
+    } catch (err) {
+      summary.failed++;
+      summary.errors.push({ speciesCode: r.speciesCode, reason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return summary;
+}

--- a/tools/photo-curation/src/score-orchestration.ts
+++ b/tools/photo-curation/src/score-orchestration.ts
@@ -8,9 +8,14 @@ import { fetchInatCandidates as realFetchInatCandidates } from '@bird-watch/inge
 import { sha8 } from './hash.js';
 import {
   selectUnreviewed, updateCurrentPhotoHash, upsertScore, markReviewed,
-  insertCandidate, maxSourceRound,
+  insertCandidate, maxSourceRound, getScoreByHash,
 } from './store.js';
 import { scoreBatch, mimeFromUrl, extFromMime } from './sources.js';
+import {
+  Pacer, withBackoff, clampPool, realClock,
+  EDGE_PACE_MS, INAT_PACE_MS, CANDIDATE_POOL_CAP,
+  type Clock,
+} from './pacing.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Bug 1 (#992) — orchestrator-driven scoring, split into two runnable Node
@@ -47,10 +52,25 @@ export interface PrepareDeps {
   download: (url: string) => Promise<Buffer>;
   /** Cache dir for downloaded thumbs + the manifest. */
   thumbDir: string;
+  /**
+   * Injected clock so unit tests assert download pacing WITHOUT a real wait.
+   * Defaults to the real `setTimeout`-backed clock.
+   */
+  clock?: Clock;
+  /**
+   * Min ms between successive bird-maps.com edge downloads (Cloudflare limits
+   * 60 req/min/IP). Defaults to EDGE_PACE_MS (1100). Tests may lower it, but the
+   * spacing is still asserted via the injected clock, not wall-time.
+   */
+  paceMs?: number;
 }
 
 export interface PrepareResult {
   picked: number;
+  /** How many were skipped because their current content-hash is already scored. */
+  skipped: number;
+  /** External edge downloads actually performed (for the batch usage log). */
+  downloads: number;
   /** Absolute path to the manifest JSON the operator hands to the score agents. */
   manifestPath: string;
   manifest: ManifestEntry[];
@@ -64,6 +84,18 @@ export interface PrepareResult {
  * and write a manifest JSON to `<thumbDir>/manifest.json`. Returns the manifest
  * + its path. Per-row download failures abort the prepare (a bad URL is an
  * operator-visible signal — unlike a single bad candidate in the deny loop).
+ *
+ * Conservative external-API usage (#992 addendum):
+ *   • No-rework: BEFORE downloading, skip any row whose already-stamped current
+ *     content_hash is already scored (getScoreByHash) — never re-download or
+ *     re-score an unchanged image.
+ *   • Edge pacing: downloads are SERIAL and paced ≥ EDGE_PACE_MS (1.1 s) apart
+ *     because the bird-maps.com edge (Cloudflare) limits 60 req/min/IP. The
+ *     pacing is injectable (`deps.clock`/`deps.paceMs`) so tests assert spacing
+ *     deterministically without a real wait.
+ *   • Transient (429/5xx) downloads get jittered exponential backoff with a
+ *     bounded retry count.
+ *   • The batch logs how many external downloads it made.
  */
 export async function scorePrepare(
   db: Database.Database, limit: number, deps: PrepareDeps,
@@ -71,9 +103,24 @@ export async function scorePrepare(
   const rows = selectUnreviewed(db, scoreBatch.clampLimit(limit));
   await mkdir(deps.thumbDir, { recursive: true });
 
+  const clock = deps.clock ?? realClock;
+  const pacer = new Pacer(deps.paceMs ?? EDGE_PACE_MS, clock);
+
   const manifest: ManifestEntry[] = [];
+  let skipped = 0;
+  let downloads = 0;
   for (const row of rows) {
-    const bytes = await deps.download(row.url);
+    // No-rework: if this species already carries a stamped current content_hash
+    // that is already scored, skip it — never re-download an unchanged image.
+    if (row.contentHash && getScoreByHash(db, row.species_code, 'current', row.contentHash)) {
+      skipped++;
+      continue;
+    }
+
+    // Pace the edge download (serial, ≥1.1 s) — gate BEFORE the request.
+    await pacer.gate();
+    const bytes = await withBackoff(() => deps.download(row.url), { clock });
+    downloads++;
     const mime = mimeFromUrl(row.url);
     const hash = sha8(bytes);
     const imagePath = join(deps.thumbDir, `${row.species_code}.${extFromMime(mime)}`);
@@ -93,7 +140,9 @@ export async function scorePrepare(
 
   const manifestPath = join(deps.thumbDir, 'manifest.json');
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-  return { picked: rows.length, manifestPath, manifest };
+  // eslint-disable-next-line no-console
+  console.log(`[score-prepare] external calls: ${downloads} edge download(s); skipped ${skipped} already-scored`);
+  return { picked: manifest.length, skipped, downloads, manifestPath, manifest };
 }
 
 /** One agent scoring result — the score-commit input shape. */
@@ -197,11 +246,21 @@ export interface SourcePrepareDeps {
   ) => Promise<InatCandidate[]>;
   download: (url: string) => Promise<Buffer>;
   thumbDir: string;
+  /** Injected clock so unit tests assert pacing WITHOUT a real wait. */
+  clock?: Clock;
+  /** Min ms between iNat species fetches (≤1 req/sec). Defaults to INAT_PACE_MS (1100). */
+  inatPaceMs?: number;
+  /** Min ms between bird-maps.com edge downloads. Defaults to EDGE_PACE_MS (1100). */
+  edgePaceMs?: number;
 }
 
 export interface SourcePrepareResult {
   /** number of candidates sourced across all flagged species */
   picked: number;
+  /** iNat species fetches actually performed (for the batch usage log). */
+  inatFetches: number;
+  /** External edge downloads actually performed (for the batch usage log). */
+  downloads: number;
   manifestPath: string;
   manifest: SourceManifestEntry[];
 }
@@ -216,12 +275,29 @@ interface FlaggedRow {
  * download + write each thumb to `<thumbDir>/<code>-<inatId>.<ext>`, persist a
  * `photo_candidate` row (next source_round), and write a manifest the score
  * agents Read. NO judge call here — scoring is the agent + commit step.
+ *
+ * Conservative external-API usage (#992 addendum):
+ *   • iNat is third-party: the per-species fetch is paced ≥ INAT_PACE_MS
+ *     (1.1 s, ≤1 req/sec) and the pool is capped to CANDIDATE_POOL_CAP (~12) so
+ *     it never fans out unbounded.
+ *   • Each iNat fetch and each edge download gets jittered exponential backoff
+ *     on 429/5xx; a species whose iNat fetch fails persistently is ABORTED
+ *     (recorded + skipped), not the whole batch.
+ *   • Edge downloads are serial + paced ≥ EDGE_PACE_MS (Cloudflare 60/min/IP).
+ *   • Pacing is injectable (`deps.clock`/`deps.inatPaceMs`/`deps.edgePaceMs`)
+ *     so tests assert spacing deterministically without a real wait.
+ *   • The batch logs how many external calls (iNat fetches + downloads) it made.
  */
 export async function sourcePrepare(
   db: Database.Database, pool: number, deps: SourcePrepareDeps,
 ): Promise<SourcePrepareResult> {
   const fetchInat = deps.fetchInatCandidates ?? realFetchInatCandidates;
   await mkdir(deps.thumbDir, { recursive: true });
+
+  const clock = deps.clock ?? realClock;
+  const inatPacer = new Pacer(deps.inatPaceMs ?? INAT_PACE_MS, clock);
+  const edgePacer = new Pacer(deps.edgePaceMs ?? EDGE_PACE_MS, clock);
+  const cappedPool = clampPool(pool);
 
   const flagged = db.prepare(
     `SELECT c.species_code, c.com_name, c.sci_name, c.family
@@ -232,12 +308,32 @@ export async function sourcePrepare(
   ).all(defaultRubricConfig.thresholds.review) as FlaggedRow[];
 
   const manifest: SourceManifestEntry[] = [];
+  let inatFetches = 0;
+  let downloads = 0;
   for (const sp of flagged) {
     if (!sp.sci_name) continue; // can't source without a scientific name
+    const sciName = sp.sci_name;
     const round = maxSourceRound(db, sp.species_code) + 1;
-    const candidates = await fetchInat(sp.sci_name, { limit: pool });
-    for (const cand of candidates) {
-      const bytes = await deps.download(cand.photoUrl);
+
+    // iNat is third-party: pace ≤1 req/sec between species AND bound the pool.
+    // A persistent iNat failure aborts THIS species, not the batch.
+    await inatPacer.gate();
+    let candidates: InatCandidate[];
+    try {
+      candidates = await withBackoff(
+        () => fetchInat(sciName, { limit: cappedPool }), { clock },
+      );
+      inatFetches++;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[source-prepare] iNat fetch failed for ${sp.species_code} — skipping species: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+
+    for (const cand of candidates.slice(0, cappedPool)) {
+      await edgePacer.gate();
+      const bytes = await withBackoff(() => deps.download(cand.photoUrl), { clock });
+      downloads++;
       const mime = mimeFromUrl(cand.photoUrl);
       const hash = sha8(bytes);
       const imagePath = join(deps.thumbDir, `${sp.species_code}-${cand.inatId}.${extFromMime(mime)}`);
@@ -250,7 +346,7 @@ export async function sourcePrepare(
       manifest.push({
         speciesCode: sp.species_code,
         comName: sp.com_name ?? '',
-        sciName: sp.sci_name,
+        sciName,
         family: sp.family ?? '',
         inatId: cand.inatId,
         imagePath,
@@ -263,7 +359,9 @@ export async function sourcePrepare(
 
   const manifestPath = join(deps.thumbDir, 'candidates-manifest.json');
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-  return { picked: manifest.length, manifestPath, manifest };
+  // eslint-disable-next-line no-console
+  console.log(`[source-prepare] external calls: ${inatFetches} iNat fetch(es) + ${downloads} edge download(s)`);
+  return { picked: manifest.length, inatFetches, downloads, manifestPath, manifest };
 }
 
 /** One agent candidate-scoring result. Carries the inat id + content hash. */

--- a/tools/photo-curation/src/sources.test.ts
+++ b/tools/photo-curation/src/sources.test.ts
@@ -4,6 +4,7 @@ import { openDb } from './db.js';
 import { listCandidates, getScoreByHash, upsertCurrentPhoto } from './store.js';
 import { sourceCandidates, scoreAndCacheCandidates } from './sources.js';
 import { FakeJudge } from './judge.js';
+import { makeFakeClock } from './test-clock.js';
 import type { RubricConfig } from '@bird-watch/photo-quality';
 import type { InatCandidate, DenyContext } from '@bird-watch/ingestor';
 
@@ -40,6 +41,8 @@ function deps(fetchSpy: (sci: string, o: { limit: number; excludeIds?: number[];
     judge: new FakeJudge({}),
     config,
     thumbDir: '/tmp/photo-curation-test-thumbs',
+    // Instant clock so iNat/edge pacing advances virtual time only — no real wait.
+    clock: makeFakeClock(),
   };
 }
 

--- a/tools/photo-curation/src/sources.ts
+++ b/tools/photo-curation/src/sources.ts
@@ -16,6 +16,11 @@ import {
   insertCandidate, upsertScore, getScoreByHash, maxSourceRound, upsertCurrentPhoto,
   updateCurrentPhotoHash, selectUnreviewed, markReviewed,
 } from './store.js';
+import {
+  Pacer, withBackoff, clampPool, realClock,
+  EDGE_PACE_MS, INAT_PACE_MS,
+  type Clock,
+} from './pacing.js';
 
 /** Default thumb-cache dir for the production deny-loop entry point. */
 const DEFAULT_THUMB_DIR = './thumb-cache';
@@ -38,6 +43,12 @@ export interface SourceDeps {
   judge: VisionJudge;
   config: RubricConfig;
   thumbDir: string;
+  /** Injected clock so unit tests assert pacing WITHOUT a real wall-clock wait. */
+  clock?: Clock;
+  /** Min ms between iNat fetches (≤1 req/sec). Defaults to INAT_PACE_MS (1100). */
+  inatPaceMs?: number;
+  /** Min ms between bird-maps.com edge downloads. Defaults to EDGE_PACE_MS (1100). */
+  edgePaceMs?: number;
 }
 
 export interface SourceArgs {
@@ -91,10 +102,22 @@ export async function sourceCandidates(
     fetched: 0, scored: 0, cached: 0, failed: 0, sourceRound: round, errors: [],
   };
 
-  const fetchOpts: { limit: number; excludeIds?: number[]; denyContext?: DenyContext } = { limit: args.limit };
+  const clock = deps.clock ?? realClock;
+  const inatPacer = new Pacer(deps.inatPaceMs ?? INAT_PACE_MS, clock);
+  const edgePacer = new Pacer(deps.edgePaceMs ?? EDGE_PACE_MS, clock);
+
+  // Bound the iNat pool to the top ~12 (clamp the caller's limit) so no path
+  // fans out an unbounded fetch.
+  const cappedLimit = clampPool(args.limit);
+  const fetchOpts: { limit: number; excludeIds?: number[]; denyContext?: DenyContext } = { limit: cappedLimit };
   if (args.excludeIds) fetchOpts.excludeIds = args.excludeIds;
   if (args.denyContext) fetchOpts.denyContext = args.denyContext;
-  const candidates = await deps.fetchInatCandidates(args.sciName, fetchOpts);
+  // iNat is third-party: pace + jittered backoff on 429/5xx (bounded retries).
+  await inatPacer.gate();
+  const fetched = await withBackoff(
+    () => deps.fetchInatCandidates(args.sciName, fetchOpts), { clock },
+  );
+  const candidates = fetched.slice(0, cappedLimit);
   summary.fetched = candidates.length;
 
   await mkdir(deps.thumbDir, { recursive: true });
@@ -108,7 +131,9 @@ export async function sourceCandidates(
 
   for (const cand of candidates) {
     try {
-      const bytes = await deps.download(cand.photoUrl);
+      // Pace the edge download (serial, ≥1.1 s) with jittered backoff on 429/5xx.
+      await edgePacer.gate();
+      const bytes = await withBackoff(() => deps.download(cand.photoUrl), { clock });
       const mime = mimeFromUrl(cand.photoUrl);
       const hash = sha8(bytes);
       const thumbPath = join(deps.thumbDir, `${args.speciesCode}-${cand.inatId}.${extFromMime(mime)}`);
@@ -146,6 +171,8 @@ export async function sourceCandidates(
       // continue — one candidate's failure must not abort the species
     }
   }
+  // eslint-disable-next-line no-console
+  console.log(`[source-candidates] ${args.speciesCode}: external calls: 1 iNat fetch + ${candidates.length} edge download(s)`);
   return summary;
 }
 
@@ -203,7 +230,9 @@ export async function scoreAndCacheCandidates(
 
   // The judge is required from the caller (the workflow's agent-judge / a test's
   // FakeJudge); the remaining IO defaults to the production implementation but
-  // every field stays overridable for a unit test.
+  // every field stays overridable for a unit test. The pacing seam (clock +
+  // pace overrides) is forwarded only when the caller supplies it — production
+  // omits it and sourceCandidates defaults to realClock + the spec pacing.
   const resolved: SourceDeps = {
     fetchInatCandidates: deps.fetchInatCandidates ?? realFetchInatCandidates,
     download: deps.download ?? downloadBytes,
@@ -211,6 +240,9 @@ export async function scoreAndCacheCandidates(
     judge: deps.judge,
     config: deps.config ?? defaultRubricConfig,
     thumbDir: deps.thumbDir ?? DEFAULT_THUMB_DIR,
+    ...(deps.clock !== undefined ? { clock: deps.clock } : {}),
+    ...(deps.inatPaceMs !== undefined ? { inatPaceMs: deps.inatPaceMs } : {}),
+    ...(deps.edgePaceMs !== undefined ? { edgePaceMs: deps.edgePaceMs } : {}),
   };
 
   const comName = deps.comName ?? row?.com_name ?? undefined;
@@ -222,7 +254,8 @@ export async function scoreAndCacheCandidates(
       sciName,
       ...(comName !== undefined ? { comName } : {}),
       ...(family !== undefined ? { family } : {}),
-      limit: deps.limit ?? 15,
+      // Bounded pool (clamped to ~12 inside sourceCandidates). Default to the cap.
+      limit: deps.limit ?? clampPool(15),
       denyContext,
       excludeIds,
     },
@@ -350,10 +383,16 @@ export interface ScoreBatchDeps {
   download: (url: string) => Promise<Buffer>;
   config: RubricConfig;
   scoreImage?: SourceDeps['scoreImage']; // test seam; defaults to the agent-free composer
+  /** Injected clock so unit tests assert download pacing WITHOUT a real wait. */
+  clock?: Clock;
+  /** Min ms between bird-maps.com edge downloads. Defaults to EDGE_PACE_MS (1100). */
+  edgePaceMs?: number;
 }
 
 export interface ScoreBatchSummary {
   picked: number; scored: number; gatedOut: number; cached: number; failed: number;
+  /** External edge downloads actually performed (for the batch usage log). */
+  downloads: number;
   errors: Array<{ speciesCode: string; reason: string }>;
 }
 
@@ -404,7 +443,9 @@ async function composeWithJudge(
 export async function scoreOne(
   db: Database.Database, row: UnreviewedRow, deps: ScoreBatchDeps,
 ): Promise<'scored' | 'gated' | 'cached'> {
-  const bytes = await deps.download(row.url);
+  // Jittered backoff on a transient (429/5xx) edge download; the caller
+  // (scoreBatch) gates the serial pacing between rows.
+  const bytes = await withBackoff(() => deps.download(row.url), { clock: deps.clock ?? realClock });
   const mime = mimeFromUrl(row.url);
   const hash = sha8(bytes);
 
@@ -472,11 +513,16 @@ export async function scoreBatch(
   // query; its rows carry the snake_case aliases scoreOne consumes directly.
   const rows: UnreviewedRow[] = selectUnreviewed(db, clampLimit(limit));
   const summary: ScoreBatchSummary = {
-    picked: rows.length, scored: 0, gatedOut: 0, cached: 0, failed: 0, errors: [],
+    picked: rows.length, scored: 0, gatedOut: 0, cached: 0, failed: 0, downloads: 0, errors: [],
   };
+  const clock = deps.clock ?? realClock;
+  const edgePacer = new Pacer(deps.edgePaceMs ?? EDGE_PACE_MS, clock);
   for (const row of rows) {
     try {
+      // Serial edge pacing (≥1.1 s) between per-species downloads — gate first.
+      await edgePacer.gate();
       const outcome = await scoreOne(db, row, deps);
+      summary.downloads++; // scoreOne performed exactly one edge download
       if (outcome === 'scored') summary.scored++;
       else if (outcome === 'gated') summary.gatedOut++;
       else summary.cached++;
@@ -486,6 +532,8 @@ export async function scoreBatch(
       summary.errors.push({ speciesCode: row.species_code, reason: err instanceof Error ? err.message : String(err) });
     }
   }
+  // eslint-disable-next-line no-console
+  console.log(`[score] external calls: ${summary.downloads} edge download(s)`);
   return summary;
 }
 // Expose the clamp so the CLI / workflow share one source of truth.

--- a/tools/photo-curation/src/sources.ts
+++ b/tools/photo-curation/src/sources.ts
@@ -10,7 +10,7 @@ import {
 } from '@bird-watch/photo-quality';
 import type { InatCandidate, DenyContext } from '@bird-watch/ingestor';
 import { fetchInatCandidates as realFetchInatCandidates } from '@bird-watch/ingestor';
-import type { SpeciesMeta } from '@bird-watch/shared-types';
+import type { SpeciesMeta, SpeciesWithPhoto } from '@bird-watch/shared-types';
 import { sha8 } from './hash.js';
 import {
   insertCandidate, upsertScore, getScoreByHash, maxSourceRound, upsertCurrentPhoto,
@@ -60,14 +60,14 @@ export interface SourceSummary {
   errors: Array<{ inatId: number; reason: string }>;
 }
 
-function mimeFromUrl(url: string): string {
+export function mimeFromUrl(url: string): string {
   const path = url.split('?')[0]?.toLowerCase() ?? url;
   if (path.endsWith('.png')) return 'image/png';
   if (path.endsWith('.webp')) return 'image/webp';
   return 'image/jpeg';
 }
 
-function extFromMime(mime: string): string {
+export function extFromMime(mime: string): string {
   if (mime === 'image/png') return 'png';
   if (mime === 'image/webp') return 'webp';
   return 'jpg';
@@ -288,6 +288,53 @@ export async function sync(
     } catch (err) {
       summary.failed++;
       summary.errors.push({ speciesCode: code, reason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  return summary;
+}
+
+/**
+ * The whole-backlog snapshot (#992). Calls `GET /api/species/with-photos` ONCE
+ * — the read-api endpoint that INNER-JOINs `species_meta` to
+ * `species_photos(purpose='detail-panel')` and returns the ~715
+ * observed-with-photos species in a single body — and upserts every row into
+ * `photo_current` with reviewed = 0.
+ *
+ * This replaces the old no-`--species` path, which fetched `/api/species` (the
+ * full 17.8k-code eBird taxonomy, no photoUrl) and then issued a per-species
+ * `/api/species/:code` detail call each — ~17.8k requests, almost all `noPhoto`.
+ * Because the endpoint already filters to species WITH a photo, there is no
+ * `skipped` count here: every returned row carries a `photoUrl` and is upserted.
+ *
+ * Same idempotent, NO-token, reviewed=0 contract as `sync` (which the
+ * `--species <code>` single path still uses via `/api/species/:code`).
+ * content_hash is left empty at sync time; `scoreOne` re-stamps the real hash
+ * when it downloads the bytes.
+ */
+export async function syncAll(
+  db: Database.Database, deps: SyncDeps,
+): Promise<SyncSummary> {
+  const res = await fetch(`${deps.apiBase}/api/species/with-photos`, {
+    headers: { accept: 'application/json' },
+  });
+  if (!res.ok) throw new Error(`read-api ${res.status} for /api/species/with-photos`);
+  const rows = (await res.json()) as SpeciesWithPhoto[];
+
+  const summary: SyncSummary = {
+    total: rows.length, upserted: 0, skipped: 0, failed: 0, errors: [],
+  };
+  for (const row of rows) {
+    try {
+      upsertCurrentPhoto(db, {
+        speciesCode: row.code, comName: row.comName, sciName: row.sciName,
+        family: row.family, url: row.photoUrl,
+        attribution: row.photoAttribution ?? '', license: row.photoLicense ?? '',
+        contentHash: '', // hash is computed at score time, not sync time
+      });
+      summary.upserted++;
+    } catch (err) {
+      summary.failed++;
+      summary.errors.push({ speciesCode: row.code, reason: err instanceof Error ? err.message : String(err) });
     }
   }
   return summary;

--- a/tools/photo-curation/src/sync.test.ts
+++ b/tools/photo-curation/src/sync.test.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 import type Database from 'better-sqlite3';
 import { openDb } from './db.js';
 import { getScoreByHash, selectUnreviewed } from './store.js';
-import { sync, scoreBatch } from './sources.js';
+import { sync, syncAll, scoreBatch } from './sources.js';
 import { FakeJudge } from './judge.js';
 import type { RubricConfig } from '@bird-watch/photo-quality';
 
@@ -53,6 +53,54 @@ describe('sync (cheap, NO tokens)', () => {
     const summary = await sync(db, ['nopho'], { apiBase: API });
     expect(summary.skipped).toBe(1);
     expect(selectUnreviewed(db, 10)).toEqual([]);
+  });
+});
+
+describe('syncAll (#992 — one call to /api/species/with-photos, no per-species walk)', () => {
+  it('upserts every with-photos row into photo_current (reviewed=0) from ONE endpoint call', async () => {
+    let detailHits = 0;
+    server.use(
+      // The new bulk endpoint: returns the observed-with-photos set in one body.
+      http.get(`${API}/api/species/with-photos`, () =>
+        HttpResponse.json([
+          { code: 'amerob', comName: 'American Robin', sciName: 'Turdus migratorius',
+            family: 'Turdidae', photoUrl: 'https://photos.bird-maps.com/species/amerob.jpg',
+            photoAttribution: '(c) X (CC BY)', photoLicense: 'cc-by' },
+          { code: 'annhum', comName: "Anna's Hummingbird", sciName: 'Calypte anna',
+            family: 'Hummingbirds', photoUrl: 'https://photos.bird-maps.com/species/annhum.jpg',
+            photoAttribution: '(c) Y (CC BY-NC)', photoLicense: 'cc-by-nc' },
+        ]),
+      ),
+      // If the rewire regressed to a per-species walk, this would fire — the
+      // test fails loudly because onUnhandledRequest is 'error', but we also
+      // count to assert ZERO detail calls explicitly.
+      http.get(`${API}/api/species/:code`, ({ params }) => {
+        detailHits++;
+        return HttpResponse.json({ speciesCode: params.code });
+      }),
+    );
+
+    const summary = await syncAll(db, { apiBase: API });
+    expect(summary.upserted).toBe(2);
+    expect(summary.total).toBe(2);
+    expect(detailHits).toBe(0); // NO per-species detail call
+
+    const rob = db.prepare(`SELECT * FROM photo_current WHERE species_code=?`).get('amerob') as any;
+    expect(rob.com_name).toBe('American Robin');
+    expect(rob.sci_name).toBe('Turdus migratorius');
+    expect(rob.family).toBe('Turdidae');
+    expect(rob.attribution).toBe('(c) X (CC BY)');
+    expect(rob.license).toBe('cc-by');
+    expect(rob.reviewed).toBe(0);
+    // Both are visible to the batched scorer, oldest-first by code.
+    expect(selectUnreviewed(db, 10).map((r: any) => r.species_code)).toEqual(['amerob', 'annhum']);
+  });
+
+  it('throws when the bulk endpoint is unavailable', async () => {
+    server.use(
+      http.get(`${API}/api/species/with-photos`, () => new HttpResponse(null, { status: 503 })),
+    );
+    await expect(syncAll(db, { apiBase: API })).rejects.toThrow(/503/);
   });
 });
 

--- a/tools/photo-curation/src/sync.test.ts
+++ b/tools/photo-curation/src/sync.test.ts
@@ -6,7 +6,13 @@ import { openDb } from './db.js';
 import { getScoreByHash, selectUnreviewed } from './store.js';
 import { sync, syncAll, scoreBatch } from './sources.js';
 import { FakeJudge } from './judge.js';
+import { makeFakeClock } from './test-clock.js';
 import type { RubricConfig } from '@bird-watch/photo-quality';
+
+// Instant clock: scoreBatch paces edge downloads ≥1.1 s in prod, but the unit
+// tests must never incur a real wait — the fake clock advances virtual time
+// only (no setTimeout). Pacing spacing is asserted separately in pacing tests.
+const instant = () => makeFakeClock();
 
 const server = setupServer();
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -121,11 +127,11 @@ describe('scoreBatch (token-spending, resumable)', () => {
     const download = vi.fn(async (url: string) => Buffer.from(url));
     const judge = new FakeJudge({});
     // batch of 2 → first two scored + marked, one left
-    const first = await scoreBatch(db, 2, { judge, download, config });
+    const first = await scoreBatch(db, 2, { judge, download, config, clock: instant() });
     expect(first.scored).toBe(2);
     expect(selectUnreviewed(db, 10)).toHaveLength(1);
     // resume → the remaining one
-    const second = await scoreBatch(db, 2, { judge, download, config });
+    const second = await scoreBatch(db, 2, { judge, download, config, clock: instant() });
     expect(second.scored).toBe(1);
     expect(selectUnreviewed(db, 10)).toEqual([]);
   });
@@ -148,7 +154,7 @@ describe('scoreBatch (token-spending, resumable)', () => {
 
     const download = vi.fn(async (url: string) => Buffer.from(url));
     const judge = new FakeJudge({});
-    const summary = await scoreBatch(db, 10, { judge, download, config });
+    const summary = await scoreBatch(db, 10, { judge, download, config, clock: instant() });
     expect(summary.scored).toBe(1);
 
     // scoreBatch re-stamps content_hash but MUST leave attribution/license intact

--- a/tools/photo-curation/src/test-clock.ts
+++ b/tools/photo-curation/src/test-clock.ts
@@ -1,0 +1,35 @@
+import type { Clock } from './pacing.js';
+
+/**
+ * A deterministic fake clock for unit tests. `sleep(ms)` advances a virtual
+ * `now` WITHOUT a real timer and records each requested wait, so a suite that
+ * asserts ≥1.1 s pacing runs in microseconds. `starts` records the virtual
+ * timestamp at which each `Pacer.gate()`-driven call begins (read the value of
+ * `now()` right after `gate()` to capture it; or use `sleeps` to assert the
+ * exact waits requested).
+ *
+ * Test-only — imported by *.test.ts. (Knip ignore rule documents this so the
+ * file isn't flagged as an orphan; see knip.ts.)
+ */
+export interface FakeClock extends Clock {
+  /** Every sleep duration requested, in order. */
+  sleeps: number[];
+  /** The virtual current time (ms). */
+  current: number;
+}
+
+/** Build a fake clock starting at `start` ms (default 0). */
+export function makeFakeClock(start = 0): FakeClock {
+  const clock: FakeClock = {
+    current: start,
+    sleeps: [],
+    now() {
+      return clock.current;
+    },
+    async sleep(ms: number) {
+      clock.sleeps.push(ms);
+      clock.current += ms;
+    },
+  };
+  return clock;
+}

--- a/tools/photo-curation/workflows/score-current.mjs
+++ b/tools/photo-curation/workflows/score-current.mjs
@@ -1,45 +1,80 @@
 // tools/photo-curation/workflows/score-current.mjs
-// Run via the Workflow tool. Token-spending. Resumable: re-run until the
-// reviewed=0 backlog clears. --limit defaults to 10, clamped to [1,100].
+// A REAL Claude Code Workflow-tool script (Bug 1, #992). Run via the Workflow
+// tool — NEVER via `node`. Token-spending; resumable: re-run until the
+// reviewed=0 backlog clears.
 //
-// This is NOT a vitest target — it wires the real Claude Code agent() judge and
-// live fetch. The testable surface is scoreOne/scoreBatch in ../src/sources.ts,
-// unit-tested with FakeJudge + a stub download. No @anthropic-ai/sdk, no
-// ANTHROPIC_API_KEY: the judge is a Claude Code agent that Reads the local image.
-import { openDb, DEFAULT_DB_PATH } from '../dist/db.js';
-import { scoreBatch } from '../dist/sources.js';
+// CONTRACT: the body uses the Workflow primitives (`agent()`, `parallel()`)
+// ONLY. It imports NO `node:fs` and NO `better-sqlite3` — those have no meaning
+// in the Workflow sandbox, and mixing them with `agent()` is exactly the bug
+// this file replaces (the old hybrid runner ran in neither environment). All
+// filesystem + SQLite work happens inside the Node CLI halves the agents shell
+// out to:
+//
+//   photo-curate score-prepare --limit N   → selects reviewed=0, downloads each
+//                                             photo, writes ./thumb-cache/<code>.<ext>
+//                                             + a manifest JSON, prints its path.
+//   <parallel score agents>                → each Reads one imagePath, applies
+//                                             the rubric judge prompt, returns
+//                                             {speciesCode, criteria, flags, rationale}.
+//   photo-curate score-commit results.json → composeReport → upsertScore +
+//                                             markReviewed (clears the backlog).
+//
+// The testable surface is scorePrepare/scoreCommit in ../src/score-orchestration.ts
+// (unit-tested with a temp sqlite + a stubbed download). See
+// docs/runbooks/photo-curation-scoring.md for the operator flow.
 import { defaultRubricConfig } from '@bird-watch/photo-quality';
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
 
-const limit = scoreBatch.clampLimit(Number(process.env.LIMIT ?? 10));
-const THUMB_DIR = './thumb-cache';
-await mkdir(THUMB_DIR, { recursive: true });
+const LIMIT = Number(process.env.LIMIT ?? 10);
 
-// download writes bytes to a local file so the agent can Read it.
-const download = async (url) => {
-  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
-  if (!res.ok) throw new Error(`download ${res.status} for ${url}`);
-  const buf = Buffer.from(await res.arrayBuffer());
-  return buf;
-};
+// 1) PREPARE — a Bash agent shells out to the Node `score-prepare` half, which
+//    selects the next LIMIT reviewed=0 photos, downloads each to ./thumb-cache,
+//    and writes a manifest JSON. The agent returns the manifest contents +
+//    the manifest path as structured output.
+const prepared = await agent({
+  prompt: `Run \`npx photo-curate score-prepare --limit ${LIMIT}\` in tools/photo-curation.
+It prints a human summary line then, on its own final line, the absolute path to a
+manifest JSON of shape [{ speciesCode, comName, sciName, family, imagePath, contentHash }].
+Read that manifest file and return its parsed contents as \`manifest\` plus the
+\`manifestPath\`. If the manifest is empty, return manifest: [] — the backlog is clear.`,
+  tools: ['Bash', 'Read'],
+  schema: { manifestPath: 'string', manifest: 'object[]' },
+});
 
-// The real judge: a Claude Code agent that Reads the local image + applies the
-// rubric prompt and returns StructuredOutput {criteria, flags, rationale}.
-const judge = {
-  async judge(img, ctx, prompt) {
-    const path = join(THUMB_DIR, `${ctx.speciesCode}.jpg`);
-    await writeFile(path, img.buffer);
-    // `agent` is the Workflow-tool dispatch primitive; it Reads `path` and
-    // returns the rubric StructuredOutput. No @anthropic-ai/sdk, no API key.
-    return await agent({
-      prompt: `${prompt}\n\nRead the image at ${path} for ${ctx.comName} (${ctx.sciName}).`,
-      schema: { criteria: 'object', flags: 'string[]', rationale: 'string' },
-    });
-  },
-};
+// 2) SCORE — one agent PER photo, fanned out with parallel(). Each Reads its
+//    own imagePath and applies the SAME rubric prompt the FakeJudge stands in
+//    for in tests, returning the judge sub-scores/flags/rationale. No DB, no
+//    download — the bytes are already on disk from prepare.
+const results = await parallel(
+  (prepared.manifest ?? []).map(entry => agent({
+    prompt: `${defaultRubricConfig.judgePrompt}
 
-const db = openDb(DEFAULT_DB_PATH);
-const summary = await scoreBatch(db, limit, { judge, download, config: defaultRubricConfig });
-console.log(`[score-current] ${JSON.stringify(summary, null, 2)}`);
-db.close();
+Read the image at ${entry.imagePath} for ${entry.comName} (${entry.sciName}), family ${entry.family}.
+Return structured output: an integer 0–10 for each of the seven criteria
+(framing, subjectClarity, liveness, naturalness, pose, background, lighting), a
+\`flags\` array of any applicable disqualifier strings, and a one-sentence
+\`rationale\`. Echo the \`speciesCode\` "${entry.speciesCode}" back unchanged.`,
+    tools: ['Read'],
+    schema: {
+      speciesCode: 'string',
+      criteria: 'object',
+      flags: 'string[]',
+      rationale: 'string',
+    },
+  })),
+);
+
+// 3) COMMIT — a Bash agent writes the collected results to results.json and
+//    shells out to the Node `score-commit` half, which composeReport()s each,
+//    upserts the score (role='current'), and marks the species reviewed.
+const commit = await agent({
+  prompt: `Write this JSON to tools/photo-curation/results.json, then run
+\`npx photo-curate score-commit results.json\` in tools/photo-curation and return
+its summary line:
+
+${JSON.stringify(results, null, 2)}`,
+  tools: ['Write', 'Bash'],
+  schema: { summary: 'string' },
+});
+
+console.log(`[score-current] prepared ${prepared.manifest?.length ?? 0}; committed via score-commit:`);
+console.log(commit.summary);

--- a/tools/photo-curation/workflows/source-candidates.mjs
+++ b/tools/photo-curation/workflows/source-candidates.mjs
@@ -1,71 +1,79 @@
 // tools/photo-curation/workflows/source-candidates.mjs
-// Run via the Workflow tool. Token-spending. Pre-scores a DEEP iNat pool (~15)
-// per FLAGGED species (current overall < defaultRubricConfig.thresholds.review)
-// so Slice 5's deny route can advance to an already-scored alternate instantly.
+// A REAL Claude Code Workflow-tool script (Bug 1, #992). Run via the Workflow
+// tool — NEVER via `node`. Token-spending. Pre-scores a DEEP iNat pool per
+// FLAGGED species (current overall < defaultRubricConfig.thresholds.review) so
+// Slice 5's deny route can advance to an already-scored alternate instantly.
 //
-// NOT a vitest target — it wires the real Claude Code agent() judge and live
-// fetch/sharp. The testable surface is sourceCandidates in ../src/sources.ts,
-// unit-tested with FakeJudge + injected fetch/download/scoreImage. No
-// @anthropic-ai/sdk, no ANTHROPIC_API_KEY: the judge Reads the local image.
-import { openDb, DEFAULT_DB_PATH } from '../dist/db.js';
-import { sourceCandidates } from '../dist/sources.js';
-import { scoreImage, defaultRubricConfig } from '@bird-watch/photo-quality';
-import { fetchInatCandidates } from '@bird-watch/ingestor';
-import { writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+// CONTRACT: the body uses the Workflow primitives (`agent()`, `parallel()`)
+// ONLY — NO `node:fs`, NO `better-sqlite3`, NO `@bird-watch/ingestor` fetch.
+// All filesystem + SQLite + iNat-fetch work happens inside the Node CLI halves
+// the agents shell out to:
+//
+//   photo-curate source-prepare --pool N    → finds flagged species, fetches +
+//                                              downloads a deep iNat pool each,
+//                                              inserts candidate rows, writes a
+//                                              manifest JSON, prints its path.
+//   <parallel score agents>                 → each Reads one candidate imagePath,
+//                                              applies the judge prompt, returns
+//                                              {speciesCode, inatId, contentHash,
+//                                               criteria, flags, rationale}.
+//   photo-curate source-commit results.json → composeReport → upsertScore
+//                                              (role='candidate').
+//
+// The testable surface is sourcePrepare/sourceCommit in
+// ../src/score-orchestration.ts (unit-tested with a temp sqlite + stubbed
+// fetch/download). See docs/runbooks/photo-curation-scoring.md.
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
 
-const POOL = 15; // deep pool per flagged species (same batch cap as scoring)
-const THUMB_DIR = './thumb-cache';
-await mkdir(THUMB_DIR, { recursive: true });
+const POOL = Number(process.env.POOL ?? 15);
 
-// download writes bytes to a local file so the agent can Read it.
-const download = async (url) => {
-  const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
-  if (!res.ok) throw new Error(`download ${res.status} for ${url}`);
-  return Buffer.from(await res.arrayBuffer());
-};
+// 1) PREPARE — a Bash agent shells out to the Node `source-prepare` half.
+const prepared = await agent({
+  prompt: `Run \`npx photo-curate source-prepare --pool ${POOL}\` in tools/photo-curation.
+It prints a human summary line then, on its own final line, the absolute path to a
+manifest JSON of shape
+[{ speciesCode, comName, sciName, family, inatId, imagePath, contentHash, attribution, license }].
+Read that manifest file and return its parsed contents as \`manifest\` plus the
+\`manifestPath\`. If the manifest is empty, return manifest: [] — no flagged species.`,
+  tools: ['Bash', 'Read'],
+  schema: { manifestPath: 'string', manifest: 'object[]' },
+});
 
-// The real judge: a Claude Code agent that Reads the local image + applies the
-// rubric prompt and returns StructuredOutput {criteria, flags, rationale}.
-const judge = {
-  async judge(img, ctx, prompt) {
-    const path = join(THUMB_DIR, `${ctx.speciesCode}-cand.jpg`);
-    await writeFile(path, img.buffer);
-    return await agent({
-      prompt: `${prompt}\n\nRead the image at ${path} for ${ctx.comName} (${ctx.sciName}).`,
-      schema: { criteria: 'object', flags: 'string[]', rationale: 'string' },
-    });
-  },
-};
+// 2) SCORE — one agent PER candidate, fanned out with parallel(). Each Reads
+//    its own imagePath and applies the rubric prompt, echoing speciesCode,
+//    inatId and contentHash back so source-commit can re-key the score row.
+const results = await parallel(
+  (prepared.manifest ?? []).map(entry => agent({
+    prompt: `${defaultRubricConfig.judgePrompt}
 
-const db = openDb(DEFAULT_DB_PATH);
-
-// Flagged species: a scored current photo below the review threshold, joined to
-// photo_current for the sciName the iNat sourcer keys on.
-const flagged = db.prepare(
-  `SELECT c.species_code AS speciesCode, c.com_name AS comName,
-          c.sci_name AS sciName, c.family AS family
-     FROM photo_score s
-     JOIN photo_current c ON c.species_code = s.species_code
-    WHERE s.role = 'current' AND s.overall < ?
-    ORDER BY s.overall ASC`,
-).all(defaultRubricConfig.thresholds.review);
-
-const results = [];
-for (const sp of flagged) {
-  const summary = await sourceCandidates(
-    db,
-    { speciesCode: sp.speciesCode, sciName: sp.sciName, comName: sp.comName, family: sp.family, limit: POOL },
-    {
-      fetchInatCandidates,
-      download,
-      scoreImage,
-      judge,
-      config: defaultRubricConfig,
-      thumbDir: THUMB_DIR,
+Read the candidate image at ${entry.imagePath} for ${entry.comName} (${entry.sciName}),
+family ${entry.family}. Return structured output: an integer 0–10 for each of the
+seven criteria (framing, subjectClarity, liveness, naturalness, pose, background,
+lighting), a \`flags\` array of any applicable disqualifier strings, and a
+one-sentence \`rationale\`. Echo back unchanged: speciesCode "${entry.speciesCode}",
+inatId ${entry.inatId}, contentHash "${entry.contentHash}".`,
+    tools: ['Read'],
+    schema: {
+      speciesCode: 'string',
+      inatId: 'number',
+      contentHash: 'string',
+      criteria: 'object',
+      flags: 'string[]',
+      rationale: 'string',
     },
-  );
-  results.push(summary);
-}
-console.log(`[source-candidates] ${JSON.stringify({ flagged: flagged.length, results }, null, 2)}`);
-db.close();
+  })),
+);
+
+// 3) COMMIT — a Bash agent writes results.json and shells out to source-commit.
+const commit = await agent({
+  prompt: `Write this JSON to tools/photo-curation/candidate-results.json, then run
+\`npx photo-curate source-commit candidate-results.json\` in tools/photo-curation
+and return its summary line:
+
+${JSON.stringify(results, null, 2)}`,
+  tools: ['Write', 'Bash'],
+  schema: { summary: 'string' },
+});
+
+console.log(`[source-candidates] sourced ${prepared.manifest?.length ?? 0} candidate(s); committed via source-commit:`);
+console.log(commit.summary);


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Op as Operator
    participant CLI as photo-curate (Node)
    participant WF as score-current.mjs (Workflow)
    participant Agent as Claude Code agent
    participant API as read-api
    participant SQLite as review.sqlite

    Note over Op,SQLite: Bug 2 — sync calls ONE bulk endpoint
    Op->>CLI: photo-curate sync
    CLI->>API: GET /api/species/with-photos (one INNER JOIN)
    API-->>CLI: ~715 species with photos
    CLI->>SQLite: upsert photo_current (reviewed=0)

    Note over Op,SQLite: Bug 1 — runnable Node halves plus a real Workflow
    Op->>WF: run via Workflow tool
    WF->>CLI: score-prepare (Bash agent)
    CLI->>SQLite: select reviewed=0
    CLI-->>WF: manifest.json plus imagePaths
    WF->>Agent: parallel score agents Read each image
    Agent-->>WF: criteria, flags, rationale
    WF->>CLI: score-commit results.json (Bash agent)
    CLI->>SQLite: composeReport, upsertScore, markReviewed
```

## Summary

- **Bug 2 (sync scope):** `sync` walked the full 17.8k-code eBird taxonomy and then issued a per-species `/api/species/:code` detail call each — ~17.8k requests, almost all `noPhoto`. Added `GET /api/species/with-photos` (one INNER JOIN in `db-client` against `species_photos(purpose='detail-panel')`) that returns the ~715 observed-with-photos species in a single body; the no-`--species` sync path now calls it once and upserts all rows. The `--species <code>` path still uses `/api/species/:code`. The endpoint rides the existing per-species `species` cache tier and deploys on merge via `deploy-read-api`.
- **Bug 1 (runnable scoring):** the `score-current.mjs` / `source-candidates.mjs` runners imported `better-sqlite3` + `node:fs` **and** called `agent()`, so they ran in neither plain Node (no `agent()`) nor the Workflow sandbox (no fs/DB). Split scoring into runnable, unit-tested Node halves (`score-prepare`/`score-commit`, `source-prepare`/`source-commit` in `score-orchestration.ts`) and rewrote both `.mjs` files as real Workflow-tool scripts whose bodies use `agent()`/`parallel()` ONLY — a prepare agent shells out to the Node prepare half, parallel score agents `Read` each image + apply the rubric judge prompt, a commit agent shells out to the Node commit half.
- Added `docs/runbooks/photo-curation-scoring.md` (operator flow: `sync` → score in batches of 10, resumable) and refreshed the `knip.ts` `.mjs` ignore comment for the rewired surface.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test` for the touched workspaces — green: `@bird-watch/photo-curation` (99), `@bird-watch/read-api` (176, incl. 2 new `with-photos` cases), `@bird-watch/db-client` `species.test.ts` (31, incl. 3 new `getSpeciesWithPhotos` cases)
- [x] New unit / integration tests added: db-client testcontainers (`getSpeciesWithPhotos` — INNER JOIN, purpose-scoped, empty), read-api app test (`/api/species/with-photos` — only-with-photos + route-ordering), photo-curation (`syncAll` via msw v2, `scorePrepare`/`scoreCommit`/`sourcePrepare`/`sourceCommit` with temp sqlite)
- [x] `.mjs` Workflow scripts validated structurally: no `fs`/`better-sqlite3` imports, `node --check` passes on both
- [x] `npm run build` (root) — clean; `npm run lint` — clean; `npx knip` — clean (exit 0); `npm install --package-lock-only && git diff --exit-code package-lock.json` — no drift
- [x] Mermaid diagram renders (verified with `@mermaid-js/mermaid-cli` — no `;`/`<br/>` in sequenceDiagram messages)
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` changes

## Plan reference

Part of epic #974. Fixes #992 — two operational bugs from the first live smoke run of `tools/photo-curation`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
