### PR TITLE
fix(photo-curation): eval comparability — pin the rubric to the baseline's version, exclude det-gate rows, provenance + model/token knobs

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -17,7 +17,45 @@ the `bird-maps` project:
 Every per-judgment span nests **under the experiment trace** (not the project
 Logs stream), so the dataset rows and their spans are linked in the Braintrust
 UI. (See the run-row wiring in `src/eval/run-row.ts` and the tracing seam in
-`src/judges/traced.ts`.)
+`src/judges/traced.ts`.) Each span's `metrics` carry the judgment `latency`
+(seconds) **and the Gemini token counts** (`prompt_tokens`,
+`completion_tokens` — thinking tokens included — and `total_tokens`, from the
+response's `usageMetadata`), so per-row and aggregate cost are readable
+directly in the experiment dashboard.
+
+## Comparability: the rubric pin and the det-gate exclusion (#1037)
+
+**The rubric version is part of the dataset, not the live code.** Every
+baseline row in `review.sqlite` records the `rubric_version` it was scored
+under (`0.2.1` for the 902-score Opus pass). The eval **pins the judge prompt
+to that recorded version**: the dataset builder asserts that every fetched row
+carries one single, known version (a mixed or missing version is a **hard
+fail at dataset-build time** — re-score the baseline rather than judging under
+different criteria), and the eval selects the matching prompt from the
+version-keyed snapshots in `eval/rubric-prompts.ts`. Judging a v0.2.1 baseline
+with the live v0.2.2 prompt would turn the v0.2.2 criteria changes
+(same-species multiples OK, mild adult preference — commit 974d8c5) into
+phantom "disagreement". When the baseline is someday re-scored under v0.2.2+,
+the pin follows automatically (the live config's version maps to the live
+prompt).
+
+Provenance is logged on both sides so a future mismatch is visible instead of
+silent: every dataset row carries `metadata.expectedRubricVersion` (from the
+DB) and every judgment span's input carries `judgedRubricVersion` (what the
+judge actually ran) — equal by construction under the pin. The experiment
+metadata records the pinned `rubricVersion` and the judge `model`.
+
+**Deterministic-gate rows are excluded from the dataset.** 13 of the 902
+baseline rows are sharpness-heuristic verdicts
+(`rationale LIKE 'deterministic gate%'`, `keep = 0`, `quality_score = 0`) —
+gate output, not Opus findings — so the judge is never graded against them
+(they also dragged `score_mae` via the synthetic 0).
+
+> **Comparing to pre-pin experiments** (e.g. `HEAD-1781238943`): excluding the
+> 13 all-`keep=0` det-gate rows shifts the stratum balance (536 → 523
+> replace-side) and therefore the deterministic stratified sample. A pinned
+> re-run is **criteria-comparable but not row-identical** to those earlier
+> experiments — compare scorer means, not row-by-row.
 
 ## Prerequisites
 
@@ -50,7 +88,8 @@ from the photo-curation run-worktree**, not from CI:
 | `REVIEW_DB` | yes | path to `review.sqlite` (e.g. `./review.sqlite`) |
 | `THUMB_DIR` | yes | path to the thumbnail cache (e.g. `./thumb-cache`) |
 | `EVAL_SAMPLE` | no (default `150`) | stratified keep/replace sample size for a full run |
-| `GEMINI_PACE_MS` | no (default `12000`) | min ms between Gemini calls (12 s ⇒ ≤ 5 RPM, the measured free-tier cap); adjust only when a paid tier raises the per-minute quota |
+| `EVAL_MODEL` | no (default `gemini-2.5-flash`) | the judge model to construct; recorded in the experiment metadata and on every span. Same dataset + same pinned rubric + a different `EVAL_MODEL` = directly comparable experiments — "grade the models against the original findings" is a one-env-var operation |
+| `GEMINI_PACE_MS` | no (default `12000`) | min ms between Gemini calls (12 s ⇒ ≤ 5 RPM, the measured free-tier cap); adjust only when a paid tier raises the per-minute quota. An explicit `0` disables pacing; an unparseable value fails loud at startup |
 
 Put the non-secret values plus `GEMINI_API_KEY` in a local `.env.local`
 (gitignored). `bt eval --env-file .env.local` loads them into the eval process:
@@ -149,5 +188,9 @@ After the `--first 5` smoke, confirm in the Braintrust `bird-maps` project:
 3. Opening a row shows the per-judgment span **nested under the experiment**
    (not floating in the project Logs stream) with the species input, the Gemini
    output, and `metrics.latency` populated.
+4. The row's `metadata.expectedRubricVersion` equals the span input's
+   `judgedRubricVersion` (the #1037 pin holding), and the span's
+   `prompt_tokens` / `completion_tokens` / `total_tokens` metrics are
+   populated.
 
 Note the experiment URL in the PR as the manual smoke evidence.

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -7,12 +7,25 @@
 //
 //   data  — buildEvalRows(openDb(REVIEW_DB), {thumbDir, sample}) (#1013), the
 //           stratified Opus-current rows: each {input:{imagePath,species…},
-//           expected:{keep,qualityScore}}.
-//   task  — runRow({judge, readImage, prompt}, input) (this PR's run-row.ts).
+//           expected:{keep,qualityScore}, metadata:{…,expectedRubricVersion}}.
+//           Det-gate rows are excluded and the single-rubric-version invariant
+//           is asserted inside the builder (#1037).
+//   task  — runRow({judge, readImage, prompt}, input) (run-row.ts).
 //           Braintrust calls task(input, hooks): the FIRST positional arg IS the
 //           row's `input` value, so we write `task: (input) => …`, NOT
 //           `({input})` (which would read a nonexistent `.input` → undefined).
 //   scores— keepAgreement / scoreMAE / keepConfusion (#1014).
+//
+// COMPARABILITY (#1037): the judge prompt is PINNED to the baseline's recorded
+// rubric_version — the rubric version is part of the dataset, not the live
+// code. The dataset is built EAGERLY at module load so (a) a mixed/unknown
+// version fails before any Gemini call is even possible, and (b) the pinned
+// version is known in time to select the prompt and to stamp the experiment
+// metadata at Eval() registration. That build needs only REVIEW_DB/THUMB_DIR
+// (already import-time requirements) — local sqlite + readdir, no network and
+// no API keys, so `bt eval --list` still works keyless. EVAL_MODEL picks the
+// judge model (default gemini-2.5-flash): same dataset + same pinned rubric +
+// different model = directly comparable experiments.
 //
 // The judge is obtained through `resolveTracedJudge` — the ONLY public way to
 // build a judge (#1012); there is no un-traced scoring path. Because the wrapper
@@ -23,18 +36,22 @@
 //
 // This file lives OUTSIDE src/ (the tool's tsconfig is rootDir:src), so it is
 // not part of the tsc build and not a vitest target; `bt eval` runs it directly.
-// Its testable core — the row→judge mapping — is covered by src/eval/run-row.test.ts.
+// Its testable cores are covered next door: the row→judge mapping by
+// src/eval/run-row.test.ts, the dataset invariants by
+// src/eval/build-dataset.test.ts, and the prompt pin + model knob by
+// eval/rubric-prompts.test.ts.
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { readFileSync } from 'node:fs';
 import { Eval } from 'braintrust';
-import { defaultRubricConfig, type ImageInput, type VisionJudge } from '@bird-watch/photo-quality';
+import type { ImageInput, VisionJudge } from '@bird-watch/photo-quality';
 import { openDb } from '../src/db.js';
 import { buildEvalRows } from '../src/eval/build-dataset.js';
 import { resolveTracedJudge } from '../src/judges/index.js';
 import { keepAgreement, scoreMAE, keepConfusion } from '../src/eval/scorers.js';
 import { runRow } from '../src/eval/run-row.js';
 import { mimeFromUrl } from '../src/sources.js';
+import { judgePromptForRubricVersion, resolveEvalModel } from './rubric-prompts.js';
 
 /** Fail loud on a missing required env var — never run the eval half-configured. */
 function requireEnv(name: string): string {
@@ -48,6 +65,18 @@ function requireEnv(name: string): string {
 const REVIEW_DB = requireEnv('REVIEW_DB');
 const THUMB_DIR = requireEnv('THUMB_DIR');
 const EVAL_SAMPLE = Number(process.env.EVAL_SAMPLE ?? 150);
+const EVAL_MODEL = resolveEvalModel(process.env);
+
+// Eager build (#1037): hard-fails here on a mixed/unknown rubric_version or an
+// empty baseline — before any judge construction, prompt selection, or network.
+const rows = buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE });
+
+// Non-empty + single-version are guaranteed by the builder's assertions, so
+// row 0 carries THE baseline version. The prompt pin follows it: judging a
+// v0.2.1 baseline uses the frozen v0.2.1 prompt even when the live config has
+// moved on — and an unknown version throws rather than judging under drift.
+const PINNED_RUBRIC_VERSION = rows[0]!.metadata.expectedRubricVersion;
+const JUDGE_PROMPT = judgePromptForRubricVersion(PINNED_RUBRIC_VERSION);
 
 /** Read a cached thumbnail into an ImageInput; mime is derived from the path's extension. */
 function readImage(imagePath: string): ImageInput {
@@ -66,10 +95,14 @@ function readImage(imagePath: string): ImageInput {
 // dataset introspection must not throw before the keys are even needed.
 let _judge: VisionJudge | undefined;
 const getJudge = (): VisionJudge =>
-  (_judge ??= resolveTracedJudge(process.env, { project: 'bird-maps', model: 'gemini-2.5-flash' }));
+  (_judge ??= resolveTracedJudge(process.env, {
+    project: 'bird-maps',
+    model: EVAL_MODEL,
+    rubricVersion: PINNED_RUBRIC_VERSION,
+  }));
 
 Eval('bird-maps', {
-  data: () => buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE }),
+  data: () => rows,
   // Rows run SERIALLY (one at a time): the shared judge's single Pacer enforces
   // the GEMINI_PACE_MS gate globally only if rows don't race it. Braintrust's default
   // concurrency is unbounded, so we pin it to 1 — without this, concurrent rows
@@ -79,6 +112,9 @@ Eval('bird-maps', {
   // `input` value. `getJudge()` lazily builds the ONE shared judge (fails loud on
   // a missing GEMINI/BRAINTRUST key) and reuses it for every row.
   task: (input) =>
-    runRow({ judge: getJudge(), readImage, prompt: defaultRubricConfig.judgePrompt }, input),
+    runRow({ judge: getJudge(), readImage, prompt: JUDGE_PROMPT }, input),
   scores: [keepAgreement, scoreMAE, keepConfusion],
+  // Experiment provenance (#1037): which model judged, under which pinned
+  // criteria — so cross-model / cross-pin experiments are sliceable by name.
+  metadata: { model: EVAL_MODEL, rubricVersion: PINNED_RUBRIC_VERSION },
 });

--- a/tools/photo-curation/eval/rubric-prompts.test.ts
+++ b/tools/photo-curation/eval/rubric-prompts.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
+import {
+  judgePromptForRubricVersion,
+  DEFAULT_EVAL_MODEL,
+  resolveEvalModel,
+} from './rubric-prompts.js';
+
+// Markers that exist ONLY in the v0.2.2 prompt (commit 974d8c5): the
+// same-species-multiples STEP 3 clarification and the adult-plumage STEP 4
+// tiebreaker. The v0.2.1 snapshot must contain NEITHER — that criteria delta
+// is exactly the drift the pin exists to hold constant (#1037).
+const V022_MULTIPLES_MARKER = 'Several individuals of the SAME species';
+const V022_ADULT_MARKER = 'mildly prefer an ADULT';
+
+describe('judgePromptForRubricVersion', () => {
+  it('returns the v0.2.1 snapshot for version 0.2.1 (no v0.2.2 criteria)', () => {
+    const prompt = judgePromptForRubricVersion('0.2.1');
+    // The shared four-step field-mark framing is present…
+    expect(prompt).toContain('STEP 1 — Diagnostic field marks');
+    expect(prompt).toContain('keep (boolean');
+    // …but the v0.2.2 criteria changes are NOT.
+    expect(prompt).not.toContain(V022_MULTIPLES_MARKER);
+    expect(prompt).not.toContain(V022_ADULT_MARKER);
+    expect(prompt).not.toBe(defaultRubricConfig.judgePrompt);
+  });
+
+  it('maps the LIVE config version to the live prompt (pin follows a re-scored baseline)', () => {
+    expect(judgePromptForRubricVersion(defaultRubricConfig.version)).toBe(
+      defaultRubricConfig.judgePrompt,
+    );
+  });
+
+  it('throws on an unknown version, naming it', () => {
+    expect(() => judgePromptForRubricVersion('9.9.9')).toThrow(/9\.9\.9/);
+  });
+});
+
+describe('resolveEvalModel', () => {
+  it('defaults to gemini-2.5-flash when EVAL_MODEL is unset', () => {
+    expect(resolveEvalModel({})).toBe('gemini-2.5-flash');
+    expect(DEFAULT_EVAL_MODEL).toBe('gemini-2.5-flash');
+  });
+
+  it('respects an EVAL_MODEL override', () => {
+    expect(resolveEvalModel({ EVAL_MODEL: 'gemini-2.0-flash-lite' })).toBe('gemini-2.0-flash-lite');
+  });
+
+  it('treats an empty EVAL_MODEL as unset (fail-safe to the default)', () => {
+    expect(resolveEvalModel({ EVAL_MODEL: '' })).toBe('gemini-2.5-flash');
+  });
+});

--- a/tools/photo-curation/eval/rubric-prompts.ts
+++ b/tools/photo-curation/eval/rubric-prompts.ts
@@ -1,0 +1,103 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Version-keyed judge prompts + the EVAL_MODEL knob (#1037) — the two
+// comparability knobs the eval reads.
+//
+// Principle: the rubric version is part of the DATASET, not the live code. An
+// interchangeability eval grades the judge against a baseline scored under a
+// specific rubric version, so the judge must be prompted with THAT version's
+// text — judging a v0.2.1 baseline with the live v0.2.2 prompt turns rubric
+// drift (same-species multiples OK, mild adult preference; commit 974d8c5)
+// into phantom "disagreement". `judgePromptForRubricVersion` selects the
+// prompt by the version `buildEvalRows` asserted over the baseline; an
+// unknown version throws — never silently judge under different criteria.
+//
+// The map carries (a) the frozen v0.2.1 snapshot below (recovered verbatim
+// from git: `git show 974d8c5^:packages/photo-quality/src/rubric.config.ts`)
+// and (b) the LIVE config's version → live prompt, so when the baseline is
+// someday re-scored under v0.2.2+ the pin follows automatically with no edit
+// here. The snapshot text is FROZEN — a calibration tune bumps the live
+// version in @bird-watch/photo-quality; it must never retouch this history.
+//
+// This module lives next to the eval entry (outside src/) because it is
+// eval-only config: production scoring always uses the live
+// defaultRubricConfig, and nothing under src/ may depend on a frozen prompt.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { defaultRubricConfig } from '@bird-watch/photo-quality';
+
+/**
+ * The v0.2.1 judge prompt, verbatim as the 902-row Opus baseline was scored
+ * (every `review.sqlite` role='current' row is stamped rubric_version 0.2.1).
+ * Differs from v0.2.2 by exactly two criteria changes it predates: the STEP 3
+ * same-species-multiples clarification and the STEP 4 adult-plumage tiebreaker.
+ */
+const JUDGE_PROMPT_V0_2_1 = `You are the photo editor for a PREMIUM printed bird field guide, choosing the single best
+identification photograph for each species. You are judging ONE photograph of the species
+named in the request. Work in four steps and return everything as structured output.
+
+STEP 1 — Diagnostic field marks. From your ornithological knowledge of this species, name the
+3–6 field marks a birder uses to identify it and separate it from similar species — specific
+plumage patterns, bare-part colors, or structural features.
+
+STEP 2 — Criteria. Return an integer 0–10 for EACH:
+- framing: subject size/placement; 10 = bird well-sized and uncropped, 0 = a distant speck or clipped.
+- subjectClarity: focus on the bird, especially the EYE; 10 = tack-sharp, 0 = soft/motion-blurred.
+- liveness: alive and healthy; 10 = alert healthy bird, 0 = dead/sick/injured.
+- naturalness: wild bird in a natural setting; 10 = natural perch/habitat, 0 = in-hand/captive/feeder/studio/specimen.
+- pose: diagnostic view; 10 = clean profile or three-quarter showing field marks, 0 = tail-on/obscured/head hidden.
+- background: clean and non-distracting; 10 = subject cleanly separated, 0 = cluttered/camouflaging.
+- lighting: even natural light, true color; 10 = ideal, 0 = harsh flash/blown highlights/crushed shadows.
+
+STEP 3 — Disqualifier flags. Return any that clearly apply (exact strings):
+"dead","in-hand","specimen","sick","distant","multiple-subjects","watermark","captive","harsh-flash".
+
+STEP 4 — Decision. Judging THIS photo against the Step 1 diagnostic marks: how many are clearly
+visible and readable? A KEEPER must show a LIVE, WILD bird; be sharp (especially the eye); be
+large enough and unobstructed enough that its diagnostic marks can be read; sit in a natural
+setting (NOT in a human hand, banding grip, cage/aviary, feeder/seed-tray, studio backdrop, or
+museum specimen; not dead or sick); and render true color. A merely acceptable snapshot — or one
+where the diagnostic marks are hidden by pose, distance, or clutter — should be REPLACED, even if
+technically sharp. Be strict about wild provenance.
+
+Return: fieldMarks (array of the Step 1 marks), the seven criteria, flags, keep (boolean — keep as
+the species' guide photo, or replace), qualityScore (0–100), and a one-sentence rationale naming
+which diagnostic marks are visible or missing.`;
+
+/**
+ * Judge prompts keyed by rubric version. Frozen snapshots first; the live
+ * config's entry is spread last so a live version equal to a snapshot key
+ * (impossible today, but harmless) resolves to the identical live text.
+ */
+const RUBRIC_PROMPTS: Readonly<Record<string, string>> = {
+  '0.2.1': JUDGE_PROMPT_V0_2_1,
+  [defaultRubricConfig.version]: defaultRubricConfig.judgePrompt,
+};
+
+/**
+ * The judge prompt for `version`, or a hard throw when no prompt is known for
+ * it (#1037 decision 1) — a baseline whose criteria we cannot reproduce must
+ * never be silently judged under different ones.
+ */
+export function judgePromptForRubricVersion(version: string): string {
+  const prompt = RUBRIC_PROMPTS[version];
+  if (prompt === undefined) {
+    throw new Error(
+      `[rubric-prompts] no judge prompt is pinned for rubric_version '${version}' (known: ${Object.keys(RUBRIC_PROMPTS).join(', ')}) — snapshot that version's judgePrompt here before judging against its baseline`,
+    );
+  }
+  return prompt;
+}
+
+/** Default judge model — the gate decision (#1010) is about gemini-2.5-flash. */
+export const DEFAULT_EVAL_MODEL = 'gemini-2.5-flash';
+
+/**
+ * The judge model for this run: `EVAL_MODEL` when set and non-empty, else
+ * {@link DEFAULT_EVAL_MODEL}. Same dataset + same pinned rubric + a different
+ * `EVAL_MODEL` = directly comparable experiments — "grade the models on how
+ * close they come to the original findings" is a one-env-var operation. The
+ * model is recorded in the experiment metadata AND on every judgment span.
+ */
+export function resolveEvalModel(env: { EVAL_MODEL?: string }): string {
+  return env.EVAL_MODEL || DEFAULT_EVAL_MODEL;
+}

--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -18,7 +18,12 @@ afterEach(() => {
   rmSync(thumbDir, { recursive: true, force: true });
 });
 
-/** Insert one photo_current + one role='current' photo_score for a species. */
+/**
+ * Insert one photo_current + one role='current' photo_score for a species.
+ * `rubricVersion` defaults to the baseline's real provenance stamp ('0.2.1');
+ * `rationale` defaults to an Opus-style sentence — pass the det-gate prefix
+ * ('deterministic gate failed: …') to seed a heuristic (non-Opus) verdict.
+ */
 function seedCurrent(
   code: string,
   fields: {
@@ -29,6 +34,8 @@ function seedCurrent(
     keep: number | null;
     qualityScore: number | null;
     overall: number;
+    rationale?: string | null;
+    rubricVersion?: string | null;
   },
 ): void {
   db.prepare(
@@ -37,9 +44,18 @@ function seedCurrent(
   ).run(code, fields.comName, fields.sciName, fields.family, fields.contentHash);
   db.prepare(
     `INSERT INTO photo_score (species_code, role, content_hash, overall, verdict,
-                              criteria_json, flags_json, keep, quality_score, scored_at)
-     VALUES (?, 'current', ?, ?, 'good', '{}', '[]', ?, ?, 'now')`,
-  ).run(code, fields.contentHash, fields.overall, fields.keep, fields.qualityScore);
+                              criteria_json, flags_json, keep, quality_score, rationale,
+                              rubric_version, scored_at)
+     VALUES (?, 'current', ?, ?, 'good', '{}', '[]', ?, ?, ?, ?, 'now')`,
+  ).run(
+    code,
+    fields.contentHash,
+    fields.overall,
+    fields.keep,
+    fields.qualityScore,
+    fields.rationale === undefined ? 'sharp wild adult, diagnostic marks visible' : fields.rationale,
+    fields.rubricVersion === undefined ? '0.2.1' : fields.rubricVersion,
+  );
 }
 
 /** Write a zero-byte image file `<code>.<ext>` into thumbDir. */
@@ -91,7 +107,7 @@ describe('buildEvalRows', () => {
       family: 'Turdidae',
     });
     expect(robin.expected).toEqual({ keep: true, qualityScore: 88 });
-    expect(robin.metadata).toEqual({ contentHash: 'h-amerob' });
+    expect(robin.metadata).toEqual({ contentHash: 'h-amerob', expectedRubricVersion: '0.2.1' });
 
     // Image resolved by extension glob, not hardcoded .jpg.
     expect(basename(rows.find((r) => r.input.speciesCode === 'norcar')!.input.imagePath)).toBe('norcar.png');
@@ -187,5 +203,72 @@ describe('buildEvalRows', () => {
     seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
     writeImage('amerob');
     expect(buildEvalRows(db, { thumbDir })).toHaveLength(1);
+  });
+
+  // #1037 decision 2: det-gate rows are heuristic verdicts, not Opus findings —
+  // the judge must never be graded against them.
+  it('excludes deterministic-gate rows from the fetched set', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('detgat', {
+      comName: 'Det Gate', sciName: 'D g', family: 'Fam', contentHash: 'h-detgat',
+      keep: 0, qualityScore: 0, overall: 0,
+      rationale: 'deterministic gate failed: sharpness 0.00001 below floor 0.00005',
+    });
+    for (const c of ['amerob', 'norcar', 'detgat']) writeImage(c);
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows.map((r) => r.input.speciesCode).sort()).toEqual(['amerob', 'norcar']);
+  });
+
+  // The exclusion predicate must be NULL-safe: `rationale NOT LIKE …` alone is
+  // NULL for a NULL rationale, which would silently drop Opus rows without one.
+  it('keeps a row whose rationale is NULL (not a det-gate verdict)', () => {
+    seedCurrent('norale', { comName: 'No Rationale', sciName: 'N r', family: 'Fam', contentHash: 'h-norale', keep: 1, qualityScore: 70, overall: 70, rationale: null });
+    writeImage('norale');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['norale']);
+  });
+
+  // #1037 decision 1/3: every row carries the version the baseline was judged
+  // under, so the experiment can prove expected == judged criteria per row.
+  it('populates metadata.expectedRubricVersion from the DB rubric_version', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 0, qualityScore: 40, overall: 45 });
+    writeImage('amerob');
+    writeImage('norcar');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(row.metadata.expectedRubricVersion).toBe('0.2.1');
+  });
+
+  // #1037 decision 1: the invariant is asserted over the FULL fetched set
+  // BEFORE sampling — a mixed-version DB fails deterministically, regardless of
+  // whether the odd row would have landed in the sample.
+  it('throws on a mixed rubric_version baseline even when sampling', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35, rubricVersion: '0.2.2' });
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
+
+    expect(() => buildEvalRows(db, { thumbDir, sample: 2 })).toThrow(/mixed rubric_version/i);
+    // The message names both versions so the operator knows what to re-score.
+    expect(() => buildEvalRows(db, { thumbDir, sample: 2 })).toThrow(/0\.2\.1.*0\.2\.2|0\.2\.2.*0\.2\.1/s);
+  });
+
+  it('throws when any fetched row has no rubric_version (unknown provenance)', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+    seedCurrent('unkver', { comName: 'Unknown Version', sciName: 'U v', family: 'Fam', contentHash: 'h-unkver', keep: 0, qualityScore: 40, overall: 45, rubricVersion: null });
+    writeImage('amerob');
+    writeImage('unkver');
+
+    expect(() => buildEvalRows(db, { thumbDir })).toThrow(/rubric_version/);
+  });
+
+  it('throws on an empty baseline (no version to pin the judge prompt to)', () => {
+    expect(() => buildEvalRows(db, { thumbDir })).toThrow(/no role='current' scores/i);
   });
 });

--- a/tools/photo-curation/src/eval/build-dataset.ts
+++ b/tools/photo-curation/src/eval/build-dataset.ts
@@ -23,6 +23,14 @@ export interface EvalRow {
   };
   metadata: {
     contentHash: string;
+    /**
+     * The `rubric_version` the baseline row was judged under (#1037): the
+     * version whose criteria `expected` encodes. The eval pins the judge
+     * prompt to this version, and the judgment span logs the version it
+     * judged WITH (`judgedRubricVersion`) — equal by construction, logged on
+     * both sides so any future mismatch is visible in Braintrust, not silent.
+     */
+    expectedRubricVersion: string;
   };
 }
 
@@ -52,9 +60,46 @@ interface ScoreJoinRow {
   quality_score: number | null;
   overall: number;
   content_hash: string;
+  rubric_version: string | null;
   com_name: string;
   sci_name: string;
   family: string;
+}
+
+/**
+ * Assert the single-rubric-version invariant (#1037 decision 1) over the FULL
+ * fetched row set and return that version. Runs BEFORE image resolution and
+ * BEFORE sampling, so a mixed-version or unknown-provenance baseline fails
+ * deterministically — never depending on which rows a seed happens to sample.
+ * The rubric version is part of the DATASET, not the live code: an
+ * interchangeability eval must hold criteria constant at the version the
+ * baseline was judged under, so anything else is a hard fail, never a silent
+ * judge-under-different-criteria run.
+ */
+function assertSingleRubricVersion(joinRows: ScoreJoinRow[]): string {
+  if (joinRows.length === 0) {
+    throw new Error(
+      "[build-dataset] no role='current' scores found — there is no baseline rubric version to pin the judge prompt to (is REVIEW_DB the scored baseline?)",
+    );
+  }
+  const missing = joinRows.filter((r) => r.rubric_version === null || r.rubric_version === '');
+  if (missing.length > 0) {
+    throw new Error(
+      `[build-dataset] ${missing.length} of ${joinRows.length} fetched rows have no rubric_version — unknown provenance cannot be judged under pinned criteria (e.g. ${missing[0]!.species_code})`,
+    );
+  }
+  const counts = new Map<string, number>();
+  for (const r of joinRows) {
+    const v = r.rubric_version as string;
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  if (counts.size > 1) {
+    const breakdown = [...counts.entries()].map(([v, n]) => `${v} × ${n}`).join(', ');
+    throw new Error(
+      `[build-dataset] mixed rubric_versions in the fetched baseline (${breakdown}) — an interchangeability eval must hold criteria constant; re-score the baseline to one version`,
+    );
+  }
+  return counts.keys().next().value as string;
 }
 
 /**
@@ -111,6 +156,12 @@ function resolveImage(thumbDir: string, speciesCode: string): string | null {
 /**
  * Build stratified eval rows from the role='current' Opus scores in `db`.
  *
+ * Deterministic-gate rows are excluded at the query (#1037 decision 2), and
+ * the single-rubric-version invariant is asserted over the full fetched set
+ * before anything else (#1037 decision 1) — see
+ * {@link assertSingleRubricVersion}. Every surviving row carries
+ * `metadata.expectedRubricVersion` (the asserted version).
+ *
  * Reads every current score joined to its `photo_current` metadata, coalesces
  * `keep`/`qualityScore` exactly as the review store does (`store.ts`
  * getScoreByHash: missing `keep` ⇒ kept, missing `quality_score` ⇒ `overall`),
@@ -129,14 +180,22 @@ export function buildEvalRows(
 ): EvalRow[] {
   const { thumbDir, sample, seed = DEFAULT_SEED } = opts;
 
+  // Det-gate rows (`rationale LIKE 'deterministic gate%'`) are sharpness-
+  // heuristic verdicts with keep=0 / quality_score=0 — not Opus findings, so
+  // the judge must never be graded against them (#1037 decision 2). The
+  // predicate is NULL-safe: a bare `NOT LIKE` evaluates to NULL (row dropped)
+  // for a NULL rationale, which would silently exclude Opus rows without one.
   const joinRows = db
     .prepare(
       `SELECT s.species_code, s.keep, s.quality_score, s.overall, s.content_hash,
-              c.com_name, c.sci_name, c.family
+              s.rubric_version, c.com_name, c.sci_name, c.family
          FROM photo_score s JOIN photo_current c USING(species_code)
-        WHERE s.role = 'current'`,
+        WHERE s.role = 'current'
+          AND (s.rationale IS NULL OR s.rationale NOT LIKE 'deterministic gate%')`,
     )
     .all() as ScoreJoinRow[];
+
+  const rubricVersion = assertSingleRubricVersion(joinRows);
 
   const rows: EvalRow[] = [];
   for (const row of joinRows) {
@@ -159,7 +218,7 @@ export function buildEvalRows(
         keep: row.keep === null ? true : row.keep === 1,
         qualityScore: row.quality_score ?? row.overall,
       },
-      metadata: { contentHash: row.content_hash },
+      metadata: { contentHash: row.content_hash, expectedRubricVersion: rubricVersion },
     });
   }
 

--- a/tools/photo-curation/src/judges/gemini.test.ts
+++ b/tools/photo-curation/src/judges/gemini.test.ts
@@ -171,6 +171,40 @@ describe('GeminiVisionJudge', () => {
     expect(clock.sleeps).toContain(13_000);
   });
 
+  // #1038 review carry-along: Google can pack PerMinute + PerDay violations
+  // into ONE QuotaFailure.violations[]. A first-violation-wins read would see
+  // only PerMinute and never latch the drained daily cap — the scan must
+  // prefer a /PerDay/ violation wherever it sits in the array.
+  it('prefers the /PerDay/ violation when a 429 packs PerMinute first', async () => {
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      const body = {
+        error: {
+          code: 429, message: 'Resource has been exhausted', status: 'RESOURCE_EXHAUSTED',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.QuotaFailure',
+              violations: [
+                { quotaMetric: 'generativelanguage.googleapis.com/generate_content_free_tier_requests', quotaId: PER_MINUTE_QUOTA_ID, quotaValue: '5' },
+                { quotaMetric: 'generativelanguage.googleapis.com/generate_content_free_tier_requests', quotaId: PER_DAY_QUOTA_ID, quotaValue: '20' },
+              ],
+            },
+          ],
+        },
+      };
+      return new Response(JSON.stringify(body), { status: 429, headers: { 'content-type': 'application/json' } });
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    // The daily latch fires (named after the PerDay quotaId), after ONE fetch —
+    // not a PerMinute-shaped retry loop.
+    await expect(judge.judge(img, ctx, 'p')).rejects.toThrow(new RegExp(PER_DAY_QUOTA_ID));
+    expect(n).toBe(1);
+    await expect(judge.judge(img, ctx, 'p')).rejects.toBeInstanceOf(GeminiDailyQuotaError);
+    expect(n).toBe(1);
+  });
+
   it('latches on a daily-cap 429: GeminiDailyQuotaError on the FIRST trip, one fetch total', async () => {
     let n = 0;
     const fetchImpl = async () => {
@@ -238,6 +272,45 @@ describe('GeminiVisionJudge', () => {
       await judge.judge(img, ctx, 'p');
       await judge.judge(img, ctx, 'p');
       expect(clock.sleeps).toContain(30_000);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  // #1038 review carry-along: `Number(...) || 12_000` swallowed an explicit 0.
+  it('honors an explicit GEMINI_PACE_MS=0 (pacing off) via a presence check', async () => {
+    vi.stubEnv('GEMINI_PACE_MS', '0');
+    vi.resetModules();
+    try {
+      const mod = await import('./gemini.js');
+      expect(mod.GEMINI_PACE_MS).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it('falls back to the default for an EMPTY GEMINI_PACE_MS (Number("") is 0, not intent)', async () => {
+    vi.stubEnv('GEMINI_PACE_MS', '');
+    vi.resetModules();
+    try {
+      const mod = await import('./gemini.js');
+      expect(mod.GEMINI_PACE_MS).toBe(12_000);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it('fails loud on an unparseable GEMINI_PACE_MS instead of silently un-pacing', async () => {
+    // The pre-#1037 `|| 12_000` masked NaN by falling back; a bare presence
+    // check would instead feed NaN to the Pacer and disable pacing silently —
+    // so an invalid value must throw at import, not burst the API.
+    vi.stubEnv('GEMINI_PACE_MS', 'fast');
+    vi.resetModules();
+    try {
+      await expect(import('./gemini.js')).rejects.toThrow(/GEMINI_PACE_MS/);
     } finally {
       vi.unstubAllEnvs();
       vi.resetModules();

--- a/tools/photo-curation/src/judges/gemini.test.ts
+++ b/tools/photo-curation/src/judges/gemini.test.ts
@@ -22,9 +22,10 @@ const VALID_OUTPUT: JudgeOutput = {
 };
 
 /** Build a Response-like object whose JSON body wraps `text` in the Gemini envelope. */
-function geminiOk(text: string): Response {
+function geminiOk(text: string, usageMetadata?: object): Response {
   const body = {
     candidates: [{ content: { parts: [{ text }] } }],
+    ...(usageMetadata === undefined ? {} : { usageMetadata }),
   };
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
 }
@@ -241,6 +242,38 @@ describe('GeminiVisionJudge', () => {
       vi.unstubAllEnvs();
       vi.resetModules();
     }
+  });
+
+  // #1037 decision 5: token usage is captured INTERNALLY (JudgeOutput is
+  // unchanged and @bird-watch/photo-quality stays SDK-free); the tracing seam
+  // reads it via this accessor after each judgment.
+  it('captures the response usageMetadata, readable via lastUsage()', async () => {
+    const usage = { promptTokenCount: 1234, candidatesTokenCount: 56, thoughtsTokenCount: 10, totalTokenCount: 1300 };
+    const fetchImpl = async () => geminiOk(JSON.stringify(VALID_OUTPUT), usage);
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    expect(judge.lastUsage()).toBeUndefined(); // nothing judged yet
+    await judge.judge(img, ctx, 'p');
+    expect(judge.lastUsage()).toEqual(usage);
+  });
+
+  it('lastUsage() reflects the LATEST response and clears when usageMetadata is absent', async () => {
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      return n === 1
+        ? geminiOk(JSON.stringify(VALID_OUTPUT), { promptTokenCount: 100, candidatesTokenCount: 20, totalTokenCount: 120 })
+        : geminiOk(JSON.stringify(VALID_OUTPUT)); // no usageMetadata
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    await judge.judge(img, ctx, 'p');
+    expect(judge.lastUsage()).toEqual({ promptTokenCount: 100, candidatesTokenCount: 20, totalTokenCount: 120 });
+
+    // A second judgment without usageMetadata must not leak the first row's
+    // numbers onto the second row's span.
+    await judge.judge(img, ctx, 'p');
+    expect(judge.lastUsage()).toBeUndefined();
   });
 
   it('re-asks once on a non-JSON body then throws GeminiJudgeError', async () => {

--- a/tools/photo-curation/src/judges/gemini.ts
+++ b/tools/photo-curation/src/judges/gemini.ts
@@ -36,13 +36,33 @@ import { CRITERIA_KEYS } from '@bird-watch/photo-quality';
 import { Pacer, withBackoff, realClock, type Clock } from '../pacing.js';
 
 /**
+ * Resolve the pacing env knob. A presence check — NOT `Number(...) || default`
+ * — so an explicit `GEMINI_PACE_MS=0` (pacing off, e.g. a paid tier with its
+ * own quota ceiling) is honored rather than silently swallowed (#1038 review).
+ * An EMPTY value falls back to the default (`Number('')` is 0, which is not
+ * intent), and an unparseable or negative value throws at import: the old
+ * `|| 12_000` masked NaN by falling back, and a bare presence check would
+ * instead feed NaN to the Pacer and disable pacing silently — bursting the
+ * API is worse than failing loud.
+ */
+function resolvePaceMs(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return 12_000;
+  const ms = Number(raw);
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error(`GEMINI_PACE_MS must be a non-negative number of ms, got '${raw}'`);
+  }
+  return ms;
+}
+
+/**
  * Min ms between Gemini calls. Default 12_000 → ≤5 RPM, the free-tier
  * per-minute cap measured 2026-06-11 (#1036; the previous, faster default
  * targeted a since-halved tier). Env-overridable via `GEMINI_PACE_MS` — the same
  * no-rebuild tuning-knob pattern as the ingestor's `--pace-ms` — so a paid
- * tier with a self-imposed quota cap can loosen it without a code change.
+ * tier with a self-imposed quota cap can loosen it (down to an explicit `0` =
+ * no pacing) without a code change.
  */
-export const GEMINI_PACE_MS = Number(process.env.GEMINI_PACE_MS) || 12_000;
+export const GEMINI_PACE_MS = resolvePaceMs(process.env.GEMINI_PACE_MS);
 
 /** Thrown when the model's reply cannot be parsed into a JudgeOutput, even after one re-ask. */
 export class GeminiJudgeError extends Error {
@@ -118,6 +138,12 @@ function parseRetryDelayMs(retryDelay: string): number | undefined {
  * `error.details[]` with `QuotaFailure.violations[].quotaId` and
  * `RetryInfo.retryDelay`. A non-JSON or differently-shaped body yields `{}`,
  * preserving the plain-transient (jittered backoff) behavior.
+ *
+ * The quotaId scan covers EVERY violation across every QuotaFailure detail and
+ * prefers a `/PerDay/` one (#1038 review): Google can pack PerMinute + PerDay
+ * into one `violations[]` with PerMinute first, and a first-violation-wins
+ * read would never latch the drained daily cap — the run would retry a quota
+ * that resets at midnight, not in seconds.
  */
 async function readQuotaSignals(res: Response): Promise<QuotaSignals> {
   let body: unknown;
@@ -129,16 +155,14 @@ async function readQuotaSignals(res: Response): Promise<QuotaSignals> {
   const details = (body as { error?: { details?: unknown } } | null)?.error?.details;
   if (!Array.isArray(details)) return {};
   const signals: QuotaSignals = {};
+  const quotaIds: string[] = [];
   for (const detail of details) {
     if (typeof detail !== 'object' || detail === null) continue;
     const d = detail as { violations?: unknown; retryDelay?: unknown };
-    if (signals.quotaId === undefined && Array.isArray(d.violations)) {
+    if (Array.isArray(d.violations)) {
       for (const violation of d.violations) {
         const quotaId = (violation as { quotaId?: unknown } | null)?.quotaId;
-        if (typeof quotaId === 'string') {
-          signals.quotaId = quotaId;
-          break;
-        }
+        if (typeof quotaId === 'string') quotaIds.push(quotaId);
       }
     }
     if (typeof d.retryDelay === 'string') {
@@ -146,6 +170,8 @@ async function readQuotaSignals(res: Response): Promise<QuotaSignals> {
       if (ms !== undefined) signals.retryDelayMs = ms;
     }
   }
+  const preferred = quotaIds.find((id) => /PerDay/.test(id)) ?? quotaIds[0];
+  if (preferred !== undefined) signals.quotaId = preferred;
   return signals;
 }
 

--- a/tools/photo-curation/src/judges/gemini.ts
+++ b/tools/photo-curation/src/judges/gemini.ts
@@ -75,6 +75,32 @@ export class GeminiDailyQuotaError extends Error {
   }
 }
 
+/**
+ * Token usage from a v1beta response's `usageMetadata` (#1037). Captured
+ * internally so the tracing seam can log Braintrust token metrics WITHOUT
+ * touching the SDK-free `JudgeOutput` contract in @bird-watch/photo-quality.
+ * `thoughtsTokenCount` appears only when the model spent thinking tokens;
+ * `totalTokenCount` includes them when present.
+ */
+export interface GeminiUsage {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  thoughtsTokenCount?: number;
+  totalTokenCount?: number;
+}
+
+/** Read the optional `usageMetadata` numbers out of a 200 response envelope. */
+function extractUsage(json: unknown): GeminiUsage | undefined {
+  const raw = (json as { usageMetadata?: unknown } | null)?.usageMetadata;
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const u = raw as Record<string, unknown>;
+  const usage: GeminiUsage = {};
+  for (const key of ['promptTokenCount', 'candidatesTokenCount', 'thoughtsTokenCount', 'totalTokenCount'] as const) {
+    if (typeof u[key] === 'number') usage[key] = u[key];
+  }
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
 /** Quota signals parsed from a Google 429 body's `error.details[]` (#1036). */
 interface QuotaSignals {
   quotaId?: string;
@@ -274,6 +300,8 @@ export class GeminiVisionJudge implements VisionJudge {
   private readonly clock: Clock;
   /** quotaId of the tripped daily cap; once set, judge() fails fast forever (#1036). */
   private dailyExhaustedQuotaId: string | null = null;
+  /** usageMetadata of the LATEST 200 response — overwritten (or cleared) per response (#1037). */
+  private _lastUsage: GeminiUsage | undefined;
 
   constructor(opts: GeminiVisionJudgeOptions) {
     if (!opts.apiKey) {
@@ -304,7 +332,21 @@ export class GeminiVisionJudge implements VisionJudge {
       );
     }
     const json: unknown = await res.json();
+    // Overwrite (or clear) per response so a row's span never inherits a
+    // PREVIOUS row's token counts. On a parse re-ask the second response wins:
+    // lastUsage() is per-output, not a per-row cost accumulator.
+    this._lastUsage = extractUsage(json);
     return extractText(json);
+  }
+
+  /**
+   * Token usage of the latest 200 response, or `undefined` when none has been
+   * seen (or the latest carried no `usageMetadata`). The tracing seam reads
+   * this right after a judgment resolves to surface Braintrust token metrics
+   * (#1037 decision 5) — `JudgeOutput` itself stays unchanged.
+   */
+  lastUsage(): GeminiUsage | undefined {
+    return this._lastUsage;
   }
 
   /** One paced, backoff-wrapped ask → parsed JudgeOutput. */

--- a/tools/photo-curation/src/judges/traced.test.ts
+++ b/tools/photo-curation/src/judges/traced.test.ts
@@ -6,7 +6,7 @@ import {
   MissingGeminiKey,
   type BraintrustLoggerSeam,
 } from './traced.js';
-import { defaultRubricConfig } from '@bird-watch/photo-quality';
+import type { GeminiUsage } from './gemini.js';
 import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
 
 const img: ImageInput = {
@@ -78,7 +78,7 @@ function makeRecordingLogger(clock?: () => number): RecordingLogger {
 describe('tracedJudge', () => {
   it('returns the inner output and records one span with input/output/metadata', async () => {
     const logger = makeRecordingLogger();
-    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', logger });
+    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger });
 
     const out = await judge.judge(img, ctx, PROMPT);
 
@@ -98,9 +98,12 @@ describe('tracedJudge', () => {
       model: 'gemini-2.5-flash',
       sourceUrl: 'https://example.test/amerob.jpg',
     });
-    // rubricVersion is the STABLE config version, NOT the full prompt body (#1015).
-    expect(inputLog!.input.rubricVersion).toBe(defaultRubricConfig.version);
-    expect(inputLog!.input.rubricVersion).not.toBe(PROMPT);
+    // judgedRubricVersion is the version the judge was INVOKED with (#1037: a
+    // stable tag from the caller, not defaultRubricConfig and not the prompt
+    // body) — alongside the dataset row's expectedRubricVersion it makes any
+    // future pin mismatch visible in Braintrust instead of silent.
+    expect(inputLog!.input.judgedRubricVersion).toBe('0.2.1');
+    expect(inputLog!.input.judgedRubricVersion).not.toBe(PROMPT);
 
     // output span-log: the full JudgeOutput.
     const outputLog = span.logs.find((l) => 'output' in l) as { output: JudgeOutput } | undefined;
@@ -120,7 +123,7 @@ describe('tracedJudge', () => {
 
   it('propagates an inner error and still closes the span', async () => {
     const logger = makeRecordingLogger();
-    const judge = tracedJudge(new ThrowingJudge(), { project: 'bird-maps', model: 'opus', logger });
+    const judge = tracedJudge(new ThrowingJudge(), { project: 'bird-maps', model: 'opus', rubricVersion: '0.2.1', logger });
 
     await expect(judge.judge(img, ctx, PROMPT)).rejects.toThrow('inner boom');
     expect(logger.spans).toHaveLength(1);
@@ -132,7 +135,7 @@ describe('tracedJudge', () => {
     let i = 0;
     const clock = () => ticks[Math.min(i++, ticks.length - 1)]!;
     const logger = makeRecordingLogger(clock);
-    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', logger });
+    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger });
 
     await judge.judge(img, ctx, PROMPT);
 
@@ -141,25 +144,85 @@ describe('tracedJudge', () => {
       | undefined;
     expect(metaLog!.metadata.latencyMs).toBe(250);
   });
+
+  // #1037 decision 5: the usage accessor feeds Braintrust's STANDARD token
+  // metric names. completion_tokens includes thinking tokens (they are output
+  // we pay for); total_tokens prefers the response's own totalTokenCount.
+  it('logs prompt/completion/total token metrics from the usage accessor', async () => {
+    const usage: GeminiUsage = { promptTokenCount: 1234, candidatesTokenCount: 56, thoughtsTokenCount: 10, totalTokenCount: 1300 };
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new FakeJudge(), {
+      project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger,
+      usage: () => usage,
+    });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    const metaLog = logger.spans[0]!.logs.find((l) => 'metrics' in l) as
+      | { metrics: Record<string, number> }
+      | undefined;
+    expect(metaLog!.metrics).toMatchObject({
+      prompt_tokens: 1234,
+      completion_tokens: 66, // candidates 56 + thoughts 10
+      total_tokens: 1300,
+    });
+    expect(typeof metaLog!.metrics.latency).toBe('number'); // latency still present
+  });
+
+  it('falls back to prompt+completion for total_tokens when totalTokenCount is absent', async () => {
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new FakeJudge(), {
+      project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger,
+      usage: () => ({ promptTokenCount: 100, candidatesTokenCount: 20 }),
+    });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    const metaLog = logger.spans[0]!.logs.find((l) => 'metrics' in l) as
+      | { metrics: Record<string, number> }
+      | undefined;
+    expect(metaLog!.metrics).toMatchObject({ prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 });
+  });
+
+  it('omits token metrics (keeping latency) when no usage is available', async () => {
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new FakeJudge(), {
+      project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger,
+      usage: () => undefined,
+    });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    const metaLog = logger.spans[0]!.logs.find((l) => 'metrics' in l) as
+      | { metrics: Record<string, number> }
+      | undefined;
+    expect(typeof metaLog!.metrics.latency).toBe('number');
+    expect(metaLog!.metrics).not.toHaveProperty('prompt_tokens');
+    expect(metaLog!.metrics).not.toHaveProperty('completion_tokens');
+    expect(metaLog!.metrics).not.toHaveProperty('total_tokens');
+  });
 });
 
 describe('resolveTracedJudge', () => {
   it('throws MissingGeminiKey when GEMINI_API_KEY is absent', () => {
-    expect(() => resolveTracedJudge({}, { project: 'bird-maps', model: 'gemini-2.5-flash' })).toThrow(
-      MissingGeminiKey,
-    );
+    expect(() =>
+      resolveTracedJudge({}, { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1' }),
+    ).toThrow(MissingGeminiKey);
   });
 
   it('throws MissingBraintrustKey when only GEMINI_API_KEY is present', () => {
     expect(() =>
-      resolveTracedJudge({ GEMINI_API_KEY: 'g' }, { project: 'bird-maps', model: 'gemini-2.5-flash' }),
+      resolveTracedJudge(
+        { GEMINI_API_KEY: 'g' },
+        { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1' },
+      ),
     ).toThrow(MissingBraintrustKey);
   });
 
   it('returns a traced VisionJudge when both keys are present', () => {
     const judge = resolveTracedJudge(
       { GEMINI_API_KEY: 'g', BRAINTRUST_API_KEY: 'b' },
-      { project: 'bird-maps', model: 'gemini-2.5-flash' },
+      { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1' },
     );
     expect(typeof judge.judge).toBe('function');
   });

--- a/tools/photo-curation/src/judges/traced.ts
+++ b/tools/photo-curation/src/judges/traced.ts
@@ -32,9 +32,8 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { initLogger, traced } from 'braintrust';
-import { defaultRubricConfig } from '@bird-watch/photo-quality';
 import type { ImageInput, JudgeOutput, SpeciesContext, VisionJudge } from '@bird-watch/photo-quality';
-import { GeminiVisionJudge } from './gemini.js';
+import { GeminiVisionJudge, type GeminiUsage } from './gemini.js';
 
 /** Thrown at construction when `BRAINTRUST_API_KEY` is absent — never score blind. */
 export class MissingBraintrustKey extends Error {
@@ -75,26 +74,67 @@ export interface TracedJudgeOptions {
   project: string;
   /** The judge model name recorded on each span (e.g. `gemini-2.5-flash`). */
   model: string;
+  /**
+   * The rubric version the judge is INVOKED with — i.e. the version whose
+   * prompt text the caller hands to `judge()` (#1037). Logged on every span
+   * input as `judgedRubricVersion` so it can be compared against the dataset
+   * row's `expectedRubricVersion` in Braintrust: equal by construction under
+   * the eval's pin, and any future mismatch is visible/sliceable, not silent.
+   */
+  rubricVersion: string;
   /** The span boundary — injectable so tests need no network or key. */
   logger: BraintrustLoggerSeam;
+  /**
+   * Optional accessor for the inner judge's latest-call token usage (#1037
+   * decision 5). Read AFTER each judgment resolves; keeps the usage hand-off
+   * internal to this package so `JudgeOutput` stays SDK-free and unchanged.
+   */
+  usage?: () => GeminiUsage | undefined;
+}
+
+/**
+ * Map a `GeminiUsage` onto Braintrust's STANDARD token metric names.
+ * `completion_tokens` includes thinking tokens (output we pay for, mirroring
+ * the OpenAI-style convention); `total_tokens` prefers the response's own
+ * `totalTokenCount` and falls back to prompt+completion. Each metric is
+ * emitted only when computable — never a fabricated 0.
+ */
+function tokenMetrics(usage: GeminiUsage | undefined): Record<string, number> {
+  if (usage === undefined) return {};
+  const metrics: Record<string, number> = {};
+  const { promptTokenCount, candidatesTokenCount, thoughtsTokenCount, totalTokenCount } = usage;
+  if (promptTokenCount !== undefined) metrics.prompt_tokens = promptTokenCount;
+  if (candidatesTokenCount !== undefined) {
+    metrics.completion_tokens = candidatesTokenCount + (thoughtsTokenCount ?? 0);
+  }
+  if (totalTokenCount !== undefined) {
+    metrics.total_tokens = totalTokenCount;
+  } else if (metrics.prompt_tokens !== undefined && metrics.completion_tokens !== undefined) {
+    metrics.total_tokens = metrics.prompt_tokens + metrics.completion_tokens;
+  }
+  return metrics;
 }
 
 /**
  * Decorate any `VisionJudge` with a Braintrust span. Each `judge()` runs the
- * inner judge inside `logger.traced`, logging `input` (species framing + a
- * STABLE rubric version + model + source URL), `output` (the full
+ * inner judge inside `logger.traced`, logging `input` (species framing + the
+ * judged rubric version + model + source URL), `output` (the full
  * `JudgeOutput`), `metadata` (`latencyMs`, `model`), and `metrics`
  * (`latency` in seconds — Braintrust's aggregated latency field, so the
- * experiment dashboard rolls up p50/p95 across judgments). The span closes on
- * success AND on error (the inner error propagates unchanged).
+ * experiment dashboard rolls up p50/p95 across judgments — plus the
+ * `prompt_tokens`/`completion_tokens`/`total_tokens` from `opts.usage` when
+ * available). The span closes on success AND on error (the inner error
+ * propagates unchanged).
  *
- * `rubricVersion` logs `defaultRubricConfig.version` (a stable tag like
- * `0.2.2`), NOT the full prompt body (#1015 review): the prompt text is large
- * and noisy on every span; the version is the durable knob that changes only on
- * a calibration tune, which is what we actually want to compare experiments by.
+ * `judgedRubricVersion` logs `opts.rubricVersion` (a stable tag like `0.2.1`),
+ * NOT the full prompt body (#1015 review): the prompt text is large and noisy
+ * on every span; the version is the durable knob that changes only on a
+ * calibration tune, which is what we actually want to compare experiments by.
+ * It comes from the CALLER — not `defaultRubricConfig` — because under the
+ * #1037 pin the judge may run a snapshot prompt older than the live config.
  */
 export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): VisionJudge {
-  const { project, model, logger } = opts;
+  const { project, model, rubricVersion, logger, usage } = opts;
   const now = logger.nowMs ?? Date.now;
   return {
     async judge(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
@@ -105,7 +145,7 @@ export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): Visio
             comName: ctx.comName,
             sciName: ctx.sciName,
             family: ctx.family,
-            rubricVersion: defaultRubricConfig.version,
+            judgedRubricVersion: rubricVersion,
             model,
             sourceUrl: img.sourceUrl,
             project,
@@ -118,7 +158,7 @@ export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): Visio
           output,
           metadata: { latencyMs, model },
           // Braintrust's aggregated `metrics.latency` is in SECONDS — divide ms.
-          metrics: { latency: latencyMs / 1000 },
+          metrics: { latency: latencyMs / 1000, ...tokenMetrics(usage?.()) },
         });
         return output;
       });
@@ -137,6 +177,12 @@ export interface ResolveTracedJudgeOptions {
   project: string;
   /** The Gemini model to construct (e.g. `gemini-2.5-flash`). */
   model: string;
+  /**
+   * The rubric version of the prompt this judge will be invoked with (#1037)
+   * — logged as `judgedRubricVersion` on every span. REQUIRED so the caller
+   * cannot construct a judge without declaring which criteria it judges under.
+   */
+  rubricVersion: string;
 }
 
 /**
@@ -164,5 +210,13 @@ export function resolveTracedJudge(env: JudgeEnv, opts: ResolveTracedJudgeOption
     traced: (fn) => traced(fn),
   };
   const inner = new GeminiVisionJudge({ apiKey: env.GEMINI_API_KEY, model: opts.model });
-  return tracedJudge(inner, { project: opts.project, model: opts.model, logger });
+  return tracedJudge(inner, {
+    project: opts.project,
+    model: opts.model,
+    rubricVersion: opts.rubricVersion,
+    logger,
+    // Internal usage hand-off (#1037 decision 5): the wrapper reads the inner
+    // judge's latest usageMetadata after each judgment and logs token metrics.
+    usage: () => inner.lastUsage(),
+  });
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    DB[("review.sqlite<br/>photo_score role='current'")] -->|"query excludes rationale LIKE 'deterministic gate%' (13 of 902)"| FETCH["buildEvalRows — full fetched set"]
    FETCH --> ASSERT{"single rubric_version<br/>over the FULL set?"}
    ASSERT -->|"mixed / missing / empty"| FAIL["HARD FAIL at dataset-build time<br/>(never judge under drifted criteria)"]
    ASSERT -->|"'0.2.1' × N"| SAMPLE["stratified sample<br/>each row: metadata.expectedRubricVersion"]
    SAMPLE --> PIN["judgePromptForRubricVersion('0.2.1')<br/>frozen v0.2.1 snapshot in eval/rubric-prompts.ts<br/>(live version maps to live prompt; unknown throws)"]
    PIN --> JUDGE["resolveTracedJudge(env, { project, model: EVAL_MODEL, rubricVersion })"]
    JUDGE --> SPAN["judgment span<br/>input.judgedRubricVersion == expectedRubricVersion<br/>metrics: latency + prompt/completion/total tokens"]
    SPAN --> EXP["experiment metadata: { model, rubricVersion }"]
```

```mermaid
sequenceDiagram
    participant T as tracedJudge (traced.ts)
    participant G as GeminiVisionJudge (gemini.ts)
    participant API as Gemini v1beta

    T->>G: judge(img, ctx, pinned prompt)
    G->>API: POST generateContent
    API-->>G: 200 { candidates, usageMetadata }
    Note over G: _lastUsage = usageMetadata<br/>(overwritten per response)
    G-->>T: JudgeOutput — contract UNCHANGED, photo-quality stays SDK-free
    T->>T: usage() accessor reads lastUsage()
    T->>T: span.log({ metrics: latency, prompt_tokens,<br/>completion_tokens (incl. thinking), total_tokens })
```

## Summary

- The first FINAL eval run (`HEAD-1781238943`, keep_agreement 76.67% vs the ≥90% gate) measured with two confounds: the judge ran the **live v0.2.2 prompt against a v0.2.1-scored baseline** (974d8c5 changed real criteria — same-species multiples, adult preference), and **13 deterministic-gate rows** (heuristic verdicts, keep=0/score=0, no LLM) landed in the proxy ground truth. This PR pins the judge prompt to the baseline's recorded `rubric_version` (single-version invariant asserted over the full fetched set BEFORE sampling; mixed/unknown = hard fail) and excludes det-gate rows at the query (NULL-safe predicate).
- Provenance + comparability knobs: dataset rows carry `expectedRubricVersion`, judgment spans log `judgedRubricVersion` (equal by construction — a future mismatch is visible in Braintrust, not silent), `EVAL_MODEL` (default `gemini-2.5-flash`) makes cross-model runs a one-env-var operation, and spans gain Braintrust-standard token metrics from Gemini `usageMetadata` — threaded internally via a `lastUsage()` accessor so `JudgeOutput` stays unchanged and `@bird-watch/photo-quality` stays SDK-free.
- Carry-along hardening from PR #1038's review: `readQuotaSignals` now prefers a `/PerDay/` violation when a 429 packs PerMinute+PerDay into one `violations[]` (the daily latch fires regardless of order), and `GEMINI_PACE_MS` uses a presence check (explicit `0` honored; empty falls back; unparseable fails loud instead of silently un-pacing).
- Runbook documents the pin, the det-gate exclusion (strata shift 536→523 replace-side: pinned re-runs are **criteria-comparable but not row-identical** to pre-pin experiments — compare scorer means, not rows), the `EVAL_MODEL` env row, and the token-metrics smoke checks.

Closes #1037

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — 266 tests green (21 files; +13 new: builder det-gate/invariant/provenance, prompt-pin + EVAL_MODEL, usage capture, span token metrics + judgedRubricVersion, two-violation 429, pace-ms presence semantics)
- [x] New unit / integration tests added (TDD: failing test confirmed before each implementation; existing seams — fixture DB, recording-fake logger, injected fetchImpl/clock; no real network)
- [ ] New Playwright e2e spec added — N/A, no user-visible frontend behavior
- [x] `npm run build -w @bird-watch/photo-curation` (tsc) — clean; eval-tree files (outside rootDir) typecheck clean under the repo's strict flags; `npx knip` exit 0
- [x] v0.2.1 prompt snapshot verified **byte-identical** to `git show 974d8c5^:packages/photo-quality/src/rubric.config.ts`
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — implements issue #1037 (bot-approved spec), filed from the first FINAL eval run of epic #1010; the pinned re-run itself is an operator action, not CI.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)