### PR TITLE
fix(frontend): graceful fallback when legend silhouette mask URL fails (#1028)

### DIFF
--- a/frontend/e2e/silhouette-override.spec.ts
+++ b/frontend/e2e/silhouette-override.spec.ts
@@ -1,30 +1,71 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 /**
  * Issue #502 — admin-api-uploaded silhouette override rendering.
+ * Issue #1028 — graceful degradation when the override mask URL fails to load.
  *
  * The FamilyLegend chip prefers `svgUrl` (CDN URL) over inline `svgData`
- * (path-d) when both are present. We stub `/api/silhouettes` to return one
- * row with `svgUrl` populated and assert that the legend renders the new
- * `.family-silhouette-img` mask-div element.
+ * (path-d). When `svgUrl` is set FamilySilhouette renders a CSS-mask
+ * `.family-silhouette-img` <span> (the mask paints nothing visible if the
+ * URL fails — the #1028 blank-row bug). FamilySilhouette now preloads the
+ * mask URL via `new Image()` and, on load failure, falls through to the
+ * inline `<svg>` (the curated `svgData` shape, or the FAMILY_PATHS
+ * placeholder) so a curated legend row is NEVER painted blank.
  *
- * No DB writes. No real upload — the rendering contract is what's under
- * test, not the upload pipeline (that's the admin-api test suite's job).
+ * Both tests drive the legend deterministically by stubbing `/api/observations`
+ * with an AGGREGATED response (scope=us cold-load is aggregated, z<6) carrying
+ * a single `cuculidae` bucket, and `/api/silhouettes` with a matching
+ * `cuculidae` row. No DB writes; no real upload; no seed dependency.
  */
 
-test.describe('Silhouette override (#502)', () => {
+const CUCULIDAE_BUCKET = {
+  mode: 'aggregated' as const,
+  buckets: [
+    {
+      lat: 39,
+      lng: -98,
+      count: 7,
+      speciesCount: 2,
+      families: [
+        {
+          code: 'cuculidae',
+          count: 7,
+          speciesCount: 2,
+          species: [
+            { code: 'greroa', count: 4 },
+            { code: 'yebcuc', count: 3 },
+          ],
+          name: 'Cuckoos & Roadrunners',
+        },
+      ],
+    },
+  ],
+  meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() },
+};
+
+async function stubAggregatedCuckoos(page: Page) {
+  await page.route('**/api/observations**', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(CUCULIDAE_BUCKET),
+    });
+  });
+}
+
+test.describe('Silhouette override (#502 / #1028)', () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
-  test('legend chip renders mask-div when svgUrl is set', async ({ page }) => {
-    // Inline 1×1 transparent SVG data-URL so the test doesn't depend on a
-    // real CDN host. The component's mask-div doesn't need network success
-    // to render the wrapper element with the correct class + style; the
-    // mask-image just won't paint visibly, which is fine for this assertion.
+  test('legend chip renders the mask-div when svgUrl loads successfully', async ({ page }) => {
+    // A 1×1 SVG data-URL: `new Image().src = <data-url>` resolves to `onload`
+    // in the browser, so the optimistic mask span stays (no fallback).
     const svgDataUrl =
       'data:image/svg+xml;utf8,' +
       encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2 12 L22 12 L12 2 Z"/></svg>');
 
+    await stubAggregatedCuckoos(page);
     await page.route('**/api/silhouettes', async route => {
       await route.fulfill({
         status: 200,
@@ -32,8 +73,13 @@ test.describe('Silhouette override (#502)', () => {
         body: JSON.stringify([
           {
             familyCode: 'cuculidae',
+            commonName: 'Cuckoos & Roadrunners',
             color: '#A05A3A',
-            // svgData kept non-null to verify imgUrl wins precedence.
+            colorDark: '#C98A6A',
+            source: null,
+            license: null,
+            creator: null,
+            // svgData kept non-null so the fallback would reach a real shape too.
             svgData: 'M5 13 L17 7 L17 10 Z',
             svgUrl: svgDataUrl,
           },
@@ -45,20 +91,59 @@ test.describe('Silhouette override (#502)', () => {
     await app.goto('view=map');
     await app.waitForAppReady();
 
-    // Find the cuculidae legend entry. The legend renders one entry per
-    // family present in the current observation window. To make this test
-    // deterministic regardless of seed data, we don't filter by family
-    // code in the URL — we just check that *if* the legend renders the
-    // cuculidae chip, it uses the mask-div form when svgUrl is present.
-    // If no cuculidae observations are seeded, the legend simply won't
-    // render that family — in that case we assert the contract holds for
-    // whichever family the silhouettes stub provides.
-    const maskDivs = page.locator('.family-silhouette-img');
-    // Allow up to 5s for the silhouettes response → legend render path.
-    await expect(maskDivs.first()).toBeVisible({ timeout: 5_000 }).catch(() => {
-      // If no entry matches our stubbed silhouette, the test is non-applicable
-      // for this seed — skip rather than fail. The unit tests in
-      // FamilySilhouette.test.tsx cover the rendering contract directly.
+    // Desktop default-expanded legend renders the cuculidae chip. Because the
+    // mask URL loads, the chip stays in mask-div form. This assertion GATES —
+    // the `.catch(() => {})` swallow that previously made it a no-op is gone.
+    const maskDiv = page
+      .locator('button[data-testid="family-legend-entry"] .family-silhouette-img')
+      .first();
+    await expect(maskDiv).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('legend chip stays visible (falls back to svg) when svgUrl 404s', async ({ page }) => {
+    // #1028 root case: a dead/blocked CDN URL. Stub it to 404 so the mask
+    // preload fires `onerror` and FamilySilhouette swaps to the inline <svg>.
+    const deadUrl = 'https://silhouettes.bird-maps.com/family/cuculidae.dead404.svg';
+
+    await stubAggregatedCuckoos(page);
+    await page.route(deadUrl, async route => {
+      await route.fulfill({ status: 404, contentType: 'text/plain', body: 'not found' });
     });
+    await page.route('**/api/silhouettes', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            familyCode: 'cuculidae',
+            commonName: 'Cuckoos & Roadrunners',
+            color: '#A05A3A',
+            colorDark: '#C98A6A',
+            source: null,
+            license: null,
+            creator: null,
+            // Curated svgData (branch a): the fallback reaches the real shape.
+            svgData: 'M5 13 L17 7 L17 10 Z',
+            svgUrl: deadUrl,
+          },
+        ]),
+      });
+    });
+
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const chip = page.locator('button[data-testid="family-legend-entry"]').first();
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    // The blank mask span must have been replaced by a visible <svg> glyph —
+    // the curated svgData path, NOT an empty mask. This is the #1028 fix:
+    // a curated legend row never paints blank even when the CDN URL is dead.
+    const svgPath = chip.locator('.family-silhouette svg path');
+    await expect(svgPath).toBeVisible({ timeout: 10_000 });
+    await expect(svgPath).toHaveAttribute('d', 'M5 13 L17 7 L17 10 Z');
+    // And the dead mask div must NOT be present (we swapped away from it).
+    await expect(chip.locator('.family-silhouette-img')).toHaveCount(0);
   });
 });

--- a/frontend/src/components/ds/FamilySilhouette.test.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { FamilySilhouette } from './FamilySilhouette.js';
 import type { FamilyCode } from '../../config/family-palette.js';
 
@@ -217,6 +217,271 @@ describe('<FamilySilhouette>', () => {
     );
     expect(container.querySelector('.family-silhouette-img')).not.toBeNull();
     expect(container.querySelector('path')).toBeNull();
+  });
+
+  // --- imgUrl mask-load-failure graceful degradation (#1028) ---
+  //
+  // CSS `mask-image` gives no load event, so the component preloads the
+  // mask URL via `new Image()`. On a successful load the optimistic mask
+  // <span> stays; on `onerror` (404 / CSP block / cert / bad content-type)
+  // the component falls through to the inline <svg> (resolvedPathD) so a
+  // curated legend row is NEVER painted blank. These tests install a
+  // controllable Image stub whose load/error firing is driven by hand.
+
+  describe('mask-load-failure fallback', () => {
+    interface FakeImage {
+      onload: (() => void) | null;
+      onerror: (() => void) | null;
+      src: string;
+    }
+    let instances: FakeImage[];
+    let OriginalImage: typeof Image;
+
+    beforeEach(() => {
+      instances = [];
+      OriginalImage = globalThis.Image;
+      // Minimal Image stub: capture every instance so the test can fire
+      // onload/onerror deterministically. Setting `src` is a no-op (no real
+      // network in jsdom).
+      class StubImage {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        private _src = '';
+        constructor() {
+          instances.push(this as unknown as FakeImage);
+        }
+        get src(): string {
+          return this._src;
+        }
+        set src(value: string) {
+          this._src = value;
+        }
+      }
+      // @ts-expect-error — assigning a stub class over the DOM Image ctor.
+      globalThis.Image = StubImage;
+    });
+
+    afterEach(() => {
+      globalThis.Image = OriginalImage;
+    });
+
+    const fireError = () => {
+      act(() => {
+        for (const img of instances) img.onerror?.();
+      });
+    };
+    const fireLoad = () => {
+      act(() => {
+        for (const img of instances) img.onload?.();
+      });
+    };
+
+    it('renders the optimistic mask span on the initial paint (before load resolves)', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      // SSR/initial render: mask span present, no inline svg yet.
+      expect(container.querySelector('.family-silhouette-img')).not.toBeNull();
+      expect(container.querySelector('svg')).toBeNull();
+    });
+
+    it('preloads the mask URL via an Image so failure can be detected', () => {
+      render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      expect(instances.length).toBeGreaterThan(0);
+      expect(instances[instances.length - 1].src).toBe(
+        'https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg',
+      );
+    });
+
+    it('falls back to the inline pathD <svg> when the mask resource fails to load', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      fireError();
+      // After failure: mask span is gone, the curated pathD <svg> is shown.
+      expect(container.querySelector('.family-silhouette-img')).toBeNull();
+      const path = container.querySelector('path');
+      expect(path).not.toBeNull();
+      // The curated shape (the pathD prop), NOT a blank span.
+      expect(path).toHaveAttribute('d', 'M12 2 L20 22 L4 22 Z');
+      // 24×24 DB coordinate space when pathD is present.
+      expect(container.querySelector('svg')).toHaveAttribute('viewBox', '0 0 24 24');
+    });
+
+    it('falls back to the FAMILY_PATHS placeholder <svg> when the mask fails and pathD is absent', () => {
+      // Branch (b): svgUrl-only family. Mask failure must still paint a
+      // visible (generic) shape rather than a blank span.
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      fireError();
+      expect(container.querySelector('.family-silhouette-img')).toBeNull();
+      const path = container.querySelector('path');
+      expect(path).not.toBeNull();
+      expect(path?.getAttribute('d')?.length).toBeGreaterThan(0);
+    });
+
+    it('keeps the mask span (no fallback) when the mask resource loads successfully', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      fireLoad();
+      expect(container.querySelector('.family-silhouette-img')).not.toBeNull();
+      expect(container.querySelector('svg')).toBeNull();
+    });
+
+    it('ROOT CAUSE: the optimistic mask span has no child glyph — a failed mask paints nothing visible, which is why the fallback is required', () => {
+      // This pins the precise #1028 root cause: the imgUrl branch renders a
+      // bare <span class="family-silhouette-img"> whose ONLY paint is the CSS
+      // mask resource. It has zero element children — no <svg>, no <img> — so
+      // if the mask URL is dead the span is invisible with no native error
+      // signal. That silent-blank is exactly what the Image-preload + svg
+      // fallback below converts into a visible glyph.
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      const span = container.querySelector('.family-silhouette-img')!;
+      // The bare span renders NO glyph element of its own (the blank-row bug).
+      expect(span.querySelector('svg')).toBeNull();
+      expect(span.querySelector('img')).toBeNull();
+      expect(span.children.length).toBe(0);
+      // After the mask fails to load, the same row paints a real <svg> glyph.
+      fireError();
+      expect(container.querySelector('.family-silhouette svg path')).not.toBeNull();
+    });
+
+    it('re-arms the optimistic mask span when imgUrl changes after a prior failure', () => {
+      const { container, rerender } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.bad.svg"
+        />,
+      );
+      fireError();
+      expect(container.querySelector('.family-silhouette-img')).toBeNull();
+      // A new URL is a fresh attempt — render the mask optimistically again.
+      rerender(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          pathD="M12 2 L20 22 L4 22 Z"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.good.svg"
+        />,
+      );
+      expect(container.querySelector('.family-silhouette-img')).not.toBeNull();
+    });
+  });
+
+  // --- url() CSS-token quoting (#1028) ---
+  //
+  // The mask-image custom property was `url(${imgUrl})` — unquoted. A URL
+  // containing a `)`, whitespace, or other CSS-token-breaking character
+  // truncates or invalidates the token, silently breaking the mask. The
+  // value must be emitted as a quoted `url("...")` with the URL escaped.
+
+  describe('url() quoting', () => {
+    it('emits a quoted url("...") mask-image even for a plain URL', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          imgUrl="https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg"
+        />,
+      );
+      const style = container.querySelector('.family-silhouette-img')!.getAttribute('style')!;
+      expect(style).toContain(
+        'url("https://silhouettes.bird-maps.com/family/cuculidae.deadbeef.svg")',
+      );
+    });
+
+    it('escapes a URL containing a ) so the CSS token cannot break out', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          imgUrl="https://cdn.example.com/family/a(1).svg"
+        />,
+      );
+      const style = container.querySelector('.family-silhouette-img')!.getAttribute('style')!;
+      // The raw, unescaped `(1)` must NOT appear bare inside the url() token.
+      expect(style).toContain('--family-silhouette-mask: url(');
+      // A backslash-escaped paren keeps the token well-formed.
+      expect(style).toContain('\\)');
+      // The closing `)` of url() must be the wrapper's, not the URL's — i.e.
+      // there must be a quote immediately before the final url() close.
+      expect(style).toMatch(/url\("[^"]*\\\)[^"]*"\)/);
+    });
+
+    it('escapes a URL containing whitespace so the CSS token cannot break', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          imgUrl="https://cdn.example.com/family/a b.svg"
+        />,
+      );
+      const style = container.querySelector('.family-silhouette-img')!.getAttribute('style')!;
+      // Whitespace must be wrapped in quotes (and stays inside the quoted url()).
+      expect(style).toMatch(/url\("[^"]* [^"]*"\)/);
+    });
+
+    it('escapes a double-quote in the URL so it cannot close the quoted string early', () => {
+      const { container } = render(
+        <FamilySilhouette
+          family="cuculidae"
+          layout="thumb"
+          color="#A05A3A"
+          imgUrl={'https://cdn.example.com/family/a".svg'}
+        />,
+      );
+      const style = container.querySelector('.family-silhouette-img')!.getAttribute('style')!;
+      // The embedded quote must be backslash-escaped, not a bare ".
+      expect(style).toContain('\\"');
+    });
   });
 
   // --- Accessibility ---

--- a/frontend/src/components/ds/FamilySilhouette.tsx
+++ b/frontend/src/components/ds/FamilySilhouette.tsx
@@ -23,10 +23,34 @@
  *       docs/design/01-spec/accessibility.md (WCAG 1.4.1 shape encoding)
  */
 import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { getFamilyChannel } from '../../config/family-palette.js';
 import type { FamilyCode, ShapeVariant } from '../../config/family-palette.js';
 
 export type SilhouetteLayout = 'inline' | 'masthead' | 'thumb';
+
+/**
+ * Quote + escape a URL for safe use inside a CSS `url("...")` token.
+ *
+ * The mask custom property was previously interpolated as a bare
+ * `url(${imgUrl})`. A URL containing `)`, whitespace, `"`, or `\` (legal in a
+ * URL but CSS-token-significant) would truncate or invalidate the token,
+ * silently breaking the mask paint. We emit a double-quoted url() and escape
+ * the four characters that can break out of a double-quoted CSS string:
+ * backslash (escape char itself), double-quote (string delimiter), and the
+ * raw newline characters CSS strings may not contain literally. `)`/whitespace
+ * are safe *inside* a quoted string, but we escape `)` and newlines defensively
+ * so the value is robust regardless of where a consumer interpolates it.
+ */
+function cssUrl(rawUrl: string): string {
+  const escaped = rawUrl
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\)/g, '\\)')
+    .replace(/\n/g, '\\A ')
+    .replace(/\r/g, '\\D ');
+  return `url("${escaped}")`;
+}
 
 export interface FamilySilhouetteProps {
   /** FamilyCode string or null. Unknown codes fall back to the null-family neutral path. */
@@ -117,7 +141,40 @@ export function FamilySilhouette({
   // This lets one uploaded asset render tinted with each family's color
   // without per-color asset variants. Map's SDF pipeline ignores imgUrl and
   // reads pathD (sprite registration is synchronous at map init).
-  if (imgUrl) {
+  //
+  // Graceful degradation (#1028): CSS `mask-image` exposes NO load event, so a
+  // dead/blocked mask URL (404, CSP, mixed-content, cert, bad content-type)
+  // would paint a bare invisible span — the exact bug behind 7 blank AZ legend
+  // rows. We preload the URL via `new Image()` and, on `onerror`, flip
+  // `maskFailed` so the render falls through to the inline `<svg>` (the curated
+  // pathD when present, else the FAMILY_PATHS placeholder). The mask renders
+  // OPTIMISTICALLY on first paint (SSR-safe — the effect only runs client-side),
+  // so a healthy CDN paints with zero flicker; only a real failure swaps to svg.
+  //
+  // Hooks must run unconditionally (Rules of Hooks), so this state lives above
+  // every early return even though it is only consumed on the imgUrl branch.
+  const [maskFailed, setMaskFailed] = useState(false);
+  useEffect(() => {
+    if (!imgUrl) return;
+    // Re-arm on each new URL: a fresh URL is a fresh attempt.
+    setMaskFailed(false);
+    let cancelled = false;
+    const probe = new Image();
+    probe.onload = () => {
+      // Healthy mask — keep the optimistic span. (No state change needed.)
+    };
+    probe.onerror = () => {
+      if (!cancelled) setMaskFailed(true);
+    };
+    probe.src = imgUrl;
+    return () => {
+      cancelled = true;
+      probe.onload = null;
+      probe.onerror = null;
+    };
+  }, [imgUrl]);
+
+  if (imgUrl && !maskFailed) {
     const resolvedColor = color ?? '#5a6472';
     return (
       <span
@@ -126,7 +183,7 @@ export function FamilySilhouette({
         data-family={String(family)}
         data-layout={layout}
         style={{
-          ['--family-silhouette-mask' as string]: `url(${imgUrl})`,
+          ['--family-silhouette-mask' as string]: cssUrl(imgUrl),
           ['--family-silhouette-color' as string]: resolvedColor,
         } as React.CSSProperties}
         aria-label={ariaLabel}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    L[FamilyLegend row<br/>svgUrl non-null] --> FS[FamilySilhouette]
    FS --> P{"Image preload<br/>new Image().src = svgUrl"}
    P -->|onload| MASK["render optimistic<br/>&lt;span .family-silhouette-img&gt;<br/>mask-image: url(quoted)"]
    P -->|onerror<br/>404 / CSP / cert / bad type| FB["maskFailed = true<br/>fall through to inline &lt;svg&gt;"]
    FB --> A{svgData present?}
    A -->|yes — branch a| CUR["curated shape<br/>&lt;svg viewBox=0 0 24 24&gt;"]
    A -->|no — branch b| PLA["FAMILY_PATHS placeholder<br/>&lt;svg viewBox=0 0 100 100&gt;"]
    MASK -.->|BEFORE: no failure path<br/>= silent blank row| BLANK[(7 blank AZ rows)]
```

## Summary

- **Why:** 7 of 56 AZ family-legend rows (Cuckoos & Roadrunners, Gnatcatchers, Olive Warbler, Silky-Flycatchers, Verdins, Vireos, Yellow-breasted Chat) rendered a blank silhouette. Root cause: a curated row with a non-null `svgUrl` renders a bare `<span class="family-silhouette-img">` whose only paint is the CSS `mask-image` resource. CSS `mask-image` has **no load event**, so a dead/blocked mask URL (404 / CSP / mixed-content / cert / bad content-type) leaves an invisible span with no error signal — a silent blank. Map markers were unaffected because the SDF sprite reads `svgData` only.
- **Fix (load-layer, in `FamilySilhouette.tsx`):** preload the mask URL via `new Image()`; on `onerror`, fall through to the inline `<svg>` (curated `svgData`, else the `FAMILY_PATHS` placeholder) so a curated row is **never** painted blank. Mask renders optimistically on first paint (SSR-safe; effect is client-only) → healthy CDN paints with zero flicker. Also hardened the unquoted `url(${imgUrl})` → quoted/escaped `url("...")` so a `)`, whitespace, `"`, or `\` in the URL can't break the CSS token.
- **Out of scope / untouched:** the marker SDF sprite pipeline (`silhouette-sprite.ts`, `use-silhouette-catalogue.ts`) renders correctly and is not touched. `FamilyLegend.tsx` already passes both `imgUrl` and `pathD`, so branch-(a) rows reach the real shape on fallback with no change there.

**Per-family branch table** (Contract step 1). Prod `/api/silhouettes` is unreachable from CI (the API host is `api.bird-maps.com` and CF managed-challenge blocks datacenter IPs; the dev seed has all 7 NULL/NULL). Per the admin-api atomic-write invariant the issue cites (`UPDATE family_silhouettes SET svg_url=$1, svg_data=$2` with `validateSvg` always extracting a non-empty `pathD`), the 2026-06-09 curated uploads are **expected branch (a)** (`svgData` non-null):

| Family | Expected branch | Fix path |
|---|---|---|
| Cuckoos & Roadrunners (`cuculidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Gnatcatchers (`polioptilidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Olive Warbler (`peucedramidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Silky-Flycatchers (`ptiliogonatidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Verdins (`remizidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Vireos (`vireonidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |
| Yellow-breasted Chat (`icteriidae`) | (a) — expected by invariant | mask-load fallback → curated `svgData` shape |

Prod unreachable from CI env; per the admin-api atomic-write invariant all 7 are expected branch (a); post-deploy per-family verification recommended (non-gating). No in-repo snapshot/fixture was found proving any are branch (b). The `url()` quoting fix and the mask-load fallback together cover branch (b) too (svgUrl-only rows degrade to the `FAMILY_PATHS` placeholder rather than blank), so even if any family is actually (b), it no longer paints blank.

## Screenshots

Live-verified at the 5 canonical viewports × 2 themes on the dev server (PR head `7c25d35`, real read-api + seeded Postgres), legend **expanded**. Every family-legend row renders a visible silhouette glyph at all viewports/themes — **no blank rows, no regression** (the dev-data families resolve via the `svgData`/`pathD` path; 13 rows at desktop, 10 at the responsive cap). Console clean — the only dark-mode noise is the pre-existing `circle-11` basemap-sprite warning (#947), out of scope (→ #1027).

The actual mask-load-failure → `<svg>` **fallback** (the fix's core behavior) is proven by the new `silhouette-override.spec.ts` 404-URL case (runs in CI) + the unit tests — not live-demoed here because the dev DB has no `svgUrl`-bearing family and injecting one would mutate the Postgres shared with concurrent dev sessions.

| Viewport | Light | Dark |
|---|---|---|
| **390×844** mobile | <img width="260" alt="s2-1079-390-light" src="https://github.com/user-attachments/assets/13b04723-fe31-44a5-8588-98afc7471f49" /> | <img width="260" alt="s2-1079-390-dark" src="https://github.com/user-attachments/assets/54ed599f-e5d6-4909-bf69-d886524389dc" /> |
| **768×1024** tablet | <img width="260" alt="s2-1079-768-light" src="https://github.com/user-attachments/assets/bbb4acc3-f743-4d0b-b8d3-19abf3dd7cbe" /> | <img width="260" alt="s2-1079-768-dark" src="https://github.com/user-attachments/assets/ba3f570a-53d0-4745-bf88-0aac00a24f12" /> |
| **1024×768** laptop | <img width="260" alt="s2-1079-1024-light" src="https://github.com/user-attachments/assets/d75326fb-6065-4bcc-bdd8-9c0094678cdc" /> | <img width="260" alt="s2-1079-1024-dark" src="https://github.com/user-attachments/assets/849edfa9-82c8-4ca1-93a8-c713d311b78a" /> |
| **1440×900** desktop | <img width="260" alt="s2-1079-1440-light" src="https://github.com/user-attachments/assets/b1a15fec-ea2c-43f2-8bdf-31821b164efe" /> | <img width="260" alt="s2-1079-1440-dark" src="https://github.com/user-attachments/assets/6c3e38c3-5d6c-4b26-987e-6f95ad35eee9" /> |
| **1920×1080** wide | <img width="260" alt="s2-1079-1920-light" src="https://github.com/user-attachments/assets/26cf391d-1e6b-4251-ab9d-1bc2f94f91e1" /> | <img width="260" alt="s2-1079-1920-dark" src="https://github.com/user-attachments/assets/c93533d8-7dc1-418b-925c-f0f0766fe5bc" /> |


- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no new className; reuses the existing `.family-silhouette-img` / `.family-silhouette svg` rules in `ds-primitives.css`.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs (5 viewports × 2 themes) captured live at PR head `7c25d35`; every legend row renders a silhouette, no regression.

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend` — green (86 files / 1319 tests, incl. the new mask-failure-fallback + `url()` quoting tests; FamilySilhouette suite 34, FamilyLegend suite 32)
- [x] New unit tests added — `FamilySilhouette.test.tsx`: optimistic first paint, Image preload, mask-failure → inline pathD `<svg>` (branch a) + `FAMILY_PATHS` placeholder (branch b), success keeps span, re-arm on URL change, root-cause pin, `url()` quoting (`)`, whitespace, `"`).
- [x] New Playwright e2e — `e2e/silhouette-override.spec.ts`: **removed** the assertion-swallowing `.catch(() => {})` so the happy-path assertion gates; **added** a 404-URL case asserting the legend chip still renders a visible `<svg>` glyph. Both drive the legend deterministically via an aggregated `cuculidae` bucket stub (no seed dependency). `playwright test --list` discovers both; full e2e runs in CI (needs the DB-backed read-api webServer).
- [x] `npm run build` — clean production build
- [x] `npx knip` — clean (exit 0; only a pre-existing unrelated config hint)
- [x] (UI only) Playwright MCP smoke — done by orchestrator: legend expanded across 5×2, console-clean (modulo pre-existing #947), all rows render silhouettes; 10 user-attachments above.

## Plan reference

Out of plan — design-review remediation, wave 0 / S2 (issue #1028, label `dr-`). Investigation+fix for verified finding O7 (7 blank AZ legend rows).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

