### PR TITLE
infra: stage photo-judge eval secrets in Secret Manager (#1016)

### DIFF
--- a/infra/terraform/photo-judge-secrets.tf
+++ b/infra/terraform/photo-judge-secrets.tf
@@ -1,0 +1,46 @@
+# ── Photo-judge eval secrets (issue #1016, part of #1010) ────────────────────
+#
+# Spec: docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md §5.
+#
+# The photo-quality field-mark judge runs a Braintrust eval that calls Gemini
+# Vision. Both the Gemini API key and the Braintrust API key live in GCP Secret
+# Manager so the IaC path is ready when the deferred Cloud Run job lands. This
+# iteration stages ONLY the two secret containers — no compute, no IAM binding,
+# no secret version:
+#
+#   * No secret VERSION: real values are set out-of-band so they never touch
+#     terraform.tfvars, plan output, or state JSON. Populate post-`terraform
+#     apply` via (value piped on stdin, never echoed):
+#       gcloud secrets versions add bird-watch-gemini-api-key \
+#         --project=bird-maps-prod --data-file=- < /path/to/gemini-key
+#       gcloud secrets versions add bird-watch-braintrust-api-key \
+#         --project=bird-maps-prod --data-file=- < /path/to/braintrust-key
+#     Same pattern as the SendGrid / R2 / Healthchecks secrets.
+#
+#   * No IAM binding and no SA var: the consuming service account arrives with
+#     the deferred Cloud Run job (gated on Gemini clearing its agreement gate).
+#     Binding an existing SA to secrets it cannot yet use is premature coupling
+#     (YAGNI). The local/CI eval reads the keys from .env.local / CI secrets,
+#     not from Secret Manager — these entries only stage the Cloud-Run-later
+#     path.
+#
+# `replication { auto {} }` is the post-provider-v5 form (the `automatic = true`
+# boolean was removed in google provider v5); matches the 8 existing secrets in
+# ingestor.tf / digest.tf. secret_id is immutable post-create and carries the
+# `bird-watch-` prefix convention.
+
+resource "google_secret_manager_secret" "gemini_api_key" {
+  secret_id = "bird-watch-gemini-api-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret" "braintrust_api_key" {
+  secret_id = "bird-watch-braintrust-api-key"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.secretmanager]
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -20,3 +20,9 @@ deployer_service_account_email = "REPLACE_ME@REPLACE_ME.iam.gserviceaccount.com"
 # NOT set here; they live in Secret Manager (bird-watch-healthchecks-<kind>)
 # populated out-of-band post-`terraform apply` via `gcloud secrets versions add`.
 # alert_email           = "julian.kennon.d@gmail.com"
+
+# Photo-judge eval secrets (issue #1016, see photo-judge-secrets.tf). Like the
+# Healthchecks URLs above, the Gemini and Braintrust API keys are NOT set here:
+# they live in Secret Manager (bird-watch-gemini-api-key,
+# bird-watch-braintrust-api-key) with values populated out-of-band post-apply
+# via `gcloud secrets versions add` so they never touch tfvars, plan, or state.


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph "GCP Secret Manager (this PR — containers only)"
        G[bird-watch-gemini-api-key]
        B[bird-watch-braintrust-api-key]
    end
    OOB["gcloud secrets versions add<br/>(value out-of-band, post-apply)"] -.->|adds version| G
    OOB -.->|adds version| B
    G -.->|consumed later by| CR["deferred Cloud Run job<br/>(not in this PR — gated on Gemini agreement)"]
    B -.-> CR
```

Two empty `google_secret_manager_secret` containers are created now. No version (value), no IAM binding, and no consuming compute exist yet — those arrive with the deferred Cloud Run job.

## Summary

- **Why now:** stage the durable IaC path for the photo-judge Braintrust eval (part of #1010) so the Secret Manager entries are ready when the deferred Cloud Run job lands — the eval today reads keys from `.env.local` / CI, but the IaC must not lag.
- **Why no version / IAM / SA:** values are set out-of-band via `gcloud secrets versions add` so they never touch `terraform.tfvars`, plan output, or state JSON; the consuming service account arrives with the deferred Cloud Run job, so binding an existing SA to unusable secrets now is premature coupling (YAGNI). Exactly two `google_secret_manager_secret` resources, both `bird-watch-`-prefixed, using `replication { auto {} }` (post-provider-v5 form, matching the 8 existing secrets in `ingestor.tf` / `digest.tf`).

## Screenshots

N/A — not UI (infra/terraform only).

## Test plan

- [x] `terraform init -backend=false` — succeeds
- [x] `terraform fmt -check` — clean (exit 0)
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] Grep new `.tf` for secret-value literals / `secret_data` / `_version` / `_iam` — zero hits (only the two `secret_id` identifiers)
- [x] Resource count: exactly two `google_secret_manager_secret`, no other resource types
- e2e / Playwright / npm: N/A — no app code touched; CI runs them.

## Plan reference

Part of #1010. Spec: `docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md` §5. Closes #1016.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)