### PR TITLE
fix(photo-curation): Gemini judge quota-signal handling — parse the 429 body, latch the daily cap, honor RetryInfo, 12s pacing

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -27,7 +27,9 @@ from the photo-curation run-worktree**, not from CI:
 - **`review.sqlite`** with `role='current'` Opus scores (the 902-score baseline).
 - **`thumb-cache/<species_code>.{jpg,png,webp}`** — the cached current
   thumbnails the Opus pass scored. No re-download.
-- A Gemini API key (free tier is fine) and a Braintrust API key.
+- A Gemini API key and a Braintrust API key. Free tier covers only a smoke run
+  (20 requests/day — see the daily-cap section); a full 150-row run needs the
+  paid-tier path.
 - `npm install` at the repo root, and the full workspace dep chain built once.
   `@bird-watch/photo-curation` depends on `@bird-watch/ingestor` (and
   `@bird-watch/photo-quality` / `@bird-watch/shared-types`), and `ingestor`
@@ -48,6 +50,7 @@ from the photo-curation run-worktree**, not from CI:
 | `REVIEW_DB` | yes | path to `review.sqlite` (e.g. `./review.sqlite`) |
 | `THUMB_DIR` | yes | path to the thumbnail cache (e.g. `./thumb-cache`) |
 | `EVAL_SAMPLE` | no (default `150`) | stratified keep/replace sample size for a full run |
+| `GEMINI_PACE_MS` | no (default `12000`) | min ms between Gemini calls (12 s ⇒ ≤ 5 RPM, the measured free-tier cap); adjust only when a paid tier raises the per-minute quota |
 
 Put the non-secret values plus `GEMINI_API_KEY` in a local `.env.local`
 (gitignored). `bt eval --env-file .env.local` loads them into the eval process:
@@ -83,11 +86,15 @@ The package also exposes `npm run eval -w @bird-watch/photo-curation`
 
 > **Pacing.** The eval runs **serially** (`maxConcurrency: 1`) over **one
 > shared** traced judge, so that judge's single `Pacer` gates the whole run to
-> ≤ 10 RPM (≈ 6 s/call) — a 150-row run takes on the order of 15 minutes of wall
-> clock. That serial single-judge wiring is what keeps the run inside Gemini's
-> free tier (per-row judges would each reset the pacer; unbounded concurrency
-> would race it). That is expected — do not parallelize around the pacer or
-> construct a judge per row.
+> ≈ 12 s/call (`GEMINI_PACE_MS`, default `12000` ⇒ ≤ 5 RPM — the free-tier
+> per-minute cap measured 2026-06-11, #1036) — a 150-row run is on the order of
+> 30 minutes of wall clock *if the daily quota allows it* (it does not on free
+> tier; see below). That serial single-judge wiring is what keeps the run inside
+> the per-minute cap (per-row judges would each reset the pacer; unbounded
+> concurrency would race it). That is expected — do not parallelize around the
+> pacer or construct a judge per row. On a minute-cap `429` the retry honors the
+> server's `RetryInfo.retryDelay` hint (13–38 s observed) rather than only the
+> jittered backoff.
 
 ### Reading the result
 
@@ -101,13 +108,28 @@ The package also exposes `npm run eval -w @bird-watch/photo-curation`
   `keep_agreement ≥ 90%` **and** `falseKeep` is low. Below the gate → hybrid
   (Gemini first pass, Opus re-judges the close calls) — see the design spec.
 
-## Free-tier RPD cap — resume
+## Daily cap (20 RPD free tier) — abort + resume
 
-Gemini's free tier has a **requests-per-day** cap. The per-minute pacing keeps
-you under the RPM limit, but a large run can still hit the daily ceiling:
+Gemini's free tier caps `gemini-2.5-flash` at **20 requests per day** (measured
+2026-06-11, #1036: `GenerateRequestsPerDayPerProjectPerModel-FreeTier`,
+`quotaValue: "20"`). The per-minute pacing keeps you under the 5 RPM limit, but
+**a 150-row run does NOT fit in a free-tier day** — at 20 RPD even a re-ask-free
+run covers at most 20 rows before the cap trips.
 
-- On a `429` the judge retries with jittered backoff (the RPM leg). If the
-  **daily** cap is exhausted, calls keep failing — stop the run.
+- On a minute-cap `429` the judge retries, sleeping at least the server's
+  `RetryInfo.retryDelay`. On a **daily-cap** `429` the run **aborts fast**: the
+  judge throws `GeminiDailyQuotaError` (the message names the tripped
+  `quotaId`) on the first trip and latches — every subsequent row fails with
+  the same error and **zero further network**, so the run no longer burns the
+  next day's quota on pointless retries. Stop the run when you see it.
+- **Paid tier (the realistic path for a full 150-row run):** enable billing on
+  the Gemini API project
+  ([ai.google.dev/gemini-api/docs/billing](https://ai.google.dev/gemini-api/docs/billing)),
+  then in the GCP console **lower the per-model per-day quota** to a
+  self-imposed ceiling as a hard spend cap, and set `GEMINI_PACE_MS` to match
+  whatever per-minute quota the paid tier grants (e.g. a 60 RPM tier tolerates
+  `GEMINI_PACE_MS=1100`). The judge's quota handling is tier-agnostic — the
+  same parse/latch logic protects against whatever caps are configured.
 - **Resume strategy:** there is no checkpoint file. Re-run with a **smaller
   `EVAL_SAMPLE`** (or `--first N`) the same day, or wait for the quota to reset
   (~midnight Pacific) and re-run the full sample. The dataset builder's sample

--- a/docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md
+++ b/docs/specs/2026-06-11-photo-judge-braintrust-eval-design.md
@@ -70,6 +70,16 @@ in a future iteration; the eval harness is identical either way (only the datase
   429/backoff, mirroring the tool's existing external-call idiom; abort-one not
   the-batch. Free-tier RPD cap is handled by resuming or sampling, not by
   removing pacing.
+
+  > **Correction (2026-06-12, #1036):** the free tier measured on the first
+  > keyed run (2026-06-11 `curl` probes) is **5 RPM / 20 RPD** for
+  > `gemini-2.5-flash` — not the ~10 RPM / ~250 RPD this section assumed. The
+  > pacing default is now **≈12 s/call** (`GEMINI_PACE_MS`, env-overridable);
+  > the judge parses the 429 body's quota signals (`quotaId` +
+  > `RetryInfo.retryDelay`), honors the server's retry hint on minute-cap
+  > trips, and **latches with `GeminiDailyQuotaError`** once the daily cap
+  > trips (no further network for the judge's lifetime). A 150-row run does
+  > NOT fit in a free-tier day; see the runbook's paid-tier path.
 - **Auth:** `GEMINI_API_KEY` from env. SDK: `@google/genai` — **pull fresh
   context7 docs before coding** (responseSchema + inline image API churn).
 

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -57,8 +57,9 @@ function readImage(imagePath: string): ImageInput {
 // ── Single shared judge (the pacing fix, #1015 review) ───────────────────────
 // The judge owns the per-instance `Pacer` (src/judges/gemini.ts → ../pacing.ts).
 // Constructing one judge PER ROW would reset that Pacer on every call, defeating
-// the ≤10 RPM / 6 s-per-call gate the runbook promises — a 150-row `bt eval`
-// would burst unpaced and trip Gemini's free-tier RPM/RPD with 429s. So we build
+// the GEMINI_PACE_MS gate the runbook promises (default 12 s/call ⇒ ≤5 RPM, the
+// measured free-tier cap, #1036) — a 150-row `bt eval` would burst unpaced and
+// trip Gemini's free-tier RPM/RPD with 429s. So we build
 // the judge EXACTLY ONCE and share the instance (hence the single Pacer) across
 // all rows. Memoized via a getter so it is NOT constructed at import time:
 // `resolveTracedJudge` fails loud on a missing key, and `bt eval --list` /
@@ -70,7 +71,7 @@ const getJudge = (): VisionJudge =>
 Eval('bird-maps', {
   data: () => buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE }),
   // Rows run SERIALLY (one at a time): the shared judge's single Pacer enforces
-  // the 6 s gate globally only if rows don't race it. Braintrust's default
+  // the GEMINI_PACE_MS gate globally only if rows don't race it. Braintrust's default
   // concurrency is unbounded, so we pin it to 1 — without this, concurrent rows
   // sharing one Pacer could still burst past the RPM cap.
   maxConcurrency: 1,

--- a/tools/photo-curation/src/judges/gemini.test.ts
+++ b/tools/photo-curation/src/judges/gemini.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { GeminiVisionJudge, GeminiJudgeError, GEMINI_PACE_MS } from './gemini.js';
+import { describe, it, expect, vi } from 'vitest';
+import { GeminiVisionJudge, GeminiJudgeError, GeminiDailyQuotaError, GEMINI_PACE_MS } from './gemini.js';
 import { makeFakeClock } from '../test-clock.js';
 import type { ImageInput, SpeciesContext, JudgeOutput } from '@bird-watch/photo-quality';
 
@@ -29,9 +29,39 @@ function geminiOk(text: string): Response {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
 }
 
-/** A 429 (transient) Response — withBackoff should retry past it. */
+/** A 429 (transient) Response with an UNPARSEABLE body — withBackoff should retry past it. */
 function gemini429(): Response {
   return new Response('rate limited', { status: 429 });
+}
+
+/** The quotaIds measured on the free tier 2026-06-11 (#1036). */
+const PER_MINUTE_QUOTA_ID = 'GenerateRequestsPerMinutePerProjectPerModel-FreeTier';
+const PER_DAY_QUOTA_ID = 'GenerateRequestsPerDayPerProjectPerModel-FreeTier';
+
+/** Google's structured 429: `error.details[]` carries QuotaFailure violations + RetryInfo. */
+function gemini429Quota(quotaId: string, retryDelay?: string): Response {
+  const details: unknown[] = [
+    {
+      '@type': 'type.googleapis.com/google.rpc.QuotaFailure',
+      violations: [
+        {
+          quotaMetric: 'generativelanguage.googleapis.com/generate_content_free_tier_requests',
+          quotaId,
+          quotaValue: '5',
+        },
+      ],
+    },
+  ];
+  if (retryDelay !== undefined) {
+    details.push({ '@type': 'type.googleapis.com/google.rpc.RetryInfo', retryDelay });
+  }
+  const body = {
+    error: { code: 429, message: 'Resource has been exhausted', status: 'RESOURCE_EXHAUSTED', details },
+  };
+  return new Response(JSON.stringify(body), {
+    status: 429,
+    headers: { 'content-type': 'application/json' },
+  });
 }
 
 /** A 500 (transient 5xx) Response — withBackoff should retry past it too. */
@@ -121,6 +151,96 @@ describe('GeminiVisionJudge', () => {
 
     expect(n).toBe(2);
     expect(out.keep).toBe(true);
+  });
+
+  it('waits at least the RetryInfo retryDelay before retrying a minute-cap 429', async () => {
+    const clock = makeFakeClock();
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      return n === 1 ? gemini429Quota(PER_MINUTE_QUOTA_ID, '13s') : geminiOk(JSON.stringify(VALID_OUTPUT));
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock, fetchImpl });
+
+    const out = await judge.judge(img, ctx, 'p');
+
+    expect(n).toBe(2);
+    expect(out.keep).toBe(true);
+    // The backoff sleep honors the server hint: max(13 000, jittered ≤ 500) = 13 000.
+    expect(clock.sleeps).toContain(13_000);
+  });
+
+  it('latches on a daily-cap 429: GeminiDailyQuotaError on the FIRST trip, one fetch total', async () => {
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      return gemini429Quota(PER_DAY_QUOTA_ID, '38s');
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    // The FIRST trip surfaces as GeminiDailyQuotaError (not a wrapped GeminiJudgeError) …
+    await expect(judge.judge(img, ctx, 'p')).rejects.toBeInstanceOf(GeminiDailyQuotaError);
+    // … after exactly ONE network call: a drained daily cap is non-transient, no retries.
+    expect(n).toBe(1);
+
+    // The latch: every subsequent judge() call throws with ZERO additional fetches.
+    await expect(judge.judge(img, ctx, 'p')).rejects.toBeInstanceOf(GeminiDailyQuotaError);
+    expect(n).toBe(1);
+  });
+
+  it('names the tripped quotaId in the error message (RPM vs RPD trips distinguishable)', async () => {
+    // RPD: the daily error names the quotaId and the reset.
+    const daily = new GeminiVisionJudge({
+      apiKey: 'k',
+      clock: makeFakeClock(),
+      fetchImpl: async () => gemini429Quota(PER_DAY_QUOTA_ID),
+    });
+    await expect(daily.judge(img, ctx, 'p')).rejects.toThrow(new RegExp(PER_DAY_QUOTA_ID));
+
+    // RPM: a minute-cap 429 that survives every backoff attempt still carries its quotaId
+    // (this is the Braintrust span error text — a bare "Gemini 429" is undiagnosable).
+    const minute = new GeminiVisionJudge({
+      apiKey: 'k',
+      clock: makeFakeClock(),
+      fetchImpl: async () => gemini429Quota(PER_MINUTE_QUOTA_ID),
+    });
+    await expect(minute.judge(img, ctx, 'p')).rejects.toThrow(new RegExp(PER_MINUTE_QUOTA_ID));
+  });
+
+  it('preserves plain transient handling for a 429 with an unparseable body (4 attempts)', async () => {
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      return gemini429(); // text body — no quota signals to parse
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    await expect(judge.judge(img, ctx, 'p')).rejects.toBeInstanceOf(GeminiJudgeError);
+    expect(n).toBe(4); // initial + withBackoff's default 3 retries — the pre-#1036 behavior
+  });
+
+  it('defaults GEMINI_PACE_MS to 12_000 ms (≤5 RPM — the measured free-tier cap)', () => {
+    expect(GEMINI_PACE_MS).toBe(12_000);
+  });
+
+  it('honors a GEMINI_PACE_MS env override without a rebuild', async () => {
+    vi.stubEnv('GEMINI_PACE_MS', '30000');
+    vi.resetModules();
+    try {
+      const mod = await import('./gemini.js');
+      expect(mod.GEMINI_PACE_MS).toBe(30_000);
+
+      // And the override actually drives the judge's Pacer.
+      const clock = makeFakeClock();
+      const fetchImpl = async () => geminiOk(JSON.stringify(VALID_OUTPUT));
+      const judge = new mod.GeminiVisionJudge({ apiKey: 'k', clock, fetchImpl });
+      await judge.judge(img, ctx, 'p');
+      await judge.judge(img, ctx, 'p');
+      expect(clock.sleeps).toContain(30_000);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 
   it('re-asks once on a non-JSON body then throws GeminiJudgeError', async () => {

--- a/tools/photo-curation/src/judges/gemini.ts
+++ b/tools/photo-curation/src/judges/gemini.ts
@@ -37,8 +37,8 @@ import { Pacer, withBackoff, realClock, type Clock } from '../pacing.js';
 
 /**
  * Min ms between Gemini calls. Default 12_000 → ≤5 RPM, the free-tier
- * per-minute cap measured 2026-06-11 (#1036; the old 6_000 targeted a 10 RPM
- * tier that no longer exists). Env-overridable via `GEMINI_PACE_MS` — the same
+ * per-minute cap measured 2026-06-11 (#1036; the previous, faster default
+ * targeted a since-halved tier). Env-overridable via `GEMINI_PACE_MS` — the same
  * no-rebuild tuning-knob pattern as the ingestor's `--pace-ms` — so a paid
  * tier with a self-imposed quota cap can loosen it without a code change.
  */

--- a/tools/photo-curation/src/judges/gemini.ts
+++ b/tools/photo-curation/src/judges/gemini.ts
@@ -13,8 +13,13 @@
 //     OpenAPI-3.0 subset with UPPERCASE `type` enums), and the JSON answer is at
 //     `candidates[0].content.parts[0].text`.
 //   • Pacing + retry REUSE `Pacer.gate()` + `withBackoff` from ../pacing.ts —
-//     never hand-rolled. `GEMINI_PACE_MS = 6_000` → ≤10 RPM, comfortably under
-//     the free-tier per-minute cap.
+//     never hand-rolled. `GEMINI_PACE_MS` (default 12_000 → ≤5 RPM, the
+//     free-tier per-minute cap measured 2026-06-11, #1036) gates every call and
+//     is env-overridable for paid tiers.
+//   • Quota signals are PARSED from the 429 body (#1036) — `error.details[]`
+//     is the only quota ground truth Google exposes (no remaining-quota API).
+//     A `PerDay` quotaId latches the judge: the daily cap resets ~midnight
+//     Pacific, far outside any backoff window, so further calls are pointless.
 //   • Everything is injectable (clock, fetchImpl) so the unit tests assert
 //     pacing/parse/retry deterministically with no real network and no real
 //     wall-clock wait.
@@ -30,8 +35,14 @@ import type {
 import { CRITERIA_KEYS } from '@bird-watch/photo-quality';
 import { Pacer, withBackoff, realClock, type Clock } from '../pacing.js';
 
-/** Min ms between Gemini calls → ≤10 RPM (well under the free-tier per-minute cap). */
-export const GEMINI_PACE_MS = 6_000;
+/**
+ * Min ms between Gemini calls. Default 12_000 → ≤5 RPM, the free-tier
+ * per-minute cap measured 2026-06-11 (#1036; the old 6_000 targeted a 10 RPM
+ * tier that no longer exists). Env-overridable via `GEMINI_PACE_MS` — the same
+ * no-rebuild tuning-knob pattern as the ingestor's `--pace-ms` — so a paid
+ * tier with a self-imposed quota cap can loosen it without a code change.
+ */
+export const GEMINI_PACE_MS = Number(process.env.GEMINI_PACE_MS) || 12_000;
 
 /** Thrown when the model's reply cannot be parsed into a JudgeOutput, even after one re-ask. */
 export class GeminiJudgeError extends Error {
@@ -41,14 +52,101 @@ export class GeminiJudgeError extends Error {
   }
 }
 
-/** A status-carrying error so ../pacing.ts `isTransient` retries 429/5xx via withBackoff. */
+/**
+ * Thrown when Gemini's DAILY quota is exhausted (#1036). The first `PerDay`
+ * 429 latches the judge instance: this same type is thrown on that first trip
+ * AND on every subsequent `judge()` call — without another network request.
+ * Rationale: the eval shares ONE judge across serially-run rows
+ * (maxConcurrency: 1, #1015); without the latch a mid-run cap trip burns every
+ * remaining row × (maxRetries + 1) pointless requests.
+ */
+export class GeminiDailyQuotaError extends Error {
+  /** Honored FIRST by ../pacing.ts `isTransient` — never retried. */
+  readonly nonTransient = true;
+  constructor(
+    readonly quotaId: string,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `Gemini free-tier daily cap exhausted (${quotaId}) — resume after midnight Pacific`,
+      options,
+    );
+    this.name = 'GeminiDailyQuotaError';
+  }
+}
+
+/** Quota signals parsed from a Google 429 body's `error.details[]` (#1036). */
+interface QuotaSignals {
+  quotaId?: string;
+  retryDelayMs?: number;
+}
+
+/** Parse a proto-JSON Duration like `"13s"` / `"3.5s"` into ms (undefined if unparseable). */
+function parseRetryDelayMs(retryDelay: string): number | undefined {
+  const m = /^(\d+(?:\.\d+)?)s$/.exec(retryDelay.trim());
+  return m ? Math.round(Number(m[1]) * 1000) : undefined;
+}
+
+/**
+ * Read quota signals out of a non-2xx response body. Google's 429 carries
+ * `error.details[]` with `QuotaFailure.violations[].quotaId` and
+ * `RetryInfo.retryDelay`. A non-JSON or differently-shaped body yields `{}`,
+ * preserving the plain-transient (jittered backoff) behavior.
+ */
+async function readQuotaSignals(res: Response): Promise<QuotaSignals> {
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return {};
+  }
+  const details = (body as { error?: { details?: unknown } } | null)?.error?.details;
+  if (!Array.isArray(details)) return {};
+  const signals: QuotaSignals = {};
+  for (const detail of details) {
+    if (typeof detail !== 'object' || detail === null) continue;
+    const d = detail as { violations?: unknown; retryDelay?: unknown };
+    if (signals.quotaId === undefined && Array.isArray(d.violations)) {
+      for (const violation of d.violations) {
+        const quotaId = (violation as { quotaId?: unknown } | null)?.quotaId;
+        if (typeof quotaId === 'string') {
+          signals.quotaId = quotaId;
+          break;
+        }
+      }
+    }
+    if (typeof d.retryDelay === 'string') {
+      const ms = parseRetryDelayMs(d.retryDelay);
+      if (ms !== undefined) signals.retryDelayMs = ms;
+    }
+  }
+  return signals;
+}
+
+/**
+ * A status-carrying error so ../pacing.ts `isTransient`/`withBackoff` can act
+ * on it. Enriched (#1036) with the 429 body's quota signals: `quotaId` (also
+ * woven into the message — that string is what lands in the Braintrust span's
+ * `error` field, where a bare "Gemini 429" is undiagnosable), `retryDelayMs`
+ * (server RetryInfo hint; `withBackoff` sleeps at least this long), and
+ * `nonTransient` for `/PerDay/` quotaIds (a drained daily cap is not flake).
+ */
 class GeminiHttpError extends Error {
+  readonly quotaId?: string;
+  readonly retryDelayMs?: number;
+  readonly nonTransient?: boolean;
   constructor(
     readonly status: number,
     message: string,
+    signals: QuotaSignals = {},
   ) {
     super(message);
     this.name = 'GeminiHttpError';
+    if (signals.quotaId !== undefined) {
+      this.quotaId = signals.quotaId;
+      if (/PerDay/.test(signals.quotaId)) this.nonTransient = true;
+    }
+    if (signals.retryDelayMs !== undefined) this.retryDelayMs = signals.retryDelayMs;
   }
 }
 
@@ -163,9 +261,10 @@ function toJudgeOutput(raw: unknown): JudgeOutput {
 }
 
 /**
- * Gemini-backed `VisionJudge`. Paces calls (≤10 RPM), retries transient
- * 429/5xx via `withBackoff`, and on an unparseable body re-asks ONCE before
- * throwing `GeminiJudgeError`.
+ * Gemini-backed `VisionJudge`. Paces calls (`GEMINI_PACE_MS`, default ≤5 RPM),
+ * retries transient 429/5xx via `withBackoff` honoring the server's RetryInfo
+ * hint, fails fast (latched) once the daily quota trips, and on an unparseable
+ * body re-asks ONCE before throwing `GeminiJudgeError`.
  */
 export class GeminiVisionJudge implements VisionJudge {
   private readonly apiKey: string;
@@ -173,6 +272,8 @@ export class GeminiVisionJudge implements VisionJudge {
   private readonly fetchImpl: FetchImpl;
   private readonly pacer: Pacer;
   private readonly clock: Clock;
+  /** quotaId of the tripped daily cap; once set, judge() fails fast forever (#1036). */
+  private dailyExhaustedQuotaId: string | null = null;
 
   constructor(opts: GeminiVisionJudgeOptions) {
     if (!opts.apiKey) {
@@ -194,7 +295,13 @@ export class GeminiVisionJudge implements VisionJudge {
       body: JSON.stringify(buildRequestBody(img, ctx, prompt)),
     });
     if (!res.ok) {
-      throw new GeminiHttpError(res.status, `Gemini ${res.status} for ${this.model}:generateContent`);
+      const signals = await readQuotaSignals(res);
+      const quota = signals.quotaId === undefined ? '' : ` (quotaId: ${signals.quotaId})`;
+      throw new GeminiHttpError(
+        res.status,
+        `Gemini ${res.status} for ${this.model}:generateContent${quota}`,
+        signals,
+      );
     }
     const json: unknown = await res.json();
     return extractText(json);
@@ -203,14 +310,34 @@ export class GeminiVisionJudge implements VisionJudge {
   /** One paced, backoff-wrapped ask → parsed JudgeOutput. */
   private async ask(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
     await this.pacer.gate();
-    const text = await withBackoff(() => this.callOnce(img, ctx, prompt), { clock: this.clock });
+    let text: string;
+    try {
+      text = await withBackoff(() => this.callOnce(img, ctx, prompt), { clock: this.clock });
+    } catch (err) {
+      // First daily-cap trip: latch the judge and surface the dedicated type.
+      // (withBackoff never retried it — `nonTransient` short-circuits isTransient.)
+      if (err instanceof GeminiHttpError && err.nonTransient === true && err.quotaId !== undefined) {
+        this.dailyExhaustedQuotaId = err.quotaId;
+        throw new GeminiDailyQuotaError(err.quotaId, { cause: err });
+      }
+      throw err;
+    }
     return toJudgeOutput(JSON.parse(text));
   }
 
   async judge(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
+    // Latched daily exhaustion: fail fast with ZERO pacing and ZERO network.
+    if (this.dailyExhaustedQuotaId !== null) {
+      throw new GeminiDailyQuotaError(this.dailyExhaustedQuotaId);
+    }
     try {
       return await this.ask(img, ctx, prompt);
     } catch (err) {
+      // The daily-cap classification must NOT be swallowed into the generic
+      // wrap: the FIRST PerDay trip throws the same type latched trips do.
+      if (err instanceof GeminiDailyQuotaError) {
+        throw err;
+      }
       // A transport/HTTP failure that survived withBackoff is unrecoverable —
       // surface it. Only a PARSE failure earns a single re-ask.
       if (err instanceof GeminiHttpError) {
@@ -224,6 +351,9 @@ export class GeminiVisionJudge implements VisionJudge {
     try {
       return await this.ask(img, ctx, prompt);
     } catch (err) {
+      if (err instanceof GeminiDailyQuotaError) {
+        throw err;
+      }
       throw new GeminiJudgeError(
         `Gemini returned an unparseable answer after one re-ask: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },

--- a/tools/photo-curation/src/pacing.test.ts
+++ b/tools/photo-curation/src/pacing.test.ts
@@ -80,6 +80,50 @@ describe('withBackoff', () => {
     await expect(withBackoff(fn, { clock, maxRetries: 2, random: () => 0 })).rejects.toThrow(/503/);
     expect(calls).toBe(3); // initial + 2 retries
   });
+
+  it('sleeps at least the server-provided retryDelayMs when the error carries one', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 3) throw Object.assign(new Error('429'), { status: 429, retryDelayMs: 13_000 });
+      return 'ok';
+    };
+    // random()=1 → jittered would be 500 then 1000 — both below the 13 s server hint.
+    const out = await withBackoff(fn, { clock, baseMs: 500, random: () => 1 });
+    expect(out).toBe('ok');
+    expect(clock.sleeps).toEqual([13_000, 13_000]); // max(hint, jittered) = the hint
+  });
+
+  it('keeps the jittered backoff when it exceeds the server hint (max of the two)', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls < 2) throw Object.assign(new Error('429'), { status: 429, retryDelayMs: 1_000 });
+      return 'ok';
+    };
+    // random()=1, baseMs 2000 → jittered 2000 > the 1 s hint.
+    const out = await withBackoff(fn, { clock, baseMs: 2_000, random: () => 1 });
+    expect(out).toBe('ok');
+    expect(clock.sleeps).toEqual([2_000]);
+  });
+
+  it('does not retry at all when the error is marked nonTransient (e.g. a daily-quota trip)', async () => {
+    const clock = makeFakeClock();
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      throw Object.assign(new Error('Gemini 429 (…PerDay…)'), {
+        status: 429,
+        nonTransient: true,
+        retryDelayMs: 38_000,
+      });
+    };
+    await expect(withBackoff(fn, { clock })).rejects.toThrow(/429/);
+    expect(calls).toBe(1); // a drained daily quota makes every retry pointless
+    expect(clock.sleeps).toEqual([]);
+  });
 });
 
 describe('isTransient', () => {
@@ -90,6 +134,12 @@ describe('isTransient', () => {
     expect(isTransient(new Error('download 429 for https://x'))).toBe(true);
     expect(isTransient(new Error('read-api 502 for amerob'))).toBe(true);
     expect(isTransient(new Error('boom'))).toBe(false);
+  });
+
+  it('honors an explicit nonTransient marker — even over a 429 status or message', () => {
+    expect(isTransient({ status: 429, nonTransient: true })).toBe(false);
+    // The marker is checked FIRST: a 429-bearing message does not resurrect the retry.
+    expect(isTransient(Object.assign(new Error('Gemini 429 (PerDay)'), { nonTransient: true }))).toBe(false);
   });
 });
 

--- a/tools/photo-curation/src/pacing.ts
+++ b/tools/photo-curation/src/pacing.ts
@@ -65,11 +65,24 @@ export class Pacer {
 /** A transient (retryable) upstream failure — 429 or 5xx. */
 export interface RetryableError {
   status?: number;
+  /**
+   * Explicit non-retryable marker, checked BEFORE any status/message heuristic.
+   * Callers set it when they KNOW retrying is pointless (e.g. the Gemini judge
+   * marks a daily-quota 429 — the cap won't un-drain inside any backoff window).
+   * Keeps domain knowledge on the error, not in this generic module (#1036).
+   */
+  nonTransient?: boolean;
+  /**
+   * Server-provided minimum delay before the next attempt, in ms (e.g. Google's
+   * `RetryInfo.retryDelay`). `withBackoff` sleeps at least this long.
+   */
+  retryDelayMs?: number;
 }
 
 /** Whether an error is a transient upstream failure worth retrying (429 / 5xx). */
 export function isTransient(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false;
+  if ((err as RetryableError).nonTransient === true) return false;
   const status = (err as RetryableError).status;
   if (typeof status === 'number') {
     return status === 429 || status >= 500;
@@ -97,7 +110,9 @@ export interface BackoffOptions {
  * Non-transient errors throw immediately (a 404 is a bug, not flakiness). After
  * `maxRetries` transient failures the last error is rethrown so the CALLER can
  * abort the species (not the whole batch). Full-jitter variant (AWS write-up):
- * `sleep(random() * base * 2^attempt)`.
+ * `sleep(random() * base * 2^attempt)`. When the error carries a server retry
+ * hint (`retryDelayMs`), the sleep is `max(hint, jittered)` — a jittered 0.5–2 s
+ * wait inside a 13–38 s drained-quota window is guaranteed to fail again.
  */
 export async function withBackoff<T>(
   fn: () => Promise<T>,
@@ -117,7 +132,8 @@ export async function withBackoff<T>(
       if (!isTransient(err) || attempt === maxRetries) break;
       const ceiling = baseMs * Math.pow(2, attempt);
       const withJitter = Math.floor(random() * ceiling);
-      await clock.sleep(withJitter);
+      const hint = (err as RetryableError).retryDelayMs;
+      await clock.sleep(typeof hint === 'number' ? Math.max(hint, withJitter) : withJitter);
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Eval as bt eval row (serial, shared judge)
    participant Judge as GeminiVisionJudge
    participant Backoff as withBackoff (pacing.ts)
    participant Gemini as Gemini v1beta

    Eval->>Judge: judge(img, ctx, prompt)
    alt daily cap already latched
        Judge--xEval: GeminiDailyQuotaError — ZERO network
    else
        Judge->>Judge: Pacer.gate() — GEMINI_PACE_MS (default 12_000 ⇒ ≤5 RPM, env-overridable)
        Judge->>Gemini: POST generateContent
        Gemini-->>Judge: 429 + error.details[] (QuotaFailure, RetryInfo)
        Judge->>Judge: parse quotaId + retryDelay ("13s" → 13_000 ms)
        alt quotaId matches /PerDay/
            Judge->>Backoff: GeminiHttpError{nonTransient: true, quotaId}
            Backoff--xJudge: rethrow immediately (isTransient checks nonTransient FIRST)
            Judge--xEval: GeminiDailyQuotaError (latch set — every later call fails fast)
        else minute cap
            Judge->>Backoff: GeminiHttpError{retryDelayMs: 13_000, quotaId}
            Backoff->>Backoff: sleep max(retryDelayMs, jittered)
            Backoff->>Gemini: retry POST (attempts still bounded by maxRetries)
        end
    end
```

## Summary

- The first keyed eval run (#1036) failed every row `Gemini 429` and was undiagnosable from Braintrust spans: the judge discarded the 429 body — the only quota ground truth Google exposes — and retried a drained DAILY cap (20 RPD measured, not the ~250 assumed) with 0.5–2 s jitter inside 13–38 s `RetryInfo` windows, burning 4 requests per row against the next day's quota.
- `callOnce` now parses `error.details[]` (quotaId + `RetryInfo.retryDelay`) and weaves the quotaId into the error message (lands in the span `error` field, so RPM vs RPD trips are distinguishable). A `/PerDay/` quotaId marks the error `nonTransient` — honored FIRST by the generic `isTransient` in `pacing.ts` (no Gemini knowledge leaks in) — and latches the judge: the first trip AND every subsequent `judge()` call throw `GeminiDailyQuotaError` with zero further network. Minute-cap retries sleep `max(retryDelayMs, jittered)`.
- `GEMINI_PACE_MS` drops to a 12 s default (≤5 RPM, the measured free-tier cap; the old 6 s targeted a 10 RPM tier that no longer exists) and becomes env-overridable for the paid-tier path. All stale 10 RPM / 6 s references updated: gemini.ts comments, the eval-file comment, a dated correction note in the design spec, and the runbook (measured 5 RPM / 20 RPD, paid-tier path, `GEMINI_PACE_MS` env row, fail-fast abort behavior).

Closes #1036

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — 245/245 green (no root `typecheck` script; `npm run build -w @bird-watch/photo-curation` (`tsc`) is the typecheck equivalent and is clean)
- [x] New unit tests added (TDD, fake clock + injected `fetchImpl`, no real network): RetryInfo hint honored (sleep ≥ 13 000 ms via fake clock); daily-cap latch (ONE fetch total, `GeminiDailyQuotaError` on first trip and on later calls with zero fetches); quotaId in error message for both RPM and RPD trips; unparseable 429 body preserves pre-#1036 jittered 4-attempt behavior; `GEMINI_PACE_MS` default 12 000 + env override; `isTransient` nonTransient-wins + `withBackoff` max(hint, jitter) in `pacing.test.ts`
- [ ] New Playwright e2e spec added — N/A, operator-run tool, no user-visible frontend behavior
- [x] `npm run build -w @bird-watch/photo-curation` — clean; `npx knip` — exit 0
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — implements bot-approved self-contained issue #1036 (plans live in issues per repo convention; part of the photo-judge Braintrust eval epic #1010 follow-ups).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)