### PR TITLE
feat(photo-curation): eval scorers — keep-agreement, score-MAE, keep-confusion

### DIFF
--- a/tools/photo-curation/src/eval/scorers.test.ts
+++ b/tools/photo-curation/src/eval/scorers.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { keepAgreement, scoreMAE, keepConfusion } from './scorers.js';
+
+/**
+ * The Braintrust scorer args are `{input, output, expected, metadata}`; these
+ * three scorers read only `output` + `expected`, which are JudgeOutput-shaped
+ * (the relevant fields are `keep: boolean` and `qualityScore: number`). The
+ * scorers are pure — no IO — so they can be unit-tested directly.
+ */
+const judge = (keep: boolean, qualityScore: number) => ({ keep, qualityScore });
+
+describe('keepAgreement', () => {
+  it('scores 1 when output.keep matches expected.keep', () => {
+    expect(keepAgreement({ output: judge(true, 80), expected: judge(true, 80) })).toEqual({
+      name: 'keep_agreement',
+      score: 1,
+    });
+    expect(keepAgreement({ output: judge(false, 20), expected: judge(false, 90) })).toEqual({
+      name: 'keep_agreement',
+      score: 1,
+    });
+  });
+
+  it('scores 0 when output.keep mismatches expected.keep', () => {
+    expect(keepAgreement({ output: judge(true, 80), expected: judge(false, 80) })).toEqual({
+      name: 'keep_agreement',
+      score: 0,
+    });
+    expect(keepAgreement({ output: judge(false, 80), expected: judge(true, 80) })).toEqual({
+      name: 'keep_agreement',
+      score: 0,
+    });
+  });
+});
+
+describe('scoreMAE', () => {
+  it('scores 1 for an exact qualityScore match', () => {
+    expect(scoreMAE({ output: judge(true, 80), expected: judge(true, 80) })).toEqual({
+      name: 'score_mae',
+      score: 1,
+    });
+  });
+
+  it('scores 0.5 for a 50-point absolute error', () => {
+    expect(scoreMAE({ output: judge(true, 80), expected: judge(true, 30) })).toEqual({
+      name: 'score_mae',
+      score: 0.5,
+    });
+  });
+
+  it('scores 0 for a full 100-point absolute error', () => {
+    expect(scoreMAE({ output: judge(true, 0), expected: judge(true, 100) })).toEqual({
+      name: 'score_mae',
+      score: 0,
+    });
+  });
+
+  it('clamps to 0 for an out-of-domain qualityScore (no negative scores)', () => {
+    // |130 - 50| / 100 = 0.8 → 1 - 0.8 = 0.2 is in-domain; push further:
+    // a >100-point error would yield a negative raw score, which we clamp to 0.
+    expect(scoreMAE({ output: judge(true, 130), expected: judge(true, 0) })).toEqual({
+      name: 'score_mae',
+      score: 0,
+    });
+  });
+});
+
+describe('keepConfusion', () => {
+  it('keep/keep — no confusion, score 1, neither flag set', () => {
+    expect(keepConfusion({ output: judge(true, 80), expected: judge(true, 80) })).toEqual({
+      name: 'keep_confusion',
+      score: 1,
+      metadata: { falseKeep: 0, falseReplace: 0 },
+    });
+  });
+
+  it('keep/replace — false-keep (the dangerous direction), score 0', () => {
+    expect(keepConfusion({ output: judge(true, 80), expected: judge(false, 20) })).toEqual({
+      name: 'keep_confusion',
+      score: 0,
+      metadata: { falseKeep: 1, falseReplace: 0 },
+    });
+  });
+
+  it('replace/keep — false-replace, score 0', () => {
+    expect(keepConfusion({ output: judge(false, 20), expected: judge(true, 80) })).toEqual({
+      name: 'keep_confusion',
+      score: 0,
+      metadata: { falseKeep: 0, falseReplace: 1 },
+    });
+  });
+
+  it('replace/replace — no confusion, score 1, neither flag set', () => {
+    expect(keepConfusion({ output: judge(false, 20), expected: judge(false, 30) })).toEqual({
+      name: 'keep_confusion',
+      score: 1,
+      metadata: { falseKeep: 0, falseReplace: 0 },
+    });
+  });
+});

--- a/tools/photo-curation/src/eval/scorers.ts
+++ b/tools/photo-curation/src/eval/scorers.ts
@@ -1,0 +1,67 @@
+/**
+ * Braintrust eval scorers for the photo-judge experiment (C4, #1014; part of
+ * #1010). Three headline metrics comparing a candidate judge `output` against
+ * the reference `expected` (both JudgeOutput-shaped — only `keep` and
+ * `qualityScore` matter here):
+ *
+ *   - keepAgreement  — exact boolean match of `keep` (the #969 ≥90% gate).
+ *   - scoreMAE       — normalized 1 - |Δ qualityScore| / 100, clamped to [0,1].
+ *   - keepConfusion  — splits disagreements into false-keep (output keeps what
+ *                      expected would replace — the DANGEROUS direction: it
+ *                      ships a bad photo) vs false-replace.
+ *
+ * Braintrust calls scorers with `{input, output, expected, metadata}`; these
+ * read only `output` + `expected`. All three are PURE — no IO — so they unit-
+ * test directly and can run inside the eval harness without side effects.
+ */
+
+/** The subset of JudgeOutput these scorers depend on. */
+export interface ScorerJudgeOutput {
+  keep: boolean;
+  qualityScore: number;
+}
+
+/** Braintrust scorer args, narrowed to the fields these scorers consume. */
+export interface ScorerArgs {
+  output: ScorerJudgeOutput;
+  expected: ScorerJudgeOutput;
+}
+
+export interface ScorerResult {
+  name: string;
+  score: number;
+}
+
+export interface KeepConfusionResult extends ScorerResult {
+  metadata: { falseKeep: number; falseReplace: number };
+}
+
+/** Exact boolean agreement on the keep/replace gate. */
+export function keepAgreement({ output, expected }: ScorerArgs): ScorerResult {
+  return { name: 'keep_agreement', score: output.keep === expected.keep ? 1 : 0 };
+}
+
+/**
+ * Normalized mean-absolute-error on qualityScore, clamped to [0,1] so an
+ * out-of-domain qualityScore (e.g. >100-point error) can never produce a
+ * negative score.
+ */
+export function scoreMAE({ output, expected }: ScorerArgs): ScorerResult {
+  const score = Math.max(0, 1 - Math.abs(output.qualityScore - expected.qualityScore) / 100);
+  return { name: 'score_mae', score };
+}
+
+/**
+ * Confusion split. score is 1 when keep agrees, 0 on any disagreement; the
+ * metadata names WHICH disagreement: falseKeep is the dangerous direction
+ * (output keeps what expected would replace → ships a bad photo).
+ */
+export function keepConfusion({ output, expected }: ScorerArgs): KeepConfusionResult {
+  const falseKeep = output.keep && !expected.keep ? 1 : 0;
+  const falseReplace = !output.keep && expected.keep ? 1 : 0;
+  return {
+    name: 'keep_confusion',
+    score: output.keep === expected.keep ? 1 : 0,
+    metadata: { falseKeep, falseReplace },
+  };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    BT["Braintrust eval\n{input, output, expected, metadata}"]
    BT --> KA["keepAgreement\noutput.keep === expected.keep\n→ {keep_agreement, 1|0}"]
    BT --> MAE["scoreMAE\n1 - |ΔqualityScore|/100, clamp[0,1]\n→ {score_mae, score}"]
    BT --> KC["keepConfusion\n→ {keep_confusion, 1|0,\nmetadata:{falseKeep, falseReplace}}"]
    KC -.->|"output.keep && !expected.keep"| FK["falseKeep = 1\n(dangerous: ships a bad photo)"]
    KC -.->|"!output.keep && expected.keep"| FR["falseReplace = 1"]
```

## Summary

- Adds the three headline Braintrust eval scorers for the photo-judge experiment (issue #1014, part of #1010), so a candidate judge `output` can be measured against the reference `expected`: `keepAgreement` (the #969 ≥90% keep gate), `scoreMAE`, and `keepConfusion`.
- `keepConfusion` is the safety lens — it splits any keep/replace disagreement into **false-keep** (output keeps what `expected` would replace — the dangerous direction, because it ships a bad photo) vs **false-replace**, surfaced via `metadata`.
- `scoreMAE` clamps to `[0,1]` (`Math.max(0, 1 - |Δ|/100)`) so an out-of-domain `qualityScore` (>100-point error) can never produce a negative score. All three are pure (no IO); Braintrust scorer args are `{input, output, expected, metadata}`, of which these read `output` + `expected`.

## Screenshots

N/A — not UI (change is under `tools/photo-curation/src/eval/`, no `frontend/**` files).

## Test plan

- [x] `npm run build` then `npm test -w @bird-watch/photo-curation` — green (16 files, 208 tests; the new `scorers.test.ts` adds 10 cases covering keepAgreement match/mismatch, scoreMAE at 80/80=1, 80/30=0.5, 0/100=0, and the out-of-domain 130/0 clamp-to-0, plus all four keepConfusion quadrants).
- [x] New unit tests added — `tools/photo-curation/src/eval/scorers.test.ts` (TDD: failing test confirmed before implementation).
- [x] N/A — no user-visible behavior changed, so no Playwright e2e spec.
- [x] `npm run build` — clean production build.
- [x] `npx knip --no-progress` — clean (exit 0); the new file + test mirror the existing `hash.ts`/`hash.test.ts` pattern (test file is the entry point that consumes all three exports), so no knip ignore rule is needed.
- [x] `npm run lint` — green.

## Plan reference

Part of epic #1010 (photo-judge Braintrust eval). Implements issue #1014 (C4 — Eval scorers). Spec: `docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md` §4. Closes #1014.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)