### PR TITLE
feat(photo-quality): judge prompt — same-species multiples OK + mild adult preference (v0.2.2)

### DIFF
--- a/packages/photo-quality/src/index.test.ts
+++ b/packages/photo-quality/src/index.test.ts
@@ -10,7 +10,7 @@ describe('public surface', () => {
     expect(typeof pkg.contentHash).toBe('function');
     expect(typeof pkg.scoreCacheKey).toBe('function');
     expect(typeof pkg.FakeJudge).toBe('function');
-    expect(pkg.defaultRubricConfig.version).toBe('0.2.1');
+    expect(pkg.defaultRubricConfig.version).toBe('0.2.2');
     // No SDK judge, no model field — the production judge is a Claude Code agent (#971).
     expect('model' in pkg.defaultRubricConfig).toBe(false);
     expect((pkg as Record<string, unknown>).ClaudeVisionJudge).toBeUndefined();

--- a/packages/photo-quality/src/rubric.config.test.ts
+++ b/packages/photo-quality/src/rubric.config.test.ts
@@ -52,6 +52,16 @@ describe('defaultRubricConfig', () => {
     for (const flag of DISQUALIFIER_FLAGS) expect(p).toContain(flag);
   });
 
+  it('judge prompt carries the v0.2.2 same-species + adult-preference refinements', () => {
+    const p = defaultRubricConfig.judgePrompt;
+    // multiple-subjects clarification: flag DIFFERENT species, never conspecifics.
+    expect(p).toMatch(/DIFFERENT species/i);
+    expect(p).toMatch(/SAME species/i);
+    // mild adult-plumage tiebreaker in the decision step.
+    expect(p).toMatch(/adult/i);
+    expect(p).toMatch(/tiebreaker|juvenile|immature/i);
+  });
+
   it('has deterministic-gate minimums', () => {
     const d = defaultRubricConfig.deterministic;
     expect(d.minMegapixels).toBeGreaterThan(0);

--- a/packages/photo-quality/src/rubric.config.ts
+++ b/packages/photo-quality/src/rubric.config.ts
@@ -49,6 +49,10 @@ STEP 2 — Criteria. Return an integer 0–10 for EACH:
 
 STEP 3 — Disqualifier flags. Return any that clearly apply (exact strings):
 "dead","in-hand","specimen","sick","distant","multiple-subjects","watermark","captive","harsh-flash".
+Apply "multiple-subjects" ONLY when a bird of a DIFFERENT species shares the frame, or when no
+single individual is the clear subject. Several individuals of the SAME species (a pair or small
+group) are acceptable for a field guide — do NOT flag or down-rate them; they can aid identification
+by showing plumage variation (e.g. male and female, or age classes).
 
 STEP 4 — Decision. Judging THIS photo against the Step 1 diagnostic marks: how many are clearly
 visible and readable? A KEEPER must show a LIVE, WILD bird; be sharp (especially the eye); be
@@ -56,7 +60,10 @@ large enough and unobstructed enough that its diagnostic marks can be read; sit 
 setting (NOT in a human hand, banding grip, cage/aviary, feeder/seed-tray, studio backdrop, or
 museum specimen; not dead or sick); and render true color. A merely acceptable snapshot — or one
 where the diagnostic marks are hidden by pose, distance, or clutter — should be REPLACED, even if
-technically sharp. Be strict about wild provenance.
+technically sharp. Be strict about wild provenance. All else equal, mildly prefer an ADULT in
+diagnostic plumage as the species' lead photo; a juvenile, immature, or downy chick is acceptable
+but slightly less ideal (it often lacks the adult field marks a guide leads with). Weight this as a
+small tiebreaker, NOT a disqualifier.
 
 Return: fieldMarks (array of the Step 1 marks), the seven criteria, flags, keep (boolean — keep as
 the species' guide photo, or replace), qualityScore (0–100), and a one-sentence rationale naming
@@ -69,8 +76,13 @@ export const defaultRubricConfig: RubricConfig = {
   // #969 follow-up: deterministic floors recalibrated to the real 500px catalog
   // (the 0.3 MP / 0.005 sharpness floors rejected 100% of it before the judge).
   // Bumping it invalidates every cached score so the backlog re-scores under the
-  // corrected gate.
-  version: '0.2.1',
+  // corrected gate. 0.2.2 = prompt-only refinement: same-species multiples are
+  // OK (STEP 3 clarifies multiple-subjects flags DIFFERENT species, not
+  // conspecifics) + a mild ADULT-plumage tiebreaker in the keep/replace decision
+  // (STEP 4). No criteria/weights/caps/gate change; bumping it invalidates cached
+  // scores so future scoring uses the refined prompt (rows scored under 0.2.1 keep
+  // their version until re-scored).
+  version: '0.2.2',
   deterministic: {
     // BROKEN-FILE floor only (recalibrated, #969 follow-up). bird-maps.com serves
     // a uniform 500px-long-edge catalog: measured 0.12–0.22 MP (500×375 = 0.19 MP).


### PR DESCRIPTION
## Diagrams

N/A — prompt-text-only change to `JUDGE_PROMPT` plus a version bump and tests. No data/control flow changes to diagram. For context, the version is what keys the score cache:

```mermaid
flowchart LR
    Judge["JUDGE_PROMPT (v0.2.2)"] --> Cache["score cache key = contentHash + rubricVersion"]
    Cache -->|version changed| Rescore["future scoring re-runs under new prompt"]
    Cache -->|rows @ 0.2.1| Keep["existing rows keep their version until re-scored"]
```

## Summary

- **Same-species multiples are OK.** STEP 3 now clarifies the `multiple-subjects` flag so it does NOT penalize conspecifics: it applies only when a bird of a *different* species shares the frame, or when no single individual is the clear subject. A pair or small group of the *same* species is acceptable for a field guide and can even aid identification by showing plumage variation (male/female, age classes). This stops the judge wrongly down-rating, e.g., a male-and-female pair shot.
- **Mild adult preference.** STEP 4 adds a small *tiebreaker* (explicitly NOT a disqualifier): all else equal, mildly prefer an adult in diagnostic plumage as the lead photo, since juvenile/immature/downy birds often lack the adult field marks a guide leads with.
- **Version `0.2.1` → `0.2.2`.** The version keys the content-hash score cache, so the bump invalidates cached scores and future scoring runs under the refined prompt. Rows already scored under `0.2.1` keep their version until they are re-scored — no retroactive rewrite.

No change to the seven criteria, the weights, the disqualifier caps, the deterministic gate, or the schema/flags. Prompt text + version + tests only.

## Screenshots

N/A — not frontend/** UI.

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-quality` — green (48/48)
- [x] New unit test added — `rubric.config.test.ts` "judge prompt carries the v0.2.2 same-species + adult-preference refinements" asserts the prompt CONTAINS `/DIFFERENT species/i` + `/SAME species/i` (multiple-subjects clarification) and `/adult/i` + `/tiebreaker|juvenile|immature/i` (adult preference), locking the intent against silent regression; `index.test.ts` version assertion updated to `0.2.2`
- [x] `npm run build` — clean production build
- [x] `npx tsc --noEmit` — clean
- [x] `npx knip` — clean (no errors)
- [x] No `package-lock.json` drift
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no UI
- [ ] (UI only) Playwright MCP smoke — N/A, not frontend/**

## Plan reference

Out of plan — targeted refinement to the photo-quality judge prompt (epic #974 photo-quality curation lineage).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)