### PR TITLE
feat(photo-curation): eval dataset builder from review.sqlite + thumb-cache (#1013)

### DIFF
--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import type Database from 'better-sqlite3';
+import { openDb } from '../db.js';
+import { buildEvalRows, mulberry32, shuffleInPlace, DEFAULT_SEED } from './build-dataset.js';
+
+let db: Database.Database;
+let thumbDir: string;
+
+beforeEach(() => {
+  db = openDb(':memory:');
+  thumbDir = mkdtempSync(join(tmpdir(), 'eval-thumbs-'));
+});
+afterEach(() => {
+  db.close();
+  rmSync(thumbDir, { recursive: true, force: true });
+});
+
+/** Insert one photo_current + one role='current' photo_score for a species. */
+function seedCurrent(
+  code: string,
+  fields: {
+    comName: string;
+    sciName: string;
+    family: string;
+    contentHash: string;
+    keep: number | null;
+    qualityScore: number | null;
+    overall: number;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO photo_current (species_code, com_name, sci_name, family, content_hash)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(code, fields.comName, fields.sciName, fields.family, fields.contentHash);
+  db.prepare(
+    `INSERT INTO photo_score (species_code, role, content_hash, overall, verdict,
+                              criteria_json, flags_json, keep, quality_score, scored_at)
+     VALUES (?, 'current', ?, ?, 'good', '{}', '[]', ?, ?, 'now')`,
+  ).run(code, fields.contentHash, fields.overall, fields.keep, fields.qualityScore);
+}
+
+/** Write a zero-byte image file `<code>.<ext>` into thumbDir. */
+function writeImage(code: string, ext = 'jpg'): void {
+  writeFileSync(join(thumbDir, `${code}.${ext}`), '');
+}
+
+describe('mulberry32 / shuffleInPlace', () => {
+  it('mulberry32 is deterministic for a fixed seed', () => {
+    const a = mulberry32(123);
+    const b = mulberry32(123);
+    const seqA = [a(), a(), a()];
+    const seqB = [b(), b(), b()];
+    expect(seqA).toEqual(seqB);
+    expect(seqA.every((x) => x >= 0 && x < 1)).toBe(true);
+  });
+
+  it('shuffleInPlace permutes deterministically per seed', () => {
+    const arr1 = ['a', 'b', 'c', 'd', 'e'];
+    const arr2 = ['a', 'b', 'c', 'd', 'e'];
+    shuffleInPlace(arr1, mulberry32(7));
+    shuffleInPlace(arr2, mulberry32(7));
+    expect(arr1).toEqual(arr2);
+    expect([...arr1].sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});
+
+describe('buildEvalRows', () => {
+  // TDD #1: 4 currents (2 keep / 2 not, all keep non-null) + 4 images → 4 rows.
+  it('builds one row per current with correct input/expected and contentHash', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
+    writeImage('amerob');
+    writeImage('norcar', 'png');
+    writeImage('houspa', 'webp');
+    writeImage('rocpig');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows).toHaveLength(4);
+
+    const robin = rows.find((r) => r.input.speciesCode === 'amerob')!;
+    expect(robin.input).toEqual({
+      imagePath: join(thumbDir, 'amerob.jpg'),
+      speciesCode: 'amerob',
+      comName: 'American Robin',
+      sciName: 'Turdus migratorius',
+      family: 'Turdidae',
+    });
+    expect(robin.expected).toEqual({ keep: true, qualityScore: 88 });
+    expect(robin.metadata).toEqual({ contentHash: 'h-amerob' });
+
+    // Image resolved by extension glob, not hardcoded .jpg.
+    expect(basename(rows.find((r) => r.input.speciesCode === 'norcar')!.input.imagePath)).toBe('norcar.png');
+    expect(basename(rows.find((r) => r.input.speciesCode === 'houspa')!.input.imagePath)).toBe('houspa.webp');
+
+    const pigeon = rows.find((r) => r.input.speciesCode === 'rocpig')!;
+    expect(pigeon.expected).toEqual({ keep: false, qualityScore: 30 });
+  });
+
+  // Coalesce rules mirror getScoreByHash (store.ts).
+  it('coalesces keep (null⇒true) and qualityScore (null⇒overall)', () => {
+    seedCurrent('coales', { comName: 'C', sciName: 'C c', family: 'Fam', contentHash: 'h-coales', keep: null, qualityScore: null, overall: 62 });
+    writeImage('coales');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].expected).toEqual({ keep: true, qualityScore: 62 });
+  });
+
+  // TDD #2: one image missing → 3 rows, that one skipped + note logged.
+  it('skips a current whose image is missing and logs a note', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
+    writeImage('amerob');
+    writeImage('norcar');
+    // houspa image deliberately absent.
+    writeImage('rocpig');
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.input.speciesCode).sort()).toEqual(['amerob', 'norcar', 'rocpig']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('houspa');
+    warn.mockRestore();
+  });
+
+  // TDD #3: sample:2 over 2-keep/2-not → exactly 1 keep + 1 not, exact codes pinned.
+  it('stratified sample:2 returns exactly 1 keep + 1 not with the pinned species_codes for the default seed', () => {
+    // Insertion order fixes the pre-shuffle stratum order:
+    //   keep = [amerob, norcar], not = [houspa, rocpig]
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
+
+    const rows = buildEvalRows(db, { thumbDir, sample: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.expected.keep)).toHaveLength(1);
+    expect(rows.filter((r) => !r.expected.keep)).toHaveLength(1);
+    // Pins mulberry32(DEFAULT_SEED) + Fisher–Yates: norcar (keep) then houspa (not).
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['norcar', 'houspa']);
+  });
+
+  // The pin must be tied to the documented default seed value.
+  it('uses 0xb12d as the default seed (rendered from the issue label 0xB1RD)', () => {
+    expect(DEFAULT_SEED).toBe(0xb12d);
+  });
+
+  // TDD #4: sample:3 (odd) over 2-keep/2-not → rounding rule keepTake=2, notTake=1.
+  it('stratified sample:3 applies the rounding rule (keepTake=round(3*2/4)=2, notTake=1)', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
+
+    const rows = buildEvalRows(db, { thumbDir, sample: 3 });
+    expect(rows).toHaveLength(3);
+    expect(rows.filter((r) => r.expected.keep)).toHaveLength(2);
+    expect(rows.filter((r) => !r.expected.keep)).toHaveLength(1);
+    // Pins the deterministic order for the default seed: norcar, amerob (keep), houspa (not).
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['norcar', 'amerob', 'houspa']);
+  });
+
+  it('returns all rows unsampled when sample is omitted', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    writeImage('amerob');
+    expect(buildEvalRows(db, { thumbDir })).toHaveLength(1);
+  });
+});

--- a/tools/photo-curation/src/eval/build-dataset.ts
+++ b/tools/photo-curation/src/eval/build-dataset.ts
@@ -1,0 +1,204 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
+
+/**
+ * One Braintrust eval row built from the Opus current-scores in review.sqlite.
+ * `expected` is the Opus keep/score, used as proxy ground truth (#1010/#1013):
+ * a later run compares a cheaper judge's output against it. `imagePath` points
+ * at the cached current thumbnail; `metadata.contentHash` ties the row back to
+ * the exact image bytes the Opus pass scored.
+ */
+export interface EvalRow {
+  input: {
+    imagePath: string;
+    speciesCode: string;
+    comName: string;
+    sciName: string;
+    family: string;
+  };
+  expected: {
+    keep: boolean;
+    qualityScore: number;
+  };
+  metadata: {
+    contentHash: string;
+  };
+}
+
+/** Options for {@link buildEvalRows}. */
+export interface BuildEvalRowsOpts {
+  /** Directory holding the cached current thumbnails (`<code>.jpg|.png|.webp`). */
+  thumbDir: string;
+  /** When set, stratified-sample down to this many rows (keep=true / keep=false). */
+  sample?: number;
+  /** PRNG seed for the deterministic stratified sample. Defaults to {@link DEFAULT_SEED}. */
+  seed?: number;
+}
+
+/**
+ * Default PRNG seed. The issue (#1013) labels this `0xB1RD` — a stylized
+ * "BIRD" that is NOT a valid hex literal (`R` is not a hex digit), so it is
+ * rendered here to the valid leetspeak hex `0xB12D` (B-I-R-D). The numeric
+ * value is what makes the sample deterministic; nothing downstream pins the
+ * spelling, so any fixed constant satisfies the contract.
+ */
+export const DEFAULT_SEED = 0xb12d;
+
+/** A row of the role='current' score join, before coalescing. */
+interface ScoreJoinRow {
+  species_code: string;
+  keep: number | null;
+  quality_score: number | null;
+  overall: number;
+  content_hash: string;
+  com_name: string;
+  sci_name: string;
+  family: string;
+}
+
+/**
+ * A 32-bit mulberry32 PRNG. Pure and deterministic: same `seed` → same stream.
+ * Returns a function yielding floats in [0, 1).
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function next(): number {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * In-place Fisher–Yates shuffle of `arr` driven by `rng`. Mutates and returns
+ * the array. Standard high-to-low-index walk so the shuffle is fully determined
+ * by the `rng` stream.
+ */
+export function shuffleInPlace<T>(arr: T[], rng: () => number): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j] as T, arr[i] as T];
+  }
+  return arr;
+}
+
+/**
+ * Resolve the cached thumbnail for `speciesCode` under `thumbDir` by extension
+ * glob (`<code>.*`) — currents are written `.jpg`/`.png`/`.webp` by `extFromMime`
+ * (sources.ts), so a hardcoded `.jpg` would silently miss non-jpeg currents.
+ * Returns the first matching filename, or `null` when nothing matches.
+ */
+function resolveImage(thumbDir: string, speciesCode: string): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(thumbDir);
+  } catch {
+    return null;
+  }
+  const prefix = `${speciesCode}.`;
+  const match = entries.find((name) => name.startsWith(prefix));
+  return match ?? null;
+}
+
+/**
+ * Build stratified eval rows from the role='current' Opus scores in `db`.
+ *
+ * Reads every current score joined to its `photo_current` metadata, coalesces
+ * `keep`/`qualityScore` exactly as the review store does (`store.ts`
+ * getScoreByHash: missing `keep` ⇒ kept, missing `quality_score` ⇒ `overall`),
+ * resolves each image by extension glob, and skips (with a logged note) any
+ * row whose image is absent from `thumbDir`.
+ *
+ * When `opts.sample` is set, the surviving rows are split into keep=true /
+ * keep=false strata, each shuffled by a seeded mulberry32 Fisher–Yates, and a
+ * proportional allocation is taken from the front of each shuffled stratum
+ * (clamp remainder pushed to the other stratum). Output is deterministic for a
+ * fixed `seed`.
+ */
+export function buildEvalRows(
+  db: Database.Database,
+  opts: BuildEvalRowsOpts,
+): EvalRow[] {
+  const { thumbDir, sample, seed = DEFAULT_SEED } = opts;
+
+  const joinRows = db
+    .prepare(
+      `SELECT s.species_code, s.keep, s.quality_score, s.overall, s.content_hash,
+              c.com_name, c.sci_name, c.family
+         FROM photo_score s JOIN photo_current c USING(species_code)
+        WHERE s.role = 'current'`,
+    )
+    .all() as ScoreJoinRow[];
+
+  const rows: EvalRow[] = [];
+  for (const row of joinRows) {
+    const file = resolveImage(thumbDir, row.species_code);
+    if (file === null) {
+      console.warn(
+        `[build-dataset] skipping ${row.species_code}: no cached image in ${thumbDir}`,
+      );
+      continue;
+    }
+    rows.push({
+      input: {
+        imagePath: join(thumbDir, file),
+        speciesCode: row.species_code,
+        comName: row.com_name,
+        sciName: row.sci_name,
+        family: row.family,
+      },
+      expected: {
+        keep: row.keep === null ? true : row.keep === 1,
+        qualityScore: row.quality_score ?? row.overall,
+      },
+      metadata: { contentHash: row.content_hash },
+    });
+  }
+
+  if (sample === undefined) return rows;
+
+  return stratifiedSample(rows, sample, seed);
+}
+
+/**
+ * Deterministic stratified sample of `rows` down to `sample` rows.
+ *
+ * Splits into keep=true / keep=false strata, shuffles each with a seeded
+ * mulberry32 Fisher–Yates, then takes a proportional allocation
+ * (`keepTake = round(sample * keepRows / total)`, `notTake = sample - keepTake`),
+ * each clamped to its stratum size with the clamp remainder pushed to the other
+ * stratum. Takes the first `keepTake`/`notTake` of each shuffled stratum and
+ * concatenates (keep stratum first).
+ */
+function stratifiedSample(rows: EvalRow[], sample: number, seed: number): EvalRow[] {
+  const total = rows.length;
+  if (sample >= total) return rows;
+
+  const keepRows = rows.filter((r) => r.expected.keep);
+  const notRows = rows.filter((r) => !r.expected.keep);
+
+  const rng = mulberry32(seed);
+  shuffleInPlace(keepRows, rng);
+  shuffleInPlace(notRows, rng);
+
+  let keepTake = Math.round((sample * keepRows.length) / total);
+  let notTake = sample - keepTake;
+
+  // Clamp each take to its stratum size, pushing any remainder to the other
+  // stratum (so the total stays `sample` whenever the strata can satisfy it).
+  if (keepTake > keepRows.length) {
+    notTake += keepTake - keepRows.length;
+    keepTake = keepRows.length;
+  }
+  if (notTake > notRows.length) {
+    keepTake += notTake - notRows.length;
+    notTake = notRows.length;
+  }
+  // The first clamp can over-fill keep if not was short; clamp once more.
+  if (keepTake > keepRows.length) keepTake = keepRows.length;
+
+  return [...keepRows.slice(0, keepTake), ...notRows.slice(0, notTake)];
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A["review.sqlite<br/>photo_score role='current'<br/>+ photo_current"] --> B[buildEvalRows]
    C["thumb-cache/<br/>&lt;code&gt;.jpg|.png|.webp"] --> B
    B -->|"glob &lt;code&gt;.*<br/>skip+log if missing"| D{image found?}
    D -->|no| E["console.warn note<br/>(row dropped)"]
    D -->|yes| F["coalesce keep/qualityScore<br/>(getScoreByHash rules)"]
    F --> G{sample set?}
    G -->|no| H["all rows"]
    G -->|yes| I["stratify keep=true / keep=false<br/>mulberry32(seed) Fisher–Yates<br/>proportional keepTake"]
    H --> J["EvalRow[]"]
    I --> J
    J -.->|C5 pushes later| K["Braintrust dataset (bird-maps)"]
```

## Summary

<!-- 1–3 bullets supporting the diagram(s) above. Lead with the *why*. -->

- C3 of the Braintrust photo-judge eval (#1010): the cheaper judge needs a labeled set to be measured against, so this turns the 902 Opus current-scores + cached thumbnails into stratified eval rows whose `expected` is the Opus keep/score (proxy ground truth).
- Coalesces `keep`/`qualityScore` exactly as the review store's `getScoreByHash` does (null `keep` ⇒ kept; null `quality_score` ⇒ `overall`), and resolves each image by extension glob `<code>.*` because currents are written `.jpg`/`.png`/`.webp` by `extFromMime` — a hardcoded `.jpg` would silently miss non-jpeg currents; missing images are skipped with a logged note.
- Sampling is deterministic (seeded `mulberry32` + per-stratum Fisher–Yates, proportional `keepTake = round(sample*keep/total)` with clamp-remainder pushed to the other stratum) so a fixed seed reproduces the same dataset; tests pin the exact `species_codes` for the default seed. Pure file + sqlite read — no Braintrust network (C5 pushes the dataset).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test -w @bird-watch/photo-curation` — green (16 files, 207 tests; 9 new in `build-dataset.test.ts`)
- [x] New unit tests added — TDD #1 (4 rows, input/expected/contentHash), #2 (missing image skipped + note logged), #3 (`sample:2` → exactly 1 keep + 1 not, exact `species_codes` pinned), #4 (`sample:3` rounding rule `keepTake=round(3*2/4)=2`), plus `mulberry32`/`shuffleInPlace` determinism and a default-seed pin
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, not UI
- [x] `npm run build` (root) — clean; `npm run build -w @bird-watch/photo-curation` (`tsc`) — clean
- [x] `npx knip --no-progress` — clean (exit 0); `npm run lint` (root) — clean
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Part of #1010 (Braintrust photo-judge eval). Closes #1013. Design spec: `docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md` §3 (Eval dataset builder).

Note: the issue labels the default seed `0xB1RD`, which is not a valid hex literal (`R` is not a hex digit); it is rendered to the valid leetspeak hex `0xB12D`. Nothing downstream pins the spelling, only the numeric value.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)