### PR TITLE
feat(photo-curation): Braintrust tracing wrapper + construction choke point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.12.0.tgz",
+      "integrity": "sha512-5F2ob4cMYezbaUGAk+YltbDvb9BFIghN92ubct9Ho/0MFx4FkChCxYV99NkU6Kx+RAgaqBV6yxKuWreQ6K8SOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
@@ -766,6 +789,97 @@
       "resolved": "packages/shared-types",
       "link": true
     },
+    "node_modules/@braintrust/bt-darwin-arm64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-darwin-arm64/-/bt-darwin-arm64-0.11.1.tgz",
+      "integrity": "sha512-jhL/X24ss4e4qMMdlXtxO8rA957Z77wJA59XXFHqpuaaVCd4pXE5JPUQBkms9dHcs4efJhY3Lx9zNQqoaeCqWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@braintrust/bt-darwin-x64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-darwin-x64/-/bt-darwin-x64-0.11.1.tgz",
+      "integrity": "sha512-f4l25gVUpCJ99mFS9y+zmnYOcevtI7KLLvlLF/xOil2YCIx/KCM6AqS96jj6CJW74B7hYhd74dLnFKMFFL429w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@braintrust/bt-linux-arm64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-linux-arm64/-/bt-linux-arm64-0.11.1.tgz",
+      "integrity": "sha512-01GWsP/p17I3yy0kxkp+Yt8w5L28j3nFL+7iLCkQWtDdfCGkuRsnrIbrY8dbnqGo/wvgz7uPXBkCXoIuNsfoxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@braintrust/bt-linux-x64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-linux-x64/-/bt-linux-x64-0.11.1.tgz",
+      "integrity": "sha512-E/XwRuhPrZxD+IZgSbPCuj4gywBrim/g+tU0MjWxFohpMMkJJW2CxMCIO+6RVk8gTxlVh/ajCIjv2/Ph1Yugeg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@braintrust/bt-linux-x64-musl": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-linux-x64-musl/-/bt-linux-x64-musl-0.11.1.tgz",
+      "integrity": "sha512-QLqlFsF6HKON5Vc0c8JfpQ4vrl4KjmInGF1Vsqy+ecVkgXVk8pwCVibb8Ea/udVpBQqctAaNMn7ZsmvWR2vO8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@braintrust/bt-win32-arm64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-win32-arm64/-/bt-win32-arm64-0.11.1.tgz",
+      "integrity": "sha512-0LSVXZ/tE79VVcpRjaTE+iTMQR4EKNC6tteAS01uKT34eID7OqJ7xJijZOthe11kGqMcX8nnNbdDrWHqLczDow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@braintrust/bt-win32-x64": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@braintrust/bt-win32-x64/-/bt-win32-x64-0.11.1.tgz",
+      "integrity": "sha512-JPo3xffJvW0OKowqpbh+XtlafpoZq8VXzhOcW2yQmHcN56Me2u9plPiXi4gzrpgz2cnFx6/EiJ1bTa3F25F0RA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -776,6 +890,16 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -952,7 +1076,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,7 +1092,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,7 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,7 +1140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,7 +1156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,7 +1172,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1071,7 +1188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,7 +1204,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1105,7 +1220,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1122,7 +1236,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,7 +1252,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1156,7 +1268,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1173,7 +1284,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,7 +1300,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,7 +1316,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1224,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1258,7 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,7 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,7 +1396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1309,7 +1412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,7 +1428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1343,7 +1444,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,7 +1460,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1377,7 +1476,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,12 +2187,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -2109,11 +2245,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
       }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
@@ -2187,6 +2328,12 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -3220,6 +3367,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -3736,7 +3898,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -3985,6 +4146,23 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@vercel/functions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-1.6.0.tgz",
+      "integrity": "sha512-R6FKQrYT5MZs5IE1SqeCJWxMuBdHawFcCZboKKw8p7s+6/mcd55Gx6tWmyKnQTyrSEA04NH73Tc9CbqpEle8RA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vis.gl/react-mapbox": {
       "version": "8.1.1",
       "license": "MIT",
@@ -4203,6 +4381,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4212,9 +4402,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4437,6 +4642,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "dev": true,
@@ -4491,6 +4702,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/async": {
@@ -4553,7 +4773,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4785,13 +5004,74 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braintrust": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/braintrust/-/braintrust-3.17.0.tgz",
+      "integrity": "sha512-nyV+j/FJJJsWnkiSn9tAoNSTsMtDfbH4v8EQpBTYGj1120eXFPcPPs66kkkKcYuN0tEo/Ai7VO8Ujcy5j3SrUQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.12.0",
+        "@next/env": "^14.2.3",
+        "@vercel/functions": "^1.0.2",
+        "ajv": "^8.20.0",
+        "argparse": "^2.0.1",
+        "cli-progress": "^3.12.0",
+        "cli-table3": "^0.6.5",
+        "cors": "^2.8.5",
+        "dc-browser": "^1.0.4",
+        "dotenv": "^16.4.5",
+        "esbuild": "0.28.0",
+        "eventsource-parser": "^1.1.2",
+        "express": "^5.2.1",
+        "http-errors": "^2.0.0",
+        "minimatch": "^10.2.5",
+        "module-details-from-path": "^1.0.4",
+        "mustache": "^4.2.0",
+        "pluralize": "^8.0.0",
+        "simple-git": "^3.36.0",
+        "source-map": "^0.7.4",
+        "termi-link": "^1.0.1",
+        "unplugin": "^2.3.5",
+        "uuid": "^11.1.1",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "braintrust": "dist/cli.js",
+        "bt": "bin/bt"
+      },
+      "optionalDependencies": {
+        "@braintrust/bt-darwin-arm64": "0.11.1",
+        "@braintrust/bt-darwin-x64": "0.11.1",
+        "@braintrust/bt-linux-arm64": "0.11.1",
+        "@braintrust/bt-linux-x64": "0.11.1",
+        "@braintrust/bt-linux-x64-musl": "0.11.1",
+        "@braintrust/bt-win32-arm64": "0.11.1",
+        "@braintrust/bt-win32-x64": "0.11.1"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.34 || ^4.0"
+      }
+    },
+    "node_modules/braintrust/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/buffer": {
@@ -4913,6 +5193,33 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "license": "ISC"
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
@@ -5059,6 +5366,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cpu-features": {
       "version": "0.0.10",
       "dev": true,
@@ -5173,6 +5497,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/dc-browser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dc-browser/-/dc-browser-1.0.4.tgz",
+      "integrity": "sha512-7oEtnzNlcE+hr4OvO3GR6Gndgw8BhW+wKOEwMqSleyY7N29jbAxzyW5BaJl7qBCw+6OIxfMWtY0T+6dxq8RWLw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5382,6 +5712,18 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5444,7 +5786,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5531,7 +5872,6 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5583,6 +5923,27 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5623,6 +5984,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/expand-template": {
@@ -5737,6 +6107,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "dev": true,
@@ -5761,6 +6137,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -6401,7 +6793,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6618,6 +7009,12 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/json-stringify-pretty-compact": {
       "version": "3.0.0",
@@ -7093,6 +7490,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -7160,7 +7566,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -7200,6 +7605,12 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -7249,6 +7660,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
       }
     },
     "node_modules/mute-stream": {
@@ -7422,6 +7842,15 @@
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7754,7 +8183,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7808,6 +8236,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/point-in-polygon-hao": {
@@ -8419,6 +8856,12 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/semver": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
@@ -8721,6 +9164,23 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/sinon": {
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
@@ -8786,6 +9246,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -8930,7 +9399,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8957,7 +9425,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9226,6 +9693,15 @@
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/termi-link": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/termi-link/-/termi-link-1.1.0.tgz",
+      "integrity": "sha512-2qSN6TnomHgVLtk+htSWbaYs4Rd2MH/RU7VpHTy6MBstyNyWbM4yKd1DCYpE3fDg8dmGWojXCngNi/MHCzGuAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/testcontainers": {
@@ -9568,6 +10044,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "dev": true,
@@ -9804,6 +10295,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "license": "MIT"
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -10004,10 +10501,18 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "packages/db-client": {
@@ -10480,6 +10985,7 @@
         "@bird-watch/photo-quality": "*",
         "@bird-watch/shared-types": "*",
         "better-sqlite3": "^11.8.1",
+        "braintrust": "^3.17.0",
         "commander": "^13.1.0",
         "express": "^5.2.1",
         "sharp": "^0.34.1"

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -16,6 +16,7 @@
     "@bird-watch/photo-quality": "*",
     "@bird-watch/shared-types": "*",
     "better-sqlite3": "^11.8.1",
+    "braintrust": "^3.17.0",
     "commander": "^13.1.0",
     "express": "^5.2.1",
     "sharp": "^0.34.1"

--- a/tools/photo-curation/src/judges/index.ts
+++ b/tools/photo-curation/src/judges/index.ts
@@ -1,0 +1,23 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Judges barrel — the PUBLIC construction surface (#1012).
+//
+// This barrel deliberately exports ONLY `resolveTracedJudge` (and the fail-loud
+// error types it can throw). It does NOT re-export `GeminiVisionJudge`: the raw
+// ctor lives in ./gemini.ts for its own unit test, but a consumer importing from
+// the judges surface cannot obtain an un-traced judge. Every judge reachable
+// here is wrapped in a Braintrust span. Do NOT add `export … from './gemini.js'`
+// — that would breach the construction-boundary guarantee (and its test).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export {
+  resolveTracedJudge,
+  MissingBraintrustKey,
+  MissingGeminiKey,
+} from './traced.js';
+export type {
+  BraintrustLoggerSeam,
+  BraintrustSpan,
+  JudgeEnv,
+  ResolveTracedJudgeOptions,
+  TracedJudgeOptions,
+} from './traced.js';

--- a/tools/photo-curation/src/judges/traced.test.ts
+++ b/tools/photo-curation/src/judges/traced.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  tracedJudge,
+  resolveTracedJudge,
+  MissingBraintrustKey,
+  MissingGeminiKey,
+  type BraintrustLoggerSeam,
+} from './traced.js';
+import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
+
+const img: ImageInput = {
+  buffer: Buffer.from('fake-jpeg-bytes'),
+  mime: 'image/jpeg',
+  sourceUrl: 'https://example.test/amerob.jpg',
+};
+const ctx: SpeciesContext = {
+  speciesCode: 'amerob',
+  comName: 'American Robin',
+  sciName: 'Turdus migratorius',
+  family: 'Turdidae',
+};
+const PROMPT = 'rubric prompt v3';
+
+/** A canned JudgeOutput the inner judge returns. */
+const VALID_OUTPUT: JudgeOutput = {
+  fieldMarks: ['rufous breast', 'gray head'],
+  criteria: { framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 8, lighting: 8 },
+  flags: [],
+  keep: true,
+  qualityScore: 85,
+  rationale: 'sharp wild adult',
+};
+
+/** A trivial inner VisionJudge that returns a fixed output. */
+class FakeJudge implements VisionJudge {
+  async judge(): Promise<JudgeOutput> {
+    return VALID_OUTPUT;
+  }
+}
+
+/** An inner VisionJudge that always throws — used to assert error propagation. */
+class ThrowingJudge implements VisionJudge {
+  async judge(): Promise<JudgeOutput> {
+    throw new Error('inner boom');
+  }
+}
+
+/** Records every `span.log({...})` payload and whether the span body completed. */
+interface RecordingLogger extends BraintrustLoggerSeam {
+  spans: Array<{ logs: object[]; closed: boolean }>;
+}
+
+/**
+ * A fake logger seam. `traced` opens one virtual span, hands a recording
+ * `span` to the body, and marks the span closed once the body settles
+ * (resolve OR reject) — mirroring the real SDK's finally-close semantics.
+ * `clock()` is consulted for a deterministic latency measurement.
+ */
+function makeRecordingLogger(clock?: () => number): RecordingLogger {
+  const spans: RecordingLogger['spans'] = [];
+  return {
+    spans,
+    async traced<T>(fn: (span: { log: (f: object) => void }) => Promise<T>): Promise<T> {
+      const record = { logs: [] as object[], closed: false };
+      spans.push(record);
+      const span = { log: (f: object) => record.logs.push(f) };
+      try {
+        return await fn(span);
+      } finally {
+        record.closed = true;
+      }
+    },
+    nowMs: clock,
+  };
+}
+
+describe('tracedJudge', () => {
+  it('returns the inner output and records one span with input/output/metadata', async () => {
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', logger });
+
+    const out = await judge.judge(img, ctx, PROMPT);
+
+    expect(out).toEqual(VALID_OUTPUT);
+    expect(logger.spans).toHaveLength(1);
+    const span = logger.spans[0]!;
+    expect(span.closed).toBe(true);
+
+    // input span-log: species framing + rubric/model/sourceUrl.
+    const inputLog = span.logs.find((l) => 'input' in l) as { input: Record<string, unknown> } | undefined;
+    expect(inputLog).toBeTruthy();
+    expect(inputLog!.input).toMatchObject({
+      speciesCode: 'amerob',
+      comName: 'American Robin',
+      sciName: 'Turdus migratorius',
+      family: 'Turdidae',
+      model: 'gemini-2.5-flash',
+      sourceUrl: 'https://example.test/amerob.jpg',
+    });
+    expect(inputLog!.input.rubricVersion).toBe(PROMPT);
+
+    // output span-log: the full JudgeOutput.
+    const outputLog = span.logs.find((l) => 'output' in l) as { output: JudgeOutput } | undefined;
+    expect(outputLog).toBeTruthy();
+    expect(outputLog!.output).toEqual(VALID_OUTPUT);
+
+    // metadata span-log: latencyMs + model.
+    const metaLog = span.logs.find((l) => 'metadata' in l) as
+      | { metadata: { latencyMs: number; model: string } }
+      | undefined;
+    expect(metaLog).toBeTruthy();
+    expect(metaLog!.metadata.model).toBe('gemini-2.5-flash');
+    expect(typeof metaLog!.metadata.latencyMs).toBe('number');
+  });
+
+  it('propagates an inner error and still closes the span', async () => {
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new ThrowingJudge(), { project: 'bird-maps', model: 'opus', logger });
+
+    await expect(judge.judge(img, ctx, PROMPT)).rejects.toThrow('inner boom');
+    expect(logger.spans).toHaveLength(1);
+    expect(logger.spans[0]!.closed).toBe(true);
+  });
+
+  it('records an exact latencyMs from an injected clock (1000 → 1250 = 250)', async () => {
+    const ticks = [1000, 1250];
+    let i = 0;
+    const clock = () => ticks[Math.min(i++, ticks.length - 1)]!;
+    const logger = makeRecordingLogger(clock);
+    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', logger });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    const metaLog = logger.spans[0]!.logs.find((l) => 'metadata' in l) as
+      | { metadata: { latencyMs: number } }
+      | undefined;
+    expect(metaLog!.metadata.latencyMs).toBe(250);
+  });
+});
+
+describe('resolveTracedJudge', () => {
+  it('throws MissingGeminiKey when GEMINI_API_KEY is absent', () => {
+    expect(() => resolveTracedJudge({}, { project: 'bird-maps', model: 'gemini-2.5-flash' })).toThrow(
+      MissingGeminiKey,
+    );
+  });
+
+  it('throws MissingBraintrustKey when only GEMINI_API_KEY is present', () => {
+    expect(() =>
+      resolveTracedJudge({ GEMINI_API_KEY: 'g' }, { project: 'bird-maps', model: 'gemini-2.5-flash' }),
+    ).toThrow(MissingBraintrustKey);
+  });
+
+  it('returns a traced VisionJudge when both keys are present', () => {
+    const judge = resolveTracedJudge(
+      { GEMINI_API_KEY: 'g', BRAINTRUST_API_KEY: 'b' },
+      { project: 'bird-maps', model: 'gemini-2.5-flash' },
+    );
+    expect(typeof judge.judge).toBe('function');
+  });
+});
+
+describe('judges barrel — construction-boundary guarantee', () => {
+  it('exports resolveTracedJudge but NOT the raw GeminiVisionJudge ctor', async () => {
+    const barrel = await import('./index.js');
+    expect(typeof barrel.resolveTracedJudge).toBe('function');
+    expect((barrel as Record<string, unknown>).GeminiVisionJudge).toBeUndefined();
+  });
+});

--- a/tools/photo-curation/src/judges/traced.ts
+++ b/tools/photo-curation/src/judges/traced.ts
@@ -1,0 +1,142 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Braintrust tracing wrapper + construction choke point (#1012, part of #1010).
+//
+// The load-bearing requirement (spec §Components.2): NOTHING scores un-traced.
+// Every judgment must log one span to the hosted `bird-maps` Braintrust project.
+// We enforce that structurally at the *public construction boundary*: the judges
+// barrel (./index.ts) exports ONLY `resolveTracedJudge`, which constructs a
+// `GeminiVisionJudge` and wraps it in a Braintrust span. `GeminiVisionJudge` is
+// exported from ./gemini.ts for its own unit test, but is absent from the barrel
+// — so a consumer importing from the package surface cannot obtain an un-traced
+// judge. This is an export-surface guarantee, not a claim the class is unreachable.
+//
+// Design notes (deliberate):
+//   • `BraintrustLoggerSeam` is the injectable span boundary. Tests pass a
+//     recording fake (no network, no key); production passes an `initLogger`-
+//     backed adapter built in `resolveTracedJudge`. The seam narrows the SDK to
+//     the one method we use (`traced(fn)` → a span with `.log({...})`).
+//   • Key absence FAILS LOUD (`MissingGeminiKey` / `MissingBraintrustKey`) —
+//     we never score blind (spec §Error handling).
+//   • The Braintrust SDK API was verified against the current docs (context7,
+//     2026-06-11): `initLogger({projectName, apiKey})`, `logger.traced(async
+//     span => …)`, and `span.log({input})` / `span.log({output, metadata})`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { initLogger } from 'braintrust';
+import type { ImageInput, JudgeOutput, SpeciesContext, VisionJudge } from '@bird-watch/photo-quality';
+import { GeminiVisionJudge } from './gemini.js';
+
+/** Thrown at construction when `BRAINTRUST_API_KEY` is absent — never score blind. */
+export class MissingBraintrustKey extends Error {
+  constructor(message = 'BRAINTRUST_API_KEY is required — refusing to score un-traced') {
+    super(message);
+    this.name = 'MissingBraintrustKey';
+  }
+}
+
+/** Thrown at construction when `GEMINI_API_KEY` is absent. */
+export class MissingGeminiKey extends Error {
+  constructor(message = 'GEMINI_API_KEY is required to construct the Gemini judge') {
+    super(message);
+    this.name = 'MissingGeminiKey';
+  }
+}
+
+/** The one span method we use, narrowed so a test fake needs no SDK types. */
+export interface BraintrustSpan {
+  log(fields: object): void;
+}
+
+/**
+ * The injectable Braintrust boundary. `traced(fn)` opens one span, runs `fn`
+ * with it, and closes the span once `fn` settles (resolve OR reject) — exactly
+ * the real SDK's `logger.traced` contract. `nowMs` is an optional clock so the
+ * wrapper measures latency deterministically in tests; production omits it and
+ * the wrapper falls back to `Date.now`.
+ */
+export interface BraintrustLoggerSeam {
+  traced<T>(fn: (span: BraintrustSpan) => Promise<T>): Promise<T>;
+  /** Optional injected clock (ms). Defaults to `Date.now` when absent. */
+  nowMs?: () => number;
+}
+
+export interface TracedJudgeOptions {
+  /** The Braintrust project these spans log to (e.g. `bird-maps`). */
+  project: string;
+  /** The judge model name recorded on each span (e.g. `gemini-2.5-flash`). */
+  model: string;
+  /** The span boundary — injectable so tests need no network or key. */
+  logger: BraintrustLoggerSeam;
+}
+
+/**
+ * Decorate any `VisionJudge` with a Braintrust span. Each `judge()` runs the
+ * inner judge inside `logger.traced`, logging `input` (species framing + rubric
+ * version + model + source URL), `output` (the full `JudgeOutput`), and
+ * `metadata` (`latencyMs`, `model`). The span closes on success AND on error
+ * (the inner error propagates unchanged).
+ */
+export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): VisionJudge {
+  const { project, model, logger } = opts;
+  const now = logger.nowMs ?? Date.now;
+  return {
+    async judge(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
+      return logger.traced(async (span) => {
+        span.log({
+          input: {
+            speciesCode: ctx.speciesCode,
+            comName: ctx.comName,
+            sciName: ctx.sciName,
+            family: ctx.family,
+            rubricVersion: prompt,
+            model,
+            sourceUrl: img.sourceUrl,
+            project,
+          },
+        });
+        const start = now();
+        const output = await inner.judge(img, ctx, prompt);
+        span.log({
+          output,
+          metadata: { latencyMs: now() - start, model },
+        });
+        return output;
+      });
+    },
+  };
+}
+
+/** The env subset the resolver reads. Both keys are required to construct. */
+export interface JudgeEnv {
+  GEMINI_API_KEY?: string;
+  BRAINTRUST_API_KEY?: string;
+}
+
+export interface ResolveTracedJudgeOptions {
+  /** The Braintrust project to log to (e.g. `bird-maps`). */
+  project: string;
+  /** The Gemini model to construct (e.g. `gemini-2.5-flash`). */
+  model: string;
+}
+
+/**
+ * The ONLY public way to build a production judge. Fails loud on a missing key
+ * (`MissingGeminiKey` / `MissingBraintrustKey`), builds an `initLogger`-backed
+ * Braintrust seam, constructs the Gemini judge, and returns it wrapped in a
+ * tracing span. Because the judges barrel re-exports only this function, every
+ * judge a consumer can obtain is traced.
+ */
+export function resolveTracedJudge(env: JudgeEnv, opts: ResolveTracedJudgeOptions): VisionJudge {
+  if (!env.GEMINI_API_KEY) {
+    throw new MissingGeminiKey();
+  }
+  if (!env.BRAINTRUST_API_KEY) {
+    throw new MissingBraintrustKey();
+  }
+  const bt = initLogger({ projectName: opts.project, apiKey: env.BRAINTRUST_API_KEY });
+  const logger: BraintrustLoggerSeam = {
+    traced: (fn) => bt.traced(fn),
+  };
+  const inner = new GeminiVisionJudge({ apiKey: env.GEMINI_API_KEY, model: opts.model });
+  return tracedJudge(inner, { project: opts.project, model: opts.model, logger });
+}


### PR DESCRIPTION
## Diagrams

The construction boundary: the judges barrel exposes only `resolveTracedJudge`, so every judge a consumer can obtain is already wrapped in a Braintrust span. The raw `GeminiVisionJudge` ctor stays in `gemini.ts` for its own unit test but is absent from the barrel.

```mermaid
flowchart LR
    consumer["consumer<br/>(eval / scoring run)"] -->|imports| barrel["judges/index.ts<br/>(barrel)"]
    barrel -->|exports ONLY| resolve["resolveTracedJudge(env, opts)"]
    resolve -->|"!GEMINI_API_KEY"| mgk["throw MissingGeminiKey"]
    resolve -->|"!BRAINTRUST_API_KEY"| mbk["throw MissingBraintrustKey"]
    resolve -->|both keys present| init["initLogger({projectName, apiKey})"]
    init --> seam["BraintrustLoggerSeam"]
    resolve --> gemini["new GeminiVisionJudge"]
    gemini --> traced["tracedJudge(inner, {project, model, logger})"]
    seam --> traced
    traced -->|"logger.traced(span => …)"| span["span.log(input) → inner.judge() → span.log(output, metadata)"]
    gemini -. "absent from barrel<br/>(no un-traced path)" .-> barrel
```

## Summary

- **Why:** the photo-judge eval requires that *nothing scores un-traced* (spec §Components.2). This enforces that structurally at the public construction boundary rather than by convention — the `judges` barrel exports only `resolveTracedJudge`, which fails loud on a missing key and returns a judge already wrapped in a Braintrust span.
- `tracedJudge(inner, opts)` decorates any `VisionJudge`: each `judge()` runs inside `logger.traced`, logging `input` (species framing + rubric version + model + sourceUrl), `output` (the `JudgeOutput`), and `metadata` (`latencyMs`, `model`). The `BraintrustLoggerSeam` is injectable, so tests need no network or key.
- `resolveTracedJudge(env, opts)` throws `MissingGeminiKey` / `MissingBraintrustKey` on absent keys (never score blind), builds an `initLogger`-backed seam, constructs `GeminiVisionJudge`, and returns the traced judge. Braintrust SDK shape (`initLogger` / `traced` / `span.log`) verified via context7 (2026-06-11).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test -w @bird-watch/photo-curation` — 17 files / 211 tests green (7 new in `traced.test.ts`)
- [x] Full root `npm test` (the CI `test` gate) — all workspaces green
- [x] `npm run build -w @bird-watch/photo-quality && npm run build -w @bird-watch/photo-curation` — tsc clean (CI does not run the tool's tsc; covered here)
- [x] `npx knip --no-progress` — clean, no new findings (`braintrust` is traced via the direct import in `traced.ts`; no ignore added)
- [x] `npm run build` and `npm run lint` at repo root — green
- [x] New unit tests added: inner output + one span (input/output/metadata); inner-throw propagates + span closes; fail-loud `MissingGeminiKey`/`MissingBraintrustKey`; exact `latencyMs === 250` from an injected clock; barrel exports `resolveTracedJudge` only (`GeminiVisionJudge === undefined`)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Part of #1010. Closes #1012. Spec: `docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)