### PR TITLE
feat(photo-curation): source-attempt tracking (skip re-searched) + apply promotes candidate to current

### DIFF
--- a/tools/photo-curation/src/apply-swaps.test.ts
+++ b/tools/photo-curation/src/apply-swaps.test.ts
@@ -17,11 +17,23 @@ afterAll(() => server.close());
  */
 function makeDb(): Database.Database {
   const db = new Database(':memory:');
+  // Mirrors the tables apply-swaps reads (incl. the #974 local-promotion ones:
+  // photo_score role='current'/'candidate', source_attempt, swap_selection).
+  // A photo_current.reviewed column matches the real openDb schema.
   db.exec(`
     CREATE TABLE photo_current (
       species_code TEXT PRIMARY KEY, com_name TEXT, sci_name TEXT, family TEXT,
-      url TEXT, attribution TEXT, license TEXT, content_hash TEXT
+      url TEXT, attribution TEXT, license TEXT, content_hash TEXT,
+      reviewed INTEGER NOT NULL DEFAULT 0
     );
+    CREATE TABLE photo_score (
+      id INTEGER PRIMARY KEY, species_code TEXT, role TEXT, candidate_inat_id INTEGER,
+      content_hash TEXT, overall REAL, verdict TEXT, criteria_json TEXT, flags_json TEXT,
+      keep INTEGER, quality_score REAL, field_marks TEXT, rationale TEXT,
+      rubric_version TEXT, scored_at TEXT
+    );
+    CREATE UNIQUE INDEX idx_photo_score_subject
+      ON photo_score (species_code, role, content_hash);
     CREATE TABLE photo_candidate (
       id INTEGER PRIMARY KEY, species_code TEXT, inat_id INTEGER, photo_url TEXT,
       thumb_path TEXT, attribution TEXT, license TEXT,
@@ -31,6 +43,14 @@ function makeDb(): Database.Database {
       species_code TEXT PRIMARY KEY, action TEXT, chosen_candidate_id INTEGER,
       deny_reason TEXT, deny_tags_json TEXT, decided_at TEXT,
       applied INTEGER DEFAULT 0, applied_at TEXT
+    );
+    CREATE TABLE swap_selection (
+      species_code TEXT PRIMARY KEY, chosen_inat_id INTEGER, decided_at TEXT
+    );
+    CREATE TABLE source_attempt (
+      species_code TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'inat',
+      attempted_at TEXT NOT NULL, candidates_found INTEGER, best_score INTEGER,
+      outcome TEXT, PRIMARY KEY (species_code, source)
     );
   `);
   return db;
@@ -290,6 +310,135 @@ describe('selectAppliableSwaps (operator override → apply target)', () => {
     // Explicit "no swap" → species drops out of the apply set entirely.
     setSwapSelection(db, 'norcar', null);
     expect(selectAppliableSwaps(db)).toHaveLength(0);
+    db.close();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #974 — apply-swaps promotes the applied candidate to the species' CURRENT
+// photo + score on a successful prod push, so the species leaves needs-swap.
+// Uses the real openDb so every table the promotion touches exists.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runApplySwaps — promote applied candidate to current (#974)', () => {
+  /** Seed flag1: current keep=0 (needs-swap) + a sourced+scored candidate keep=1. */
+  function seedFlaggedWithCandidate(
+    db: ReturnType<typeof openDb>, code: string, inatId: number,
+  ): void {
+    upsertCurrentPhoto(db, {
+      speciesCode: code, comName: 'Common', sciName: 'Genus species', family: 'fam',
+      url: `https://photos.bird-maps.com/${code}.old.jpg`, attribution: '(c) old', license: 'cc-by',
+      contentHash: 'oldhash',
+    });
+    const curReport: QualityReport = {
+      overall: 30, verdict: 'reject',
+      deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+      criteria: { framing: 3, subjectClarity: 3, liveness: 3, naturalness: 3, pose: 3, background: 3, lighting: 3 },
+      flags: [], fieldMarks: [], keep: false, qualityScore: 30, rationale: 'flagged', rubricVersion: '0.2.0',
+    };
+    upsertScore(db, { speciesCode: code, role: 'current', candidateInatId: null, contentHash: 'oldhash', report: curReport });
+
+    insertCandidate(db, {
+      speciesCode: code, inatId, photoUrl: `https://inat.example/${inatId}/original.jpg`,
+      thumbPath: `t/${inatId}.jpg`, attribution: '(c) New Photographer', license: 'cc0', sourceRound: 1,
+    });
+    const candReport: QualityReport = {
+      overall: 85, verdict: 'good',
+      deterministic: { width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0, passedGate: true, failReasons: [] },
+      criteria: { framing: 9, subjectClarity: 9, liveness: 9, naturalness: 8, pose: 8, background: 8, lighting: 9 },
+      flags: [], fieldMarks: ['clean perch'], keep: true, qualityScore: 88, rationale: 'sharp wild alt', rubricVersion: '0.2.0',
+    };
+    upsertScore(db, { speciesCode: code, role: 'candidate', candidateInatId: inatId, contentHash: 'candhash', report: candReport });
+
+    // The operator approve decision targeting this candidate.
+    db.prepare(
+      `INSERT INTO photo_decision (species_code, action, chosen_candidate_id, decided_at, applied)
+       VALUES (?, 'approve', (SELECT id FROM photo_candidate WHERE species_code=? AND inat_id=?), '2026-06-10T00:00:00.000Z', 0)`,
+    ).run(code, code, inatId);
+  }
+
+  it('on success: promotes candidate to current (keep flips → species leaves keep=0), records applied, clears swap_selection', async () => {
+    const db = openDb(':memory:');
+    seedFlaggedWithCandidate(db, 'norcar', 7001);
+    // An operator override row exists; promotion must clear it.
+    setSwapSelection(db, 'norcar', 7001);
+    // A source_attempt exists; promotion sets it 'applied'.
+    db.prepare(`INSERT INTO source_attempt (species_code, source, attempted_at, candidates_found, outcome) VALUES ('norcar','inat','t',1,'better-found')`).run();
+
+    // Sanity: before apply, norcar is in the keep=0 needs-swap set.
+    const before = db.prepare(`SELECT keep FROM photo_score WHERE species_code='norcar' AND role='current'`).get() as { keep: number };
+    expect(before.keep).toBe(0);
+
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, () =>
+        HttpResponse.json({ url: 'https://photos.bird-maps.com/norcar.NEWHASH.jpg', key: 'species/norcar.NEWHASH.jpg' }),
+      ),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+    expect(result.applied).toEqual(['norcar']);
+
+    // photo_current now points at the candidate (prod URL from the admin body).
+    const cur = db.prepare(`SELECT url, attribution, license, content_hash FROM photo_current WHERE species_code='norcar'`).get() as { url: string; attribution: string; license: string; content_hash: string };
+    expect(cur.url).toBe('https://photos.bird-maps.com/norcar.NEWHASH.jpg');
+    expect(cur.attribution).toBe('(c) New Photographer');
+    expect(cur.license).toBe('cc0');
+    expect(cur.content_hash).toBe('candhash');
+
+    // photo_score role='current' is now the candidate's report — keep flipped to 1,
+    // so norcar drops out of the keep=0 needs-swap set.
+    const after = db.prepare(`SELECT keep, quality_score, field_marks FROM photo_score WHERE species_code='norcar' AND role='current'`).get() as { keep: number; quality_score: number; field_marks: string };
+    expect(after.keep).toBe(1);
+    expect(after.quality_score).toBe(88);
+    expect(JSON.parse(after.field_marks)).toEqual(['clean perch']);
+    const stillFlagged = db.prepare(`SELECT COUNT(*) n FROM photo_score WHERE role='current' AND keep=0`).get() as { n: number };
+    expect(stillFlagged.n).toBe(0);
+
+    // source_attempt → 'applied' (best_score = the promoted quality_score).
+    const sa = db.prepare(`SELECT outcome, best_score FROM source_attempt WHERE species_code='norcar' AND source='inat'`).get() as { outcome: string; best_score: number };
+    expect(sa.outcome).toBe('applied');
+    expect(sa.best_score).toBe(88);
+
+    // swap_selection cleared.
+    expect(db.prepare(`SELECT COUNT(*) n FROM swap_selection WHERE species_code='norcar'`).get()).toEqual({ n: 0 });
+    db.close();
+  });
+
+  it('on push FAILURE: the species is NOT promoted (stays needs-swap, applied=0)', async () => {
+    const db = openDb(':memory:');
+    seedFlaggedWithCandidate(db, 'baleag', 7002);
+
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    const result = await runApplySwaps(makeDeps(db));
+    expect(result.applied).toEqual([]);
+    expect(result.failed[0]!.speciesCode).toBe('baleag');
+
+    // current photo + score UNCHANGED — still the old flagged keep=0 photo.
+    const cur = db.prepare(`SELECT url, content_hash FROM photo_current WHERE species_code='baleag'`).get() as { url: string; content_hash: string };
+    expect(cur.url).toBe('https://photos.bird-maps.com/baleag.old.jpg');
+    expect(cur.content_hash).toBe('oldhash');
+    const score = db.prepare(`SELECT keep FROM photo_score WHERE species_code='baleag' AND role='current'`).get() as { keep: number };
+    expect(score.keep).toBe(0); // still needs-swap
+    expect((db.prepare(`SELECT applied FROM photo_decision WHERE species_code='baleag'`).get() as { applied: number }).applied).toBe(0);
+    db.close();
+  });
+
+  it('falls back to the candidate source url when the admin body has no url', async () => {
+    const db = openDb(':memory:');
+    seedFlaggedWithCandidate(db, 'amecro', 7003);
+
+    server.use(
+      http.put(`${ADMIN_BASE}/admin/species-photos/:code`, () => HttpResponse.json({})),
+    );
+
+    await runApplySwaps(makeDeps(db));
+    const cur = db.prepare(`SELECT url FROM photo_current WHERE species_code='amecro'`).get() as { url: string };
+    expect(cur.url).toBe('https://inat.example/7003/original.jpg');
     db.close();
   });
 });

--- a/tools/photo-curation/src/apply-swaps.ts
+++ b/tools/photo-curation/src/apply-swaps.ts
@@ -1,5 +1,19 @@
 import type Database from 'better-sqlite3';
+import type { QualityReport, CriteriaScores } from '@bird-watch/photo-quality';
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
 import { selectSwaps } from './swaps.js';
+import {
+  upsertCurrentPhoto, upsertScore, clearSwapSelection, setSourceAttemptOutcome,
+} from './store.js';
+
+/**
+ * apply-swaps resolves source_attempt outcomes against this source (#974). The
+ * apply path reads the legacy photo_decision approve rows, which don't carry the
+ * search source, so 'inat' is assumed — the only image source wired today. When
+ * a second source is added, thread it through ApplyDeps and selectPendingSwaps
+ * (the photo_decision row would need a `source` column) and pass it here.
+ */
+const APPLY_SOURCE = 'inat';
 
 /**
  * swap-review v2 §3 — the operator-override-aware apply source. Derives the
@@ -29,6 +43,8 @@ export function selectAppliableSwaps(db: Database.Database): PendingSwap[] {
         newUrl: p.photoUrl,
         attribution: p.attribution,
         license: p.license,
+        chosenCandidateId: p.candidateId,
+        inatId: p.inatId,
       };
     });
 }
@@ -62,6 +78,12 @@ export interface PendingSwap {
   newUrl: string;                    // chosen candidate's photo_url → admin `sourceUrl`
   attribution: string;
   license: string;
+  // #974 local-promotion fields: the candidate being applied. On a successful
+  // prod push these promote the candidate to the species' CURRENT photo + score
+  // so it leaves the keep=0 needs-swap set. Optional so the override-derived
+  // selectAppliableSwaps source (which has no decision row) still type-checks.
+  chosenCandidateId?: number;        // photo_candidate.id of the applied candidate
+  inatId?: number;                   // photo_candidate.inat_id (joins to its role='candidate' score)
 }
 
 export interface ApplyFailure {
@@ -91,7 +113,9 @@ function selectPendingSwaps(db: Database.Database): PendingSwap[] {
               COALESCE(cur.url, '(none)')            AS oldUrl,
               cand.photo_url    AS newUrl,
               cand.attribution  AS attribution,
-              cand.license      AS license
+              cand.license      AS license,
+              cand.id           AS chosenCandidateId,
+              cand.inat_id      AS inatId
          FROM photo_decision d
          JOIN photo_candidate cand ON cand.id = d.chosen_candidate_id
          LEFT JOIN photo_current cur ON cur.species_code = d.species_code
@@ -109,7 +133,10 @@ function countAlreadyApplied(db: Database.Database): number {
   return row.n;
 }
 
-async function pushOne(deps: ApplyDeps, swap: PendingSwap): Promise<void> {
+/** The admin PUT response (best-effort). `url` is the new content-hashed prod URL. */
+interface AdminPutResponse { url?: string; key?: string }
+
+async function pushOne(deps: ApplyDeps, swap: PendingSwap): Promise<AdminPutResponse> {
   const url = `${deps.adminBase.replace(/\/$/, '')}/admin/species-photos/${swap.speciesCode}`;
   const res = await deps.fetch(url, {
     method: 'PUT',
@@ -132,6 +159,121 @@ async function pushOne(deps: ApplyDeps, swap: PendingSwap): Promise<void> {
     }
     throw new Error(`HTTP ${res.status}${detail ? `: ${detail}` : ''}`);
   }
+  // The admin endpoint returns the new content-hashed prod URL — used as the
+  // promoted photo_current.url when present. A body we can't parse is non-fatal:
+  // the push succeeded, so fall back to the candidate's source url for promotion.
+  try {
+    return (await res.json()) as AdminPutResponse;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Promote the just-applied candidate to the species' CURRENT photo + score
+ * (#974), in ONE transaction with marking the decision applied. After this the
+ * species' current keep flips to the candidate's keep (a good swap → keep=1), so
+ * it drops out of the keep=0 / needs-swap set and the overall list updates.
+ *
+ *  • photo_current.url/attribution/license → the prod URL the admin endpoint
+ *    returned (content-hashed), or the candidate's source url as a fallback.
+ *  • photo_score role='current' ← the candidate's STORED report (its keep,
+ *    quality_score, field_marks, criteria, flags, rationale, content_hash) at the
+ *    current rubric_version.
+ *  • source_attempt → 'applied' (best_score = the promoted quality_score).
+ *  • swap_selection cleared (the swap is done).
+ *
+ * Skipped (with a logged note, never thrown) when the candidate has no stored
+ * role='candidate' score — promotion needs the report, and a missing one means
+ * the candidate was approved out-of-band; the prod push already succeeded, so we
+ * still mark the decision applied and leave the local current photo untouched.
+ */
+function promoteApplied(
+  deps: ApplyDeps, swap: PendingSwap, prodUrl: string | undefined,
+): void {
+  const db = deps.db;
+  const inatId = swap.inatId;
+  if (inatId === undefined) {
+    deps.log(`  note ${swap.speciesCode}: no inat id on the swap — skipped local promotion`);
+    return;
+  }
+  // The candidate's stored report (role='candidate') by its inat id. content_hash
+  // isn't known here, so read by (species, role, inat) directly.
+  const candRow = db.prepare(
+    `SELECT content_hash, overall, verdict, criteria_json, flags_json, keep,
+            quality_score, field_marks, rationale, rubric_version
+       FROM photo_score
+      WHERE species_code = ? AND role = 'candidate' AND candidate_inat_id = ?`,
+  ).get(swap.speciesCode, inatId) as CandidateScoreRow | undefined;
+  if (!candRow) {
+    deps.log(`  note ${swap.speciesCode}: no stored candidate score for inat ${inatId} — pushed to prod, skipped local promotion`);
+    return;
+  }
+
+  const cur = db.prepare(
+    `SELECT com_name, sci_name, family FROM photo_current WHERE species_code = ?`,
+  ).get(swap.speciesCode) as { com_name: string | null; sci_name: string | null; family: string | null } | undefined;
+
+  const newHash = candRow.content_hash ?? '';
+  const newUrl = prodUrl ?? swap.newUrl;
+  const report: QualityReport = {
+    overall: candRow.overall,
+    verdict: candRow.verdict as QualityReport['verdict'],
+    deterministic: {
+      width: 0, height: 0, megapixels: 0, sharpness: 0, exposure: 0, aspectRatio: 0,
+      passedGate: true, failReasons: [],
+    },
+    criteria: JSON.parse(candRow.criteria_json) as CriteriaScores,
+    flags: JSON.parse(candRow.flags_json) as string[],
+    fieldMarks: candRow.field_marks ? (JSON.parse(candRow.field_marks) as string[]) : [],
+    keep: candRow.keep === 1,
+    qualityScore: candRow.quality_score ?? candRow.overall,
+    rationale: candRow.rationale,
+    // promote to the CURRENT rubric version (apply forward only — no re-scoring).
+    rubricVersion: defaultRubricConfig.version,
+  };
+
+  // photo_current → the candidate's photo. upsertCurrentPhoto resets reviewed=0
+  // is NOT desired here, but the displayed list keys on photo_score.keep, so the
+  // upsert below + the role='current' score upsert together flip keep to the
+  // candidate's. (upsertCurrentPhoto leaves reviewed at its column default; a
+  // re-score pass would reset it, which we don't run — apply forward only.)
+  upsertCurrentPhoto(db, {
+    speciesCode: swap.speciesCode,
+    comName: cur?.com_name ?? swap.comName,
+    sciName: cur?.sci_name ?? '',
+    family: cur?.family ?? '',
+    url: newUrl,
+    attribution: swap.attribution,
+    license: swap.license,
+    contentHash: newHash,
+  });
+  // Replace the species' role='current' score outright. upsertScore keys on
+  // (species_code, role, content_hash), so a NEW content_hash would INSERT a
+  // second current-role row and leave the stale keep=0 row behind — the species
+  // would still appear in needs-swap. Delete the old current score(s) first so
+  // exactly one current-role row (the promoted keep=1 candidate) remains.
+  db.prepare(`DELETE FROM photo_score WHERE species_code = ? AND role = 'current'`)
+    .run(swap.speciesCode);
+  upsertScore(db, {
+    speciesCode: swap.speciesCode, role: 'current', candidateInatId: null,
+    contentHash: newHash, report,
+  });
+  setSourceAttemptOutcome(db, swap.speciesCode, APPLY_SOURCE, 'applied', Math.round(report.qualityScore));
+  clearSwapSelection(db, swap.speciesCode);
+}
+
+interface CandidateScoreRow {
+  content_hash: string | null;
+  overall: number;
+  verdict: string;
+  criteria_json: string;
+  flags_json: string;
+  keep: number | null;
+  quality_score: number | null;
+  field_marks: string | null;
+  rationale: string;
+  rubric_version: string;
 }
 
 export async function runApplySwaps(deps: ApplyDeps): Promise<ApplyResult> {
@@ -172,8 +314,16 @@ export async function runApplySwaps(deps: ApplyDeps): Promise<ApplyResult> {
   // means a failed apply never leaves a dangling live URL (spec §8).
   for (const swap of swaps) {
     try {
-      await pushOne(deps, swap);
-      markApplied.run(deps.now(), swap.speciesCode);
+      // Prod push FIRST. Only on a 2xx do we mark applied AND promote the
+      // candidate to the species' current — both in one transaction so a
+      // promotion that throws never leaves a half-applied local state (#974). A
+      // push failure throws here, before any local mutation.
+      const prod = await pushOne(deps, swap);
+      const commit = deps.db.transaction(() => {
+        markApplied.run(deps.now(), swap.speciesCode);
+        promoteApplied(deps, swap, prod.url);
+      });
+      commit();
       applied.push(swap.speciesCode);
       deps.log(`  OK  ${swap.speciesCode}`);
     } catch (err) {

--- a/tools/photo-curation/src/cli.ts
+++ b/tools/photo-curation/src/cli.ts
@@ -91,14 +91,17 @@ program
   .description('Fetch + download a deep iNat candidate pool for FLAGGED species and write a manifest the source agents Read (Node half of the source-candidates Workflow — Bug 1, #992).')
   .option('--pool <n>', 'iNat candidates per flagged species', '15')
   .option('--limit <n>', 'cap how many keep=0 species to source this run, worst-first (default: all)')
-  .action(async (opts: { pool: string; limit?: string }) => {
+  .option('--source <name>', 'image source key; species already searched under it are skipped (#974)', 'inat')
+  .action(async (opts: { pool: string; limit?: string; source: string }) => {
     const db = openDb(DEFAULT_DB_PATH);
     try {
       // --limit caps the number of keep=0 species sourced (worst-first); omit for
       // all. Only set the opt when the flag was passed (exactOptionalPropertyTypes).
-      const limitOpts = opts.limit !== undefined ? { limit: Number(opts.limit) } : {};
+      // --source keys the skip ledger: a species already searched under this
+      // source is excluded; a different source re-tries an iNat-exhausted species.
+      const sourceOpts = { source: opts.source, ...(opts.limit !== undefined ? { limit: Number(opts.limit) } : {}) };
       const result = await sourcePrepare(
-        db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR }, limitOpts,
+        db, Number(opts.pool), { download: downloadBytes, thumbDir: THUMB_DIR }, sourceOpts,
       );
       console.log(`[source-prepare] sourced ${result.picked} candidate(s) — ${result.inatFetches} iNat fetch(es) + ${result.downloads} edge download(s); manifest at ${result.manifestPath}`);
       console.log(result.manifestPath);
@@ -111,11 +114,12 @@ program
   .command('source-commit')
   .description('Commit agent candidate scores (composeReport → upsertScore role=candidate) — Node half of the source-candidates Workflow (Bug 1, #992).')
   .argument('<results.json>', 'path to the agent results JSON: [{ speciesCode, inatId, contentHash, criteria, flags, rationale }]')
-  .action(async (resultsPath: string) => {
+  .option('--source <name>', 'image source whose source_attempt rows to resolve (must match source-prepare; #974)', 'inat')
+  .action(async (resultsPath: string, opts: { source: string }) => {
     const db = openDb(DEFAULT_DB_PATH);
     try {
       const results = JSON.parse(await readFile(resultsPath, 'utf8')) as SourceResult[];
-      const summary = await sourceCommit(db, results);
+      const summary = await sourceCommit(db, results, { source: opts.source });
       console.log(`[source-commit] ${JSON.stringify(summary, null, 2)}`);
       process.exit(summary.failed > 0 ? 1 : 0);
     } finally {

--- a/tools/photo-curation/src/db.test.ts
+++ b/tools/photo-curation/src/db.test.ts
@@ -53,6 +53,21 @@ describe('openDb', () => {
     expect(row.reviewed).toBe(0);
   });
 
+  it('source_attempt has the contract columns and (species_code, source) PK (#974)', () => {
+    db = openDb(':memory:');
+    expect(columns(db, 'source_attempt')).toEqual([
+      'species_code', 'source', 'attempted_at', 'candidates_found', 'best_score', 'outcome',
+    ]);
+    // composite PK on (species_code, source).
+    const pk = (db.prepare(`PRAGMA table_info(source_attempt)`).all() as { name: string; pk: number }[])
+      .filter(c => c.pk > 0).map(c => c.name).sort();
+    expect(pk).toEqual(['source', 'species_code']);
+    // source defaults to 'inat'.
+    db.prepare(`INSERT INTO source_attempt (species_code, attempted_at) VALUES (?, ?)`).run('amerob', 'now');
+    const row = db.prepare(`SELECT source FROM source_attempt WHERE species_code=?`).get('amerob') as { source: string };
+    expect(row.source).toBe('inat');
+  });
+
   it('photo_decision defaults applied=0 and exposes the four-action shape', () => {
     db = openDb(':memory:');
     db.prepare(

--- a/tools/photo-curation/src/db.ts
+++ b/tools/photo-curation/src/db.ts
@@ -83,6 +83,26 @@ CREATE TABLE IF NOT EXISTS swap_selection (
   decided_at     TEXT
 );
 
+-- Per-(species, source) sourcing ledger (#974 skim-the-bottom loop). One row
+-- per species per image source the curator has searched, so a future
+-- source-prepare under the same --source can SKIP a species already searched
+-- under that source (no re-picking the same images) while a DIFFERENT source can
+-- still retry it. outcome in 'searched' (sourced, not yet committed) /
+-- 'better-found' (a committed candidate cleared the Δ>=20 gate) / 'exhausted'
+-- (searched, nothing better — stays needs-swap but future same-source sourcing
+-- skips it) / 'applied' (a swap was pushed to prod). best_score is the best
+-- non-duplicate candidate's quality_score at commit/apply time. PK is the
+-- (species_code, source) pair so re-recording a search upserts in place.
+CREATE TABLE IF NOT EXISTS source_attempt (
+  species_code     TEXT NOT NULL,
+  source           TEXT NOT NULL DEFAULT 'inat',
+  attempted_at     TEXT NOT NULL,
+  candidates_found INTEGER,
+  best_score       INTEGER,
+  outcome          TEXT,
+  PRIMARY KEY (species_code, source)
+);
+
 -- One report per (subject, content_hash): re-scoring an unchanged image is a
 -- no-op the orchestrator can detect before calling the judge.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_photo_score_subject

--- a/tools/photo-curation/src/score-orchestration.test.ts
+++ b/tools/photo-curation/src/score-orchestration.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { openDb } from './db.js';
-import { upsertCurrentPhoto, upsertScore, getScoreByHash, selectUnreviewed, listCandidates, updateCurrentPhotoHash } from './store.js';
+import { upsertCurrentPhoto, upsertScore, getScoreByHash, selectUnreviewed, listCandidates, updateCurrentPhotoHash, getSourceAttempt, recordSourceAttempt } from './store.js';
 import { sha8 } from './hash.js';
 import {
   scorePrepare, scoreCommit, sourcePrepare, sourceCommit,
@@ -443,6 +443,124 @@ describe('sourceCommit (Node, testable — Bug 1 source-candidates split)', () =
     expect(['great', 'good']).toContain(stored!.verdict);
     expect(stored!.keep).toBe(true);
     expect(stored!.qualityScore).toBe(88);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #974 — source-keyed skip ledger. source-prepare records a source_attempt per
+// species it sources, and SKIPS species already searched under the run's source.
+// source-commit resolves 'searched' → 'better-found' | 'exhausted'.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('sourcePrepare — source_attempt skip + record (#974)', () => {
+  it('records outcome=searched for each newly-sourced species, with the non-dup candidate count', async () => {
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1');
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P', license: 'cc-by' },
+      { inatId: 12, photoUrl: 'https://inat.example/12.jpg', attribution: '(c) Q', license: 'cc0' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
+
+    const attempt = getSourceAttempt(db, 'flag1', 'inat');
+    expect(attempt).not.toBeNull();
+    expect(attempt!.outcome).toBe('searched');
+    expect(attempt!.candidatesFound).toBe(2);
+    expect(attempt!.source).toBe('inat');
+  });
+
+  it('SKIPS a species already searched under the run source, but sources it under a DIFFERENT --source', async () => {
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1');
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P', license: 'cc-by' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+
+    // Pre-record an iNat attempt — flag1 is already searched under 'inat'.
+    recordSourceAttempt(db, { speciesCode: 'flag1', source: 'inat', candidatesFound: 1, outcome: 'exhausted' });
+
+    // source-prepare under the SAME source (default 'inat') must skip flag1.
+    const inatRun = await sourcePrepare(
+      db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() },
+    );
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(0);
+    expect(inatRun.picked).toBe(0);
+
+    // source-prepare under a DIFFERENT source CAN retry the iNat-exhausted species.
+    const otherRun = await sourcePrepare(
+      db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() },
+      { source: 'macaulay' },
+    );
+    expect(fetchInatCandidates).toHaveBeenCalledTimes(1);
+    expect(otherRun.picked).toBe(1);
+    // A fresh source_attempt row was recorded under the new source.
+    expect(getSourceAttempt(db, 'flag1', 'macaulay')!.outcome).toBe('searched');
+    // The original iNat row is untouched.
+    expect(getSourceAttempt(db, 'flag1', 'inat')!.outcome).toBe('exhausted');
+  });
+});
+
+describe('sourceCommit — outcome resolution (#974)', () => {
+  // Seed a flagged current (quality_score 30) + a sourced candidate, then commit
+  // an agent score for that candidate. The gate decides better-found / exhausted.
+  async function prepCandidate(qs: number): Promise<string> {
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1'); // current quality_score = 30
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P', license: 'cc-by' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+    const prep = await sourcePrepare(db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() });
+    return prep.manifest[0]!.contentHash;
+  }
+  function commitWith(hash: string, qs: number): Promise<unknown> {
+    const results: SourceResult[] = [{
+      speciesCode: 'flag1', inatId: 11, contentHash: hash,
+      fieldMarks: [], criteria: { framing: 8, subjectClarity: 8, liveness: 8, naturalness: 8, pose: 8, background: 8, lighting: 8 },
+      flags: [], keep: true, qualityScore: qs, rationale: 'alt',
+    }];
+    return sourceCommit(db, results);
+  }
+
+  it("sets 'better-found' (with best_score) when a candidate clears the Δ>=20 gate", async () => {
+    const hash = await prepCandidate(60);
+    // candidate qs 60 vs current 30 → Δ30 ≥ 20 → better-found.
+    await commitWith(hash, 60);
+    const a = getSourceAttempt(db, 'flag1', 'inat');
+    expect(a!.outcome).toBe('better-found');
+    expect(a!.bestScore).toBe(60);
+  });
+
+  it("sets 'exhausted' when no candidate clears the gate (Δ<20)", async () => {
+    const hash = await prepCandidate(45);
+    // candidate qs 45 vs current 30 → Δ15 < 20 → exhausted.
+    await commitWith(hash, 45);
+    const a = getSourceAttempt(db, 'flag1', 'inat');
+    expect(a!.outcome).toBe('exhausted');
+  });
+
+  it('resolves the outcome on the run source passed to sourceCommit', async () => {
+    // Source under 'macaulay', then commit with the SAME source → that row resolves.
+    seedCurrent('flag1', 'https://photos.example/flag1.jpg');
+    seedFlaggedScore('flag1');
+    const fetchInatCandidates = vi.fn(async () => [
+      { inatId: 11, photoUrl: 'https://inat.example/11.jpg', attribution: '(c) P', license: 'cc-by' },
+    ]);
+    const download = vi.fn(async (url: string) => Buffer.from(url));
+    const prep = await sourcePrepare(
+      db, 5, { fetchInatCandidates, download, thumbDir: workDir, clock: instant() }, { source: 'macaulay' },
+    );
+    const hash = prep.manifest[0]!.contentHash;
+    const results: SourceResult[] = [{
+      speciesCode: 'flag1', inatId: 11, contentHash: hash, fieldMarks: [],
+      criteria: { framing: 8, subjectClarity: 8, liveness: 8, naturalness: 8, pose: 8, background: 8, lighting: 8 },
+      flags: [], keep: true, qualityScore: 70, rationale: 'alt',
+    }];
+    await sourceCommit(db, results, { source: 'macaulay' });
+    expect(getSourceAttempt(db, 'flag1', 'macaulay')!.outcome).toBe('better-found');
   });
 });
 

--- a/tools/photo-curation/src/score-orchestration.ts
+++ b/tools/photo-curation/src/score-orchestration.ts
@@ -14,7 +14,9 @@ import { sha8 } from './hash.js';
 import {
   selectUnreviewed, updateCurrentPhotoHash, upsertScore, markReviewed,
   insertCandidate, maxSourceRound, getScoreByHash,
+  recordSourceAttempt, setSourceAttemptOutcome,
 } from './store.js';
+import { selectSwaps } from './swaps.js';
 import { scoreBatch, mimeFromUrl, extFromMime } from './sources.js';
 import {
   Pacer, withBackoff, clampPool, realClock,
@@ -399,6 +401,9 @@ interface FlaggedRow {
  *     (paid) judge never scores a photo we already have. `skippedDuplicates`
  *     counts these (≈20% of candidates in a real run).
  */
+/** The default image source key for a source-prepare/commit run (#974). */
+export const DEFAULT_SOURCE = 'inat';
+
 /** Optional caps for a source-prepare run. */
 export interface SourcePrepareOpts {
   /**
@@ -408,6 +413,17 @@ export interface SourcePrepareOpts {
    * operator sources the N worst-scored needs-replacement species per run.
    */
   limit?: number;
+  /**
+   * The image source being searched (#974). Defaults to DEFAULT_SOURCE ('inat').
+   * The flagged-species query EXCLUDES any species that already has a
+   * source_attempt row for THIS source, so a second `source-prepare --source
+   * inat` never re-sources an already-searched species (no re-picking the same
+   * images); a DIFFERENT --source is unaffected and CAN retry an iNat-exhausted
+   * species. Each newly-sourced species gets a recordSourceAttempt(outcome=
+   * 'searched') row; source-commit later resolves it to 'better-found' or
+   * 'exhausted'.
+   */
+  source?: string;
 }
 
 export async function sourcePrepare(
@@ -436,14 +452,21 @@ export async function sourcePrepare(
     typeof rawLimit === 'number' && Number.isFinite(rawLimit) && rawLimit >= 1
       ? Math.floor(rawLimit)
       : null;
+  // Source-keyed skip (#974): exclude any species that ALREADY has a
+  // source_attempt row for THIS source — once iNat has been searched for a
+  // species, the next `source-prepare --source inat` never re-sources it (no
+  // re-picking the same images). A different --source has its own ledger rows
+  // and so CAN retry an iNat-exhausted species.
+  const source = opts.source ?? DEFAULT_SOURCE;
   const flagged = db.prepare(
     `SELECT c.species_code, c.com_name, c.sci_name, c.family, c.content_hash
        FROM photo_score s
        JOIN photo_current c ON c.species_code = s.species_code
       WHERE s.role = 'current' AND s.keep = 0
+        AND c.species_code NOT IN (SELECT species_code FROM source_attempt WHERE source = ?)
       ORDER BY s.quality_score ASC, c.species_code ASC
       ${speciesLimit !== null ? 'LIMIT ?' : ''}`,
-  ).all(...(speciesLimit !== null ? [speciesLimit] : [])) as FlaggedRow[];
+  ).all(...(speciesLimit !== null ? [source, speciesLimit] : [source])) as FlaggedRow[];
 
   const manifest: SourceManifestEntry[] = [];
   let inatFetches = 0;
@@ -472,6 +495,10 @@ export async function sourcePrepare(
       continue;
     }
 
+    // Count only the REAL (non-same-picture) candidates this species yielded,
+    // so the source_attempt ledger reflects the genuine candidate pool. The
+    // same-picture dedup below increments this only for inserted candidates.
+    let speciesCandidates = 0;
     for (const cand of candidates.slice(0, cappedPool)) {
       await edgePacer.gate();
       const bytes = await withBackoff(() => deps.download(cand.photoUrl), { clock });
@@ -492,6 +519,7 @@ export async function sourcePrepare(
         thumbPath: imagePath, attribution: cand.attribution, license: cand.license,
         sourceRound: round,
       });
+      speciesCandidates++;
       manifest.push({
         speciesCode: sp.species_code,
         comName: sp.com_name ?? '',
@@ -504,6 +532,17 @@ export async function sourcePrepare(
         license: cand.license,
       });
     }
+
+    // Record this species as searched under the run's source (#974). Only real
+    // (non-duplicate) candidates are counted; outcome='searched' is resolved to
+    // 'better-found'/'exhausted' by source-commit. This row is what makes the
+    // NEXT `source-prepare --source <source>` skip the species.
+    recordSourceAttempt(db, {
+      speciesCode: sp.species_code,
+      source,
+      candidatesFound: speciesCandidates,
+      outcome: 'searched',
+    });
   }
 
   const manifestPath = join(deps.thumbDir, 'candidates-manifest.json');
@@ -526,16 +565,38 @@ export interface SourceResult {
   rationale: string;
 }
 
+/** Optional knobs for a source-commit run. */
+export interface SourceCommitOpts {
+  /**
+   * The image source whose source_attempt rows to resolve (#974). Defaults to
+   * DEFAULT_SOURCE ('inat') — must match the source-prepare run that staged the
+   * candidates. After committing the candidate scores, each species in the batch
+   * has its 'searched' attempt resolved to 'better-found' (a non-duplicate
+   * candidate clears the Δ≥MIN_IMPROVEMENT gate) or 'exhausted' (searched,
+   * nothing better — stays needs-swap but future sourcing under this source
+   * skips it).
+   */
+  source?: string;
+}
+
 /**
  * source-commit: composeReport each agent candidate result and persist it as
  * role='candidate' keyed by (species_code, content_hash) with the inat id, so
  * the review server's deny route can advance to a scored alternate. A missing
  * content hash is recorded as a failure, not thrown.
+ *
+ * Outcome resolution (#974): after the candidate scores are upserted, each
+ * distinct species in the batch has its source_attempt outcome resolved by
+ * reusing the swap gate (selectSwaps, whose `outscores`/`delta` encode the SAME
+ * same-picture-exclusion + Δ≥MIN_IMPROVEMENT logic apply-swaps uses — no
+ * duplicated threshold). If the best non-duplicate committed candidate would be
+ * auto-proposed → 'better-found' with best_score; otherwise → 'exhausted'.
  */
 export async function sourceCommit(
-  db: Database.Database, results: SourceResult[],
+  db: Database.Database, results: SourceResult[], opts: SourceCommitOpts = {},
 ): Promise<CommitSummary> {
   const summary: CommitSummary = { committed: 0, failed: 0, errors: [] };
+  const committedSpecies = new Set<string>();
   for (const r of results) {
     try {
       if (!r.contentHash) {
@@ -559,10 +620,34 @@ export async function sourceCommit(
         speciesCode: r.speciesCode, role: 'candidate', candidateInatId: r.inatId,
         contentHash: r.contentHash, report,
       });
+      committedSpecies.add(r.speciesCode);
       summary.committed++;
     } catch (err) {
       summary.failed++;
       summary.errors.push({ speciesCode: r.speciesCode, reason: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  // Resolve each committed species' 'searched' source_attempt to a terminal
+  // sourcing outcome by reusing selectSwaps' gate. A species appears in the
+  // selectSwaps output only when it has ≥1 non-duplicate scored candidate; its
+  // `outscores` is true iff the best such candidate clears Δ≥MIN_IMPROVEMENT (the
+  // exact predicate apply-swaps would propose on). No row for the species (no
+  // non-dup candidate) → nothing cleared → 'exhausted'.
+  if (committedSpecies.size > 0) {
+    const source = opts.source ?? DEFAULT_SOURCE;
+    const swapByCode = new Map(selectSwaps(db).map(s => [s.speciesCode, s]));
+    for (const code of committedSpecies) {
+      const swap = swapByCode.get(code);
+      if (swap?.outscores) {
+        // best non-dup candidate's quality_score = current + delta (delta is
+        // computed against the best candidate AFTER same-picture dedup). Use the
+        // gate's own number rather than re-deriving so the two never diverge.
+        const bestScore = (swap.current.qualityScore ?? 0) + swap.delta;
+        setSourceAttemptOutcome(db, code, source, 'better-found', Math.round(bestScore));
+      } else {
+        setSourceAttemptOutcome(db, code, source, 'exhausted');
+      }
     }
   }
   return summary;

--- a/tools/photo-curation/src/store.test.ts
+++ b/tools/photo-curation/src/store.test.ts
@@ -6,6 +6,7 @@ import {
   insertCandidate, listCandidates, markCandidatesExcluded,
   selectUnreviewed, markReviewed, updateCurrentPhotoHash,
   setSwapSelection, getSwapSelection,
+  recordSourceAttempt, getSourceAttempt, setSourceAttemptOutcome, listSourceAttempts,
 } from './store.js';
 import type { QualityReport } from '@bird-watch/photo-quality';
 
@@ -174,5 +175,61 @@ describe('swap_selection (operator override)', () => {
     const noSwap = getSwapSelection(db, 'norcar');
     expect(noSwap).not.toBeNull();
     expect(noSwap!.chosenInatId).toBeNull();
+  });
+});
+
+describe('source_attempt (per-source sourcing ledger #974)', () => {
+  it('getSourceAttempt returns null when no attempt is recorded', () => {
+    expect(getSourceAttempt(db, 'norcar', 'inat')).toBeNull();
+  });
+
+  it('recordSourceAttempt upserts on the (species, source) PK', () => {
+    recordSourceAttempt(db, { speciesCode: 'norcar', source: 'inat', candidatesFound: 4, outcome: 'searched' });
+    const first = getSourceAttempt(db, 'norcar', 'inat');
+    expect(first).not.toBeNull();
+    expect(first!.candidatesFound).toBe(4);
+    expect(first!.outcome).toBe('searched');
+    expect(first!.bestScore).toBeNull();
+    expect(typeof first!.attemptedAt).toBe('string');
+
+    // Re-record (same PK) overwrites in place — one row, new values.
+    recordSourceAttempt(db, { speciesCode: 'norcar', source: 'inat', candidatesFound: 7, outcome: 'better-found', bestScore: 88 });
+    expect((db.prepare(`SELECT COUNT(*) n FROM source_attempt WHERE species_code='norcar' AND source='inat'`).get() as { n: number }).n).toBe(1);
+    const updated = getSourceAttempt(db, 'norcar', 'inat');
+    expect(updated!.candidatesFound).toBe(7);
+    expect(updated!.outcome).toBe('better-found');
+    expect(updated!.bestScore).toBe(88);
+  });
+
+  it('the same species under a DIFFERENT source is a separate row', () => {
+    recordSourceAttempt(db, { speciesCode: 'norcar', source: 'inat', candidatesFound: 2, outcome: 'exhausted' });
+    recordSourceAttempt(db, { speciesCode: 'norcar', source: 'macaulay', candidatesFound: 5, outcome: 'searched' });
+    expect(getSourceAttempt(db, 'norcar', 'inat')!.outcome).toBe('exhausted');
+    expect(getSourceAttempt(db, 'norcar', 'macaulay')!.outcome).toBe('searched');
+    expect((db.prepare(`SELECT COUNT(*) n FROM source_attempt WHERE species_code='norcar'`).get() as { n: number }).n).toBe(2);
+  });
+
+  it('setSourceAttemptOutcome updates outcome (and best_score) of an existing row', () => {
+    recordSourceAttempt(db, { speciesCode: 'norcar', source: 'inat', candidatesFound: 3, outcome: 'searched' });
+    setSourceAttemptOutcome(db, 'norcar', 'inat', 'better-found', 91);
+    const a = getSourceAttempt(db, 'norcar', 'inat');
+    expect(a!.outcome).toBe('better-found');
+    expect(a!.bestScore).toBe(91);
+    expect(a!.candidatesFound).toBe(3); // untouched
+
+    // Outcome-only update leaves best_score as-is.
+    setSourceAttemptOutcome(db, 'norcar', 'inat', 'applied');
+    const b = getSourceAttempt(db, 'norcar', 'inat');
+    expect(b!.outcome).toBe('applied');
+    expect(b!.bestScore).toBe(91);
+  });
+
+  it('listSourceAttempts returns all rows for a source only', () => {
+    recordSourceAttempt(db, { speciesCode: 'aaa', source: 'inat', candidatesFound: 1, outcome: 'exhausted' });
+    recordSourceAttempt(db, { speciesCode: 'bbb', source: 'inat', candidatesFound: 2, outcome: 'searched' });
+    recordSourceAttempt(db, { speciesCode: 'ccc', source: 'macaulay', candidatesFound: 3, outcome: 'searched' });
+    const inat = listSourceAttempts(db, 'inat');
+    expect(inat.map(a => a.speciesCode).sort()).toEqual(['aaa', 'bbb']);
+    expect(listSourceAttempts(db, 'macaulay').map(a => a.speciesCode)).toEqual(['ccc']);
   });
 });

--- a/tools/photo-curation/src/store.ts
+++ b/tools/photo-curation/src/store.ts
@@ -367,3 +367,121 @@ export function getSwapSelection(
     decidedAt: row.decided_at,
   };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// source_attempt — the per-(species, source) sourcing ledger (#974). Once iNat
+// has been searched for a species, source-prepare --source inat never re-sources
+// it; a different --source is unaffected and CAN retry an iNat-exhausted species.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The four terminal states of a source attempt (DB column `outcome`). */
+export type SourceAttemptOutcome = 'searched' | 'better-found' | 'exhausted' | 'applied';
+
+/** A persisted per-(species, source) source attempt. */
+export interface SourceAttempt {
+  speciesCode: string;
+  source: string;
+  attemptedAt: string;
+  candidatesFound: number | null;
+  bestScore: number | null;
+  outcome: SourceAttemptOutcome | null;
+}
+
+interface SourceAttemptRow {
+  species_code: string;
+  source: string;
+  attempted_at: string;
+  candidates_found: number | null;
+  best_score: number | null;
+  outcome: SourceAttemptOutcome | null;
+}
+
+function mapSourceAttempt(row: SourceAttemptRow): SourceAttempt {
+  return {
+    speciesCode: row.species_code,
+    source: row.source,
+    attemptedAt: row.attempted_at,
+    candidatesFound: row.candidates_found,
+    bestScore: row.best_score,
+    outcome: row.outcome,
+  };
+}
+
+/**
+ * Upsert a source attempt on its (species_code, source) PK. source-prepare calls
+ * this with outcome='searched' for each species it sources this run; a re-record
+ * overwrites in place (attempted_at re-stamped). `bestScore` is optional —
+ * defaults to null, filled at commit/apply time via setSourceAttemptOutcome.
+ */
+export function recordSourceAttempt(
+  db: Database.Database,
+  a: {
+    speciesCode: string;
+    source: string;
+    candidatesFound: number;
+    outcome: SourceAttemptOutcome;
+    bestScore?: number;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO source_attempt
+       (species_code, source, attempted_at, candidates_found, best_score, outcome)
+     VALUES (@speciesCode, @source, @attemptedAt, @candidatesFound, @bestScore, @outcome)
+     ON CONFLICT(species_code, source) DO UPDATE SET
+       attempted_at=excluded.attempted_at,
+       candidates_found=excluded.candidates_found,
+       best_score=excluded.best_score,
+       outcome=excluded.outcome`,
+  ).run({
+    speciesCode: a.speciesCode,
+    source: a.source,
+    attemptedAt: new Date().toISOString(),
+    candidatesFound: a.candidatesFound,
+    bestScore: a.bestScore ?? null,
+    outcome: a.outcome,
+  });
+}
+
+/** Read the source attempt for a (species, source), or null when none recorded. */
+export function getSourceAttempt(
+  db: Database.Database, speciesCode: string, source: string,
+): SourceAttempt | null {
+  const row = db.prepare(
+    `SELECT species_code, source, attempted_at, candidates_found, best_score, outcome
+       FROM source_attempt WHERE species_code=? AND source=?`,
+  ).get(speciesCode, source) as SourceAttemptRow | undefined;
+  return row ? mapSourceAttempt(row) : null;
+}
+
+/**
+ * Update the outcome (and optionally best_score) of an EXISTING source attempt
+ * without disturbing its candidates_found / attempted_at. source-commit resolves
+ * 'searched' → 'better-found'|'exhausted'; apply-swaps sets 'applied'. A no-op
+ * when no row exists (UPDATE … WHERE matches nothing).
+ */
+export function setSourceAttemptOutcome(
+  db: Database.Database,
+  speciesCode: string,
+  source: string,
+  outcome: SourceAttemptOutcome,
+  bestScore?: number,
+): void {
+  if (bestScore === undefined) {
+    db.prepare(
+      `UPDATE source_attempt SET outcome=? WHERE species_code=? AND source=?`,
+    ).run(outcome, speciesCode, source);
+  } else {
+    db.prepare(
+      `UPDATE source_attempt SET outcome=?, best_score=? WHERE species_code=? AND source=?`,
+    ).run(outcome, bestScore, speciesCode, source);
+  }
+}
+
+/** List every source attempt for a source (newest attempt first). */
+export function listSourceAttempts(db: Database.Database, source: string): SourceAttempt[] {
+  const rows = db.prepare(
+    `SELECT species_code, source, attempted_at, candidates_found, best_score, outcome
+       FROM source_attempt WHERE source=? ORDER BY attempted_at DESC, species_code ASC`,
+  ).all(source) as SourceAttemptRow[];
+  return rows.map(mapSourceAttempt);
+}


### PR DESCRIPTION
## Diagrams

The iterative "skim the bottom" curation loop. `source_attempt` is the per-(species, source) ledger that makes each phase idempotent: once a source is searched for a species it is never re-picked under that source, and applying a good swap promotes the candidate to the species' current photo so it leaves the needs-swap set.

```mermaid
flowchart TD
    A["source-prepare --source inat --limit N<br/>worst-first keep=0 species<br/>EXCLUDE any with a source_attempt row for this source"] -->|"per sourced species"| B["recordSourceAttempt(outcome='searched')"]
    B --> C["score candidates (agents) → source-commit --source inat"]
    C -->|"best non-dup clears Δ≥20 (selectSwaps gate)"| D["outcome='better-found' (+best_score)"]
    C -->|"nothing better"| E["outcome='exhausted'<br/>stays needs-swap, future iNat sourcing SKIPS it"]
    D --> F["operator approves → apply-swaps"]
    F -->|"prod PUT ok"| G["PROMOTE candidate → current<br/>photo_current + photo_score role='current'<br/>keep flips → leaves keep=0<br/>source_attempt='applied', swap_selection cleared"]
    F -->|"prod PUT fails"| H["NOT promoted — stays needs-swap, applied=0"]
    E -.->|"later: a DIFFERENT --source"| A
```

## Summary

- **Skim-the-bottom, no re-picking.** A new idempotent `source_attempt(species_code, source, attempted_at, candidates_found, best_score, outcome)` table (PK `(species_code, source)`) records every species searched under each image source. `source-prepare` gains `--source` (default `inat`) and excludes species already searched under that source, so repeated runs walk *new* worst-N species instead of re-fetching the same iNat images. `exhausted` species are skipped by future same-source sourcing but a different `--source` can retry them.
- **Outcome resolution reuses the swap gate.** `source-commit --source <name>` resolves each batch species' `'searched'` row to `'better-found'` (best non-dup candidate clears Δ≥`MIN_IMPROVEMENT`, with `best_score`) or `'exhausted'`, computed via `selectSwaps` — the same threshold/same-picture logic apply-swaps proposes on, not a duplicated constant.
- **Apply updates the overall list.** The operator's key ask: on a successful prod push, `apply-swaps` now promotes the applied candidate to the species' `photo_current` + `photo_score` role='current' (its `keep`/`quality_score`/`field_marks`/`criteria`/`flags`/`rationale`/`content_hash` at the current rubric version), so `keep` flips to 1 and the species **leaves needs-swap**. It also sets `source_attempt='applied'` and clears the `swap_selection` override — all in one transaction. A push failure promotes nothing. The admin-returned content-hashed prod URL is used when present, else the candidate's source url. ("Apply forward only" — no re-scoring.)

## Screenshots

N/A — not frontend/** UI (tool code under `tools/photo-curation`: CLI + local SQLite store + apply-swaps).

## Test plan

- [x] `tsc --noEmit` (photo-curation) — clean; root `npm run build` — clean production build
- [x] `npm run test --workspace @bird-watch/photo-curation` — 198 passed (15 files), +14 new
- [x] `npx knip` — exit 0; no `package-lock.json` drift
- [x] New unit tests added: source_attempt store helpers (db.test + store.test); `source-prepare` source-keyed skip + cross-source retry + `outcome='searched'`; `source-commit` `better-found`/`exhausted` + source-keyed resolution; `apply-swaps` promotion on success (keep flips, species leaves keep=0, `source_attempt='applied'`, `swap_selection` cleared, prod-url-vs-fallback) and NO promotion on push failure
- [x] N/A — not UI (no Playwright e2e / MCP smoke; tool code, no `frontend/**`)

## Plan reference

Out of plan — photo-quality curation epic #974 follow-on (iterative skim-the-bottom sourcing loop + apply-promotes-to-current).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
