### PR TITLE
feat(photo-curation): swap gates (same-picture + Δ≥20) + dedup + click-to-pick candidate override

### DIFF
--- a/tools/photo-curation/public/app.css
+++ b/tools/photo-curation/public/app.css
@@ -64,6 +64,13 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .alt.selected { border-color: var(--status-good); }
 .alt img { width: 96px; height: 72px; object-fit: cover; display: block; }
 .alt .alt-score { font-size: var(--type-xs); text-align: center; padding: 2px; }
+/* pending-swaps renders each candidate as a clickable <button class="alt"> for
+   the click-to-pick override; strip the UA button chrome + restore pointer
+   (the read-only `.rejected .alt` below forces cursor:default on swap.js divs). */
+button.alt { font: inherit; color: inherit; padding: 0; text-align: inherit; -webkit-appearance: none; appearance: none; }
+.rejected button.alt { cursor: pointer; width: 96px; }
+.rejected button.alt img { width: 96px; height: 72px; }
+.rejected button.alt.selected { border-color: var(--status-good); }
 .action-bar { display: flex; gap: 12px; margin-top: 20px; flex-wrap: wrap; align-items: center; }
 .btn { font: inherit; padding: 10px 18px; border-radius: var(--radius-lg); border: 1px solid var(--border); cursor: pointer; background: var(--surface); color: var(--text); }
 .btn.approve { background: var(--status-great); color: #fff; border-color: var(--status-great); }

--- a/tools/photo-curation/public/pending-swaps.html
+++ b/tools/photo-curation/public/pending-swaps.html
@@ -14,9 +14,12 @@
     <span class="staged-indicator" id="summary">…</span>
   </header>
   <p class="readout-note">
-    Read-only pre-commit readout: for each needs-replacement species, the best
-    sourced candidate is proposed only when it <em>outscores</em> the current
-    photo. Nothing here is applied — run <code>apply-swaps</code> to commit.
+    For each needs-replacement species the best non-duplicate candidate is
+    auto-proposed only when it beats the current photo by <em>Δ ≥ 20</em>
+    (same-picture iNat re-serves are filtered out). <strong>Click any candidate
+    thumbnail</strong> to override the pick — it persists; use <em>Use auto
+    pick</em> to revert or <em>No swap</em> to keep the original. Nothing is
+    applied here — run <code>apply-swaps</code> to commit the selected picks.
   </p>
   <main class="swap-list" id="list"></main>
   <script type="module" src="/pending-swaps.js"></script>

--- a/tools/photo-curation/public/pending-swaps.js
+++ b/tools/photo-curation/public/pending-swaps.js
@@ -4,12 +4,15 @@ import { esc, safeImg } from './safe.js';
 initTheme();
 document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
 
-// READ-ONLY readout of selectSwaps(): per keep=0 species with scored candidates,
-// the current photo + score on the left, the proposed replacement (or a "no
-// improvement" state) on the right, the score delta, and the rejected candidate
-// thumbnails below. All interpolated species/attribution text + image URLs go
-// through esc()/safeImg() (untrusted eBird taxonomy + iNat user content) — this
-// page never injects raw HTML.
+// Interactive swap-review v2 readout of selectSwaps(): per keep=0 species with
+// scored NON-DUPLICATE candidates, the current photo at card size (left) and the
+// SELECTED candidate at card size (right), with the remaining candidates as
+// smaller thumbnails. Click any thumbnail to PROMOTE it to the card image and
+// make it the pick (the previous pick returns to a thumbnail); the override is
+// POSTed to /api/select-swap and persists. "Use auto pick" reverts to the Δ≥20
+// gate; "No swap" deselects (explicit). All interpolated species/attribution
+// text + image URLs go through esc()/safeImg() (untrusted eBird taxonomy + iNat
+// user content) — this page never injects raw HTML.
 
 function scoreClass(score) {
   if (score === null || score === undefined) return 'bad';
@@ -28,10 +31,15 @@ function marksHtml(marks) {
 }
 
 function deltaHtml(s) {
-  // delta = best candidate quality − current quality. Positive = improvement.
+  // delta = best NON-duplicate candidate quality − current quality.
   const sign = s.delta > 0 ? '+' : '';
   const cls = s.outscores ? 'great' : 'bad';
   return `<span class="delta-badge ${cls}">Δ ${sign}${esc(s.delta)}</span>`;
+}
+
+/** The species' current selected candidate (its inat id), or null for "no swap". */
+function selectedInatId(s) {
+  return s.proposed ? s.proposed.inatId : null;
 }
 
 function currentPane(s) {
@@ -47,22 +55,26 @@ function currentPane(s) {
     </div>`;
 }
 
+/** The right (selected-candidate) pane. Reflects the current pick, auto or operator. */
 function proposedPane(s) {
+  const pickLabel = s.operatorChosen ? 'Operator pick' : 'Auto pick (Δ≥20)';
   if (!s.proposed) {
+    const reason = s.operatorChosen
+      ? 'Operator chose <strong>no swap</strong> for this species.'
+      : `No improvement clears Δ≥20 — best candidate scored ${esc((s.current.qualityScore ?? 0) + s.delta)}, current ${esc(s.current.qualityScore ?? '—')}.`;
     return `
       <div class="pane no-improvement">
-        <div class="pane-label">Proposed replacement</div>
+        <div class="pane-label">Selected · ${esc(pickLabel)}</div>
         <div class="pane-body">
-          <p class="empty">No improvement found — keeping original.</p>
-          <p class="rationale-dim">Best candidate scored ${esc((s.current.qualityScore ?? 0) + s.delta)}, not above the current ${esc(s.current.qualityScore ?? '—')}.</p>
+          <p class="empty">${reason}</p>
         </div>
       </div>`;
   }
   const p = s.proposed;
   return `
     <div class="pane proposed">
-      <div class="pane-label">Proposed replacement · ${scoreBadge(p.qualityScore)}</div>
-      <img class="pane-photo" src="${safeImg(p.photoUrl)}" alt="proposed replacement" loading="lazy" />
+      <div class="pane-label">Selected · ${esc(pickLabel)} · ${scoreBadge(p.qualityScore)}</div>
+      <img class="pane-photo" src="${safeImg(p.photoUrl)}" alt="selected replacement" loading="lazy" />
       <div class="pane-body">
         ${marksHtml(p.fieldMarks)}
         <p class="rationale">${esc(p.rationale ?? '')}</p>
@@ -71,26 +83,45 @@ function proposedPane(s) {
     </div>`;
 }
 
-function rejectedHtml(s) {
-  // Every non-selected candidate (the alternates the gate did not pick).
-  const rejected = s.candidates.filter(c => !c.selected);
-  if (rejected.length === 0) return '';
-  const items = rejected.map(c => `
-    <div class="alt" title="${esc(c.rationale ?? '')}">
-      <img src="${safeImg(c.photoUrl)}" alt="rejected candidate ${esc(c.inatId)}" loading="lazy" />
+/** The candidate thumbnail strip — every non-duplicate candidate, the pick highlighted. */
+function candidatesStripHtml(s) {
+  if (s.candidates.length === 0) return '';
+  const sel = selectedInatId(s);
+  const items = s.candidates.map(c => `
+    <button type="button" class="alt ${c.inatId === sel ? 'selected' : ''}"
+      data-code="${esc(s.speciesCode)}" data-inat="${esc(c.inatId)}"
+      title="${esc(c.rationale ?? '')}" aria-pressed="${c.inatId === sel ? 'true' : 'false'}">
+      <img src="${safeImg(c.photoUrl)}" alt="candidate ${esc(c.inatId)}" loading="lazy" />
       <div class="alt-score">${esc(c.qualityScore ?? '—')}</div>
-    </div>`).join('');
+    </button>`).join('');
   return `
     <div class="rejected">
-      <div class="rejected-label">Other candidates (not selected)</div>
+      <div class="rejected-label">Candidates — click to pick</div>
       <div class="alternates">${items}</div>
+    </div>`;
+}
+
+/** The per-species control row: revert to auto, or choose "no swap". */
+function controlsHtml(s) {
+  return `
+    <div class="action-bar">
+      <button type="button" class="btn keep" data-code="${esc(s.speciesCode)}" data-action="auto"
+        ${s.operatorChosen ? '' : 'disabled'}>Use auto pick</button>
+      <button type="button" class="btn deny" data-code="${esc(s.speciesCode)}" data-action="no-swap"
+        ${s.operatorChosen && !s.proposed ? 'disabled' : ''}>No swap</button>
     </div>`;
 }
 
 function speciesCard(s) {
   const el = document.createElement('article');
-  el.className = 'swap-card' + (s.outscores ? ' has-swap' : ' no-swap');
-  el.innerHTML = `
+  el.className = 'swap-card' + (s.proposed ? ' has-swap' : ' no-swap');
+  el.dataset.code = s.speciesCode;
+  el.innerHTML = cardInnerHtml(s);
+  return el;
+}
+
+function cardInnerHtml(s) {
+  return `
     <div class="swap-head">
       <span class="com">${esc(s.comName)}</span>
       <span class="sci">${esc(s.sciName)}</span>
@@ -101,22 +132,105 @@ function speciesCard(s) {
       <div class="swap-arrow" aria-hidden="true">→</div>
       ${proposedPane(s)}
     </div>
-    ${rejectedHtml(s)}`;
-  return el;
+    ${candidatesStripHtml(s)}
+    ${controlsHtml(s)}`;
 }
+
+function toast(msg) {
+  const t = document.createElement('div');
+  t.className = 'toast';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), 2200);
+}
+
+// Keep the loaded swaps in memory keyed by code so a click re-renders one card
+// from the server's authoritative re-read (which re-applies the override + gates).
+let byCode = new Map();
+
+async function persistAndRefreshCard(code, inatId) {
+  await fetch('/api/select-swap', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ speciesCode: code, inatId }),
+  });
+  // Re-read the single species so the card reflects the server's gate+override
+  // resolution (a stale override id silently falls back to "no swap" server-side).
+  const data = await fetch('/api/pending-swaps').then(r => r.json());
+  const fresh = data.swaps.find(x => x.speciesCode === code);
+  const card = document.querySelector(`.swap-card[data-code="${cssEscape(code)}"]`);
+  if (fresh && card) {
+    byCode.set(code, fresh);
+    card.className = 'swap-card' + (fresh.proposed ? ' has-swap' : ' no-swap');
+    card.innerHTML = cardInnerHtml(fresh);
+  }
+  updateSummary(data);
+}
+
+// Minimal CSS.escape fallback for the species-code attribute selector (codes are
+// lowercase ASCII like "norcar", but be defensive against a stray non-ident char).
+function cssEscape(s) {
+  return (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+function updateSummary(data) {
+  document.getElementById('summary').textContent =
+    `${data.proposedCount} of ${data.total} have a proposed swap`;
+}
+
+// One delegated listener on the list handles every card's thumbnails + controls.
+document.getElementById('list').addEventListener('click', (ev) => {
+  const alt = ev.target.closest('.alt');
+  if (alt) {
+    const code = alt.dataset.code;
+    const inatId = Number(alt.dataset.inat);
+    const current = byCode.get(code);
+    // Clicking the already-selected pick is a no-op (keeps it selected).
+    if (current && selectedInatId(current) === inatId) return;
+    persistAndRefreshCard(code, inatId).then(() => toast('Pick saved'));
+    return;
+  }
+  const btn = ev.target.closest('.btn[data-action]');
+  if (btn) {
+    const code = btn.dataset.code;
+    if (btn.dataset.action === 'no-swap') {
+      // Explicit "no swap" — POST inatId:null (the server records an override row).
+      persistAndRefreshCard(code, null).then(() => toast('Marked: no swap'));
+    } else if (btn.dataset.action === 'auto') {
+      // Revert to the auto gate: DELETE the override row (distinct from a "no
+      // swap" override). Then re-read + re-render the card.
+      fetch(`/api/select-swap/${encodeURIComponent(code)}`, { method: 'DELETE' })
+        .then(async () => {
+          const data = await fetch('/api/pending-swaps').then(r => r.json());
+          const fresh = data.swaps.find(x => x.speciesCode === code);
+          const card = document.querySelector(`.swap-card[data-code="${cssEscape(code)}"]`);
+          if (fresh && card) {
+            byCode.set(code, fresh);
+            card.className = 'swap-card' + (fresh.proposed ? ' has-swap' : ' no-swap');
+            card.innerHTML = cardInnerHtml(fresh);
+          }
+          updateSummary(data);
+          toast('Reverted to auto pick');
+        });
+    }
+  }
+});
 
 async function load() {
   const res = await fetch('/api/pending-swaps');
   const data = await res.json();
   const list = document.getElementById('list');
   list.innerHTML = '';
-  document.getElementById('summary').textContent =
-    `${data.proposedCount} of ${data.total} have a proposed swap`;
+  byCode = new Map();
+  updateSummary(data);
   if (data.total === 0) {
-    list.innerHTML = '<p class="empty">No needs-replacement species with scored candidates. Run source-prepare + score the candidates first.</p>';
+    list.innerHTML = '<p class="empty">No needs-replacement species with non-duplicate scored candidates. Run source-prepare + score the candidates first.</p>';
     return;
   }
-  for (const s of data.swaps) list.appendChild(speciesCard(s));
+  for (const s of data.swaps) {
+    byCode.set(s.speciesCode, s);
+    list.appendChild(speciesCard(s));
+  }
 }
 
 load();

--- a/tools/photo-curation/src/apply-swaps.test.ts
+++ b/tools/photo-curation/src/apply-swaps.test.ts
@@ -226,6 +226,74 @@ describe('runApplySwaps', () => {
   });
 });
 
+import { selectAppliableSwaps } from './apply-swaps.js';
+import { openDb } from './db.js';
+import { upsertCurrentPhoto, upsertScore, insertCandidate, setSwapSelection } from './store.js';
+import type { QualityReport } from '@bird-watch/photo-quality';
+
+/**
+ * swap-review v2 §3: the operator-override-aware apply source. selectAppliableSwaps
+ * derives the appliable swaps from selectSwaps (whose `proposed` already reflects
+ * the swap_selection override), so apply-swaps and the pending-swaps page never
+ * diverge. This is the bridge until the photo_decision approve path is unified
+ * with the override path (follow-up noted in apply-swaps.ts).
+ */
+describe('selectAppliableSwaps (operator override → apply target)', () => {
+  function seedCur(db: ReturnType<typeof openDb>, code: string, hash: string, qs: number): void {
+    upsertCurrentPhoto(db, {
+      speciesCode: code, comName: `Com ${code}`, sciName: `Sci ${code}`, family: `Fam ${code}`,
+      url: `https://photos.bird-maps.com/${code}.jpg`, attribution: `(c) live ${code}`,
+      license: 'cc-by', contentHash: hash,
+    });
+    const report: QualityReport = {
+      overall: qs, verdict: 'reject',
+      deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+      criteria: { framing: 5, subjectClarity: 5, liveness: 5, naturalness: 5, pose: 5, background: 5, lighting: 5 },
+      flags: [], fieldMarks: [], keep: false, qualityScore: qs, rationale: 'flagged', rubricVersion: '0.2.0',
+    };
+    upsertScore(db, { speciesCode: code, role: 'current', candidateInatId: null, contentHash: hash, report });
+  }
+  function seedCand(db: ReturnType<typeof openDb>, code: string, inatId: number, qs: number): void {
+    insertCandidate(db, {
+      speciesCode: code, inatId, photoUrl: `https://inat.example/${inatId}.jpg`,
+      thumbPath: `t/${inatId}.jpg`, attribution: `(c) cand ${inatId}`, license: 'cc-by', sourceRound: 1,
+    });
+    const report: QualityReport = {
+      overall: qs, verdict: 'good',
+      deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+      criteria: { framing: 7, subjectClarity: 7, liveness: 7, naturalness: 7, pose: 7, background: 7, lighting: 7 },
+      flags: [], fieldMarks: [], keep: true, qualityScore: qs, rationale: `cand ${inatId}`, rubricVersion: '0.2.0',
+    };
+    upsertScore(db, { speciesCode: code, role: 'candidate', candidateInatId: inatId, contentHash: `c-${code}-${inatId}`, report });
+  }
+
+  it('targets the OVERRIDDEN candidate, not the auto-best, when an operator override is set', () => {
+    const db = openDb(':memory:');
+    seedCur(db, 'norcar', 'live-hash', 30);
+    seedCand(db, 'norcar', 8001, 90); // auto-best (Δ60)
+    seedCand(db, 'norcar', 8002, 60); // operator's pick (Δ30, still ≥20)
+
+    // No override → auto-best 8001 is the apply target.
+    const auto = selectAppliableSwaps(db);
+    expect(auto).toHaveLength(1);
+    expect(auto[0]!.speciesCode).toBe('norcar');
+    expect(auto[0]!.newUrl).toBe('https://inat.example/8001.jpg');
+
+    // Operator overrides to 8002 → apply target follows the override.
+    setSwapSelection(db, 'norcar', 8002);
+    const overridden = selectAppliableSwaps(db);
+    expect(overridden).toHaveLength(1);
+    expect(overridden[0]!.newUrl).toBe('https://inat.example/8002.jpg');
+    expect(overridden[0]!.attribution).toBe('(c) cand 8002');
+    expect(overridden[0]!.oldUrl).toBe('https://photos.bird-maps.com/norcar.jpg');
+
+    // Explicit "no swap" → species drops out of the apply set entirely.
+    setSwapSelection(db, 'norcar', null);
+    expect(selectAppliableSwaps(db)).toHaveLength(0);
+    db.close();
+  });
+});
+
 import { resolveAdminEnv } from './apply-swaps.js';
 
 describe('resolveAdminEnv', () => {

--- a/tools/photo-curation/src/apply-swaps.ts
+++ b/tools/photo-curation/src/apply-swaps.ts
@@ -1,4 +1,37 @@
 import type Database from 'better-sqlite3';
+import { selectSwaps } from './swaps.js';
+
+/**
+ * swap-review v2 §3 — the operator-override-aware apply source. Derives the
+ * appliable swaps from selectSwaps, whose `proposed` ALREADY reflects the
+ * swap_selection override (operator click-to-pick wins over the auto Δ≥20 gate;
+ * an explicit "no swap" yields proposed=null). Returns one PendingSwap per
+ * species with a non-null proposal, so apply-swaps and the pending-swaps page
+ * read the SAME selection and can never diverge.
+ *
+ * Follow-up (#974): the legacy `runApplySwaps` path below still reads the
+ * human approve/deny `photo_decision` rows, which is a SEPARATE selection
+ * mechanism from the auto-gate + override flow. This function is the bridge —
+ * the CLI/runner can apply from EITHER source. Unifying the two (folding the
+ * approve decision into swap_selection, or vice versa) is a deliberate
+ * follow-up, not done here, to keep the confirm-gated approve workflow's
+ * behaviour unchanged for this PR.
+ */
+export function selectAppliableSwaps(db: Database.Database): PendingSwap[] {
+  return selectSwaps(db)
+    .filter(s => s.proposed !== null)
+    .map(s => {
+      const p = s.proposed!;
+      return {
+        speciesCode: s.speciesCode,
+        comName: s.comName,
+        oldUrl: s.current.photoUrl || '(none)',
+        newUrl: p.photoUrl,
+        attribution: p.attribution,
+        license: p.license,
+      };
+    });
+}
 
 /**
  * Staged apply (spec §5.6). Reads `photo_decision` rows where

--- a/tools/photo-curation/src/db.ts
+++ b/tools/photo-curation/src/db.ts
@@ -72,6 +72,17 @@ CREATE TABLE IF NOT EXISTS photo_decision (
   resource_requested  INTEGER NOT NULL DEFAULT 0
 );
 
+-- Operator override for the pending-swaps screen (swap-review v2). One row per
+-- species the curator has explicitly picked for. chosen_inat_id NULL is an
+-- EXPLICIT "no swap" (distinct from no row = "fall back to the auto gate"); a
+-- non-null id names the candidate the operator promoted over the auto pick.
+-- selectSwaps reads this; POST /api/select-swap upserts/clears it.
+CREATE TABLE IF NOT EXISTS swap_selection (
+  species_code   TEXT PRIMARY KEY,
+  chosen_inat_id INTEGER,            -- NULL = explicit "no swap"
+  decided_at     TEXT
+);
+
 -- One report per (subject, content_hash): re-scoring an unchanged image is a
 -- no-op the orchestrator can detect before calling the judge.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_photo_score_subject

--- a/tools/photo-curation/src/score-orchestration.test.ts
+++ b/tools/photo-curation/src/score-orchestration.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { openDb } from './db.js';
-import { upsertCurrentPhoto, upsertScore, getScoreByHash, selectUnreviewed, listCandidates } from './store.js';
+import { upsertCurrentPhoto, upsertScore, getScoreByHash, selectUnreviewed, listCandidates, updateCurrentPhotoHash } from './store.js';
+import { sha8 } from './hash.js';
 import {
   scorePrepare, scoreCommit, sourcePrepare, sourceCommit,
 } from './score-orchestration.js';
@@ -375,6 +376,38 @@ describe('sourcePrepare (Node, testable — Bug 1 source-candidates split)', () 
     expect(fetchInatCandidates).toHaveBeenCalledTimes(3);
     const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ speciesCode: string }>;
     expect([...new Set(manifest.map(m => m.speciesCode))].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  // Swap-review v2 §2: same-picture dedup at SOURCE time. bird-maps.com sourced
+  // its live photos from iNat, so iNat routinely returns the byte-identical image
+  // already live. Skipping it BEFORE insert/manifest means the (paid) Opus judge
+  // never scores a photo we already have — the ≈20% resource win.
+  it('SKIPS a candidate whose bytes hash to the current photo content_hash (not inserted, not in manifest); keeps distinct candidates', async () => {
+    seedCurrent('dedupe', 'https://photos.example/dedupe.jpg');
+    seedFlaggedScore('dedupe');
+
+    // The download stub hashes Buffer.from(url). Candidate 11's bytes are the
+    // SAME image as the current live photo, so stamp the current content_hash to
+    // its sha8 — source-prepare must skip 11 and keep 12 (a distinct image).
+    const dupUrl = 'https://inat.example/dup.jpg';
+    const freshUrl = 'https://inat.example/fresh.jpg';
+    updateCurrentPhotoHash(db, 'dedupe', sha8(Buffer.from(dupUrl)));
+
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: dupUrl, attribution: '(c) P (CC BY)', license: 'cc-by' },
+      { inatId: 12, photoUrl: freshUrl, attribution: '(c) Q (CC0)', license: 'cc0' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    const result = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
+
+    // 11 (byte-identical to live) is skipped; only 12 is sourced.
+    expect(result.skippedDuplicates).toBe(1);
+    expect(result.picked).toBe(1);
+    const manifest = JSON.parse(readFileSync(result.manifestPath, 'utf8')) as Array<{ inatId: number }>;
+    expect(manifest.map(m => m.inatId)).toEqual([12]);
+    // The dup was never inserted as a candidate row (no judge will ever see it).
+    expect(listCandidates(db, 'dedupe').map(c => c.inatId)).toEqual([12]);
   });
 });
 

--- a/tools/photo-curation/src/score-orchestration.ts
+++ b/tools/photo-curation/src/score-orchestration.ts
@@ -345,12 +345,21 @@ export interface SourcePrepareResult {
   inatFetches: number;
   /** External edge downloads actually performed (for the batch usage log). */
   downloads: number;
+  /**
+   * How many candidates were SKIPPED because their downloaded bytes hash to the
+   * species' CURRENT live photo content_hash (same-picture dedup, swap-review
+   * v2 §2). A skipped dup is never inserted and never enters the manifest, so
+   * the (paid) judge never scores a photo we already have.
+   */
+  skippedDuplicates: number;
   manifestPath: string;
   manifest: SourceManifestEntry[];
 }
 
 interface FlaggedRow {
   species_code: string; com_name: string | null; sci_name: string | null; family: string | null;
+  /** The species' CURRENT live photo content hash — same-picture dups match it. */
+  content_hash: string | null;
 }
 
 /**
@@ -383,6 +392,12 @@ interface FlaggedRow {
  *   • Pacing is injectable (`deps.clock`/`deps.inatPaceMs`/`deps.edgePaceMs`)
  *     so tests assert spacing deterministically without a real wait.
  *   • The batch logs how many external calls (iNat fetches + downloads) it made.
+ *   • Same-picture dedup (swap-review v2 §2): after a candidate is downloaded
+ *     and its sha8 computed, if it equals the species' CURRENT live photo
+ *     content_hash (iNat re-served the byte-identical image already live), the
+ *     candidate is SKIPPED — not inserted, not added to the manifest — so the
+ *     (paid) judge never scores a photo we already have. `skippedDuplicates`
+ *     counts these (≈20% of candidates in a real run).
  */
 /** Optional caps for a source-prepare run. */
 export interface SourcePrepareOpts {
@@ -422,7 +437,7 @@ export async function sourcePrepare(
       ? Math.floor(rawLimit)
       : null;
   const flagged = db.prepare(
-    `SELECT c.species_code, c.com_name, c.sci_name, c.family
+    `SELECT c.species_code, c.com_name, c.sci_name, c.family, c.content_hash
        FROM photo_score s
        JOIN photo_current c ON c.species_code = s.species_code
       WHERE s.role = 'current' AND s.keep = 0
@@ -433,10 +448,14 @@ export async function sourcePrepare(
   const manifest: SourceManifestEntry[] = [];
   let inatFetches = 0;
   let downloads = 0;
+  let skippedDuplicates = 0;
   for (const sp of flagged) {
     if (!sp.sci_name) continue; // can't source without a scientific name
     const sciName = sp.sci_name;
     const round = maxSourceRound(db, sp.species_code) + 1;
+    // The species' live photo hash (read once) — a candidate whose bytes match
+    // it is the SAME picture iNat already served us; skip it (swap-review v2 §2).
+    const currentHash = sp.content_hash;
 
     // iNat is third-party: pace ≤1 req/sec between species AND bound the pool.
     // A persistent iNat failure aborts THIS species, not the batch.
@@ -459,6 +478,13 @@ export async function sourcePrepare(
       downloads++;
       const mime = mimeFromUrl(cand.photoUrl);
       const hash = sha8(bytes);
+      // Same-picture dedup (#974): iNat re-served the byte-identical live photo.
+      // A swap to the same bytes is never an improvement, so do NOT insert it and
+      // do NOT add it to the manifest — the judge never scores a photo we have.
+      if (currentHash && hash === currentHash) {
+        skippedDuplicates++;
+        continue;
+      }
       const imagePath = join(deps.thumbDir, `${sp.species_code}-${cand.inatId}.${extFromMime(mime)}`);
       await writeFile(imagePath, bytes);
       insertCandidate(db, {
@@ -483,8 +509,8 @@ export async function sourcePrepare(
   const manifestPath = join(deps.thumbDir, 'candidates-manifest.json');
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
   // eslint-disable-next-line no-console
-  console.log(`[source-prepare] external calls: ${inatFetches} iNat fetch(es) + ${downloads} edge download(s)`);
-  return { picked: manifest.length, inatFetches, downloads, manifestPath, manifest };
+  console.log(`[source-prepare] external calls: ${inatFetches} iNat fetch(es) + ${downloads} edge download(s); sourced ${manifest.length} / same-picture skipped ${skippedDuplicates}`);
+  return { picked: manifest.length, inatFetches, downloads, skippedDuplicates, manifestPath, manifest };
 }
 
 /** One agent candidate-scoring result. Carries the inat id + content hash. */

--- a/tools/photo-curation/src/server/index.test.ts
+++ b/tools/photo-curation/src/server/index.test.ts
@@ -13,6 +13,7 @@ function seedDb(): Database.Database {
     CREATE TABLE photo_score(id INTEGER PRIMARY KEY, species_code TEXT, role TEXT, candidate_inat_id INTEGER, content_hash TEXT, overall REAL, verdict TEXT, criteria_json TEXT, flags_json TEXT, keep INTEGER, quality_score REAL, field_marks TEXT, rationale TEXT, rubric_version TEXT, scored_at TEXT);
     CREATE TABLE photo_candidate(id INTEGER PRIMARY KEY, species_code TEXT, inat_id INTEGER, photo_url TEXT, thumb_path TEXT, attribution TEXT, license TEXT, excluded INTEGER DEFAULT 0, source_round INTEGER);
     CREATE TABLE photo_decision(species_code TEXT PRIMARY KEY, action TEXT, chosen_candidate_id INTEGER, deny_reason TEXT, deny_tags_json TEXT, resource_requested INTEGER NOT NULL DEFAULT 0, decided_at TEXT, applied INTEGER DEFAULT 0, applied_at TEXT);
+    CREATE TABLE swap_selection(species_code TEXT PRIMARY KEY, chosen_inat_id INTEGER, decided_at TEXT);
   `);
   const crit = JSON.stringify({ framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 6, lighting: 8 });
   db.prepare(`INSERT INTO photo_current (species_code,com_name,sci_name,family,url,attribution,license,content_hash,reviewed) VALUES ('houspa','House Sparrow','Passer domesticus','passeridae','https://photos/houspa.jpg','(c) B','cc0','hashB',1)`).run();
@@ -193,5 +194,88 @@ describe('review-server API', () => {
 
     const bad = await request(app).get('/api/pending-swaps?limit=-1');
     expect(bad.status).toBe(400);
+  });
+
+  // ── swap-review v2: operator override (click-to-pick) ──
+
+  /** Flag houspa needs-replacement and give the two candidates scores. */
+  function flagWithCandidates(db: Database.Database): void {
+    db.prepare(`UPDATE photo_score SET keep=0, quality_score=20 WHERE species_code='houspa' AND role='current'`).run();
+    db.prepare(`UPDATE photo_score SET quality_score=82 WHERE candidate_inat_id=5001`).run(); // auto best (Δ62)
+    db.prepare(`UPDATE photo_score SET quality_score=64 WHERE candidate_inat_id=5002`).run(); // operator pick
+  }
+
+  it('POST /api/select-swap records an override; GET reflects it; selectSwaps honors it (chosen != auto-best)', async () => {
+    flagWithCandidates(db);
+    const app = createServer(db);
+
+    // Auto-best is 5001; operator overrides to 5002.
+    const res = await request(app).post('/api/select-swap').send({ speciesCode: 'houspa', inatId: 5002 });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // GET /api/select-swap/:code reflects the persisted override.
+    const got = await request(app).get('/api/select-swap/houspa');
+    expect(got.status).toBe(200);
+    expect(got.body.chosenInatId).toBe(5002);
+
+    // pending-swaps now proposes the OVERRIDDEN candidate, flagged operatorChosen.
+    const swaps = await request(app).get('/api/pending-swaps');
+    const s = swaps.body.swaps[0];
+    expect(s.proposed.inatId).toBe(5002);
+    expect(s.operatorChosen).toBe(true);
+    expect(s.candidates.find((c: { inatId: number }) => c.inatId === 5002).selected).toBe(true);
+  });
+
+  it('POST /api/select-swap with inatId:null records an explicit "no swap"; selectSwaps proposes null', async () => {
+    flagWithCandidates(db);
+    const app = createServer(db);
+
+    const res = await request(app).post('/api/select-swap').send({ speciesCode: 'houspa', inatId: null });
+    expect(res.status).toBe(200);
+
+    const got = await request(app).get('/api/select-swap/houspa');
+    expect(got.body.chosenInatId).toBeNull();
+
+    const swaps = await request(app).get('/api/pending-swaps');
+    const s = swaps.body.swaps[0];
+    expect(s.proposed).toBeNull();
+    expect(s.operatorChosen).toBe(true);
+  });
+
+  it('GET /api/select-swap/:code returns chosenInatId:undefined-equivalent (null body) when no override', async () => {
+    flagWithCandidates(db);
+    const app = createServer(db);
+    const got = await request(app).get('/api/select-swap/houspa');
+    expect(got.status).toBe(200);
+    expect(got.body.override).toBeNull();
+  });
+
+  it('DELETE /api/select-swap/:code reverts to the auto gate (override row removed)', async () => {
+    flagWithCandidates(db);
+    const app = createServer(db);
+
+    // Override to 5002, then revert.
+    await request(app).post('/api/select-swap').send({ speciesCode: 'houspa', inatId: 5002 });
+    expect((await request(app).get('/api/select-swap/houspa')).body.override).not.toBeNull();
+
+    const del = await request(app).delete('/api/select-swap/houspa');
+    expect(del.status).toBe(200);
+    expect(del.body.ok).toBe(true);
+    // Override gone → auto gate resumes; auto-best 5001 is proposed, not operator.
+    expect((await request(app).get('/api/select-swap/houspa')).body.override).toBeNull();
+    const swaps = await request(app).get('/api/pending-swaps');
+    expect(swaps.body.swaps[0].proposed.inatId).toBe(5001);
+    expect(swaps.body.swaps[0].operatorChosen).toBe(false);
+  });
+
+  it('POST /api/select-swap validates speciesCode and inatId', async () => {
+    const app = createServer(db);
+    // missing speciesCode
+    expect((await request(app).post('/api/select-swap').send({ inatId: 5001 })).status).toBe(400);
+    // non-integer inatId (and not null)
+    expect((await request(app).post('/api/select-swap').send({ speciesCode: 'houspa', inatId: 'nope' })).status).toBe(400);
+    // missing inatId key entirely is rejected (must be a number or explicit null)
+    expect((await request(app).post('/api/select-swap').send({ speciesCode: 'houspa' })).status).toBe(400);
   });
 });

--- a/tools/photo-curation/src/server/index.ts
+++ b/tools/photo-curation/src/server/index.ts
@@ -7,6 +7,7 @@ import {
   type SortMode, type FilterMode,
 } from './queries.js';
 import { selectSwaps } from '../swaps.js';
+import { setSwapSelection, getSwapSelection, clearSwapSelection } from '../store.js';
 
 // NOTE: the Express server is plain Node — it CANNOT dispatch a Claude Code
 // agent, so it never scores a photo. All scoring lives in the `source-candidates`
@@ -66,6 +67,49 @@ export function createServer(db: Database.Database): Express {
     const swaps = selectSwaps(db, limit !== undefined ? { limit } : {});
     const proposedCount = swaps.filter(s => s.proposed !== null).length;
     return res.json({ swaps, total: swaps.length, proposedCount });
+  });
+
+  // Operator override for the pending-swaps screen (swap-review v2 §3). The page
+  // calls POST on a click-to-pick: `inatId` (a number) promotes that candidate
+  // over the auto Δ≥20 best; `inatId: null` is an explicit "no swap"; the auto
+  // gate is restored by clearing the row (POST inatId equal to the auto pick is
+  // still a valid explicit override — the operator chose it deliberately). The
+  // override is keyed on species_code and read back by selectSwaps, so a refresh
+  // (GET /api/pending-swaps) reflects it. GET here returns the raw stored row.
+  app.get('/api/select-swap/:code', (req: Request, res: Response) => {
+    const code = req.params.code;
+    if (typeof code !== 'string' || !code) return res.status(400).json({ error: 'species code required' });
+    const sel = getSwapSelection(db, code);
+    // `override` is the full row (null when none); `chosenInatId` is hoisted for
+    // the page's convenience (null both when no row AND when "no swap" — the page
+    // distinguishes via `override === null`).
+    return res.json({ override: sel, chosenInatId: sel ? sel.chosenInatId : null });
+  });
+
+  app.post('/api/select-swap', (req: Request, res: Response) => {
+    const { speciesCode, inatId } = req.body ?? {};
+    if (typeof speciesCode !== 'string' || !speciesCode) {
+      return res.status(400).json({ error: 'speciesCode required' });
+    }
+    // inatId MUST be present and either an integer (promote that candidate) or
+    // null (explicit "no swap"). `undefined`/missing, strings, floats, NaN are
+    // rejected — an ambiguous override would silently diverge from apply-swaps.
+    const isInt = typeof inatId === 'number' && Number.isInteger(inatId);
+    if (inatId !== null && !isInt) {
+      return res.status(400).json({ error: 'inatId must be an integer or null' });
+    }
+    setSwapSelection(db, speciesCode, inatId as number | null);
+    return res.json({ ok: true });
+  });
+
+  // Revert a species to the AUTO gate by deleting its override row (distinct
+  // from POST inatId:null, which records an explicit "no swap"). The "Use auto
+  // pick" button calls this.
+  app.delete('/api/select-swap/:code', (req: Request, res: Response) => {
+    const code = req.params.code;
+    if (typeof code !== 'string' || !code) return res.status(400).json({ error: 'species code required' });
+    clearSwapSelection(db, code);
+    return res.json({ ok: true });
   });
 
   app.get('/api/swap/:code', (req: Request, res: Response) => {

--- a/tools/photo-curation/src/store.test.ts
+++ b/tools/photo-curation/src/store.test.ts
@@ -5,6 +5,7 @@ import {
   upsertCurrentPhoto, upsertScore, getScoreByHash,
   insertCandidate, listCandidates, markCandidatesExcluded,
   selectUnreviewed, markReviewed, updateCurrentPhotoHash,
+  setSwapSelection, getSwapSelection,
 } from './store.js';
 import type { QualityReport } from '@bird-watch/photo-quality';
 
@@ -145,5 +146,33 @@ describe('store', () => {
     expect(row.content_hash).toBe('cafebabe');
     expect(row.attribution).toBe('(c) Jane Doe (CC BY 4.0)');
     expect(row.license).toBe('cc-by-4.0');
+  });
+});
+
+describe('swap_selection (operator override)', () => {
+  it('getSwapSelection returns null when no override exists', () => {
+    expect(getSwapSelection(db, 'norcar')).toBeNull();
+  });
+
+  it('setSwapSelection upserts a chosen candidate, then clears to "no swap" (null)', () => {
+    // Operator picks candidate 4242 for norcar.
+    setSwapSelection(db, 'norcar', 4242);
+    const picked = getSwapSelection(db, 'norcar');
+    expect(picked).not.toBeNull();
+    expect(picked!.chosenInatId).toBe(4242);
+    expect(typeof picked!.decidedAt).toBe('string');
+
+    // Re-pick a different candidate — upsert in place (PK species_code).
+    setSwapSelection(db, 'norcar', 9001);
+    expect(getSwapSelection(db, 'norcar')!.chosenInatId).toBe(9001);
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM swap_selection WHERE species_code='norcar'`).get() as { n: number }).n,
+    ).toBe(1);
+
+    // Explicit "no swap": chosen_inat_id NULL is recorded (NOT a delete).
+    setSwapSelection(db, 'norcar', null);
+    const noSwap = getSwapSelection(db, 'norcar');
+    expect(noSwap).not.toBeNull();
+    expect(noSwap!.chosenInatId).toBeNull();
   });
 });

--- a/tools/photo-curation/src/store.ts
+++ b/tools/photo-curation/src/store.ts
@@ -306,3 +306,64 @@ export function maxSourceRound(db: Database.Database, speciesCode: string): numb
   ).get(speciesCode) as { r: number };
   return row.r;
 }
+
+/** A persisted operator override for one species (swap-review v2). */
+export interface SwapSelection {
+  speciesCode: string;
+  /** The candidate inat id the operator promoted; null = explicit "no swap". */
+  chosenInatId: number | null;
+  decidedAt: string;
+}
+
+interface SwapSelectionRow {
+  species_code: string;
+  chosen_inat_id: number | null;
+  decided_at: string;
+}
+
+/**
+ * Upsert (or clear-to-no-swap) the operator's pending-swaps override for a
+ * species. `inatId` = a candidate's inat id promotes that candidate; `null`
+ * records an EXPLICIT "no swap" (a row with chosen_inat_id NULL) — distinct from
+ * having no row at all, which selectSwaps treats as "use the auto gate".
+ * Keyed on species_code (PK), so a re-pick overwrites in place. Idempotent.
+ */
+export function setSwapSelection(
+  db: Database.Database, speciesCode: string, inatId: number | null,
+): void {
+  db.prepare(
+    `INSERT INTO swap_selection (species_code, chosen_inat_id, decided_at)
+     VALUES (@speciesCode, @chosenInatId, @decidedAt)
+     ON CONFLICT(species_code) DO UPDATE SET
+       chosen_inat_id=excluded.chosen_inat_id, decided_at=excluded.decided_at`,
+  ).run({
+    speciesCode,
+    chosenInatId: inatId,
+    decidedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Delete a species' operator override entirely — reverts to the auto gate
+ * (selectSwaps treats "no row" as "use the Δ≥20 auto pick"). Distinct from
+ * setSwapSelection(db, code, null), which records an EXPLICIT "no swap" row.
+ * Idempotent (a no-op when no row exists).
+ */
+export function clearSwapSelection(db: Database.Database, speciesCode: string): void {
+  db.prepare(`DELETE FROM swap_selection WHERE species_code=?`).run(speciesCode);
+}
+
+/** Read a species' operator override, or null when none is recorded. */
+export function getSwapSelection(
+  db: Database.Database, speciesCode: string,
+): SwapSelection | null {
+  const row = db.prepare(
+    `SELECT species_code, chosen_inat_id, decided_at FROM swap_selection WHERE species_code=?`,
+  ).get(speciesCode) as SwapSelectionRow | undefined;
+  if (!row) return null;
+  return {
+    speciesCode: row.species_code,
+    chosenInatId: row.chosen_inat_id,
+    decidedAt: row.decided_at,
+  };
+}

--- a/tools/photo-curation/src/swaps.test.ts
+++ b/tools/photo-curation/src/swaps.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import type Database from 'better-sqlite3';
 import { openDb } from './db.js';
-import { upsertCurrentPhoto, upsertScore, insertCandidate } from './store.js';
+import { upsertCurrentPhoto, upsertScore, insertCandidate, setSwapSelection } from './store.js';
 import { selectSwaps } from './swaps.js';
 import type { QualityReport } from '@bird-watch/photo-quality';
 
@@ -9,16 +9,22 @@ let db: Database.Database;
 beforeEach(() => { db = openDb(':memory:'); });
 afterEach(() => db.close());
 
-function seedCurrent(code: string, comName: string): void {
+function seedCurrent(code: string, comName: string, contentHash = `cur-${code}`): void {
   upsertCurrentPhoto(db, {
     speciesCode: code, comName, sciName: `Sci ${code}`, family: `Fam ${code}`,
     url: `https://photos.bird-maps.com/${code}.jpg`,
-    attribution: `(c) Owner ${code}`, license: 'cc-by', contentHash: `cur-${code}`,
+    attribution: `(c) Owner ${code}`, license: 'cc-by', contentHash,
   });
 }
 
-/** A current-photo score row. keep=0 = needs replacement. */
-function seedCurrentScore(code: string, s: { keep: boolean; qualityScore: number }): void {
+/**
+ * A current-photo score row. keep=0 = needs replacement. The score's
+ * content_hash (role='current') is the live image hash the same-picture gate
+ * compares against; pass `contentHash` to match a seedCurrent dup hash.
+ */
+function seedCurrentScore(
+  code: string, s: { keep: boolean; qualityScore: number; contentHash?: string },
+): void {
   const report: QualityReport = {
     overall: s.qualityScore, verdict: s.keep ? 'good' : 'reject',
     deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
@@ -26,14 +32,18 @@ function seedCurrentScore(code: string, s: { keep: boolean; qualityScore: number
     flags: [], fieldMarks: ['eye-ring'], keep: s.keep, qualityScore: s.qualityScore,
     rationale: `current ${code} rationale`, rubricVersion: '0.2.0',
   };
-  upsertScore(db, { speciesCode: code, role: 'current', candidateInatId: null, contentHash: `cur-${code}`, report });
+  upsertScore(db, {
+    speciesCode: code, role: 'current', candidateInatId: null,
+    contentHash: s.contentHash ?? `cur-${code}`, report,
+  });
 }
 
 /** A candidate photo + its scored row (role='candidate'). */
 function seedCandidate(
   code: string, inatId: number,
-  s: { qualityScore: number; keep?: boolean; marks?: string[]; excluded?: boolean },
+  s: { qualityScore: number; keep?: boolean; marks?: string[]; excluded?: boolean; contentHash?: string },
 ): void {
+  const contentHash = s.contentHash ?? `cand-${code}-${inatId}`;
   insertCandidate(db, {
     speciesCode: code, inatId, photoUrl: `https://inaturalist-open-data.s3.amazonaws.com/${inatId}.jpg`,
     thumbPath: `thumb-cache/${code}-${inatId}.jpg`, attribution: `(c) iNat ${inatId}`,
@@ -49,7 +59,7 @@ function seedCandidate(
     flags: [], fieldMarks: s.marks ?? ['wing bars'], keep: s.keep ?? true, qualityScore: s.qualityScore,
     rationale: `candidate ${inatId} rationale`, rubricVersion: '0.2.0',
   };
-  upsertScore(db, { speciesCode: code, role: 'candidate', candidateInatId: inatId, contentHash: `cand-${code}-${inatId}`, report });
+  upsertScore(db, { speciesCode: code, role: 'candidate', candidateInatId: inatId, contentHash, report });
 }
 
 describe('selectSwaps', () => {
@@ -138,10 +148,10 @@ describe('selectSwaps', () => {
     seedCurrent('exsp', 'Excluded Sp');
     seedCurrentScore('exsp', { keep: false, qualityScore: 30 });
     seedCandidate('exsp', 800, { qualityScore: 90, excluded: true }); // denied earlier
-    seedCandidate('exsp', 900, { qualityScore: 45 });
+    seedCandidate('exsp', 900, { qualityScore: 55 }); // Δ25 ≥ 20 → proposed
 
     const r = selectSwaps(db)[0]!;
-    // 800 excluded → best is 900; proposed because 45 > 30.
+    // 800 excluded → best is 900; proposed because 55 − 30 = 25 ≥ MIN_IMPROVEMENT.
     expect(r.proposed!.inatId).toBe(900);
     expect(r.candidates.map(c => c.inatId)).toEqual([900]);
   });
@@ -154,6 +164,106 @@ describe('selectSwaps', () => {
 
     const r = selectSwaps(db)[0]!;
     expect(r.proposed!.inatId).toBe(1100);
+  });
+
+  // ── Swap-review v2 gates (same-picture dedup + minimum-improvement Δ≥20) ──
+
+  it('(g1) EXCLUDES a same-picture candidate (content_hash == current) and never proposes it', () => {
+    seedCurrent('dupsp', 'Dup Sp', 'samehash');
+    seedCurrentScore('dupsp', { keep: false, qualityScore: 30, contentHash: 'samehash' });
+    // 100 is byte-identical to the live photo (iNat returned the image already live).
+    // Even though it scores far above the current, it is never a real improvement.
+    seedCandidate('dupsp', 100, { qualityScore: 95, contentHash: 'samehash' });
+    // 200 is a genuinely different photo that clears the Δ≥20 gate.
+    seedCandidate('dupsp', 200, { qualityScore: 60, contentHash: 'otherhash' });
+
+    const r = selectSwaps(db)[0]!;
+    // The same-picture dup is filtered out entirely — not in candidates, not proposed.
+    expect(r.candidates.map(c => c.inatId)).toEqual([200]);
+    expect(r.proposed!.inatId).toBe(200);
+    expect(r.delta).toBe(30); // 60 − 30, computed against the non-dup best
+  });
+
+  it('(g2) a species whose ONLY candidate is the same-picture dup is OMITTED entirely', () => {
+    seedCurrent('onlydup', 'Only Dup', 'samebytes');
+    seedCurrentScore('onlydup', { keep: false, qualityScore: 20, contentHash: 'samebytes' });
+    seedCandidate('onlydup', 300, { qualityScore: 90, contentHash: 'samebytes' });
+
+    // After filtering the dup, no candidate remains → omitted (same as no-candidates).
+    expect(selectSwaps(db).map(r => r.speciesCode)).not.toContain('onlydup');
+  });
+
+  it('(g3) Δ boundary: a candidate beating current by exactly 19 is NOT proposed; by exactly 20 IS', () => {
+    // current 50; best candidate 69 → Δ19 < MIN_IMPROVEMENT(20) → not proposed.
+    seedCurrent('d19', 'Delta 19');
+    seedCurrentScore('d19', { keep: false, qualityScore: 50 });
+    seedCandidate('d19', 400, { qualityScore: 69 });
+
+    const r19 = selectSwaps(db).find(r => r.speciesCode === 'd19')!;
+    expect(r19.proposed).toBeNull();
+    expect(r19.outscores).toBe(false);
+    expect(r19.delta).toBe(19);
+    expect(r19.candidates.every(c => !c.selected)).toBe(true);
+
+    // current 50; best candidate 70 → Δ20 == MIN_IMPROVEMENT → proposed.
+    seedCurrent('d20', 'Delta 20');
+    seedCurrentScore('d20', { keep: false, qualityScore: 50 });
+    seedCandidate('d20', 500, { qualityScore: 70 });
+
+    const r20 = selectSwaps(db).find(r => r.speciesCode === 'd20')!;
+    expect(r20.proposed!.inatId).toBe(500);
+    expect(r20.outscores).toBe(true);
+    expect(r20.delta).toBe(20);
+  });
+
+  it('(g4) compares against the best NON-duplicate candidate, not the global best when the global best is a dup', () => {
+    seedCurrent('nondup', 'Non Dup', 'liveimg');
+    seedCurrentScore('nondup', { keep: false, qualityScore: 30, contentHash: 'liveimg' });
+    // Global best (95) is the same-picture dup → excluded. Best non-dup is 700 (58).
+    seedCandidate('nondup', 600, { qualityScore: 95, contentHash: 'liveimg' });
+    seedCandidate('nondup', 700, { qualityScore: 58, contentHash: 'fresh-a' });
+    seedCandidate('nondup', 800, { qualityScore: 40, contentHash: 'fresh-b' });
+
+    const r = selectSwaps(db)[0]!;
+    // 700 (best non-dup) is the comparison + the proposal, NOT the 95 dup.
+    expect(r.proposed!.inatId).toBe(700);
+    expect(r.delta).toBe(28); // 58 − 30
+    expect(r.candidates.map(c => c.inatId).sort((a, b) => a - b)).toEqual([700, 800]);
+  });
+
+  // ── Operator override (swap_selection) ──
+
+  it('(o1) an operator override WINS over the auto best (proposes the chosen candidate, marks operatorChosen)', () => {
+    seedCurrent('ovr', 'Override Sp');
+    seedCurrentScore('ovr', { keep: false, qualityScore: 30 });
+    seedCandidate('ovr', 100, { qualityScore: 90 }); // auto-best (Δ60)
+    seedCandidate('ovr', 200, { qualityScore: 55 }); // operator's pick
+
+    // No override → auto picks the 90.
+    expect(selectSwaps(db)[0]!.proposed!.inatId).toBe(100);
+    expect(selectSwaps(db)[0]!.operatorChosen).toBe(false);
+
+    // Operator overrides to 200; it now wins despite the 90 being the auto-best.
+    setSwapSelection(db, 'ovr', 200);
+    const r = selectSwaps(db)[0]!;
+    expect(r.proposed!.inatId).toBe(200);
+    expect(r.operatorChosen).toBe(true);
+    // `outscores` still reflects the AUTO signal (auto-best 90 clears Δ20).
+    expect(r.outscores).toBe(true);
+    expect(r.candidates.find(c => c.inatId === 200)!.selected).toBe(true);
+    expect(r.candidates.find(c => c.inatId === 100)!.selected).toBe(false);
+  });
+
+  it('(o2) an explicit NULL override is "operator: no swap" (proposed=null, operatorChosen=true)', () => {
+    seedCurrent('nosw', 'No Swap Sp');
+    seedCurrentScore('nosw', { keep: false, qualityScore: 30 });
+    seedCandidate('nosw', 300, { qualityScore: 90 }); // auto would propose this
+
+    setSwapSelection(db, 'nosw', null);
+    const r = selectSwaps(db)[0]!;
+    expect(r.proposed).toBeNull();
+    expect(r.operatorChosen).toBe(true);
+    expect(r.candidates.every(c => !c.selected)).toBe(true);
   });
 
   it('orders species worst-current-first (quality_score ASC) and honors an optional limit', () => {

--- a/tools/photo-curation/src/swaps.ts
+++ b/tools/photo-curation/src/swaps.ts
@@ -1,18 +1,45 @@
 import type Database from 'better-sqlite3';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Swap selection — the "outscores the original" gate (photo-swap epic).
+// Swap selection — two auto-gates + an operator override (swap-review v2).
 //
-// COMPUTED, not stored: this is a pure read over photo_current / photo_score /
-// photo_candidate. For every species the judge flagged for replacement
-// (role='current' keep = 0) that HAS at least one scored, non-excluded
-// candidate, it picks the best candidate and proposes it ONLY when it strictly
-// outscores the current photo's quality_score (a tie keeps the original).
+// COMPUTED, not stored (except the operator override): this is a pure read over
+// photo_current / photo_score / photo_candidate, plus the persisted operator
+// pick in swap_selection. For every species the judge flagged for replacement
+// (role='current' keep = 0) that HAS at least one scored, non-excluded candidate
+// it picks a proposal through TWO auto-gates, then lets an operator override it:
 //
-// It is the data behind the read-only `/pending-swaps` readout: a pre-commit
-// glance at what `apply-swaps` WOULD do. It writes nothing and decides nothing —
-// the human approve/deny path (photo_decision) and `apply-swaps` are unchanged.
+//   1. Same-picture gate (cheapest dedup, no perceptual hash). bird-maps.com
+//      sourced its live photos from iNaturalist, so iNat routinely returns the
+//      BYTE-IDENTICAL image already live. A "swap" to the same bytes is never an
+//      improvement, so any candidate whose content_hash equals the CURRENT
+//      photo's content_hash is EXCLUDED from the pool before the best is picked.
+//      If filtering leaves no candidate, the species is omitted (same as having
+//      no candidates).
+//   2. Minimum-improvement gate. Even a genuinely different photo is only a swap
+//      when it clears the current by a real margin: the best NON-duplicate
+//      candidate is proposed only when best − current >= MIN_IMPROVEMENT (20).
+//      A marginal bump (Δ<20) keeps the original.
+//
+// Operator override (swap_selection): a curator can click a specific candidate
+// on the pending-swaps page (POST /api/select-swap). When a swap_selection row
+// exists for a species, it WINS over the auto gate: a chosen inat id makes that
+// candidate the proposal (marked `operatorChosen`); an explicit NULL means
+// "operator: no swap" (proposed = null). With no row, the two auto gates decide.
+//
+// It is the data behind the `/pending-swaps` screen and a pre-commit glance at
+// what `apply-swaps` WOULD do. The compute writes nothing; only POST
+// /api/select-swap mutates (the swap_selection row). The human approve/deny path
+// (photo_decision) is unchanged.
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimum quality_score margin (best − current) for the auto gate to propose a
+ * swap. A candidate that beats the current by < MIN_IMPROVEMENT is a marginal
+ * bump, not a swap, and the original is kept. Boundary is inclusive: Δ == 20
+ * proposes; Δ == 19 does not.
+ */
+export const MIN_IMPROVEMENT = 20;
 
 /** The species' live (current) photo + its judge score. */
 export interface SwapCurrent {
@@ -49,14 +76,29 @@ export interface SpeciesSwap {
   /** All scored, non-excluded candidates, best-first. Each marked selected/rejected. */
   candidates: SwapCandidate[];
   /**
-   * The best candidate IFF it strictly outscores the current photo's
-   * quality_score; otherwise null ("no improvement found — keep original").
+   * The proposal after both auto-gates AND any operator override:
+   *   • operator override present (swap_selection row): the chosen candidate
+   *     (with operatorChosen=true), or null for an explicit "operator: no swap".
+   *   • no override: the best NON-duplicate candidate IFF it clears the current
+   *     by best − current >= MIN_IMPROVEMENT (same-picture dups excluded first);
+   *     otherwise null ("no improvement found — keep original").
    */
   proposed: SwapCandidate | null;
-  /** true iff a proposed replacement exists (best.qualityScore > current). */
+  /**
+   * true iff the AUTO gate would propose a replacement — i.e. the best
+   * non-duplicate candidate clears the current by Δ >= MIN_IMPROVEMENT. This is
+   * the auto signal and is independent of any operator override (the page uses
+   * it to show whether the current pick matches the auto recommendation).
+   */
   outscores: boolean;
-  /** best.qualityScore − current.qualityScore (can be ≤ 0 when no improvement). */
+  /**
+   * best(non-duplicate).qualityScore − current.qualityScore. Computed against
+   * the best candidate AFTER same-picture dups are excluded (can be < 0 or <
+   * MIN_IMPROVEMENT when no improvement clears the gate).
+   */
   delta: number;
+  /** true when `proposed` came from a persisted operator override, not the auto gate. */
+  operatorChosen: boolean;
 }
 
 export interface SelectSwapsOpts {
@@ -79,6 +121,8 @@ interface FlaggedCurrentRow {
   quality_score: number | null;
   rationale: string | null;
   field_marks: string | null;
+  /** The CURRENT photo's content hash — same-picture dups match on this. */
+  cur_hash: string | null;
 }
 
 interface CandidateScoreRow {
@@ -91,6 +135,14 @@ interface CandidateScoreRow {
   quality_score: number | null;
   rationale: string | null;
   field_marks: string | null;
+  /** The candidate's scored content hash — compared to cur_hash for the dedup gate. */
+  content_hash: string | null;
+}
+
+/** A persisted operator override: chosen inat id (null = explicit "no swap"). */
+interface SwapSelectionRow {
+  species_code: string;
+  chosen_inat_id: number | null;
 }
 
 function parseMarks(s: string | null): string[] {
@@ -105,21 +157,33 @@ function parseMarks(s: string | null): string[] {
 
 /**
  * Compute the per-species swap selection for every keep=0 species that has at
- * least one scored, non-excluded candidate. Pure read — writes nothing.
+ * least one scored, non-excluded, NON-DUPLICATE candidate. Reads photo_current /
+ * photo_score / photo_candidate plus the persisted operator override in
+ * swap_selection; writes nothing.
  *
- * The "outscores the original" rule: the best candidate (highest quality_score,
- * tie-broken by lowest inat id) is proposed ONLY when its quality_score is
- * strictly greater than the current photo's quality_score. A tie at the boundary
- * (best == current) is NOT proposed — the original is kept. Species with no
- * scored candidates are omitted.
+ * Two auto-gates then an operator override decide `proposed`:
+ *   1. Same-picture gate — every candidate whose content_hash equals the
+ *      current photo's content_hash is dropped from the pool BEFORE the best is
+ *      chosen (iNat byte-identical re-serve is never an improvement). If that
+ *      leaves no candidate, the species is OMITTED (same as no candidates).
+ *   2. Minimum-improvement gate — the best remaining candidate (highest
+ *      quality_score, tie-broken by lowest inat id) is proposed by the auto gate
+ *      ONLY when best − current >= MIN_IMPROVEMENT (20). A smaller margin keeps
+ *      the original. `outscores` reflects THIS auto decision.
+ *   3. Operator override — when a swap_selection row exists for the species it
+ *      WINS: a chosen inat id is the proposal (operatorChosen=true); an explicit
+ *      NULL chosen_inat_id is "operator: no swap" (proposed=null,
+ *      operatorChosen=true). With no row, gate 2's auto proposal is used.
  */
 export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): SpeciesSwap[] {
   // keep=0 current rows, worst-current-first. The advisory `overall` is not the
   // gate; we order + compare on the judge's own quality_score (NULL last).
+  // ps.content_hash AS cur_hash drives the same-picture dedup.
   const flagged = db.prepare(`
     SELECT pc.species_code, pc.com_name, pc.sci_name, pc.family,
            pc.url, pc.attribution, pc.license,
-           ps.quality_score, ps.rationale, ps.field_marks
+           ps.quality_score, ps.rationale, ps.field_marks,
+           ps.content_hash AS cur_hash
       FROM photo_current pc
       JOIN photo_score ps
         ON ps.species_code = pc.species_code AND ps.role = 'current'
@@ -127,10 +191,12 @@ export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): 
      ORDER BY ps.quality_score ASC, pc.species_code ASC
   `).all() as FlaggedCurrentRow[];
 
+  // cs.content_hash surfaces the candidate's scored image hash so the
+  // same-picture gate can compare it to the current photo's cur_hash.
   const candStmt = db.prepare(`
     SELECT cand.id AS candidate_id, cand.inat_id, cand.photo_url, cand.thumb_path,
            cand.attribution, cand.license,
-           cs.quality_score, cs.rationale, cs.field_marks
+           cs.quality_score, cs.rationale, cs.field_marks, cs.content_hash
       FROM photo_candidate cand
       JOIN photo_score cs
         ON cs.species_code = cand.species_code
@@ -140,18 +206,43 @@ export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): 
      ORDER BY cs.quality_score DESC, cand.inat_id ASC
   `);
 
+  // Operator overrides keyed by species_code. swap_selection may not exist on a
+  // legacy store opened before this migration; treat a missing table as "no
+  // overrides" so the readout still works (the page's POST path creates it).
+  const overrides = readSwapSelections(db);
+
   const out: SpeciesSwap[] = [];
   for (const sp of flagged) {
-    const candRows = candStmt.all(sp.species_code) as CandidateScoreRow[];
-    if (candRows.length === 0) continue; // omit: no scored candidates to choose from
+    const allCandRows = candStmt.all(sp.species_code) as CandidateScoreRow[];
 
-    // candRows is already best-first (quality_score DESC, inat_id ASC), so the
-    // first row is the best candidate with the deterministic tie-break baked in.
+    // Gate 1 — same-picture dedup: drop any candidate byte-identical to the
+    // live photo (content_hash == current cur_hash) BEFORE picking best.
+    const candRows = sp.cur_hash
+      ? allCandRows.filter(c => c.content_hash !== sp.cur_hash)
+      : allCandRows;
+    if (candRows.length === 0) continue; // omit: no non-duplicate candidate to choose from
+
+    // candRows is best-first (quality_score DESC, inat_id ASC), so the first row
+    // is the best NON-duplicate candidate with the deterministic tie-break.
     const currentScore = sp.quality_score ?? 0;
     const bestRow = candRows[0]!;
     const bestScore = bestRow.quality_score ?? 0;
-    const outscores = bestScore > currentScore;
-    const proposedInatId = outscores ? bestRow.inat_id : null;
+    const delta = bestScore - currentScore;
+    // Gate 2 — minimum-improvement: auto-propose only at Δ >= MIN_IMPROVEMENT.
+    const outscores = delta >= MIN_IMPROVEMENT;
+    const autoInatId = outscores ? bestRow.inat_id : null;
+
+    // Gate 3 — operator override wins over the auto pick when a row exists.
+    const override = overrides.get(sp.species_code);
+    const operatorChosen = override !== undefined;
+    // The override's chosen id must still be a live (non-excluded, non-dup)
+    // candidate; if it no longer is, fall back to "no swap" rather than a stale id.
+    const overrideInatId =
+      override !== undefined && override.chosen_inat_id !== null &&
+      candRows.some(c => c.inat_id === override.chosen_inat_id)
+        ? override.chosen_inat_id
+        : null;
+    const proposedInatId = operatorChosen ? overrideInatId : autoInatId;
 
     const candidates: SwapCandidate[] = candRows.map(c => ({
       candidateId: c.candidate_id,
@@ -186,7 +277,8 @@ export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): 
       candidates,
       proposed,
       outscores,
-      delta: bestScore - currentScore,
+      delta,
+      operatorChosen,
     });
   }
 
@@ -195,4 +287,23 @@ export function selectSwaps(db: Database.Database, opts: SelectSwapsOpts = {}): 
     return out.slice(0, Math.floor(limit));
   }
   return out;
+}
+
+/**
+ * Read all persisted operator overrides into a species_code → row map. A store
+ * opened before the swap_selection migration has no such table; we detect that
+ * (sqlite throws "no such table") and return an empty map so the readout still
+ * computes the pure auto gates.
+ */
+function readSwapSelections(db: Database.Database): Map<string, SwapSelectionRow> {
+  const map = new Map<string, SwapSelectionRow>();
+  try {
+    const rows = db.prepare(
+      `SELECT species_code, chosen_inat_id FROM swap_selection`,
+    ).all() as SwapSelectionRow[];
+    for (const r of rows) map.set(r.species_code, r);
+  } catch {
+    // swap_selection table absent (legacy store) — no overrides.
+  }
+  return map;
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph compute["selectSwaps (read)"]
        A[keep=0 species + scored candidates] --> B{Gate 1: same-picture<br/>content_hash == current?}
        B -- drop dups --> C[remaining pool]
        C -- none left --> OMIT[omit species]
        C --> D{Gate 2: best − current ≥ 20?}
        D -- yes --> AUTO[auto proposed]
        D -- no --> NONE[proposed = null]
        AUTO --> E{swap_selection row?}
        NONE --> E
        E -- chosen id --> OP[operator pick wins<br/>operatorChosen=true]
        E -- NULL --> NOSWAP[operator: no swap]
        E -- no row --> USEAUTO[use auto gate result]
    end
    PAGE[pending-swaps.js<br/>click-to-pick] -- POST /api/select-swap --> SEL[(swap_selection)]
    PAGE -- DELETE /api/select-swap/:code --> SEL
    SEL --> E
    OP --> APPLY[selectAppliableSwaps → apply-swaps]
    USEAUTO --> APPLY

    subgraph source["sourcePrepare (dedup at source)"]
        S1[download candidate] --> S2[sha8 bytes]
        S2 --> S3{== current content_hash?}
        S3 -- yes --> SKIP[skip: not inserted,<br/>not in manifest]
        S3 -- no --> KEEP[insert + manifest → judge]
    end
```

## Summary

- **Why two gates:** bird-maps.com sourced its photos from iNaturalist, so iNat routinely re-serves the *byte-identical* image already live (8/10 species in a real run). A swap to the same bytes is never an improvement, and a marginal score bump is not worth a swap either — so `selectSwaps` now excludes same-`content_hash` candidates first, then auto-proposes only when the best **non-duplicate** candidate clears the current by `Δ ≥ MIN_IMPROVEMENT` (20, exported from `swaps.ts`).
- **Why dedup at source too:** `sourcePrepare` skips a candidate whose downloaded bytes hash to the species' current `content_hash` *before* insert/manifest, so the paid Opus judge never scores a photo we already have (~20% fewer candidate scorings; counted as `skippedDuplicates`).
- **Operator flow (click-to-pick):** the `pending-swaps` page shows current (left) + selected candidate (right) at card size with the other non-duplicate candidates as thumbnails. Clicking a thumbnail promotes it to the pick and persists via `POST /api/select-swap` into a new `swap_selection` table; *Use auto pick* (`DELETE`) reverts to the Δ≥20 gate, *No swap* (`POST inatId:null`) keeps the original. `selectSwaps` honors the override (operator pick wins, `operatorChosen=true`), and `apply-swaps` reads the same selection via `selectAppliableSwaps` so the page and the applier never diverge. The legacy `photo_decision` approve path is unchanged — unifying it is a noted #974 follow-up.

## Screenshots

N/A — not `frontend/**` UI (local curation review server under `tools/photo-curation`).

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (184 tests, +15)
- [x] New unit / integration tests added: same-picture + Δ-boundary + best-non-dup gates in `swaps.test.ts`; operator override (chosen ≠ auto, NULL no-swap) in `swaps.test.ts`; `setSwapSelection`/`getSwapSelection` upsert+clear in `store.test.ts`; `POST`/`GET`/`DELETE /api/select-swap` in `server/index.test.ts`; source-time dedup in `score-orchestration.test.ts`; `selectAppliableSwaps` override target in `apply-swaps.test.ts`
- [x] N/A — no Playwright e2e (tool code, no `frontend/**` change)
- [x] `npm run build` — clean
- [x] `tsc --noEmit` clean · `npx knip` clean · `npm run lint` green · no `package-lock.json` drift
- [x] N/A — not UI (no `frontend/**` Playwright MCP smoke required)

## Plan reference

Out of plan — swap-review v2 enhancement on the photo-curation tool (epic #974), building on #1006 (`selectSwaps` / `/api/pending-swaps`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)