### PR TITLE
feat(photo-curation): eval diagnostics — per-axis criteria scoring, AUC/calibrated-threshold analysis script, portable R2-URL provenance

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -13,12 +13,25 @@ the `bird-maps` project:
 | `keep_agreement` | exact boolean match of `keep` (the #969 gate) | **the headline** — must be **≥ 90%** to adopt Gemini for bulk scoring |
 | `score_mae` | `1 − \|Δ qualityScore\| / 100`, clamped to `[0,1]` | how close Gemini's 0–100 estimate tracks Opus's (advisory) |
 | `keep_confusion` | splits disagreements into `falseKeep` / `falseReplace` | watch **`falseKeep`** — Gemini keeping a photo Opus would replace ships a bad photo (the dangerous direction); `falseReplace` is cheap (re-source) |
+| `criteria_mae_<axis>` (×7) | per-axis sub-score agreement: `1 − \|Δ axis\| / 10`, clamped `[0,1]`, one column for each of `framing`, `subjectClarity`, `liveness`, `naturalness`, `pose`, `background`, `lighting` (#1067) | **diagnostic, not a gate** — a low column (e.g. `criteria_mae_naturalness`) means Gemini is *systematically* off on that axis, which is exactly what would route a hybrid design. A row missing a baseline axis null-skips that column only (dropped from the mean, never scored as 0) |
+
+The 7 `criteria_mae_<axis>` columns come from `expected.criteria` (the Opus
+`photo_score.criteria_json` carried onto each dataset row). A baseline row with
+no `criteria_json` simply skips those columns for that row — it never fabricates
+agreement. Deterministic-gate rows (zeroed criteria) are already excluded from
+the dataset, so their synthetic 0s can't reach these columns.
 
 Every per-judgment span nests **under the experiment trace** (not the project
 Logs stream), so the dataset rows and their spans are linked in the Braintrust
 UI. (See the run-row wiring in `src/eval/run-row.ts` and the tracing seam in
-`src/judges/traced.ts`.) Each span's `metrics` carry the judgment `latency`
-(seconds) **and the Gemini token counts** (`prompt_tokens`,
+`src/judges/traced.ts`.) **The span's `sourceUrl` is the production R2 URL**
+(`photo_current.url`, stored verbatim — `.jpg`/`.jpeg`/`.png` extensions vary,
+so it is logged as-is, never reconstructed from a `<code>.jpeg` template that
+would 404), so Braintrust renders the **live bird-maps.com thumbnail** and the
+experiment is portable across machines. The local cache path is used only to
+read the bytes; it is never logged as a URL. The exact image bytes are pinned
+by `content_hash` in span metadata. Each span's `metrics` carry the judgment
+`latency` (seconds) **and the Gemini token counts** (`prompt_tokens`,
 `completion_tokens` — thinking tokens included — and `total_tokens`, from the
 response's `usageMetadata`), so per-row and aggregate cost are readable
 directly in the experiment dashboard.
@@ -147,6 +160,38 @@ The package also exposes `npm run eval -w @bird-watch/photo-curation`
   `keep_agreement ≥ 90%` **and** `falseKeep` is low. Below the gate → hybrid
   (Gemini first pass, Opus re-judges the close calls) — see the design spec.
 
+## Dataset-level diagnostics: `analyze-experiment` (#1067)
+
+The boolean gate hides the *shape* of the disagreement. Braintrust scorers are
+strictly per-row, so the threshold-free and calibrated reads — which need every
+row at once — live in a committed, **read-only** analysis script instead of in
+the scorers. It reads a completed experiment back (no eval run, no Gemini calls,
+no judging):
+
+```sh
+# Braintrust auth resolves from the active `bt` profile (bt auth login).
+npm run analyze -w @bird-watch/photo-curation <experiment-name-or-id>
+
+# optional: tune the ambiguity / hybrid-routing band (default 40:70, Opus score)
+npm run analyze -w @bird-watch/photo-curation <experiment> -- --band 45:65
+```
+
+It prints:
+
+| Line | What it means | How to read it |
+|---|---|---|
+| `keep agreement` | the same boolean match rate as the `keep_agreement` scorer | sanity-check it equals the experiment's headline |
+| `falseKeep` / `falseReplace` | the confusion split, as raw counts | `falseKeep` is the dangerous direction |
+| `score MAE` | mean `\|Δ qualityScore\|` in points | lower = Gemini's 0–100 tracks Opus's |
+| **`AUC`** | Gemini `qualityScore` as a ranker of the Opus `keep` label (Mann–Whitney, ties = 0.5) | **threshold-free** separability. High AUC + low keep-agreement (the pinned run: AUC 0.904 vs. 78.67%) means the boolean *threshold* is miscalibrated, not that the model can't tell good from bad |
+| **`calibrated ceiling`** | the best boolean agreement any single recalibrated `qualityScore` threshold could reach, plus the winning `score >= t` | the ceiling for a Gemini-*only* gate. On the pinned run this was **84% at t=59** — still under the 90% gate, so even a perfectly-tuned threshold doesn't adopt solo Gemini |
+| `ambiguity band [lo, hi]` | how many disagreements sit inside that Opus-score band | a disagreement near Opus's own midpoint is a genuine close call |
+| **`hybrid routing preview`** | route Gemini scores in the mid-band to Opus → **% routed** (the Opus-call budget), **auto-set agreement** (keep-agreement after routing), **residual falseKeep** (dangerous keeps that fell outside the band and were never re-judged) | quantifies whether a Gemini-first / Opus-on-close-calls hybrid clears the gate, and at what Opus cost. This is the input to the hybrid-design decision — not the hybrid itself |
+
+The AUC / calibrated-ceiling / band / routing math are pure helpers, unit-tested
+on a hand-built fixture (`scripts/analyze-experiment.test.ts`); the Braintrust
+read is `bt sql` under the hood and is injected, so the tests need no network.
+
 ## Daily cap (20 RPD free tier) — abort + resume
 
 Gemini's free tier caps `gemini-2.5-flash` at **20 requests per day** (measured
@@ -184,13 +229,22 @@ After the `--first 5` smoke, confirm in the Braintrust `bird-maps` project:
 
 1. A new **experiment** (not just Logs) was created.
 2. `keep_agreement` is **non-null** (a real number, not blank) — proves the
-   scorers received both `output` and `expected`.
+   scorers received both `output` and `expected`. The 7 `criteria_mae_<axis>`
+   columns are present and non-null on rows whose baseline carried
+   `criteria_json` (#1067).
 3. Opening a row shows the per-judgment span **nested under the experiment**
    (not floating in the project Logs stream) with the species input, the Gemini
-   output, and `metrics.latency` populated.
+   output, and `metrics.latency` populated. The span's `sourceUrl` is the
+   **bird-maps.com R2 URL** and the thumbnail **renders** in Braintrust — not a
+   local filesystem path (#1067).
 4. The row's `metadata.expectedRubricVersion` equals the span input's
-   `judgedRubricVersion` (the #1037 pin holding), and the span's
-   `prompt_tokens` / `completion_tokens` / `total_tokens` metrics are
-   populated.
+   `judgedRubricVersion` (the #1037 pin holding), `metadata.contentHash` is
+   present (#1067), and the span's `prompt_tokens` / `completion_tokens` /
+   `total_tokens` metrics are populated.
+
+After a completed run, also exercise the dataset-level read:
+`npm run analyze -w @bird-watch/photo-curation <experiment>` prints the AUC,
+calibrated ceiling, and hybrid-routing preview (see the diagnostics section
+above).
 
 Note the experiment URL in the PR as the manual smoke evidence.

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -6,15 +6,18 @@
 // score-MAE, keep-confusion) as a `bird-maps` Braintrust EXPERIMENT.
 //
 //   data  — buildEvalRows(openDb(REVIEW_DB), {thumbDir, sample}) (#1013), the
-//           stratified Opus-current rows: each {input:{imagePath,species…},
-//           expected:{keep,qualityScore}, metadata:{…,expectedRubricVersion}}.
-//           Det-gate rows are excluded and the single-rubric-version invariant
-//           is asserted inside the builder (#1037).
+//           stratified Opus-current rows: each {input:{readPath,imageUrl,
+//           species…}, expected:{keep,qualityScore,criteria?},
+//           metadata:{contentHash,…,expectedRubricVersion}}. readPath is the
+//           LOCAL byte source; imageUrl is the portable R2 URL logged as the
+//           span sourceUrl (#1067). Det-gate rows are excluded and the
+//           single-rubric-version invariant is asserted inside the builder (#1037).
 //   task  — runRow({judge, readImage, prompt}, input) (run-row.ts).
 //           Braintrust calls task(input, hooks): the FIRST positional arg IS the
 //           row's `input` value, so we write `task: (input) => …`, NOT
 //           `({input})` (which would read a nonexistent `.input` → undefined).
-//   scores— keepAgreement / scoreMAE / keepConfusion (#1014).
+//   scores— keepAgreement / scoreMAE / keepConfusion (#1014) + criteriaAxisMAE
+//           (#1067; 7 per-axis `criteria_mae_<axis>` columns).
 //
 // COMPARABILITY (#1037): the judge prompt is PINNED to the baseline's recorded
 // rubric_version — the rubric version is part of the dataset, not the live
@@ -48,7 +51,7 @@ import type { ImageInput, VisionJudge } from '@bird-watch/photo-quality';
 import { openDb } from '../src/db.js';
 import { buildEvalRows } from '../src/eval/build-dataset.js';
 import { resolveTracedJudge } from '../src/judges/index.js';
-import { keepAgreement, scoreMAE, keepConfusion } from '../src/eval/scorers.js';
+import { keepAgreement, scoreMAE, keepConfusion, criteriaAxisMAE } from '../src/eval/scorers.js';
 import { runRow } from '../src/eval/run-row.js';
 import { mimeFromUrl } from '../src/sources.js';
 import { judgePromptForRubricVersion, resolveEvalModel } from './rubric-prompts.js';
@@ -78,9 +81,14 @@ const rows = buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVA
 const PINNED_RUBRIC_VERSION = rows[0]!.metadata.expectedRubricVersion;
 const JUDGE_PROMPT = judgePromptForRubricVersion(PINNED_RUBRIC_VERSION);
 
-/** Read a cached thumbnail into an ImageInput; mime is derived from the path's extension. */
-function readImage(imagePath: string): ImageInput {
-  return { buffer: readFileSync(imagePath), mime: mimeFromUrl(imagePath), sourceUrl: imagePath };
+/**
+ * Read a cached thumbnail into an ImageInput; mime is derived from the LOCAL
+ * path's extension. Deliberately does NOT set `sourceUrl` (#1067): `runRow`
+ * sets it to the row's portable R2 `imageUrl`, so the span logs the live
+ * bird-maps.com photo, not this non-portable local cache path.
+ */
+function readImage(readPath: string): ImageInput {
+  return { buffer: readFileSync(readPath), mime: mimeFromUrl(readPath) };
 }
 
 // ── Single shared judge (the pacing fix, #1015 review) ───────────────────────
@@ -113,7 +121,11 @@ Eval('bird-maps', {
   // a missing GEMINI/BRAINTRUST key) and reuses it for every row.
   task: (input) =>
     runRow({ judge: getJudge(), readImage, prompt: JUDGE_PROMPT }, input),
-  scores: [keepAgreement, scoreMAE, keepConfusion],
+  // The 3 headline scorers plus the per-axis criteria-MAE (#1067), which emits
+  // its own `criteria_mae_<axis>` column per CRITERIA_KEYS axis (null-skipping a
+  // missing axis). `contentHash` lands in span metadata automatically: each
+  // dataset row's `metadata` (built by buildEvalRows) is logged to its span.
+  scores: [keepAgreement, scoreMAE, keepConfusion, criteriaAxisMAE],
   // Experiment provenance (#1037): which model judged, under which pinned
   // criteria — so cross-model / cross-pin experiments are sliceable by name.
   metadata: { model: EVAL_MODEL, rubricVersion: PINNED_RUBRIC_VERSION },

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "test": "vitest run",
     "curate": "tsx src/cli.ts",
-    "eval": "bt eval eval/photo-judge.eval.ts"
+    "eval": "bt eval eval/photo-judge.eval.ts",
+    "analyze": "tsx scripts/analyze-experiment.ts"
   },
   "dependencies": {
     "@bird-watch/ingestor": "*",

--- a/tools/photo-curation/scripts/analyze-experiment.test.ts
+++ b/tools/photo-curation/scripts/analyze-experiment.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest';
+import {
+  keepAgreement,
+  confusionCounts,
+  scoreMAE,
+  auc,
+  calibratedThreshold,
+  ambiguityBand,
+  hybridRouting,
+  analyze,
+  formatReport,
+  projectRows,
+  main,
+  type AnalysisRow,
+} from './analyze-experiment.js';
+
+/**
+ * A hand-built fixture set with KNOWN answers. The pure dataset-level helpers
+ * (AUC, calibrated-threshold sweep, ambiguity band, hybrid routing) are
+ * verified against these by-hand calculations — no Braintrust read, no network.
+ *
+ * Convention per row: `[outputKeep, outputScore, expectedKeep, expectedScore]`.
+ * outputScore is the Gemini qualityScore (0–100, the ranking signal);
+ * expectedScore is the Opus qualityScore (the band axis).
+ */
+function row(outputKeep: boolean, outputScore: number, expectedKeep: boolean, expectedScore: number): AnalysisRow {
+  return { outputKeep, outputScore, expectedKeep, expectedScore };
+}
+
+describe('keepAgreement', () => {
+  it('is the fraction of rows where output.keep === expected.keep', () => {
+    const rows = [
+      row(true, 80, true, 85),   // agree
+      row(false, 20, false, 15), // agree
+      row(true, 60, false, 40),  // disagree (falseKeep)
+      row(false, 30, true, 70),  // disagree (falseReplace)
+    ];
+    expect(keepAgreement(rows)).toBeCloseTo(0.5);
+  });
+
+  it('is 1 for a perfectly-agreeing set and 0 for a fully-disagreeing set', () => {
+    expect(keepAgreement([row(true, 80, true, 80), row(false, 10, false, 10)])).toBe(1);
+    expect(keepAgreement([row(true, 80, false, 10), row(false, 10, true, 80)])).toBe(0);
+  });
+});
+
+describe('confusionCounts', () => {
+  it('counts falseKeep (output keeps, expected replaces) and falseReplace', () => {
+    const rows = [
+      row(true, 80, true, 85),
+      row(true, 60, false, 40),  // falseKeep
+      row(true, 55, false, 30),  // falseKeep
+      row(false, 30, true, 70),  // falseReplace
+    ];
+    expect(confusionCounts(rows)).toEqual({ falseKeep: 2, falseReplace: 1 });
+  });
+});
+
+describe('scoreMAE', () => {
+  it('is the mean absolute difference of the quality scores', () => {
+    const rows = [
+      row(true, 80, true, 70),  // |80-70| = 10
+      row(false, 20, false, 50), // |20-50| = 30
+    ];
+    // mean(10, 30) = 20
+    expect(scoreMAE(rows)).toBeCloseTo(20);
+  });
+});
+
+describe('auc', () => {
+  // AUC = P(a random keep-positive outranks a random keep-negative) by the
+  // output score. Use Opus `keep` as the positive label, Gemini score as rank.
+  it('is 1.0 when the output score perfectly separates the keep classes', () => {
+    const rows = [
+      row(true, 90, true, 0),   // positive (Opus keep), high score
+      row(true, 80, true, 0),   // positive, high score
+      row(false, 40, false, 0), // negative, low score
+      row(false, 30, false, 0), // negative, low score
+    ];
+    expect(auc(rows)).toBeCloseTo(1);
+  });
+
+  it('is 0.5 for ties between every positive/negative pair', () => {
+    const rows = [
+      row(true, 50, true, 0),
+      row(true, 50, true, 0),
+      row(false, 50, false, 0),
+      row(false, 50, false, 0),
+    ];
+    expect(auc(rows)).toBeCloseTo(0.5);
+  });
+
+  it('is 0.75 for a known mixed ordering', () => {
+    // positives scored {90, 50}, negatives scored {60, 40}.
+    // Pairs (pos,neg): (90,60)=1, (90,40)=1, (50,60)=0, (50,40)=1 → 3/4 = 0.75.
+    const rows = [
+      row(true, 90, true, 0),
+      row(true, 50, true, 0),
+      row(false, 60, false, 0),
+      row(false, 40, false, 0),
+    ];
+    expect(auc(rows)).toBeCloseTo(0.75);
+  });
+
+  it('returns null when a class is empty (AUC undefined)', () => {
+    expect(auc([row(true, 90, true, 0), row(true, 50, true, 0)])).toBeNull();
+  });
+});
+
+describe('calibratedThreshold', () => {
+  // Sweep a score threshold t: predict keep iff outputScore >= t, then measure
+  // boolean agreement against Opus keep. Report the best agreement + winning t.
+  it('finds the threshold maximizing boolean agreement against Opus keep', () => {
+    // Opus keeps the two high-Gemini-score rows, replaces the two low ones.
+    const rows = [
+      row(true, 90, true, 0),
+      row(true, 70, true, 0),
+      row(false, 40, false, 0),
+      row(false, 20, false, 0),
+    ];
+    const { bestAgreement, threshold } = calibratedThreshold(rows);
+    expect(bestAgreement).toBeCloseTo(1); // a clean split exists
+    // A threshold in (40, 70] perfectly separates; the sweep picks one such t.
+    expect(threshold).toBeGreaterThan(40);
+    expect(threshold).toBeLessThanOrEqual(70);
+  });
+
+  it('caps below 1 when no threshold can separate the classes', () => {
+    // Interleaved: keep at 30, replace at 80 — no monotone score split works.
+    const rows = [
+      row(true, 30, true, 0),
+      row(false, 80, false, 0),
+      row(true, 80, true, 0),
+      row(false, 30, false, 0),
+    ];
+    const { bestAgreement } = calibratedThreshold(rows);
+    expect(bestAgreement).toBeLessThan(1);
+    expect(bestAgreement).toBeGreaterThanOrEqual(0.5);
+  });
+});
+
+describe('ambiguityBand', () => {
+  // Count disagreements whose Opus (expected) score sits inside [lo, hi].
+  it('counts only DISAGREEMENTS whose expected score is inside the band', () => {
+    const rows = [
+      row(true, 60, false, 55),  // disagree, expected 55 IN [50,70]
+      row(false, 40, true, 65),  // disagree, expected 65 IN band
+      row(true, 90, false, 80),  // disagree, expected 80 OUT of band
+      row(true, 70, true, 60),   // AGREE, expected 60 in band — not counted
+    ];
+    const res = ambiguityBand(rows, 50, 70);
+    expect(res.inBandDisagreements).toBe(2);
+    expect(res.totalDisagreements).toBe(3);
+  });
+});
+
+describe('hybridRouting', () => {
+  // Route any row whose Gemini score lands in the mid-band [lo, hi] to Opus
+  // (auto-correct). Outside the band, keep Gemini's decision.
+  it('routes mid-band rows to Opus, leaving the rest on Gemini', () => {
+    const rows = [
+      row(true, 55, false, 30),  // in band → routed → auto-correct (was falseKeep)
+      row(false, 60, true, 70),  // in band → routed → auto-correct (was falseReplace)
+      row(true, 90, true, 85),   // out of band, Gemini agrees
+      row(true, 95, false, 20),  // out of band, Gemini WRONG (residual falseKeep)
+      row(false, 10, false, 15), // out of band, Gemini agrees
+    ];
+    const res = hybridRouting(rows, 50, 70);
+    expect(res.routed).toBe(2);
+    expect(res.routedFraction).toBeCloseTo(2 / 5);
+    // After routing: the 2 routed become correct; out-of-band keep Gemini's
+    // call. Agreement = (2 routed-correct + agrees) / total.
+    // out-of-band: row3 agree, row4 disagree, row5 agree → 2 correct of 3.
+    // total correct = 2 + 2 = 4 of 5.
+    expect(res.autoSetAgreement).toBeCloseTo(4 / 5);
+    // residual falseKeep: out-of-band rows where Gemini keeps but Opus replaces.
+    expect(res.residualFalseKeep).toBe(1); // row4 (score 95, Gemini keep, Opus replace)
+  });
+});
+
+describe('analyze + formatReport', () => {
+  const rows = [
+    row(true, 90, true, 85),
+    row(false, 20, false, 15),
+    row(true, 60, false, 40),  // falseKeep
+    row(false, 30, true, 70),  // falseReplace
+  ];
+
+  it('analyze aggregates every diagnostic from the injected rows', () => {
+    const a = analyze(rows, { bandLo: 40, bandHi: 70 });
+    expect(a.n).toBe(4);
+    expect(a.keepAgreement).toBeCloseTo(0.5);
+    expect(a.confusion).toEqual({ falseKeep: 1, falseReplace: 1 });
+    expect(typeof a.scoreMAE).toBe('number');
+    expect(a.auc).not.toBeNull();
+    expect(a.calibrated.bestAgreement).toBeGreaterThanOrEqual(a.keepAgreement);
+    expect(a.band.lo).toBe(40);
+    expect(a.band.hi).toBe(70);
+    expect(a.hybrid.routedFraction).toBeGreaterThanOrEqual(0);
+  });
+
+  it('formatReport renders every required metric label', () => {
+    const a = analyze(rows, { bandLo: 40, bandHi: 70 });
+    const text = formatReport('exp-name', a);
+    for (const label of [
+      'keep agreement',
+      'falseKeep',
+      'falseReplace',
+      'score MAE',
+      'AUC',
+      'calibrated',
+      'threshold',
+      'band',
+      'hybrid',
+      'routed',
+    ]) {
+      expect(text.toLowerCase()).toContain(label.toLowerCase());
+    }
+  });
+});
+
+describe('projectRows', () => {
+  it('keeps only rows with both keep flags and both numeric scores', () => {
+    const raw = [
+      { output: { keep: true, qualityScore: 80 }, expected: { keep: false, qualityScore: 40 } }, // ok
+      { output: { keep: true, qualityScore: 80 }, expected: null },                               // no expected (nested span)
+      { output: { keep: true }, expected: { keep: false, qualityScore: 40 } },                     // missing output score
+      { output: { keep: 'yes', qualityScore: 80 }, expected: { keep: false, qualityScore: 40 } },  // keep not boolean
+    ];
+    const rows = projectRows(raw);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ outputKeep: true, outputScore: 80, expectedKeep: false, expectedScore: 40 });
+  });
+});
+
+describe('main (injected reader, no network)', () => {
+  it('returns 2 and prints usage when no experiment is given', async () => {
+    const reader = async () => [];
+    const code = await main([], reader);
+    expect(code).toBe(2);
+  });
+
+  it('returns 1 when the experiment has no usable rows', async () => {
+    const reader = async () => [] as AnalysisRow[];
+    const code = await main(['exp-empty'], reader);
+    expect(code).toBe(1);
+  });
+
+  it('returns 0 and reads via the injected reader for a populated experiment', async () => {
+    let asked: string | undefined;
+    const reader = async (exp: string): Promise<AnalysisRow[]> => {
+      asked = exp;
+      return [row(true, 90, true, 85), row(false, 20, false, 15)];
+    };
+    const code = await main(['exp-real', '--band', '45:65'], reader);
+    expect(code).toBe(0);
+    expect(asked).toBe('exp-real');
+  });
+});

--- a/tools/photo-curation/scripts/analyze-experiment.ts
+++ b/tools/photo-curation/scripts/analyze-experiment.ts
@@ -1,0 +1,357 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Dataset-level diagnostics for a completed photo-judge experiment (#1067).
+//
+// Braintrust scorers are strictly PER-ROW, so the threshold-free read (AUC) and
+// the calibrated-threshold sweep — which need every row at once — cannot be
+// expressed as scorers without lying about the contract. This is a committed,
+// repeatable analysis SCRIPT instead: it reads a completed experiment back
+// (via `bt sql`, injected so tests need no network), then prints
+//
+//   - keep agreement                  (boolean keep match rate)
+//   - falseKeep / falseReplace counts  (the dangerous vs. cheap disagreements)
+//   - score MAE                        (mean |Δ qualityScore|)
+//   - AUC                              (Gemini qualityScore ranking Opus keep)
+//   - calibrated-threshold ceiling     (best boolean agreement over a score
+//                                        sweep + the winning threshold)
+//   - ambiguity-band breakdown         (disagreements inside an Opus-score band)
+//   - hybrid-routing preview           (route mid-band Gemini scores to Opus →
+//                                        % routed, auto-set agreement, residual
+//                                        falseKeep)
+//
+// It is READ-ONLY: no eval run, no Gemini calls, no judging. Run it after an
+// experiment completes:  npm run analyze -w @bird-watch/photo-curation <exp>.
+//
+// The math is PURE (the exported helpers below), unit-tested on a hand-built
+// fixture with known answers (analyze-experiment.test.ts). The Braintrust read
+// is injected via `ExperimentReader`, so the tests need no network and the CLI
+// glue is the only un-unit-tested surface (mirrors eval/photo-judge.eval.ts).
+//
+// Lives OUTSIDE src/ (the tsconfig rootDir) like the eval entry, so it is not a
+// tsc build target; `tsx` runs it directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * One experiment row reduced to the four values the diagnostics need:
+ *   - outputKeep   — the candidate (Gemini) keep decision.
+ *   - outputScore  — the candidate qualityScore (0–100): the RANKING signal for
+ *                    AUC, the sweep axis for the calibrated threshold, and the
+ *                    routing axis for the hybrid preview.
+ *   - expectedKeep — the Opus baseline keep (the proxy ground-truth label).
+ *   - expectedScore— the Opus qualityScore: the AMBIGUITY-BAND axis (a
+ *                    disagreement near Opus's own midpoint is a genuine close
+ *                    call worth routing).
+ */
+export interface AnalysisRow {
+  outputKeep: boolean;
+  outputScore: number;
+  expectedKeep: boolean;
+  expectedScore: number;
+}
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────────
+
+/** Fraction of rows where the candidate and baseline keep decisions match. */
+export function keepAgreement(rows: AnalysisRow[]): number {
+  if (rows.length === 0) return 0;
+  const agree = rows.filter((r) => r.outputKeep === r.expectedKeep).length;
+  return agree / rows.length;
+}
+
+/**
+ * falseKeep = candidate keeps a photo the baseline would replace (the DANGEROUS
+ * direction — ships a bad photo). falseReplace = the cheap direction (re-source).
+ */
+export function confusionCounts(rows: AnalysisRow[]): { falseKeep: number; falseReplace: number } {
+  let falseKeep = 0;
+  let falseReplace = 0;
+  for (const r of rows) {
+    if (r.outputKeep && !r.expectedKeep) falseKeep++;
+    else if (!r.outputKeep && r.expectedKeep) falseReplace++;
+  }
+  return { falseKeep, falseReplace };
+}
+
+/** Mean absolute error of the candidate vs. baseline qualityScore (0–100 points). */
+export function scoreMAE(rows: AnalysisRow[]): number {
+  if (rows.length === 0) return 0;
+  const sum = rows.reduce((acc, r) => acc + Math.abs(r.outputScore - r.expectedScore), 0);
+  return sum / rows.length;
+}
+
+/**
+ * AUC of the candidate `outputScore` as a ranker of the Opus `keep` label:
+ * P(a random Opus-keep row outranks a random Opus-replace row), ties counting
+ * as 0.5. Computed by the exhaustive pairwise (Mann–Whitney) definition — O(n²),
+ * fine for ≤902 rows and exactly matches the by-hand fixture expectations.
+ * Returns `null` when either class is empty (AUC undefined).
+ */
+export function auc(rows: AnalysisRow[]): number | null {
+  const pos = rows.filter((r) => r.expectedKeep).map((r) => r.outputScore);
+  const neg = rows.filter((r) => !r.expectedKeep).map((r) => r.outputScore);
+  if (pos.length === 0 || neg.length === 0) return null;
+  let acc = 0;
+  for (const p of pos) {
+    for (const n of neg) {
+      if (p > n) acc += 1;
+      else if (p === n) acc += 0.5;
+    }
+  }
+  return acc / (pos.length * neg.length);
+}
+
+/**
+ * Calibrated-threshold ceiling: sweep a score threshold `t` and predict
+ * keep iff `outputScore >= t`, then measure boolean agreement against the Opus
+ * keep label. Returns the best agreement reachable and the winning `t`.
+ *
+ * Candidate thresholds are the distinct scores plus one just above the max (so
+ * "keep nothing" is reachable). The best achievable agreement is the ceiling a
+ * recalibrated Gemini-only gate could hit — when it sits well below 1.0 the
+ * disagreement is genuine model divergence, not boundary noise.
+ */
+export function calibratedThreshold(rows: AnalysisRow[]): { bestAgreement: number; threshold: number } {
+  if (rows.length === 0) return { bestAgreement: 0, threshold: 0 };
+  const scores = rows.map((r) => r.outputScore);
+  const max = Math.max(...scores);
+  // Candidate cut points: each observed score (predict keep at >= score) plus a
+  // sentinel above the max (predict keep for nothing).
+  const candidates = Array.from(new Set([...scores, max + 1])).sort((a, b) => a - b);
+  let best = { bestAgreement: -1, threshold: candidates[0]! };
+  for (const t of candidates) {
+    let agree = 0;
+    for (const r of rows) {
+      const predictedKeep = r.outputScore >= t;
+      if (predictedKeep === r.expectedKeep) agree++;
+    }
+    const agreement = agree / rows.length;
+    if (agreement > best.bestAgreement) best = { bestAgreement: agreement, threshold: t };
+  }
+  return best;
+}
+
+/**
+ * Ambiguity-band breakdown: of all keep-disagreements, how many sit inside the
+ * Opus-score band `[lo, hi]` (inclusive). A disagreement near Opus's own
+ * midpoint is a genuine close call (the kind a hybrid would route); a
+ * disagreement at the extremes is a real model miss.
+ */
+export function ambiguityBand(
+  rows: AnalysisRow[],
+  lo: number,
+  hi: number,
+): { inBandDisagreements: number; totalDisagreements: number } {
+  let inBand = 0;
+  let total = 0;
+  for (const r of rows) {
+    if (r.outputKeep === r.expectedKeep) continue;
+    total++;
+    if (r.expectedScore >= lo && r.expectedScore <= hi) inBand++;
+  }
+  return { inBandDisagreements: inBand, totalDisagreements: total };
+}
+
+/**
+ * Hybrid-routing preview: route any row whose CANDIDATE score lands in the
+ * mid-band `[lo, hi]` to Opus (which, being the baseline, decides correctly);
+ * outside the band, keep the candidate's own decision. Reports:
+ *   - routed / routedFraction — Opus-call budget the hybrid would spend.
+ *   - autoSetAgreement        — keep-agreement after routing (routed rows are
+ *                               auto-correct; out-of-band rows keep Gemini's call).
+ *   - residualFalseKeep       — falseKeeps the hybrid still ships (a dangerous
+ *                               Gemini keep whose score fell OUTSIDE the band, so
+ *                               it was never re-judged).
+ */
+export function hybridRouting(
+  rows: AnalysisRow[],
+  lo: number,
+  hi: number,
+): { routed: number; routedFraction: number; autoSetAgreement: number; residualFalseKeep: number } {
+  if (rows.length === 0) return { routed: 0, routedFraction: 0, autoSetAgreement: 0, residualFalseKeep: 0 };
+  let routed = 0;
+  let correct = 0;
+  let residualFalseKeep = 0;
+  for (const r of rows) {
+    const inBand = r.outputScore >= lo && r.outputScore <= hi;
+    if (inBand) {
+      // Routed to Opus → decided correctly by construction (Opus is the label).
+      routed++;
+      correct++;
+    } else {
+      // Keep Gemini's decision.
+      if (r.outputKeep === r.expectedKeep) correct++;
+      else if (r.outputKeep && !r.expectedKeep) residualFalseKeep++;
+    }
+  }
+  return {
+    routed,
+    routedFraction: routed / rows.length,
+    autoSetAgreement: correct / rows.length,
+    residualFalseKeep,
+  };
+}
+
+/** Tunable band edges for the ambiguity + hybrid-routing analysis. */
+export interface AnalysisOptions {
+  /** Lower edge of the ambiguity / routing band (inclusive). */
+  bandLo: number;
+  /** Upper edge of the ambiguity / routing band (inclusive). */
+  bandHi: number;
+}
+
+/** The full dataset-level diagnostic, aggregated from the experiment rows. */
+export interface Analysis {
+  n: number;
+  keepAgreement: number;
+  confusion: { falseKeep: number; falseReplace: number };
+  scoreMAE: number;
+  auc: number | null;
+  calibrated: { bestAgreement: number; threshold: number };
+  band: { lo: number; hi: number; inBandDisagreements: number; totalDisagreements: number };
+  hybrid: { routed: number; routedFraction: number; autoSetAgreement: number; residualFalseKeep: number };
+}
+
+/** Compose every pure helper into one Analysis over the rows. */
+export function analyze(rows: AnalysisRow[], opts: AnalysisOptions): Analysis {
+  const band = ambiguityBand(rows, opts.bandLo, opts.bandHi);
+  return {
+    n: rows.length,
+    keepAgreement: keepAgreement(rows),
+    confusion: confusionCounts(rows),
+    scoreMAE: scoreMAE(rows),
+    auc: auc(rows),
+    calibrated: calibratedThreshold(rows),
+    band: { lo: opts.bandLo, hi: opts.bandHi, ...band },
+    hybrid: hybridRouting(rows, opts.bandLo, opts.bandHi),
+  };
+}
+
+const pct = (x: number): string => `${(x * 100).toFixed(2)}%`;
+
+/** Render the analysis as a human-readable report block. */
+export function formatReport(experiment: string, a: Analysis): string {
+  const aucStr = a.auc === null ? 'n/a (a keep class is empty)' : a.auc.toFixed(3);
+  return [
+    `Experiment: ${experiment}  (${a.n} rows)`,
+    ``,
+    `keep agreement      ${pct(a.keepAgreement)}`,
+    `  falseKeep         ${a.confusion.falseKeep}   (Gemini keeps what Opus would replace — ships a bad photo)`,
+    `  falseReplace      ${a.confusion.falseReplace}   (Gemini replaces what Opus would keep — cheap, re-source)`,
+    `score MAE           ${a.scoreMAE.toFixed(2)} points`,
+    `AUC                 ${aucStr}   (Gemini qualityScore ranking Opus keep)`,
+    `calibrated ceiling  ${pct(a.calibrated.bestAgreement)} at score >= ${a.calibrated.threshold}`,
+    `                    (best boolean agreement a recalibrated Gemini-only threshold could reach)`,
+    ``,
+    `ambiguity band [${a.band.lo}, ${a.band.hi}] (Opus score)`,
+    `  in-band disagreements   ${a.band.inBandDisagreements} of ${a.band.totalDisagreements} total`,
+    ``,
+    `hybrid routing preview (route mid-band Gemini scores [${a.band.lo}, ${a.band.hi}] to Opus)`,
+    `  routed            ${a.hybrid.routed}  (${pct(a.hybrid.routedFraction)} of rows → Opus re-judge)`,
+    `  auto-set agreement ${pct(a.hybrid.autoSetAgreement)}  (keep agreement after routing)`,
+    `  residual falseKeep ${a.hybrid.residualFalseKeep}  (dangerous keeps that fell outside the band)`,
+  ].join('\n');
+}
+
+// ── Braintrust read (injected; not unit-tested) ──────────────────────────────
+
+/** Reads a completed experiment's rows back. Injected so tests need no network. */
+export type ExperimentReader = (experiment: string) => Promise<AnalysisRow[]>;
+
+/** A `scores`/`output`/`expected` row as `bt sql` returns it (loosely typed). */
+interface RawRow {
+  output?: { keep?: unknown; qualityScore?: unknown } | null;
+  expected?: { keep?: unknown; qualityScore?: unknown } | null;
+}
+
+function toNumber(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Project the loosely-typed `bt sql` rows onto `AnalysisRow`, dropping any row
+ * missing a keep flag or a numeric score on either side (root spans only carry
+ * output/expected; nested judgment spans don't, so they are filtered out).
+ * Exported for a focused unit test of the projection without a live read.
+ */
+export function projectRows(raw: RawRow[]): AnalysisRow[] {
+  const out: AnalysisRow[] = [];
+  for (const r of raw) {
+    const outputKeep = r.output?.keep;
+    const expectedKeep = r.expected?.keep;
+    const outputScore = toNumber(r.output?.qualityScore);
+    const expectedScore = toNumber(r.expected?.qualityScore);
+    if (
+      typeof outputKeep === 'boolean' &&
+      typeof expectedKeep === 'boolean' &&
+      outputScore !== undefined &&
+      expectedScore !== undefined
+    ) {
+      out.push({ outputKeep, outputScore, expectedKeep, expectedScore });
+    }
+  }
+  return out;
+}
+
+/**
+ * The default reader: `bt sql "SELECT output, expected FROM experiment('<exp>')"`
+ * as JSON, projected onto `AnalysisRow`. Shells out to the Braintrust CLI (auth
+ * resolves from the active `bt` profile), so it is operator-run, never in CI.
+ */
+const btSqlReader: ExperimentReader = async (experiment) => {
+  const query = `SELECT output, expected FROM experiment('${experiment}')`;
+  const { stdout } = await execFileAsync('bt', ['sql', '--json', query], {
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const parsed = JSON.parse(stdout) as unknown;
+  const rows: RawRow[] = Array.isArray(parsed)
+    ? (parsed as RawRow[])
+    : ((parsed as { data?: RawRow[] }).data ?? []);
+  return projectRows(rows);
+};
+
+/** Parse `--band lo:hi` (default 40:70) from argv; everything else is the exp name. */
+function parseArgs(argv: string[]): { experiment: string | undefined; bandLo: number; bandHi: number } {
+  let bandLo = 40;
+  let bandHi = 70;
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--band' && argv[i + 1]) {
+      const [lo, hi] = argv[++i]!.split(':').map(Number);
+      if (Number.isFinite(lo)) bandLo = lo!;
+      if (Number.isFinite(hi)) bandHi = hi!;
+    } else {
+      positional.push(argv[i]!);
+    }
+  }
+  return { experiment: positional[0], bandLo, bandHi };
+}
+
+/** CLI entry. `reader` is injectable; defaults to the `bt sql` reader. */
+export async function main(argv: string[], reader: ExperimentReader = btSqlReader): Promise<number> {
+  const { experiment, bandLo, bandHi } = parseArgs(argv);
+  if (!experiment) {
+    console.error('usage: analyze-experiment <experiment-name-or-id> [--band lo:hi]');
+    return 2;
+  }
+  const rows = await reader(experiment);
+  if (rows.length === 0) {
+    console.error(`No usable rows read from experiment '${experiment}' (is it complete, and does it carry output/expected keep + qualityScore?).`);
+    return 1;
+  }
+  console.log(formatReport(experiment, analyze(rows, { bandLo, bandHi })));
+  return 0;
+}
+
+// Run only when invoked directly (tsx scripts/analyze-experiment.ts …), never on import.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+}

--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
 import type Database from 'better-sqlite3';
 import { openDb } from '../db.js';
-import { buildEvalRows, mulberry32, shuffleInPlace, DEFAULT_SEED } from './build-dataset.js';
+import { buildEvalRows, mulberry32, shuffleInPlace, DEFAULT_SEED, parseCriteria } from './build-dataset.js';
+import { CRITERIA_KEYS, type CriteriaScores } from '@bird-watch/photo-quality';
 
 let db: Database.Database;
 let thumbDir: string;
@@ -36,21 +37,33 @@ function seedCurrent(
     overall: number;
     rationale?: string | null;
     rubricVersion?: string | null;
+    /** Stored R2 URL VERBATIM; defaults to a mixed-extension https URL. */
+    url?: string | null;
+    /** `criteria_json` blob; `null` to seed a row with no per-axis scores. */
+    criteriaJson?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO photo_current (species_code, com_name, sci_name, family, content_hash)
-     VALUES (?, ?, ?, ?, ?)`,
-  ).run(code, fields.comName, fields.sciName, fields.family, fields.contentHash);
+    `INSERT INTO photo_current (species_code, com_name, sci_name, family, url, content_hash)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    code,
+    fields.comName,
+    fields.sciName,
+    fields.family,
+    fields.url === undefined ? `https://photos.bird-maps.com/${code}.jpg` : fields.url,
+    fields.contentHash,
+  );
   db.prepare(
     `INSERT INTO photo_score (species_code, role, content_hash, overall, verdict,
                               criteria_json, flags_json, keep, quality_score, rationale,
                               rubric_version, scored_at)
-     VALUES (?, 'current', ?, ?, 'good', '{}', '[]', ?, ?, ?, ?, 'now')`,
+     VALUES (?, 'current', ?, ?, 'good', ?, '[]', ?, ?, ?, ?, 'now')`,
   ).run(
     code,
     fields.contentHash,
     fields.overall,
+    fields.criteriaJson === undefined ? '{}' : fields.criteriaJson,
     fields.keep,
     fields.qualityScore,
     fields.rationale === undefined ? 'sharp wild adult, diagnostic marks visible' : fields.rationale,
@@ -100,18 +113,20 @@ describe('buildEvalRows', () => {
 
     const robin = rows.find((r) => r.input.speciesCode === 'amerob')!;
     expect(robin.input).toEqual({
-      imagePath: join(thumbDir, 'amerob.jpg'),
+      readPath: join(thumbDir, 'amerob.jpg'),
+      imageUrl: 'https://photos.bird-maps.com/amerob.jpg',
       speciesCode: 'amerob',
       comName: 'American Robin',
       sciName: 'Turdus migratorius',
       family: 'Turdidae',
     });
+    // `{}` criteria_json has no axes → no `criteria` key (undefined, not `{}`).
     expect(robin.expected).toEqual({ keep: true, qualityScore: 88 });
     expect(robin.metadata).toEqual({ contentHash: 'h-amerob', expectedRubricVersion: '0.2.1' });
 
-    // Image resolved by extension glob, not hardcoded .jpg.
-    expect(basename(rows.find((r) => r.input.speciesCode === 'norcar')!.input.imagePath)).toBe('norcar.png');
-    expect(basename(rows.find((r) => r.input.speciesCode === 'houspa')!.input.imagePath)).toBe('houspa.webp');
+    // Image resolved by extension glob, not hardcoded .jpg — readPath is LOCAL.
+    expect(basename(rows.find((r) => r.input.speciesCode === 'norcar')!.input.readPath)).toBe('norcar.png');
+    expect(basename(rows.find((r) => r.input.speciesCode === 'houspa')!.input.readPath)).toBe('houspa.webp');
 
     const pigeon = rows.find((r) => r.input.speciesCode === 'rocpig')!;
     expect(pigeon.expected).toEqual({ keep: false, qualityScore: 30 });
@@ -196,7 +211,7 @@ describe('buildEvalRows', () => {
 
     const rows = buildEvalRows(db, { thumbDir });
     expect(rows).toHaveLength(1);
-    expect(basename(rows[0].input.imagePath)).toBe('amerob.jpg');
+    expect(basename(rows[0].input.readPath)).toBe('amerob.jpg');
   });
 
   it('returns all rows unsampled when sample is omitted', () => {
@@ -270,5 +285,75 @@ describe('buildEvalRows', () => {
 
   it('throws on an empty baseline (no version to pin the judge prompt to)', () => {
     expect(() => buildEvalRows(db, { thumbDir })).toThrow(/no role='current' scores/i);
+  });
+
+  // #1067: the R2 URL is logged VERBATIM — extensions vary in the DB
+  // (.jpg/.jpeg/.png) and a reconstructed `<code>.jpeg` template 404s for
+  // hundreds of species, so the row must carry the stored column unchanged,
+  // distinct from the LOCAL readPath.
+  it('carries photo_current.url verbatim (mixed extensions) as imageUrl, distinct from readPath', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, url: 'https://photos.bird-maps.com/amerob.jpeg' });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85, url: 'https://photos.bird-maps.com/norcar.png' });
+    writeImage('amerob'); // local cache is .jpg even though the R2 URL is .jpeg
+    writeImage('norcar', 'png');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    const robin = rows.find((r) => r.input.speciesCode === 'amerob')!;
+    expect(robin.input.imageUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
+    expect(robin.input.readPath).toBe(join(thumbDir, 'amerob.jpg'));
+    expect(robin.input.imageUrl).not.toBe(robin.input.readPath);
+
+    const card = rows.find((r) => r.input.speciesCode === 'norcar')!;
+    expect(card.input.imageUrl).toBe('https://photos.bird-maps.com/norcar.png');
+  });
+
+  // #1067: the Opus per-axis sub-scores ride into expected.criteria.
+  it('populates expected.criteria from a real criteria_json blob', () => {
+    const criteria: CriteriaScores = { framing: 8, subjectClarity: 7, liveness: 10, naturalness: 4, pose: 6, background: 5, lighting: 9 };
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: JSON.stringify(criteria) });
+    writeImage('amerob');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows[0].expected.criteria).toEqual(criteria);
+  });
+
+  // #1067: a NULL criteria_json must yield `undefined` (an axis-skip), NOT `{}`
+  // — a fabricated empty object would be indistinguishable from a real score.
+  it('leaves expected.criteria undefined (not {}) for a NULL criteria_json', () => {
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: null });
+    writeImage('amerob');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    expect(rows[0].expected.criteria).toBeUndefined();
+    expect('criteria' in rows[0].expected).toBe(false);
+  });
+});
+
+describe('parseCriteria', () => {
+  it('parses a full 7-axis blob', () => {
+    const criteria: CriteriaScores = { framing: 8, subjectClarity: 7, liveness: 10, naturalness: 4, pose: 6, background: 5, lighting: 9 };
+    expect(parseCriteria(JSON.stringify(criteria))).toEqual(criteria);
+  });
+
+  it('returns undefined for NULL or empty input', () => {
+    expect(parseCriteria(null)).toBeUndefined();
+    expect(parseCriteria('')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty object (no axes — never {})', () => {
+    expect(parseCriteria('{}')).toBeUndefined();
+  });
+
+  it('returns undefined for a partial blob missing an axis (skip, never fabricate)', () => {
+    const partial: Record<string, number> = {};
+    for (const k of CRITERIA_KEYS) partial[k] = 5;
+    delete partial.lighting;
+    expect(parseCriteria(JSON.stringify(partial))).toBeUndefined();
+  });
+
+  it('returns undefined for a malformed blob rather than throwing', () => {
+    expect(parseCriteria('{not json')).toBeUndefined();
+    expect(parseCriteria('[1,2,3]')).toBeUndefined();
+    expect(parseCriteria('"a string"')).toBeUndefined();
   });
 });

--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -236,6 +236,30 @@ describe('buildEvalRows', () => {
     expect(rows.map((r) => r.input.speciesCode).sort()).toEqual(['amerob', 'norcar']);
   });
 
+  // #1067 (bot review): the per-axis null-skip keys on ABSENCE, but a det-gate
+  // row carries ZEROED-not-null criteria (`{framing:0,…}`) — which would score
+  // as real, harsh disagreement if it reached a scorer. The ONLY thing keeping
+  // it out is the existing `rationale NOT LIKE 'deterministic gate%'` query
+  // filter; this test couples the two mechanisms so neither can silently drift.
+  it('excludes a det-gate row even when it carries zeroed (non-null) criteria — so a scorer never sees fabricated 0s', () => {
+    const zeroed = { framing: 0, subjectClarity: 0, liveness: 0, naturalness: 0, pose: 0, background: 0, lighting: 0 };
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: JSON.stringify({ framing: 8, subjectClarity: 7, liveness: 9, naturalness: 6, pose: 7, background: 6, lighting: 8 }) });
+    seedCurrent('detgat', {
+      comName: 'Det Gate', sciName: 'D g', family: 'Fam', contentHash: 'h-detgat',
+      keep: 0, qualityScore: 0, overall: 0,
+      rationale: 'deterministic gate failed: sharpness below floor',
+      criteriaJson: JSON.stringify(zeroed),
+    });
+    writeImage('amerob');
+    writeImage('detgat');
+
+    const rows = buildEvalRows(db, { thumbDir });
+    // The det-gate row is gone, so its zeroed criteria can never become an
+    // `expected.criteria` the per-axis scorer would grade as a 10-point miss.
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['amerob']);
+    expect(rows.every((r) => r.input.speciesCode !== 'detgat')).toBe(true);
+  });
+
   // The exclusion predicate must be NULL-safe: `rationale NOT LIKE …` alone is
   // NULL for a NULL rationale, which would silently drop Opus rows without one.
   it('keeps a row whose rationale is NULL (not a det-gate verdict)', () => {

--- a/tools/photo-curation/src/eval/build-dataset.ts
+++ b/tools/photo-curation/src/eval/build-dataset.ts
@@ -1,17 +1,34 @@
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type Database from 'better-sqlite3';
+import { type CriteriaScores, CRITERIA_KEYS } from '@bird-watch/photo-quality';
 
 /**
  * One Braintrust eval row built from the Opus current-scores in review.sqlite.
  * `expected` is the Opus keep/score, used as proxy ground truth (#1010/#1013):
- * a later run compares a cheaper judge's output against it. `imagePath` points
- * at the cached current thumbnail; `metadata.contentHash` ties the row back to
- * the exact image bytes the Opus pass scored.
+ * a later run compares a cheaper judge's output against it.
+ *
+ * Provenance is split into two distinct identifiers (#1067):
+ *   - `input.readPath` — the LOCAL cached thumbnail the bytes are read from
+ *     (`<thumbDir>/<code>.{jpg,png,webp}`). A read target only; it is NOT a
+ *     portable URL and is never logged as the span's `sourceUrl`.
+ *   - `input.imageUrl` — the production R2 URL (`photo_current.url`, stored
+ *     VERBATIM, mixed `.jpg`/`.jpeg`/`.png` extensions). This is what the eval
+ *     logs as the span's `sourceUrl` so Braintrust renders the real thumbnail
+ *     and the experiment is portable across machines.
+ *
+ * `metadata.contentHash` ties the row back to the exact image bytes the Opus
+ * pass scored. `expected.criteria` carries the Opus per-axis sub-scores
+ * (`photo_score.criteria_json`) when present, so the per-axis scorers can
+ * compare them against the candidate judge's; `undefined` when the baseline
+ * row has no `criteria_json` (an axis-skip, never a fabricated zero).
  */
 export interface EvalRow {
   input: {
-    imagePath: string;
+    /** LOCAL cached-thumbnail path the judge reads bytes from (not a URL). */
+    readPath: string;
+    /** Production R2 URL (`photo_current.url`), logged as the span `sourceUrl`. */
+    imageUrl: string;
     speciesCode: string;
     comName: string;
     sciName: string;
@@ -20,6 +37,8 @@ export interface EvalRow {
   expected: {
     keep: boolean;
     qualityScore: number;
+    /** Opus per-axis sub-scores (0–10) when the baseline row carried them. */
+    criteria?: CriteriaScores;
   };
   metadata: {
     contentHash: string;
@@ -61,9 +80,37 @@ interface ScoreJoinRow {
   overall: number;
   content_hash: string;
   rubric_version: string | null;
+  criteria_json: string | null;
+  url: string | null;
   com_name: string;
   sci_name: string;
   family: string;
+}
+
+/**
+ * Parse a baseline `criteria_json` blob into `CriteriaScores`, or `undefined`
+ * when the column is NULL/empty (an axis-skip on the expected side — the
+ * per-axis scorers never fabricate agreement from a missing baseline). Parse
+ * failures and shape mismatches also yield `undefined` rather than throwing:
+ * a malformed legacy blob must skip its axes, not abort the whole dataset.
+ */
+export function parseCriteria(criteriaJson: string | null): CriteriaScores | undefined {
+  if (criteriaJson === null || criteriaJson === '') return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(criteriaJson);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const out = {} as CriteriaScores;
+  for (const key of CRITERIA_KEYS) {
+    const v = obj[key];
+    if (typeof v !== 'number') return undefined;
+    out[key] = v;
+  }
+  return out;
 }
 
 /**
@@ -188,7 +235,7 @@ export function buildEvalRows(
   const joinRows = db
     .prepare(
       `SELECT s.species_code, s.keep, s.quality_score, s.overall, s.content_hash,
-              s.rubric_version, c.com_name, c.sci_name, c.family
+              s.rubric_version, s.criteria_json, c.url, c.com_name, c.sci_name, c.family
          FROM photo_score s JOIN photo_current c USING(species_code)
         WHERE s.role = 'current'
           AND (s.rationale IS NULL OR s.rationale NOT LIKE 'deterministic gate%')`,
@@ -206,9 +253,14 @@ export function buildEvalRows(
       );
       continue;
     }
+    const criteria = parseCriteria(row.criteria_json);
     rows.push({
       input: {
-        imagePath: join(thumbDir, file),
+        readPath: join(thumbDir, file),
+        // The stored R2 URL VERBATIM (#1067): extensions vary in the DB
+        // (.jpg/.jpeg/.png) and a reconstructed `<code>.jpeg` template 404s for
+        // hundreds of species, so we never template — we log the column as-is.
+        imageUrl: row.url ?? '',
         speciesCode: row.species_code,
         comName: row.com_name,
         sciName: row.sci_name,
@@ -217,6 +269,9 @@ export function buildEvalRows(
       expected: {
         keep: row.keep === null ? true : row.keep === 1,
         qualityScore: row.quality_score ?? row.overall,
+        // `undefined` (NOT `{}`) when the baseline has no criteria_json — the
+        // per-axis scorers skip a missing axis rather than scoring a phantom 0.
+        ...(criteria !== undefined ? { criteria } : {}),
       },
       metadata: { contentHash: row.content_hash, expectedRubricVersion: rubricVersion },
     });

--- a/tools/photo-curation/src/eval/run-row.test.ts
+++ b/tools/photo-curation/src/eval/run-row.test.ts
@@ -31,7 +31,11 @@ class FakeJudge implements VisionJudge {
 }
 
 const INPUT: RunRowInput = {
-  imagePath: '/thumbs/amerob.jpg',
+  // The LOCAL byte source has a .jpg cache extension; the R2 URL is .jpeg —
+  // a deliberate mismatch (#1067): the span must log the portable R2 URL, never
+  // the local path nor a reconstructed template.
+  readPath: '/thumbs/amerob.jpg',
+  imageUrl: 'https://photos.bird-maps.com/amerob.jpeg',
   speciesCode: 'amerob',
   comName: 'American Robin',
   sciName: 'Turdus migratorius',
@@ -59,7 +63,7 @@ describe('runRow', () => {
     expect(prompt).toBe('rubric prompt v1');
   });
 
-  it('passes the imagePath through to readImage exactly once', async () => {
+  it('reads bytes from readPath (the LOCAL cache), exactly once', async () => {
     const judge = new FakeJudge();
     const seen: string[] = [];
     const readImage = (p: string): ImageInput => {
@@ -72,13 +76,25 @@ describe('runRow', () => {
     expect(seen).toEqual(['/thumbs/amerob.jpg']);
   });
 
-  it('threads the source path onto the ImageInput sourceUrl (so the span records it)', async () => {
+  it('logs the portable R2 imageUrl as sourceUrl — NOT the local readPath', async () => {
     const judge = new FakeJudge();
+    // readImage sets sourceUrl to the LOCAL path; runRow must override it.
     const readImage = (p: string): ImageInput => ({ buffer: Buffer.from('x'), mime: 'image/jpeg', sourceUrl: p });
 
     await runRow({ judge, readImage, prompt: 'p' }, INPUT);
 
     const [img] = judge.calls[0]!;
-    expect(img.sourceUrl).toBe('/thumbs/amerob.jpg');
+    expect(img.sourceUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
+    expect(img.sourceUrl).not.toBe('/thumbs/amerob.jpg');
+  });
+
+  it('sets sourceUrl to the R2 imageUrl even when readImage omits sourceUrl', async () => {
+    const judge = new FakeJudge();
+    const readImage = (): ImageInput => ({ buffer: Buffer.from('x'), mime: 'image/jpeg' });
+
+    await runRow({ judge, readImage, prompt: 'p' }, INPUT);
+
+    const [img] = judge.calls[0]!;
+    expect(img.sourceUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
   });
 });

--- a/tools/photo-curation/src/eval/run-row.ts
+++ b/tools/photo-curation/src/eval/run-row.ts
@@ -20,9 +20,17 @@ import type { ImageInput, JudgeOutput, SpeciesContext, VisionJudge } from '@bird
  * One dataset row's `input` (mirrors `EvalRow.input` from build-dataset.ts).
  * Re-declared here rather than imported so this module stays decoupled from the
  * dataset builder's internals — only the field names are the contract.
+ *
+ * The image identity is split (#1067): `readPath` is the LOCAL cache path the
+ * bytes come from, `imageUrl` is the portable production R2 URL logged as the
+ * span's `sourceUrl`. They differ (cache ext vs. stored ext), so they must
+ * stay distinct.
  */
 export interface RunRowInput {
-  imagePath: string;
+  /** LOCAL cached-thumbnail path the judge reads bytes from (not logged as a URL). */
+  readPath: string;
+  /** Production R2 URL — logged as the span's portable `sourceUrl`. */
+  imageUrl: string;
   speciesCode: string;
   comName: string;
   sciName: string;
@@ -33,21 +41,27 @@ export interface RunRowInput {
 export interface RunRowDeps {
   /** The (traced) judge to score the image with. */
   judge: VisionJudge;
-  /** Reads an image path into an `ImageInput` (buffer + mime [+ sourceUrl]). */
-  readImage: (imagePath: string) => ImageInput;
+  /** Reads a LOCAL image path into an `ImageInput` (buffer + mime). */
+  readImage: (readPath: string) => ImageInput;
   /** The rubric prompt handed to the judge (e.g. `defaultRubricConfig.judgePrompt`). */
   prompt: string;
 }
 
 /**
- * Map one eval row to a judge call. Reads the row's image via `deps.readImage`,
- * builds the `SpeciesContext` from the row's species fields, and asks
- * `deps.judge` to score it with `deps.prompt`. Returns the judge's
- * `JudgeOutput` unchanged — the Braintrust scorers compare it against the row's
- * `expected` (the Opus proxy ground truth).
+ * Map one eval row to a judge call. Reads the row's image bytes from the LOCAL
+ * `readPath` via `deps.readImage`, builds the `SpeciesContext` from the row's
+ * species fields, and asks `deps.judge` to score it with `deps.prompt`.
+ *
+ * The `ImageInput.sourceUrl` handed to the judge is the row's portable R2
+ * `imageUrl` — NOT the local read path (#1067) — so the Braintrust span renders
+ * the real bird-maps.com thumbnail and the experiment is portable. We override
+ * whatever `sourceUrl` `readImage` may have set (it sees only the local path).
+ * Returns the judge's `JudgeOutput` unchanged — the Braintrust scorers compare
+ * it against the row's `expected` (the Opus proxy ground truth).
  */
 export async function runRow(deps: RunRowDeps, input: RunRowInput): Promise<JudgeOutput> {
-  const img: ImageInput = deps.readImage(input.imagePath);
+  const read: ImageInput = deps.readImage(input.readPath);
+  const img: ImageInput = { ...read, sourceUrl: input.imageUrl };
   const ctx: SpeciesContext = {
     speciesCode: input.speciesCode,
     comName: input.comName,

--- a/tools/photo-curation/src/eval/scorers.test.ts
+++ b/tools/photo-curation/src/eval/scorers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { keepAgreement, scoreMAE, keepConfusion } from './scorers.js';
+import { keepAgreement, scoreMAE, keepConfusion, criteriaAxisMAE } from './scorers.js';
+import { CRITERIA_KEYS, type CriteriaScores } from '@bird-watch/photo-quality';
 
 /**
  * The Braintrust scorer args are `{input, output, expected, metadata}`; these
@@ -97,5 +98,69 @@ describe('keepConfusion', () => {
       score: 1,
       metadata: { falseKeep: 0, falseReplace: 0 },
     });
+  });
+});
+
+describe('criteriaAxisMAE', () => {
+  const full = (over: Partial<CriteriaScores> = {}): CriteriaScores => ({
+    framing: 8, subjectClarity: 8, liveness: 8, naturalness: 8, pose: 8, background: 8, lighting: 8, ...over,
+  });
+  /** A candidate JudgeOutput-shaped value carrying full criteria. */
+  const out = (criteria: CriteriaScores) => ({ keep: true, qualityScore: 80, criteria });
+
+  it('emits exactly 7 columns, one per CRITERIA_KEYS axis, named criteria_mae_<axis>', () => {
+    const results = criteriaAxisMAE({ output: out(full()), expected: { keep: true, qualityScore: 80, criteria: full() } });
+    expect(results).toHaveLength(CRITERIA_KEYS.length);
+    expect(results.map((r) => r.name)).toEqual(CRITERIA_KEYS.map((k) => `criteria_mae_${k}`));
+  });
+
+  it('scores 1.0 on every axis when both sides match exactly', () => {
+    const results = criteriaAxisMAE({ output: out(full()), expected: { keep: true, qualityScore: 80, criteria: full() } });
+    for (const r of results) expect(r.score).toBe(1);
+  });
+
+  it('scores 0.5 on a single axis with a 5-point gap, leaving the others at 1.0', () => {
+    const results = criteriaAxisMAE({
+      output: out(full({ naturalness: 9 })),
+      expected: { keep: true, qualityScore: 80, criteria: full({ naturalness: 4 }) },
+    });
+    const byName = new Map(results.map((r) => [r.name, r.score]));
+    expect(byName.get('criteria_mae_naturalness')).toBe(0.5);
+    for (const k of CRITERIA_KEYS) {
+      if (k === 'naturalness') continue;
+      expect(byName.get(`criteria_mae_${k}`)).toBe(1);
+    }
+  });
+
+  it('scores 0 on a full 10-point axis gap', () => {
+    const results = criteriaAxisMAE({
+      output: out(full({ lighting: 10 })),
+      expected: { keep: true, qualityScore: 80, criteria: full({ lighting: 0 }) },
+    });
+    const byName = new Map(results.map((r) => [r.name, r.score]));
+    expect(byName.get('criteria_mae_lighting')).toBe(0);
+  });
+
+  it('null-skips ALL axes when the expected side has no criteria (still 7 columns)', () => {
+    const results = criteriaAxisMAE({ output: out(full()), expected: { keep: true, qualityScore: 80 } });
+    expect(results).toHaveLength(CRITERIA_KEYS.length);
+    for (const r of results) expect(r.score).toBeNull();
+  });
+
+  it('null-skips only the missing axis when one side omits a single axis', () => {
+    // Expected criteria missing `pose` (partial blob from an older baseline).
+    const partial = full();
+    delete (partial as Record<string, unknown>).pose;
+    const results = criteriaAxisMAE({
+      output: out(full()),
+      expected: { keep: true, qualityScore: 80, criteria: partial as CriteriaScores },
+    });
+    const byName = new Map(results.map((r) => [r.name, r.score]));
+    expect(byName.get('criteria_mae_pose')).toBeNull();
+    // Every other axis is unaffected (matching → 1.0).
+    for (const k of CRITERIA_KEYS) {
+      if (k === 'pose') continue;
+      expect(byName.get(`criteria_mae_${k}`)).toBe(1);
+    }
   });
 });

--- a/tools/photo-curation/src/eval/scorers.ts
+++ b/tools/photo-curation/src/eval/scorers.ts
@@ -1,24 +1,36 @@
 /**
  * Braintrust eval scorers for the photo-judge experiment (C4, #1014; part of
- * #1010). Three headline metrics comparing a candidate judge `output` against
- * the reference `expected` (both JudgeOutput-shaped — only `keep` and
- * `qualityScore` matter here):
+ * #1010). Headline metrics comparing a candidate judge `output` against the
+ * reference `expected` (both JudgeOutput-shaped):
  *
- *   - keepAgreement  — exact boolean match of `keep` (the #969 ≥90% gate).
- *   - scoreMAE       — normalized 1 - |Δ qualityScore| / 100, clamped to [0,1].
- *   - keepConfusion  — splits disagreements into false-keep (output keeps what
- *                      expected would replace — the DANGEROUS direction: it
- *                      ships a bad photo) vs false-replace.
+ *   - keepAgreement   — exact boolean match of `keep` (the #969 ≥90% gate).
+ *   - scoreMAE        — normalized 1 - |Δ qualityScore| / 100, clamped to [0,1].
+ *   - keepConfusion   — splits disagreements into false-keep (output keeps what
+ *                       expected would replace — the DANGEROUS direction: it
+ *                       ships a bad photo) vs false-replace.
+ *   - criteriaAxisMAE — per-axis agreement on the 7 `CriteriaScores` sub-scores
+ *                       (#1067): one `criteria_mae_<axis>` column per axis,
+ *                       `1 − |out − exp|/10` clamped to [0,1]. A missing axis on
+ *                       EITHER side null-skips that axis only (never a phantom 0).
  *
  * Braintrust calls scorers with `{input, output, expected, metadata}`; these
- * read only `output` + `expected`. All three are PURE — no IO — so they unit-
- * test directly and can run inside the eval harness without side effects.
+ * read only `output` + `expected`. All are PURE — no IO — so they unit-test
+ * directly and can run inside the eval harness without side effects.
  */
 
-/** The subset of JudgeOutput these scorers depend on. */
+import { type CriteriaScores, CRITERIA_KEYS } from '@bird-watch/photo-quality';
+
+/**
+ * The subset of JudgeOutput these scorers depend on. `criteria` is optional
+ * because the EXPECTED side may carry no per-axis baseline (older rows, or a
+ * NULL `criteria_json`) — that case null-skips the per-axis columns rather than
+ * fabricating agreement. The candidate `output` is always a full `JudgeOutput`
+ * and so always carries `criteria`; the optionality is for the expected side.
+ */
 export interface ScorerJudgeOutput {
   keep: boolean;
   qualityScore: number;
+  criteria?: CriteriaScores;
 }
 
 /** Braintrust scorer args, narrowed to the fields these scorers consume. */
@@ -64,4 +76,42 @@ export function keepConfusion({ output, expected }: ScorerArgs): KeepConfusionRe
     score: output.keep === expected.keep ? 1 : 0,
     metadata: { falseKeep, falseReplace },
   };
+}
+
+/** One per-axis score column. `score: null` is a deliberate axis-skip. */
+export interface AxisScoreResult {
+  name: string;
+  score: number | null;
+}
+
+/**
+ * Per-axis criteria-MAE (#1067). Returns one `criteria_mae_<axis>` column per
+ * `CriteriaScores` axis (iterating `CRITERIA_KEYS`, never hardcoded), each
+ * `1 − |output_axis − expected_axis| / 10` clamped to [0,1]. The scale divisor
+ * is 10 because criteria sub-scores are 0–10 (not 0–100 like qualityScore).
+ *
+ * A row missing an axis on EITHER side (the expected side has no `criteria`, or
+ * either side omits that key) null-skips THAT axis only — `score: null`, which
+ * Braintrust drops from the column's aggregate rather than averaging in a 0.
+ * The contract is "never fabricate agreement OR disagreement from absence": a
+ * missing baseline axis is unknown, not a perfect match and not a total miss.
+ *
+ * Braintrust supports a scorer returning an array of `{name, score}` objects,
+ * each rendering as its own column (verified via the Braintrust docs,
+ * 2026-06-12: a scorer may return `number | {score, name?, metadata?} | null`,
+ * or an array thereof). Always emits all 7 columns so the experiment UI shape
+ * is stable even when every axis skips.
+ */
+export function criteriaAxisMAE({ output, expected }: ScorerArgs): AxisScoreResult[] {
+  const out = output.criteria;
+  const exp = expected.criteria;
+  return CRITERIA_KEYS.map((axis): AxisScoreResult => {
+    const name = `criteria_mae_${axis}`;
+    const o = out?.[axis];
+    const e = exp?.[axis];
+    if (typeof o !== 'number' || typeof e !== 'number') {
+      return { name, score: null };
+    }
+    return { name, score: Math.max(0, 1 - Math.abs(o - e) / 10) };
+  });
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph Builder["build-dataset.ts (per-row)"]
        DB[("review.sqlite<br/>photo_score + photo_current")]
        DB -->|"criteria_json → expected.criteria<br/>url → input.imageUrl<br/>local cache → input.readPath"| ROW[EvalRow]
    end

    subgraph Eval["photo-judge.eval.ts (bt eval)"]
        ROW --> RUN[runRow]
        RUN -->|reads bytes from readPath| JUDGE[traced Gemini judge]
        RUN -->|sourceUrl = R2 imageUrl| SPAN["Braintrust span<br/>live thumbnail + contentHash"]
        JUDGE --> SCORERS{scorers}
        SCORERS --> S1[keep_agreement]
        SCORERS --> S2[score_mae]
        SCORERS --> S3[keep_confusion]
        SCORERS --> S4["criteria_mae_#lt;axis#gt; ×7<br/>(null-skip a missing axis)"]
    end

    subgraph Analyze["analyze-experiment.ts (read-only, post-run)"]
        EXP[(completed experiment)] -->|bt sql, injected| HELP[pure helpers]
        HELP --> AUC[AUC]
        HELP --> CAL[calibrated ceiling]
        HELP --> BAND[ambiguity band]
        HELP --> HYB[hybrid-routing preview]
    end
```

## Summary

- **Why:** the first criteria-clean gate run (78.67% keep-agreement vs. the ≥90% bar) surfaced three things the eval should measure but didn't — none changes judging behavior or the gate; all make the eval a better instrument for the next model and the hybrid-design decision (#1067).
- **Per-axis scoring:** a multi-output `criteria_mae_<axis>` scorer (one column per `CRITERIA_KEYS` axis) compares Opus's `criteria_json` sub-scores against the candidate's; a missing axis on either side null-skips that column only (never a phantom 0). The 3 existing scorers are untouched; a det-gate row's zeroed criteria can never reach a scorer (coupled to the existing query filter by test).
- **Dataset-level diagnostics:** a new committed, read-only `analyze-experiment.ts` (`npm run analyze`) prints AUC, the calibrated-threshold ceiling, the ambiguity band, and a hybrid-routing preview — the dataset-level reads that can't be per-row scorers. Pure helpers, unit-tested on a hand-built fixture; the Braintrust read is injected so tests need no network.
- **Portable provenance:** the span's `sourceUrl` is now the verbatim production R2 URL (`photo_current.url`, mixed `.jpg`/`.jpeg`/`.png` — never templated, which would 404 for hundreds of species) so Braintrust renders the live thumbnail; the local cache path is the byte-read target only; `content_hash` lands in span metadata.

## Screenshots

N/A — not UI (all changes under `tools/photo-curation/**` + a runbook).

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — green (300 tests, +18 new across build-dataset / scorers / run-row / analyze-experiment)
- [x] New unit tests added: per-axis MAE (match/gap/null-skip/7-columns), `parseCriteria`, verbatim R2 URL vs. local readPath, det-gate zeroed-criteria exclusion, AUC/calibrated-threshold/band/hybrid pure helpers on known-answer fixtures, injected-reader `main`
- [x] `npm run build -w @bird-watch/photo-curation` (tsc) — clean
- [x] `npx knip` — exit 0 (the one config hint is a pre-existing, unrelated map-v1-prototype note)
- [x] Smoke-ran `npx tsx scripts/analyze-experiment.ts` — usage/exit-code path works; the live `bt sql` read is operator-run (no network in CI)
- [ ] (UI only) N/A — not UI

## Plan reference

Closes #1067. Out of plan — eval-instrument follow-ups motivated by the pinned gate run `HEAD-1781264762`; builds on merged #1038 + #1066.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
