### PR TITLE
fix(db-client): attach pool-level 'error' handler so an idle-client error never crashes the process

### DIFF
--- a/packages/db-client/src/pool-error-handler.test.ts
+++ b/packages/db-client/src/pool-error-handler.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import pg from 'pg';
+import { createPool, closePool } from './pool.js';
+
+// These tests need NO real database. They construct a pool (which does not open
+// a connection until a query runs) and assert that an idle-client `'error'`
+// event emitted on the pool is caught by a handler `createPool` attaches —
+// rather than becoming an uncaught exception that exits the process.
+//
+// Regression guard for #1069: node-postgres docs mandate a pool-level `'error'`
+// listener; without one, an idle client erroring (a CI testcontainers teardown
+// blip, or a prod network blip) crashes the process. The `test` CI workflow
+// flaked on exactly this — an uncaught `pg-protocol` parser exception off an
+// idle socket, with zero failed assertions.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createPool idle-client error handling (#1069)', () => {
+  it('attaches a pool-level error listener so an idle-client error is not uncaught', () => {
+    const pool = createPool({ databaseUrl: 'postgresql://unused:unused@127.0.0.1:1/none' });
+    try {
+      // Without a listener, EventEmitter rethrows an emitted 'error' (which is
+      // what becomes the process-killing uncaught exception in CI). The handler
+      // createPool attaches must absorb it.
+      expect(pool.listenerCount('error')).toBeGreaterThan(0);
+    } finally {
+      closePool(pool);
+    }
+  });
+
+  it('swallows (does not rethrow) an emitted idle-client error', () => {
+    const pool = createPool({ databaseUrl: 'postgresql://unused:unused@127.0.0.1:1/none' });
+    const fakeClient = {} as pg.PoolClient;
+    try {
+      // If no handler is attached, EventEmitter throws here. The handler must
+      // not rethrow, so this emit returns cleanly.
+      expect(() =>
+        pool.emit('error', new Error('idle client boom'), fakeClient),
+      ).not.toThrow();
+    } finally {
+      closePool(pool);
+    }
+  });
+
+  it('structured-logs the idle-client error in the repo {severity, message} shape', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const pool = createPool({ databaseUrl: 'postgresql://unused:unused@127.0.0.1:1/none' });
+    const fakeClient = {} as pg.PoolClient;
+    try {
+      pool.emit('error', new Error('idle client boom'), fakeClient);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const logged = errorSpy.mock.calls[0][0];
+      expect(typeof logged).toBe('string');
+      const parsed = JSON.parse(logged as string);
+      expect(parsed.severity).toBe('ERROR');
+      expect(parsed.message).toBe('db_pool_idle_client_error');
+      expect(parsed.error).toContain('idle client boom');
+    } finally {
+      closePool(pool);
+    }
+  });
+});

--- a/packages/db-client/src/pool.ts
+++ b/packages/db-client/src/pool.ts
@@ -35,6 +35,23 @@ export function createPool(opts: PoolOptions): pg.Pool {
     statement_timeout: opts.statement_timeout ?? 15_000,
     connectionTimeoutMillis: opts.connectionTimeoutMillis ?? 10_000,
   });
+  // An idle pooled client that hits a backend/network error emits 'error' on
+  // the pool. node-postgres docs are explicit: without a pool-level listener,
+  // that event becomes an uncaught exception and the node process exits
+  // (#1069 — the `test` CI job flaked on exactly this, a pg-protocol parser
+  // error parsed off an idle socket during testcontainers teardown; the same
+  // gap would crash read-api/ingestor on any prod network blip). Log in the
+  // repo's structured {severity, message, …} shape and swallow — pg will evict
+  // and replace the dead client on its own; rethrowing would defeat the point.
+  pool.on('error', (err) => {
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: 'db_pool_idle_client_error',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  });
   if (opts.key) POOLS.set(opts.key, pool);
   return pool;
 }

--- a/packages/db-client/src/test-helpers.ts
+++ b/packages/db-client/src/test-helpers.ts
@@ -22,6 +22,22 @@ export async function startTestDb(): Promise<TestDb> {
   ).start();
   const url = container.getConnectionUri();
   const pool = new pg.Pool({ connectionString: url, max: 4 });
+  // Mirror createPool's idle-client error guard (#1069). This pool is built
+  // directly (not via createPool) to keep the integration harness's config —
+  // no statement_timeout, max: 4 — but it is precisely the pool most exposed to
+  // the flake: testcontainers tearing its container down can fire 'error' on an
+  // idle client between suites. Without a listener that becomes an uncaught
+  // exception that reds the whole `test` run. Log and swallow; pg evicts the
+  // dead client.
+  pool.on('error', (err) => {
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: 'db_pool_idle_client_error',
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  });
 
   const migrationsDir = resolve(process.cwd(), '../../migrations');
   const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Idle as Idle pooled client
    participant Pool as pg.Pool via createPool
    participant Proc as node process

    Note over Idle: backend or network error<br/>CI testcontainers teardown<br/>prod network blip
    Idle->>Pool: emit error event
    alt before this PR — no listener
        Pool-->>Proc: EventEmitter rethrows, uncaught exception
        Proc-->>Proc: process exits, test CI job reds
    else after this PR — pool.on error handler
        Pool->>Pool: console.error structured log, severity ERROR
        Pool->>Pool: pg evicts and replaces the dead client
        Note over Proc: process survives
    end
```

## Summary

- **Why:** node-postgres emits `'error'` on the pool when an *idle* pooled client hits a backend/network error. Per its docs, with no pool-level listener that event becomes an **uncaught exception and the node process exits**. `createPool` (`packages/db-client/src/pool.ts`) built `new pg.Pool(...)` with no such listener, so the Mergify-gating `test` CI job intermittently went red with an unhandled `pg-protocol` parser exception (an error parsed off an idle socket during testcontainers teardown — zero failed assertions, clean re-run green). The same gap would crash `read-api`/`ingestor` on any prod network blip. Fixes #1069.
- **What:** Attach a `pool.on('error', …)` handler in `createPool` that structured-logs in the repo's `{severity, message, …}` shape and **swallows** (does not rethrow — pg evicts/replaces the dead client itself, so rethrowing only re-creates the crash). Attached once per constructed pool (the `POOLS` memo builds keyed pools once), covering every `createPool` consumer in CI and prod. The integration `test-helpers` pool is built directly (not via `createPool`) to keep its harness config (`max: 4`, no `statement_timeout`), but it is the pool most exposed to the teardown-timing flake, so it gets the same guard (belt-and-suspenders, per the issue).
- **Not done:** no vitest `retry` / `dangerouslyIgnoreUnhandledErrors` (root-cause fix per CLAUDE.md); teardown ordering left unchanged — it was already correct (`TestDb.stop` ends the pool before stopping the container), the original teardown-ordering diagnosis was retracted in the issue.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build` — clean production build (all workspaces)
- [x] `npm run test -w @bird-watch/db-client` — green (19 files, 163 passed | 1 todo) against real testcontainers Postgres
- [x] New regression test `packages/db-client/src/pool-error-handler.test.ts` (container-free): builds a pool via `createPool`, emits `'error'`, asserts the emit does **not** throw (the uncaught-exception mechanism) and the handler logs in the expected `{severity:'ERROR', message:'db_pool_idle_client_error', error}` shape. Confirmed red on the unfixed tree (EventEmitter rethrew `idle client boom`), green after the fix.
- [x] `npx knip` — exit 0
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` change

Reproduction note (AC #2): the CI race is timing-dependent and not reliably reproducible on demand; per the issue, the container-free unit test stands in as the regression guard, proving the handler is attached and absorbs an emitted idle-client error.

## Plan reference

Out of plan — bug fix for #1069 (pre-existing, PR-independent CI flake: unhandled `pg-protocol` exception in the `test` workflow).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1069
