### PR TITLE
feat(photo-curation): token-ledger helper + required post-run logging (#997)

### DIFF
--- a/docs/runbooks/photo-curation-scoring.md
+++ b/docs/runbooks/photo-curation-scoring.md
@@ -151,6 +151,12 @@ LIMIT=10   # batch size; re-run the Workflow until the backlog is empty
 Repeat steps 1–3 (or re-run the Workflow) in batches of 10 until
 `score-prepare` returns an empty manifest.
 
+4. **Log the spend (REQUIRED).** Append one row to the token-spend ledger
+   ([#996](https://github.com/julianken/bird-sight-system/issues/996)) — see
+   [Step 5](#step-5--log-token-spend-required-after-every-run). This is **not
+   optional**: every `score_batch` run must be recorded before you start the
+   next one, or the ledger stops being comparable.
+
 ## Step 3 — source alternates for flagged species (optional)
 
 `source-candidates` pre-scores a deep iNat pool for every **flagged** species (a
@@ -168,6 +174,10 @@ agents → commit shape:
   npx photo-curate source-commit candidate-results.json
   ```
 
+After a `source-candidates` run, **log the spend (REQUIRED)** with
+`op=source_candidates` — see
+[Step 5](#step-5--log-token-spend-required-after-every-run).
+
 ## Step 4 — review + apply
 
 Start the local review server and apply approved swaps to prod:
@@ -176,6 +186,47 @@ Start the local review server and apply approved swaps to prod:
 npx photo-curate serve                  # http://localhost:5180
 npx photo-curate apply-swaps            # confirm-gated push to the admin-api
 ```
+
+## Step 5 — log token spend (REQUIRED after every run)
+
+**This step is mandatory and runs after EVERY `score`, `source-candidates`, and
+`calibration` operation — no exceptions.** Recording each run's token spend in
+the ledger ([#996](https://github.com/julianken/bird-sight-system/issues/996))
+is what makes `$/item` comparable as we change the judge model, the agent
+design, and the deterministic pre-filter. Skipping it silently breaks the
+comparison the ledger exists to enable.
+
+When the Workflow (or your manual dispatch) completes, it reports
+`subagent_tokens`, `agent_count`, `tool_uses`, and `duration_ms`. Feed those —
+plus the op metadata — straight into `log-run`, which computes the derived
+columns (`scored`, `tokens/item`, `est_$`, `$/item`) per the ledger's cost
+model and appends one formatted row directly above the
+`<!-- APPEND-ROWS-ABOVE-THIS-LINE -->` marker in #996:
+
+```bash
+npx photo-curate log-run \
+  --run-id "$RUN_ID" \
+  --op score_batch \                  # or source_candidates | calibration
+  --judge-model claude-fable-5 \      # the EXACT model the judge agents ran on
+  --agent-design generic \            # or lean_photo_judge (#994)
+  --prefilter no \                    # yes if the #994 deterministic gate ran
+  --items-in 10 \
+  --gate-rejected 0 \                 # photos the pre-filter auto-rejected (#994)
+  --agents "$AGENT_COUNT" \           # Workflow agent_count
+  --total-tokens "$SUBAGENT_TOKENS" \ # Workflow subagent_tokens
+  --tool-uses "$TOOL_USES" \          # Workflow tool_uses
+  --duration-ms "$DURATION_MS" \      # Workflow duration_ms
+  --notes "what changed this run"
+# Add --batch if the run used the Batch API (applies the 0.5x discount).
+# For an EXACT cost (when you parsed per-agent transcripts) pass all four:
+#   --input <n> --output <n> --cache-read <n> --cache-create <n>
+```
+
+`est_$` defaults to the blended 85%-input / 15%-output rate from the embedded
+price table (Fable 5 ≈ $16/MTok). `log-run` warns and does **not** append a
+duplicate if a row with the same `--run-id` already exists, so a re-run after a
+transient `gh` failure is safe. It exits non-zero on a duplicate or a
+validation error.
 
 ## Notes
 
@@ -192,3 +243,12 @@ npx photo-curate apply-swaps            # confirm-gated push to the admin-api
   structurally (`node --check`: valid JS; no `fs` / `better-sqlite3` imports).
 - The read-api `GET /api/species/with-photos` endpoint deploys on merge via the
   `deploy-read-api` workflow.
+- **Calibration runs log too.** A calibration pass (re-scoring a fixed set to
+  check judge drift) is a token-spending operation like the others — run
+  [Step 5](#step-5--log-token-spend-required-after-every-run) with
+  `--op calibration` when it finishes. The post-run `log-run` is required after
+  **score**, **source-candidates**, AND **calibration**, with no exceptions.
+- The cost math (blended + exact-split + batch discount) and the marker-splice
+  live in `tools/photo-curation/src/token-ledger.ts`, unit-tested in
+  `src/token-ledger.test.ts`; the price table is one dated constant
+  (`PRICE_TABLE`) updatable as Anthropic pricing moves.

--- a/docs/runbooks/photo-curation-scoring.md
+++ b/docs/runbooks/photo-curation-scoring.md
@@ -225,8 +225,26 @@ npx photo-curate log-run \
 `est_$` defaults to the blended 85%-input / 15%-output rate from the embedded
 price table (Fable 5 ≈ $16/MTok). `log-run` warns and does **not** append a
 duplicate if a row with the same `--run-id` already exists, so a re-run after a
-transient `gh` failure is safe. It exits non-zero on a duplicate or a
-validation error.
+transient `gh` failure is safe.
+
+### `log-run` exit codes
+
+The exit code distinguishes a benign re-run from a real failure, so a wrapping
+script can act on it. `--date`, if supplied, must be an ISO-8601 date
+(`YYYY-MM-DD`, optionally with a time); a malformed value is rejected before any
+write. Omit `--date` to default to today's UTC date.
+
+| Code | Meaning | Wrapper action |
+|---|---|---|
+| `0` | **Appended** — a new row was written. | Done. |
+| `3` | **Already logged** — this `--run-id` was already in the ledger; the append was a safe no-op (nothing was lost). | Safe to ignore — proceed. |
+| `1` | **Failed** — a genuine error (`gh` read/write failure, missing append marker, …). **Nothing was recorded.** | Must retry. |
+| `2` | **Bad argument** — a missing/malformed flag (bad `--date`, non-numeric count, unknown enum). Rejected before any write. | Fix the invocation. |
+
+The load-bearing distinction is `3` vs `1`: a script must NOT treat the benign
+duplicate (`3`) and a real write failure (`1`) the same way — exit `1` means the
+row is **not** in the ledger and the run must be re-logged, while exit `3` means
+it already is.
 
 ## Notes
 

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -11,9 +11,15 @@ import {
 } from './score-orchestration.js';
 import { startServer } from './server/serve.js';
 import { resolveAdminEnv, runApplySwaps } from './apply-swaps.js';
+import {
+  runLogRun, PRICE_TABLE, LEDGER_ISSUE,
+  type LedgerInput, type Op, type AgentDesign, type YesNo, type JudgeModel, type TokenSplit,
+} from './token-ledger.js';
+import { ghLedgerDeps } from './gh-ledger.js';
 
 const API_BASE = process.env.READ_API_BASE ?? 'https://api.bird-maps.com';
 const THUMB_DIR = process.env.THUMB_DIR ?? './thumb-cache';
+const LEDGER_REPO = process.env.LEDGER_REPO ?? 'julianken/bird-sight-system';
 
 /** Live thumbnail download for the prepare CLI (unit tests inject a stub). */
 async function downloadBytes(url: string): Promise<Buffer> {
@@ -156,6 +162,94 @@ program
       process.exit(result.failed.length > 0 ? 1 : 0);
     } finally {
       db.close();
+    }
+  });
+
+program
+  .command('log-run')
+  .description(
+    `Append one token-spend row to ledger issue #${LEDGER_ISSUE}. REQUIRED final step after every score / source-candidates / calibration run (#997). Computes scored, tokens/item, est_$ (blended 85/15 by default, exact when the four split flags are given, x0.5 with --batch), and $/item, then splices the row above the marker.`,
+  )
+  .requiredOption('--run-id <id>', 'Workflow run/task id (row identity + join key)')
+  .requiredOption('--op <op>', 'score_batch | source_candidates | calibration')
+  .requiredOption('--judge-model <model>', `exact judge model (one of: ${Object.keys(PRICE_TABLE).join(', ')})`)
+  .requiredOption('--items-in <n>', 'photos submitted to the run')
+  .requiredOption('--total-tokens <n>', 'aggregate tokens (Workflow subagent_tokens)')
+  .requiredOption('--agents <n>', 'subagents spawned (Workflow agent_count)')
+  .requiredOption('--tool-uses <n>', 'total tool invocations (Workflow tool_uses)')
+  .requiredOption('--duration-ms <n>', 'wall-clock ms (Workflow duration_ms)')
+  .option('--agent-design <design>', 'generic | lean_photo_judge', 'generic')
+  .option('--prefilter <yesno>', 'yes | no — was the #994 deterministic gate run', 'no')
+  .option('--gate-rejected <n>', 'photos auto-rejected by the pre-filter, never judged', '0')
+  .option('--date <yyyy-mm-dd>', 'run date (UTC); defaults to today')
+  .option('--batch', 'run used the Batch API (applies the 0.5x discount)')
+  .option('--notes <text>', 'run context / what changed')
+  .option('--input <n>', 'EXACT split: input tokens (requires all four split flags)')
+  .option('--output <n>', 'EXACT split: output tokens')
+  .option('--cache-read <n>', 'EXACT split: cache-read tokens')
+  .option('--cache-create <n>', 'EXACT split: cache-creation (5m write) tokens')
+  .option('--repo <owner/name>', 'ledger repo', LEDGER_REPO)
+  .action(async (opts: Record<string, string | boolean | undefined>) => {
+    const num = (v: string | boolean | undefined, name: string): number => {
+      const n = Number(v);
+      if (!Number.isFinite(n)) {
+        console.error(`--${name} must be a number (got ${String(v)})`);
+        process.exit(2);
+      }
+      return n;
+    };
+    const oneOf = <T extends string>(v: string, name: string, allowed: readonly T[]): T => {
+      if (!allowed.includes(v as T)) {
+        console.error(`--${name} must be one of: ${allowed.join(', ')} (got ${v})`);
+        process.exit(2);
+      }
+      return v as T;
+    };
+
+    // Exact split is all-or-nothing — partial flags are an operator error.
+    const splitKeys = ['input', 'output', 'cacheRead', 'cacheCreate'] as const;
+    const splitGiven = splitKeys.filter(k => opts[k] !== undefined);
+    let split: TokenSplit | undefined;
+    if (splitGiven.length > 0 && splitGiven.length < 4) {
+      console.error('--input/--output/--cache-read/--cache-create must be given together (all four) for an exact cost, or none.');
+      process.exit(2);
+    }
+    if (splitGiven.length === 4) {
+      split = {
+        input: num(opts.input, 'input'),
+        output: num(opts.output, 'output'),
+        cacheRead: num(opts.cacheRead, 'cache-read'),
+        cacheCreate: num(opts.cacheCreate, 'cache-create'),
+      };
+    }
+
+    const ledgerInput: LedgerInput = {
+      runId: String(opts.runId),
+      date: opts.date ? String(opts.date) : new Date().toISOString().slice(0, 10),
+      op: oneOf(String(opts.op), 'op', ['score_batch', 'source_candidates', 'calibration'] as const) as Op,
+      judgeModel: oneOf(String(opts.judgeModel), 'judge-model', Object.keys(PRICE_TABLE) as JudgeModel[]),
+      agentDesign: oneOf(String(opts.agentDesign), 'agent-design', ['generic', 'lean_photo_judge'] as const) as AgentDesign,
+      prefilter: oneOf(String(opts.prefilter), 'prefilter', ['yes', 'no'] as const) as YesNo,
+      itemsIn: num(opts.itemsIn, 'items-in'),
+      gateRejected: num(opts.gateRejected, 'gate-rejected'),
+      agents: num(opts.agents, 'agents'),
+      totalTokens: num(opts.totalTokens, 'total-tokens'),
+      toolUses: num(opts.toolUses, 'tool-uses'),
+      durationMs: num(opts.durationMs, 'duration-ms'),
+      batch: opts.batch === true,
+      split,
+      notes: opts.notes ? String(opts.notes) : undefined,
+    };
+
+    const deps = ghLedgerDeps({ repo: String(opts.repo), log: line => console.log(`[log-run] ${line}`) });
+    try {
+      const result = await runLogRun(ledgerInput, deps);
+      // Non-zero exit on a skipped duplicate so a wrapping script can tell the
+      // append did not happen (the row already existed).
+      process.exit(result.appended ? 0 : 1);
+    } catch (err) {
+      console.error(`[log-run] ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
     }
   });
 

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -12,7 +12,7 @@ import {
 import { startServer } from './server/serve.js';
 import { resolveAdminEnv, runApplySwaps } from './apply-swaps.js';
 import {
-  runLogRun, PRICE_TABLE, LEDGER_ISSUE,
+  runLogRun, logRunExitCode, isIsoDate, LOG_RUN_EXIT, PRICE_TABLE, LEDGER_ISSUE,
   type LedgerInput, type Op, type AgentDesign, type YesNo, type JudgeModel, type TokenSplit,
 } from './token-ledger.js';
 import { ghLedgerDeps } from './gh-ledger.js';
@@ -223,6 +223,16 @@ program
       };
     }
 
+    // --date is the only free-string operator input; validate the override so a
+    // malformed value (`2026-13-40`, `june10`) never lands verbatim in the date
+    // column. Omitted → today's UTC date. Exit 2 mirrors num()/oneOf().
+    if (opts.date !== undefined && !isIsoDate(String(opts.date))) {
+      console.error(
+        `--date must be an ISO-8601 date (YYYY-MM-DD, optionally with time) (got ${String(opts.date)})`,
+      );
+      process.exit(LOG_RUN_EXIT.BAD_ARG);
+    }
+
     const ledgerInput: LedgerInput = {
       runId: String(opts.runId),
       date: opts.date ? String(opts.date) : new Date().toISOString().slice(0, 10),
@@ -244,12 +254,23 @@ program
     const deps = ghLedgerDeps({ repo: String(opts.repo), log: line => console.log(`[log-run] ${line}`) });
     try {
       const result = await runLogRun(ledgerInput, deps);
-      // Non-zero exit on a skipped duplicate so a wrapping script can tell the
-      // append did not happen (the row already existed).
-      process.exit(result.appended ? 0 : 1);
+      // Distinct exit codes so a wrapper can tell a benign already-logged
+      // duplicate (3 — nothing more to do, safe) from a real write failure
+      // (the catch below, 1 — nothing was recorded, must retry). See
+      // LOG_RUN_EXIT for the full contract.
+      const code = logRunExitCode(result);
+      if (code === LOG_RUN_EXIT.DUPLICATE) {
+        console.error(
+          `[log-run] run "${ledgerInput.runId}" was already logged — nothing appended (exit ${LOG_RUN_EXIT.DUPLICATE}, safe to ignore).`,
+        );
+      }
+      process.exit(code);
     } catch (err) {
+      // A genuine failure — gh read/write error, missing append marker, etc.
+      // Nothing was recorded; exit 1 signals the operator/wrapper must retry.
       console.error(`[log-run] ${err instanceof Error ? err.message : String(err)}`);
-      process.exit(1);
+      console.error(`[log-run] nothing was recorded — retry (exit ${LOG_RUN_EXIT.FAILED}).`);
+      process.exit(LOG_RUN_EXIT.FAILED);
     }
   });
 

--- a/tools/photo-curation/src/gh-ledger.ts
+++ b/tools/photo-curation/src/gh-ledger.ts
@@ -1,0 +1,58 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LEDGER_ISSUE } from './token-ledger.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The live GitHub read/write for the token ledger, backed by the `gh` CLI.
+ *
+ * Read: `gh api repos/<repo>/issues/<n> --jq .body`.
+ * Write: `gh issue edit <n> --repo <repo> --body-file <tmp>` — `--body-file`
+ *        avoids shell-escaping a multi-KB markdown body on argv.
+ *
+ * This is the ONLY place that touches GitHub. The pure splice/format logic in
+ * token-ledger.ts takes these as injected deps (ReadWriteDeps) so it stays
+ * unit-testable without network. Kept out of cli.ts so the command wiring is thin.
+ */
+export function ghLedgerDeps(opts: {
+  repo: string;
+  issue?: number;
+  log: (line: string) => void;
+}) {
+  const issue = opts.issue ?? LEDGER_ISSUE;
+  return {
+    log: opts.log,
+    async readIssueBody(): Promise<string> {
+      const { stdout } = await execFileAsync('gh', [
+        'api',
+        `repos/${opts.repo}/issues/${issue}`,
+        '--jq',
+        '.body',
+      ]);
+      // `gh api --jq .body` emits the body followed by a trailing newline.
+      return stdout.replace(/\n$/, '');
+    },
+    async writeIssueBody(body: string): Promise<void> {
+      const dir = await mkdtemp(join(tmpdir(), 'token-ledger-'));
+      const file = join(dir, 'body.md');
+      try {
+        await writeFile(file, body, 'utf8');
+        await execFileAsync('gh', [
+          'issue',
+          'edit',
+          String(issue),
+          '--repo',
+          opts.repo,
+          '--body-file',
+          file,
+        ]);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/tools/photo-curation/src/token-ledger.test.ts
+++ b/tools/photo-curation/src/token-ledger.test.ts
@@ -7,6 +7,9 @@ import {
   spliceRowAboveMarker,
   hasRunId,
   runLogRun,
+  logRunExitCode,
+  isIsoDate,
+  LOG_RUN_EXIT,
   APPEND_MARKER,
   type LedgerInput,
 } from './token-ledger.js';
@@ -232,5 +235,77 @@ describe('runLogRun', () => {
     expect(Object.keys(PRICE_TABLE).sort()).toEqual(
       ['claude-fable-5', 'claude-haiku-4-5', 'claude-opus-4-8', 'claude-sonnet-4-6'].sort(),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logRunExitCode — the CLI's 0-vs-3 mapping (#998). A benign duplicate must
+// NOT share an exit code with a real write failure, or a wrapper that treats
+// "exit 1 = already logged, safe" silently skips re-logging after a true
+// failure (data loss).
+// ---------------------------------------------------------------------------
+describe('logRunExitCode', () => {
+  it('maps an appended row to exit 0', () => {
+    expect(logRunExitCode({ appended: true, row: '| r |' })).toBe(LOG_RUN_EXIT.APPENDED);
+    expect(logRunExitCode({ appended: true, row: '| r |' })).toBe(0);
+  });
+
+  it('maps a skipped duplicate to its own distinct exit code 3 (not 1)', () => {
+    expect(logRunExitCode({ appended: false, row: '| r |' })).toBe(LOG_RUN_EXIT.DUPLICATE);
+    expect(logRunExitCode({ appended: false, row: '| r |' })).toBe(3);
+  });
+
+  it('keeps the duplicate code separate from the failure and bad-arg codes', () => {
+    // The whole point of #998: a benign duplicate is distinguishable from a
+    // real write failure (1) and from a validation error (2).
+    expect(LOG_RUN_EXIT.DUPLICATE).not.toBe(LOG_RUN_EXIT.FAILED);
+    expect(LOG_RUN_EXIT.DUPLICATE).not.toBe(LOG_RUN_EXIT.BAD_ARG);
+    expect(LOG_RUN_EXIT.DUPLICATE).not.toBe(LOG_RUN_EXIT.APPENDED);
+  });
+
+  it('returns the duplicate code for a real runLogRun duplicate skip (no network)', async () => {
+    const dupBody = spliceRowAboveMarker(FIXTURE_BODY, formatRow(computeRow(baseInput)));
+    const readIssueBody = vi.fn().mockResolvedValue(dupBody);
+    const writeIssueBody = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    const result = await runLogRun(baseInput, { readIssueBody, writeIssueBody, log });
+
+    expect(result.appended).toBe(false);
+    expect(writeIssueBody).not.toHaveBeenCalled();
+    expect(logRunExitCode(result)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isIsoDate — the --date override guard (#998). Mirrors the exit-2 validation
+// the numeric/enum flags already get so a malformed date never lands verbatim
+// in the ledger's date column.
+// ---------------------------------------------------------------------------
+describe('isIsoDate', () => {
+  it('accepts a plain YYYY-MM-DD date', () => {
+    expect(isIsoDate('2026-06-10')).toBe(true);
+    expect(isIsoDate('2026-01-01')).toBe(true);
+    expect(isIsoDate('2026-12-31')).toBe(true);
+  });
+
+  it('accepts a date with an ISO time suffix (T or space separator)', () => {
+    expect(isIsoDate('2026-06-10T12:34:56Z')).toBe(true);
+    expect(isIsoDate('2026-06-10 12:34:56')).toBe(true);
+  });
+
+  it('rejects an impossible calendar date (month/day out of range)', () => {
+    expect(isIsoDate('2026-13-40')).toBe(false); // the finding's example
+    expect(isIsoDate('2026-00-10')).toBe(false);
+    expect(isIsoDate('2026-02-30')).toBe(false); // Feb 30 rolls over
+    expect(isIsoDate('2026-04-31')).toBe(false); // April has 30 days
+  });
+
+  it('rejects a structurally malformed value', () => {
+    expect(isIsoDate('june10')).toBe(false); // the finding's example
+    expect(isIsoDate('2026/06/10')).toBe(false);
+    expect(isIsoDate('26-6-1')).toBe(false);
+    expect(isIsoDate('')).toBe(false);
+    expect(isIsoDate('2026-06')).toBe(false);
   });
 });

--- a/tools/photo-curation/src/token-ledger.test.ts
+++ b/tools/photo-curation/src/token-ledger.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  PRICE_TABLE,
+  blendedRate,
+  computeRow,
+  formatRow,
+  spliceRowAboveMarker,
+  hasRunId,
+  runLogRun,
+  APPEND_MARKER,
+  type LedgerInput,
+} from './token-ledger.js';
+
+// ---------------------------------------------------------------------------
+// blended-rate convention (85% input / 15% output) — anchored to #996's worked
+// example "Fable 5 blended = $16/MTok".
+// ---------------------------------------------------------------------------
+describe('blendedRate', () => {
+  it('prices Fable 5 at $16/MTok (0.85·$10 + 0.15·$50)', () => {
+    expect(blendedRate('claude-fable-5')).toBeCloseTo(16, 10);
+  });
+  it('prices each model in the table from its input/output rates', () => {
+    expect(blendedRate('claude-opus-4-8')).toBeCloseTo(0.85 * 5 + 0.15 * 25, 10); // $8
+    expect(blendedRate('claude-sonnet-4-6')).toBeCloseTo(0.85 * 3 + 0.15 * 15, 10); // $4.80
+    expect(blendedRate('claude-haiku-4-5')).toBeCloseTo(0.85 * 1 + 0.15 * 5, 10); // $1.60
+  });
+  it('throws on an unknown model so a typo never silently mis-prices a row', () => {
+    expect(() => blendedRate('claude-unknown-9')).toThrow(/unknown model/i);
+  });
+});
+
+const baseInput: LedgerInput = {
+  runId: 'wonv0vigo',
+  date: '2026-06-10',
+  op: 'score_batch',
+  judgeModel: 'claude-fable-5',
+  agentDesign: 'generic',
+  prefilter: 'no',
+  itemsIn: 3,
+  gateRejected: 0,
+  agents: 3,
+  totalTokens: 175_790,
+  toolUses: 16,
+  durationMs: 41_000,
+  notes: 'first batches; Fable baseline (pre-#994)',
+};
+
+// ---------------------------------------------------------------------------
+// computeRow — derived columns, blended path (reproduces the two seed rows
+// already in #996).
+// ---------------------------------------------------------------------------
+describe('computeRow — blended path', () => {
+  it('reproduces seed row 1 (3 items, 175,790 tok → $2.81 / $0.94)', () => {
+    const r = computeRow(baseInput);
+    expect(r.scored).toBe(3);
+    expect(r.tokensPerItem).toBe(58_597); // 175790/3 = 58596.67 → round
+    expect(r.estUsd).toBeCloseTo(2.8126, 4); // 175790 · 16/1e6
+    expect(r.estUsdLabel).toBe('$2.81');
+    expect(r.usdPerItemLabel).toBe('$0.94'); // 2.8126/3 = 0.9375 → $0.94
+    expect(r.durS).toBe(41);
+  });
+
+  it('reproduces seed row 2 (10 items, 403,588 tok → $6.46 / $0.65)', () => {
+    const r = computeRow({
+      ...baseInput,
+      runId: 'wtjxkbo07',
+      itemsIn: 10,
+      agents: 10,
+      totalTokens: 403_588,
+      toolUses: 30,
+      durationMs: 28_000,
+    });
+    expect(r.scored).toBe(10);
+    expect(r.tokensPerItem).toBe(40_359); // 403588/10 = 40358.8 → round
+    expect(r.estUsdLabel).toBe('$6.46');
+    expect(r.usdPerItemLabel).toBe('$0.65');
+    expect(r.durS).toBe(28);
+  });
+
+  it('subtracts gate-rejected items from items_in to get scored', () => {
+    const r = computeRow({ ...baseInput, itemsIn: 12, gateRejected: 4, prefilter: 'yes' });
+    expect(r.scored).toBe(8);
+    expect(r.tokensPerItem).toBe(Math.round(175_790 / 8));
+  });
+
+  it('applies the 0.5× batch discount to est_$ and $/item only', () => {
+    const r = computeRow({ ...baseInput, batch: true });
+    expect(r.estUsd).toBeCloseTo(2.8126 / 2, 4); // half price
+    expect(r.estUsdLabel).toBe('$1.41');
+    expect(r.usdPerItemLabel).toBe('$0.47');
+    expect(r.tokensPerItem).toBe(58_597); // token count is unaffected by batch
+  });
+
+  it('prices a Haiku run at the Haiku blended rate ($1.60/MTok)', () => {
+    const r = computeRow({ ...baseInput, judgeModel: 'claude-haiku-4-5' });
+    expect(r.estUsd).toBeCloseTo(175_790 * 1.6 / 1e6, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRow — exact split path (the four Anthropic buckets).
+// ---------------------------------------------------------------------------
+describe('computeRow — exact split path', () => {
+  it('prices each bucket at its own Fable rate (input/output/cache-read/cache-create)', () => {
+    // 100k input + 10k output + 50k cache-read + 20k cache-create, Fable 5.
+    const r = computeRow({
+      ...baseInput,
+      split: { input: 100_000, output: 10_000, cacheRead: 50_000, cacheCreate: 20_000 },
+    });
+    // input 100k·$10 + output 10k·$50 + cacheRead 50k·$1 + cacheCreate(5m write) 20k·$12.50, all /1e6
+    const expected =
+      (100_000 * 10 + 10_000 * 50 + 50_000 * 1 + 20_000 * 12.5) / 1e6;
+    expect(r.estUsd).toBeCloseTo(expected, 6);
+    expect(r.exact).toBe(true);
+  });
+
+  it('halves the exact cost under --batch', () => {
+    const split = { input: 100_000, output: 10_000, cacheRead: 0, cacheCreate: 0 };
+    const full = computeRow({ ...baseInput, split });
+    const batched = computeRow({ ...baseInput, split, batch: true });
+    expect(batched.estUsd).toBeCloseTo(full.estUsd / 2, 8);
+  });
+
+  it('marks blended rows exact=false', () => {
+    expect(computeRow(baseInput).exact).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRow — the markdown cell layout (17 columns, matching #996's header).
+// ---------------------------------------------------------------------------
+describe('formatRow', () => {
+  it('emits a 17-column pipe row matching the seed-row layout', () => {
+    const row = formatRow(computeRow(baseInput));
+    expect(row).toBe(
+      '| wonv0vigo | 2026-06-10 | score_batch | claude-fable-5 | generic | no | 3 | 0 | 3 | 3 | 175,790 | 16 | 41 | 58,597 | $2.81 | $0.94 | first batches; Fable baseline (pre-#994) |',
+    );
+  });
+
+  it('annotates exact-split rows in notes so a reader knows est_$ is not blended', () => {
+    const row = formatRow(
+      computeRow({ ...baseInput, split: { input: 1000, output: 100, cacheRead: 0, cacheCreate: 0 }, notes: 'exact run' }),
+    );
+    expect(row).toContain('exact run');
+    expect(row).toMatch(/exact \$/i);
+  });
+
+  it('thousands-separates big token counts and leaves notes empty-safe', () => {
+    const row = formatRow(computeRow({ ...baseInput, notes: undefined }));
+    expect(row).toContain('| 175,790 |');
+    expect(row.endsWith('|  |')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spliceRowAboveMarker / hasRunId — marker-splice against a fixture body.
+// ---------------------------------------------------------------------------
+const FIXTURE_BODY = [
+  '## Ledger',
+  '',
+  '| run_id | date | op |',
+  '|---|---|---|',
+  '| existingrun | 2026-06-09 | score_batch |',
+  '<!-- APPEND-ROWS-ABOVE-THIS-LINE -->',
+  '',
+  '## Column legend',
+].join('\n');
+
+describe('spliceRowAboveMarker', () => {
+  it('inserts the new row on the line directly above the marker', () => {
+    const out = spliceRowAboveMarker(FIXTURE_BODY, '| newrun | 2026-06-10 | score_batch |');
+    const lines = out.split('\n');
+    const markerIdx = lines.indexOf(APPEND_MARKER);
+    expect(lines[markerIdx - 1]).toBe('| newrun | 2026-06-10 | score_batch |');
+    // the prior last row is preserved immediately above the new one
+    expect(lines[markerIdx - 2]).toBe('| existingrun | 2026-06-09 | score_batch |');
+  });
+
+  it('throws when the marker is absent (refuses to guess an insert point)', () => {
+    expect(() => spliceRowAboveMarker('no marker here', '| x |')).toThrow(/marker/i);
+  });
+});
+
+describe('hasRunId', () => {
+  it('detects an existing run_id as the first cell of a row', () => {
+    expect(hasRunId(FIXTURE_BODY, 'existingrun')).toBe(true);
+  });
+  it('returns false for a run_id not present', () => {
+    expect(hasRunId(FIXTURE_BODY, 'newrun')).toBe(false);
+  });
+  it('does not match a run_id that only appears inside notes', () => {
+    const body = FIXTURE_BODY.replace('| existingrun |', '| realrun | 2026-06-09 | note about existingrun |');
+    expect(hasRunId(body, 'existingrun')).toBe(false);
+    expect(hasRunId(body, 'realrun')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLogRun — orchestration with injected read/write (no GitHub).
+// ---------------------------------------------------------------------------
+describe('runLogRun', () => {
+  it('reads the body, splices one computed row, and writes it back', async () => {
+    const readIssueBody = vi.fn().mockResolvedValue(FIXTURE_BODY);
+    const writeIssueBody = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    const result = await runLogRun(baseInput, { readIssueBody, writeIssueBody, log });
+
+    expect(result.appended).toBe(true);
+    expect(writeIssueBody).toHaveBeenCalledOnce();
+    const written = writeIssueBody.mock.calls[0][0] as string;
+    const lines = written.split('\n');
+    const markerIdx = lines.indexOf(APPEND_MARKER);
+    expect(lines[markerIdx - 1]).toContain('| wonv0vigo |');
+    expect(lines[markerIdx - 1]).toContain('$2.81');
+  });
+
+  it('warns and does NOT write when the run_id already exists (idempotent-ish)', async () => {
+    const dupBody = spliceRowAboveMarker(FIXTURE_BODY, formatRow(computeRow(baseInput)));
+    const readIssueBody = vi.fn().mockResolvedValue(dupBody);
+    const writeIssueBody = vi.fn().mockResolvedValue(undefined);
+    const log = vi.fn();
+
+    const result = await runLogRun(baseInput, { readIssueBody, writeIssueBody, log });
+
+    expect(result.appended).toBe(false);
+    expect(writeIssueBody).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/already exists/i));
+  });
+
+  it('PRICE_TABLE carries all four priced models', () => {
+    expect(Object.keys(PRICE_TABLE).sort()).toEqual(
+      ['claude-fable-5', 'claude-haiku-4-5', 'claude-opus-4-8', 'claude-sonnet-4-6'].sort(),
+    );
+  });
+});

--- a/tools/photo-curation/src/token-ledger.ts
+++ b/tools/photo-curation/src/token-ledger.ts
@@ -1,0 +1,286 @@
+/**
+ * Token-spend ledger helper for photo-curation operations (#997, ledger #996).
+ *
+ * After every score / source-candidates / calibration run the operator records
+ * one row in ledger issue #996. This module does the cost math (blended OR
+ * exact split, ×0.5 batch), formats the markdown row, and splices it directly
+ * above the `<!-- APPEND-ROWS-ABOVE-THIS-LINE -->` marker. The GitHub read/write
+ * is injected (ReadWriteDeps) so the whole path is unit-testable without
+ * touching GitHub — the same DI idiom as apply-swaps.ts (runApplySwaps(deps)).
+ *
+ * Contract: NO `@anthropic-ai/sdk` and NO `ANTHROPIC_API_KEY`. We never call a
+ * model here — we only price token counts the Workflow already reported.
+ */
+
+export const LEDGER_ISSUE = 996;
+
+/** The marker new rows are inserted immediately above (mirrors #996 verbatim). */
+export const APPEND_MARKER = '<!-- APPEND-ROWS-ABOVE-THIS-LINE -->';
+
+/**
+ * Price table — USD per **Million** tokens. ONE constant, dated so it is
+ * updatable as Anthropic pricing moves.
+ *
+ * Anthropic live pricing, 2026-06 (from ledger #996's cost-model table). The
+ * cache multipliers are conventions, not separate columns: cache-read = 0.1×
+ * input, 5-minute cache-write = 1.25× input, 1-hour cache-write = 2× input.
+ * Re-audit when Anthropic publishes a price change; bump the date when you do.
+ */
+export const PRICE_TABLE = {
+  'claude-fable-5': { input: 10, output: 50 },
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+} as const satisfies Record<string, { input: number; output: number }>;
+
+/** Cache-rate multipliers relative to a model's input rate (#996 convention). */
+export const CACHE_READ_MULT = 0.1; // cache-read
+export const CACHE_WRITE_5M_MULT = 1.25; // 5-minute cache-write
+export const CACHE_WRITE_1H_MULT = 2; // 1-hour cache-write
+
+/** Blended-rate mix: photo scoring is input-heavy (image+rubric in, verdict out). */
+export const BLEND_INPUT_SHARE = 0.85;
+export const BLEND_OUTPUT_SHARE = 0.15;
+
+/** Batch API discount applied to est_$ (#996). */
+export const BATCH_DISCOUNT = 0.5;
+
+export type JudgeModel = keyof typeof PRICE_TABLE;
+
+export type Op = 'score_batch' | 'source_candidates' | 'calibration';
+export type AgentDesign = 'generic' | 'lean_photo_judge';
+export type YesNo = 'yes' | 'no';
+
+/**
+ * Exact per-bucket token split (the four Anthropic buckets). When supplied,
+ * est_$ is priced exactly instead of via the blended rate. `cacheCreate` is
+ * priced at the 5-minute cache-write rate (the common case); a 1-hour split is
+ * not modelled separately — keep those runs blended or extend this type.
+ */
+export interface TokenSplit {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreate: number;
+}
+
+export interface LedgerInput {
+  runId: string;
+  date: string; // YYYY-MM-DD, UTC
+  op: Op;
+  judgeModel: JudgeModel;
+  agentDesign: AgentDesign;
+  prefilter: YesNo;
+  itemsIn: number;
+  gateRejected: number;
+  agents: number;
+  totalTokens: number;
+  toolUses: number;
+  durationMs: number;
+  batch?: boolean;
+  split?: TokenSplit;
+  notes?: string;
+}
+
+export interface LedgerRow {
+  runId: string;
+  date: string;
+  op: Op;
+  judgeModel: JudgeModel;
+  agentDesign: AgentDesign;
+  prefilter: YesNo;
+  itemsIn: number;
+  gateRejected: number;
+  scored: number;
+  agents: number;
+  totalTokens: number;
+  toolUses: number;
+  durS: number;
+  tokensPerItem: number;
+  estUsd: number; // unrounded USD
+  estUsdLabel: string; // "$2.81"
+  usdPerItemLabel: string; // "$0.94"
+  exact: boolean; // true when priced from the four-bucket split
+  notes: string;
+}
+
+/** Blended USD/MTok for a model: 0.85·input + 0.15·output. */
+export function blendedRate(model: string): number {
+  const price = PRICE_TABLE[model as JudgeModel];
+  if (!price) {
+    throw new Error(
+      `unknown model "${model}" — add it to PRICE_TABLE (known: ${Object.keys(PRICE_TABLE).join(', ')})`,
+    );
+  }
+  return BLEND_INPUT_SHARE * price.input + BLEND_OUTPUT_SHARE * price.output;
+}
+
+/** Exact USD from the four Anthropic buckets, priced at the model's rates. */
+function exactUsd(model: JudgeModel, split: TokenSplit): number {
+  const price = PRICE_TABLE[model];
+  if (!price) {
+    throw new Error(`unknown model "${model}" — add it to PRICE_TABLE`);
+  }
+  const cacheReadRate = price.input * CACHE_READ_MULT;
+  const cacheWriteRate = price.input * CACHE_WRITE_5M_MULT;
+  return (
+    (split.input * price.input +
+      split.output * price.output +
+      split.cacheRead * cacheReadRate +
+      split.cacheCreate * cacheWriteRate) /
+    1e6
+  );
+}
+
+/** Format a USD number as a "$x.xx" label (2 dp). */
+function usd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+/**
+ * Compute every derived column from the run facts (#996 cost model):
+ *   scored        = items_in − gate_rejected
+ *   tokens/item   = round(total_tokens / scored)
+ *   est_$         = blended (total_tokens · blended/1e6) OR exact (four buckets),
+ *                   ×0.5 when --batch
+ *   $/item        = est_$ / scored
+ */
+export function computeRow(input: LedgerInput): LedgerRow {
+  const scored = input.itemsIn - input.gateRejected;
+  if (scored <= 0) {
+    throw new Error(
+      `scored must be > 0 (items_in ${input.itemsIn} − gate_rejected ${input.gateRejected} = ${scored})`,
+    );
+  }
+
+  const exact = input.split !== undefined;
+  let estUsd = exact
+    ? exactUsd(input.judgeModel, input.split as TokenSplit)
+    : (input.totalTokens * blendedRate(input.judgeModel)) / 1e6;
+  if (input.batch) estUsd *= BATCH_DISCOUNT;
+
+  const tokensPerItem = Math.round(input.totalTokens / scored);
+  const usdPerItem = estUsd / scored;
+
+  return {
+    runId: input.runId,
+    date: input.date,
+    op: input.op,
+    judgeModel: input.judgeModel,
+    agentDesign: input.agentDesign,
+    prefilter: input.prefilter,
+    itemsIn: input.itemsIn,
+    gateRejected: input.gateRejected,
+    scored,
+    agents: input.agents,
+    totalTokens: input.totalTokens,
+    toolUses: input.toolUses,
+    durS: Math.round(input.durationMs / 1000),
+    tokensPerItem,
+    estUsd,
+    estUsdLabel: usd(estUsd),
+    usdPerItemLabel: usd(usdPerItem),
+    exact,
+    notes: input.notes ?? '',
+  };
+}
+
+/** US-style thousands separator for token counts. */
+function group(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+/**
+ * Render a LedgerRow as the 17-column markdown table row that #996 expects:
+ * run_id | date | op | judge_model | agent_design | prefilter | items_in |
+ * gate_rej | scored | agents | total_tokens | tool_uses | dur_s | tokens/item |
+ * est_$ | $/item | notes
+ *
+ * Exact-split rows get an "exact $" suffix in notes so a reader knows est_$ is
+ * not the blended approximation.
+ */
+export function formatRow(row: LedgerRow): string {
+  const notes = row.exact
+    ? `${row.notes ? `${row.notes} · ` : ''}exact $ (per-bucket split)`
+    : row.notes;
+  const cells = [
+    row.runId,
+    row.date,
+    row.op,
+    row.judgeModel,
+    row.agentDesign,
+    row.prefilter,
+    String(row.itemsIn),
+    String(row.gateRejected),
+    String(row.scored),
+    String(row.agents),
+    group(row.totalTokens),
+    String(row.toolUses),
+    String(row.durS),
+    group(row.tokensPerItem),
+    row.estUsdLabel,
+    row.usdPerItemLabel,
+    notes,
+  ];
+  return `| ${cells.join(' | ')} |`;
+}
+
+/**
+ * Does the body already contain a ledger row whose FIRST cell is `runId`?
+ * Matches `| <runId> |` at the start of a table row only, so a run_id that
+ * merely appears inside a notes cell does not count as a duplicate.
+ */
+export function hasRunId(body: string, runId: string): boolean {
+  const escaped = runId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^\\|\\s*${escaped}\\s*\\|`, 'm');
+  return re.test(body);
+}
+
+/**
+ * Insert `rowMarkdown` on the line immediately above the APPEND marker. Throws
+ * if the marker is absent rather than guessing an insert point — a missing
+ * marker means the issue body drifted and the operator should look.
+ */
+export function spliceRowAboveMarker(body: string, rowMarkdown: string): string {
+  const lines = body.split('\n');
+  const markerIdx = lines.findIndex(line => line.trim() === APPEND_MARKER);
+  if (markerIdx === -1) {
+    throw new Error(`append marker "${APPEND_MARKER}" not found in issue body`);
+  }
+  lines.splice(markerIdx, 0, rowMarkdown);
+  return lines.join('\n');
+}
+
+export interface ReadWriteDeps {
+  readIssueBody: () => Promise<string>;
+  writeIssueBody: (body: string) => Promise<void>;
+  log: (line: string) => void;
+}
+
+export interface LogRunResult {
+  appended: boolean; // false when skipped as a duplicate run_id
+  row: string; // the formatted markdown row (whether or not it was appended)
+}
+
+/**
+ * End-to-end: read the ledger body, compute + format the row, and (unless the
+ * run_id is already present) splice it above the marker and write back. The
+ * read/write are injected so unit tests never hit GitHub.
+ */
+export async function runLogRun(input: LedgerInput, deps: ReadWriteDeps): Promise<LogRunResult> {
+  const row = formatRow(computeRow(input));
+  const body = await deps.readIssueBody();
+
+  if (hasRunId(body, input.runId)) {
+    deps.log(
+      `Run "${input.runId}" already exists in the ledger — not appending a duplicate row.`,
+    );
+    return { appended: false, row };
+  }
+
+  const next = spliceRowAboveMarker(body, row);
+  await deps.writeIssueBody(next);
+  deps.log(`Appended row for run "${input.runId}" to ledger #${LEDGER_ISSUE}.`);
+  deps.log(row);
+  return { appended: true, row };
+}

--- a/tools/photo-curation/src/token-ledger.ts
+++ b/tools/photo-curation/src/token-ledger.ts
@@ -268,6 +268,61 @@ export interface LogRunResult {
 }
 
 /**
+ * Process exit codes for the `log-run` CLI action. These are a contract a
+ * wrapping script depends on, so they live next to the logic that produces
+ * them rather than as bare literals in cli.ts:
+ *
+ *   0 = APPENDED  — a new row was spliced + written; nothing more to do.
+ *   3 = DUPLICATE — this run_id was already in the ledger; the append was a
+ *       safe no-op (nothing was lost), so a wrapper may proceed.
+ *   1 = FAILED    — a genuine error (a gh read/write failure, a missing append
+ *       marker, …); NOTHING was recorded, so the operator/wrapper MUST retry.
+ *   2 = BAD_ARG   — a malformed / missing argument; rejected before any write.
+ *
+ * The 0/3 split is the load-bearing one: before #998, a benign duplicate and a
+ * real write failure both exited 1, so a wrapper that treated exit 1 as
+ * "already logged, safe" would silently skip re-logging after a true write
+ * failure — the exact data-loss case the idempotency guard exists to prevent.
+ */
+export const LOG_RUN_EXIT = {
+  APPENDED: 0,
+  FAILED: 1,
+  BAD_ARG: 2,
+  DUPLICATE: 3,
+} as const;
+
+/** Map a successful runLogRun result to its process exit code (0 vs 3). */
+export function logRunExitCode(result: LogRunResult): number {
+  return result.appended ? LOG_RUN_EXIT.APPENDED : LOG_RUN_EXIT.DUPLICATE;
+}
+
+/**
+ * Is `value` an ISO-8601 calendar date (YYYY-MM-DD), optionally followed by a
+ * time? Used to validate the operator-supplied `--date` override before it
+ * lands verbatim in the ledger's date column, mirroring the exit-2 validation
+ * the numeric/enum flags already get. Rejects structurally-wrong strings
+ * (`june10`) AND impossible calendar dates (`2026-13-40`, `2026-02-30`) by
+ * round-tripping through Date and checking the parts survive unchanged.
+ */
+export function isIsoDate(value: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[T ].*)?$/.exec(value);
+  if (!m) return false;
+  const [, y, mo, d] = m;
+  const year = Number(y);
+  const month = Number(mo);
+  const day = Number(d);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  // Reject impossible day-of-month (e.g. 2026-02-30) by round-tripping the
+  // Y/M/D through a UTC Date and confirming nothing rolled over.
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  return (
+    dt.getUTCFullYear() === year &&
+    dt.getUTCMonth() === month - 1 &&
+    dt.getUTCDate() === day
+  );
+}
+
+/**
  * End-to-end: read the ledger body, compute + format the row, and (unless the
  * run_id is already present) splice it above the marker and write back. The
  * read/write are injected so unit tests never hit GitHub.

--- a/tools/photo-curation/src/token-ledger.ts
+++ b/tools/photo-curation/src/token-ledger.ts
@@ -33,10 +33,15 @@ export const PRICE_TABLE = {
   'claude-haiku-4-5': { input: 1, output: 5 },
 } as const satisfies Record<string, { input: number; output: number }>;
 
-/** Cache-rate multipliers relative to a model's input rate (#996 convention). */
+/**
+ * Cache-rate multipliers relative to a model's input rate (#996 convention).
+ * The exact-split path prices `cacheCreate` at the 5-minute write rate (the
+ * common case). The 1-hour write multiplier is 2× input (#996) — not wired into
+ * a split column here; extend TokenSplit if a 1-hour-cached run needs exact
+ * pricing.
+ */
 export const CACHE_READ_MULT = 0.1; // cache-read
 export const CACHE_WRITE_5M_MULT = 1.25; // 5-minute cache-write
-export const CACHE_WRITE_1H_MULT = 2; // 1-hour cache-write
 
 /** Blended-rate mix: photo scoring is input-heavy (image+rubric in, verdict out). */
 export const BLEND_INPUT_SHARE = 0.85;
@@ -77,9 +82,9 @@ export interface LedgerInput {
   totalTokens: number;
   toolUses: number;
   durationMs: number;
-  batch?: boolean;
-  split?: TokenSplit;
-  notes?: string;
+  batch?: boolean | undefined;
+  split?: TokenSplit | undefined;
+  notes?: string | undefined;
 }
 
 export interface LedgerRow {


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Op as Operator
    participant CLI as photo-curate log-run
    participant TL as token-ledger.ts
    participant GH as gh CLI
    participant Issue as Ledger #996

    Op->>CLI: run-id, op, judge-model, total-tokens, batch
    CLI->>TL: computeRow (blended 85/15 or exact split, x0.5 batch)
    TL-->>CLI: scored, tokens-per-item, est_$, $-per-item
    CLI->>GH: read issue body (gh api jq .body)
    GH-->>CLI: current ledger markdown
    CLI->>TL: hasRunId then spliceRowAboveMarker
    alt run_id already present
        TL-->>CLI: duplicate
        CLI-->>Op: warn, skip (exit 1)
    else new run_id
        TL-->>CLI: body with row above the marker
        CLI->>GH: write body (gh issue edit body-file)
        GH->>Issue: append one row above APPEND marker
        CLI-->>Op: appended (exit 0)
    end
```

## Summary

- **Why:** the token-spend ledger (#996) only stays comparable across runs if every photo-curation operation records a row — and doing the cost math by hand is error-prone. This adds a one-command helper and makes post-run logging a non-optional step, so spend gets tracked consistently as we change judge model / agent design / pre-filter.
- **What:** a pure `token-ledger.ts` module (blended 85/15 cost model from one dated `PRICE_TABLE`, exact four-bucket split, 0.5× batch discount, the `scored` / `tokens/item` / `$/item` derivations, 17-column row formatting, and a marker-splice above `<!-- APPEND-ROWS-ABOVE-THIS-LINE -->`) wired into a `photo-curate log-run` CLI subcommand. The live `gh` read/write is isolated in `gh-ledger.ts` and injected, so the math + splice are fully unit-tested with no network. Verified end-to-end against a fake `gh`: it reproduces #996's seed-row values ($2.81 / $0.94) and guards duplicate `run_id`s.
- **Docs:** the scoring runbook now has a numbered, **REQUIRED** Step 5 — run `log-run` with the Workflow completion's `subagent_tokens`/`agent_count`/`tool_uses`/`duration_ms` + op metadata after every `score` / `source-candidates` / `calibration` run, linking #996.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (135 tests, 22 new in `token-ledger.test.ts`)
- [x] New unit tests added: blended path (reproduces both #996 seed rows), exact-split path, batch discount, scored/tokens-per-item/$-per-item derivations, row formatting, marker-splice + duplicate detection against a fixture body, and `runLogRun` orchestration with injected read/write
- [x] `npm run build` (root) — clean
- [x] `npx knip` — clean (no new findings)
- [x] `package-lock.json` — unchanged
- [x] Mermaid diagram verified with `@mermaid-js/mermaid-cli` (renders; no `;`/`<br/>` in messages)
- [x] End-to-end smoke against a fake `gh`: appends the computed row above the marker, warns + skips on a duplicate `run_id`, rejects a partial split

## Plan reference

Out of plan — implements #997 ("[photo-curation] token-ledger helper + make post-run logging a required step"). Part of epic #974; ledger schema + cost model defined in #996.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
