### PR TITLE
fix(a11y): keyboard-operable marker layer + accessible names (A1, #1030)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2175,6 +2175,99 @@ describe('O2 (#770): skip-link + FamilyLegend hoisted to App-root siblings', () 
     if (!skipLink || !mapLayer) return;
     expect(mapLayer.contains(skipLink)).toBe(false);
   });
+
+  // --- C47/C48 (#1030): skip-link targets a FOCUSABLE marker surface ---------
+  //
+  // MapSurface is stubbed in this file, so the real marker DOM is not present.
+  // These tests inject fixture marker nodes (matching the production data-testid
+  // / className contracts) into the document, then click the skip-link and
+  // assert which one receives focus — exercising `focusFirstMarker`'s priority
+  // ladder and the "never no-op on a non-focusable element" guarantee.
+
+  const NON_EMPTY_OBS = {
+    data: [
+      {
+        subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.2, lng: -110.9, obsDt: new Date().toISOString(), locId: 'L1',
+        locName: 'Tucson', howMany: 1, isNotable: false, silhouetteId: null,
+        familyCode: 'tyrannidae',
+      },
+    ],
+    meta: { freshestObservationAt: new Date().toISOString() },
+  };
+
+  async function renderWithMarkersAndClickSkipLink(
+    inject: (host: HTMLElement) => HTMLElement,
+  ): Promise<{ injected: HTMLElement; skipLink: HTMLButtonElement }> {
+    mockGetObservations.mockResolvedValue(NON_EMPTY_OBS);
+    const { container } = render(<App />);
+    // Wait for observations to settle so the skip-link's onClick guard
+    // (observations.length > 0) is satisfied.
+    await waitFor(() => {
+      expect(container.querySelector('#map-layer')?.getAttribute('aria-busy')).toBe('false');
+    });
+    // Inject the fixture marker(s) into a host appended to the body (outside the
+    // RTL container is fine — focusFirstMarker queries `document`).
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const injected = inject(host);
+    const skipLink = container.querySelector(
+      '[data-testid="explore-map-markers-skip-link"]',
+    ) as HTMLButtonElement;
+    expect(skipLink).not.toBeNull();
+    act(() => {
+      skipLink.click();
+    });
+    return { injected, skipLink };
+  }
+
+  it('falls back to the hit-layer active button when no grid cells exist (#1030 C47)', async () => {
+    const { injected } = await renderWithMarkersAndClickSkipLink((host) => {
+      host.innerHTML =
+        '<div class="map-marker-hit-layer">' +
+        '<button type="button" tabindex="0" data-sub-id="S1" aria-label="Vermilion Flycatcher, …"></button>' +
+        '</div>';
+      return host.querySelector('button') as HTMLElement;
+    });
+    expect(document.activeElement).toBe(injected);
+    document.body.removeChild(injected.closest('.map-marker-hit-layer')!.parentElement!);
+  });
+
+  it('targets the coarse-pointer outer cluster button and never no-ops on a non-focusable cell (#1030 C48)', async () => {
+    const { injected } = await renderWithMarkersAndClickSkipLink((host) => {
+      // Coarse pointer: cells are non-focusable <div>s (same data-testid), and
+      // the OUTER cluster <button> carries tabIndex=0. The skip-link must skip
+      // the div and land on the focusable outer button.
+      host.innerHTML =
+        '<button type="button" data-testid="adaptive-grid-marker" tabindex="0" aria-label="Cluster">' +
+        '<div data-testid="adaptive-grid-marker-cell-rendered"></div>' +
+        '</button>';
+      return host.querySelector('[data-testid="adaptive-grid-marker"]') as HTMLElement;
+    });
+    expect(document.activeElement).toBe(injected);
+    // The non-focusable cell div did NOT receive focus.
+    expect((document.activeElement as HTMLElement).getAttribute('data-testid')).toBe(
+      'adaptive-grid-marker',
+    );
+    document.body.removeChild(injected.parentElement!);
+  });
+
+  it('prefers a focusable per-cell silhouette button over the hit layer when grid cells exist (#1030)', async () => {
+    const { injected } = await renderWithMarkersAndClickSkipLink((host) => {
+      // Fine pointer: per-cell silhouette <button>s exist AND a hit-layer
+      // button exists. The cell button must win (priority 1).
+      host.innerHTML =
+        '<div class="map-marker-hit-layer">' +
+        '<button type="button" tabindex="0" data-sub-id="S1" aria-label="hit"></button>' +
+        '</div>' +
+        '<button type="button" data-testid="adaptive-grid-marker-cell-rendered" tabindex="0" aria-label="Tyrant Flycatchers, 5 observations"></button>';
+      return host.querySelector(
+        '[data-testid="adaptive-grid-marker-cell-rendered"]',
+      ) as HTMLElement;
+    });
+    expect(document.activeElement).toBe(injected);
+    document.body.removeChild(injected.parentElement!);
+  });
 });
 
 describe('O8 (#784): React.memo render-count regression — FamilyLegend + ScopeControl', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -173,6 +173,45 @@ function craftedFromError(error: Error): string {
   return 'Something went wrong loading the bird data. Try refreshing.';
 }
 
+/**
+ * C47/C48 (#1030) — resolve and focus the first FOCUSABLE marker surface for the
+ * "Explore map markers" skip-link. Tries candidates in priority order and stops
+ * at the first one that can actually take focus, so the skip-link can never
+ * silently no-op (the C48 dead end where `firstCell?.focus()` fired on a
+ * non-focusable coarse-pointer cell <div>):
+ *
+ *   1. A focusable per-cell silhouette <button> (fine-pointer adaptive grids).
+ *      Restricted to `button` so the coarse-pointer cell <div>s (same
+ *      data-testid, but non-focusable) are skipped rather than no-op'd.
+ *   2. The keyboard-active marker hit-layer <button> (`tabIndex=0`) — the
+ *      roving-tabindex entry point for UNCLUSTERED observations at high zoom,
+ *      i.e. the fallback when no grid cells exist.
+ *   3. The coarse-pointer outer cluster <button> (`tabIndex=0`) — on touch +
+ *      hardware keyboard the cells are non-focusable, so the outer button (which
+ *      opens the ClusterListPopover) is the only focusable marker surface.
+ *
+ * Selectors are tried separately (not as one comma list) because
+ * `querySelector` returns the first DOM-order match, which would not honor this
+ * priority when several kinds coexist.
+ */
+function focusFirstMarker(): void {
+  const candidateSelectors = [
+    'button[data-testid="adaptive-grid-marker-cell-rendered"], ' +
+      'button[data-testid="adaptive-grid-marker-cell-fallback"]',
+    '.map-marker-hit-layer button[tabindex="0"]',
+    'button[data-testid="adaptive-grid-marker"][tabindex="0"]',
+  ];
+  for (const selector of candidateSelectors) {
+    const target = document.querySelector(selector) as HTMLElement | null;
+    if (target) {
+      target.focus();
+      // Confirm focus actually landed (a detached/inert element won't take it);
+      // only then stop. Otherwise fall through to the next candidate.
+      if (document.activeElement === target) return;
+    }
+  }
+}
+
 export function App() {
   const { state, set } = useUrlState();
   const isCompact = useIsCompact();
@@ -1233,10 +1272,20 @@ export function App() {
           so a fresh Tab into the scoped map view reaches this button BEFORE
           any ScopeControl or canvas element (DOM order determines tab order;
           position:fixed does NOT reorder focus). The skip-link activates
-          focus on the first marker cell (the keyboard bypass for the 344-
-          marker tap sequence). Gated on `mapVisible && scopeActive` so it
-          does not render on the unscoped landing or the non-map view.
-          The original "Skip to species list" skip-link was removed in #662. */}
+          focus on the first FOCUSABLE marker surface (the keyboard bypass for
+          the 344-marker tap sequence). Gated on `mapVisible && scopeActive` so
+          it does not render on the unscoped landing or the non-map view.
+          The original "Skip to species list" skip-link was removed in #662.
+
+          C47/C48 (#1030): the target is resolved through `focusFirstMarker`
+          below, which tries — in priority order — (1) a focusable per-cell
+          silhouette <button> (fine-pointer grids), (2) the keyboard-active
+          marker hit-layer <button> (`tabIndex=0`, the roving-tabindex entry for
+          unclustered observations when no grid cells exist), then (3) the
+          coarse-pointer outer cluster <button> (the only focusable surface on
+          touch+keyboard, where the cells are non-focusable <div>s). It NEVER
+          focuses a non-focusable element, so the skip-link can no longer
+          silently no-op (the C48 iPad-keyboard dead end). */}
       {mapVisible && scopeActive && (
         <button
           type="button"
@@ -1246,11 +1295,7 @@ export function App() {
           tabIndex={observations.length > 0 ? 0 : -1}
           onClick={() => {
             if (observations.length > 0) {
-              const firstCell = document.querySelector(
-                '[data-testid="adaptive-grid-marker-cell-rendered"], ' +
-                '[data-testid="adaptive-grid-marker-cell-fallback"]',
-              ) as HTMLElement | null;
-              firstCell?.focus();
+              focusFirstMarker();
             }
           }}
         >

--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -681,6 +681,85 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(cell.getAttribute('aria-describedby')).toBeNull();
   });
 
+  it('O2 (#1030, WCAG 4.1.2): every silhouette <button> has a non-empty accessible name (family + count)', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x1}
+        tiles={[
+          {
+            kind: 'rendered',
+            familyCode: 'tyrannidae',
+            displayName: 'Tyrant Flycatchers',
+            svgData: 'M0 0L24 24Z',
+            color: '#888',
+            colorDark: '#888',
+            count: 5,
+            species: [],
+          },
+          // fallback branch is also a <button> in pointer:fine — it must get a
+          // name too (the Lighthouse button-name fail covered both kinds).
+          {
+            kind: 'fallback',
+            familyCode: 'mimidae',
+            displayName: 'Mockingbirds and Thrashers',
+            color: '#aaa',
+            colorDark: '#aaa',
+            count: 1,
+            species: [],
+          },
+        ]}
+        totalCount={6}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 6 observations, 2 families."
+        isCoarsePointer={false}
+        onClick={noop}
+      />
+    );
+    const rendered = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    const fallbackCell = screen.getByTestId('adaptive-grid-marker-cell-fallback');
+    expect(rendered.tagName).toBe('BUTTON');
+    expect(fallbackCell.tagName).toBe('BUTTON');
+    const renderedName = rendered.getAttribute('aria-label') ?? '';
+    const fallbackName = fallbackCell.getAttribute('aria-label') ?? '';
+    expect(renderedName.trim().length).toBeGreaterThan(0);
+    expect(fallbackName.trim().length).toBeGreaterThan(0);
+    expect(renderedName).toContain('Tyrant Flycatchers');
+    expect(renderedName).toMatch(/5/);
+    expect(fallbackName).toContain('Mockingbirds and Thrashers');
+  });
+
+  it('silhouette <button> aria-label falls back to prettyFamily(code) when displayName is blank (never empty)', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[
+          {
+            kind: 'rendered',
+            familyCode: 'corvidae',
+            displayName: '',
+            svgData: 'M0 0L24 24Z',
+            color: '#888',
+            colorDark: '#888',
+            count: 3,
+            species: [],
+          },
+        ]}
+        totalCount={3}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 3 observations."
+        isCoarsePointer={false}
+        onClick={noop}
+      />
+    );
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    const name = cell.getAttribute('aria-label') ?? '';
+    expect(name.trim().length).toBeGreaterThan(0);
+    // prettyFamily('corvidae') → 'Corvidae'
+    expect(name).toContain('Corvidae');
+  });
+
   it('pointer:fine: active cell gets aria-describedby, inactive cells do not (spec §4.8)', async () => {
     const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
     render(
@@ -1071,6 +1150,57 @@ describe('AdaptiveGridMarker — cell popover coarse-pointer (Phase 2, #559)', (
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Cluster: 17 observations, 2 families/)).toBeInTheDocument();
     // onClick (zoom-to-expansion handler) must NOT fire on coarse + flag-ON.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('C48 (#1030, WCAG 2.4.1+2.1.1): coarse outer <button> is keyboard-focusable (tabIndex=0) so iPad + hardware keyboard can reach the marker layer', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[
+          rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', []),
+          rendered('flycatchers', 12, 'M0 0L24 24Z', '#aaa', '#aaa', []),
+        ]}
+        totalCount={17}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 17 observations, 2 families."
+        isCoarsePointer={true}
+        onClick={noop}
+      />
+    );
+    const outer = screen.getByTestId('adaptive-grid-marker');
+    expect(outer.tagName).toBe('BUTTON');
+    // On coarse pointers the cells are non-focusable <div>s; the OUTER button is
+    // the only focusable surface, so it must be in the Tab order (tabIndex=0).
+    expect(outer.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('coarse outer <button> activates its ClusterListPopover on Enter (keyboard parity with tap)', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    const onClick = vi.fn();
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={[
+          rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+            { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+          ]),
+          rendered('flycatchers', 12, 'M0 0L24 24Z', '#aaa', '#aaa', [
+            { comName: 'Black Phoebe', count: 12, speciesCode: 'blkpho' },
+          ]),
+        ]}
+        totalCount={17}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 17 observations, 2 families."
+        isCoarsePointer={true}
+        onClick={onClick}
+      />
+    );
+    const outer = screen.getByTestId('adaptive-grid-marker');
+    // A native <button> fires onClick for Enter/Space; assert the popover opens.
+    fireEvent.click(outer);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(onClick).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -2,6 +2,7 @@ import { useState, useId, useRef, useEffect } from 'react';
 import type { MouseEvent as ReactMouseEvent, CSSProperties, KeyboardEvent } from 'react';
 import type { AdaptiveTile, ResolvedGrid } from './adaptive-grid.js';
 import { visibleCapacity } from './adaptive-grid.js';
+import { prettyFamily } from '../../derived.js';
 import { FALLBACK_SILHOUETTE_PATH } from './silhouette-fallback.js';
 import { useMediaQuery } from '../../hooks/use-media-query.js';
 import { useTheme } from '../../hooks/use-theme.js';
@@ -123,6 +124,25 @@ export const GRID_PADDING_PX = 3;
 
 const HIT_MIN_FINE = 44;
 const HIT_MIN_COARSE = 48;
+
+/**
+ * O2 (#1030, WCAG 4.1.2): accessible name for a per-family silhouette `<button>`
+ * cell. The cells were name-less (`aria-haspopup`/`aria-describedby` only) — a
+ * Lighthouse `button-name` fail. Format: "{family}, {count} observation[s]".
+ *
+ * `displayName` is the tile's resolved colloquial family name
+ * (`resolveFamilyName(familyCode, …)`); it falls back to `prettyFamily(code)`
+ * (a capitalized scientific code) when blank/absent so the label is NEVER
+ * empty. The count is pluralized so the announcement reads naturally.
+ */
+function cellAriaLabel(tile: AdaptiveTile): string {
+  const family =
+    tile.displayName && tile.displayName.trim().length > 0
+      ? tile.displayName
+      : prettyFamily(tile.familyCode);
+  const unit = tile.count === 1 ? 'observation' : 'observations';
+  return `${family}, ${tile.count} ${unit}`;
+}
 
 const NOTABLE_AMBER = '#f59e0b';
 
@@ -323,7 +343,15 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
     ? ({ role: 'group' as const })
     : ({
         type: 'button' as const,
-        tabIndex: -1,
+        // C48 (#1030, WCAG 2.4.1+2.1.1): on coarse pointers the per-cell
+        // silhouettes are non-focusable <div>s, so this OUTER button is the only
+        // focusable surface — it MUST be in the Tab order (tabIndex=0) for an
+        // iPad + hardware keyboard to reach the marker layer (and the skip-link
+        // targets it, never a non-focusable element). On fine pointers without
+        // per-cell interaction the cluster is reached via the per-cell buttons /
+        // hit layer, so the outer button stays out of the Tab order (-1),
+        // preserving #558's single-tab-stop and the existing test contract.
+        tabIndex: clusterListInteractive ? 0 : -1,
         onClick: (e: ReactMouseEvent<HTMLElement>) => {
           if (clusterListInteractive && !isSingleLeaf) {
             // Phase 2: open the cluster-list popover instead of the parent's
@@ -526,6 +554,7 @@ function TileCell({
           tabIndex={0}
           data-testid="adaptive-grid-marker-cell-fallback"
           className="adaptive-grid-marker__cell adaptive-grid-marker__cell--fallback"
+          aria-label={cellAriaLabel(tile)}
           aria-haspopup="dialog"
           aria-expanded={isExpanded ? 'true' : 'false'}
           aria-describedby={previewId}
@@ -621,6 +650,7 @@ function TileCell({
         tabIndex={0}
         data-testid="adaptive-grid-marker-cell-rendered"
         className="adaptive-grid-marker__cell"
+        aria-label={cellAriaLabel(tile)}
         aria-haspopup="dialog"
         aria-expanded={isExpanded ? 'true' : 'false'}
         aria-describedby={previewId}

--- a/frontend/src/components/map/MapMarkerHitLayer.test.tsx
+++ b/frontend/src/components/map/MapMarkerHitLayer.test.tsx
@@ -135,8 +135,12 @@ describe('MapMarkerHitLayer', () => {
     expect(label).toContain('unknown family');
   });
 
-  it('renders hit-target buttons with tabIndex=-1 (skip-link is the keyboard entry, not Tab cycling)', () => {
-    const markers = [makeMarker({ comName: 'A' }), makeMarker({ comName: 'B', subId: 'b' })];
+  it('uses a roving tabindex: exactly one button at tabIndex=0, the rest tabIndex=-1 (#1030 — preserves #558 single-tab-stop while staying keyboard-operable)', () => {
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+      makeMarker({ comName: 'C', subId: 'c' }),
+    ];
     render(
       <MapMarkerHitLayer
         map={makeFakeMap()}
@@ -144,9 +148,138 @@ describe('MapMarkerHitLayer', () => {
         onSelect={vi.fn()}
       />,
     );
-    for (const btn of screen.getAllByRole('button')) {
-      expect(btn.getAttribute('tabindex')).toBe('-1');
-    }
+    const btns = screen.getAllByRole('button');
+    const zeros = btns.filter((b) => b.getAttribute('tabindex') === '0');
+    const minusOnes = btns.filter((b) => b.getAttribute('tabindex') === '-1');
+    expect(zeros).toHaveLength(1);
+    expect(minusOnes).toHaveLength(btns.length - 1);
+    // List order: the FIRST marker is the initial active button.
+    expect(btns[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  it('ArrowRight moves the active (tabIndex=0) button to the next marker in list order', () => {
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+      makeMarker({ comName: 'C', subId: 'c' }),
+    ];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    const first = screen.getByLabelText(/^A,/);
+    expect(first.getAttribute('tabindex')).toBe('0');
+    act(() => {
+      fireEvent.keyDown(first, { key: 'ArrowRight' });
+    });
+    const second = screen.getByLabelText(/^B,/);
+    expect(second.getAttribute('tabindex')).toBe('0');
+    expect(first.getAttribute('tabindex')).toBe('-1');
+    // The newly-active button receives focus so the user lands on it.
+    expect(document.activeElement).toBe(second);
+  });
+
+  it('ArrowLeft from the first marker wraps to the last marker', () => {
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+      makeMarker({ comName: 'C', subId: 'c' }),
+    ];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    const first = screen.getByLabelText(/^A,/);
+    act(() => {
+      fireEvent.keyDown(first, { key: 'ArrowLeft' });
+    });
+    const last = screen.getByLabelText(/^C,/);
+    expect(last.getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('ArrowRight from the last marker wraps to the first marker', () => {
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+    ];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    const first = screen.getByLabelText(/^A,/);
+    const last = screen.getByLabelText(/^B,/);
+    // Move active onto the last marker (A → B), then ArrowRight wraps B → A.
+    act(() => {
+      fireEvent.keyDown(first, { key: 'ArrowRight' }); // active → B
+    });
+    expect(last.getAttribute('tabindex')).toBe('0');
+    act(() => {
+      fireEvent.keyDown(last, { key: 'ArrowRight' }); // wrap → A
+    });
+    expect(first.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('Enter on the active button opens the popover (onSelect with its subId)', () => {
+    const onSelect = vi.fn();
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+    ];
+    render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={onSelect} />,
+    );
+    const first = screen.getByLabelText(/^A,/);
+    act(() => {
+      fireEvent.keyDown(first, { key: 'ArrowRight' }); // active → B
+    });
+    const second = screen.getByLabelText(/^B,/);
+    act(() => {
+      fireEvent.keyDown(second, { key: 'Enter' });
+    });
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('clamps the active index when the marker set shrinks (e.g. zoom-gate empties then repopulates)', () => {
+    const three = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+      makeMarker({ comName: 'C', subId: 'c' }),
+    ];
+    const { rerender } = render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={three} onSelect={vi.fn()} />,
+    );
+    // Move active to the last (index 2).
+    act(() => {
+      fireEvent.keyDown(screen.getByLabelText(/^A,/), { key: 'ArrowLeft' });
+    });
+    expect(screen.getByLabelText(/^C,/).getAttribute('tabindex')).toBe('0');
+
+    // Marker set shrinks to one — index 2 is now out of range → clamp to 0.
+    const one = [makeMarker({ comName: 'Z', subId: 'z' })];
+    rerender(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={one} onSelect={vi.fn()} />,
+    );
+    const onlyBtn = screen.getByRole('button');
+    expect(onlyBtn.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('survives the zoom-gate empty marker set (buildHitMarkers returns []) and resets active to 0 on repopulation', () => {
+    const markers = [
+      makeMarker({ comName: 'A', subId: 'a' }),
+      makeMarker({ comName: 'B', subId: 'b' }),
+    ];
+    const { rerender } = render(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    act(() => {
+      fireEvent.keyDown(screen.getByLabelText(/^A,/), { key: 'ArrowRight' }); // active → B (index 1)
+    });
+    // Zoom out below CLUSTER_MAX_ZOOM → buildHitMarkers returns [] → layer renders null.
+    rerender(<MapMarkerHitLayer map={makeFakeMap()} markers={[]} onSelect={vi.fn()} />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    // Zoom back in → markers repopulate; active index must have clamped to 0.
+    rerender(
+      <MapMarkerHitLayer map={makeFakeMap()} markers={markers} onSelect={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/^A,/).getAttribute('tabindex')).toBe('0');
   });
 
   it('falls back to "unknown location" when locName is null', () => {

--- a/frontend/src/components/map/MapMarkerHitLayer.tsx
+++ b/frontend/src/components/map/MapMarkerHitLayer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { prettyFamily } from '../../derived.js';
 
 /**
@@ -12,10 +13,16 @@ import { prettyFamily } from '../../derived.js';
  *     way to give each point an `aria-label`, keyboard focus, and a 40×40
  *     (48×48 coarse-pointer) hit target.
  *
- * The hit layer is intentionally NOT in the global Tab order. Per the
- * issue body Gotchas — a 344-marker tab sequence is hostile to keyboard
- * users. The live "Explore map markers" skip-link in MapSurface routes Tab
- * traffic to the first marker cell (#558, which is properly navigable).
+ * Roving tabindex (#1030, WCAG 2.1.1): the hit layer keeps a SINGLE Tab stop
+ * (preserving #558's intent — a 344-marker tab sequence is hostile) but is now
+ * keyboard-OPERABLE. Exactly one button carries `tabIndex={0}` (the "active"
+ * marker, list order); the rest carry `tabIndex={-1}`. Arrow keys move the
+ * active marker (wrapping at the ends) and focus follows; Enter/Space opens the
+ * ObservationPopover via `onSelect`. The live "Explore map markers" skip-link in
+ * App routes Tab traffic to the active button (the hit-layer fallback when no
+ * grid cells exist). When the marker set changes — including the zoom-gate
+ * unmount where `buildHitMarkers` returns `[]` below `CLUSTER_MAX_ZOOM` — the
+ * active index is clamped to the new length (reset to 0 when no longer valid).
  *
  * Position updates: we re-project on every `move` event. The `move` event
  * fires continuously during pan/zoom, so positions stay glued to the map.
@@ -133,6 +140,93 @@ export function MapMarkerHitLayer(props: MapMarkerHitLayerProps) {
   const sizeRef = useRef(size);
   sizeRef.current = size;
 
+  // Roving tabindex (#1030): index of the single Tab-stop / arrow-navigable
+  // "active" marker, in `markers` list order. Initialised to 0 (the first
+  // marker). Clamped below whenever the marker set changes length.
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Clamp the active index to the current marker set. Covers the zoom-gate
+  // empty case (`markers.length === 0` → reset to 0 so a later repopulation
+  // lands on the first marker) and any shrink (e.g. deconflict / filter change
+  // dropping markers) that would leave `activeIndex` past the end. Done in an
+  // effect so the render below always reads an in-range index.
+  useEffect(() => {
+    setActiveIndex((prev) => {
+      if (markers.length === 0) return 0;
+      return prev >= markers.length ? 0 : prev;
+    });
+  }, [markers.length]);
+
+  // Per-marker button refs (list order) so an arrow-key move can imperatively
+  // focus the newly-active button. Kept length-synced with `markers` each render.
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  buttonRefs.current.length = markers.length;
+
+  // When the active index moves via the KEYBOARD (not a plain Tab/focus event),
+  // focus must follow to the newly-active button. A pointer-focus or Tab-in
+  // sets `activeIndex` through `onFocus` and must NOT re-steal focus. This ref
+  // is the "the next active change came from a key press, move focus to it"
+  // flag, consumed in the commit-phase effect below.
+  const focusOnNextActiveRef = useRef(false);
+
+  // Move focus to the active button AFTER React commits the tabIndex flip, so
+  // the element is programmatically focusable in its final state. Guarded by the
+  // keyboard-intent flag so a Tab-in / pointer focus doesn't bounce focus.
+  useEffect(() => {
+    if (!focusOnNextActiveRef.current) return;
+    focusOnNextActiveRef.current = false;
+    buttonRefs.current[activeIndex]?.focus();
+  }, [activeIndex]);
+
+  const moveActiveTo = useCallback(
+    (resolver: (prev: number, n: number) => number) => {
+      const n = markers.length;
+      if (n === 0) return;
+      focusOnNextActiveRef.current = true;
+      setActiveIndex((prev) => resolver(prev, n));
+    },
+    [markers.length],
+  );
+
+  const onKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          e.preventDefault();
+          moveActiveTo((prev, n) => (prev + 1) % n); // wrap at the end
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          e.preventDefault();
+          moveActiveTo((prev, n) => (prev - 1 + n) % n); // wrap at the start
+          break;
+        case 'Home':
+          e.preventDefault();
+          moveActiveTo(() => 0);
+          break;
+        case 'End':
+          e.preventDefault();
+          moveActiveTo((_prev, n) => n - 1);
+          break;
+        case 'Enter':
+        case ' ':
+          // Enter/Space activate the focused marker (open its popover). The
+          // native <button> already fires onClick for these, but markers are
+          // commonly reached via the skip-link + arrow keys where the browser's
+          // default activation still applies — handling here keeps the contract
+          // explicit and testable (fireEvent.keyDown in RTL does not synthesize
+          // the click). preventDefault stops Space from scrolling the page.
+          e.preventDefault();
+          onSelect(markers[index].subId);
+          break;
+        default:
+          break;
+      }
+    },
+    [moveActiveTo, markers, onSelect],
+  );
+
   if (markers.length === 0) return null;
 
   return (
@@ -146,17 +240,26 @@ export function MapMarkerHitLayer(props: MapMarkerHitLayerProps) {
         pointerEvents: 'none',
       }}
     >
-      {markers.map((m) => {
+      {markers.map((m, i) => {
         const pos = positions[m.subId];
         if (!pos) return null;
+        const isActive = i === activeIndex;
         return (
           <button
             key={m.subId}
+            ref={(el) => {
+              buttonRefs.current[i] = el;
+            }}
             type="button"
-            tabIndex={-1}
+            // Roving tabindex (#1030): exactly one button (the active one) is in
+            // the Tab order; arrow keys move which one that is. This keeps #558's
+            // single-tab-stop while making every marker reachable by keyboard.
+            tabIndex={isActive ? 0 : -1}
             data-sub-id={m.subId}
             aria-label={formatAriaLabel(m)}
             onClick={() => onSelect(m.subId)}
+            onFocus={() => setActiveIndex(i)}
+            onKeyDown={(e) => onKeyDown(e, i)}
             style={{
               position: 'absolute',
               left: `${pos.x - half}px`,

--- a/frontend/src/components/map/MapMarkerHitLayer.tsx
+++ b/frontend/src/components/map/MapMarkerHitLayer.tsx
@@ -218,7 +218,10 @@ export function MapMarkerHitLayer(props: MapMarkerHitLayerProps) {
           // explicit and testable (fireEvent.keyDown in RTL does not synthesize
           // the click). preventDefault stops Space from scrolling the page.
           e.preventDefault();
-          onSelect(markers[index].subId);
+          {
+            const marker = markers[index];
+            if (marker) onSelect(marker.subId);
+          }
           break;
         default:
           break;


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    SkipLink["Explore-map-markers skip-link (App.tsx)"] -->|"focusFirstMarker priority ladder"| Resolve{"first focusable marker?"}
    Resolve -->|"1: fine-pointer cell button"| Cell["adaptive-grid silhouette button (aria-label = family + count)"]
    Resolve -->|"2: no grid cells: hit layer"| Hit["hit-layer active button (tabIndex=0)"]
    Resolve -->|"3: coarse pointer"| Outer["outer cluster button (tabIndex=0, opens ClusterListPopover)"]
    Hit -->|"ArrowLeft / ArrowRight (wrap)"| Hit
    Hit -->|"Enter / Space"| Popover["ObservationPopover (onSelect)"]
    Outer -->|"Enter / Space"| ClusterPopover["ClusterListPopover"]
```

```mermaid
stateDiagram-v2
    [*] --> Active0: "markers populate (active index = 0, tabIndex=0)"
    Active0 --> ActiveN: "ArrowRight / ArrowLeft (wrap at ends, focus follows)"
    ActiveN --> Active0: "marker set shrinks or zoom-gate empties (buildHitMarkers -> []): clamp to 0"
    ActiveN --> [*]: "Enter -> onSelect(subId)"
```

## Summary

- **C47 (WCAG 2.1.1):** the unclustered marker hit layer was hard-coded `tabIndex={-1}` on every button with no keyboard alternative — keyboard users could not open unclustered observation popovers at all. `MapMarkerHitLayer` now uses a roving tabindex (exactly one `tabIndex=0`, preserving #558's single-tab-stop), arrow keys move the active marker with wrap, focus follows, Enter/Space activate, and the active index is clamped on every marker-set change — including the zoom-gate empty case (`buildHitMarkers` returns `[]` below `CLUSTER_MAX_ZOOM`).
- **C48 (WCAG 2.4.1+2.1.1):** on coarse pointers the per-cell silhouettes are non-focusable `<div>`s, so the outer cluster `<button>` (which opens the `ClusterListPopover`) now takes `tabIndex=0` — and the skip-link resolves its target through a priority ladder that verifies focus actually landed, so it can never silently no-op on a non-focusable cell (the iPad + hardware-keyboard dead end).
- **O2 (WCAG 4.1.2):** every per-family silhouette `<button>` now carries an `aria-label` (`"{family}, {count} observation[s]"`, family from the tile's colloquial `displayName` falling back to `prettyFamily(code)`), fixing the Lighthouse `button-name` failure.

## Screenshots

Live a11y pass at the rebased head `a357ec9` (over the merged A2 #1084) on the dev server. Each shot is the marker layer with a grid marker **keyboard-focused** — the blue focus ring + the focus-triggered family preview show the now-keyboard-reachable, named markers.

Verified live (orchestrator-driven Playwright):
- **O2 (`aria-label`):** every grid-marker silhouette `<button>` carries a non-empty accessible name — sampled "Tyrant Flycatchers, 3 observations", "New World Vultures, 1 observation" (correct singular/plural); **40/40 named, 0 empty**. Fixes the Lighthouse `button-name` failure.
- **C48 (skip-link never no-ops):** with the skip-link **active** (per-obs zoom, `observations.length > 0`), focusing it and pressing **Enter** moves focus to a real focusable grid-cell marker (landed on "Herons & Egrets, 1 observation", `tabindex=0`). When there are no focusable per-obs markers (national aggregated view), the skip-link is correctly inert (`aria-hidden`, `tabIndex=-1`) — so it cannot fire on a non-focusable target. The `focusFirstMarker` priority ladder confirms `document.activeElement === target` before stopping.
- **C47 (roving tabindex on the hit layer):** the hit layer is zoom-gated to `z ≥ CLUSTER_MAX_ZOOM (22)`, and the sparse dev seed has no two observations within a ~10 m street-level viewport, so the roving behavior is **covered by the RTL suite** (exactly one `tabIndex=0`, Arrow-wrap, Enter→`onSelect`, clamp-on-shrink/zoom-gate-empty) rather than the live pass — the live pass exercises the fine-pointer grid-cell + skip-link paths above.
- Console clean on a clean single load (0 errors / 0 warnings). The only ambient noise during the multi-viewport sweep is the **pre-existing** basemap `null`-expression warning tracked as **#1027 (S1)** (reproduces on production) and the known dark-basemap `circle-11` warning (**#947**); this PR touches zero map-render/layer code.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="260" alt="a1-390-light" src="https://github.com/user-attachments/assets/f55bb379-27d7-408b-8114-1df0e6aeec01" /> | <img width="260" alt="a1-390-dark" src="https://github.com/user-attachments/assets/182d6f7c-c0f9-43d0-82b8-1ae3adf4e6bd" /> |
| 768×1024 (tablet) | <img width="260" alt="a1-768-light" src="https://github.com/user-attachments/assets/07eda28f-2b03-4ba7-a12d-21944875f81f" /> | <img width="260" alt="a1-768-dark" src="https://github.com/user-attachments/assets/040cc6fb-e092-41d9-9235-220035bef139" /> |
| 1024×768 (small laptop) | <img width="260" alt="a1-1024-light" src="https://github.com/user-attachments/assets/36522dcc-1d7d-43fd-a616-27206e678233" /> | <img width="260" alt="a1-1024-dark" src="https://github.com/user-attachments/assets/5ee87bcb-f6db-4056-b0b5-f8d391336c9f" /> |
| 1440×900 (desktop) | <img width="260" alt="a1-1440-light" src="https://github.com/user-attachments/assets/2c4af34b-ed3e-41c0-ac2d-84d897d1f45d" /> | <img width="260" alt="a1-1440-dark" src="https://github.com/user-attachments/assets/bbbb4997-6056-4ce4-bf93-8497c7f51fcb" /> |
| 1920×1080 (wide) | <img width="260" alt="a1-1920-light" src="https://github.com/user-attachments/assets/2f9b6675-0748-4916-ac05-6b17c7245de4" /> | <img width="260" alt="a1-1920-dark" src="https://github.com/user-attachments/assets/7539b934-2a9c-40a4-80f9-a20deab4d338" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no new className; behavior/markup only (no styling changes)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — 10 published (5 viewports × light/dark)


## Test plan

- [x] `npx tsc -b frontend` — clean (added a `noUncheckedIndexedAccess` guard on the Enter handler)
- [x] `npm test --workspace @bird-watch/frontend` — 1332 tests / 86 files green, incl. the inverted `MapMarkerHitLayer.test.tsx` roving-tabindex assertion + new arrow/wrap/Enter/clamp coverage, coarse-outer `tabIndex=0`, silhouette `aria-label`, and skip-link fallback-targeting tests (verified each fails without its implementation)
- [x] `npm run lint` — green
- [x] `npm run build` — clean production build
- [x] `npx knip` — green
- [x] New unit tests added (behavior changed)
- [ ] New Playwright e2e spec — N/A: existing `map-skip-link-and-hit-layer.spec.ts` / `map-cell-popover.spec.ts` already cover the skip-link → marker focus path and stay green (the per-cell focus priority is preserved on fine pointer); orchestrator runs the live Playwright a11y pass (390/768/1440, both themes)
- [x] (UI only) Playwright MCP smoke — orchestrator live a11y verify: 40/40 marker aria-labels, skip-link→grid-cell focus (no no-op), 5 viewports × both themes, console clean (modulo pre-existing #1027/S1 + #947)

## Plan reference

Closes #1030. Part of #1029 (design-review remediation, Wave 1 / A1). Out of `docs/plans` — plans live in issues.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

