### PR TITLE
fix(ingestor): serialize per-state eBird pair + per-call pacing for 1 rps burst limit

### DIFF
--- a/services/ingestor/src/cli.test.ts
+++ b/services/ingestor/src/cli.test.ts
@@ -34,6 +34,11 @@ describe('runCli', () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV, EBIRD_API_KEY: 'k', DATABASE_URL: 'postgres://x' };
     process.exitCode = undefined;
+    // Flag-parsing kinds (`recent` since #999, `backfill` since Phase 3.5)
+    // read process.argv.slice(3); under vitest the real argv carries
+    // runner-specific arguments that would trip strict unknown-flag
+    // rejection. Pin a flagless argv; tests that exercise flags set their own.
+    process.argv = ['node', 'cli.ts'];
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
   afterEach(() => {
@@ -348,6 +353,101 @@ describe('runCli', () => {
 
     it('rejects --state=US-CA-001-x (more than one subnational segment)', async () => {
       process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA-001-x'];
+      const runBackfillSpy = vi.fn();
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runBackfillSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── --pace-ms flag (#999) ─────────────────────────────────────────────────
+  // eBird's limits effective 2026-06-10 (10k/day + 1 req/sec burst) made
+  // pacing operationally load-bearing. --pace-ms=<n> lets the scheduler tune
+  // per-call pacing via containerOverrides without an image rebuild; absent,
+  // the runner defaults (1500ms) apply.
+  describe('--pace-ms flag (#999)', () => {
+    const SUCCESS_RECENT: RunSummary = {
+      status: 'success', fetched: 0, upserted: 0,
+      statesSucceeded: 49, statesFailed: 0,
+    };
+    const SUCCESS_BACKFILL = {
+      status: 'success' as const, fetched: 0, upserted: 0, daysProcessed: 19,
+    };
+
+    it('"recent" passes --pace-ms through to runIngest', async () => {
+      process.argv = ['node', 'cli.ts', 'recent', '--pace-ms=2500'];
+      const runIngestSpy = vi.fn().mockResolvedValue(SUCCESS_RECENT);
+      const deps = makeDeps({ runIngest: runIngestSpy });
+      await runCli('recent', deps);
+      expect(runIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ paceMs: 2500 })
+      );
+    });
+
+    it('"recent" accepts --pace-ms=0 (explicit no pacing)', async () => {
+      process.argv = ['node', 'cli.ts', 'recent', '--pace-ms=0'];
+      const runIngestSpy = vi.fn().mockResolvedValue(SUCCESS_RECENT);
+      const deps = makeDeps({ runIngest: runIngestSpy });
+      await runCli('recent', deps);
+      expect(runIngestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ paceMs: 0 })
+      );
+    });
+
+    it('"recent" omits paceMs when the flag is absent so the runner default applies', async () => {
+      process.argv = ['node', 'cli.ts', 'recent'];
+      const runIngestSpy = vi.fn().mockResolvedValue(SUCCESS_RECENT);
+      const deps = makeDeps({ runIngest: runIngestSpy });
+      await runCli('recent', deps);
+      expect(runIngestSpy).toHaveBeenCalledTimes(1);
+      const arg = runIngestSpy.mock.calls[0]![0] as { paceMs?: number };
+      expect('paceMs' in arg).toBe(false);
+    });
+
+    it.each(['fast', '-100', '1.5', ''])(
+      '"recent" rejects --pace-ms=%s (must be a non-negative integer)',
+      async (bad) => {
+        process.argv = ['node', 'cli.ts', 'recent', `--pace-ms=${bad}`];
+        const runIngestSpy = vi.fn();
+        const deps = makeDeps({ runIngest: runIngestSpy });
+        await runCli('recent', deps);
+        expect(process.exitCode).toBe(1);
+        expect(runIngestSpy).not.toHaveBeenCalled();
+      }
+    );
+
+    it('"recent" rejects unknown flags (same strictness as backfill)', async () => {
+      process.argv = ['node', 'cli.ts', 'recent', '--pacems=2000'];
+      const runIngestSpy = vi.fn();
+      const deps = makeDeps({ runIngest: runIngestSpy });
+      await runCli('recent', deps);
+      expect(process.exitCode).toBe(1);
+      expect(runIngestSpy).not.toHaveBeenCalled();
+    });
+
+    it('"backfill" passes --pace-ms through to runBackfill alongside --state/--back', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--state=US-CA', '--back=14', '--pace-ms=2000'];
+      const runBackfillSpy = vi.fn().mockResolvedValue(SUCCESS_BACKFILL);
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ regionCode: 'US-CA', days: 14, paceMs: 2000 })
+      );
+    });
+
+    it('"backfill" omits paceMs when the flag is absent so the runner default applies', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill'];
+      const runBackfillSpy = vi.fn().mockResolvedValue(SUCCESS_BACKFILL);
+      const deps = makeDeps({ runBackfill: runBackfillSpy });
+      await runCli('backfill', deps);
+      expect(runBackfillSpy).toHaveBeenCalledTimes(1);
+      const arg = runBackfillSpy.mock.calls[0]![0] as { paceMs?: number };
+      expect('paceMs' in arg).toBe(false);
+    });
+
+    it('"backfill" rejects a malformed --pace-ms', async () => {
+      process.argv = ['node', 'cli.ts', 'backfill', '--pace-ms=quick'];
       const runBackfillSpy = vi.fn();
       const deps = makeDeps({ runBackfill: runBackfillSpy });
       await runCli('backfill', deps);

--- a/services/ingestor/src/cli.ts
+++ b/services/ingestor/src/cli.ts
@@ -106,6 +106,30 @@ export interface CliDeps {
 }
 
 /**
+ * #999 — shared `--pace-ms=<n>` validation for the `recent` and `backfill`
+ * kinds. eBird's limits effective 2026-06-10 (10k req/day + 1 req/sec burst,
+ * 429 on breach) made per-call pacing operationally load-bearing, so the
+ * scheduler must be able to tune it via containerOverrides without an image
+ * rebuild. Returns the parsed non-negative integer, or undefined after
+ * emitting the standard bird_ingest_invalid_flag line (the caller sets
+ * exitCode and returns).
+ */
+function parsePaceMs(raw: string): number | undefined {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 0 || String(n) !== raw) {
+    console.log(JSON.stringify({
+      severity: 'ERROR',
+      message: 'bird_ingest_invalid_flag',
+      flag: '--pace-ms',
+      value: raw,
+      expected: 'non-negative integer milliseconds',
+    }));
+    return undefined;
+  }
+  return n;
+}
+
+/**
  * Executes one ingest run and returns without throwing for run-level failures.
  *
  * Sets `process.exitCode = 1` on `summary.status === 'failure'` so Cloud Run
@@ -249,16 +273,46 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // Per-state fan-out (#840): runIngest loops CONUS_STATE_CODES internally
       // (one /recent + /recent/notable per state) because eBird's region-recent
       // endpoint dedups to one-observation-per-species region-wide — a single
-      // 'US' call starved every non-AZ state. paceMs defaults to 1000ms inside
-      // runIngest, applied as ONE inter-round pause per state (recent + notable
-      // fire concurrently per round), so ~48 pauses × 1s ≈ 48s of pacing — well
-      // under the 900s job timeout. (The two endpoints per state make ~98 HTTP
-      // calls total, but they're not serialized 1s apart; the pacing is the ~48
-      // inter-round sleeps, not the call count.) The status ladder (success |
+      // 'US' call starved every non-AZ state. Pacing is PER CALL (#999):
+      // runIngest fetches each state's pair sequentially and sleeps paceMs
+      // (default 1500ms) before every eBird call except the run's first,
+      // because eBird enforces a 1 req/sec burst cap effective 2026-06-10 —
+      // the pacing IS the call count now: 49 states × 2 serialized calls
+      // ≈ 98 calls × (1.5s + latency) ≈ 3–4 min/run, well under the 900s job
+      // timeout and the 30-min cron interval. The status ladder (success |
       // partial | failure) is keyed on per-state failure count + 429
       // circuit-break, and `partial` still pings the success heartbeat below
       // (only `failure` skips it).
-      summary = await deps.runIngest({ pool, apiKey });
+      //
+      // argv shape: ["node", "cli.ts", "recent", "--pace-ms=1500"]. The flag
+      // is optional (#999) — it exists so the scheduler can tune pacing via
+      // containerOverrides without an image rebuild; absent, runIngest's
+      // default applies.
+      const flags = process.argv.slice(3);
+      let paceMs: number | undefined;
+      for (const f of flags) {
+        if (f.startsWith('--pace-ms=')) {
+          const parsed = parsePaceMs(f.slice('--pace-ms='.length));
+          if (parsed === undefined) {
+            process.exitCode = 1;
+            return;
+          }
+          paceMs = parsed;
+        } else {
+          console.log(JSON.stringify({
+            severity: 'ERROR',
+            message: 'bird_ingest_invalid_flag',
+            flag: f,
+            expected: '--pace-ms=N',
+          }));
+          process.exitCode = 1;
+          return;
+        }
+      }
+      summary = await deps.runIngest({
+        pool, apiKey,
+        ...(paceMs !== undefined && { paceMs }),
+      });
     } else if (kind === 'hotspots') {
       summary = await deps.runHotspotIngest({ pool, apiKey, regionCode: 'US-AZ' });
     } else if (kind === 'backfill') {
@@ -272,11 +326,15 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
       // /historic call can blow past eBird's response-size limit (HTTP 500
       // on large states like CA), and the mitigation is to fan out per
       // county.
+      // --pace-ms=N (#999) overrides runBackfill's 1500ms per-call pacing
+      // default (eBird 1 req/sec burst cap, effective 2026-06-10) so the
+      // scheduler can tune it via containerOverrides without a rebuild.
       // argv shape: ["node", "cli.ts", "backfill", "--state=US-CA", "--back=14"]
       //         or: ["node", "cli.ts", "backfill", "--state=US-CA-001", "--back=14"].
       const flags = process.argv.slice(3);
       let regionCode = 'US-AZ';
       let days = 19;
+      let paceMs: number | undefined;
       for (const f of flags) {
         if (f.startsWith('--state=')) {
           const v = f.slice('--state='.length);
@@ -307,19 +365,29 @@ export async function runCli(kind: string, deps: CliDeps): Promise<void> {
             return;
           }
           days = n;
+        } else if (f.startsWith('--pace-ms=')) {
+          const parsed = parsePaceMs(f.slice('--pace-ms='.length));
+          if (parsed === undefined) {
+            process.exitCode = 1;
+            return;
+          }
+          paceMs = parsed;
         } else {
           console.log(JSON.stringify({
             severity: 'ERROR',
             message: 'bird_ingest_invalid_flag',
             flag: f,
-            expected: '--state=US-XX[-NNN] or --back=N',
+            expected: '--state=US-XX[-NNN], --back=N, or --pace-ms=N',
           }));
           process.exitCode = 1;
           return;
         }
       }
       backfillState = regionCode;
-      summary = await deps.runBackfill({ pool, apiKey, regionCode, days });
+      summary = await deps.runBackfill({
+        pool, apiKey, regionCode, days,
+        ...(paceMs !== undefined && { paceMs }),
+      });
     } else if (kind === 'backfill-extended') {
       // 'backfill-extended': one-shot 365-day backfill at 1 rps; this is NOT
       // scheduled — it's an operator-triggered one-shot to populate historical

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi, type MockInstance } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { EbirdClient, EbirdClientError, EbirdServerError } from './client.js';
@@ -227,7 +227,7 @@ describe('EbirdClient — structured per-attempt request logging (#999)', () => 
   // attempt (including retries), message `bird_ebird_request`, same
   // single-line JSON convention as bird_ingest_run_completed in cli.ts.
 
-  function loggedRequests(spy: ReturnType<typeof vi.spyOn>) {
+  function loggedRequests(spy: MockInstance<typeof console.log>) {
     return spy.mock.calls
       .map(([a]) => { try { return JSON.parse(String(a)); } catch { return null; } })
       .filter((o): o is Record<string, unknown> =>

--- a/services/ingestor/src/ebird/client.test.ts
+++ b/services/ingestor/src/ebird/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { EbirdClient, EbirdClientError, EbirdServerError } from './client.js';
@@ -216,6 +216,101 @@ describe('EbirdClient.fetchTaxonomy', () => {
     // rejects with EbirdClientError(400) — so this test fails loudly if the
     // param is re-added.
     await expect(client.fetchTaxonomy()).resolves.toEqual([]);
+  });
+});
+
+describe('EbirdClient — structured per-attempt request logging (#999)', () => {
+  // eBird's limits effective 2026-06-10 (10k req/day + 1 req/sec burst) made
+  // ground-truth request counts operationally necessary — before this,
+  // successful runs logged ZERO per-request lines, so there was no way to
+  // monitor quota consumption from Cloud Logging. One compact line per HTTP
+  // attempt (including retries), message `bird_ebird_request`, same
+  // single-line JSON convention as bird_ingest_run_completed in cli.ts.
+
+  function loggedRequests(spy: ReturnType<typeof vi.spyOn>) {
+    return spy.mock.calls
+      .map(([a]) => { try { return JSON.parse(String(a)); } catch { return null; } })
+      .filter((o): o is Record<string, unknown> =>
+        !!o && (o as Record<string, unknown>)['message'] === 'bird_ebird_request');
+  }
+
+  it('emits one bird_ebird_request line per attempt with endpoint path, 1-based attempt and status', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    let calls = 0;
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () => {
+        calls++;
+        if (calls < 3) return new HttpResponse('boom', { status: 503 });
+        return HttpResponse.json(SAMPLE_OBS);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    await client.fetchRecent('US-AZ');
+
+    const lines = loggedRequests(logSpy);
+    expect(lines).toHaveLength(3); // 2 failed attempts + the success — retries included
+    expect(lines[0]).toMatchObject({
+      severity: 'INFO',
+      message: 'bird_ebird_request',
+      endpoint: '/v2/data/obs/US-AZ/recent',
+      attempt: 1,
+      status: 503,
+    });
+    expect(lines[1]).toMatchObject({ attempt: 2, status: 503 });
+    expect(lines[2]).toMatchObject({ attempt: 3, status: 200 });
+    logSpy.mockRestore();
+  });
+
+  it('logs non-OK terminal statuses too (429 visible for quota triage)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () =>
+        new HttpResponse('rate limited', { status: 429 })
+      )
+    );
+    const client = new EbirdClient({ apiKey: 'k', retryBaseMs: 1, maxRetries: 5 });
+    await expect(client.fetchRecent('US-AZ')).rejects.toThrow(/429/);
+
+    const lines = loggedRequests(logSpy);
+    expect(lines).toHaveLength(1); // 4xx is not retried — exactly one attempt
+    expect(lines[0]).toMatchObject({ attempt: 1, status: 429 });
+    logSpy.mockRestore();
+  });
+
+  it('logs an errorClass (no status) when the attempt fails at the transport layer (timeout)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', async () => {
+        await new Promise(r => setTimeout(r, 50));
+        return HttpResponse.json([]);
+      })
+    );
+    const client = new EbirdClient({ apiKey: 'k', maxRetries: 0, retryBaseMs: 1, requestTimeoutMs: 5 });
+    await expect(client.fetchRecent('US-AZ')).rejects.toThrow();
+
+    const lines = loggedRequests(logSpy);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).not.toHaveProperty('status');
+    expect(String(lines[0]?.['errorClass'])).toMatch(/TimeoutError|AbortError/);
+    logSpy.mockRestore();
+  });
+
+  it('never logs the API key (travels only in the x-ebirdapitoken header)', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent', () =>
+        HttpResponse.json(SAMPLE_OBS)
+      )
+    );
+    const SECRET = 'sekrit-api-key-do-not-log-31337';
+    const client = new EbirdClient({ apiKey: SECRET });
+    await client.fetchRecent('US-AZ');
+
+    expect(loggedRequests(logSpy).length).toBeGreaterThan(0);
+    for (const call of logSpy.mock.calls) {
+      expect(String(call[0])).not.toContain(SECRET);
+    }
+    logSpy.mockRestore();
   });
 });
 

--- a/services/ingestor/src/ebird/client.ts
+++ b/services/ingestor/src/ebird/client.ts
@@ -102,6 +102,7 @@ export class EbirdClient {
           headers: { 'x-ebirdapitoken': this.apiKey, accept: 'application/json' },
           signal: AbortSignal.timeout(this.requestTimeoutMs),
         });
+        this.logAttempt(url, attempt, { status: res.status });
         if (res.status >= 500) {
           throw new EbirdServerError(res.status, await res.text());
         }
@@ -116,6 +117,15 @@ export class EbirdClient {
         return (await res.json()) as T;
       } catch (err) {
         lastError = err;
+        // EbirdClientError / EbirdServerError mean fetch resolved and the
+        // attempt was already logged above with its HTTP status. Anything
+        // else is a transport-level failure (network error, timeout) — emit
+        // the attempt line with the error class since no status exists.
+        if (!(err instanceof EbirdClientError) && !(err instanceof EbirdServerError)) {
+          this.logAttempt(url, attempt, {
+            errorClass: err instanceof Error ? err.name : typeof err,
+          });
+        }
         if (err instanceof EbirdClientError) throw err; // 4xx — don't retry
         if (attempt === this.maxRetries) break;
         // Full-jitter exponential backoff (AWS write-up variant).
@@ -130,6 +140,31 @@ export class EbirdClient {
       throw new EbirdServerError(0, `Request timed out after ${this.requestTimeoutMs}ms`);
     }
     throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /**
+   * One structured line per outbound eBird HTTP attempt — including retries
+   * (#999). eBird's limits effective 2026-06-10 (10k req/day + 1 req/sec
+   * burst) made ground-truth request counts operationally necessary: before
+   * this, a successful run logged ZERO per-request lines, so quota
+   * consumption was invisible in Cloud Logging. ~4,700 lines/day at current
+   * cadence — acceptable volume. Single-line compact JSON on stdout, same
+   * convention as cli.ts's bird_ingest_run_completed. Logs ONLY the URL path
+   * — never headers (the API key travels in `x-ebirdapitoken`) and never the
+   * query string, so no key material can leak into logs.
+   */
+  private logAttempt(
+    url: URL,
+    attempt: number,
+    outcome: { status?: number; errorClass?: string }
+  ): void {
+    console.log(JSON.stringify({
+      severity: 'INFO',
+      message: 'bird_ebird_request',
+      endpoint: url.pathname,
+      attempt: attempt + 1, // 1-based for triage readability ("attempt 3")
+      ...outcome,
+    }));
   }
 }
 

--- a/services/ingestor/src/run-backfill.test.ts
+++ b/services/ingestor/src/run-backfill.test.ts
@@ -53,9 +53,11 @@ describe('runBackfill', () => {
     );
 
     const today = new Date('2026-04-16T00:00:00Z');
+    // paceMs: 0 — pacing now defaults to 1500 (#999); tests opt out for speed,
+    // matching the run-ingest.test.ts convention.
     const summary = await runBackfill({
       pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
-      days: 3, today,
+      days: 3, today, paceMs: 0,
     });
     expect(calls).toBe(3);
     expect(summary.status).toBe('success');
@@ -94,7 +96,7 @@ describe('runBackfill', () => {
     const today = new Date('2026-04-16T00:00:00Z');
     const summary = await runBackfill({
       pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
-      days: 3, today,
+      days: 3, today, paceMs: 0,
     });
     expect(summary.status).toBe('success');
 
@@ -132,7 +134,7 @@ describe('runBackfill', () => {
     const client = new EbirdClient({ apiKey: 'k', maxRetries: 0 });
     const summary = await runBackfill({
       pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
-      days: 3, today, client,
+      days: 3, today, client, paceMs: 0,
     });
 
     expect(summary.status).toBe('partial');
@@ -144,6 +146,32 @@ describe('runBackfill', () => {
     const subIds = obs.map(o => o.subId).sort();
     expect(subIds).toContain('SDay15');
     expect(subIds).toContain('SDay13');
+  });
+
+  it('defaults paceMs to 1500 when not injected (eBird 1 rps burst cap, #999)', async () => {
+    // eBird's limits effective 2026-06-10 include a 1 req/sec burst cap. The
+    // daily 04:00 backfill previously defaulted paceMs to 0 — up to 20
+    // back-to-back /historic calls with no pacing. Pin the new default
+    // behaviorally via the setTimeout spy (no exported constant — knip flags
+    // test-only exports): days=2 with the default → exactly one 1500ms pacing
+    // sleep (between the two historic calls; never before the first).
+    server.use(
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/recent/notable', () => HttpResponse.json([])),
+      http.get('https://api.ebird.org/v2/data/obs/US-AZ/historic/:y/:m/:d', () => HttpResponse.json([])),
+    );
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const today = new Date('2026-04-16T00:00:00Z');
+    const summary = await runBackfill({
+      pool: db.pool, apiKey: 'k', regionCode: 'US-AZ', days: 2, today,
+    });
+
+    expect(summary.status).toBe('success');
+    const pacingCalls = setTimeoutSpy.mock.calls.filter(
+      ([, delay]) => delay === 1_500
+    );
+    expect(pacingCalls).toHaveLength(1);
+    setTimeoutSpy.mockRestore();
   });
 
   it('paces successive day fetches when paceMs > 0, skipping the wait before the first call', async () => {
@@ -220,7 +248,7 @@ describe('runBackfill', () => {
     const client = new EbirdClient({ apiKey: 'k', maxRetries: 0 });
     const summary = await runBackfill({
       pool: db.pool, apiKey: 'k', regionCode: 'US-AZ',
-      days: 3, today, client,
+      days: 3, today, client, paceMs: 0,
     });
     expect(summary.status).toBe('partial');
 

--- a/services/ingestor/src/run-backfill.ts
+++ b/services/ingestor/src/run-backfill.ts
@@ -12,10 +12,14 @@ export interface RunBackfillOptions {
   today?: Date;          // injectable for tests
   client?: EbirdClient;
   /**
-   * Min millis between successive `client.fetchHistoric` calls. Defaults to 0
-   * (no pacing) so the existing 30-day backfill is unaffected. The
-   * `backfill-extended` 365-day kind in cli.ts passes 1000 to keep us under
-   * eBird's rate limit on a long run. Mirrors the run-photos.ts pattern.
+   * Min millis between successive `client.fetchHistoric` calls. Defaults to
+   * 1500 (#999): eBird enforces a 1 req/sec burst cap effective 2026-06-10
+   * (429 on breach), and the daily 04:00 backfill previously made up to 20
+   * back-to-back calls with NO pacing. First-call-skip is preserved, so a
+   * run sleeps paceMs × (days − 1), not × days. The `backfill-extended`
+   * 365-day kind in cli.ts passes an explicit 1000 — compliant for its
+   * strictly-sequential single calls, and 1.5s would creep its 366-call run
+   * toward the 900s job timeout. Mirrors the run-photos.ts pattern.
    */
   paceMs?: number;
 }
@@ -61,7 +65,7 @@ export async function runBackfill(o: RunBackfillOptions): Promise<RunBackfillSum
       // Pace successive eBird calls. Skip the wait before the first call;
       // otherwise a 365-day run sits idle for paceMs * 365 when paceMs *
       // (365 - 1) would do. Mirrors run-photos.ts:113-116.
-      if (!firstCall && (o.paceMs ?? 0) > 0) await sleep(o.paceMs!);
+      if (!firstCall && (o.paceMs ?? 1_500) > 0) await sleep(o.paceMs ?? 1_500);
       firstCall = false;
 
       // Per-day diagnostic logging (issue #TBD): the prior single-catch

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, type JsonBodyType } from 'msw';
 import { CONUS_STATE_CODES } from '@bird-watch/shared-types';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
 import { upsertSpeciesMeta, getObservations, getRecentIngestRuns } from '@bird-watch/db-client';
@@ -25,7 +25,7 @@ const NOTABLE = [
 ];
 
 /** Stub /recent + /recent/notable for a single state. */
-function stateHandlers(state: string, recent: unknown, notable: unknown) {
+function stateHandlers(state: string, recent: JsonBodyType, notable: JsonBodyType) {
   return [
     http.get(`https://api.ebird.org/v2/data/obs/${state}/recent`, () => HttpResponse.json(recent)),
     http.get(`https://api.ebird.org/v2/data/obs/${state}/recent/notable`, () => HttpResponse.json(notable)),

--- a/services/ingestor/src/run-ingest.test.ts
+++ b/services/ingestor/src/run-ingest.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { CONUS_STATE_CODES } from '@bird-watch/shared-types';
 import { startTestDb, type TestDb } from '@bird-watch/db-client/dist/test-helpers.js';
 import { upsertSpeciesMeta, getObservations, getRecentIngestRuns } from '@bird-watch/db-client';
 import { runIngest } from './run-ingest.js';
+import type { EbirdClient } from './ebird/client.js';
 
 const server = setupServer();
 let db: TestDb;
@@ -157,6 +158,94 @@ describe('runIngest — per-state fan-out across all CONUS states (#840)', () =>
     const nmAnna = obs.find(o => o.subId === 'S201')!;
     expect(azAnna.isNotable).toBe(true);  // AZ's S101 is in AZ's notable set
     expect(nmAnna.isNotable).toBe(false); // NM's S201 is NOT — keyset is per-state
+  });
+});
+
+describe('runIngest — eBird 1 rps burst pacing (#999)', () => {
+  // eBird enforced new limits effective 2026-06-10: 10k req/day AND a
+  // 1 req/sec burst cap (429 on breach). The pre-#999 Promise.all fired a
+  // state's /recent + /recent/notable in the same instant, draining eBird's
+  // burst bucket ~13 states into every sweep. These tests pin the fix:
+  // the pair is strictly sequential and EVERY call (not every state round)
+  // is paced.
+
+  it('serializes the per-state pair — fetchNotable does not start until fetchRecent has resolved', async () => {
+    const events: string[] = [];
+    const fakeClient = {
+      async fetchRecent(state: string) {
+        events.push(`recent:start:${state}`);
+        // Hold the recent call open long enough that a concurrent notable
+        // call (the pre-#999 Promise.all shape) would observably start first.
+        await new Promise(r => setTimeout(r, 20));
+        events.push(`recent:resolve:${state}`);
+        return [];
+      },
+      async fetchNotable(state: string) {
+        events.push(`notable:start:${state}`);
+        return [];
+      },
+    } as unknown as EbirdClient;
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ', 'US-NM'], paceMs: 0,
+      client: fakeClient,
+    });
+
+    expect(summary.status).toBe('success');
+    for (const state of ['US-AZ', 'US-NM']) {
+      const recentResolved = events.indexOf(`recent:resolve:${state}`);
+      const notableStarted = events.indexOf(`notable:start:${state}`);
+      expect(recentResolved).toBeGreaterThanOrEqual(0);
+      expect(notableStarted).toBeGreaterThan(recentResolved);
+    }
+  });
+
+  it('paces EVERY eBird call, skipping only the very first call of the run (per-call, not per-round)', async () => {
+    const fakeClient = {
+      async fetchRecent() { return []; },
+      async fetchNotable() { return []; },
+    } as unknown as EbirdClient;
+
+    // Spy on setTimeout instead of asserting wall-clock bounds (flake-prone on
+    // slow CI runners under the repo's retries:0 policy). Fake timers are not
+    // an option here: node-postgres needs real timers for I/O. Filtering on
+    // `delay === 25` isolates the pacing sleeps from pg/infra timers — the
+    // same pattern as run-backfill.test.ts's pacing test.
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ', 'US-NM'], paceMs: 25,
+      client: fakeClient,
+    });
+
+    expect(summary.status).toBe('success');
+    const pacingCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 25);
+    // 2 states × 2 calls = 4 eBird calls; per-call pacing sleeps before every
+    // call except the run's first → exactly 3. The pre-#999 per-round pacing
+    // would have slept exactly once (between the two state rounds).
+    expect(pacingCalls).toHaveLength(3);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('defaults paceMs to 1500 when not injected (eBird burst cap headroom)', async () => {
+    const fakeClient = {
+      async fetchRecent() { return []; },
+      async fetchNotable() { return []; },
+    } as unknown as EbirdClient;
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    // One state = 2 calls = exactly 1 pacing sleep at the default. This test
+    // pays one real 1.5s wait to pin the default without exporting the
+    // constant (knip flags test-only exports).
+    const summary = await runIngest({
+      pool: db.pool, apiKey: 'k', stateCodes: ['US-AZ'],
+      client: fakeClient,
+    });
+
+    expect(summary.status).toBe('success');
+    const pacingCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 1_500);
+    expect(pacingCalls).toHaveLength(1);
+    setTimeoutSpy.mockRestore();
   });
 });
 

--- a/services/ingestor/src/run-ingest.ts
+++ b/services/ingestor/src/run-ingest.ts
@@ -32,12 +32,15 @@ export interface RunIngestOptions {
    */
   stateCodes?: readonly string[];
   /**
-   * Min millis between successive per-state fetch rounds. 49 states × 2 calls
-   * (recent + notable) = ~98 eBird calls/run, every 30 min — without pacing this
-   * bursts one key/IP into eBird's (opaque) rate limit. Default 1000ms (codebase
-   * precedent: cli.ts:323's backfill-extended path); at ~98 calls × 1000ms ≈ 98s
-   * this fits comfortably under the 900s Cloud Run job timeout. Tests pass 0.
-   * First-call-skip pattern mirrors run-backfill.ts:64.
+   * Min millis between successive eBird calls — applied PER CALL (#999):
+   * every /recent and /recent/notable request sleeps `paceMs` first, except
+   * the very first call of the run. eBird enforces a 1 req/sec burst cap
+   * (effective 2026-06-10; 429 on breach), so a state's pair must never fire
+   * in the same instant — the pre-#999 per-round pacing let exactly that
+   * happen and depleted the burst bucket ~13 states into every sweep.
+   * Default 1500ms: 49 states × 2 calls = 98 calls/run, ≈ 98 × (1.5s pace +
+   * latency) ≈ 3–4 min — comfortably under the 900s Cloud Run job timeout
+   * and the 30-min cron interval. Tests pass 0.
    */
   paceMs?: number;
   /**
@@ -70,7 +73,7 @@ export interface RunSummary {
   error?: string;
 }
 
-const DEFAULT_PACE_MS = 1_000;
+const DEFAULT_PACE_MS = 1_500;
 const DEFAULT_PARTIAL_THRESHOLD = 5;
 const DEFAULT_MAX_429_STREAK = 3;
 
@@ -123,22 +126,29 @@ export async function runIngest(opts: RunIngestOptions): Promise<RunSummary> {
   let consecutive429 = 0;
 
   try {
-    let firstRound = true;
-    for (const state of states) {
-      // Pace successive per-state rounds; skip the wait before the first.
-      // Mirrors run-backfill.ts:64 / run-photos.ts.
-      if (!firstRound && paceMs > 0) await sleep(paceMs);
-      firstRound = false;
+    // Per-call pacing (#999): sleep before EVERY eBird call except the very
+    // first of the run. eBird's 1 req/sec burst cap (effective 2026-06-10)
+    // counts individual requests, so pacing per state ROUND while the pair
+    // fired concurrently drained the burst bucket two tokens at a time.
+    let firstCall = true;
+    const paceBeforeCall = async () => {
+      if (!firstCall && paceMs > 0) await sleep(paceMs);
+      firstCall = false;
+    };
 
+    for (const state of states) {
       try {
         // Per-state notable intersection: `is_notable` requires BOTH this
         // state's /recent AND its /recent/notable. Keysets are built per state
         // and NOT intersected across states (a subId/speciesCode pair is
-        // state-local).
-        const [recent, notable] = await Promise.all([
-          client.fetchRecent(state, { back }),
-          client.fetchNotable(state, { back }),
-        ]);
+        // state-local). The pair is fetched SEQUENTIALLY — recent, then
+        // notable — never concurrently, so the per-call pacing above actually
+        // bounds the instantaneous request rate (#999). A 429 on either call
+        // marks the whole state rate-limited, same as the concurrent shape did.
+        await paceBeforeCall();
+        const recent = await client.fetchRecent(state, { back });
+        await paceBeforeCall();
+        const notable = await client.fetchNotable(state, { back });
         const notableKeys = notableKeyset(notable);
         for (const o of recent) inputs.push(toObservationInput(o, notableKeys));
         statesSucceeded++;


### PR DESCRIPTION
## Diagrams

**Before (outage):** each state's pair fired in the same instant; `paceMs` slept only between state rounds. Net token drain depleted eBird's burst bucket ~13 states into every sweep (first 429 always on US-IA, the 14th CONUS code).

```mermaid
sequenceDiagram
    participant Ingestor
    participant eBird
    Note over Ingestor,eBird: BEFORE — Promise.all fires 2 requests per instant
    par Promise.all
        Ingestor->>eBird: GET /US-XX/recent
    and
        Ingestor->>eBird: GET /US-XX/recent/notable
    end
    Note over Ingestor: sleep paceMs (1000ms) only between state rounds
    eBird-->>Ingestor: 429 at ~state 14 (burst bucket empty)
```

**After:** the pair is strictly sequential, and every eBird call (except the run's first) waits `paceMs` — instantaneous rate is bounded at ≤1 req/1.5s.

```mermaid
sequenceDiagram
    participant Ingestor
    participant eBird
    Note over Ingestor,eBird: AFTER — serialized, paced per call
    Ingestor->>eBird: GET /US-XX/recent
    Note over Ingestor: sleep 1500ms
    Ingestor->>eBird: GET /US-XX/recent/notable
    Note over Ingestor: sleep 1500ms before every call except the run's first
```

## Summary

- **Why:** eBird enforced new API limits effective 2026-06-10 (10,000 req/day AND a 1 req/sec burst cap, 429 on breach). The half-hourly `recent` ingest has failed 13+ consecutive runs since 16:30 UTC. Daily volume is fine (~4,725/day ≈ 47% of cap) — the breach is purely burst-rate, so the fix is timing-only: serialize each state's `recent`/`notable` pair and pace every call (`DEFAULT_PACE_MS` 1000→1500; 98 calls ≈ 3–4 min/run, far under the 900s job timeout and 30-min cron). All error semantics are preserved exactly: per-state isolation, 429 streak counter + `max429Streak` circuit-break, Retry-After-aware backoff, `partialFailureThreshold`, accumulate-then-upsert-once (#484).
- The daily 04:00 backfill had the same exposure (up to 20 back-to-back `/historic` calls with `paceMs ?? 0`) — its default is now 1500ms too. `backfill-extended` keeps its explicit 1000ms: strictly-sequential single calls are 1 rps-compliant, and 1.5s would creep its 366-call run toward the 900s timeout.
- Two operability additions for the incident class: a `--pace-ms=<n>` CLI flag on the `recent` + `backfill` kinds (tunable via scheduler containerOverrides, no rebuild) and one structured `bird_ebird_request` log line per outbound HTTP attempt in `EbirdClient.getJson` (path + attempt + status/error class; never headers or key material) — successful runs previously logged zero per-request lines, so quota consumption was invisible.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test --workspace @bird-watch/ingestor` — 25 files, 261 tests passed (includes real Postgres via testcontainers)
- [x] New unit / integration tests added: pair-serialization ordering, per-call pacing count (3 sleeps for 2 states × 2 calls), 1500ms defaults pinned behaviorally for both runners (no test-only exports — knip), `--pace-ms` accept/reject/pass-through for both kinds, per-attempt log lines incl. 429 + timeout + no-key-material
- [x] `npm run lint` (repo root) — clean
- [x] `npm run build` (repo root) — clean (pre-existing frontend chunk-size note only)
- [x] `npx knip` — no findings (pre-existing configuration hint only)
- [x] No e2e spec — no user-visible frontend behavior changed

## Plan reference

Out of plan — live incident remediation. Fixes #999.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)