### PR TITLE
feat(photo-curation): photo-judge.eval.ts + runbook — bt eval entry (C5, #1015)

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -1,0 +1,121 @@
+# Photo-judge eval — Gemini vs. the Opus baseline (`bt eval`)
+
+## What this measures
+
+The eval (`tools/photo-curation/eval/photo-judge.eval.ts`) runs the **traced
+Gemini 2.5 Flash judge** over the cached current-photo thumbnails and scores its
+agreement with the existing **Opus 902-score baseline** (the proxy ground truth
+in `review.sqlite`). It reports three metrics as a Braintrust **experiment** in
+the `bird-maps` project:
+
+| Scorer | What it measures | Read it as |
+|---|---|---|
+| `keep_agreement` | exact boolean match of `keep` (the #969 gate) | **the headline** — must be **≥ 90%** to adopt Gemini for bulk scoring |
+| `score_mae` | `1 − \|Δ qualityScore\| / 100`, clamped to `[0,1]` | how close Gemini's 0–100 estimate tracks Opus's (advisory) |
+| `keep_confusion` | splits disagreements into `falseKeep` / `falseReplace` | watch **`falseKeep`** — Gemini keeping a photo Opus would replace ships a bad photo (the dangerous direction); `falseReplace` is cheap (re-source) |
+
+Every per-judgment span nests **under the experiment trace** (not the project
+Logs stream), so the dataset rows and their spans are linked in the Braintrust
+UI. (See the run-row wiring in `src/eval/run-row.ts` and the tracing seam in
+`src/judges/traced.ts`.)
+
+## Prerequisites
+
+This eval reads local data and calls the live Gemini API — it is **operator-run
+from the photo-curation run-worktree**, not from CI:
+
+- **`review.sqlite`** with `role='current'` Opus scores (the 902-score baseline).
+- **`thumb-cache/<species_code>.{jpg,png,webp}`** — the cached current
+  thumbnails the Opus pass scored. No re-download.
+- A Gemini API key (free tier is fine) and a Braintrust API key.
+- `npm install` at the repo root, and the workspace dep chain built once
+  (`npm run build -w @bird-watch/photo-quality`) so `@bird-watch/photo-quality`
+  resolves. `bt eval` runs the TypeScript entry directly via the auto-detected
+  `tsx` runner — no separate build of the eval file is needed.
+
+## Environment variables
+
+| Var | Required | Purpose |
+|---|---|---|
+| `GEMINI_API_KEY` | yes | authenticates the Gemini `generateContent` calls |
+| `BRAINTRUST_API_KEY` | yes | authenticates span/experiment writes; **absence fails loud** — we never score un-traced |
+| `REVIEW_DB` | yes | path to `review.sqlite` (e.g. `./review.sqlite`) |
+| `THUMB_DIR` | yes | path to the thumbnail cache (e.g. `./thumb-cache`) |
+| `EVAL_SAMPLE` | no (default `150`) | stratified keep/replace sample size for a full run |
+
+Put the non-secret values plus `GEMINI_API_KEY` in a local `.env.local`
+(gitignored). `bt eval --env-file .env.local` loads them into the eval process:
+
+```sh
+# tools/photo-curation/.env.local  (NOT committed)
+GEMINI_API_KEY=AIza…
+REVIEW_DB=./review.sqlite
+THUMB_DIR=./thumb-cache
+EVAL_SAMPLE=150
+```
+
+**Braintrust auth resolves from the active `bt` profile** (`bt auth login` /
+`bt auth status`) — you do not have to pass `BRAINTRUST_API_KEY` if a profile is
+logged in. If you prefer the env var, add it to `.env.local` too; either path
+satisfies the fail-loud check.
+
+## Run it
+
+From `tools/photo-curation/`:
+
+```sh
+# 1. Smoke — first 5 rows, summary clearly labeled NON-FINAL.
+bt eval --first 5 --env-file .env.local eval/photo-judge.eval.ts
+
+# 2. Full first run — the stratified EVAL_SAMPLE rows (default 150), FINAL.
+bt eval --env-file .env.local eval/photo-judge.eval.ts
+```
+
+The package also exposes `npm run eval -w @bird-watch/photo-curation`
+(`bt eval eval/photo-judge.eval.ts`); pass flags after `--`, e.g.
+`npm run eval -w @bird-watch/photo-curation -- --first 5 --env-file .env.local`.
+
+> **Pacing.** The Gemini judge paces itself to ≤ 10 RPM (≈ 6 s/call), so a
+> 150-row run takes on the order of 15 minutes of wall clock. That is expected —
+> do not parallelize around the pacer.
+
+### Reading the result
+
+- `bt eval` prints a summary table with each scorer's mean; the `--first 5`
+  run is labeled a non-final smoke, the full run is labeled final.
+- The experiment appears in Braintrust under the **`bird-maps`** project →
+  **Experiments**. Open it to compare `keep_agreement` against the Opus baseline
+  and to drill into individual judgments (each row's span, input image ref,
+  Gemini output, and the three scores).
+- **Decision gate:** Gemini is adopted for bulk scoring iff
+  `keep_agreement ≥ 90%` **and** `falseKeep` is low. Below the gate → hybrid
+  (Gemini first pass, Opus re-judges the close calls) — see the design spec.
+
+## Free-tier RPD cap — resume
+
+Gemini's free tier has a **requests-per-day** cap. The per-minute pacing keeps
+you under the RPM limit, but a large run can still hit the daily ceiling:
+
+- On a `429` the judge retries with jittered backoff (the RPM leg). If the
+  **daily** cap is exhausted, calls keep failing — stop the run.
+- **Resume strategy:** there is no checkpoint file. Re-run with a **smaller
+  `EVAL_SAMPLE`** (or `--first N`) the same day, or wait for the quota to reset
+  (~midnight Pacific) and re-run the full sample. The dataset builder's sample
+  is **deterministic for a fixed seed**, so a re-run scores the same rows — use
+  a smaller `--first` to make incremental progress, or accept that the full run
+  is a fresh experiment once the quota resets.
+- Partial spans already written to Braintrust are preserved; a resumed run
+  creates a new experiment rather than appending to the interrupted one.
+
+## Smoke-verify checklist (first live run)
+
+After the `--first 5` smoke, confirm in the Braintrust `bird-maps` project:
+
+1. A new **experiment** (not just Logs) was created.
+2. `keep_agreement` is **non-null** (a real number, not blank) — proves the
+   scorers received both `output` and `expected`.
+3. Opening a row shows the per-judgment span **nested under the experiment**
+   (not floating in the project Logs stream) with the species input, the Gemini
+   output, and `metrics.latency` populated.
+
+Note the experiment URL in the PR as the manual smoke evidence.

--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -28,10 +28,16 @@ from the photo-curation run-worktree**, not from CI:
 - **`thumb-cache/<species_code>.{jpg,png,webp}`** — the cached current
   thumbnails the Opus pass scored. No re-download.
 - A Gemini API key (free tier is fine) and a Braintrust API key.
-- `npm install` at the repo root, and the workspace dep chain built once
-  (`npm run build -w @bird-watch/photo-quality`) so `@bird-watch/photo-quality`
-  resolves. `bt eval` runs the TypeScript entry directly via the auto-detected
-  `tsx` runner — no separate build of the eval file is needed.
+- `npm install` at the repo root, and the full workspace dep chain built once.
+  `@bird-watch/photo-curation` depends on `@bird-watch/ingestor` (and
+  `@bird-watch/photo-quality` / `@bird-watch/shared-types`), and `ingestor`
+  pulls in `@bird-watch/db-client` — so building only
+  `@bird-watch/photo-quality` leaves the eval's `import`s unresolved. Run the
+  root `npm run build` (it builds the chain in order:
+  shared-types → db-client → photo-quality → ingestor → …), or build that
+  prefix explicitly. (`@bird-watch/geo`, also a transitive dep, is source-only
+  with no build step.) `bt eval` then runs the TypeScript entry directly via the
+  auto-detected `tsx` runner — no separate build of the eval file is needed.
 
 ## Environment variables
 
@@ -75,9 +81,13 @@ The package also exposes `npm run eval -w @bird-watch/photo-curation`
 (`bt eval eval/photo-judge.eval.ts`); pass flags after `--`, e.g.
 `npm run eval -w @bird-watch/photo-curation -- --first 5 --env-file .env.local`.
 
-> **Pacing.** The Gemini judge paces itself to ≤ 10 RPM (≈ 6 s/call), so a
-> 150-row run takes on the order of 15 minutes of wall clock. That is expected —
-> do not parallelize around the pacer.
+> **Pacing.** The eval runs **serially** (`maxConcurrency: 1`) over **one
+> shared** traced judge, so that judge's single `Pacer` gates the whole run to
+> ≤ 10 RPM (≈ 6 s/call) — a 150-row run takes on the order of 15 minutes of wall
+> clock. That serial single-judge wiring is what keeps the run inside Gemini's
+> free tier (per-row judges would each reset the pacer; unbounded concurrency
+> would race it). That is expected — do not parallelize around the pacer or
+> construct a judge per row.
 
 ### Reading the result
 

--- a/knip.ts
+++ b/knip.ts
@@ -321,10 +321,25 @@ const config: KnipConfig = {
       //             deleted but its script left on disk. Re-audit 2026-07-27 —
       //             confirm public/pending-swaps.html still references it (grep
       //             `src="/pending-swaps.js"`).
+      //
+      // 2026-06-11 (#1015, C5): eval/photo-judge.eval.ts is the Braintrust eval
+      //             entry, invoked ONLY via the package "eval" script's shell
+      //             string `bt eval eval/photo-judge.eval.ts` — `bt` is the
+      //             Braintrust CLI runner; knip cannot trace a binary's
+      //             shell-string argument, so it flags the file as unused
+      //             (same class as the workflows/*.mjs Workflow-tool entries
+      //             above). It lives OUTSIDE src/ (the tsconfig rootDir), is not
+      //             a tsc target, and is not a vitest target; its testable core
+      //             (the row→judge mapping) is covered by src/eval/run-row.test.ts.
+      //             Risk: masks a genuinely orphaned eval file if the "eval"
+      //             script is ever removed but the file left on disk. Re-audit
+      //             2026-07-27 — confirm package.json still has the "eval" script
+      //             pointing at this path.
       ignore: [
         'workflows/score-current.mjs', 'workflows/source-candidates.mjs',
         'public/overview.js', 'public/swap.js', 'public/theme.js',
         'public/pending-swaps.js',
+        'eval/photo-judge.eval.ts',
       ],
     },
   },

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -1,0 +1,71 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Braintrust eval entry (C5, #1015; part of #1010) — run via `bt eval`.
+//
+// Scores the TRACED Gemini judge against the Opus 902-score proxy baseline in
+// review.sqlite, reporting the #969 calibration metrics (keep-agreement %,
+// score-MAE, keep-confusion) as a `bird-maps` Braintrust EXPERIMENT.
+//
+//   data  — buildEvalRows(openDb(REVIEW_DB), {thumbDir, sample}) (#1013), the
+//           stratified Opus-current rows: each {input:{imagePath,species…},
+//           expected:{keep,qualityScore}}.
+//   task  — runRow({judge, readImage, prompt}, input) (this PR's run-row.ts).
+//           Braintrust calls task(input, hooks): the FIRST positional arg IS the
+//           row's `input` value, so we write `task: (input) => …`, NOT
+//           `({input})` (which would read a nonexistent `.input` → undefined).
+//   scores— keepAgreement / scoreMAE / keepConfusion (#1014).
+//
+// The judge is obtained through `resolveTracedJudge` — the ONLY public way to
+// build a judge (#1012); there is no un-traced scoring path. Because the wrapper
+// opens its span via the bare ambient `braintrust` `traced` (not an
+// initLogger-bound one), each per-judgment span NESTS UNDER this experiment's
+// trace rather than landing in the project Logs stream (verified via context7,
+// 2026-06-11: `traced` parents to the active span → experiment → logger).
+//
+// This file lives OUTSIDE src/ (the tool's tsconfig is rootDir:src), so it is
+// not part of the tsc build and not a vitest target; `bt eval` runs it directly.
+// Its testable core — the row→judge mapping — is covered by src/eval/run-row.test.ts.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { readFileSync } from 'node:fs';
+import { Eval } from 'braintrust';
+import { defaultRubricConfig, type ImageInput } from '@bird-watch/photo-quality';
+import { openDb } from '../src/db.js';
+import { buildEvalRows } from '../src/eval/build-dataset.js';
+import { resolveTracedJudge } from '../src/judges/index.js';
+import { keepAgreement, scoreMAE, keepConfusion } from '../src/eval/scorers.js';
+import { runRow } from '../src/eval/run-row.js';
+import { mimeFromUrl } from '../src/sources.js';
+
+/** Fail loud on a missing required env var — never run the eval half-configured. */
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(`${name} is required to run the photo-judge eval (see docs/runbooks/photo-judge-eval.md)`);
+  }
+  return v;
+}
+
+const REVIEW_DB = requireEnv('REVIEW_DB');
+const THUMB_DIR = requireEnv('THUMB_DIR');
+const EVAL_SAMPLE = Number(process.env.EVAL_SAMPLE ?? 150);
+
+/** Read a cached thumbnail into an ImageInput; mime is derived from the path's extension. */
+function readImage(imagePath: string): ImageInput {
+  return { buffer: readFileSync(imagePath), mime: mimeFromUrl(imagePath), sourceUrl: imagePath };
+}
+
+Eval('bird-maps', {
+  data: () => buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE }),
+  // Braintrust calls task(input, hooks) — the first positional arg is the row's
+  // `input` value. resolveTracedJudge fails loud on a missing GEMINI/BRAINTRUST key.
+  task: (input) =>
+    runRow(
+      {
+        judge: resolveTracedJudge(process.env, { project: 'bird-maps', model: 'gemini-2.5-flash' }),
+        readImage,
+        prompt: defaultRubricConfig.judgePrompt,
+      },
+      input,
+    ),
+  scores: [keepAgreement, scoreMAE, keepConfusion],
+});

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -28,7 +28,7 @@
 
 import { readFileSync } from 'node:fs';
 import { Eval } from 'braintrust';
-import { defaultRubricConfig, type ImageInput } from '@bird-watch/photo-quality';
+import { defaultRubricConfig, type ImageInput, type VisionJudge } from '@bird-watch/photo-quality';
 import { openDb } from '../src/db.js';
 import { buildEvalRows } from '../src/eval/build-dataset.js';
 import { resolveTracedJudge } from '../src/judges/index.js';
@@ -54,18 +54,30 @@ function readImage(imagePath: string): ImageInput {
   return { buffer: readFileSync(imagePath), mime: mimeFromUrl(imagePath), sourceUrl: imagePath };
 }
 
+// ── Single shared judge (the pacing fix, #1015 review) ───────────────────────
+// The judge owns the per-instance `Pacer` (src/judges/gemini.ts → ../pacing.ts).
+// Constructing one judge PER ROW would reset that Pacer on every call, defeating
+// the ≤10 RPM / 6 s-per-call gate the runbook promises — a 150-row `bt eval`
+// would burst unpaced and trip Gemini's free-tier RPM/RPD with 429s. So we build
+// the judge EXACTLY ONCE and share the instance (hence the single Pacer) across
+// all rows. Memoized via a getter so it is NOT constructed at import time:
+// `resolveTracedJudge` fails loud on a missing key, and `bt eval --list` /
+// dataset introspection must not throw before the keys are even needed.
+let _judge: VisionJudge | undefined;
+const getJudge = (): VisionJudge =>
+  (_judge ??= resolveTracedJudge(process.env, { project: 'bird-maps', model: 'gemini-2.5-flash' }));
+
 Eval('bird-maps', {
   data: () => buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE }),
+  // Rows run SERIALLY (one at a time): the shared judge's single Pacer enforces
+  // the 6 s gate globally only if rows don't race it. Braintrust's default
+  // concurrency is unbounded, so we pin it to 1 — without this, concurrent rows
+  // sharing one Pacer could still burst past the RPM cap.
+  maxConcurrency: 1,
   // Braintrust calls task(input, hooks) — the first positional arg is the row's
-  // `input` value. resolveTracedJudge fails loud on a missing GEMINI/BRAINTRUST key.
+  // `input` value. `getJudge()` lazily builds the ONE shared judge (fails loud on
+  // a missing GEMINI/BRAINTRUST key) and reuses it for every row.
   task: (input) =>
-    runRow(
-      {
-        judge: resolveTracedJudge(process.env, { project: 'bird-maps', model: 'gemini-2.5-flash' }),
-        readImage,
-        prompt: defaultRubricConfig.judgePrompt,
-      },
-      input,
-    ),
+    runRow({ judge: getJudge(), readImage, prompt: defaultRubricConfig.judgePrompt }, input),
   scores: [keepAgreement, scoreMAE, keepConfusion],
 });

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "curate": "tsx src/cli.ts"
+    "curate": "tsx src/cli.ts",
+    "eval": "bt eval eval/photo-judge.eval.ts"
   },
   "dependencies": {
     "@bird-watch/ingestor": "*",

--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -170,6 +170,19 @@ describe('buildEvalRows', () => {
     expect(rows.map((r) => r.input.speciesCode)).toEqual(['norcar', 'amerob', 'houspa']);
   });
 
+  // C3 polish (#1015): when a species has two cached extensions, the chosen
+  // file must be DETERMINISTIC (readdir order is filesystem-dependent). The
+  // resolver sorts the listing, so `.jpg` (sorts before `.png`/`.webp`) wins.
+  it('deterministically resolves a two-extension species to the sort-first file', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    writeImage('amerob', 'png');
+    writeImage('amerob', 'jpg');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows).toHaveLength(1);
+    expect(basename(rows[0].input.imagePath)).toBe('amerob.jpg');
+  });
+
   it('returns all rows unsampled when sample is omitted', () => {
     seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
     writeImage('amerob');

--- a/tools/photo-curation/src/eval/build-dataset.ts
+++ b/tools/photo-curation/src/eval/build-dataset.ts
@@ -89,7 +89,11 @@ export function shuffleInPlace<T>(arr: T[], rng: () => number): T[] {
  * Resolve the cached thumbnail for `speciesCode` under `thumbDir` by extension
  * glob (`<code>.*`) — currents are written `.jpg`/`.png`/`.webp` by `extFromMime`
  * (sources.ts), so a hardcoded `.jpg` would silently miss non-jpeg currents.
- * Returns the first matching filename, or `null` when nothing matches.
+ * Returns the first matching filename (in sorted order), or `null` when nothing
+ * matches. The directory listing is SORTED before the lookup so that when a
+ * species somehow has two cached extensions (e.g. a stale `amerob.png` beside a
+ * fresh `amerob.jpg`), the chosen file is deterministic across machines/runs —
+ * `readdirSync` order is filesystem-dependent.
  */
 function resolveImage(thumbDir: string, speciesCode: string): string | null {
   let entries: string[];
@@ -98,6 +102,7 @@ function resolveImage(thumbDir: string, speciesCode: string): string | null {
   } catch {
     return null;
   }
+  entries.sort();
   const prefix = `${speciesCode}.`;
   const match = entries.find((name) => name.startsWith(prefix));
   return match ?? null;

--- a/tools/photo-curation/src/eval/run-row.test.ts
+++ b/tools/photo-curation/src/eval/run-row.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { runRow, type RunRowInput } from './run-row.js';
+import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
+
+/**
+ * The tool's `tsc` is EXCLUDED from CI (the build gate runs the workspace
+ * builds, not this tool's), so this vitest file is the ONLY safety net for the
+ * row→judge wiring that `photo-judge.eval.ts` depends on. It exercises the exact
+ * mapping the eval task relies on: an `EvalRow.input` becomes an `ImageInput`
+ * (via the injected `readImage`) + a `SpeciesContext`, and the judge is called
+ * with the rubric prompt. No network, no real judge, no filesystem.
+ */
+
+const VALID_OUTPUT: JudgeOutput = {
+  fieldMarks: ['rufous breast', 'gray head'],
+  criteria: { framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 8, lighting: 8 },
+  flags: [],
+  keep: true,
+  qualityScore: 85,
+  rationale: 'sharp wild adult',
+};
+
+/** Records every (img, ctx, prompt) it is asked to judge; returns a canned output. */
+class FakeJudge implements VisionJudge {
+  readonly calls: Array<[ImageInput, SpeciesContext, string]> = [];
+  constructor(private readonly out: JudgeOutput = VALID_OUTPUT) {}
+  async judge(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
+    this.calls.push([img, ctx, prompt]);
+    return this.out;
+  }
+}
+
+const INPUT: RunRowInput = {
+  imagePath: '/thumbs/amerob.jpg',
+  speciesCode: 'amerob',
+  comName: 'American Robin',
+  sciName: 'Turdus migratorius',
+  family: 'Turdidae',
+};
+
+describe('runRow', () => {
+  it('reads the image, builds the species context, and returns the judge output', async () => {
+    const judge = new FakeJudge();
+    const readImage = (p: string): ImageInput => ({ buffer: Buffer.from(`bytes:${p}`), mime: 'image/jpeg' });
+
+    const out = await runRow({ judge, readImage, prompt: 'rubric prompt v1' }, INPUT);
+
+    expect(out).toEqual(VALID_OUTPUT);
+    expect(judge.calls).toHaveLength(1);
+    const [img, ctx, prompt] = judge.calls[0]!;
+    expect(img.buffer).toEqual(Buffer.from('bytes:/thumbs/amerob.jpg'));
+    expect(img.mime).toBe('image/jpeg');
+    expect(ctx).toEqual({
+      speciesCode: 'amerob',
+      comName: 'American Robin',
+      sciName: 'Turdus migratorius',
+      family: 'Turdidae',
+    });
+    expect(prompt).toBe('rubric prompt v1');
+  });
+
+  it('passes the imagePath through to readImage exactly once', async () => {
+    const judge = new FakeJudge();
+    const seen: string[] = [];
+    const readImage = (p: string): ImageInput => {
+      seen.push(p);
+      return { buffer: Buffer.from('x'), mime: 'image/png' };
+    };
+
+    await runRow({ judge, readImage, prompt: 'p' }, INPUT);
+
+    expect(seen).toEqual(['/thumbs/amerob.jpg']);
+  });
+
+  it('threads the source path onto the ImageInput sourceUrl (so the span records it)', async () => {
+    const judge = new FakeJudge();
+    const readImage = (p: string): ImageInput => ({ buffer: Buffer.from('x'), mime: 'image/jpeg', sourceUrl: p });
+
+    await runRow({ judge, readImage, prompt: 'p' }, INPUT);
+
+    const [img] = judge.calls[0]!;
+    expect(img.sourceUrl).toBe('/thumbs/amerob.jpg');
+  });
+});

--- a/tools/photo-curation/src/eval/run-row.ts
+++ b/tools/photo-curation/src/eval/run-row.ts
@@ -1,0 +1,58 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Row → judge wiring for the Braintrust eval (C5, #1015; part of #1010).
+//
+// `photo-judge.eval.ts` is run by `bt eval`, whose `task(input, hooks)` gets
+// each dataset row's `input` as the FIRST positional argument. This module is
+// the pure, dependency-injected mapping from that row to a `JudgeOutput`:
+//
+//   EvalRow.input ──(readImage)──▶ ImageInput ─┐
+//                                              ├─▶ judge.judge(img, ctx, prompt)
+//   EvalRow.input ───────────────▶ SpeciesContext ─┘
+//
+// Everything is injected (`judge`, `readImage`, `prompt`) so the only CI-visible
+// safety net for the eval wiring — the tool's `tsc` is excluded from CI — is the
+// vitest in run-row.test.ts (a FakeJudge + a fake readImage; no network, no fs).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { ImageInput, JudgeOutput, SpeciesContext, VisionJudge } from '@bird-watch/photo-quality';
+
+/**
+ * One dataset row's `input` (mirrors `EvalRow.input` from build-dataset.ts).
+ * Re-declared here rather than imported so this module stays decoupled from the
+ * dataset builder's internals — only the field names are the contract.
+ */
+export interface RunRowInput {
+  imagePath: string;
+  speciesCode: string;
+  comName: string;
+  sciName: string;
+  family: string;
+}
+
+/** The injected collaborators a `runRow` call needs. */
+export interface RunRowDeps {
+  /** The (traced) judge to score the image with. */
+  judge: VisionJudge;
+  /** Reads an image path into an `ImageInput` (buffer + mime [+ sourceUrl]). */
+  readImage: (imagePath: string) => ImageInput;
+  /** The rubric prompt handed to the judge (e.g. `defaultRubricConfig.judgePrompt`). */
+  prompt: string;
+}
+
+/**
+ * Map one eval row to a judge call. Reads the row's image via `deps.readImage`,
+ * builds the `SpeciesContext` from the row's species fields, and asks
+ * `deps.judge` to score it with `deps.prompt`. Returns the judge's
+ * `JudgeOutput` unchanged — the Braintrust scorers compare it against the row's
+ * `expected` (the Opus proxy ground truth).
+ */
+export async function runRow(deps: RunRowDeps, input: RunRowInput): Promise<JudgeOutput> {
+  const img: ImageInput = deps.readImage(input.imagePath);
+  const ctx: SpeciesContext = {
+    speciesCode: input.speciesCode,
+    comName: input.comName,
+    sciName: input.sciName,
+    family: input.family,
+  };
+  return deps.judge.judge(img, ctx, deps.prompt);
+}

--- a/tools/photo-curation/src/eval/scorers.test.ts
+++ b/tools/photo-curation/src/eval/scorers.test.ts
@@ -56,8 +56,9 @@ describe('scoreMAE', () => {
   });
 
   it('clamps to 0 for an out-of-domain qualityScore (no negative scores)', () => {
-    // |130 - 50| / 100 = 0.8 → 1 - 0.8 = 0.2 is in-domain; push further:
-    // a >100-point error would yield a negative raw score, which we clamp to 0.
+    // |130 - 0| / 100 = 1.3 → 1 - 1.3 = -0.3, a NEGATIVE raw score that the
+    // Math.max(0, …) clamp pulls up to 0 (an out-of-domain >100-point error
+    // can never produce a negative metric).
     expect(scoreMAE({ output: judge(true, 130), expected: judge(true, 0) })).toEqual({
       name: 'score_mae',
       score: 0,

--- a/tools/photo-curation/src/judges/gemini.test.ts
+++ b/tools/photo-curation/src/judges/gemini.test.ts
@@ -34,6 +34,11 @@ function gemini429(): Response {
   return new Response('rate limited', { status: 429 });
 }
 
+/** A 500 (transient 5xx) Response — withBackoff should retry past it too. */
+function gemini500(): Response {
+  return new Response('internal error', { status: 500 });
+}
+
 describe('GeminiVisionJudge', () => {
   it('maps a valid candidates[0].content.parts[0].text JSON into a JudgeOutput', async () => {
     const fetchImpl = async () => geminiOk(JSON.stringify(VALID_OUTPUT));
@@ -92,6 +97,23 @@ describe('GeminiVisionJudge', () => {
     const fetchImpl = async () => {
       n += 1;
       return n === 1 ? gemini429() : geminiOk(JSON.stringify(VALID_OUTPUT));
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    const out = await judge.judge(img, ctx, 'p');
+
+    expect(n).toBe(2);
+    expect(out.keep).toBe(true);
+  });
+
+  it('recovers from a transient 500 then 200 via withBackoff', async () => {
+    // The 5xx leg of isTransient/withBackoff: a one-off server error must be
+    // retried, not surfaced as a GeminiJudgeError (only a non-2xx that survives
+    // every backoff attempt is terminal).
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      return n === 1 ? gemini500() : geminiOk(JSON.stringify(VALID_OUTPUT));
     };
     const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
 

--- a/tools/photo-curation/src/judges/traced.test.ts
+++ b/tools/photo-curation/src/judges/traced.test.ts
@@ -6,6 +6,7 @@ import {
   MissingGeminiKey,
   type BraintrustLoggerSeam,
 } from './traced.js';
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
 import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
 
 const img: ImageInput = {
@@ -97,20 +98,24 @@ describe('tracedJudge', () => {
       model: 'gemini-2.5-flash',
       sourceUrl: 'https://example.test/amerob.jpg',
     });
-    expect(inputLog!.input.rubricVersion).toBe(PROMPT);
+    // rubricVersion is the STABLE config version, NOT the full prompt body (#1015).
+    expect(inputLog!.input.rubricVersion).toBe(defaultRubricConfig.version);
+    expect(inputLog!.input.rubricVersion).not.toBe(PROMPT);
 
     // output span-log: the full JudgeOutput.
     const outputLog = span.logs.find((l) => 'output' in l) as { output: JudgeOutput } | undefined;
     expect(outputLog).toBeTruthy();
     expect(outputLog!.output).toEqual(VALID_OUTPUT);
 
-    // metadata span-log: latencyMs + model.
+    // metadata span-log: latencyMs + model, plus aggregated metrics.latency (s).
     const metaLog = span.logs.find((l) => 'metadata' in l) as
-      | { metadata: { latencyMs: number; model: string } }
+      | { metadata: { latencyMs: number; model: string }; metrics: { latency: number } }
       | undefined;
     expect(metaLog).toBeTruthy();
     expect(metaLog!.metadata.model).toBe('gemini-2.5-flash');
     expect(typeof metaLog!.metadata.latencyMs).toBe('number');
+    // metrics.latency is the same measurement in SECONDS (Braintrust aggregation).
+    expect(metaLog!.metrics.latency).toBeCloseTo(metaLog!.metadata.latencyMs / 1000);
   });
 
   it('propagates an inner error and still closes the span', async () => {

--- a/tools/photo-curation/src/judges/traced.ts
+++ b/tools/photo-curation/src/judges/traced.ts
@@ -18,11 +18,21 @@
 //   • Key absence FAILS LOUD (`MissingGeminiKey` / `MissingBraintrustKey`) —
 //     we never score blind (spec §Error handling).
 //   • The Braintrust SDK API was verified against the current docs (context7,
-//     2026-06-11): `initLogger({projectName, apiKey})`, `logger.traced(async
-//     span => …)`, and `span.log({input})` / `span.log({output, metadata})`.
+//     2026-06-11): `initLogger({projectName, apiKey})`, the bare module-level
+//     `traced(async span => …)`, and `span.log({input})` /
+//     `span.log({output, metadata, metrics})`.
+//   • SPAN NESTING (#1015 review): `resolveTracedJudge`'s seam opens spans via
+//     the BARE ambient `traced` (imported from `braintrust`), NOT
+//     `initLogger(...).traced`. Per the SDK, `traced` parents to the currently
+//     active span → experiment → logger, in that order. So inside a `bt eval`
+//     task the per-judgment span nests UNDER the experiment trace; outside an
+//     eval it falls back to the `initLogger`-registered project logger (so
+//     production scoring still logs). `initLogger` is still called to establish
+//     that fallback context — it is the active logger when no experiment is.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { initLogger } from 'braintrust';
+import { initLogger, traced } from 'braintrust';
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
 import type { ImageInput, JudgeOutput, SpeciesContext, VisionJudge } from '@bird-watch/photo-quality';
 import { GeminiVisionJudge } from './gemini.js';
 
@@ -71,10 +81,17 @@ export interface TracedJudgeOptions {
 
 /**
  * Decorate any `VisionJudge` with a Braintrust span. Each `judge()` runs the
- * inner judge inside `logger.traced`, logging `input` (species framing + rubric
- * version + model + source URL), `output` (the full `JudgeOutput`), and
- * `metadata` (`latencyMs`, `model`). The span closes on success AND on error
- * (the inner error propagates unchanged).
+ * inner judge inside `logger.traced`, logging `input` (species framing + a
+ * STABLE rubric version + model + source URL), `output` (the full
+ * `JudgeOutput`), `metadata` (`latencyMs`, `model`), and `metrics`
+ * (`latency` in seconds — Braintrust's aggregated latency field, so the
+ * experiment dashboard rolls up p50/p95 across judgments). The span closes on
+ * success AND on error (the inner error propagates unchanged).
+ *
+ * `rubricVersion` logs `defaultRubricConfig.version` (a stable tag like
+ * `0.2.2`), NOT the full prompt body (#1015 review): the prompt text is large
+ * and noisy on every span; the version is the durable knob that changes only on
+ * a calibration tune, which is what we actually want to compare experiments by.
  */
 export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): VisionJudge {
   const { project, model, logger } = opts;
@@ -88,7 +105,7 @@ export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): Visio
             comName: ctx.comName,
             sciName: ctx.sciName,
             family: ctx.family,
-            rubricVersion: prompt,
+            rubricVersion: defaultRubricConfig.version,
             model,
             sourceUrl: img.sourceUrl,
             project,
@@ -96,9 +113,12 @@ export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): Visio
         });
         const start = now();
         const output = await inner.judge(img, ctx, prompt);
+        const latencyMs = now() - start;
         span.log({
           output,
-          metadata: { latencyMs: now() - start, model },
+          metadata: { latencyMs, model },
+          // Braintrust's aggregated `metrics.latency` is in SECONDS — divide ms.
+          metrics: { latency: latencyMs / 1000 },
         });
         return output;
       });
@@ -133,9 +153,15 @@ export function resolveTracedJudge(env: JudgeEnv, opts: ResolveTracedJudgeOption
   if (!env.BRAINTRUST_API_KEY) {
     throw new MissingBraintrustKey();
   }
-  const bt = initLogger({ projectName: opts.project, apiKey: env.BRAINTRUST_API_KEY });
+  // `initLogger` registers the project logger as the fallback active context
+  // (so production scoring — no experiment — still logs to bird-maps). The seam
+  // itself opens spans via the BARE ambient `traced`, which parents to the
+  // active span → experiment → logger: inside a `bt eval` task that is the
+  // experiment, so the per-judgment span nests under the experiment trace
+  // instead of the project Logs stream (#1015 review).
+  initLogger({ projectName: opts.project, apiKey: env.BRAINTRUST_API_KEY });
   const logger: BraintrustLoggerSeam = {
-    traced: (fn) => bt.traced(fn),
+    traced: (fn) => traced(fn),
   };
   const inner = new GeminiVisionJudge({ apiKey: env.GEMINI_API_KEY, model: opts.model });
   return tracedJudge(inner, { project: opts.project, model: opts.model, logger });


### PR DESCRIPTION
## Diagrams

The Braintrust eval wiring this PR completes (C5, the final child of #1010):

```mermaid
flowchart TD
    subgraph data["data: buildEvalRows (#1013)"]
        SQLITE["review.sqlite<br/>(Opus role='current')"] --> ROWS["EvalRow[]<br/>{input, expected:{keep,qualityScore}}"]
        THUMBS["thumb-cache/&lt;code&gt;.{jpg,png,webp}"] --> ROWS
    end

    subgraph task["task(input, hooks) — runRow (this PR)"]
        ROWS -->|input| RR["runRow{judge, readImage, prompt}"]
        RR -->|readImage| IMG["ImageInput"]
        RR -->|species fields| CTX["SpeciesContext"]
        IMG --> JUDGE
        CTX --> JUDGE["resolveTracedJudge (#1012)<br/>= tracedJudge(GeminiVisionJudge #1011)"]
    end

    JUDGE -->|output JudgeOutput| SCORERS["scores: keepAgreement / scoreMAE / keepConfusion (#1014)"]
    JUDGE -.->|span via ambient traced| EXP["bird-maps EXPERIMENT<br/>(spans nest UNDER the experiment)"]
    SCORERS --> EXP
```

## Summary

- **Why:** #1010 needs a `bt eval` entry that runs the traced Gemini judge over the Opus-902 proxy baseline and reports the #969 keep-agreement gate (≥90%) as a `bird-maps` experiment. This is the final child (C5) — it wires C1–C4 together into a runnable eval plus the operator runbook.
- **What (C5 core):** `runRow` (the testable row→judge mapping, the only CI-visible safety net since the tool's tsc is CI-excluded), `eval/photo-judge.eval.ts` (the `Eval('bird-maps', …)` entry using the `task(input, hooks)` signature — first positional arg IS the row's `input`), the runbook, the `eval` package script, and the knip ignore for the `bt eval` shell-string entry (without it knip goes red and blocks Mergify).
- **Folded review-polish from the wave** (each a separate, labeled commit):
  - **Span nesting under the experiment (the important one)** — *from #1012's traced.ts.* `resolveTracedJudge`'s seam now opens spans via the **bare ambient `braintrust` `traced`**, not `initLogger(...).traced`. Per the SDK (context7, 2026-06-11), `traced` parents to the active span → experiment → logger; so inside a `bt eval` task the per-judgment span nests **under the experiment** instead of writing to the project Logs stream. `initLogger` is still called to establish the production-logging fallback context.
  - **Stable rubricVersion + aggregated latency** — *from #1012's traced.ts.* Log `defaultRubricConfig.version` (e.g. `0.2.2`) for the span `rubricVersion` field instead of the full prompt body, and record latency under Braintrust's aggregated `metrics.latency` (seconds) alongside `metadata.latencyMs`.
  - **5xx retry test** — *from #1011's gemini.test.ts.* Added a 500→200 recovery test for the 5xx leg of `withBackoff`/`isTransient` (previously only the 429 leg was covered).
  - **Deterministic two-extension resolution** — *from #1013's build-dataset.ts.* `entries.sort()` before the `.find()` so a species with two cached extensions resolves to the same file across machines (`readdir` order is filesystem-dependent).
  - **Stale comment fix** — *from #1014's scorers.test.ts.* Corrected the `scoreMAE` clamp comment whose operands (`|130 - 50|`) didn't match the call below it (`|130 - 0|`).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm test -w @bird-watch/photo-curation` — **235 passed** (includes the new `run-row.test.ts`, the 5xx retry leg, the two-extension determinism test, and the updated traced/scorers assertions).
- [x] New unit tests added — `run-row.test.ts` (FakeJudge mapping), gemini 5xx retry, build-dataset two-extension determinism.
- [x] N/A — no user-visible behavior changed (no e2e spec needed).
- [x] `npm run build -w @bird-watch/photo-quality && npm run build -w @bird-watch/photo-curation` — tsc clean; `npm run build` (root) — clean; standalone typecheck of `eval/photo-judge.eval.ts` — clean.
- [x] `npx knip --no-progress` — exit 0 (the `eval/photo-judge.eval.ts` ignore keeps it green); `npm run lint` — green.
- [ ] **Live `bt eval --first 5` smoke** — deferred to the orchestrator post-merge (the run-worktree's `review.sqlite` + `thumb-cache` and `BRAINTRUST_API_KEY` are not available in this isolated worktree). Runbook documents the smoke and the first-run smoke-verify checklist (experiment created, non-null keep-agreement, span nested under the experiment).
- [x] (UI only) N/A — not UI.

## Plan reference

Closes #1015. Part of #1010 (photo-judge Braintrust eval). Spec: `docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md`. Plans live in issues (not `docs/plans/`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
