### PR TITLE
fix(frontend): scope select commits via Go/Enter, not on change (WCAG 3.2.2)

### DIFF
--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -55,6 +55,14 @@ export class AppPage {
   readonly scopeControl: Locator;
   /** The in-state state-switch `<select>` (`aria-label='Switch state'`). */
   readonly scopeControlStateSelect: Locator;
+  /**
+   * #1035 (WCAG 3.2.2): the in-state state-row "Go" commit button. Changing the
+   * `<select>` no longer navigates by itself — an explicit Go (or Enter) commits
+   * the staged state via `onPickState`. Scoped to the State row's `<form>` (the
+   * one containing the "Switch state" select) so it never collides with the
+   * embedded ZipInput's own "Go" submit. Mirrors `chooserStateGo`.
+   */
+  readonly scopeControlStateGo: Locator;
   /** The in-state niche "Whole US" escape hatch (state view only). */
   readonly scopeControlWholeUs: Locator;
   /** The "Change scope" exit affordance → returns to the chooser. */
@@ -157,6 +165,12 @@ export class AppPage {
     this.scopeDisclosureTrigger = this.appHeader.getByRole('button', { name: /change region|close scope options/i });
     this.scopeControl = page.getByRole('region', { name: 'Change the map scope' });
     this.scopeControlStateSelect = this.scopeControl.getByLabel('Switch state', { exact: true });
+    // #1035: the State-row "Go" is the ScopeControl's "Go" that lives in the same
+    // <form> as the "Switch state" <select> — scope it there so it never matches
+    // the embedded ZipInput's "Go" submit (both read "Go"). Mirrors chooserStateGo.
+    this.scopeControlStateGo = this.scopeControl
+      .locator('form', { has: page.getByLabel('Switch state', { exact: true }) })
+      .getByRole('button', { name: 'Go', exact: true });
     this.scopeControlWholeUs = this.scopeControl.getByRole('button', { name: 'Whole US', exact: true });
     this.scopeControlExit = this.scopeControl.getByRole('button', { name: 'Change scope' });
 
@@ -303,6 +317,19 @@ export class AppPage {
   async pickStateInChooser(stateCode: string): Promise<void> {
     await this.chooserStateSelect.selectOption(stateCode);
     await this.chooserStateGo.click();
+  }
+
+  /**
+   * #1035 (WCAG 3.2.2): switch state via the in-state ScopeControl by staging a
+   * selection then committing with the new "Go" button. Changing the `<select>`
+   * no longer navigates by itself — only Go/Enter commits — so the e2e
+   * round-trip must drive the explicit commit, exactly like `pickStateInChooser`
+   * does for the landing chooser. Call `openScopeDisclosure()` first (the form is
+   * mounted-but-hidden behind the 🔍 disclosure in a scoped view).
+   */
+  async switchStateViaScopeControl(stateCode: string): Promise<void> {
+    await this.scopeControlStateSelect.selectOption(stateCode);
+    await this.scopeControlStateGo.click();
   }
 
   /**

--- a/frontend/e2e/scope-disclosure.spec.ts
+++ b/frontend/e2e/scope-disclosure.spec.ts
@@ -246,9 +246,10 @@ test.describe('Scope disclosure (#828)', () => {
     const app = await setup(page, apiStub);
 
     await app.openScopeDisclosure();
-    // Switch to another state via the revealed <select>.
+    // Switch to another state via the revealed <select> + Go (#1035: change no
+    // longer navigates; the explicit Go commit does).
     const target = STATES_FIXTURE.find(s => s.stateCode === 'US-FL')!;
-    await app.scopeControlStateSelect.selectOption(target.stateCode);
+    await app.switchStateViaScopeControl(target.stateCode);
 
     // The URL round-trips to the new scope (the persisted action — unlike the
     // disclosure open/closed state, which is component-local, not in the URL).

--- a/frontend/e2e/state-artboard.spec.ts
+++ b/frontend/e2e/state-artboard.spec.ts
@@ -574,8 +574,8 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
 
     // #828: reveal the scope form (collapsed behind the 🔍 disclosure).
     await app.openScopeDisclosure();
-    // Switch AZ → NY in place (the on-map ScopeControl select). No remount.
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    // Switch AZ → NY in place (the on-map ScopeControl select + Go #1035). No remount.
+    await app.switchStateViaScopeControl('US-NY');
     await expect(page).toHaveURL(/[?&]state=US-NY\b/);
     await app.waitForAppReady();
 
@@ -845,7 +845,8 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
     // switching states via the in-card select.
     await app.openScopeDisclosure();
     // state→state updates the SAME polite region's text (no focus move).
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    // #1035: select + Go commit (change no longer navigates).
+    await app.switchStateViaScopeControl('US-NY');
     await expect(page).toHaveURL(/[?&]state=US-NY\b/);
     await expect(
       page.locator('[role="status"][aria-live="polite"]').filter({ hasText: /Showing / }),
@@ -900,7 +901,8 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
 
     // #828: reveal the scope form (collapsed behind the 🔍 disclosure).
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    // #1035: select + Go commit (change no longer navigates).
+    await app.switchStateViaScopeControl('US-NY');
     await expect(page).toHaveURL(/[?&]state=US-NY\b/);
 
     // Poll for the captured duration (the camera effect fires post-URL-commit).
@@ -957,9 +959,10 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
       }
 
       // Activation still drives the transition over the mask: switch AZ → NY via
-      // keyboard on the focused select.
+      // the keyboard-operable select + Go commit (#1035: change no longer
+      // navigates — the explicit Go/Enter commit does, for every input modality).
       await app.scopeControlStateSelect.focus();
-      await app.scopeControlStateSelect.selectOption('US-NY');
+      await app.switchStateViaScopeControl('US-NY');
       await expect(page).toHaveURL(/[?&]state=US-NY\b/);
 
       assertCleanConsole();

--- a/frontend/e2e/state-scope-midmotion-longitude.spec.ts
+++ b/frontend/e2e/state-scope-midmotion-longitude.spec.ts
@@ -229,8 +229,9 @@ test.describe('#848: state framing longitude when switching states mid-animation
     expect(moving, 'camera is mid-flight after easeTo(duration:4000)').toBe(true);
 
     // Switch to NY WHILE the camera is moving. NO resize/drag/reload.
+    // #1035: select + Go commit (change no longer navigates).
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    await app.switchStateViaScopeControl('US-NY');
 
     await waitSettled(page, app);
     await assertFramedToTarget(page);
@@ -276,7 +277,8 @@ test.describe('#848: state framing longitude when switching states mid-animation
     ]);
 
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    // #1035: select + Go commit (change no longer navigates).
+    await app.switchStateViaScopeControl('US-NY');
 
     await waitSettled(page, app);
     await assertFramedToTarget(page);
@@ -300,7 +302,8 @@ test.describe('#848: state framing longitude when switching states mid-animation
     expect(moving, 'camera is mid-flight after easeTo(duration:4000)').toBe(true);
 
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-FL');
+    // #1035: select + Go commit (change no longer navigates).
+    await app.switchStateViaScopeControl('US-FL');
 
     await waitSettled(page, app);
     await assertFramedToTarget(page);

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -501,7 +501,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
 
     // In-app switch to FL via the in-card scope control — NO resize/drag/reload.
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-FL');
+    await app.switchStateViaScopeControl('US-FL');
 
     // (a) The camera flips to FL.
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-FL');
@@ -537,7 +537,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.mapLede).toHaveText(/^\d+ species$/);
 
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-NY');
+    await app.switchStateViaScopeControl('US-NY');
 
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-NY');
     await expect(app.mapLede).toHaveText(/^\d+ species$/);
@@ -567,7 +567,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await app.waitForAppReady();
 
     await app.openScopeDisclosure();
-    await app.scopeControlStateSelect.selectOption('US-AZ');
+    await app.switchStateViaScopeControl('US-AZ');
 
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
     await expect(app.mapLede).toHaveText(/^\d+ species$/);

--- a/frontend/src/components/ScopeControl.test.tsx
+++ b/frontend/src/components/ScopeControl.test.tsx
@@ -45,6 +45,18 @@ function renderControl(
   return props;
 }
 
+/**
+ * The state-row "Go" commit button. Both the embedded <ZipInput> and the state
+ * row expose a "Go" submit (#1035), so scope to the form that contains the
+ * "Switch state" <select> — mirrors the POM's chooser-Go disambiguation.
+ */
+function getStateGo(): HTMLElement {
+  const select = screen.getByRole('combobox', { name: /switch state/i });
+  const form = select.closest('form');
+  if (!form) throw new Error('state <select> must be inside a <form> for Enter/Go commit');
+  return within(form).getByRole('button', { name: /^go$/i });
+}
+
 describe('<ScopeControl>', () => {
   beforeEach(() => {
     mockLoadZipIndex.mockReset().mockResolvedValue(undefined);
@@ -86,17 +98,60 @@ describe('<ScopeControl>', () => {
     expect(select.value).toBe('US-CA');
   });
 
-  it('selecting a state emits onPickState once with the chosen US-XX code', async () => {
+  // WCAG 3.2.2 (On Input, #1035): changing the <select> must NOT navigate by
+  // itself — only an explicit Go/Enter commit emits the scope. Mirrors the
+  // landing chooser's transient-value-then-Go pattern.
+  it('changing the select does NOT call onPickState (WCAG 3.2.2 — change never navigates)', async () => {
     const { onPickState } = renderControl();
     await userEvent.selectOptions(
       screen.getByRole('combobox', { name: /switch state/i }),
       'US-NY',
     );
+    // Selection is staged locally; no navigation fires on change for any input
+    // modality (keyboard arrow-browse or pointer pick).
+    expect(onPickState).not.toHaveBeenCalled();
+  });
+
+  it('select + Go commits: emits onPickState once with the chosen US-XX code', async () => {
+    const { onPickState } = renderControl();
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: /switch state/i }),
+      'US-NY',
+    );
+    await userEvent.click(getStateGo());
     expect(onPickState).toHaveBeenCalledTimes(1);
     expect(onPickState).toHaveBeenCalledWith('US-NY');
   });
 
-  it('in a ?scope=us view the select shows the neutral placeholder, and a state pick still calls onPickState', async () => {
+  it('Enter on the focused Go (form submit) commits: emits onPickState once with the chosen US-XX code', async () => {
+    const { onPickState } = renderControl();
+    const select = screen.getByRole('combobox', { name: /switch state/i });
+    await userEvent.selectOptions(select, 'US-CA');
+    // Enter on the focused submit button fires the enclosing form's onSubmit →
+    // commit. (Native selects swallow Enter rather than submit, so the keyboard
+    // commit path is the submit button — same form-submit handler as Go-click.)
+    const go = getStateGo();
+    go.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onPickState).toHaveBeenCalledTimes(1);
+    expect(onPickState).toHaveBeenCalledWith('US-CA');
+  });
+
+  it('Go is disabled while the placeholder is selected, and committing it is a no-op', async () => {
+    const { onPickState } = renderControl({ scope: { kind: 'us' } });
+    const select = screen.getByRole('combobox', {
+      name: /switch state/i,
+    }) as HTMLSelectElement;
+    // Whole-US view starts on the neutral placeholder (no pending state).
+    expect(select.value).toBe('');
+    const go = getStateGo();
+    expect(go).toBeDisabled();
+    // Even a programmatic click cannot commit while the placeholder is selected.
+    await userEvent.click(go);
+    expect(onPickState).not.toHaveBeenCalled();
+  });
+
+  it('in a ?scope=us view the select shows the neutral placeholder, and select + Go calls onPickState', async () => {
     const { onPickState } = renderControl({ scope: { kind: 'us' } });
     const select = screen.getByRole('combobox', {
       name: /switch state/i,
@@ -106,6 +161,7 @@ describe('<ScopeControl>', () => {
     expect(within(select).getAllByRole('option')[0]).toHaveTextContent(/switch state/i);
 
     await userEvent.selectOptions(select, 'US-AZ');
+    await userEvent.click(getStateGo());
     expect(onPickState).toHaveBeenCalledTimes(1);
     expect(onPickState).toHaveBeenCalledWith('US-AZ');
   });
@@ -157,16 +213,20 @@ describe('<ScopeControl>', () => {
   it('a11y: select + buttons are reachable by accessible name and keyboard-operable in order', async () => {
     renderControl();
     const select = screen.getByRole('combobox', { name: /switch state/i });
+    const go = getStateGo();
     const zip = screen.getByRole('textbox', { name: /ZIP code/i });
     const exit = screen.getByRole('button', { name: /change scope/i });
     expect(select).toBeInTheDocument();
+    expect(go).toBeInTheDocument();
     expect(zip).toBeInTheDocument();
     expect(exit).toBeInTheDocument();
 
-    // Tab order: state select → ZIP input → (whole-US) → exit. No trap — the
-    // exit button is reachable from the select via tabbing.
+    // Tab order: state select → Go (commit) → ZIP input → (whole-US) → exit. No
+    // trap — every control is reachable from the select via forward tabbing.
     select.focus();
     expect(select).toHaveFocus();
+    await userEvent.tab();
+    expect(go).toHaveFocus();
     await userEvent.tab();
     expect(zip).toHaveFocus();
   });

--- a/frontend/src/components/ScopeControl.tsx
+++ b/frontend/src/components/ScopeControl.tsx
@@ -95,6 +95,27 @@ function ScopeControlImpl(
   // view the neutral placeholder ("") is selected (no state is active).
   const selectedState = scope.kind === 'state' ? scope.stateCode : '';
 
+  // WCAG 3.2.2 (On Input, #1035): the <select> sets a TRANSIENT local value;
+  // changing it never navigates. An explicit Go button / Enter (form submit)
+  // commits the pending value via `onPickState`. This mirrors the landing
+  // chooser (ScopeChooser) so both pointer and keyboard use the same commit
+  // model — `change` is inert for every input modality, so keyboard arrow-browse
+  // through options no longer yanks scope mid-browse. The pending value is
+  // seeded from (and re-syncs to) the current scope so the displayed selection
+  // tracks the active scope until the user stages a different one.
+  const [pendingState, setPendingState] = React.useState(selectedState);
+  React.useEffect(() => {
+    setPendingState(selectedState);
+  }, [selectedState]);
+
+  function handleStateSubmit(e: React.FormEvent): void {
+    e.preventDefault();
+    // The placeholder (value "") is never a valid scope — Go is disabled there,
+    // but guard the submit path too (Enter could otherwise fire on an empty
+    // selection).
+    if (pendingState) onPickState(pendingState);
+  }
+
   // When embedded inside the identity card, use a class that does NOT apply
   // the old absolute-positioned overlay CSS. The identity card owns the layout.
   const wrapperClass = embedded ? 'scope-control scope-control--embedded' : 'scope-control';
@@ -105,21 +126,34 @@ function ScopeControlImpl(
       role="region"
       aria-label="Change the map scope"
     >
-      <select
-        ref={firstFieldRef}
-        className="scope-control__select"
-        aria-label="Switch state"
-        value={selectedState}
-        // Only a non-empty selection emits a scope; the placeholder is inert.
-        onChange={(e) => e.target.value && onPickState(e.target.value)}
-      >
-        <option value="">Switch state…</option>
-        {states.map((s) => (
-          <option key={s.stateCode} value={s.stateCode}>
-            {s.name}
-          </option>
-        ))}
-      </select>
+      {/* WCAG 3.2.2 (#1035): the select stages a pending value; an explicit Go
+          (or Enter, via this form's submit) commits it. `change` never
+          navigates — same commit model for pointer and keyboard. */}
+      <form className="scope-control__state-form" onSubmit={handleStateSubmit}>
+        <select
+          ref={firstFieldRef}
+          className="scope-control__select"
+          aria-label="Switch state"
+          value={pendingState}
+          // Inert on change: only stage the selection locally (no navigation).
+          onChange={(e) => setPendingState(e.target.value)}
+        >
+          <option value="">Switch state…</option>
+          {states.map((s) => (
+            <option key={s.stateCode} value={s.stateCode}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="scope-control__go"
+          // Inert while the placeholder is selected — there is nothing to commit.
+          disabled={!pendingState}
+        >
+          Go
+        </button>
+      </form>
 
       {/* <ZipInput> (#739) owns the ZIP input, lazy index load, lookup, and the
           "not recognized" / malformed / fetch-error UX. ScopeControl forwards

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2892,7 +2892,11 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    own muted color at equal specificity) untouched regardless of source order;
    .zip-input__submit is always enabled so the guard is a no-op there. */
 [data-theme="dark"] .zip-input__submit,
-[data-theme="dark"] .scope-chooser__btn:not(:disabled) {
+[data-theme="dark"] .scope-chooser__btn:not(:disabled),
+/* #1035: the in-state ScopeControl [Go] commit button uses the same dark fill,
+   so it needs the same dark-mode label flip (light fill → dark text) to clear
+   AA. :not(:disabled) leaves .scope-control__go:disabled's muted color alone. */
+[data-theme="dark"] .scope-control__go:not(:disabled) {
   color: var(--color-bg-surface);
 }
 .zip-input__status {
@@ -3211,6 +3215,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    de-emphasized Whole-US / Change-scope links keep the base text-strong ring
    (they are link-like, not form fields). */
 .app-header-scope-rows .scope-control__select:focus-visible,
+.app-header-scope-rows .scope-control__go:focus-visible,
 .app-header-scope-rows .zip-input__field:focus-visible,
 .app-header-scope-rows .zip-input__submit:focus-visible {
   outline: 2px solid transparent;
@@ -3218,6 +3223,16 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
+/* #1035 (WCAG 3.2.2): the state <select> and its commit [Go] share one
+   horizontal row inside a <form> — changing the select stages a value; only Go
+   / Enter commits. Mirrors the landing chooser's `.scope-chooser__row`. */
+.scope-control__state-form {
+  display: flex;
+  flex: 0 1 auto;
+  align-items: stretch;
+  gap: var(--space-sm);
+  min-inline-size: 0;
+}
 .scope-control__select {
   flex: 0 1 auto;
   min-inline-size: 0;
@@ -3231,6 +3246,31 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
 .scope-control__select:focus-visible {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
+}
+/* #1035: the explicit Go commit button — styled like the chooser's
+   `.scope-chooser__btn` (primary dark fill, white text) but sized to the
+   in-card `--type-sm` scale the other ScopeControl controls use. Disabled while
+   the placeholder is selected (nothing to commit). */
+.scope-control__go {
+  flex: 0 0 auto;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--type-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-white);
+  background: var(--color-text-strong);
+  border: 1px solid var(--color-text-strong);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.scope-control__go:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+.scope-control__go:disabled {
+  color: var(--color-text-muted);
+  background: var(--color-bg-tint);
+  border-color: var(--color-border-ui);
+  cursor: not-allowed;
 }
 .scope-control__zip {
   flex: 0 1 auto;
@@ -3277,8 +3317,14 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
     flex-wrap: wrap;
     gap: var(--space-sm);
   }
-  .scope-control__select {
+  /* #1035: the state row (select + [Go]) takes its own full-width line; the
+     select flexes to fill it and [Go] keeps its intrinsic width beside it. */
+  .scope-control__state-form {
     flex: 1 1 100%;
+    min-inline-size: 0;
+  }
+  .scope-control__select {
+    flex: 1 1 auto;
   }
   /* #842: at the narrow widths the identity card is capped to
      `calc(100% - 200px)` (line ~594) so it doesn't collide with the controls


### PR DESCRIPTION
## Diagrams

State machine for the in-state scope `<select>` — change stages a value, only Go/Enter commits (WCAG 3.2.2 On Input):

```mermaid
stateDiagram-v2
    [*] --> Synced: mount (pending = active scope)
    Synced --> Pending: onChange (stage value, NO navigate)
    Pending --> Pending: onChange (re-stage)
    Pending --> Committed: Go click / Enter (form submit)
    Committed --> onPickState: emit US-XX
    Synced --> Synced: Go disabled while placeholder selected
    onPickState --> Synced: scope prop updates, pending re-syncs
```

## Summary

- **Why:** the in-state `ScopeControl` `<select>` wired `onChange` straight into `onPickState`, so changing the selection navigated scope by itself — a WCAG 3.2.2 (On Input) failure. Keyboard users arrow-browsing options fire `change` per keypress in some browsers, yanking scope mid-browse.
- **What:** mirror the landing chooser's commit model — the select stages a transient local value; an explicit **Go** button (or Enter via the wrapping form's submit) commits it through `onPickState`. `change` is inert for every input modality; Go is disabled while the neutral placeholder is selected. The `memo(forwardRef)` boundary and the #837 first-field focus ref on the `<select>` are preserved.
- **E2E sweep:** the change-navigates contract was baked into 11 `scopeControlStateSelect.selectOption(...)`→assert-navigation call sites across 4 specs. Added a POM helper `switchStateViaScopeControl(stateCode)` (select + click Go, scoped to the State-row form) and swept all 11 onto it.

## Screenshots

Live-verified at the 5 canonical viewports × 2 themes on the dev server (PR head `72bd888`, real read-api + seeded Postgres), **scope disclosure open** so the new Go button shows top-left. WCAG 3.2.2 contract confirmed live (`browser_evaluate` + real click): changing the state `<select>` to US-CA left the URL at `?state=US-AZ` (**change never navigates**); the placeholder selection **disables** Go; a real state **enables** it; **clicking Go commits** (→ `?state=US-CA`, title "Bird Maps · California"). Console clean — only the pre-existing `circle-11` basemap-sprite warning (#947, out of scope). The Go button carries the chooser's primary-fill styling + dark-mode label flip + in-card softened focus ring.

| Viewport | Light | Dark |
|---|---|---|
| **390×844** mobile | <img width="260" alt="a6-1082-390-light" src="https://github.com/user-attachments/assets/88021996-0984-4c0a-ae40-a776e78ecf4b" /> | <img width="260" alt="a6-1082-390-dark" src="https://github.com/user-attachments/assets/177fed24-0a78-44b6-a993-2385b2fbb3c5" /> |
| **768×1024** tablet | <img width="260" alt="a6-1082-768-light" src="https://github.com/user-attachments/assets/92d6b8de-4710-4f84-8f8d-abe65f6dee92" /> | <img width="260" alt="a6-1082-768-dark" src="https://github.com/user-attachments/assets/c86c4650-7a4a-4d55-b4d1-6a3c83b01bde" /> |
| **1024×768** laptop | <img width="260" alt="a6-1082-1024-light" src="https://github.com/user-attachments/assets/de8b1628-5308-4c02-a627-4ec06fcf717b" /> | <img width="260" alt="a6-1082-1024-dark" src="https://github.com/user-attachments/assets/fa847114-a2d9-4c56-86be-b63a4bb87dd4" /> |
| **1440×900** desktop | <img width="260" alt="a6-1082-1440-light" src="https://github.com/user-attachments/assets/176202aa-d07d-4704-baad-ef67396beefd" /> | <img width="260" alt="a6-1082-1440-dark" src="https://github.com/user-attachments/assets/2671fdc3-55dd-4f85-8e68-9ef9759286b1" /> |
| **1920×1080** wide | <img width="260" alt="a6-1082-1920-light" src="https://github.com/user-attachments/assets/5e2de325-75b2-4cfb-8c8d-1754a53698e1" /> | <img width="260" alt="a6-1082-1920-dark" src="https://github.com/user-attachments/assets/199b4556-4d31-47ec-8bf4-64d4b747e06d" /> |


- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` — `.scope-control__state-form` and `.scope-control__go` both have rules (incl. dark-mode label flip + in-card softened focus ring).
- [x] Multi-viewport design QA: 10 `user-attachments` URLs (5 viewports × 2 themes) captured live at PR head `72bd888`.

## Test plan

- [x] `npx tsc -b frontend` — green; `npm test --workspace @bird-watch/frontend` — 86 files / 1322 tests green (incl. the new ScopeControl WCAG-3.2.2 tests: change does NOT navigate, select+Go commits, select+Enter commits, Go inert on placeholder).
- [x] New unit tests added — ScopeControl.test.tsx covers the new commit model.
- [x] E2E updated — POM helper + 11-call-site sweep; `npx playwright test … --list` compiles all 4 affected specs (32 tests).
- [x] `npm run build` — clean production build.
- [x] `npm run lint` — green; `npx knip` — clean.
- [x] (UI only) Playwright MCP smoke — done by orchestrator: change-no-navigate + placeholder-disables-Go + Go-click-commits all confirmed live; console 0 errors/0 warnings (modulo pre-existing #947); 10 user-attachments above.

## Plan reference

Closes #1035. Part of #1029 (design-review remediation, wave A6). Out-of-plan-doc — tracked as a GitHub issue, not a `docs/plans` file (repo convention: plans live in issues).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

