### PR TITLE
fix(frontend): ObservationPopover dialog contract + a11y row/focus fixes (#1031)

### DIFF
--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -12,9 +12,12 @@ import { AppPage } from './pages/app-page.js';
 //   4. Mobile tap→cluster-list→expand-family→species→?detail= nav (@coarse, 390×844, coarse-pointer)
 //
 // Phase 2 lessons baked in (5 CI iterations to land 1 test):
-//   - Use `.click({ force: true })` on `<a role="link">` without href.
-//   - `.cluster-list-popover__rows a[role="link"]` is more reliable than
-//     getByRole('link').filter({hasText:...}) for links without href.
+//   - #1031 (C54): species rows are native <button>s now (was
+//     `<a role="link">`); target `.cell-popover__row-button` /
+//     `.cluster-list-popover__row-button`. `.click({ force: true })` is kept
+//     because rows can sit below the fold of a scrollable popover.
+//   - The `.…__rows .…__row-button` class selector is more reliable than
+//     getByRole('button').filter({hasText:...}) given the per-row text.
 //   - Avoid page.goBack() + re-open-popover (z-index issue intercepts pointer).
 //   - `[data-testid="adaptive-grid-marker"]` is the canonical "map settled" gate.
 //   - iPad (gen 6) 768×1024 is the coarse-pointer device; mobile 390×844 uses
@@ -67,9 +70,10 @@ test('desktop 1440×900: hover cell → preview → click → popover → specie
   // #859: at default zoom (z=3 → aggregated mode) every row now carries a REAL
   // species code (the server nests `AggregatedFamily.species` per bucket, so
   // the synthetic `agg-*` codes #715 used to gate against are gone). Rows are
-  // clickable links → ?detail=<real-code>. If WebGL painted no rows we fall back
+  // clickable buttons → ?detail=<real-code>. If WebGL painted no rows we fall back
   // to asserting the popover at least mounted (the popover-opens check above).
-  const link = page.locator('.cell-popover__rows a[role="link"]').first();
+  // #1031 (C54): rows are native <button>s now, not `<a role="link">`.
+  const link = page.locator('.cell-popover__rows .cell-popover__row-button').first();
   const linkVisible = await link.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
   if (!linkVisible) {
     // No clickable row rendered in this headless run — verify the popover rows
@@ -270,15 +274,16 @@ test('@coarse tablet 768×1024: tap marker → cluster-list popover → tap spec
   // to commit so the family's species rows have mounted.
   await expect(familyToggle).toHaveAttribute('aria-expanded', 'true', { timeout: 5_000 });
 
-  // Tap a clickable species link in the now-expanded family.
+  // Tap a clickable species row in the now-expanded family.
   // #859: at default zoom (aggregated mode) every row now carries a REAL
   // species code (server-nested `AggregatedFamily.species`), so rows render as
-  // clickable links — the synthetic `agg-*` static-span path #715 gated against
-  // is gone. If no clickable row rendered in this headless run, fall back to
-  // verifying the popover rows at least exist as DOM nodes. Rows may be
+  // clickable controls — the synthetic `agg-*` static-span path #715 gated
+  // against is gone. If no clickable row rendered in this headless run, fall
+  // back to verifying the popover rows at least exist as DOM nodes. Rows may be
   // off-screen in a scrollable popover container on smaller viewports — use
   // `attached` rather than `visible` for the existence check.
-  const link = page.locator('.cluster-list-popover__rows a[role="link"]').first();
+  // #1031 (C54): rows are native <button>s now, not `<a role="link">`.
+  const link = page.locator('.cluster-list-popover__rows .cluster-list-popover__row-button').first();
   const linkVisible = await link.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
   if (!linkVisible) {
     await expect(page.locator('[data-testid="cluster-list-popover-row"]').first()).toBeAttached();
@@ -328,8 +333,8 @@ test.skip('@coarse mobile 390×844: tap marker → cluster-list → expand-famil
     await expect.poll(() => page.getByTestId('cluster-list-popover-row').count()).toBeGreaterThan(rowsBefore);
   }
 
-  // Tap a species link. Force-click for <a> without href (Phase 2 lesson).
-  const link = page.locator('.cluster-list-popover__rows a[role="link"]').first();
+  // Tap a species row. #1031 (C54): rows are native <button>s now.
+  const link = page.locator('.cluster-list-popover__rows .cluster-list-popover__row-button').first();
   await link.waitFor({ state: 'visible' });
   await link.click({ force: true });
 

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -909,15 +909,26 @@ button.adaptive-grid-marker__cell {
   padding: 2px 0;
 }
 
-.cell-popover__row--clickable a[role="link"] {
+/* #1031 (C54): species rows are now native <button>s (free Enter/Space,
+   correct AT announcement). The button needs the chrome reset an <a> didn't
+   (border/background/font/padding), then re-adopts the link affordance —
+   matching the sibling `.cell-popover__more` control. */
+.cell-popover__row-button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   color: var(--color-text-link);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.cell-popover__row--clickable a[role="link"]:hover,
-.cell-popover__row--clickable a[role="link"]:focus-visible {
+.cell-popover__row-button:hover,
+.cell-popover__row-button:focus-visible {
   text-decoration-thickness: 2px;
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
@@ -975,7 +986,7 @@ button.adaptive-grid-marker__cell {
     color: CanvasText;
     box-shadow: none;
   }
-  .cell-popover__row--clickable a[role="link"] {
+  .cell-popover__row-button {
     color: LinkText;
   }
   .cell-popover__more {
@@ -1134,15 +1145,28 @@ button.adaptive-grid-marker__cell {
                   /* chromium emulation; family-toggle + Done retain the 44px min. */
 }
 
-.cluster-list-popover__row a[role="link"] {
+/* #1031 (C54): species rows are now native <button>s (free Enter/Space,
+   correct AT announcement). The button takes the chrome reset an <a> didn't
+   need, then re-adopts the link affordance. Kept `display: block; width: 100%`
+   (not flex) so it renders a non-zero bbox — the row's `padding: 8px 0`
+   supplies the tap spacing the prior comment warned must not move onto the
+   inner element. */
+.cluster-list-popover__row-button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   color: var(--color-text-link);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.cluster-list-popover__row a[role="link"]:hover,
-.cluster-list-popover__row a[role="link"]:focus-visible {
+.cluster-list-popover__row-button:hover,
+.cluster-list-popover__row-button:focus-visible {
   text-decoration-thickness: 2px;
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
@@ -1193,7 +1217,7 @@ button.adaptive-grid-marker__cell {
     color: CanvasText;
     box-shadow: none;
   }
-  .cluster-list-popover__row a[role="link"] {
+  .cluster-list-popover__row-button {
     color: LinkText;
   }
   .cluster-list-popover__done {

--- a/frontend/src/components/map/CellPopover.test.tsx
+++ b/frontend/src/components/map/CellPopover.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CellPopover } from './CellPopover.js';
 import type { SpeciesAggregate } from './adaptive-grid.js';
 
@@ -149,7 +150,9 @@ describe('<CellPopover>', () => {
     expect(screen.getByText('Click or tap for full list')).toBeInTheDocument();
   });
 
-  it('renders rows with role="link" when speciesCode !== null', () => {
+  // #1031 (C54): clickable rows are native <button>s (correct AT
+  // announcement + free Enter/Space), not `<a role="link">`.
+  it('renders clickable rows as <button> when speciesCode !== null', () => {
     const anchor = makeAnchor();
     render(
       <CellPopover
@@ -161,10 +164,13 @@ describe('<CellPopover>', () => {
         onSelectSpecies={vi.fn()}
       />
     );
-    expect(screen.getByRole('link', { name: /Anna's Hummingbird/i })).toBeInTheDocument();
+    const row = screen.getByRole('button', { name: /Anna's Hummingbird/i });
+    expect(row.tagName).toBe('BUTTON');
+    // No leftover 'link' role from the old hand-rolled implementation.
+    expect(screen.queryByRole('link', { name: /Anna's Hummingbird/i })).toBeNull();
   });
 
-  it('renders rows as <span> with NO link role when speciesCode === null (spuh/slash)', () => {
+  it('renders rows as <span> with NO link/button role when speciesCode === null (spuh/slash)', () => {
     const anchor = makeAnchor();
     render(
       <CellPopover
@@ -178,6 +184,7 @@ describe('<CellPopover>', () => {
     );
     expect(screen.getByText(/Sandpiper sp\./)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Sandpiper sp\./ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Sandpiper sp\./ })).toBeNull();
   });
 
   it('calls onSelectSpecies(speciesCode) when a clickable row is clicked', () => {
@@ -193,12 +200,15 @@ describe('<CellPopover>', () => {
         onSelectSpecies={onSelectSpecies}
       />
     );
-    fireEvent.click(screen.getByRole('link', { name: /Anna's Hummingbird/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Anna's Hummingbird/i }));
     expect(onSelectSpecies).toHaveBeenCalledWith('annhum');
     expect(onSelectSpecies).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers onSelectSpecies on Enter key when a clickable row is focused', () => {
+  // #1031 (C54): a native <button> activates on Enter AND Space for free —
+  // no hand-rolled onKeyDown. Exercise the real keyboard path via userEvent
+  // (fireEvent.keyDown can't drive native button activation).
+  it('triggers onSelectSpecies on Enter and Space (native button activation)', async () => {
     const anchor = makeAnchor();
     const onSelectSpecies = vi.fn();
     render(
@@ -211,10 +221,14 @@ describe('<CellPopover>', () => {
         onSelectSpecies={onSelectSpecies}
       />
     );
-    const row = screen.getByRole('link', { name: /Anna's Hummingbird/i });
+    const row = screen.getByRole('button', { name: /Anna's Hummingbird/i });
     row.focus();
-    fireEvent.keyDown(row, { key: 'Enter' });
-    expect(onSelectSpecies).toHaveBeenCalledWith('annhum');
+    expect(document.activeElement).toBe(row);
+    await userEvent.keyboard('{Enter}');
+    expect(onSelectSpecies).toHaveBeenLastCalledWith('annhum');
+    await userEvent.keyboard(' ');
+    expect(onSelectSpecies).toHaveBeenLastCalledWith('annhum');
+    expect(onSelectSpecies).toHaveBeenCalledTimes(2);
   });
 
   it('does NOT call onSelectSpecies when a null-code row is clicked', () => {
@@ -247,8 +261,8 @@ describe('<CellPopover>', () => {
         onSelectSpecies={onSelectSpecies}
       />
     );
-    // Real common names render as clickable links wired to the REAL code.
-    fireEvent.click(screen.getByRole('link', { name: /Mallard/i }));
+    // Real common names render as clickable buttons wired to the REAL code.
+    fireEvent.click(screen.getByRole('button', { name: /Mallard/i }));
     expect(onSelectSpecies).toHaveBeenCalledWith('mallar3');
     // No Latin family code leaks into a row, and no synthetic agg-* code.
     expect(screen.queryByText(/anatidae/)).toBeNull();

--- a/frontend/src/components/map/CellPopover.tsx
+++ b/frontend/src/components/map/CellPopover.tsx
@@ -11,8 +11,9 @@ import { prettyFamily } from '../../derived.js';
  * Renders the family's species rows as `{count}× {comName}`. With #859 the
  * `species` rows carry REAL eBird codes resolved against the species dictionary
  * (no more synthetic `agg-*` rows / Latin family-code names), so every row with
- * a non-null `speciesCode` is a working `role="link"` into the species detail.
- * Spuh/slash/hybrid taxa (`speciesCode === null`) render as a static `<span>`.
+ * a non-null `speciesCode` is a working native `<button>` (#1031 C54 — was
+ * `<a role="link">`) into the species detail. Spuh/slash/hybrid taxa
+ * (`speciesCode === null`) render as a static `<span>`.
  *
  * `+N more` is an ACTIVE DRILL-IN (#859 D): when a family has more distinct
  * species than the popover shows (`overflowCount > 0`), the footer is a button
@@ -184,13 +185,6 @@ export function CellPopover(props: CellPopoverProps) {
     return () => document.removeEventListener('mousedown', onMouseDown);
   }, [onDismiss]);
 
-  function onRowKeyDown(e: KeyboardEvent<HTMLAnchorElement>, code: string) {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onSelectSpecies(code);
-    }
-  }
-
   // #863: the inline `position: fixed` wins over the CSS `.cell-popover`'s
   // `position: absolute`, anchoring the portaled card to the clicked cell. Until
   // the layout effect has measured (one pre-paint pass), keep it off-screen so it
@@ -231,20 +225,26 @@ export function CellPopover(props: CellPopoverProps) {
         {visible.map((s) => {
           const code = s.speciesCode;
           if (code !== null) {
+            // #1031 (C54): the `--clickable` modifier scoped the old
+            // `a[role="link"]` rule; the new `.cell-popover__row-button`
+            // self-scopes its affordance, so the modifier is dropped.
             return (
-              <li key={s.comName} className="cell-popover__row cell-popover__row--clickable">
-                <a
-                  role="link"
-                  tabIndex={0}
+              <li key={s.comName} className="cell-popover__row">
+                {/* #1031 (C54): native <button> rather than `<a role="link"
+                    tabIndex={0}>` with hand-rolled Enter+Space — the row drives
+                    an in-page URL-state switch (onSelectSpecies), not a real
+                    navigation, so 'link' semantics mis-announced it and Space
+                    had to be emulated. A button announces correctly and gets
+                    Enter/Space activation for free. Mirrors the
+                    ObservationPopover detail-link precedent. */}
+                <button
+                  type="button"
+                  className="cell-popover__row-button"
                   data-testid="cell-popover-row"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onSelectSpecies(code);
-                  }}
-                  onKeyDown={(e) => onRowKeyDown(e, code)}
+                  onClick={() => onSelectSpecies(code)}
                 >
                   {s.count}x {s.comName}
-                </a>
+                </button>
               </li>
             );
           }

--- a/frontend/src/components/map/ClusterListPopover.test.tsx
+++ b/frontend/src/components/map/ClusterListPopover.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ClusterListPopover } from './ClusterListPopover.js';
 import type { FamilyAggregate, SpeciesAggregate } from './adaptive-grid.js';
 
@@ -270,9 +271,39 @@ describe('<ClusterListPopover>', () => {
     );
     // #859: expand the family before clicking its (now-revealed) species row.
     fireEvent.click(screen.getByRole('button', { name: /Hummingbirds/i }));
-    fireEvent.click(screen.getByRole('link', { name: /Anna's Hummingbird/i }));
+    // #1031 (C54): the species row is a native <button> (not `<a role="link">`).
+    const row = screen.getByRole('button', { name: /Anna's Hummingbird/i });
+    expect(row.tagName).toBe('BUTTON');
+    expect(screen.queryByRole('link', { name: /Anna's Hummingbird/i })).toBeNull();
+    fireEvent.click(row);
     expect(onSelectSpecies).toHaveBeenCalledWith('annhum');
     expect(onSelectSpecies).toHaveBeenCalledTimes(1);
+  });
+
+  // #1031 (C54): a native <button> row activates on Enter AND Space for free.
+  it('species row activates on Enter and Space (native button activation)', async () => {
+    const anchor = makeAnchor();
+    const onSelectSpecies = vi.fn();
+    render(
+      <ClusterListPopover
+        families={[family('hummingbirds', 5)]}
+        speciesByFamily={speciesByFamily([['hummingbirds', [species("Anna's Hummingbird", 5, 'annhum')]]])}
+        totalCount={5}
+        uniqueFamilies={1}
+        anchorEl={anchor}
+        onDismiss={vi.fn()}
+        onSelectSpecies={onSelectSpecies}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Hummingbirds/i }));
+    const row = screen.getByRole('button', { name: /Anna's Hummingbird/i });
+    row.focus();
+    expect(document.activeElement).toBe(row);
+    await userEvent.keyboard('{Enter}');
+    expect(onSelectSpecies).toHaveBeenLastCalledWith('annhum');
+    await userEvent.keyboard(' ');
+    expect(onSelectSpecies).toHaveBeenLastCalledWith('annhum');
+    expect(onSelectSpecies).toHaveBeenCalledTimes(2);
   });
 
   it('species row with null speciesCode renders as <span> (no link role; no callback on click)', () => {
@@ -293,11 +324,13 @@ describe('<ClusterListPopover>', () => {
     fireEvent.click(screen.getByRole('button', { name: /Sandpipers/i }));
     expect(screen.getByText(/Sandpiper sp\./)).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Sandpiper sp\./ })).toBeNull();
+    // #1031 (C54): null-code taxa stay static <span>s — no button either.
+    expect(screen.queryByRole('button', { name: /Sandpiper sp\./ })).toBeNull();
     fireEvent.click(screen.getByText(/Sandpiper sp\./));
     expect(onSelectSpecies).not.toHaveBeenCalled();
   });
 
-  it('renders REAL common names as working links — never a Latin family code or agg-* (#859)', () => {
+  it('renders REAL common names as working buttons — never a Latin family code or agg-* (#859)', () => {
     const anchor = makeAnchor();
     const onSelectSpecies = vi.fn();
     render(
@@ -313,9 +346,9 @@ describe('<ClusterListPopover>', () => {
         onSelectSpecies={onSelectSpecies}
       />
     );
-    // #859: expand the family before its REAL-named species links resolve.
+    // #859: expand the family before its REAL-named species buttons resolve.
     fireEvent.click(screen.getByRole('button', { name: /Anatidae/i }));
-    fireEvent.click(screen.getByRole('link', { name: /Mallard/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Mallard/i }));
     expect(onSelectSpecies).toHaveBeenCalledWith('mallar3');
     // No Latin family code and no synthetic agg-* code leaks into any row.
     expect(screen.queryByText(/anatidae/)).toBeNull();

--- a/frontend/src/components/map/ClusterListPopover.tsx
+++ b/frontend/src/components/map/ClusterListPopover.tsx
@@ -16,7 +16,8 @@ import { prettyFamily } from '../../derived.js';
  * expands to its top 8 species + per-family "+N more" drill-in (or the legacy
  * "…and N more species" footer) ONLY when the user clicks/activates its
  * header. Spuh/slash/hybrid taxa with `speciesCode === null` render as static
- * `<span>` (no link); otherwise as `<a role="link">`.
+ * `<span>` (no link); otherwise as a native `<button>` (#1031 C54 — was
+ * `<a role="link">`).
  *
  * Dismiss surfaces: "Done" button at bottom, ESC, click-outside. Each
  * returns focus to the supplied `anchorEl` (the outer marker `<button>`).
@@ -231,22 +232,19 @@ export function ClusterListPopover(props: ClusterListPopoverProps) {
                           className="cluster-list-popover__row"
                           data-testid="cluster-list-popover-row"
                         >
-                          <a
-                            role="link"
-                            tabIndex={0}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              onSpeciesRowClick(code);
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                onSpeciesRowClick(code);
-                              }
-                            }}
+                          {/* #1031 (C54): native <button> rather than
+                              `<a role="link" tabIndex={0}>` with hand-rolled
+                              Enter+Space — the row drives an in-page URL-state
+                              switch (onSelectSpecies), not a real navigation.
+                              A button announces correctly and activates on
+                              Enter/Space for free. */}
+                          <button
+                            type="button"
+                            className="cluster-list-popover__row-button"
+                            onClick={() => onSpeciesRowClick(code)}
                           >
                             {s.count}x {s.comName}
-                          </a>
+                          </button>
                         </li>
                       );
                     }

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -1952,14 +1952,16 @@ describe('#864 — lone unclustered bucket silhouette opens its real species', (
     expect(familyToggle).toHaveTextContent('Tyrant Flycatchers (7)');
 
     // Expand → the real common name (resolved via the dictionary) renders, with
-    // a working species link (non-null code ⇒ <a role="link">).
+    // a working species control. #1031 (C54): the row is a native <button> now
+    // (was `<a role="link">`) — correct AT announcement + free Enter/Space.
     await act(async () => {
       fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
       await Promise.resolve();
     });
     const link = screen.getByText(/Western Wood-Pewee/);
     expect(link).toBeInTheDocument();
-    expect(link.closest('[role="link"]')).not.toBeNull();
+    expect(link.closest('button.cluster-list-popover__row-button')).not.toBeNull();
+    expect(link.closest('[role="link"]')).toBeNull();
   });
 
   it('clicking an unclustered feature WITH a subId still opens the observation popover (unchanged)', async () => {

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -453,6 +453,33 @@ describe('MapCanvas', () => {
     expect(screen.getByTestId('map-canvas')).toBeInTheDocument();
   });
 
+  // #1031 fallback-focusability guard. ObservationPopover.returnFocus() falls
+  // back to `document.querySelector('[data-testid="map-canvas"]').focus()` when
+  // the originating marker has left the DOM/viewport. A plain <div> with no
+  // tabIndex is NOT focusable, so that `.focus()` is a silent no-op and focus
+  // drops to document.body — the exact outcome the fallback exists to prevent.
+  // Assert against the REAL production wrapper (not a hand-built stand-in, which
+  // is how the ObservationPopover unit test masked this): tabIndex must be -1
+  // (focusable programmatically, OUT of the keyboard tab order). If a future
+  // edit removes the attribute, this fails.
+  it('#1031: the map-canvas wrapper is programmatically focusable (tabIndex=-1) so the popover focus-return fallback is not a no-op', () => {
+    render(<MapCanvas observations={[]} />);
+    const wrapper = screen.getByTestId('map-canvas');
+    // Assert the ATTRIBUTE, not the `.tabIndex` property: jsdom returns -1 for
+    // `div.tabIndex` even when the attribute is absent (the property reflects
+    // "not in tab order", which a plain div also satisfies), so a property-only
+    // check would pass spuriously on the buggy markup. The attribute is the
+    // thing that actually makes the element focusable, and the thing a future
+    // edit could remove — so guard on it.
+    expect(wrapper.getAttribute('tabindex')).toBe('-1');
+    // Behavioral proof: a programmatic .focus() must land on the wrapper, not
+    // silently no-op down to document.body (the bug the fallback fell into when
+    // the attribute was missing — a focusable target is the whole point).
+    wrapper.focus();
+    expect(document.activeElement).toBe(wrapper);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
   it('passes a GeoJSON FeatureCollection to the Source component', () => {
     render(<MapCanvas observations={[makeObs()]} silhouettes={SILHOUETTES} />);
     const data = capturedSourceProps['data'] as { type: string; features: unknown[] };

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1670,7 +1670,19 @@ export function MapCanvas({
   const map = mapReady ? mapRef.current?.getMap() ?? null : null;
 
   return (
-    <div ref={mapWrapperRef} data-testid="map-canvas" style={{ width: '100%', height: '100%', position: 'relative' }}>
+    <div
+      ref={mapWrapperRef}
+      data-testid="map-canvas"
+      // #1031: programmatically focusable, but OUT of the keyboard tab order.
+      // ObservationPopover.returnFocus() falls back to `.focus()`-ing this
+      // wrapper when the originating marker has left the DOM/viewport; a plain
+      // <div> with no tabIndex is not focusable, so that `.focus()` is a silent
+      // no-op and focus drops to document.body — the exact outcome the fallback
+      // exists to prevent. `-1` makes the programmatic focus land here while
+      // keeping the map out of the Tab sequence (it is not a keyboard control).
+      tabIndex={-1}
+      style={{ width: '100%', height: '100%', position: 'relative' }}
+    >
       <MapView
         ref={mapRef}
         initialViewState={initialViewState}

--- a/frontend/src/components/map/ObservationPopover.test.tsx
+++ b/frontend/src/components/map/ObservationPopover.test.tsx
@@ -298,13 +298,24 @@ describe('ObservationPopover', () => {
       }
     });
 
-    it('falls back to focusing the map wrapper when no opener element resolves', async () => {
+    it('falls back to targeting the map wrapper when no opener element resolves', async () => {
       const onClose = vi.fn();
       // No marker button in the DOM for this subId (marker left the
       // data/viewport). The map wrapper IS present.
+      //
+      // This wrapper deliberately mirrors PRODUCTION exactly — a bare <div>
+      // with no tabIndex. Earlier this test hand-set `wrapper.tabIndex = -1`,
+      // which the production wrapper (MapCanvas.tsx) did NOT have, so the test
+      // gave false confidence: it asserted focus LANDED on a focusable div the
+      // production code never produced. Whether the real wrapper is actually
+      // focusable is now guarded honestly in MapCanvas.test.tsx ('#1031: the
+      // map-canvas wrapper is programmatically focusable'). Here, in isolation
+      // from the real wrapper, we assert only what this unit can honestly own:
+      // that `returnFocus()`'s fallback RESOLVES and `.focus()`-targets the map
+      // wrapper (rather than no-op-ing on an unresolved element / document.body).
       const wrapper = document.createElement('div');
       wrapper.setAttribute('data-testid', 'map-canvas');
-      wrapper.tabIndex = -1;
+      const focusSpy = vi.spyOn(wrapper, 'focus');
       document.body.appendChild(wrapper);
       render(
         <ObservationPopover
@@ -315,9 +326,9 @@ describe('ObservationPopover', () => {
       );
       await userEvent.keyboard('{Escape}');
       expect(onClose).toHaveBeenCalledTimes(1);
-      // Must NOT silently drop to document.body — focus the map wrapper.
-      expect(document.activeElement).toBe(wrapper);
-      expect(document.activeElement).not.toBe(document.body);
+      // The fallback must reach the map wrapper, not silently no-op.
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+      focusSpy.mockRestore();
       wrapper.remove();
     });
   });

--- a/frontend/src/components/map/ObservationPopover.test.tsx
+++ b/frontend/src/components/map/ObservationPopover.test.tsx
@@ -197,4 +197,128 @@ describe('ObservationPopover', () => {
     expect(dialog.style.left).toBe('');
     expect(dialog.style.top).toBe('');
   });
+
+  // #1031 — dialog contract (focus-in, Escape, focus-return). Mirrors the
+  // CellPopover / ClusterListPopover sibling contract. Because the popover's
+  // open path is coordinate-based (the triggering element is discarded at
+  // click time), focus-return RE-QUERIES the live opener element by subId at
+  // dismissal time rather than holding an `anchorEl` prop.
+  describe('dialog contract (#1031)', () => {
+    it('moves focus into the dialog (onto the heading) on mount', () => {
+      render(
+        <ObservationPopover
+          observation={makeObs()}
+          onClose={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      const dialog = screen.getByRole('dialog');
+      // Focus lands inside the dialog — on the programmatically-focusable
+      // heading (tabIndex=-1), matching CellPopover.
+      expect(dialog.contains(document.activeElement)).toBe(true);
+      const heading = screen.getByText('Vermilion Flycatcher');
+      expect(document.activeElement).toBe(heading);
+      expect(heading).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('Escape closes and returns focus to a displaced-silhouette opener (data-subid)', async () => {
+      const onClose = vi.fn();
+      const opener = document.createElement('button');
+      opener.setAttribute('data-subid', 'S001');
+      document.body.appendChild(opener);
+      render(
+        <ObservationPopover
+          observation={makeObs({ subId: 'S001' })}
+          onClose={onClose}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      await userEvent.keyboard('{Escape}');
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(opener);
+      opener.remove();
+    });
+
+    it('Escape closes and returns focus to a hit-layer opener (data-sub-id, tabIndex=-1)', async () => {
+      const onClose = vi.fn();
+      const opener = document.createElement('button');
+      opener.setAttribute('data-sub-id', 'S001');
+      opener.tabIndex = -1; // hit-layer buttons are tabIndex={-1} — .focus() still works
+      document.body.appendChild(opener);
+      render(
+        <ObservationPopover
+          observation={makeObs({ subId: 'S001' })}
+          onClose={onClose}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      await userEvent.keyboard('{Escape}');
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(opener);
+      opener.remove();
+    });
+
+    it('× close returns focus to the originating marker button (both spellings)', async () => {
+      // data-subid spelling.
+      {
+        const onClose = vi.fn();
+        const opener = document.createElement('button');
+        opener.setAttribute('data-subid', 'S001');
+        document.body.appendChild(opener);
+        const { unmount } = render(
+          <ObservationPopover
+            observation={makeObs({ subId: 'S001' })}
+            onClose={onClose}
+            onSelectSpecies={vi.fn()}
+          />,
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(document.activeElement).toBe(opener);
+        unmount();
+        opener.remove();
+      }
+      // data-sub-id spelling.
+      {
+        const onClose = vi.fn();
+        const opener = document.createElement('button');
+        opener.setAttribute('data-sub-id', 'S002');
+        document.body.appendChild(opener);
+        render(
+          <ObservationPopover
+            observation={makeObs({ subId: 'S002' })}
+            onClose={onClose}
+            onSelectSpecies={vi.fn()}
+          />,
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(document.activeElement).toBe(opener);
+        opener.remove();
+      }
+    });
+
+    it('falls back to focusing the map wrapper when no opener element resolves', async () => {
+      const onClose = vi.fn();
+      // No marker button in the DOM for this subId (marker left the
+      // data/viewport). The map wrapper IS present.
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('data-testid', 'map-canvas');
+      wrapper.tabIndex = -1;
+      document.body.appendChild(wrapper);
+      render(
+        <ObservationPopover
+          observation={makeObs({ subId: 'GONE' })}
+          onClose={onClose}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      await userEvent.keyboard('{Escape}');
+      expect(onClose).toHaveBeenCalledTimes(1);
+      // Must NOT silently drop to document.body — focus the map wrapper.
+      expect(document.activeElement).toBe(wrapper);
+      expect(document.activeElement).not.toBe(document.body);
+      wrapper.remove();
+    });
+  });
 });

--- a/frontend/src/components/map/ObservationPopover.tsx
+++ b/frontend/src/components/map/ObservationPopover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { Observation } from '@bird-watch/shared-types';
 
@@ -64,7 +64,49 @@ export function ObservationPopover({
   onSelectSpecies,
 }: ObservationPopoverProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const headingRef = useRef<HTMLSpanElement | null>(null);
   const [measuredH, setMeasuredH] = useState<number>(FALLBACK_H);
+
+  // #1031 — dialog focus-return. ObservationPopover's open path is
+  // coordinate-based: the triggering marker button is discarded at click
+  // time (`onOpen(obs,[lng,lat])` / `onSelect(subId)` both funnel into
+  // `setSelectedObs` with only the obs + screen pos). So instead of holding
+  // an `anchorEl` prop like the sibling popovers, we RE-QUERY the live opener
+  // element by subId at dismissal time. The data attribute is spelled two
+  // different ways across the two opener surfaces, so the selector covers
+  // BOTH: `[data-subid]` (DisplacedSilhouetteLayer.tsx — the displaced
+  // silhouette button) and `[data-sub-id]` (MapMarkerHitLayer.tsx — the
+  // hit-layer button, which is `tabIndex={-1}`; programmatic `.focus()` still
+  // works). Re-query (not a captured `e.currentTarget`) is deliberate: both
+  // opener layers re-render with the viewport, so a node captured at click
+  // time can be unmounted by close time and `.focus()` would silently no-op —
+  // the live re-query always finds the current node. If neither resolves
+  // (marker left the data/viewport), fall back to the map wrapper rather than
+  // dropping focus to `document.body`.
+  const subId = observation?.subId;
+  const returnFocus = useCallback(() => {
+    if (typeof document === 'undefined') return;
+    const opener = subId
+      ? document.querySelector<HTMLElement>(
+          `[data-subid="${subId}"], [data-sub-id="${subId}"]`,
+        )
+      : null;
+    if (opener) {
+      opener.focus();
+      return;
+    }
+    const wrapper = document.querySelector<HTMLElement>(
+      '[data-testid="map-canvas"]',
+    );
+    wrapper?.focus();
+  }, [subId]);
+
+  // Dismiss = close + return focus, shared by the × button and Escape so the
+  // focus-return contract holds on every close path.
+  const dismiss = useCallback(() => {
+    onClose();
+    returnFocus();
+  }, [onClose, returnFocus]);
 
   // Measure the rendered popover height once it's in the DOM. The flipY
   // decision below uses `measuredH` so popovers with long content (e.g.
@@ -83,6 +125,26 @@ export function ObservationPopover({
     ro.observe(node);
     return () => ro.disconnect();
   }, [observation]);
+
+  // #1031 — move focus into the dialog on open (spec §4.8 popover focus
+  // management; mirrors CellPopover/ClusterListPopover). The heading carries
+  // `tabIndex={-1}` so it is programmatically focusable. Keyed on the obs
+  // identity so re-opening for a different observation re-lands focus.
+  useEffect(() => {
+    if (!observation) return;
+    headingRef.current?.focus();
+  }, [observation]);
+
+  // #1031 — document-level Escape → close + focus return. Matches the sibling
+  // popovers' Escape contract; the × button shares the same `dismiss`.
+  useEffect(() => {
+    if (!observation) return;
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if (e.key === 'Escape') dismiss();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [observation, dismiss]);
 
   if (!observation) return null;
 
@@ -125,7 +187,11 @@ export function ObservationPopover({
       style={style}
     >
       <div className="observation-popover-header">
-        <span className="observation-popover-name">
+        <span
+          ref={headingRef}
+          className="observation-popover-name"
+          tabIndex={-1}
+        >
           {observation.comName}
         </span>
         {observation.isNotable && (
@@ -136,7 +202,7 @@ export function ObservationPopover({
         <button
           type="button"
           className="observation-popover-close"
-          onClick={onClose}
+          onClick={dismiss}
           aria-label="Close"
         >
           &times;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1603,7 +1603,13 @@ body:has(.species-detail-sheet--peek) .family-legend {
 .observation-popover-detail-link:hover,
 .observation-popover-detail-link:focus-visible {
   color: var(--color-accent-notable-fg);
-  outline: none;
+}
+/* #1031 (C49, WCAG 2.4.7 + 1.4.1): keyboard focus must be visible and
+   distinguishable from hover. The prior `outline: none` left focus shown by
+   text color alone — identical to hover. Restore the shared focus recipe. */
+.observation-popover-detail-link:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Diagrams

ObservationPopover now honors the dialog contract its `role="dialog"` announces — focus-in, Escape, and focus-return — matching its sibling popovers. Focus-return is re-query-based because the coordinate open path discards the trigger.

```mermaid
sequenceDiagram
    participant User
    participant Marker as "Opener button (displaced-silhouette / hit-layer)"
    participant Map as "MapCanvas (openPopoverAt → setSelectedObs)"
    participant Pop as "ObservationPopover (role=dialog)"

    User->>Marker: "click (onOpen / onSelect — trigger discarded)"
    Marker->>Map: "setSelectedObs({obs, pos})"
    Map->>Pop: "mount with observation + position"
    Pop->>Pop: "focus heading (tabIndex=-1)"
    User->>Pop: "Escape OR click ×"
    Pop->>Map: "onClose() → setSelectedObs(null)"
    Pop->>Marker: "re-query [data-subid|data-sub-id=subId].focus()"
    Note over Pop,Marker: "fallback → [data-testid=map-canvas].focus() (never document.body)"
```

```mermaid
graph LR
    A["Species row (sibling popovers)"] -->|"#1031 C54"| B["native &lt;button&gt;: correct AT announce + free Enter/Space"]
    A -.->|"was"| C["&lt;a role=link tabIndex=0&gt; + hand-rolled onKeyDown"]
```

## Summary

- **C46 (major):** `ObservationPopover` set `role="dialog"` but never moved focus in, had no Escape handler (close wired only to the × button), and never returned focus. Siblings (`CellPopover`, `ClusterListPopover`) do all three. Now it focuses the heading (`tabIndex={-1}`) on mount, closes on document-level Escape, and returns focus on every close path via a shared `dismiss`.
- **Focus-return wiring** can't mirror the siblings: the open path is coordinate-based and the trigger is discarded at click time. We re-query the live opener by subId at dismissal — selector covers **both** data-attr spellings (`[data-subid]` displaced-silhouette, `[data-sub-id]` hit-layer, whose buttons are `tabIndex={-1}` — `.focus()` still works). If neither resolves (marker left the data/viewport), fall back to the map wrapper rather than dropping to `document.body`. Re-query beats a captured `currentTarget` because both opener layers re-render with the viewport (a captured node can be unmounted by close time).
- **C49 (WCAG 2.4.7 + 1.4.1):** the 'See species details' link's `:focus-visible` set `outline: none`, so keyboard focus read identically to hover. Restored the shared recipe (`2px solid var(--color-text-strong)`, offset 2px).
- **C54 (final commit, sibling files only):** species rows converted from `<a role="link" tabIndex={0}>` + hand-rolled Enter/Space to native `<button>` — correct announcement, free activation, `onKeyDown` deleted. Kept bounded as the last step so the dialog-contract work reviews independently.

## Screenshots

Live-verified at the rebased head `a646b6d` (rebased over the merged A6 #1082) on the dev server. The ObservationPopover dialog was opened on the displaced-silhouette open path at all 5 canonical viewports × light/dark. **Keyboard contract confirmed live:** focus moves into the dialog heading on open; **Escape** and the **×** button both dismiss and return focus to the originating marker button (`[data-subid]`); the "See species details" focus ring renders the strong `2px solid` outline (C49), no longer `outline: none`. Species rows are native `<button>`s (C54). Console was clean across the sweep **except** the pre-existing basemap null-expression warning tracked separately as **#1027 (S1)** — it reproduces identically on production (`blob:https://bird-maps.com/…`), so it is not introduced here; this PR touches **zero** map-layer/paint code.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="260" alt="a2-390-light" src="https://github.com/user-attachments/assets/1deb0d30-a39a-4619-afb1-3f22d02c6029" /> | <img width="260" alt="a2-390-dark" src="https://github.com/user-attachments/assets/8798b3d0-6744-4b9a-be8c-4a87229e0eb5" /> |
| 768×1024 (tablet) | <img width="260" alt="a2-768-light" src="https://github.com/user-attachments/assets/a3eabe34-799d-4936-8419-77fe1d41bb63" /> | <img width="260" alt="a2-768-dark" src="https://github.com/user-attachments/assets/59c1fc90-1f56-4ae8-b621-a0a3647c6904" /> |
| 1024×768 (small laptop) | <img width="260" alt="a2-1024-light" src="https://github.com/user-attachments/assets/985892f0-ae33-42a4-a196-3860d995ee3a" /> | <img width="260" alt="a2-1024-dark" src="https://github.com/user-attachments/assets/6b8ab90b-32dc-4d82-b228-79c5351ac528" /> |
| 1440×900 (desktop) | <img width="260" alt="a2-1440-light" src="https://github.com/user-attachments/assets/e28f0aa9-fae8-4d86-a9ce-ccdf400acbd9" /> | <img width="260" alt="a2-1440-dark" src="https://github.com/user-attachments/assets/2aa642d3-6575-47e8-a115-6f926444dcc0" /> |
| 1920×1080 (wide) | <img width="260" alt="a2-1920-light" src="https://github.com/user-attachments/assets/b3e95b2f-550f-404b-8cd8-38efd2573e21" /> | <img width="260" alt="a2-1920-dark" src="https://github.com/user-attachments/assets/480d9563-060e-45db-94cc-569c218b035d" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css` (verified via `scripts/check-orphan-classnames.sh` — PASS; new `.cell-popover__row-button` / `.cluster-list-popover__row-button` rules added, dead `.cell-popover__row--clickable` modifier removed)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — 10 published (5 viewports × light/dark)


## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — green (1325 tests, 86 files)
- [x] `npm run lint` — clean
- [x] `npx tsc -b frontend` — clean
- [x] `npm run build` — clean production build
- [x] `npx knip` — clean
- [x] `scripts/check-orphan-classnames.sh` — PASS
- [x] New unit tests added: ObservationPopover dialog-contract (focus-in, Escape + × focus-return for both opener spellings, map-wrapper fallback); CellPopover / ClusterListPopover button-role + native Enter/Space activation
- [x] e2e selectors updated (`map-cell-popover.spec.ts` retargeted to `.…__row-button`); full e2e run via CI + orchestrator live verify
- [x] (UI only) Playwright MCP smoke — orchestrator live keyboard verify on the displaced-silhouette open path, 5 viewports × both themes: focus-in + Escape/× focus-return confirmed; console clean except the pre-existing #1027/S1 basemap warning

## Plan reference

Part of #1029 (design-review remediation). Implements #1031 (A2). `Closes #1031`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

