### PR TITLE
feat(db): species_photo_scores prod table — append-only baseline pin (C1 #1070)

### DIFF
--- a/migrations/1700000053000_add_species_photo_scores.sql
+++ b/migrations/1700000053000_add_species_photo_scores.sql
@@ -1,0 +1,60 @@
+-- Up Migration
+--
+-- species_photo_scores — append-only, immutable photo-quality judge scores
+-- promoted from the operator-local `review.sqlite` into prod Postgres (epic
+-- #1074, child C1 #1070).
+--
+-- WHY append-only: re-scoring a photo INSERTs a new row, never UPDATEs an
+-- existing one. A frozen `(model, rubric_version)` pin is then an immutable,
+-- reproducible ground-truth baseline the photo-judge eval (#1010, C4 #1073)
+-- grades a candidate scorer against. Mutating a score in place would silently
+-- move the baseline out from under any prior eval run, breaking reproducibility.
+--
+-- UNIQUE (species_code, content_hash, model, rubric_version) is what enforces
+-- the append-without-duplicate contract: the SAME image (content_hash) judged
+-- by the SAME (model, rubric_version) is recorded once; a different image, a
+-- newer model, or a bumped rubric each get their own row. This is also the
+-- conflict target the C2 idempotent backfill (#1072) upserts against.
+--
+-- The pin index (model, rubric_version) serves the eval's primary read pattern:
+-- "fetch every score for this frozen baseline pin". It is intentionally NOT on
+-- (species_code) first — per-species reads ride the UNIQUE constraint's index.
+--
+-- Columns mirroring the judge's output:
+--   keep           — the binary keep/swap verdict (NOT NULL — every score has one).
+--   quality_score  — overall 0–10 score (REAL, nullable: the 13 deterministic-gate
+--                    rows have a verdict but no model-assigned numeric score).
+--   criteria       — the 7-axis 0–10 score map (JSONB).
+--   field_marks    — the diagnostic field-marks array (JSONB).
+--   rationale      — the judge's free-text justification (nullable).
+--   model          — the judging model id (e.g. 'claude-opus-4-8', or
+--                    'deterministic-gate' for the gate rows — see epic #1074).
+--   rubric_version — the rubric the score was produced under.
+--
+-- JSONB (not TEXT-for-json) for criteria/field_marks follows the repo's
+-- structured-column convention (observation_grid_agg.families is JSONB,
+-- migration 51000): we store machine-shaped data the DB can index/query, not
+-- opaque blobs.
+--
+-- FK species_code → species_meta(species_code) ON DELETE CASCADE matches every
+-- other species-keyed child table (species_photos 20000, species_descriptions
+-- 30000): deleting a species reaps its scores.
+CREATE TABLE species_photo_scores (
+  id             BIGSERIAL PRIMARY KEY,
+  species_code   TEXT NOT NULL REFERENCES species_meta(species_code) ON DELETE CASCADE,
+  content_hash   TEXT NOT NULL,
+  model          TEXT NOT NULL,
+  rubric_version TEXT NOT NULL,
+  keep           BOOLEAN NOT NULL,
+  quality_score  REAL,
+  criteria       JSONB,
+  field_marks    JSONB,
+  rationale      TEXT,
+  scored_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (species_code, content_hash, model, rubric_version)
+);
+
+CREATE INDEX idx_species_photo_scores_pin ON species_photo_scores (model, rubric_version);
+
+-- Down Migration
+DROP TABLE IF EXISTS species_photo_scores;

--- a/packages/db-client/src/species-photo-scores-migration.test.ts
+++ b/packages/db-client/src/species-photo-scores-migration.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Integration test for migration 1700000053000 — species_photo_scores table
+ * (epic #1074, child C1 #1070).
+ *
+ * Locks the schema contract for the append-only photo-quality score table that
+ * gives the photo-judge eval (#1010) an immutable, reproducible baseline pin.
+ * Mirrors the shape of species-descriptions-migration.test.ts and
+ * state-boundaries-migration.test.ts: columns / FK / UNIQUE / pin index /
+ * append-only / CASCADE invariants are verified against a fully-migrated
+ * PostGIS testcontainer.
+ *
+ * No DB mocks per CLAUDE.md "No DB mocks in tests".
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers before any query.
+import './pool.js';
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+const MIGRATION_FILE = '1700000053000_add_species_photo_scores.sql';
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const sql = readFileSync(filePath, 'utf-8');
+  const [rawUpPart = '', rawDownPart = ''] = sql.split(/-- Down Migration/i);
+  return {
+    up: rawUpPart.replace(/-- Up Migration/i, '').trim(),
+    down: rawDownPart.trim(),
+  };
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  // Apply all Up migrations in numeric order. startTestDb does the same.
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  for (const f of files) {
+    const { up } = parseMigration(join(migrationsDir, f));
+    if (up) {
+      await pool.query(up);
+    }
+  }
+
+  // Seed a parent species for the FK.
+  await pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+     VALUES ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers')`
+  );
+}, 180_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+describe('migration 1700000053000_add_species_photo_scores — Up', () => {
+  it('creates species_photo_scores with the documented columns and types', async () => {
+    const { rows } = await pool.query<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>(
+      `SELECT column_name, data_type, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_name = 'species_photo_scores'
+        ORDER BY ordinal_position`
+    );
+    const byName = Object.fromEntries(rows.map(r => [r.column_name, r]));
+
+    expect(Object.keys(byName).sort()).toEqual(
+      [
+        'criteria', 'content_hash', 'field_marks', 'id', 'keep', 'model',
+        'quality_score', 'rationale', 'rubric_version', 'scored_at',
+        'species_code',
+      ].sort()
+    );
+
+    // id BIGSERIAL → bigint NOT NULL with a sequence default.
+    expect(byName.id?.data_type).toBe('bigint');
+    expect(byName.id?.is_nullable).toBe('NO');
+    expect(byName.id?.column_default).toMatch(/nextval/);
+
+    // species_code TEXT NOT NULL.
+    expect(byName.species_code?.data_type).toBe('text');
+    expect(byName.species_code?.is_nullable).toBe('NO');
+
+    // content_hash TEXT NOT NULL.
+    expect(byName.content_hash?.data_type).toBe('text');
+    expect(byName.content_hash?.is_nullable).toBe('NO');
+
+    // model TEXT NOT NULL.
+    expect(byName.model?.data_type).toBe('text');
+    expect(byName.model?.is_nullable).toBe('NO');
+
+    // rubric_version TEXT NOT NULL.
+    expect(byName.rubric_version?.data_type).toBe('text');
+    expect(byName.rubric_version?.is_nullable).toBe('NO');
+
+    // keep BOOLEAN NOT NULL.
+    expect(byName.keep?.data_type).toBe('boolean');
+    expect(byName.keep?.is_nullable).toBe('NO');
+
+    // quality_score REAL (nullable — deterministic-gate rows have no numeric score).
+    expect(byName.quality_score?.data_type).toBe('real');
+    expect(byName.quality_score?.is_nullable).toBe('YES');
+
+    // criteria JSONB (nullable).
+    expect(byName.criteria?.data_type).toBe('jsonb');
+    expect(byName.criteria?.is_nullable).toBe('YES');
+
+    // field_marks JSONB (nullable).
+    expect(byName.field_marks?.data_type).toBe('jsonb');
+    expect(byName.field_marks?.is_nullable).toBe('YES');
+
+    // rationale TEXT (nullable).
+    expect(byName.rationale?.data_type).toBe('text');
+    expect(byName.rationale?.is_nullable).toBe('YES');
+
+    // scored_at TIMESTAMPTZ NOT NULL DEFAULT NOW().
+    expect(byName.scored_at?.data_type).toBe('timestamp with time zone');
+    expect(byName.scored_at?.is_nullable).toBe('NO');
+    expect(byName.scored_at?.column_default).toMatch(/now\(\)/i);
+  });
+
+  it('declares species_code as a FK to species_meta with ON DELETE CASCADE', async () => {
+    const { rows } = await pool.query<{
+      delete_rule: string;
+      foreign_table: string;
+      foreign_column: string;
+    }>(
+      `SELECT rc.delete_rule,
+              ccu.table_name  AS foreign_table,
+              ccu.column_name AS foreign_column
+         FROM information_schema.referential_constraints rc
+         JOIN information_schema.constraint_column_usage ccu
+              ON rc.unique_constraint_name = ccu.constraint_name
+         JOIN information_schema.key_column_usage kcu
+              ON rc.constraint_name = kcu.constraint_name
+        WHERE kcu.table_name = 'species_photo_scores'
+          AND kcu.column_name = 'species_code'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.delete_rule).toBe('CASCADE');
+    expect(rows[0]?.foreign_table).toBe('species_meta');
+    expect(rows[0]?.foreign_column).toBe('species_code');
+  });
+
+  it('declares the UNIQUE constraint over (species_code, content_hash, model, rubric_version)', async () => {
+    const { rows } = await pool.query<{ columns: string }>(
+      `SELECT string_agg(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS columns
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.table_name = 'species_photo_scores'
+          AND tc.constraint_type = 'UNIQUE'
+        GROUP BY tc.constraint_name`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.columns).toBe('species_code,content_hash,model,rubric_version');
+  });
+
+  it('creates the pin index on (model, rubric_version)', async () => {
+    const { rows } = await pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+        WHERE tablename = 'species_photo_scores'
+          AND indexname = 'idx_species_photo_scores_pin'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.indexdef).toMatch(/\(model, rubric_version\)/);
+  });
+
+  it('UNIQUE blocks a duplicate (species_code, content_hash, model, rubric_version) but allows a re-score under a different model/rubric (append-only)', async () => {
+    await pool.query(
+      `INSERT INTO species_photo_scores
+         (species_code, content_hash, model, rubric_version, keep, quality_score, criteria, field_marks, rationale)
+       VALUES ('vermfly', 'sha256:aaa', 'claude-opus-4-8', 'v1', true, 8.5,
+               '{"composition": 9}'::jsonb, '["red crest"]'::jsonb, 'sharp, diagnostic')`
+    );
+
+    // Exact same key → blocked.
+    await expect(
+      pool.query(
+        `INSERT INTO species_photo_scores
+           (species_code, content_hash, model, rubric_version, keep)
+         VALUES ('vermfly', 'sha256:aaa', 'claude-opus-4-8', 'v1', false)`
+      )
+    ).rejects.toThrow(/duplicate key|unique/i);
+
+    // Same image, different model → appends (new row).
+    await pool.query(
+      `INSERT INTO species_photo_scores
+         (species_code, content_hash, model, rubric_version, keep)
+       VALUES ('vermfly', 'sha256:aaa', 'gemini-2.5-flash', 'v1', true)`
+    );
+    // Same image+model, bumped rubric → appends (new row).
+    await pool.query(
+      `INSERT INTO species_photo_scores
+         (species_code, content_hash, model, rubric_version, keep)
+       VALUES ('vermfly', 'sha256:aaa', 'claude-opus-4-8', 'v2', true)`
+    );
+
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_photo_scores WHERE content_hash = 'sha256:aaa'`
+    );
+    expect(Number(rows[0]?.count)).toBe(3);
+    await pool.query(`DELETE FROM species_photo_scores`);
+  });
+
+  it('allows a deterministic-gate row with a NULL quality_score', async () => {
+    await pool.query(
+      `INSERT INTO species_photo_scores
+         (species_code, content_hash, model, rubric_version, keep, quality_score)
+       VALUES ('vermfly', 'sha256:gate', 'deterministic-gate', 'v1', false, NULL)`
+    );
+    const { rows } = await pool.query<{ quality_score: number | null }>(
+      `SELECT quality_score FROM species_photo_scores WHERE content_hash = 'sha256:gate'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.quality_score).toBeNull();
+    await pool.query(`DELETE FROM species_photo_scores`);
+  });
+
+  it('CASCADEs score rows when the parent species is deleted', async () => {
+    await pool.query(
+      `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+       VALUES ('annhum-tmp', 'Anna''s Hummingbird', 'Calypte anna', 'trochilidae', 'Hummingbirds')`
+    );
+    await pool.query(
+      `INSERT INTO species_photo_scores
+         (species_code, content_hash, model, rubric_version, keep)
+       VALUES ('annhum-tmp', 'sha256:bbb', 'claude-opus-4-8', 'v1', true)`
+    );
+    await pool.query(`DELETE FROM species_meta WHERE species_code = 'annhum-tmp'`);
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM species_photo_scores WHERE species_code = 'annhum-tmp'`
+    );
+    expect(Number(rows[0]?.count)).toBe(0);
+  });
+});
+
+describe('migration 1700000053000_add_species_photo_scores — Down/Up round-trip', () => {
+  it('Down drops the table; re-applying Up restores it cleanly and is idempotent', async () => {
+    const migrationsDir = resolve(process.cwd(), '../../migrations');
+    const { up, down } = parseMigration(join(migrationsDir, MIGRATION_FILE));
+    expect(down).toBeTruthy();
+
+    await pool.query(down);
+    const { rows: gone } = await pool.query<{ reg: string | null }>(
+      `SELECT to_regclass('species_photo_scores') AS reg`
+    );
+    expect(gone[0]?.reg).toBeNull();
+
+    // Down is idempotent — running it again must not error.
+    await expect(pool.query(down)).resolves.toBeDefined();
+
+    // Re-apply Up so the table (and its pin index) come back cleanly.
+    await pool.query(up);
+    const { rows: back } = await pool.query<{ reg: string | null }>(
+      `SELECT to_regclass('species_photo_scores') AS reg`
+    );
+    expect(back[0]?.reg).not.toBeNull();
+
+    const { rows: idx } = await pool.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+        WHERE tablename = 'species_photo_scores'
+          AND indexname = 'idx_species_photo_scores_pin'`
+    );
+    expect(idx).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
erDiagram
    species_meta ||--o{ species_photo_scores : "species_code (FK, ON DELETE CASCADE)"
    species_photo_scores {
        bigserial id PK
        text species_code FK
        text content_hash
        text model
        text rubric_version
        boolean keep
        real quality_score "nullable"
        jsonb criteria "nullable — 7-axis 0–10 map"
        jsonb field_marks "nullable — diagnostic marks"
        text rationale "nullable"
        timestamptz scored_at "DEFAULT NOW()"
    }
```

```mermaid
flowchart LR
    A["re-score a photo"] -->|"INSERT (never UPDATE)"| T[species_photo_scores]
    U["UNIQUE(species_code,<br/>content_hash, model, rubric_version)"] -.->|"blocks exact dup,<br/>allows new model/rubric"| T
    P["idx_..._pin<br/>(model, rubric_version)"] -.->|"serves eval's<br/>'frozen baseline pin' read"| T
    E["photo-judge eval (#1010, C4)"] -->|"reads frozen pin"| T
```

## Summary

- **Why:** the 902 Opus photo-quality scores currently live only in one operator's `review.sqlite`, which makes the photo-judge eval (#1010) non-reproducible and blocks any cloud scorer. This promotes them to a prod-resident table — an immutable, reproducible baseline pin — and gives a future production scorer a first-class place to write. (Epic #1074.)
- **Append-only is the invariant:** re-scoring INSERTs a new row, never mutates. `UNIQUE(species_code, content_hash, model, rubric_version)` enforces append-without-duplicate (and is C2's upsert conflict target #1071); the `(model, rubric_version)` pin index serves the eval's "fetch the frozen pin" read. Mutating in place would silently move the baseline out from under a prior eval run.
- **C1 only:** this is just the table + its migration test. db-client functions (C2 #1071), backfill (C3 #1072), and eval changes (C4 #1073) are out of scope.

## Screenshots

N/A — not UI. (Migration SQL + a db-client migration test; no `frontend/**` changes.)

## Test plan

- [x] `npm run test -w @bird-watch/db-client` — green (19 files / 168 passed + 1 todo, testcontainers, no mocks). New `species-photo-scores-migration.test.ts` asserts columns/types, FK CASCADE, the `UNIQUE` constraint, the pin index, append-on-different-pin, NULL `quality_score` for deterministic-gate rows, and clean idempotent down/up round-trip.
- [x] TDD red→green: ran the new test with the migration file moved aside → all 8 fail (table absent); restored → all 8 pass.
- [x] `node-pg-migrate up` applies the full chain (mine last) AND `node-pg-migrate down` rolls it back cleanly (`to_regclass` → NULL) against a throwaway PostGIS container — not just the test harness's SQL split.
- [x] `npm run build` — clean across all workspaces.
- [x] `npx knip` — exit 0 (only the pre-existing unrelated `map-v1-prototype` config hint).
- [ ] New Playwright e2e spec — N/A (no user-visible behavior).

## Plan reference

Part of epic #1074 (promote-scores-to-prod), child **C1**. Closes #1070. Plans live in issues, not `docs/plans/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)