### PR TITLE
feat(photo-curation): swap selection (outscores gate) + --limit sourcing + pending-swaps readout

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -310,9 +310,21 @@ const config: KnipConfig = {
       //             flagged redundant). If that test is ever removed, knip will
       //             report safe.js as unused — re-add it to this ignore list
       //             (with the overview/swap import rationale above) at that time.
+      //
+      // 2026-06-10 (photo-swap epic): public/pending-swaps.js — Screen 3, the
+      //             read-only swap readout. Same profile as overview.js/swap.js:
+      //             a browser ES module loaded at runtime via pending-swaps.html's
+      //             `<script type="module" src="/pending-swaps.js">` (it `import`s
+      //             /theme.js + ./safe.js), never imported by any TS/JS module
+      //             knip can trace, so it is flagged as an unused file. Risk:
+      //             masks a genuinely orphaned public asset if the screen is
+      //             deleted but its script left on disk. Re-audit 2026-07-27 —
+      //             confirm public/pending-swaps.html still references it (grep
+      //             `src="/pending-swaps.js"`).
       ignore: [
         'workflows/score-current.mjs', 'workflows/source-candidates.mjs',
         'public/overview.js', 'public/swap.js', 'public/theme.js',
+        'public/pending-swaps.js',
       ],
     },
   },

--- a/tools/photo-curation/public/app.css
+++ b/tools/photo-curation/public/app.css
@@ -76,4 +76,34 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .quick-chip { font-size: var(--type-sm); padding: 4px 10px; border-radius: 999px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text); cursor: pointer; }
 .quick-chip.active { background: var(--status-bad); color: #fff; border-color: var(--status-bad); }
 .back-link { font-size: var(--type-sm); color: var(--status-good); text-decoration: none; }
+.nav-link { font-size: var(--type-sm); color: var(--status-good); text-decoration: none; padding: 6px 10px; border: 1px solid var(--border); border-radius: 8px; }
 .toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); background: var(--surface); border: 1px solid var(--border); box-shadow: var(--card-elevation); border-radius: var(--radius-lg); padding: 12px 20px; font-size: var(--type-sm); }
+
+/* ── Screen 3: pending-swaps readout (read-only) ── */
+.readout-note { max-width: 1100px; margin: 16px auto 0; padding: 0 24px; font-size: var(--type-sm); color: var(--text-dim); }
+.readout-note code { background: var(--surface-2); padding: 1px 5px; border-radius: 5px; }
+.swap-list { max-width: 1100px; margin: 0 auto; padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+.swap-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); padding: 16px 18px; }
+.swap-card.has-swap { box-shadow: inset 4px 0 0 var(--status-great), var(--card-elevation); }
+.swap-card.no-swap { box-shadow: inset 4px 0 0 var(--border), var(--card-elevation); }
+.swap-card .swap-head { font-size: var(--type-md); margin-bottom: 12px; }
+.swap-card .swap-head .com { font-size: var(--type-lg); font-weight: 700; }
+.delta-badge { margin-left: auto; font-size: var(--type-sm); font-weight: 700; padding: 2px 10px; border-radius: 999px; color: #fff; }
+.delta-badge.great { background: var(--status-great); }
+.delta-badge.bad { background: var(--text-dim); }
+/* current → arrow → proposed: a thin centered arrow column between the panes. */
+.compare.arrow-between { grid-template-columns: 1fr auto 1fr; align-items: center; }
+.swap-arrow { font-size: var(--type-hero); color: var(--text-dim); text-align: center; padding: 0 4px; }
+.rationale { font-size: var(--type-sm); color: var(--text); margin: 8px 0 0; line-height: 1.4; }
+.rationale-dim { font-size: var(--type-sm); color: var(--text-dim); margin: 8px 0 0; line-height: 1.4; }
+.pane.no-improvement { background: var(--surface-2); display: flex; flex-direction: column; justify-content: center; }
+.pane.proposed { box-shadow: inset 0 3px 0 var(--status-great); }
+.rejected { margin-top: 12px; border-top: 1px solid var(--border); padding-top: 8px; }
+.rejected-label { font-size: var(--type-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; }
+.rejected .alternates { padding: 8px 0 0; }
+.rejected .alt { width: 80px; cursor: default; }
+.rejected .alt img { width: 80px; height: 60px; }
+@media (max-width: 640px) {
+  .compare.arrow-between { grid-template-columns: 1fr; }
+  .swap-arrow { transform: rotate(90deg); padding: 4px 0; }
+}

--- a/tools/photo-curation/public/index.html
+++ b/tools/photo-curation/public/index.html
@@ -9,6 +9,7 @@
 <body>
   <header class="app-header">
     <h1 class="app-title">Photo Curation</h1>
+    <a class="nav-link" href="/pending-swaps">Pending swaps →</a>
     <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
     <span class="staged-indicator" id="staged">staged: 0 approved</span>
   </header>

--- a/tools/photo-curation/public/pending-swaps.html
+++ b/tools/photo-curation/public/pending-swaps.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Photo Curation — Pending Swaps</title>
+  <link rel="stylesheet" href="/app.css" />
+</head>
+<body>
+  <header class="app-header">
+    <a class="back-link" href="/">← Overview</a>
+    <h1 class="app-title">Pending Swaps</h1>
+    <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
+    <span class="staged-indicator" id="summary">…</span>
+  </header>
+  <p class="readout-note">
+    Read-only pre-commit readout: for each needs-replacement species, the best
+    sourced candidate is proposed only when it <em>outscores</em> the current
+    photo. Nothing here is applied — run <code>apply-swaps</code> to commit.
+  </p>
+  <main class="swap-list" id="list"></main>
+  <script type="module" src="/pending-swaps.js"></script>
+</body>
+</html>

--- a/tools/photo-curation/public/pending-swaps.js
+++ b/tools/photo-curation/public/pending-swaps.js
@@ -1,0 +1,122 @@
+import { initTheme, toggleTheme } from '/theme.js';
+import { esc, safeImg } from './safe.js';
+
+initTheme();
+document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+// READ-ONLY readout of selectSwaps(): per keep=0 species with scored candidates,
+// the current photo + score on the left, the proposed replacement (or a "no
+// improvement" state) on the right, the score delta, and the rejected candidate
+// thumbnails below. All interpolated species/attribution text + image URLs go
+// through esc()/safeImg() (untrusted eBird taxonomy + iNat user content) — this
+// page never injects raw HTML.
+
+function scoreClass(score) {
+  if (score === null || score === undefined) return 'bad';
+  if (score >= 75) return 'great';
+  if (score >= 50) return 'good';
+  return 'bad';
+}
+
+function scoreBadge(score) {
+  return `<span class="score-badge ${scoreClass(score)}">${esc(score ?? '—')}</span>`;
+}
+
+function marksHtml(marks) {
+  if (!marks || marks.length === 0) return '';
+  return `<div class="flag-chips">${marks.map(m => `<span class="flag-chip">${esc(m)}</span>`).join('')}</div>`;
+}
+
+function deltaHtml(s) {
+  // delta = best candidate quality − current quality. Positive = improvement.
+  const sign = s.delta > 0 ? '+' : '';
+  const cls = s.outscores ? 'great' : 'bad';
+  return `<span class="delta-badge ${cls}">Δ ${sign}${esc(s.delta)}</span>`;
+}
+
+function currentPane(s) {
+  return `
+    <div class="pane">
+      <div class="pane-label">Current (live) · ${scoreBadge(s.current.qualityScore)}</div>
+      <img class="pane-photo" src="${safeImg(s.current.photoUrl)}" alt="current ${esc(s.comName)}" loading="lazy" />
+      <div class="pane-body">
+        ${marksHtml(s.current.fieldMarks)}
+        <p class="rationale">${esc(s.current.rationale ?? '')}</p>
+        <p class="attribution">${esc(s.current.attribution)} · ${esc(s.current.license)}</p>
+      </div>
+    </div>`;
+}
+
+function proposedPane(s) {
+  if (!s.proposed) {
+    return `
+      <div class="pane no-improvement">
+        <div class="pane-label">Proposed replacement</div>
+        <div class="pane-body">
+          <p class="empty">No improvement found — keeping original.</p>
+          <p class="rationale-dim">Best candidate scored ${esc((s.current.qualityScore ?? 0) + s.delta)}, not above the current ${esc(s.current.qualityScore ?? '—')}.</p>
+        </div>
+      </div>`;
+  }
+  const p = s.proposed;
+  return `
+    <div class="pane proposed">
+      <div class="pane-label">Proposed replacement · ${scoreBadge(p.qualityScore)}</div>
+      <img class="pane-photo" src="${safeImg(p.photoUrl)}" alt="proposed replacement" loading="lazy" />
+      <div class="pane-body">
+        ${marksHtml(p.fieldMarks)}
+        <p class="rationale">${esc(p.rationale ?? '')}</p>
+        <p class="attribution">${esc(p.attribution)} · ${esc(p.license)} · iNat ${esc(p.inatId)}</p>
+      </div>
+    </div>`;
+}
+
+function rejectedHtml(s) {
+  // Every non-selected candidate (the alternates the gate did not pick).
+  const rejected = s.candidates.filter(c => !c.selected);
+  if (rejected.length === 0) return '';
+  const items = rejected.map(c => `
+    <div class="alt" title="${esc(c.rationale ?? '')}">
+      <img src="${safeImg(c.photoUrl)}" alt="rejected candidate ${esc(c.inatId)}" loading="lazy" />
+      <div class="alt-score">${esc(c.qualityScore ?? '—')}</div>
+    </div>`).join('');
+  return `
+    <div class="rejected">
+      <div class="rejected-label">Other candidates (not selected)</div>
+      <div class="alternates">${items}</div>
+    </div>`;
+}
+
+function speciesCard(s) {
+  const el = document.createElement('article');
+  el.className = 'swap-card' + (s.outscores ? ' has-swap' : ' no-swap');
+  el.innerHTML = `
+    <div class="swap-head">
+      <span class="com">${esc(s.comName)}</span>
+      <span class="sci">${esc(s.sciName)}</span>
+      ${deltaHtml(s)}
+    </div>
+    <div class="compare arrow-between">
+      ${currentPane(s)}
+      <div class="swap-arrow" aria-hidden="true">→</div>
+      ${proposedPane(s)}
+    </div>
+    ${rejectedHtml(s)}`;
+  return el;
+}
+
+async function load() {
+  const res = await fetch('/api/pending-swaps');
+  const data = await res.json();
+  const list = document.getElementById('list');
+  list.innerHTML = '';
+  document.getElementById('summary').textContent =
+    `${data.proposedCount} of ${data.total} have a proposed swap`;
+  if (data.total === 0) {
+    list.innerHTML = '<p class="empty">No needs-replacement species with scored candidates. Run source-prepare + score the candidates first.</p>';
+    return;
+  }
+  for (const s of data.swaps) list.appendChild(speciesCard(s));
+}
+
+load();

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -90,10 +90,16 @@ program
   .command('source-prepare')
   .description('Fetch + download a deep iNat candidate pool for FLAGGED species and write a manifest the source agents Read (Node half of the source-candidates Workflow — Bug 1, #992).')
   .option('--pool <n>', 'iNat candidates per flagged species', '15')
-  .action(async (opts: { pool: string }) => {
+  .option('--limit <n>', 'cap how many keep=0 species to source this run, worst-first (default: all)')
+  .action(async (opts: { pool: string; limit?: string }) => {
     const db = openDb(DEFAULT_DB_PATH);
     try {
-      const result = await sourcePrepare(db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR });
+      // --limit caps the number of keep=0 species sourced (worst-first); omit for
+      // all. Only set the opt when the flag was passed (exactOptionalPropertyTypes).
+      const limitOpts = opts.limit !== undefined ? { limit: Number(opts.limit) } : {};
+      const result = await sourcePrepare(
+        db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR }, limitOpts,
+      );
       console.log(`[source-prepare] sourced ${result.picked} candidate(s) — ${result.inatFetches} iNat fetch(es) + ${result.downloads} edge download(s); manifest at ${result.manifestPath}`);
       console.log(result.manifestPath);
     } finally {

--- a/tools/photo-curation/src/score-orchestration.test.ts
+++ b/tools/photo-curation/src/score-orchestration.test.ts
@@ -328,6 +328,54 @@ describe('sourcePrepare (Node, testable — Bug 1 source-candidates split)', () 
     // The kept (keep=1) species got NO candidates sourced, low composite notwithstanding.
     expect(listCandidates(db, 'keep1')).toHaveLength(0);
   });
+
+  // Photo-swap epic: a species `--limit <n>` caps how many keep=0 species are
+  // sourced per run (so an operator can source the N worst before scoring),
+  // honoring the existing worst-first order (quality_score ASC, species_code ASC).
+  // No limit (the default) = ALL keep=0 species (backward-compatible).
+  it('species --limit sources only the N WORST-scored keep=0 species (quality_score ASC), leaving the rest untouched', async () => {
+    // Three flagged (keep=0) species with distinct quality scores. Worst → best:
+    // worst(10) < mid(40) < best(70). A fourth species is kept (keep=1) — never
+    // a candidate for sourcing regardless of limit.
+    seedCurrent('worst', 'https://photos.example/worst.jpg'); seedScore('worst', { overall: 10, keep: false, qualityScore: 10 });
+    seedCurrent('mid', 'https://photos.example/mid.jpg'); seedScore('mid', { overall: 40, keep: false, qualityScore: 40 });
+    seedCurrent('best', 'https://photos.example/best.jpg'); seedScore('best', { overall: 70, keep: false, qualityScore: 70 });
+    seedCurrent('kept', 'https://photos.example/kept.jpg'); seedScore('kept', { overall: 20, keep: true, qualityScore: 25 });
+
+    const fetchInatCandidates = vi.fn(async (sci: string) => {
+      const id = sci.includes('worst') ? 1 : sci.includes('mid') ? 2 : 3;
+      return [{ inatId: id, photoUrl: `https://inat.example/${id}.jpg`, attribution: '(c) P (CC BY)', license: 'cc-by' }];
+    });
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    // limit 2 → only the two worst keep=0 species (worst=10, mid=40) are sourced.
+    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() }, { limit: 2 });
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(2);
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ speciesCode: string }>;
+    expect([...new Set(manifest.map(m => m.speciesCode))].sort()).toEqual(['mid', 'worst']);
+    // The best-scored keep=0 species (just outside the limit) got NO candidates.
+    expect(listCandidates(db, 'best')).toHaveLength(0);
+    // The kept species is never sourced.
+    expect(listCandidates(db, 'kept')).toHaveLength(0);
+  });
+
+  it('no species limit (default) sources ALL keep=0 species — backward-compatible', async () => {
+    seedCurrent('a', 'https://photos.example/a.jpg'); seedScore('a', { overall: 10, keep: false, qualityScore: 10 });
+    seedCurrent('b', 'https://photos.example/b.jpg'); seedScore('b', { overall: 40, keep: false, qualityScore: 40 });
+    seedCurrent('c', 'https://photos.example/c.jpg'); seedScore('c', { overall: 70, keep: false, qualityScore: 70 });
+
+    const fetchInatCandidates = vi.fn(async (sci: string) => {
+      const id = sci.includes('a') ? 1 : sci.includes('b') ? 2 : 3;
+      return [{ inatId: id, photoUrl: `https://inat.example/${id}.jpg`, attribution: '(c) P (CC BY)', license: 'cc-by' }];
+    });
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    // No opts → every keep=0 species sourced (3 fetches).
+    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(3);
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ speciesCode: string }>;
+    expect([...new Set(manifest.map(m => m.speciesCode))].sort()).toEqual(['a', 'b', 'c']);
+  });
 });
 
 describe('sourceCommit (Node, testable — Bug 1 source-candidates split)', () => {

--- a/tools/photo-curation/src/score-orchestration.ts
+++ b/tools/photo-curation/src/score-orchestration.ts
@@ -384,8 +384,20 @@ interface FlaggedRow {
  *     so tests assert spacing deterministically without a real wait.
  *   • The batch logs how many external calls (iNat fetches + downloads) it made.
  */
+/** Optional caps for a source-prepare run. */
+export interface SourcePrepareOpts {
+  /**
+   * Cap on how many keep=0 species to source this run. Undefined (the default)
+   * sources ALL keep=0 species (backward-compatible). When set, applies
+   * `LIMIT <limit>` to the worst-first (quality_score ASC) flagged query, so the
+   * operator sources the N worst-scored needs-replacement species per run.
+   */
+  limit?: number;
+}
+
 export async function sourcePrepare(
   db: Database.Database, pool: number, deps: SourcePrepareDeps,
+  opts: SourcePrepareOpts = {},
 ): Promise<SourcePrepareResult> {
   const fetchInat = deps.fetchInatCandidates ?? realFetchInatCandidates;
   await mkdir(deps.thumbDir, { recursive: true });
@@ -400,13 +412,23 @@ export async function sourcePrepare(
   // server's `needs-swap` filter (queries.ts). `overall` is advisory-only now, so
   // order by the judge's own quality estimate (worst first); gate-rejected #994
   // rows carry quality_score = 0 and so sort first.
+  // An optional species `--limit` caps how many keep=0 species are sourced this
+  // run (worst-first). A positive integer applies `LIMIT ?`; anything else (the
+  // default) sources ALL keep=0 species. Clamp to a non-negative integer so a
+  // stray 0/negative/NaN never produces a malformed LIMIT.
+  const rawLimit = opts.limit;
+  const speciesLimit =
+    typeof rawLimit === 'number' && Number.isFinite(rawLimit) && rawLimit >= 1
+      ? Math.floor(rawLimit)
+      : null;
   const flagged = db.prepare(
     `SELECT c.species_code, c.com_name, c.sci_name, c.family
        FROM photo_score s
        JOIN photo_current c ON c.species_code = s.species_code
       WHERE s.role = 'current' AND s.keep = 0
-      ORDER BY s.quality_score ASC, c.species_code ASC`,
-  ).all() as FlaggedRow[];
+      ORDER BY s.quality_score ASC, c.species_code ASC
+      ${speciesLimit !== null ? 'LIMIT ?' : ''}`,
+  ).all(...(speciesLimit !== null ? [speciesLimit] : [])) as FlaggedRow[];
 
   const manifest: SourceManifestEntry[] = [];
   let inatFetches = 0;

--- a/tools/photo-curation/src/server/index.test.ts
+++ b/tools/photo-curation/src/server/index.test.ts
@@ -144,4 +144,54 @@ describe('review-server API', () => {
     const res = await request(app).post('/api/decision').send({ speciesCode: 'houspa', action: 'bogus' });
     expect(res.status).toBe(400);
   });
+
+  it('GET /api/pending-swaps returns the swap selection (outscores gate)', async () => {
+    // Flag houspa's current as needs-replacement (keep=0, low quality) and give
+    // its two candidates quality scores so the gate has something to compare.
+    db.prepare(`UPDATE photo_score SET keep=0, quality_score=20 WHERE species_code='houspa' AND role='current'`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=82, field_marks='["wing bars"]' WHERE candidate_inat_id=5001`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=64 WHERE candidate_inat_id=5002`).run();
+
+    const app = createServer(db);
+    const res = await request(app).get('/api/pending-swaps');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.proposedCount).toBe(1);
+    const s = res.body.swaps[0];
+    expect(s.speciesCode).toBe('houspa');
+    expect(s.current.qualityScore).toBe(20);
+    // best candidate (82) outscores current (20) → proposed.
+    expect(s.proposed.inatId).toBe(5001);
+    expect(s.outscores).toBe(true);
+    expect(s.delta).toBe(62);
+    expect(s.candidates.find((c: { inatId: number }) => c.inatId === 5001).selected).toBe(true);
+  });
+
+  it('GET /api/pending-swaps reports proposed:null when no candidate outscores the current', async () => {
+    // current quality 90; candidates 82/64 — neither outscores → proposed:null.
+    db.prepare(`UPDATE photo_score SET keep=0, quality_score=90 WHERE species_code='houspa' AND role='current'`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=82 WHERE candidate_inat_id=5001`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=64 WHERE candidate_inat_id=5002`).run();
+
+    const app = createServer(db);
+    const res = await request(app).get('/api/pending-swaps');
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);          // still listed (has candidates)
+    expect(res.body.proposedCount).toBe(0);  // but nothing proposed
+    expect(res.body.swaps[0].proposed).toBeNull();
+    expect(res.body.swaps[0].outscores).toBe(false);
+  });
+
+  it('GET /api/pending-swaps honors ?limit and rejects a bad limit with 400', async () => {
+    db.prepare(`UPDATE photo_score SET keep=0, quality_score=20 WHERE species_code='houspa' AND role='current'`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=82 WHERE candidate_inat_id=5001`).run();
+    const app = createServer(db);
+
+    const ok = await request(app).get('/api/pending-swaps?limit=0');
+    expect(ok.status).toBe(200);
+    expect(ok.body.total).toBe(0); // capped to zero species
+
+    const bad = await request(app).get('/api/pending-swaps?limit=-1');
+    expect(bad.status).toBe(400);
+  });
 });

--- a/tools/photo-curation/src/server/index.ts
+++ b/tools/photo-curation/src/server/index.ts
@@ -6,6 +6,7 @@ import {
   listOverview, getSwapView, writeDecision, denyAndAdvance,
   type SortMode, type FilterMode,
 } from './queries.js';
+import { selectSwaps } from '../swaps.js';
 
 // NOTE: the Express server is plain Node — it CANNOT dispatch a Claude Code
 // agent, so it never scores a photo. All scoring lives in the `source-candidates`
@@ -31,6 +32,12 @@ export function createServer(db: Database.Database): Express {
   app.get('/swap/:code', (_req: Request, res: Response) => {
     res.sendFile('swap.html', { root: publicDir });
   });
+  // The pending-swaps readout: a READ-ONLY pre-commit glance at what apply-swaps
+  // would do (current vs proposed per keep=0 species). Served verbatim; the data
+  // comes from GET /api/pending-swaps below.
+  app.get('/pending-swaps', (_req: Request, res: Response) => {
+    res.sendFile('pending-swaps.html', { root: publicDir });
+  });
 
   // ── JSON API ──
   app.get('/api/overview', (req: Request, res: Response) => {
@@ -41,6 +48,24 @@ export function createServer(db: Database.Database): Express {
     const rows = listOverview(db, { sort, filter });
     const staged = db.prepare(`SELECT COUNT(*) AS c FROM photo_decision WHERE action='approve' AND applied=0`).get() as { c: number };
     return res.json({ rows, stagedApproved: staged.c, sort, filter });
+  });
+
+  // READ-ONLY swap readout (the "outscores the original" gate). Returns, per
+  // keep=0 species WITH scored candidates, the current photo + score, the ranked
+  // candidates (each marked selected/rejected), and the proposed replacement
+  // (null = no improvement found). Optional ?limit=N caps how many species are
+  // returned, worst-current-first. This NEVER mutates — apply-swaps is separate.
+  app.get('/api/pending-swaps', (req: Request, res: Response) => {
+    const rawLimit = req.query.limit;
+    let limit: number | undefined;
+    if (typeof rawLimit === 'string' && rawLimit !== '') {
+      const n = Number(rawLimit);
+      if (!Number.isFinite(n) || n < 0) return res.status(400).json({ error: `bad limit: ${rawLimit}` });
+      limit = n;
+    }
+    const swaps = selectSwaps(db, limit !== undefined ? { limit } : {});
+    const proposedCount = swaps.filter(s => s.proposed !== null).length;
+    return res.json({ swaps, total: swaps.length, proposedCount });
   });
 
   app.get('/api/swap/:code', (req: Request, res: Response) => {

--- a/tools/photo-curation/src/swaps.test.ts
+++ b/tools/photo-curation/src/swaps.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDb } from './db.js';
+import { upsertCurrentPhoto, upsertScore, insertCandidate } from './store.js';
+import { selectSwaps } from './swaps.js';
+import type { QualityReport } from '@bird-watch/photo-quality';
+
+let db: Database.Database;
+beforeEach(() => { db = openDb(':memory:'); });
+afterEach(() => db.close());
+
+function seedCurrent(code: string, comName: string): void {
+  upsertCurrentPhoto(db, {
+    speciesCode: code, comName, sciName: `Sci ${code}`, family: `Fam ${code}`,
+    url: `https://photos.bird-maps.com/${code}.jpg`,
+    attribution: `(c) Owner ${code}`, license: 'cc-by', contentHash: `cur-${code}`,
+  });
+}
+
+/** A current-photo score row. keep=0 = needs replacement. */
+function seedCurrentScore(code: string, s: { keep: boolean; qualityScore: number }): void {
+  const report: QualityReport = {
+    overall: s.qualityScore, verdict: s.keep ? 'good' : 'reject',
+    deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+    criteria: { framing: 5, subjectClarity: 5, liveness: 5, naturalness: 5, pose: 5, background: 5, lighting: 5 },
+    flags: [], fieldMarks: ['eye-ring'], keep: s.keep, qualityScore: s.qualityScore,
+    rationale: `current ${code} rationale`, rubricVersion: '0.2.0',
+  };
+  upsertScore(db, { speciesCode: code, role: 'current', candidateInatId: null, contentHash: `cur-${code}`, report });
+}
+
+/** A candidate photo + its scored row (role='candidate'). */
+function seedCandidate(
+  code: string, inatId: number,
+  s: { qualityScore: number; keep?: boolean; marks?: string[]; excluded?: boolean },
+): void {
+  insertCandidate(db, {
+    speciesCode: code, inatId, photoUrl: `https://inaturalist-open-data.s3.amazonaws.com/${inatId}.jpg`,
+    thumbPath: `thumb-cache/${code}-${inatId}.jpg`, attribution: `(c) iNat ${inatId}`,
+    license: 'cc-by', sourceRound: 1,
+  });
+  if (s.excluded) {
+    db.prepare(`UPDATE photo_candidate SET excluded=1 WHERE species_code=? AND inat_id=?`).run(code, inatId);
+  }
+  const report: QualityReport = {
+    overall: s.qualityScore, verdict: 'good',
+    deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+    criteria: { framing: 7, subjectClarity: 7, liveness: 7, naturalness: 7, pose: 7, background: 7, lighting: 7 },
+    flags: [], fieldMarks: s.marks ?? ['wing bars'], keep: s.keep ?? true, qualityScore: s.qualityScore,
+    rationale: `candidate ${inatId} rationale`, rubricVersion: '0.2.0',
+  };
+  upsertScore(db, { speciesCode: code, role: 'candidate', candidateInatId: inatId, contentHash: `cand-${code}-${inatId}`, report });
+}
+
+describe('selectSwaps', () => {
+  it('(a) the best candidate OUTSCORES the current → that candidate is proposed', () => {
+    seedCurrent('housfi', 'House Finch');
+    seedCurrentScore('housfi', { keep: false, qualityScore: 30 });
+    seedCandidate('housfi', 100, { qualityScore: 55 });
+    seedCandidate('housfi', 200, { qualityScore: 80 }); // best
+
+    const results = selectSwaps(db);
+    expect(results).toHaveLength(1);
+    const r = results[0]!;
+    expect(r.speciesCode).toBe('housfi');
+    expect(r.comName).toBe('House Finch');
+
+    // current carries its quality score + rationale + photo url.
+    expect(r.current.qualityScore).toBe(30);
+    expect(r.current.rationale).toBe('current housfi rationale');
+    expect(r.current.photoUrl).toBe('https://photos.bird-maps.com/housfi.jpg');
+
+    // best = the 80-scored candidate (200); proposed = best since 80 > 30.
+    expect(r.proposed).not.toBeNull();
+    expect(r.proposed!.inatId).toBe(200);
+    expect(r.proposed!.qualityScore).toBe(80);
+    expect(r.outscores).toBe(true);
+    expect(r.delta).toBe(50); // 80 - 30
+
+    // candidates: all candidates, each marked selected/rejected. 200 selected.
+    expect(r.candidates.map(c => c.inatId).sort((a, b) => a - b)).toEqual([100, 200]);
+    expect(r.candidates.find(c => c.inatId === 200)!.selected).toBe(true);
+    expect(r.candidates.find(c => c.inatId === 100)!.selected).toBe(false);
+    // candidate field marks + attribution surface for the readout.
+    expect(r.candidates.find(c => c.inatId === 200)!.fieldMarks).toEqual(['wing bars']);
+    expect(r.candidates.find(c => c.inatId === 200)!.attribution).toBe('(c) iNat 200');
+  });
+
+  it('(b) NO candidate outscores the current → proposed=null, outscores=false (keep original)', () => {
+    seedCurrent('amerob', 'American Robin');
+    seedCurrentScore('amerob', { keep: false, qualityScore: 60 });
+    seedCandidate('amerob', 300, { qualityScore: 50 });
+    seedCandidate('amerob', 400, { qualityScore: 55 }); // best candidate, still < 60
+
+    const r = selectSwaps(db)[0]!;
+    expect(r.proposed).toBeNull();
+    expect(r.outscores).toBe(false);
+    expect(r.delta).toBe(-5); // best(55) - current(60)
+    // No candidate is selected when none outscores.
+    expect(r.candidates.every(c => !c.selected)).toBe(true);
+  });
+
+  it('(c) a TIE at the boundary (best == current) is NOT proposed (strict >)', () => {
+    seedCurrent('bewwre', "Bewick's Wren");
+    seedCurrentScore('bewwre', { keep: false, qualityScore: 70 });
+    seedCandidate('bewwre', 500, { qualityScore: 70 }); // exactly equal
+
+    const r = selectSwaps(db)[0]!;
+    expect(r.proposed).toBeNull();
+    expect(r.outscores).toBe(false);
+    expect(r.delta).toBe(0);
+    expect(r.candidates.every(c => !c.selected)).toBe(true);
+  });
+
+  it('(d) a keep=0 species with NO scored candidates is OMITTED', () => {
+    seedCurrent('withcand', 'With Cand');
+    seedCurrentScore('withcand', { keep: false, qualityScore: 20 });
+    seedCandidate('withcand', 600, { qualityScore: 75 });
+
+    // keep=0 but no candidates sourced/scored yet — omitted.
+    seedCurrent('nocand', 'No Cand');
+    seedCurrentScore('nocand', { keep: false, qualityScore: 20 });
+
+    const codes = selectSwaps(db).map(r => r.speciesCode);
+    expect(codes).toContain('withcand');
+    expect(codes).not.toContain('nocand');
+  });
+
+  it('excludes a kept (keep=1) species even if it has scored candidates', () => {
+    seedCurrent('keepme', 'Keep Me');
+    seedCurrentScore('keepme', { keep: true, qualityScore: 40 });
+    seedCandidate('keepme', 700, { qualityScore: 90 });
+
+    expect(selectSwaps(db).map(r => r.speciesCode)).not.toContain('keepme');
+  });
+
+  it('ignores EXCLUDED candidates when picking best/proposed', () => {
+    seedCurrent('exsp', 'Excluded Sp');
+    seedCurrentScore('exsp', { keep: false, qualityScore: 30 });
+    seedCandidate('exsp', 800, { qualityScore: 90, excluded: true }); // denied earlier
+    seedCandidate('exsp', 900, { qualityScore: 45 });
+
+    const r = selectSwaps(db)[0]!;
+    // 800 excluded → best is 900; proposed because 45 > 30.
+    expect(r.proposed!.inatId).toBe(900);
+    expect(r.candidates.map(c => c.inatId)).toEqual([900]);
+  });
+
+  it('tie-breaks equal-top candidates deterministically by lowest inat id', () => {
+    seedCurrent('tiesp', 'Tie Sp');
+    seedCurrentScore('tiesp', { keep: false, qualityScore: 30 });
+    seedCandidate('tiesp', 1200, { qualityScore: 80 });
+    seedCandidate('tiesp', 1100, { qualityScore: 80 }); // same score, lower id → wins
+
+    const r = selectSwaps(db)[0]!;
+    expect(r.proposed!.inatId).toBe(1100);
+  });
+
+  it('orders species worst-current-first (quality_score ASC) and honors an optional limit', () => {
+    seedCurrent('w', 'Worst'); seedCurrentScore('w', { keep: false, qualityScore: 10 }); seedCandidate('w', 1, { qualityScore: 60 });
+    seedCurrent('m', 'Mid'); seedCurrentScore('m', { keep: false, qualityScore: 40 }); seedCandidate('m', 2, { qualityScore: 60 });
+    seedCurrent('b', 'Best'); seedCurrentScore('b', { keep: false, qualityScore: 70 }); seedCandidate('b', 3, { qualityScore: 90 });
+
+    const all = selectSwaps(db);
+    expect(all.map(r => r.speciesCode)).toEqual(['w', 'm', 'b']);
+
+    // limit=2 → only the two worst-current species, still worst-first.
+    const limited = selectSwaps(db, { limit: 2 });
+    expect(limited.map(r => r.speciesCode)).toEqual(['w', 'm']);
+  });
+});

--- a/tools/photo-curation/src/swaps.ts
+++ b/tools/photo-curation/src/swaps.ts
@@ -1,0 +1,198 @@
+import type Database from 'better-sqlite3';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Swap selection — the "outscores the original" gate (photo-swap epic).
+//
+// COMPUTED, not stored: this is a pure read over photo_current / photo_score /
+// photo_candidate. For every species the judge flagged for replacement
+// (role='current' keep = 0) that HAS at least one scored, non-excluded
+// candidate, it picks the best candidate and proposes it ONLY when it strictly
+// outscores the current photo's quality_score (a tie keeps the original).
+//
+// It is the data behind the read-only `/pending-swaps` readout: a pre-commit
+// glance at what `apply-swaps` WOULD do. It writes nothing and decides nothing —
+// the human approve/deny path (photo_decision) and `apply-swaps` are unchanged.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The species' live (current) photo + its judge score. */
+export interface SwapCurrent {
+  photoUrl: string;
+  attribution: string;
+  license: string;
+  /** The judge's 0–100 quality estimate — the number the gate compares against. */
+  qualityScore: number | null;
+  rationale: string | null;
+  fieldMarks: string[];
+}
+
+/** One scored candidate, marked selected (the proposed pick) or rejected. */
+export interface SwapCandidate {
+  candidateId: number;     // photo_candidate.id
+  inatId: number;
+  photoUrl: string;
+  thumbPath: string;
+  attribution: string;
+  license: string;
+  qualityScore: number | null;
+  rationale: string | null;
+  fieldMarks: string[];
+  /** true for the single proposed candidate; false for every rejected alternate. */
+  selected: boolean;
+}
+
+export interface SpeciesSwap {
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  current: SwapCurrent;
+  /** All scored, non-excluded candidates, best-first. Each marked selected/rejected. */
+  candidates: SwapCandidate[];
+  /**
+   * The best candidate IFF it strictly outscores the current photo's
+   * quality_score; otherwise null ("no improvement found — keep original").
+   */
+  proposed: SwapCandidate | null;
+  /** true iff a proposed replacement exists (best.qualityScore > current). */
+  outscores: boolean;
+  /** best.qualityScore − current.qualityScore (can be ≤ 0 when no improvement). */
+  delta: number;
+}
+
+export interface SelectSwapsOpts {
+  /**
+   * Cap how many species are returned, worst-current-first (quality_score ASC).
+   * Undefined = all. Applied AFTER the has-scored-candidates filter, so the cap
+   * counts only species that actually have a candidate pool.
+   */
+  limit?: number;
+}
+
+interface FlaggedCurrentRow {
+  species_code: string;
+  com_name: string | null;
+  sci_name: string | null;
+  family: string | null;
+  url: string | null;
+  attribution: string | null;
+  license: string | null;
+  quality_score: number | null;
+  rationale: string | null;
+  field_marks: string | null;
+}
+
+interface CandidateScoreRow {
+  candidate_id: number;
+  inat_id: number;
+  photo_url: string | null;
+  thumb_path: string | null;
+  attribution: string | null;
+  license: string | null;
+  quality_score: number | null;
+  rationale: string | null;
+  field_marks: string | null;
+}
+
+function parseMarks(s: string | null): string[] {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s) as unknown;
+    return Array.isArray(v) ? (v as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Compute the per-species swap selection for every keep=0 species that has at
+ * least one scored, non-excluded candidate. Pure read — writes nothing.
+ *
+ * The "outscores the original" rule: the best candidate (highest quality_score,
+ * tie-broken by lowest inat id) is proposed ONLY when its quality_score is
+ * strictly greater than the current photo's quality_score. A tie at the boundary
+ * (best == current) is NOT proposed — the original is kept. Species with no
+ * scored candidates are omitted.
+ */
+export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): SpeciesSwap[] {
+  // keep=0 current rows, worst-current-first. The advisory `overall` is not the
+  // gate; we order + compare on the judge's own quality_score (NULL last).
+  const flagged = db.prepare(`
+    SELECT pc.species_code, pc.com_name, pc.sci_name, pc.family,
+           pc.url, pc.attribution, pc.license,
+           ps.quality_score, ps.rationale, ps.field_marks
+      FROM photo_current pc
+      JOIN photo_score ps
+        ON ps.species_code = pc.species_code AND ps.role = 'current'
+     WHERE ps.keep = 0
+     ORDER BY ps.quality_score ASC, pc.species_code ASC
+  `).all() as FlaggedCurrentRow[];
+
+  const candStmt = db.prepare(`
+    SELECT cand.id AS candidate_id, cand.inat_id, cand.photo_url, cand.thumb_path,
+           cand.attribution, cand.license,
+           cs.quality_score, cs.rationale, cs.field_marks
+      FROM photo_candidate cand
+      JOIN photo_score cs
+        ON cs.species_code = cand.species_code
+       AND cs.role = 'candidate'
+       AND cs.candidate_inat_id = cand.inat_id
+     WHERE cand.species_code = ? AND cand.excluded = 0
+     ORDER BY cs.quality_score DESC, cand.inat_id ASC
+  `);
+
+  const out: SpeciesSwap[] = [];
+  for (const sp of flagged) {
+    const candRows = candStmt.all(sp.species_code) as CandidateScoreRow[];
+    if (candRows.length === 0) continue; // omit: no scored candidates to choose from
+
+    // candRows is already best-first (quality_score DESC, inat_id ASC), so the
+    // first row is the best candidate with the deterministic tie-break baked in.
+    const currentScore = sp.quality_score ?? 0;
+    const bestRow = candRows[0]!;
+    const bestScore = bestRow.quality_score ?? 0;
+    const outscores = bestScore > currentScore;
+    const proposedInatId = outscores ? bestRow.inat_id : null;
+
+    const candidates: SwapCandidate[] = candRows.map(c => ({
+      candidateId: c.candidate_id,
+      inatId: c.inat_id,
+      photoUrl: c.photo_url ?? '',
+      thumbPath: c.thumb_path ?? '',
+      attribution: c.attribution ?? '',
+      license: c.license ?? '',
+      qualityScore: c.quality_score,
+      rationale: c.rationale,
+      fieldMarks: parseMarks(c.field_marks),
+      selected: c.inat_id === proposedInatId,
+    }));
+
+    const proposed = proposedInatId === null
+      ? null
+      : candidates.find(c => c.inatId === proposedInatId) ?? null;
+
+    out.push({
+      speciesCode: sp.species_code,
+      comName: sp.com_name ?? '',
+      sciName: sp.sci_name ?? '',
+      family: sp.family ?? '',
+      current: {
+        photoUrl: sp.url ?? '',
+        attribution: sp.attribution ?? '',
+        license: sp.license ?? '',
+        qualityScore: sp.quality_score,
+        rationale: sp.rationale,
+        fieldMarks: parseMarks(sp.field_marks),
+      },
+      candidates,
+      proposed,
+      outscores,
+      delta: bestScore - currentScore,
+    });
+  }
+
+  const limit = opts.limit;
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit >= 0) {
+    return out.slice(0, Math.floor(limit));
+  }
+  return out;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph operator["operator flow"]
      A["source-prepare --limit N --pool 5<br/>(N worst keep=0 species, worst-first)"] --> B["score candidates<br/>(agents → source-commit)"]
      B --> C["source-commit<br/>role=candidate scores"]
      C --> D["review /pending-swaps<br/>(READ-ONLY readout)"]
      D --> E["apply-swaps<br/>(y/N-gated commit — unchanged)"]
    end
    D -. "GET /api/pending-swaps" .-> S["selectSwaps(db)"]
    S --> G{"best.qualityScore<br/>&gt; current?"}
    G -- "yes" --> P["proposed = best candidate"]
    G -- "no / tie" --> K["proposed = null<br/>(keep original)"]
```

## Summary

- **Why:** the curation tool sources + scores iNat candidates for `keep=0` species but had no pre-commit view of *which* candidate would replace each photo (or what was rejected and why), and no way to cap a sourcing run to the N worst species. This adds the missing "outscores the original" selection and a read-only readout so an operator can eyeball every proposed swap before `apply-swaps` commits.
- **`selectSwaps(db)`** (new `src/swaps.ts`, pure/COMPUTED — no schema change): per `keep=0` species *with* scored candidates, picks `best` (highest `quality_score`, lowest-`inat_id` tie-break) and proposes it **only when `best.quality_score > current.quality_score`** (a tie keeps the original). Returns `{ current, candidates (each selected/rejected), proposed|null, outscores, delta }`. Species with no scored candidates are omitted.
- **`source-prepare --limit N`** caps how many `keep=0` species are sourced per run, worst-first (`LIMIT` on the existing `quality_score ASC` query); no limit = all species (backward-compatible). **`GET /api/pending-swaps`** (+ `?limit=N`) + the read-only **`public/pending-swaps.html`** page render current→proposed (or "No improvement found — keeping original"), the score delta, and rejected candidate thumbnails. `esc()`/`safeImg()` for all interpolated text/URLs; linked from the overview nav. The page does NOT apply swaps — `apply-swaps` stays the separate y/N-gated commit.

## Screenshots

N/A — not `frontend/**` UI (local curation review server under `tools/photo-curation`).

## Test plan

- [x] `npx tsc --noEmit -p tools/photo-curation/tsconfig.json` — clean
- [x] `npm run test --workspace @bird-watch/photo-curation` — 169 passed (15 files)
- [x] New unit tests: `selectSwaps` outscores gate (`swaps.test.ts` — cases a/b/c/d: best-outscores → proposed, none-outscores → null, boundary tie `==` not proposed, no-candidates omitted, plus excluded-candidate / tie-break / worst-first-limit), the `source-prepare --limit` query path (`score-orchestration.test.ts`), and the `/api/pending-swaps` route incl. `?limit` + bad-limit 400 (`server/index.test.ts`)
- [x] `npm run build` — clean
- [x] `npx knip` — exit 0 (added `public/pending-swaps.js` to the `tools/photo-curation` ignore list with a dated re-audit comment, mirroring `overview.js`/`swap.js`)
- [x] Local smoke: served the page against a seeded sqlite, drove it via Playwright MCP — cards render current→proposed + rejected thumbnails + Δ; only console message is a benign `/favicon.ico` 404 shared by all three tool pages (not introduced here). No `package-lock.json` drift.

## Plan reference

Out of plan — incremental enhancement to the photo-quality curation tool (epic #974). `tools/`-only (CLI + local Express review server); not the production `frontend/**`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)