### PR TITLE
feat(photo-curation): backfill 902 review.sqlite scores into prod, idempotent (C3 #1072)

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -1,5 +1,34 @@
 # Photo-judge eval — Gemini vs. the Opus baseline (`bt eval`)
 
+## One-time prerequisite: promote the `review.sqlite` baseline to prod (#1072)
+
+Before the baseline can be read from prod (the eval's #1073/C4 read path and any
+other consumer of `species_photo_scores`), the 902 `role='current'` Opus scores
+in the operator-local `review.sqlite` must be backfilled into the prod
+`species_photo_scores` table **once**. This is an **operator-run** step — it
+reads a local SQLite that does not exist in CI and writes to PROD, the same
+posture as the silhouette admin scripts.
+
+```sh
+# From the photo-curation run-worktree (where review.sqlite lives).
+# DATABASE_URL must be a PROD read-WRITE connection string (NOT the read-replica
+# / read-only URL — the script INSERTs). REVIEW_DB defaults to ./review.sqlite.
+DATABASE_URL='postgres://…prod-rw…' REVIEW_DB=./review.sqlite \
+  npm run backfill-scores -w @bird-watch/photo-curation
+```
+
+It prints a one-line summary — `read 902, inserted 902, skipped-existing 0` on
+the first run. The insert is **idempotent** (C2's `insertPhotoScores`,
+`ON CONFLICT (species_code, content_hash, model, rubric_version) DO NOTHING`), so
+a **second run prints `inserted 0`** and is safe to re-run.
+
+Provenance is split by the locked mapping (#1072): the **889 Opus-judged** rows
+land under `model = 'claude-opus-4-8'`, and the **13 deterministic-gate** rows
+(`rationale LIKE 'deterministic gate%'`, `keep = 0`, `quality_score = 0`) land
+under `model = 'deterministic-gate'` — never mislabeled as the Opus pin (they
+were never LLM-judged). Both carry `rubric_version = '0.2.1'`. The eval's
+det-gate exclusion (#1037, below) keys off the same marker.
+
 ## What this measures
 
 The eval (`tools/photo-curation/eval/photo-judge.eval.ts`) runs the **traced

--- a/package-lock.json
+++ b/package-lock.json
@@ -10981,6 +10981,7 @@
       "name": "@bird-watch/photo-curation",
       "version": "0.0.1",
       "dependencies": {
+        "@bird-watch/db-client": "*",
         "@bird-watch/ingestor": "*",
         "@bird-watch/photo-quality": "*",
         "@bird-watch/shared-types": "*",

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -11,9 +11,11 @@
     "test": "vitest run",
     "curate": "tsx src/cli.ts",
     "eval": "bt eval eval/photo-judge.eval.ts",
-    "analyze": "tsx scripts/analyze-experiment.ts"
+    "analyze": "tsx scripts/analyze-experiment.ts",
+    "backfill-scores": "tsx scripts/backfill-scores-to-prod.ts"
   },
   "dependencies": {
+    "@bird-watch/db-client": "*",
     "@bird-watch/ingestor": "*",
     "@bird-watch/photo-quality": "*",
     "@bird-watch/shared-types": "*",

--- a/tools/photo-curation/scripts/backfill-scores-to-prod.test.ts
+++ b/tools/photo-curation/scripts/backfill-scores-to-prod.test.ts
@@ -110,6 +110,11 @@ describe('mapRow — provenance + field mapping (locked)', () => {
     // Non-det-gate (null rationale) defaults to the Opus pin.
     expect(out.model).toBe(OPUS_MODEL);
   });
+
+  it('fails loud on a NULL keep (NOT NULL in the source schema) instead of coercing to false', () => {
+    const nullKeep: ReviewScoreRow = { ...opusRow, species_code: 'badrow', keep: null };
+    expect(() => mapRow(nullKeep)).toThrow(/NULL keep for species 'badrow'/);
+  });
 });
 
 describe('runBackfill — summary + idempotency (injected insert, no network)', () => {

--- a/tools/photo-curation/scripts/backfill-scores-to-prod.test.ts
+++ b/tools/photo-curation/scripts/backfill-scores-to-prod.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  mapRow,
+  runBackfill,
+  OPUS_MODEL,
+  DET_GATE_MODEL,
+  RUBRIC_VERSION,
+  type ReviewScoreRow,
+} from './backfill-scores-to-prod.js';
+
+/**
+ * A representative Opus-judged `role='current'` row as `better-sqlite3` returns
+ * it (verbatim shapes pulled from the real review.sqlite baseline): keep is the
+ * SQLite INTEGER 0/1, criteria_json / field_marks are JSON strings, quality_score
+ * is a REAL.
+ */
+const opusRow: ReviewScoreRow = {
+  species_code: 'abetow',
+  content_hash: '8d556766',
+  keep: 0,
+  quality_score: 58,
+  criteria_json:
+    '{"framing":8,"subjectClarity":7,"liveness":10,"naturalness":4,"pose":8,"background":7,"lighting":7}',
+  field_marks: '["Black mask","Pinkish conical bill"]',
+  rationale: 'A live, sharp wild bird … should be replaced for a premium guide.',
+};
+
+/** A deterministic-gate row: rationale starts 'deterministic gate', keep=0, score=0, empty field_marks. */
+const detGateRow: ReviewScoreRow = {
+  species_code: 'baitea',
+  content_hash: 'e6c1dc40',
+  keep: 0,
+  quality_score: 0,
+  criteria_json:
+    '{"framing":0,"subjectClarity":0,"liveness":0,"naturalness":0,"pose":0,"background":0,"lighting":0}',
+  field_marks: '[]',
+  rationale: 'deterministic gate failed: below-min-sharpness',
+};
+
+describe('mapRow — provenance + field mapping (locked)', () => {
+  it('maps an Opus-judged row to the claude-opus-4-8 model pin', () => {
+    const out = mapRow(opusRow);
+    expect(out.model).toBe(OPUS_MODEL);
+    expect(out.model).toBe('claude-opus-4-8');
+    expect(out.rubricVersion).toBe(RUBRIC_VERSION);
+    expect(out.rubricVersion).toBe('0.2.1');
+  });
+
+  it('maps a deterministic-gate row (rationale starts "deterministic gate") to the deterministic-gate model — NOT the Opus pin', () => {
+    const out = mapRow(detGateRow);
+    expect(out.model).toBe(DET_GATE_MODEL);
+    expect(out.model).toBe('deterministic-gate');
+    expect(out.model).not.toBe(OPUS_MODEL);
+    expect(out.rubricVersion).toBe('0.2.1');
+  });
+
+  it('preserves content_hash verbatim', () => {
+    expect(mapRow(opusRow).contentHash).toBe('8d556766');
+    expect(mapRow(detGateRow).contentHash).toBe('e6c1dc40');
+  });
+
+  it('converts the SQLite INTEGER keep flag to a boolean', () => {
+    expect(mapRow(opusRow).keep).toBe(false);
+    expect(mapRow({ ...opusRow, keep: 1 }).keep).toBe(true);
+  });
+
+  it('carries quality_score verbatim (det-gate keeps its 0, not null)', () => {
+    expect(mapRow(opusRow).qualityScore).toBe(58);
+    expect(mapRow(detGateRow).qualityScore).toBe(0);
+  });
+
+  it('parses criteria_json into the criteria object', () => {
+    expect(mapRow(opusRow).criteria).toEqual({
+      framing: 8,
+      subjectClarity: 7,
+      liveness: 10,
+      naturalness: 4,
+      pose: 8,
+      background: 7,
+      lighting: 7,
+    });
+  });
+
+  it('parses field_marks into a string array (empty array stays empty, never null)', () => {
+    expect(mapRow(opusRow).fieldMarks).toEqual(['Black mask', 'Pinkish conical bill']);
+    expect(mapRow(detGateRow).fieldMarks).toEqual([]);
+  });
+
+  it('carries rationale verbatim', () => {
+    expect(mapRow(detGateRow).rationale).toBe('deterministic gate failed: below-min-sharpness');
+  });
+
+  it('handles NULL json + score columns as SQL NULL (defensive — real baseline has none)', () => {
+    const nullish: ReviewScoreRow = {
+      species_code: 'nullsp',
+      content_hash: 'deadbeef',
+      keep: 1,
+      quality_score: null,
+      criteria_json: null,
+      field_marks: null,
+      rationale: null,
+    };
+    const out = mapRow(nullish);
+    expect(out.qualityScore).toBeNull();
+    expect(out.criteria).toBeNull();
+    expect(out.fieldMarks).toBeNull();
+    expect(out.rationale).toBeNull();
+    expect(out.keep).toBe(true);
+    expect(out.contentHash).toBe('deadbeef');
+    // Non-det-gate (null rationale) defaults to the Opus pin.
+    expect(out.model).toBe(OPUS_MODEL);
+  });
+});
+
+describe('runBackfill — summary + idempotency (injected insert, no network)', () => {
+  it('maps every row and reports read / inserted / skipped from the inserted count', async () => {
+    const rows: ReviewScoreRow[] = [opusRow, detGateRow, { ...opusRow, species_code: 'annhum', content_hash: 'cafe' }];
+    // First run: the prod table is empty, so insertPhotoScores inserts all 3.
+    const insert = vi.fn(async (toInsert) => toInsert.length);
+    const log = vi.fn();
+
+    const summary = await runBackfill({ rows, insert, log });
+
+    expect(summary).toEqual({ read: 3, inserted: 3, skipped: 0 });
+    expect(insert).toHaveBeenCalledTimes(1);
+    const mapped = insert.mock.calls[0]![0];
+    expect(mapped).toHaveLength(3);
+    expect(mapped[0]!.model).toBe(OPUS_MODEL);
+    expect(mapped[1]!.model).toBe(DET_GATE_MODEL);
+    // The summary line is printed.
+    expect(log.mock.calls.flat().join(' ')).toMatch(/read 3.*inserted 3.*skipped-existing 0/s);
+  });
+
+  it('reports inserted=0 / skipped=N on a second run (ON CONFLICT DO NOTHING)', async () => {
+    const rows: ReviewScoreRow[] = [opusRow, detGateRow];
+    // Second run: every tuple already exists, insertPhotoScores returns 0.
+    const insert = vi.fn(async () => 0);
+
+    const summary = await runBackfill({ rows, insert, log: () => {} });
+
+    expect(summary).toEqual({ read: 2, inserted: 0, skipped: 2 });
+  });
+
+  it('handles an empty baseline (read 0, inserted 0)', async () => {
+    const summary = await runBackfill({ rows: [], insert: async () => 0, log: () => {} });
+    expect(summary).toEqual({ read: 0, inserted: 0, skipped: 0 });
+  });
+});

--- a/tools/photo-curation/scripts/backfill-scores-to-prod.ts
+++ b/tools/photo-curation/scripts/backfill-scores-to-prod.ts
@@ -72,6 +72,19 @@ function parseJsonColumn<T>(raw: string | null): T | null {
 }
 
 /**
+ * Map the SQLite INTEGER `keep` flag (0/1) to a boolean. `keep` is NOT NULL in
+ * the source schema, so a NULL here is a data-integrity violation — fail loud
+ * (matching `parseJsonColumn`'s posture) rather than silently coercing it to
+ * `false`, which would flip a missing-data row into a confident "replace".
+ */
+function parseKeep(keep: number | null, speciesCode: string): boolean {
+  if (keep == null) {
+    throw new Error(`backfill-scores: NULL keep for species '${speciesCode}' (keep is NOT NULL in review.sqlite — refusing to coerce to false).`);
+  }
+  return keep !== 0;
+}
+
+/**
  * PURE: project a review.sqlite `role='current'` row onto a `PhotoScoreRow`,
  * applying the locked provenance mapping. Unit-tested — no SQLite, no network.
  */
@@ -82,7 +95,7 @@ export function mapRow(row: ReviewScoreRow): PhotoScoreRow {
     contentHash: row.content_hash,
     model,
     rubricVersion: RUBRIC_VERSION,
-    keep: Boolean(row.keep),
+    keep: parseKeep(row.keep, row.species_code),
     qualityScore: row.quality_score,
     criteria: parseJsonColumn<Record<string, number>>(row.criteria_json),
     fieldMarks: parseJsonColumn<string[]>(row.field_marks),

--- a/tools/photo-curation/scripts/backfill-scores-to-prod.ts
+++ b/tools/photo-curation/scripts/backfill-scores-to-prod.ts
@@ -1,0 +1,189 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// One-time, operator-run backfill of the review.sqlite photo-quality baseline
+// into prod `species_photo_scores` (epic #1074, C3 #1072).
+//
+// Loads the 902 `role='current'` rows from the operator-local review.sqlite and
+// inserts them into prod Postgres via C2's `insertPhotoScores`, which is
+// idempotent (`ON CONFLICT (species_code, content_hash, model, rubric_version)
+// DO NOTHING`). A second run therefore inserts 0 — the frozen
+// `(model, rubric_version)` pin stays an immutable ground-truth baseline.
+//
+// PROVENANCE MAPPING (locked, #1072):
+//   - The 889 Opus-judged rows (rationale NOT 'deterministic gate%') →
+//       model = 'claude-opus-4-8', rubric_version = '0.2.1'.
+//   - The 13 deterministic-gate rows (rationale 'deterministic gate%',
+//       keep = 0, quality_score = 0) → model = 'deterministic-gate',
+//       rubric_version = '0.2.1'. They were NEVER LLM-judged — mislabeling them
+//       as the Opus pin would poison the eval's baseline (#1037 already excludes
+//       them at dataset-build time, but the row must carry the honest model).
+// content_hash / keep / quality_score / rationale are carried verbatim;
+// criteria_json → criteria and field_marks → fieldMarks are JSON-parsed.
+//
+// Operator-run, NOT CI: it reads a local SQLite that does not exist in CI and
+// writes to PROD with a read-write connection string (same posture as the
+// silhouette admin scripts). The pure mapping (`mapRow`) and the orchestration
+// (`runBackfill`, with the prod write injected) are unit-tested without a
+// network or a real DB — only the thin CLI glue (`main`) opens the real SQLite
+// and prod pool.
+//
+// Lives OUTSIDE src/ (the tsconfig rootDir), like the eval + analyze entries, so
+// it is not a tsc build target; `tsx` runs it directly via
+//   npm run backfill-scores -w @bird-watch/photo-curation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { PhotoScoreRow } from '@bird-watch/shared-types';
+
+/** The frozen baseline pin: every backfilled row records rubric v0.2.1 (#1072). */
+export const RUBRIC_VERSION = '0.2.1';
+/** Model pin for the 889 Opus-judged rows. */
+export const OPUS_MODEL = 'claude-opus-4-8';
+/** Model pin for the 13 deterministic-gate (sharpness-heuristic) rows. */
+export const DET_GATE_MODEL = 'deterministic-gate';
+
+/** Marker that classifies a row as a deterministic-gate verdict, not an Opus finding. */
+const DET_GATE_PREFIX = 'deterministic gate';
+
+/**
+ * One `photo_score` row with `role='current'` as `better-sqlite3` returns it.
+ * SQLite types: `keep` is an INTEGER 0/1; `quality_score` is a REAL;
+ * `criteria_json` / `field_marks` are JSON strings; the rest are TEXT. Any
+ * column may be SQL NULL (the real baseline has none, but the mapping handles it
+ * defensively).
+ */
+export interface ReviewScoreRow {
+  species_code: string;
+  content_hash: string;
+  keep: number | null;
+  quality_score: number | null;
+  criteria_json: string | null;
+  field_marks: string | null;
+  rationale: string | null;
+}
+
+/** A deterministic-gate row is one whose rationale starts with the gate marker. */
+function isDeterministicGate(rationale: string | null): boolean {
+  return rationale != null && rationale.startsWith(DET_GATE_PREFIX);
+}
+
+/** Parse a JSON column, returning `null` for a NULL/blank cell. Throws on malformed JSON (fail loud). */
+function parseJsonColumn<T>(raw: string | null): T | null {
+  if (raw == null) return null;
+  return JSON.parse(raw) as T;
+}
+
+/**
+ * PURE: project a review.sqlite `role='current'` row onto a `PhotoScoreRow`,
+ * applying the locked provenance mapping. Unit-tested — no SQLite, no network.
+ */
+export function mapRow(row: ReviewScoreRow): PhotoScoreRow {
+  const model = isDeterministicGate(row.rationale) ? DET_GATE_MODEL : OPUS_MODEL;
+  return {
+    speciesCode: row.species_code,
+    contentHash: row.content_hash,
+    model,
+    rubricVersion: RUBRIC_VERSION,
+    keep: Boolean(row.keep),
+    qualityScore: row.quality_score,
+    criteria: parseJsonColumn<Record<string, number>>(row.criteria_json),
+    fieldMarks: parseJsonColumn<string[]>(row.field_marks),
+    rationale: row.rationale,
+  };
+}
+
+/** The injected prod write — `insertPhotoScores(pool, rows)` curried over the pool. Returns rows inserted. */
+export type InsertScores = (rows: PhotoScoreRow[]) => Promise<number>;
+
+/** Read N, inserted M, skipped-existing K. `skipped = read − inserted`. */
+export interface BackfillSummary {
+  read: number;
+  inserted: number;
+  skipped: number;
+}
+
+/**
+ * Map every baseline row, push them through the injected idempotent insert, and
+ * return the summary. PURE of I/O: `insert` is injected (defaults to nothing —
+ * the caller supplies the prod-bound `insertPhotoScores`), so the unit test
+ * needs no network. `inserted` is what the DB actually wrote (`< read` on a
+ * re-run); `skipped` is the ON CONFLICT DO NOTHING remainder.
+ */
+export async function runBackfill(opts: {
+  rows: ReviewScoreRow[];
+  insert: InsertScores;
+  log?: (...args: unknown[]) => void;
+}): Promise<BackfillSummary> {
+  const log = opts.log ?? (() => {});
+  const mapped = opts.rows.map(mapRow);
+  const inserted = await opts.insert(mapped);
+  const summary: BackfillSummary = {
+    read: mapped.length,
+    inserted,
+    skipped: mapped.length - inserted,
+  };
+  log(
+    `backfill-scores: read ${summary.read}, inserted ${summary.inserted}, skipped-existing ${summary.skipped}`,
+  );
+  return summary;
+}
+
+// ── CLI glue (operator-run; opens real SQLite + prod pool; not unit-tested) ───
+
+/** SQL for the 902 `role='current'` baseline rows, projected to `ReviewScoreRow`. */
+const SELECT_CURRENT_SCORES = `
+  SELECT species_code, content_hash, keep, quality_score, criteria_json, field_marks, rationale
+  FROM photo_score
+  WHERE role = 'current'
+  ORDER BY species_code
+`;
+
+/**
+ * CLI entry. Opens review.sqlite (`REVIEW_DB`, default ./review.sqlite), opens a
+ * prod RW pool (`DATABASE_URL`), and runs the backfill. `process.env` and the
+ * dynamic imports are read at call time so the unit test never reaches here.
+ */
+export async function main(env: NodeJS.ProcessEnv = process.env): Promise<number> {
+  const databaseUrl = env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error(
+      'backfill-scores: DATABASE_URL is required (a PROD read-WRITE connection string). Aborting.',
+    );
+    return 2;
+  }
+  const dbPath = env.REVIEW_DB ?? './review.sqlite';
+
+  // Imported dynamically so the pure unit test never loads better-sqlite3 / pg.
+  const [{ default: Database }, { createPool, closePool, insertPhotoScores }] = await Promise.all([
+    import('better-sqlite3'),
+    import('@bird-watch/db-client'),
+  ]);
+
+  const sqlite = new Database(dbPath, { readonly: true, fileMustExist: true });
+  let rows: ReviewScoreRow[];
+  try {
+    rows = sqlite.prepare(SELECT_CURRENT_SCORES).all() as ReviewScoreRow[];
+  } finally {
+    sqlite.close();
+  }
+
+  const pool = createPool({ databaseUrl });
+  try {
+    await runBackfill({
+      rows,
+      insert: (toInsert) => insertPhotoScores(pool, toInsert),
+      log: (...args) => console.log(...args),
+    });
+  } finally {
+    await closePool(pool);
+  }
+  return 0;
+}
+
+// Run only when invoked directly (tsx scripts/backfill-scores-to-prod.ts), never on import.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph operator["operator run-worktree (NOT CI)"]
        sqlite[("review.sqlite\n902 role='current' rows")]
    end
    sqlite -->|"better-sqlite3\nSELECT … WHERE role='current'"| map["mapRow (pure)"]
    map -->|"889 Opus rows"| opus["model='claude-opus-4-8'\nrubric='0.2.1'"]
    map -->|"13 det-gate rows\n(rationale 'deterministic gate%')"| gate["model='deterministic-gate'\nrubric='0.2.1'"]
    opus --> insert
    gate --> insert
    insert["insertPhotoScores (C2)\nON CONFLICT DO NOTHING"] -->|"DATABASE_URL (prod RW)"| pg[("prod\nspecies_photo_scores")]
    insert -.->|"2nd run: inserted=0"| pg
```

## Summary

- **Why:** the photo-judge eval (C4 #1073) and any other consumer need to read the frozen ground-truth baseline from **prod Postgres**, not a machine-local SQLite. This promotes the 902 `role='current'` Opus scores once, idempotently, via C2's `insertPhotoScores` (`ON CONFLICT DO NOTHING`) — a second run inserts 0.
- **Operator-run, not CI:** the script reads a local SQLite that doesn't exist on a runner and writes to prod with a **read-write** connection string (same posture as the silhouette admin scripts). It lives in `scripts/` (outside the `tsc` rootDir) and runs via `tsx` through `npm run backfill-scores -w @bird-watch/photo-curation`, mirroring `analyze-experiment.ts`.
- **Honest provenance (locked #1072):** the 889 Opus-judged rows pin `model='claude-opus-4-8'`; the 13 deterministic-gate rows (`rationale LIKE 'deterministic gate%'`, `keep=0`, `quality_score=0`) pin `model='deterministic-gate'` — they were never LLM-judged and must not borrow the Opus pin. Both carry `rubric_version='0.2.1'`. Verified against the real baseline: 902 total = 889 opus + 13 det-gate.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — green (23 files, 312 tests; 12 new in `backfill-scores-to-prod.test.ts`)
- [x] New unit tests added — the **pure** `mapRow` (provenance split, INTEGER→bool `keep`, `criteria_json`/`field_marks` JSON parse, verbatim `content_hash`/`quality_score`/`rationale`, defensive NULL handling) and `runBackfill` (read/inserted/skipped summary + `inserted=0` on a re-run) with the prod write **injected** — no network, no real DB
- [x] N/A — no user-visible behavior, no Playwright e2e
- [x] `npm run build -w @bird-watch/photo-curation` — clean
- [x] `npx knip` — exit 0 (npm-script entry traces the script; new `@bird-watch/db-client` dep traced — no ignore rule needed)
- [x] `npm ci --dry-run` — lockfile consistent after adding the `@bird-watch/db-client` workspace dep
- [x] Runbook (`docs/runbooks/photo-judge-eval.md`) documents the one-time operator step + the prod RW connection-string requirement

## Plan reference

Out of plan (plans-in-issues) — implements child **C3 #1072** of epic **#1074** (promote-scores-to-prod). Depends on C1 (migration) + C2 (`insertPhotoScores`), both merged.

Closes #1072.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)