### PR TITLE
fix(detail-sheet): no dismissal path — shared sheet header (grabber + close + Escape)

### DIFF
--- a/frontend/e2e/safe-area.spec.ts
+++ b/frontend/e2e/safe-area.spec.ts
@@ -82,6 +82,9 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
     const safeAreaResult = await page.evaluate(() => {
       const matchedPaddingValues: string[] = [];
       const matchedPaddingShorthands: string[] = [];
+      // #430 — landscape notch insets on the base rule (left + right).
+      const matchedPaddingLeftValues: string[] = [];
+      const matchedPaddingRightValues: string[] = [];
 
       for (const sheet of Array.from(document.styleSheets)) {
         let rules: CSSRuleList;
@@ -100,13 +103,22 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
 
           const paddingBottom = rule.style.getPropertyValue('padding-bottom');
           const padding = rule.style.getPropertyValue('padding');
+          const paddingLeft = rule.style.getPropertyValue('padding-left');
+          const paddingRight = rule.style.getPropertyValue('padding-right');
 
           if (paddingBottom) matchedPaddingValues.push(paddingBottom);
           if (padding) matchedPaddingShorthands.push(padding);
+          if (paddingLeft) matchedPaddingLeftValues.push(paddingLeft);
+          if (paddingRight) matchedPaddingRightValues.push(paddingRight);
         }
       }
 
-      return { matchedPaddingValues, matchedPaddingShorthands };
+      return {
+        matchedPaddingValues,
+        matchedPaddingShorthands,
+        matchedPaddingLeftValues,
+        matchedPaddingRightValues,
+      };
     });
 
     // The production declaration at styles.css:1219:
@@ -125,6 +137,38 @@ test.describe('SpeciesDetailSheet safe-area inset guard (MOB-5 / V1 #788)', () =
       `Found padding-bottom values: ${JSON.stringify(safeAreaResult.matchedPaddingValues)}; ` +
       `padding shorthand values: ${JSON.stringify(safeAreaResult.matchedPaddingShorthands)}. ` +
       `This fails if styles.css:1219 (padding-bottom: env(safe-area-inset-bottom, 0)) is removed.`,
+    ).toBe(true);
+
+    // ── 1b. #430 — landscape-notch left/right insets (falsifiable probe) ───────
+    //
+    // On a notched iPhone held landscape the camera cutout intrudes from one
+    // side; the base .species-detail-sheet rule must consume
+    // env(safe-area-inset-left) and env(safe-area-inset-right) so the grip +
+    // content clear it. Same authored-CSSStyleRule-source-string probe as the
+    // padding-bottom guard above — fails on removal of either declaration.
+    const leftValues = [
+      ...safeAreaResult.matchedPaddingLeftValues,
+      ...safeAreaResult.matchedPaddingShorthands,
+    ];
+    const rightValues = [
+      ...safeAreaResult.matchedPaddingRightValues,
+      ...safeAreaResult.matchedPaddingShorthands,
+    ];
+    expect(
+      leftValues.some((v) => v.includes('env(safe-area-inset-left')),
+      `Expected a .species-detail-sheet rule with padding-left (or padding ` +
+      `shorthand) containing env(safe-area-inset-left). ` +
+      `Found padding-left: ${JSON.stringify(safeAreaResult.matchedPaddingLeftValues)}; ` +
+      `padding shorthand: ${JSON.stringify(safeAreaResult.matchedPaddingShorthands)}. ` +
+      `This fails if the #430 padding-left: env(safe-area-inset-left, 0) is removed.`,
+    ).toBe(true);
+    expect(
+      rightValues.some((v) => v.includes('env(safe-area-inset-right')),
+      `Expected a .species-detail-sheet rule with padding-right (or padding ` +
+      `shorthand) containing env(safe-area-inset-right). ` +
+      `Found padding-right: ${JSON.stringify(safeAreaResult.matchedPaddingRightValues)}; ` +
+      `padding shorthand: ${JSON.stringify(safeAreaResult.matchedPaddingShorthands)}. ` +
+      `This fails if the #430 padding-right: env(safe-area-inset-right, 0) is removed.`,
     ).toBe(true);
 
     // ── 2. padding-top authored CSS source-string assertion ───────────────────

--- a/frontend/e2e/sheet-snap.spec.ts
+++ b/frontend/e2e/sheet-snap.spec.ts
@@ -110,6 +110,31 @@ test.describe('SpeciesDetailSheet snap behavior', () => {
     await expect(page.locator('[data-testid=species-detail-sheet]')).toHaveCount(0);
   });
 
+  test('× single-pointer dismissal clears ?detail= (WCAG 2.5.7, #1026)', async ({ page, apiStub }) => {
+    await apiStub.stubEmpty();
+    await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
+    await apiStub.stubPhotoImage();
+    const app = new AppPage(page);
+    await app.goto('detail=vermfly&view=detail');
+    await app.waitForAppReady();
+
+    const sheet = page.locator('[data-testid=species-detail-sheet]');
+    await expect(sheet).toHaveAttribute('data-snap-state', 'half');
+
+    // The shared SheetHeader × is the non-drag dismissal alternative to the
+    // swipe-down handle. A single click must dismiss the sheet and clear the
+    // detail URL state (same post-close URL contract as drag-dismiss above:
+    // both ?view= and ?detail= drop since 'map' is the default view).
+    await page.getByRole('button', { name: 'Close species detail' }).click();
+
+    await expect(page).not.toHaveURL(/view=detail/);
+    await expect.poll(
+      () => new URL(page.url()).searchParams.get('detail'),
+      { timeout: 5_000 },
+    ).toBeNull();
+    await expect(page.locator('[data-testid=species-detail-sheet]')).toHaveCount(0);
+  });
+
   test('drag-up grows the sheet ~1:1; a fast up-flick snaps to full', async ({ page, apiStub }) => {
     await apiStub.stubEmpty();
     await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ import { regionLabelFor } from './config/region.js';
 import { prefetchMapCanvas } from './prefetch.js';
 import { SurfaceTitleSync } from './components/SurfaceTitleSync.js';
 import { StatusBlock } from './components/ds/StatusBlock.js';
+import { SheetHeader } from './components/ds/SheetHeader.js';
 
 const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? '' });
 
@@ -336,6 +337,10 @@ export function App() {
     if (!filtersOpen) return;
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') {
+        // preventDefault so the detail sheet's bubble-phase Escape handler
+        // (#1026 carve-out 1) yields when BOTH sheets are open — this capture-
+        // phase handler fires first, claims the key, and closes filters only.
+        e.preventDefault();
         setFiltersOpen(false);
       }
     };
@@ -1275,14 +1280,17 @@ export function App() {
             role="region"
             aria-label="Filters"
           >
-            <button
-              type="button"
-              className="filters-panel-close"
-              onClick={() => setFiltersOpen(false)}
-              aria-label="Close filters"
-            >
-              ×
-            </button>
+            {/* Shared sheet-header × (#1026): the same bare-× affordance the
+                detail sheet now uses. No grabber — the filters surface is a
+                plain panel, not a draggable detent sheet (full detent mechanics
+                for filters are out of scope). `aria-label="Close filters"` and
+                the `filters-panel-close` className stay byte-identical so the
+                existing CSS and the e2e POM selector resolve unchanged. */}
+            <SheetHeader
+              closeLabel="Close filters"
+              onClose={() => setFiltersOpen(false)}
+              closeClassName="filters-panel-close"
+            />
             <FiltersBar
               since={state.since}
               notable={state.notable}

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -205,32 +205,216 @@ describe('<SpeciesDetailSheet>', () => {
     await waitFor(() => expect(mainEl).not.toHaveAttribute('inert'));
   });
 
-  it('ESC scoped: collapses sheet only when focus is inside the sheet', async () => {
-    const onClose = vi.fn();
-    render(
-      <SpeciesDetailSheet
-        speciesCode="vermfly"
-        apiClient={makeClient()}
-        onClose={onClose}
-        mainRef={{ current: mainEl }}
-      />
-    );
-    const sheet = await screen.findByTestId('species-detail-sheet');
-    const expand = await screen.findByRole('button', { name: /expand/i });
-    await userEvent.click(expand);
-    expect(sheet).toHaveAttribute('data-snap-state', 'full');
+  // ─── Single-pointer dismissal: the shared × (WCAG 2.5.7, #1026) ────────────
+  //
+  // The sheet used to offer NO single-pointer, non-drag dismissal: the only
+  // affordance was the drag handle (swipe-down) — which fails WCAG 2.5.7 (a
+  // dragging gesture needs a single-pointer alternative). The shared SheetHeader
+  // × is that alternative; it is visible at EVERY snap and calls
+  // closeWithRestore (so #910 focus-restore is preserved on this path too).
+  describe('× close button (single-pointer dismissal — WCAG 2.5.7)', () => {
+    it('renders the × at half (the open detent) and click → onClose', async () => {
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+      const close = screen.getByRole('button', { name: 'Close species detail' });
+      expect(close).toBeInTheDocument();
+      await userEvent.click(close);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
 
-    // Move focus outside the sheet (back into <main>) — ESC should NOT
-    // collapse the sheet now.
-    mainEl.tabIndex = 0;
-    mainEl.focus();
-    await userEvent.keyboard('{Escape}');
-    expect(sheet).toHaveAttribute('data-snap-state', 'full');
+    it('renders the × at full and click → onClose', async () => {
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      const expand = await screen.findByRole('button', { name: /expand/i });
+      await userEvent.click(expand);
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+      const close = screen.getByRole('button', { name: 'Close species detail' });
+      expect(close).toBeInTheDocument();
+      await userEvent.click(close);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
 
-    // Move focus back inside the sheet — ESC should collapse it (full → half).
-    expand.focus();
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+    it('renders the × at peek and click → onClose', async () => {
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      const handle = await screen.findByTestId('species-detail-sheet-handle');
+      // Drag down from half to the peek detent (slow, short drag — settles to
+      // the nearest detent by position, below the dismiss floor).
+      handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 1, bubbles: true }));
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+      const close = screen.getByRole('button', { name: 'Close species detail' });
+      expect(close).toBeInTheDocument();
+      await userEvent.click(close);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Escape — pinned predicate (#1026) ─────────────────────────────────────
+  //
+  // Escape now DISMISSES the sheet (closeWithRestore → onClose), matching the
+  // desktop rail + the filters sheet, rather than stepwise-collapsing detents.
+  // The handler is document-level in the BUBBLE phase (so the scope popover's
+  // stopPropagation claim still wins) and bails in exactly three cases:
+  //   1. e.defaultPrevented (an inner widget already claimed the key)
+  //   2. focus is inside an open native <dialog> (Credits closes natively)
+  //   3. focus is inside a [role="dialog"] surface (portaled popovers) OR
+  //      inside the map layer (mainRef) — MapLibre / popovers own Escape there.
+  describe('Escape dismisses (pinned predicate)', () => {
+    it('Escape with focus on document.body → onClose fires (no keyboard trap)', async () => {
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+      // Normal post-open state: focus is NOT inside the sheet (it sits on body).
+      (document.activeElement as HTMLElement | null)?.blur?.();
+      expect(document.activeElement === document.body || document.activeElement === null).toBe(true);
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('Escape with focus inside the sheet → DISMISSES (onClose), not stepwise-collapse', async () => {
+      // Inverted from the old contract: a focus-inside Escape used to step
+      // full→half. It now dismisses outright (matching rail + filters).
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      const expand = await screen.findByRole('button', { name: /expand/i });
+      await userEvent.click(expand);
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+      expand.focus();
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('Escape with focus inside the map layer (mainRef) → sheet stays open (carve-out 3, map owns Escape)', async () => {
+      // Renamed from the old focus-scoping test: the sheet stays open NOT
+      // because Escape is focus-scoped to the sheet, but because mainEl IS
+      // mainRef.current (the #map-layer) — MapLibre / its controls own Escape
+      // when focus is on the map.
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      const expand = await screen.findByRole('button', { name: /expand/i });
+      await userEvent.click(expand);
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+      // Focus an element INSIDE mainRef.current (#map-layer) — Escape must NOT
+      // close the sheet (the map owns the key there).
+      const mapChild = document.createElement('button');
+      mapChild.type = 'button';
+      mainEl.appendChild(mapChild);
+      mapChild.focus();
+      await userEvent.keyboard('{Escape}');
+      expect(onClose).not.toHaveBeenCalled();
+      expect(sheet).toHaveAttribute('data-snap-state', 'full');
+    });
+
+    it('Escape with focus inside a body-portaled [role="dialog"] → sheet stays open (carve-out 3, popover owns Escape)', async () => {
+      // The Cell/ClusterList popovers createPortal to document.body so mainRef
+      // containment cannot cover them; their own Escape handlers do not
+      // preventDefault and register after the sheet's listener. Without the
+      // [role="dialog"] half of carve-out 3 one keypress would double-close
+      // popover + sheet. Both popovers focus a heading on mount, so
+      // closest('[role="dialog"]') is truthy whenever one is open.
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+      // A body-portaled role="dialog" stub with a focused inner element.
+      const dialog = document.createElement('div');
+      dialog.setAttribute('role', 'dialog');
+      const inner = document.createElement('button');
+      inner.type = 'button';
+      dialog.appendChild(inner);
+      document.body.appendChild(dialog);
+      inner.focus();
+      await userEvent.keyboard('{Escape}');
+      expect(onClose).not.toHaveBeenCalled();
+      dialog.remove();
+    });
+
+    it('Escape that an inner widget already handled (defaultPrevented) → sheet stays open (carve-out 1)', async () => {
+      const onClose = vi.fn();
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={onClose}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+      // A CAPTURE-phase listener that claims the key before the sheet's
+      // BUBBLE-phase listener runs — this is exactly how the filters Escape
+      // handler (App.tsx, capture phase) yields guard 1 when both are open.
+      const claim = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') e.preventDefault();
+      };
+      document.addEventListener('keydown', claim, true);
+      try {
+        const evt = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+        document.body.dispatchEvent(evt);
+        expect(onClose).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener('keydown', claim, true);
+      }
+    });
   });
 
   it('drag-down past peek dismisses (calls onClose)', async () => {
@@ -255,6 +439,46 @@ describe('<SpeciesDetailSheet>', () => {
     handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 700, pointerId: 1, bubbles: true }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('drag-slop (6px, #431): a 5px move does NOT translate; a 7px move tracks the finger', async () => {
+    // #431: the translation must not start on the FIRST pointermove. A
+    // DRAG_SLOP_PX = 6 dead-band gates BOTH the `moved` flag AND the
+    // setLiveHeight translation (the old 4px gated only click suppression, so
+    // the sheet jiggled on a sub-threshold tap-drag). Below the slop the height
+    // stays at the detent (no inline style.height tracking); past it, it tracks.
+    render(
+      <SpeciesDetailSheet
+        speciesCode="vermfly"
+        apiClient={makeClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />,
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    const handle = await screen.findByTestId('species-detail-sheet-handle');
+    const half = Math.round(window.innerHeight * 0.6);
+
+    // A 5px upward move (under the 6px slop) must NOT move the sheet height.
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 395, pointerId: 1, bubbles: true }));
+    // liveHeight stays null → the rendered px equals the detent height (half).
+    // Give React a tick to (not) re-render; the height must still be the detent.
+    await waitFor(() => {
+      const px = Number((sheet as HTMLElement).style.height.match(/([\d.]+)px/)?.[1]);
+      expect(px).toBe(half);
+    });
+
+    // Now cross the slop: a 7px move (from the 400 anchor → 393) tracks 1:1.
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 393, pointerId: 1, bubbles: true }));
+    await waitFor(() => {
+      const px = Number((sheet as HTMLElement).style.height.match(/([\d.]+)px/)?.[1]);
+      // grow = startY - clientY = 400 - 393 = 7 → height ≈ half + 7.
+      expect(px).toBeGreaterThanOrEqual(half + 7 - 1);
+      expect(px).toBeLessThanOrEqual(half + 7 + 1);
+    });
+
+    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 393, pointerId: 1, bubbles: true }));
   });
 
   it('1:1 drag-up grows the sheet height by the drag delta', async () => {
@@ -909,12 +1133,10 @@ describe('<SpeciesDetailSheet> — F9 focus restore on close (#910)', () => {
     __resetSpeciesDetailCache();
   });
 
-  it('restores focus on the keyboard close path (ESC at peek collapses → onClose → restore)', async () => {
-    // The sheet has no dedicated close BUTTON — the handle toggles
-    // expand/collapse and closing is the collapse() call at the peek detent,
-    // reached by ESC (keyboard) or drag-dismiss (pointer). This covers the
-    // keyboard close: ESC with focus inside the sheet at peek → collapse() →
-    // closeWithRestore() → onClose, restoring focus to the opener.
+  it('restores focus on the keyboard close path (ESC with focus inside the sheet → onClose → restore)', async () => {
+    // #1026: Escape now DISMISSES the sheet outright (closeWithRestore →
+    // onClose), no longer stepping detents. With focus inside the sheet (on the
+    // handle) Escape fires onClose and restores focus to the opener.
     const onClose = vi.fn();
     opener.focus();
     expect(opener).toHaveFocus();
@@ -929,20 +1151,17 @@ describe('<SpeciesDetailSheet> — F9 focus restore on close (#910)', () => {
     const sheet = await screen.findByTestId('species-detail-sheet');
     await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
     const handle = await screen.findByTestId('species-detail-sheet-handle');
-    // Drag half → peek (a slow short downward drag settles to the nearest detent).
-    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
-    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 1, bubbles: true }));
-    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 1, bubbles: true }));
-    handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 1, bubbles: true }));
-    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
-    // ESC with focus inside the sheet at peek → collapse() → onClose.
+    // ESC with focus inside the sheet → closeWithRestore() → onClose.
     handle.focus();
     await userEvent.keyboard('{Escape}');
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     await waitFor(() => expect(opener).toHaveFocus());
   });
 
-  it('restores focus on ESC close stepping down from half (ESC half→peek, ESC peek→onClose → restore)', async () => {
+  it('restores focus on the × single-pointer close (×→closeWithRestore→onClose→restore)', async () => {
+    // #1026: the shared × is the single-pointer, non-drag close path (WCAG
+    // 2.5.7). It must run through closeWithRestore so #910 focus-restore holds
+    // on this path too (not only the keyboard/drag paths).
     const onClose = vi.fn();
     opener.focus();
     render(
@@ -954,15 +1173,8 @@ describe('<SpeciesDetailSheet> — F9 focus restore on close (#910)', () => {
       />,
     );
     const sheet = await screen.findByTestId('species-detail-sheet');
-    const handle = await screen.findByTestId('species-detail-sheet-handle');
     await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
-    // Pure-keyboard close: ESC with focus inside the sheet steps the detent down
-    // (collapse): half → peek, then peek → onClose. No pointer drag involved.
-    handle.focus();
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
-    handle.focus();
-    await userEvent.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: 'Close species detail' }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
     await waitFor(() => expect(opener).toHaveFocus());
   });

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -19,6 +19,7 @@ import {
 import { analytics } from '../analytics.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
 import { Photo } from './ds/Photo.js';
+import { SheetHeader } from './ds/SheetHeader.js';
 import type { FamilyCode } from '../config/family-palette.js';
 
 export type SnapState = 'peek' | 'half' | 'full';
@@ -39,6 +40,13 @@ const VELOCITY_FLICK_PX_PER_MS = 0.5;
 // The sheet can shrink below peek during a downward drag toward the dismiss
 // threshold; it never renders shorter than this.
 const DRAG_MIN_HEIGHT_PX = 56;
+// Drag slop (#431). Below this many px of travel from the pointerdown anchor
+// the gesture is treated as a tap, not a drag: NEITHER the `moved` flag (which
+// suppresses the post-drag click) NOR the live-height translation engages, so a
+// finger that jiggles a few px on a tap does not nudge the sheet ("drag-start
+// jiggle"). The old 4px threshold gated only `moved` (click suppression) — the
+// translation still started on the FIRST pointermove. 6px gates BOTH.
+const DRAG_SLOP_PX = 6;
 const order: SnapState[] = ['peek', 'half', 'full'];
 
 // Content-tier hysteresis. The visible content tier ([data-content]) is driven
@@ -397,20 +405,54 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     else closeWithRestore();
   }, [snap, goToSnap, closeWithRestore]);
 
-  // ESC scoped: only collapse when focus is inside the sheet. If focus
-  // is on a map element (cluster button), MapLibre handles ESC itself.
+  // Escape DISMISSES the sheet (#1026) — matching the desktop rail
+  // (SpeciesDetailRail) and the filters sheet (App.tsx), NOT the old
+  // stepwise-collapse-by-detent behavior. WCAG no-keyboard-trap: the prior
+  // handler early-returned unless focus was inside the sheet, so Escape did
+  // nothing in the normal post-open state (focus on body/map) — a trap.
+  //
+  // BUBBLE phase (NOT capture): the scope popover claims Escape via
+  // stopPropagation() on a React synthetic handler (AppHeader), which fires at
+  // the React root BELOW document; a capture-phase document listener would beat
+  // it and defeat that claim. On the bubble phase, the scope popover's
+  // stopPropagation halts the event before it reaches this document listener.
+  //
+  // Bail in exactly three cases, else closeWithRestore() + preventDefault():
+  //   1. e.defaultPrevented — an inner widget already claimed the key.
+  //   2. focus is inside an open native <dialog> — the Credits modal closes
+  //      NATIVELY on Escape without setting defaultPrevented; without this guard
+  //      one keypress would close the modal AND the sheet. (A native <dialog>'s
+  //      implicit role is NOT matched by closest('[role="dialog"]'), so guard 3
+  //      can't cover it — this separate closest('dialog') check is required.)
+  //   3. focus is inside any [role="dialog"] surface OR inside the map layer
+  //      (mainRef). The map half preserves MapLibre-controls Escape intent. The
+  //      [role="dialog"] half covers the Cell/ClusterList popovers: they portal
+  //      to document.body so mainRef containment can't reach them; their own
+  //      Escape handlers don't preventDefault and register after this one, so
+  //      without the guard one keypress would double-close popover + sheet. Both
+  //      popovers focus their heading on mount, so closest('[role="dialog"]') is
+  //      truthy whenever one is open.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      const sheet = sheetRef.current;
-      if (!sheet) return;
-      if (!sheet.contains(document.activeElement)) return;
-      collapse();
+      // 1. Already handled by an inner widget.
+      if (e.defaultPrevented) return;
+      const active = document.activeElement;
+      // 2. Inside an open native <dialog> (Credits) — it closes natively.
+      const nativeDialog = active?.closest?.('dialog');
+      if (nativeDialog instanceof HTMLDialogElement && nativeDialog.open) return;
+      // 3. Inside an explicit dialog-role surface (portaled popovers) OR the map.
+      //    Exclude the sheet's OWN root, which carries role="dialog" at full —
+      //    a focus-inside-sheet Escape must DISMISS, not bail on its own role.
+      const dialogAncestor = active?.closest?.('[role="dialog"]');
+      if (dialogAncestor && dialogAncestor !== sheetRef.current) return;
+      if (mainRef.current?.contains(active)) return;
+      closeWithRestore();
       e.preventDefault();
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [collapse]);
+  }, [closeWithRestore, mainRef]);
 
   // Height-driven 1:1 drag. Bound on the handle only (touch-action discipline
   // unchanged — .sheet-handle owns the gesture; .sheet-fg keeps native pan-y).
@@ -460,7 +502,12 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       d.vy = (e.clientY - d.lastY) / dt; // px/ms, positive = moving down
       d.lastY = e.clientY;
       d.lastT = now;
-      if (Math.abs(e.clientY - d.startY) > 4) d.moved = true;
+      // #431 drag-slop: until the finger has travelled past DRAG_SLOP_PX from the
+      // anchor, treat the gesture as a tap — do NOT set `moved` and do NOT start
+      // the translation (the height holds at the detent). This kills the
+      // drag-start jiggle a sub-threshold tap-drag used to produce.
+      if (Math.abs(e.clientY - d.startY) <= DRAG_SLOP_PX) return;
+      d.moved = true;
       // Drag up (clientY decreases) grows the sheet; drag down shrinks it.
       const grow = d.startY - e.clientY;
       const maxH = heightFor('full');
@@ -720,28 +767,41 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
       >
         {liveMessage}
       </div>
-      <button
-        ref={handleRef}
-        type="button"
-        data-testid="species-detail-sheet-handle"
-        className="sheet-handle"
-        aria-label={isFull ? 'Collapse species detail' : 'Expand species detail'}
-        onClick={() => {
-          // Suppress the click that fires after a drag (pointerup → click).
-          // A pure tap (no movement) still expands/collapses as a fallback.
-          if (didDragRef.current) {
-            didDragRef.current = false;
-            return;
-          }
-          (isFull ? collapse : expand)();
-        }}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-      >
-        <span aria-hidden="true" className="sheet-handle-grip" />
-      </button>
+      {/* Shared sheet header (#1026): grabber (the pointer-wired drag handle) +
+          bare × close, the same affordance vocabulary the filters sheet adopts.
+          The grabber is handed in as a slot so this sheet keeps full ownership
+          of the drag/snap/inert wiring (refs, pointer handlers, tap-toggle).
+          The × is the single-pointer, non-drag dismissal (WCAG 2.5.7); it runs
+          through closeWithRestore so #910 focus-restore holds on this path too,
+          and it is visible at every snap (the SheetHeader is always rendered). */}
+      <SheetHeader
+        closeLabel="Close species detail"
+        onClose={closeWithRestore}
+        grabber={
+          <button
+            ref={handleRef}
+            type="button"
+            data-testid="species-detail-sheet-handle"
+            className="sheet-handle"
+            aria-label={isFull ? 'Collapse species detail' : 'Expand species detail'}
+            onClick={() => {
+              // Suppress the click that fires after a drag (pointerup → click).
+              // A pure tap (no movement) still expands/collapses as a fallback.
+              if (didDragRef.current) {
+                didDragRef.current = false;
+                return;
+              }
+              (isFull ? collapse : expand)();
+            }}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerUp}
+          >
+            <span aria-hidden="true" className="sheet-handle-grip" />
+          </button>
+        }
+      />
       {/* Field-guide body: TWO stable layout pages cross-dissolved by recipe #08
           (page-side-by-side). data-page selects the active page; the inactive
           page is opacity:0 + pointer-events:none + a short translate/blur per

--- a/frontend/src/components/ds/SheetHeader.test.tsx
+++ b/frontend/src/components/ds/SheetHeader.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SheetHeader } from './SheetHeader.js';
+
+describe('<SheetHeader>', () => {
+  it('renders the bare × close button with the supplied aria-label', () => {
+    render(<SheetHeader closeLabel="Close filters" onClose={vi.fn()} />);
+    const close = screen.getByRole('button', { name: 'Close filters' });
+    expect(close).toBeInTheDocument();
+    // Bare × glyph — no text label baked in (the accessible name is the
+    // aria-label so the shared affordance vocabulary is a single × icon).
+    expect(close.textContent).toBe('×');
+  });
+
+  it('calls onClose when the × is clicked', async () => {
+    const onClose = vi.fn();
+    render(<SheetHeader closeLabel="Close species detail" onClose={onClose} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Close species detail' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the supplied close-button className (so existing CSS + e2e selectors hold)', () => {
+    render(
+      <SheetHeader
+        closeLabel="Close filters"
+        onClose={vi.fn()}
+        closeClassName="filters-panel-close"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Close filters' })).toHaveClass(
+      'filters-panel-close',
+    );
+  });
+
+  it('renders a grabber slot when `grabber` is provided (detail-sheet drag handle)', () => {
+    render(
+      <SheetHeader
+        closeLabel="Close species detail"
+        onClose={vi.fn()}
+        grabber={
+          <button type="button" data-testid="my-grabber">
+            grab
+          </button>
+        }
+      />,
+    );
+    // The grabber slot is rendered verbatim — the detail sheet hands in its own
+    // pointer-wired drag handle so the delicate gesture/inert wiring is untouched.
+    expect(screen.getByTestId('my-grabber')).toBeInTheDocument();
+    // The × still renders alongside the grabber (grabber + × shared vocabulary).
+    expect(
+      screen.getByRole('button', { name: 'Close species detail' }),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the grabber when none is supplied (filters sheet has × only)', () => {
+    render(<SheetHeader closeLabel="Close filters" onClose={vi.fn()} />);
+    // Only the close button is a button; no grabber slot is rendered.
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAccessibleName('Close filters');
+  });
+});

--- a/frontend/src/components/ds/SheetHeader.tsx
+++ b/frontend/src/components/ds/SheetHeader.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react';
+
+/**
+ * SheetHeader — the ONE shared sheet-header affordance vocabulary (#1026).
+ *
+ * Both the mobile detail sheet (SpeciesDetailSheet) and the filters sheet
+ * (App.tsx) adopt this so a user who learns "grabber + × + Escape" on one sheet
+ * carries it to the other (V31: the sheets used to expose opposite affordance
+ * sets — the detail sheet had a grabber and no ×, the filters sheet had a × and
+ * no grabber). The grabber is a SLOT: the detail sheet hands in its existing
+ * pointer-wired `.sheet-handle` button so the delicate drag/snap/inert wiring is
+ * never pulled into a shared component (that wiring stays local to the sheet and
+ * its tests). The filters sheet supplies no grabber — it is a plain bottom panel,
+ * not a draggable detent surface (full detent mechanics for filters are out of
+ * scope per the issue) — so it gets the × alone.
+ *
+ * The × is a BARE icon button (the shared convention SpeciesDetailRail.tsx
+ * already uses): glyph `×`, accessible name via `closeLabel`, ≥44px hit area
+ * supplied by the consumer's CSS (`.filters-panel-close` / `.sheet-close`).
+ * `closeClassName` keeps the existing `.filters-panel-close` selector
+ * byte-identical so the filters CSS and the e2e POM (`getByRole('button',
+ * { name: /Close filters/i })`) resolve unchanged.
+ */
+export interface SheetHeaderProps {
+  /** Accessible name for the close button. The filters sheet MUST pass exactly
+   *  `"Close filters"` (e2e + POM resolve on it); the detail sheet passes
+   *  `"Close species detail"` (matches SpeciesDetailRail). */
+  closeLabel: string;
+  /** Fired when the × is activated. The detail sheet wires `closeWithRestore`
+   *  here so #910 focus-restore is preserved on the single-pointer close path. */
+  onClose: () => void;
+  /** className for the × button. Defaults to the detail-sheet `sheet-close`;
+   *  the filters sheet passes `filters-panel-close` to keep its CSS + e2e
+   *  selector unchanged. */
+  closeClassName?: string;
+  /** Optional grabber affordance rendered before the ×. The detail sheet passes
+   *  its pointer-wired drag handle; the filters sheet omits it. */
+  grabber?: ReactNode;
+}
+
+export function SheetHeader({
+  closeLabel,
+  onClose,
+  closeClassName = 'sheet-close',
+  grabber,
+}: SheetHeaderProps) {
+  return (
+    <>
+      {grabber}
+      <button
+        type="button"
+        className={closeClassName}
+        aria-label={closeLabel}
+        onClick={onClose}
+      >
+        ×
+      </button>
+    </>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1817,6 +1817,12 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
      .species-detail-sheet--full below. */
   padding-top: var(--space-xs, 4px);
   padding-bottom: env(safe-area-inset-bottom, 0);
+  /* #430: clear the landscape notch. On a notched iPhone held landscape the
+     status-bar/camera cutout intrudes from the left or right; without these
+     insets the grip + content sit under the notch (~44px). The base rule needs
+     both sides because the device can rotate either way. */
+  padding-left: env(safe-area-inset-left, 0);
+  padding-right: env(safe-area-inset-right, 0);
   /* Settle tween uses the transitions-dev card-resize tuning (recipe
      01-card-resize). The transition is gated OFF during an active drag via
      [data-dragging='true'] below so the drag tracks the finger 1:1.
@@ -1878,6 +1884,40 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   height: 4px;
   border-radius: 2px;
   background: var(--color-text-muted);
+}
+
+/* Shared sheet-header × (#1026) — the detail sheet's single-pointer, non-drag
+   dismissal (WCAG 2.5.7). Mirrors .filters-panel-close (the converged
+   vocabulary): bare × glyph, ≥44px hit target, pulled to the sheet's top-right
+   corner. The sheet root is position:fixed so this absolute anchor resolves
+   against it. Sits above the handle (z-index) so it stays tappable at every
+   snap; inset by the right safe-area so it clears the landscape notch (#430). */
+.sheet-close {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  position: absolute;
+  top: var(--space-xs, 4px);
+  right: calc(8px + env(safe-area-inset-right, 0px));
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: var(--type-md, 17px);
+  line-height: 1;
+  color: var(--color-text-strong);
+  z-index: 2;
+}
+.sheet-close:hover {
+  background: var(--color-bg-tint);
+}
+.sheet-close:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
 }
 
 /* ── Field-guide detent layouts (page-side-by-side, recipe #08) ─────────────


### PR DESCRIPTION
## Diagrams

State machine of the detail-sheet dismissal paths after this change. The ×
(single pointer) and Escape (keyboard) join drag-down as first-class
DISMISS edges — the old build had no single-pointer/keyboard exit at all.

```mermaid
stateDiagram-v2
    [*] --> Open: ?detail= set (mobile)
    state Open {
        peek --> half: handle tap / drag up
        half --> full: handle tap / "Read account" / flick up
        full --> half: handle tap / flick down
        half --> peek: drag down / flick down
    }
    Open --> Dismissed: × click (single pointer, WCAG 2.5.7)
    Open --> Dismissed: Escape (keyboard, with carve-outs)
    Open --> Dismissed: drag-down past floor (swipe)
    Dismissed --> [*]: closeWithRestore() → onClose → ?detail= cleared, focus restored
```

Escape carve-out decision tree (bubble-phase, document-level):

```mermaid
flowchart TD
    K[keydown Escape] --> D{defaultPrevented?}
    D -- yes --> B1[bail — inner widget claimed it]
    D -- no --> ND{focus in OPEN native dialog? Credits}
    ND -- yes --> B2[bail — dialog closes natively]
    ND -- no --> RD{focus in role=dialog NOT the sheet? portaled popovers}
    RD -- yes --> B3[bail — popover owns Escape]
    RD -- no --> M{focus inside map layer mainRef?}
    M -- yes --> B4[bail — MapLibre owns Escape]
    M -- no --> C[closeWithRestore + preventDefault]
```

## Summary

- **Why:** the mobile detail sheet had NO single-pointer or keyboard dismissal — only a swipe-down on the small handle (fails WCAG 2.5.7) and a focus-scoped Escape that did nothing in the normal post-open state (focus on body/map), keyboard-trapping the user. Practical exit was the browser Back button.
- **What:** a shared `SheetHeader` (grabber + bare ×) adopted by BOTH the detail sheet and the filters sheet so they speak one close-affordance vocabulary (was: opposite sets — grabber-no-× vs ×-no-grabber, V31). The × is visible at every snap and runs `closeWithRestore` (preserves #910 focus-restore). Escape now DISMISSES (matching the rail + filters) via a document-level bubble-phase handler with three carve-outs (defaultPrevented / open native `<dialog>` / `[role=dialog]` popovers or map layer).
- **Also:** drag-slop raised 4px→6px gating both `moved` AND the translation (#431 jiggle); landscape `env(safe-area-inset-left/right)` insets on the sheet (#430); the filters Escape handler gains `preventDefault()` so the sheet's carve-out 1 yields when both are open.

## Screenshots

Live-verified at the 5 canonical viewports × 2 themes on the dev server (PR head `2439315`, real read-api + seeded Postgres), with the detail surface open. **390/768** show the detail **sheet** carrying the new × "Close species detail" + grabber (the shared `SheetHeader`); **1024/1440/1920** show the unchanged detail **rail** — no desktop regression. Behavior verified live: Escape-with-focus-on-`body` dismisses (`?detail=` clears) and the × single-pointer click dismisses, both fixing the old keyboard-trap / WCAG 2.5.7 gap. Console clean — the only dark-mode noise was the pre-existing `circle-11` basemap-sprite warning (#947) and transient OpenFreeMap tile-CDN flakiness, both out of scope (basemap warnings → #1027).

| Viewport | Light | Dark |
|---|---|---|
| **390×844** · iPhone (mobile sheet) | <img width="260" alt="crit1077-390-light" src="https://github.com/user-attachments/assets/5dde57d0-4429-4bc1-9371-6730342b72ff" /> | <img width="260" alt="crit1077-390-dark" src="https://github.com/user-attachments/assets/0e620189-b868-422c-aa3f-8c889f10ac82" /> |
| **768×1024** · iPad portrait (tablet) | <img width="260" alt="crit1077-768-light" src="https://github.com/user-attachments/assets/7d219184-5af6-417b-a14c-e6065bdcc504" /> | <img width="260" alt="crit1077-768-dark" src="https://github.com/user-attachments/assets/c8d8781a-78fb-41a8-9ff1-fd3b9c954773" /> |
| **1024×768** · iPad landscape (laptop) | <img width="260" alt="crit1077-1024-light" src="https://github.com/user-attachments/assets/bd6fb5a6-878c-4d72-b30b-142c05753b99" /> | <img width="260" alt="crit1077-1024-dark" src="https://github.com/user-attachments/assets/dceab51e-1258-4f4d-84b5-62bb5d99c2d1" /> |
| **1440×900** · desktop standard | <img width="260" alt="crit1077-1440-light" src="https://github.com/user-attachments/assets/93d70118-b99d-4690-9961-d476ea71168f" /> | <img width="260" alt="crit1077-1440-dark" src="https://github.com/user-attachments/assets/0b24875e-90ef-4987-93a9-b546d45108e4" /> |
| **1920×1080** · wide desktop | <img width="260" alt="crit1077-1920-light" src="https://github.com/user-attachments/assets/3d89a3d4-4cd3-4079-a1e0-6bf171fee09d" /> | <img width="260" alt="crit1077-1920-dark" src="https://github.com/user-attachments/assets/745dc39f-0564-4eb3-8b89-a081a83bdbb6" /> |


- [x] Every new/renamed `className` in this PR has a matching CSS rule — `.sheet-close` added to `frontend/src/styles.css`; `scripts/check-orphan-classnames.sh` passes.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs (5 viewports × 2 themes) captured live at PR head `2439315`.

## Test plan

- [x] `npx tsc -b frontend` — green; `npm test --workspace @bird-watch/frontend` — 1308 passed (86 files), including the rewritten Escape tests, the × tests, and the 6px drag-slop test.
- [x] New unit tests added — `SheetHeader.test.tsx` (5), `SpeciesDetailSheet.test.tsx` (× at peek/half/full, Escape pinned-predicate incl. all carve-outs, drag-slop, × focus-restore).
- [x] New Playwright e2e specs added — `sheet-snap.spec.ts` (× dismissal clears `?detail=`), `safe-area.spec.ts` (padding-left/right env() probe). Both run green live (read-api + Postgres reused, Vite started by Playwright): 5/5 sheet specs, 8/8 filters specs (confirms `Close filters` selector unchanged).
- [x] `npm run build` — clean production build.
- [x] Lint: `npm run lint` clean + Sky-Atlas forbidden-raw-token guard clean; `npx knip` exit 0; orphan-classname-check PASS.
- [x] (UI only) Multi-viewport Playwright MCP smoke + screenshots — done by orchestrator: 5×2 live-drive, console-clean, × + Escape-on-body dismissal confirmed, 10 user-attachments URLs above.

## Plan reference

Out of plan — design-review remediation CRITICAL finding. Implements issue #1026.

Closes #1026
Closes #430
Closes #431

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

