### PR TITLE
feat(db-client): insertPhotoScores + getPhotoScores read/write surface (C2 #1071)

### DIFF
--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -23,6 +23,7 @@ export {
   type SpeciesPhotoInput,
   type SpeciesDescriptionInput,
 } from './species.js';
+export { insertPhotoScores, getPhotoScores } from './photo-scores.js';
 export { getSilhouettes } from './silhouettes.js';
 export { resolveStateForPoint, listStatesWithBbox } from './state-boundaries.js';
 export {

--- a/packages/db-client/src/photo-scores.test.ts
+++ b/packages/db-client/src/photo-scores.test.ts
@@ -71,6 +71,24 @@ describe('insertPhotoScores', () => {
     );
     expect(rows[0].c).toBe(4);
   });
+
+  it('a mixed batch of existing + new tuples returns only the newly-inserted count', async () => {
+    // Pre-seed one tuple, then submit a batch that re-includes it alongside two
+    // genuinely new tuples. rowCount must be 2 (the new rows only) — NOT 3 (the
+    // batch size). This `< rows.length` partial count is the signal C3's
+    // idempotent-progress reporting (#1072) leans on, so guard it directly.
+    expect(await insertPhotoScores(db.pool, [baseRow])).toBe(1);
+    const inserted = await insertPhotoScores(db.pool, [
+      baseRow, // conflict — dropped
+      { ...baseRow, contentHash: 'sha256-new1' }, // new
+      { ...baseRow, contentHash: 'sha256-new2' }, // new
+    ]);
+    expect(inserted).toBe(2);
+    const { rows } = await db.pool.query(
+      `SELECT COUNT(*)::int AS c FROM species_photo_scores WHERE species_code = 'vermfly'`,
+    );
+    expect(rows[0].c).toBe(3);
+  });
 });
 
 describe('getPhotoScores', () => {

--- a/packages/db-client/src/photo-scores.test.ts
+++ b/packages/db-client/src/photo-scores.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { startTestDb, type TestDb } from './test-helpers.js';
+import { insertPhotoScores, getPhotoScores } from './photo-scores.js';
+import { upsertSpeciesMeta } from './species.js';
+import type { PhotoScoreRow } from '@bird-watch/shared-types';
+
+let db: TestDb;
+beforeAll(async () => { db = await startTestDb(); }, 90_000);
+afterAll(async () => { await db?.stop(); });
+
+// species_photo_scores FKs species_code → species_meta(species_code). Each test
+// truncates both and seeds the parent rows it needs.
+beforeEach(async () => {
+  await db.pool.query('TRUNCATE species_photo_scores, species_meta CASCADE');
+  await upsertSpeciesMeta(db.pool, [
+    { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher', sciName: 'Pyrocephalus rubinus',
+      familyCode: 'tyrannidae', familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+    { speciesCode: 'annhum', comName: "Anna's Hummingbird", sciName: 'Calypte anna',
+      familyCode: 'trochilidae', familyName: 'Hummingbirds', taxonOrder: 4001 },
+  ]);
+});
+
+const baseRow: PhotoScoreRow = {
+  speciesCode: 'vermfly',
+  contentHash: 'sha256-aaa',
+  model: 'claude-opus-4-8',
+  rubricVersion: 'v1',
+  keep: true,
+  qualityScore: 8.5,
+  criteria: { sharpness: 9, pose: 8, lighting: 7, background: 6, framing: 8, fieldMarks: 9, naturalness: 8 },
+  fieldMarks: ['red underparts', 'dark mask'],
+  rationale: 'Sharp, diagnostic, keep.',
+};
+
+describe('insertPhotoScores', () => {
+  it('inserts N rows and returns N', async () => {
+    const n = await insertPhotoScores(db.pool, [
+      baseRow,
+      { ...baseRow, speciesCode: 'annhum', contentHash: 'sha256-bbb', keep: false },
+    ]);
+    expect(n).toBe(2);
+    const { rows } = await db.pool.query('SELECT COUNT(*)::int AS c FROM species_photo_scores');
+    expect(rows[0].c).toBe(2);
+  });
+
+  it('returns 0 for an empty input', async () => {
+    expect(await insertPhotoScores(db.pool, [])).toBe(0);
+  });
+
+  it('re-inserting the same (species_code, content_hash, model, rubric_version) is a no-op', async () => {
+    expect(await insertPhotoScores(db.pool, [baseRow])).toBe(1);
+    // Same conflict tuple, different payload — ON CONFLICT DO NOTHING keeps the
+    // original row and reports 0 inserted.
+    expect(await insertPhotoScores(db.pool, [{ ...baseRow, keep: false, rationale: 'changed' }])).toBe(0);
+    const { rows } = await db.pool.query('SELECT COUNT(*)::int AS c FROM species_photo_scores');
+    expect(rows[0].c).toBe(1);
+    const fetched = await getPhotoScores(db.pool, { model: 'claude-opus-4-8', rubricVersion: 'v1' });
+    expect(fetched).toHaveLength(1);
+    // Append-only: the FIRST write wins, the conflicting re-insert is dropped.
+    expect(fetched[0].keep).toBe(true);
+    expect(fetched[0].rationale).toBe('Sharp, diagnostic, keep.');
+  });
+
+  it('a different model, rubric_version, or content_hash for the same species appends a new row', async () => {
+    expect(await insertPhotoScores(db.pool, [baseRow])).toBe(1);
+    expect(await insertPhotoScores(db.pool, [{ ...baseRow, model: 'gemini-2.5-flash' }])).toBe(1);
+    expect(await insertPhotoScores(db.pool, [{ ...baseRow, rubricVersion: 'v2' }])).toBe(1);
+    expect(await insertPhotoScores(db.pool, [{ ...baseRow, contentHash: 'sha256-zzz' }])).toBe(1);
+    const { rows } = await db.pool.query(
+      `SELECT COUNT(*)::int AS c FROM species_photo_scores WHERE species_code = 'vermfly'`,
+    );
+    expect(rows[0].c).toBe(4);
+  });
+});
+
+describe('getPhotoScores', () => {
+  it('returns only rows matching the (model, rubricVersion) pin', async () => {
+    await insertPhotoScores(db.pool, [
+      baseRow,
+      { ...baseRow, contentHash: 'sha256-bbb', speciesCode: 'annhum' },
+      // Different pin — must be excluded.
+      { ...baseRow, model: 'gemini-2.5-flash' },
+      { ...baseRow, rubricVersion: 'v2' },
+    ]);
+    const pinned = await getPhotoScores(db.pool, { model: 'claude-opus-4-8', rubricVersion: 'v1' });
+    expect(pinned).toHaveLength(2);
+    expect(pinned.every(r => r.model === 'claude-opus-4-8' && r.rubricVersion === 'v1')).toBe(true);
+    expect(pinned.map(r => r.speciesCode).sort()).toEqual(['annhum', 'vermfly']);
+  });
+
+  it('round-trips criteria/fieldMarks JSONB and the keep verdict', async () => {
+    await insertPhotoScores(db.pool, [baseRow]);
+    const [row] = await getPhotoScores(db.pool, { model: 'claude-opus-4-8', rubricVersion: 'v1' });
+    expect(row.speciesCode).toBe('vermfly');
+    expect(row.contentHash).toBe('sha256-aaa');
+    expect(row.keep).toBe(true);
+    expect(row.qualityScore).toBeCloseTo(8.5);
+    expect(row.criteria).toEqual(baseRow.criteria);
+    expect(row.fieldMarks).toEqual(['red underparts', 'dark mask']);
+    expect(row.rationale).toBe('Sharp, diagnostic, keep.');
+  });
+
+  it('round-trips NULL quality_score and NULL criteria/fieldMarks (deterministic-gate row)', async () => {
+    await insertPhotoScores(db.pool, [
+      { speciesCode: 'annhum', contentHash: 'sha256-gate', model: 'deterministic-gate',
+        rubricVersion: 'v1', keep: false, qualityScore: null, criteria: null,
+        fieldMarks: null, rationale: null },
+    ]);
+    const [row] = await getPhotoScores(db.pool, { model: 'deterministic-gate', rubricVersion: 'v1' });
+    expect(row.keep).toBe(false);
+    expect(row.qualityScore).toBeNull();
+    expect(row.criteria).toBeNull();
+    expect(row.fieldMarks).toBeNull();
+    expect(row.rationale).toBeNull();
+  });
+
+  it('returns [] when no row matches the pin', async () => {
+    await insertPhotoScores(db.pool, [baseRow]);
+    expect(await getPhotoScores(db.pool, { model: 'nonexistent', rubricVersion: 'v9' })).toEqual([]);
+  });
+});

--- a/packages/db-client/src/photo-scores.ts
+++ b/packages/db-client/src/photo-scores.ts
@@ -1,0 +1,91 @@
+import type { Pool } from './pool.js';
+import type { PhotoScoreRow } from '@bird-watch/shared-types';
+
+/**
+ * Append-only insert of photo-quality judge scores into `species_photo_scores`
+ * (epic #1074). Idempotent: the UNIQUE `(species_code, content_hash, model,
+ * rubric_version)` constraint is the conflict target, and `ON CONFLICT DO
+ * NOTHING` makes a re-insert of the same tuple a no-op — the FIRST write wins,
+ * so a frozen `(model, rubric_version)` pin stays an immutable baseline. A
+ * different image, model, or rubric each APPENDs its own row. Returns the
+ * number of rows actually inserted (`rowCount`), which is < `rows.length` when
+ * some tuples already existed.
+ *
+ * criteria/field_marks are JSONB columns: the params are `JSON.stringify`d and
+ * cast `::jsonb` so a JS object/array round-trips faithfully (and `null` stays
+ * SQL NULL, not the JSON string "null").
+ */
+export async function insertPhotoScores(pool: Pool, rows: PhotoScoreRow[]): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  const values: unknown[] = [];
+  const placeholders: string[] = [];
+
+  rows.forEach((r, i) => {
+    const o = i * 9;
+    placeholders.push(
+      `($${o + 1}, $${o + 2}, $${o + 3}, $${o + 4}, $${o + 5}, $${o + 6}, $${o + 7}::jsonb, $${o + 8}::jsonb, $${o + 9})`
+    );
+    values.push(
+      r.speciesCode,
+      r.contentHash,
+      r.model,
+      r.rubricVersion,
+      r.keep,
+      r.qualityScore,
+      r.criteria === null ? null : JSON.stringify(r.criteria),
+      r.fieldMarks === null ? null : JSON.stringify(r.fieldMarks),
+      r.rationale,
+    );
+  });
+
+  const { rowCount } = await pool.query(
+    `INSERT INTO species_photo_scores
+       (species_code, content_hash, model, rubric_version, keep, quality_score, criteria, field_marks, rationale)
+     VALUES ${placeholders.join(',')}
+     ON CONFLICT (species_code, content_hash, model, rubric_version) DO NOTHING`,
+    values
+  );
+  return rowCount ?? 0;
+}
+
+/**
+ * Read every score for one frozen baseline pin `(model, rubric_version)` — the
+ * eval's (#1010, C4 #1073) primary read pattern, served by the
+ * `idx_species_photo_scores_pin (model, rubric_version)` index. JSONB columns
+ * deserialize to JS values automatically; `quality_score` is REAL (float4),
+ * which pg parses as a JS number natively.
+ */
+export async function getPhotoScores(
+  pool: Pool,
+  pin: { model: string; rubricVersion: string },
+): Promise<PhotoScoreRow[]> {
+  const { rows } = await pool.query<{
+    species_code: string;
+    content_hash: string;
+    model: string;
+    rubric_version: string;
+    keep: boolean;
+    quality_score: number | null;
+    criteria: Record<string, number> | null;
+    field_marks: string[] | null;
+    rationale: string | null;
+  }>(
+    `SELECT species_code, content_hash, model, rubric_version, keep,
+            quality_score, criteria, field_marks, rationale
+     FROM species_photo_scores
+     WHERE model = $1 AND rubric_version = $2`,
+    [pin.model, pin.rubricVersion]
+  );
+  return rows.map(r => ({
+    speciesCode: r.species_code,
+    contentHash: r.content_hash,
+    model: r.model,
+    rubricVersion: r.rubric_version,
+    keep: r.keep,
+    qualityScore: r.quality_score,
+    criteria: r.criteria,
+    fieldMarks: r.field_marks,
+    rationale: r.rationale,
+  }));
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -331,6 +331,38 @@ export interface SpeciesWithPhoto {
 }
 
 /**
+ * One row of `species_photo_scores` (epic #1074) — an append-only, immutable
+ * photo-quality judge score promoted from the operator-local `review.sqlite`
+ * into prod Postgres. A frozen `(model, rubricVersion)` pin is an immutable,
+ * reproducible ground-truth baseline the photo-judge eval (#1010, C4 #1073)
+ * grades a candidate scorer against; re-scoring a photo APPENDS a new row,
+ * never mutating an existing one (see migration 1700000053000).
+ *
+ * The `(speciesCode, contentHash, model, rubricVersion)` tuple is unique — the
+ * SAME image judged by the SAME `(model, rubricVersion)` is recorded once.
+ *
+ * Nullability mirrors the DB columns:
+ * - `qualityScore` is null for the deterministic-gate rows (a verdict but no
+ *   model-assigned numeric score);
+ * - `criteria`/`fieldMarks` are JSONB and may be null;
+ * - `rationale` is the judge's free-text justification, nullable.
+ */
+export interface PhotoScoreRow {
+  speciesCode: string;
+  contentHash: string;
+  model: string;
+  rubricVersion: string;
+  keep: boolean;
+  /** Overall 0–10 score; null for deterministic-gate rows. */
+  qualityScore: number | null;
+  /** 7-axis 0–10 score map (JSONB). */
+  criteria: Record<string, number> | null;
+  /** Diagnostic field-marks array (JSONB). */
+  fieldMarks: string[] | null;
+  rationale: string | null;
+}
+
+/**
  * Discriminated-union response from GET /api/observations.
  *
  * - `mode === 'observations'` (default; also when zoom >= 6 with bbox):


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph C3["C3 backfill (#1072)"]
      direction TB
      review[(review.sqlite)]
    end
    subgraph C4["C4 photo-judge eval (#1073)"]
      direction TB
      eval[grade candidate scorer]
    end

    review -->|"insertPhotoScores(rows)"| insert
    insert["INSERT … ON CONFLICT\n(species_code, content_hash, model, rubric_version)\nDO NOTHING"]
    insert --> tbl[(species_photo_scores\nappend-only · C1 #1070)]
    tbl -->|"getPhotoScores({ model, rubricVersion })"| read[frozen-pin baseline rows]
    read --> eval

    note["re-insert of same tuple → 0 rows (no-op)\ndifferent model / rubric / content_hash → +1 row"]
    insert -.-> note
```

## Summary

- C2 of epic #1074: adds the db-client read/write surface over the append-only `species_photo_scores` table (C1 #1070), so the C3 backfill can promote operator-local judge scores into prod Postgres and the C4 eval can read a frozen `(model, rubric_version)` baseline.
- **Why `ON CONFLICT DO NOTHING` (not upsert):** a frozen pin must be an immutable, reproducible ground-truth baseline. The FIRST write of a `(species_code, content_hash, model, rubric_version)` tuple wins; re-scores of the same tuple are dropped, so a prior eval's baseline can never be moved out from under it. `insertPhotoScores` returns `rowCount` actually inserted (`< rows.length` when some tuples already existed) — the signal C3 uses to report idempotent backfill progress.
- Mirrors `hotspots.ts` / `species.ts` conventions: snake_case DB ↔ camelCase mapping, `PhotoScoreRow` type in `@bird-watch/shared-types`, both functions exported from the package index. `criteria` / `field_marks` are JSONB — params are `JSON.stringify`'d and cast `::jsonb` so objects/arrays round-trip and `null` stays SQL NULL (not the string `"null"`).

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/db-client` — green (testcontainers, real Postgres+PostGIS, no mocks per repo rule). 21/21 test files, 179 passed.
- [x] New integration tests added: N-insert returns N; re-insert of same tuple is a no-op (returns 0, first write wins, no duplicate row); a different model / rubric_version / content_hash appends a new row; pin-scoped reads return only matching rows; criteria/field_marks JSONB and NULL quality_score/criteria/field_marks round-trip.
- [x] `npm run build` — clean (all workspaces).
- [x] `npm run lint` — clean.
- [x] `npx knip` — exit 0.
- [ ] New Playwright e2e spec added — N/A, no user-visible behavior.

## Plan reference

Part of epic #1074 (promote-scores-to-prod). Closes #1071 (child C2). Depends on C1 #1070 (table, merged). Blocks C3 #1072 (backfill) and C4 #1073 (eval). Plans live in issues for this repo, not `docs/plans/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)