### PR TITLE
feat(photo-curation): eval reads frozen baseline from prod, hash-verified (C4 #1073)

### DIFF
--- a/docs/runbooks/photo-judge-eval.md
+++ b/docs/runbooks/photo-judge-eval.md
@@ -33,9 +33,23 @@ det-gate exclusion (#1037, below) keys off the same marker.
 
 The eval (`tools/photo-curation/eval/photo-judge.eval.ts`) runs the **traced
 Gemini 2.5 Flash judge** over the cached current-photo thumbnails and scores its
-agreement with the existing **Opus 902-score baseline** (the proxy ground truth
-in `review.sqlite`). It reports three metrics as a Braintrust **experiment** in
-the `bird-maps` project:
+agreement with the existing **Opus 902-score baseline** — now read from **prod
+`species_photo_scores`** (#1073/C4), pinned to `(BASELINE_MODEL,
+BASELINE_RUBRIC)` (defaults `claude-opus-4-8` / `0.2.1`). It reports three
+metrics as a Braintrust **experiment** in the `bird-maps` project:
+
+> **Where the baseline and the image come from (#1073).** The **score** comes
+> from prod (`getPhotoScores(pool, {model, rubricVersion})`); the **species
+> metadata** (name/family/`url`) comes from the local `review.sqlite`
+> `photo_current` join; and the **image bytes** come from the local
+> `thumb-cache`. Because score and image now live in different stores, the eval
+> **hashes the local image and verifies it equals the score row's
+> `content_hash`** before judging — a mismatch SKIPS the row (logged), exactly
+> like an absent image. This preserves the guarantee that **Gemini scores the
+> exact bytes the Opus baseline did**. The det-gate rows
+> (`model='deterministic-gate'`) simply do not match the Opus model pin, so the
+> pinned read never returns them — the #1037 det-gate exclusion is now a
+> property of the pin, not a query filter.
 
 | Scorer | What it measures | Read it as |
 |---|---|---|
@@ -67,14 +81,16 @@ directly in the experiment dashboard.
 
 ## Comparability: the rubric pin and the det-gate exclusion (#1037)
 
-**The rubric version is part of the dataset, not the live code.** Every
-baseline row in `review.sqlite` records the `rubric_version` it was scored
-under (`0.2.1` for the 902-score Opus pass). The eval **pins the judge prompt
-to that recorded version**: the dataset builder asserts that every fetched row
-carries one single, known version (a mixed or missing version is a **hard
-fail at dataset-build time** — re-score the baseline rather than judging under
-different criteria), and the eval selects the matching prompt from the
-version-keyed snapshots in `eval/rubric-prompts.ts`. Judging a v0.2.1 baseline
+**The rubric version is part of the dataset, not the live code.** The baseline
+is read from prod pinned to `(BASELINE_MODEL, BASELINE_RUBRIC)` (#1073), so
+every fetched row already shares one `rubric_version` (`0.2.1` for the 902-score
+Opus pass) — the single-version invariant is **trivially satisfied by the pin**.
+The eval **pins the judge prompt to that recorded version**: the dataset builder
+still asserts the single-known-version invariant as a defensive backstop (an
+empty pinned read, or a hand-injected mixed/missing version, is a **hard fail at
+dataset-build time** — re-score the baseline rather than judging under different
+criteria), and the eval selects the matching prompt from the version-keyed
+snapshots in `eval/rubric-prompts.ts`. Judging a v0.2.1 baseline
 with the live v0.2.2 prompt would turn the v0.2.2 criteria changes
 (same-species multiples OK, mild adult preference — commit 974d8c5) into
 phantom "disagreement". When the baseline is someday re-scored under v0.2.2+,
@@ -88,10 +104,13 @@ judge actually ran) — equal by construction under the pin. The experiment
 metadata records the pinned `rubricVersion` and the judge `model`.
 
 **Deterministic-gate rows are excluded from the dataset.** 13 of the 902
-baseline rows are sharpness-heuristic verdicts
-(`rationale LIKE 'deterministic gate%'`, `keep = 0`, `quality_score = 0`) —
-gate output, not Opus findings — so the judge is never graded against them
-(they also dragged `score_mae` via the synthetic 0).
+baseline rows are sharpness-heuristic verdicts (`keep = 0`, `quality_score = 0`)
+— gate output, not Opus findings — so the judge is never graded against them
+(they also dragged `score_mae` via the synthetic 0). Under the prod read
+(#1073) they were backfilled under `model = 'deterministic-gate'`, so the
+pinned `getPhotoScores(..., model: 'claude-opus-4-8', ...)` **never returns
+them** — the exclusion is now a property of the model pin, not a `rationale`
+query filter.
 
 > **Comparing to pre-pin experiments** (e.g. `HEAD-1781238943`): excluding the
 > 13 all-`keep=0` det-gate rows shifts the stratum balance (536 → 523
@@ -101,12 +120,20 @@ gate output, not Opus findings — so the judge is never graded against them
 
 ## Prerequisites
 
-This eval reads local data and calls the live Gemini API — it is **operator-run
-from the photo-curation run-worktree**, not from CI:
+This eval reads the baseline from prod, reads local images, and calls the live
+Gemini API — it is **operator-run from the photo-curation run-worktree**, not
+from CI:
 
-- **`review.sqlite`** with `role='current'` Opus scores (the 902-score baseline).
+- **A prod connection (`DATABASE_URL`)** — a **read-only** Postgres connection
+  string is sufficient (the eval only SELECTs from `species_photo_scores`). The
+  baseline must already be in prod: run the **one-time backfill above (#1072)**
+  first, or the pinned read returns zero rows and the dataset build fails loud.
+- **`review.sqlite`** — still required, but now only for the **species-metadata
+  join** (`photo_current.url`/`com_name`/`sci_name`/`family`); the SCORES are
+  read from prod, not from here.
 - **`thumb-cache/<species_code>.{jpg,png,webp}`** — the cached current
-  thumbnails the Opus pass scored. No re-download.
+  thumbnails the Opus pass scored. No re-download. Each is **hash-verified**
+  against the prod row's `content_hash`; a diverged cache image is skipped.
 - A Gemini API key and a Braintrust API key. Free tier covers only a smoke run
   (20 requests/day — see the daily-cap section); a full 150-row run needs the
   paid-tier path.
@@ -127,8 +154,11 @@ from the photo-curation run-worktree**, not from CI:
 |---|---|---|
 | `GEMINI_API_KEY` | yes | authenticates the Gemini `generateContent` calls |
 | `BRAINTRUST_API_KEY` | yes | authenticates span/experiment writes; **absence fails loud** — we never score un-traced |
-| `REVIEW_DB` | yes | path to `review.sqlite` (e.g. `./review.sqlite`) |
-| `THUMB_DIR` | yes | path to the thumbnail cache (e.g. `./thumb-cache`) |
+| `DATABASE_URL` | yes | **prod** Postgres connection string the baseline is read from (#1073). A **read-only** URL suffices — the eval only SELECTs `species_photo_scores`. Requires the C3 backfill to have run |
+| `REVIEW_DB` | yes | path to `review.sqlite` (e.g. `./review.sqlite`) — now only the species-metadata join (`photo_current`), not the scores |
+| `THUMB_DIR` | yes | path to the thumbnail cache (e.g. `./thumb-cache`); each image is hash-verified against the prod `content_hash` |
+| `BASELINE_MODEL` | no (default `claude-opus-4-8`) | the `model` half of the frozen-baseline pin passed to `getPhotoScores` (#1073). Override only to evaluate a baseline re-scored under a different model |
+| `BASELINE_RUBRIC` | no (default `0.2.1`) | the `rubric_version` half of the pin. Override only when the baseline was re-scored under a new rubric version |
 | `EVAL_SAMPLE` | no (default `150`) | stratified keep/replace sample size for a full run |
 | `EVAL_MODEL` | no (default `gemini-2.5-flash`) | the judge model to construct; recorded in the experiment metadata and on every span. Same dataset + same pinned rubric + a different `EVAL_MODEL` = directly comparable experiments — "grade the models against the original findings" is a one-env-var operation |
 | `GEMINI_PACE_MS` | no (default `12000`) | min ms between Gemini calls (12 s ⇒ ≤ 5 RPM, the measured free-tier cap); adjust only when a paid tier raises the per-minute quota. An explicit `0` disables pacing; an unparseable value fails loud at startup |
@@ -139,9 +169,16 @@ Put the non-secret values plus `GEMINI_API_KEY` in a local `.env.local`
 ```sh
 # tools/photo-curation/.env.local  (NOT committed)
 GEMINI_API_KEY=AIza…
+# Prod baseline (#1073). A READ-ONLY connection string is sufficient — the eval
+# only SELECTs species_photo_scores. The C3 backfill must have run first.
+DATABASE_URL=postgres://…prod-ro…
 REVIEW_DB=./review.sqlite
 THUMB_DIR=./thumb-cache
 EVAL_SAMPLE=150
+# Optional — the frozen-baseline pin (defaults shown). Override only to evaluate
+# a baseline re-scored under a different (model, rubric).
+# BASELINE_MODEL=claude-opus-4-8
+# BASELINE_RUBRIC=0.2.1
 ```
 
 **Braintrust auth resolves from the active `bt` profile** (`bt auth login` /

--- a/tools/photo-curation/eval/photo-judge.eval.ts
+++ b/tools/photo-curation/eval/photo-judge.eval.ts
@@ -1,17 +1,24 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // Braintrust eval entry (C5, #1015; part of #1010) — run via `bt eval`.
 //
-// Scores the TRACED Gemini judge against the Opus 902-score proxy baseline in
-// review.sqlite, reporting the #969 calibration metrics (keep-agreement %,
-// score-MAE, keep-confusion) as a `bird-maps` Braintrust EXPERIMENT.
+// Scores the TRACED Gemini judge against the frozen Opus 902-score proxy
+// baseline — now read from PROD `species_photo_scores` (C4 #1073), pinned to
+// `(BASELINE_MODEL, BASELINE_RUBRIC)` — reporting the #969 calibration metrics
+// (keep-agreement %, score-MAE, keep-confusion) as a `bird-maps` Braintrust
+// EXPERIMENT.
 //
-//   data  — buildEvalRows(openDb(REVIEW_DB), {thumbDir, sample}) (#1013), the
-//           stratified Opus-current rows: each {input:{readPath,imageUrl,
+//   data  — buildEvalRows(openDb(REVIEW_DB), {getScores, thumbDir, sample}) (#1073),
+//           the stratified baseline rows: each {input:{readPath,imageUrl,
 //           species…}, expected:{keep,qualityScore,criteria?},
-//           metadata:{contentHash,…,expectedRubricVersion}}. readPath is the
-//           LOCAL byte source; imageUrl is the portable R2 URL logged as the
-//           span sourceUrl (#1067). Det-gate rows are excluded and the
-//           single-rubric-version invariant is asserted inside the builder (#1037).
+//           metadata:{contentHash,…,expectedRubricVersion}}. The SCORE comes
+//           from prod (`getPhotoScores(pool, pin)`); the species metadata + the
+//           image BYTES come from the local review store + thumb-cache, and each
+//           local image is HASH-VERIFIED against the prod row's content_hash so
+//           Gemini scores the exact bytes the baseline did (#1073). readPath is
+//           the LOCAL byte source; imageUrl is the portable R2 URL logged as the
+//           span sourceUrl (#1067). Det-gate rows never match the Opus model pin,
+//           and the single-rubric-version invariant is trivially held by the pin
+//           (asserted defensively inside the builder, #1037).
 //   task  — runRow({judge, readImage, prompt}, input) (run-row.ts).
 //           Braintrust calls task(input, hooks): the FIRST positional arg IS the
 //           row's `input` value, so we write `task: (input) => …`, NOT
@@ -21,13 +28,15 @@
 //
 // COMPARABILITY (#1037): the judge prompt is PINNED to the baseline's recorded
 // rubric_version — the rubric version is part of the dataset, not the live
-// code. The dataset is built EAGERLY at module load so (a) a mixed/unknown
-// version fails before any Gemini call is even possible, and (b) the pinned
-// version is known in time to select the prompt and to stamp the experiment
-// metadata at Eval() registration. That build needs only REVIEW_DB/THUMB_DIR
-// (already import-time requirements) — local sqlite + readdir, no network and
-// no API keys, so `bt eval --list` still works keyless. EVAL_MODEL picks the
-// judge model (default gemini-2.5-flash): same dataset + same pinned rubric +
+// code. The dataset is built EAGERLY at module load (top-level await) so (a) a
+// mixed/unknown version fails before any Gemini call is even possible, and (b)
+// the pinned version is known in time to select the prompt and to stamp the
+// experiment metadata at Eval() registration. That build now reads the baseline
+// from PROD (`DATABASE_URL`, a read-only connection) instead of the local
+// sqlite — it still uses local sqlite for the species-metadata join + readdir
+// for the image, and needs no Gemini/Braintrust key, so `bt eval --list` still
+// works keyless (it only needs the DB reachable). EVAL_MODEL picks the judge
+// model (default gemini-2.5-flash): same dataset + same pinned rubric +
 // different model = directly comparable experiments.
 //
 // The judge is obtained through `resolveTracedJudge` — the ONLY public way to
@@ -48,8 +57,9 @@
 import { readFileSync } from 'node:fs';
 import { Eval } from 'braintrust';
 import type { ImageInput, VisionJudge } from '@bird-watch/photo-quality';
+import { createPool, closePool, getPhotoScores } from '@bird-watch/db-client';
 import { openDb } from '../src/db.js';
-import { buildEvalRows } from '../src/eval/build-dataset.js';
+import { buildEvalRows, resolveBaselinePin } from '../src/eval/build-dataset.js';
 import { resolveTracedJudge } from '../src/judges/index.js';
 import { keepAgreement, scoreMAE, keepConfusion, criteriaAxisMAE } from '../src/eval/scorers.js';
 import { runRow } from '../src/eval/run-row.js';
@@ -67,12 +77,26 @@ function requireEnv(name: string): string {
 
 const REVIEW_DB = requireEnv('REVIEW_DB');
 const THUMB_DIR = requireEnv('THUMB_DIR');
+// PROD baseline connection (#1073). A READ-ONLY connection string suffices — the
+// eval only SELECTs from species_photo_scores via C2's getPhotoScores.
+const DATABASE_URL = requireEnv('DATABASE_URL');
 const EVAL_SAMPLE = Number(process.env.EVAL_SAMPLE ?? 150);
 const EVAL_MODEL = resolveEvalModel(process.env);
+// The frozen-baseline pin (#1073): defaults claude-opus-4-8 / 0.2.1, env-overridable.
+const BASELINE_PIN = resolveBaselinePin(process.env);
 
-// Eager build (#1037): hard-fails here on a mixed/unknown rubric_version or an
-// empty baseline — before any judge construction, prompt selection, or network.
-const rows = buildEvalRows(openDb(REVIEW_DB), { thumbDir: THUMB_DIR, sample: EVAL_SAMPLE });
+// Eager build (#1037/#1073): reads the pinned baseline from PROD and hash-
+// verifies each local image against it. Hard-fails here on a mixed/unknown
+// rubric_version or an empty baseline — before any judge construction, prompt
+// selection, or Gemini network. The pool is opened, drained for the read, and
+// closed immediately: the dataset is materialized eagerly, so nothing past this
+// point needs the DB.
+const pool = createPool({ databaseUrl: DATABASE_URL, max: 1 });
+const rows = await buildEvalRows(openDb(REVIEW_DB), {
+  thumbDir: THUMB_DIR,
+  sample: EVAL_SAMPLE,
+  getScores: () => getPhotoScores(pool, BASELINE_PIN),
+}).finally(() => closePool(pool));
 
 // Non-empty + single-version are guaranteed by the builder's assertions, so
 // row 0 carries THE baseline version. The prompt pin follows it: judging a

--- a/tools/photo-curation/src/eval/build-dataset.test.ts
+++ b/tools/photo-curation/src/eval/build-dataset.test.ts
@@ -4,8 +4,20 @@ import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
 import type Database from 'better-sqlite3';
 import { openDb } from '../db.js';
-import { buildEvalRows, mulberry32, shuffleInPlace, DEFAULT_SEED, parseCriteria } from './build-dataset.js';
-import { CRITERIA_KEYS, type CriteriaScores } from '@bird-watch/photo-quality';
+import {
+  buildEvalRows,
+  mulberry32,
+  shuffleInPlace,
+  DEFAULT_SEED,
+  parseCriteria,
+  criteriaFromRecord,
+  resolveBaselinePin,
+  DEFAULT_BASELINE_MODEL,
+  DEFAULT_BASELINE_RUBRIC,
+  type ScoreReader,
+} from './build-dataset.js';
+import { CRITERIA_KEYS, type CriteriaScores, contentHash } from '@bird-watch/photo-quality';
+import type { PhotoScoreRow } from '@bird-watch/shared-types';
 
 let db: Database.Database;
 let thumbDir: string;
@@ -19,61 +31,75 @@ afterEach(() => {
   rmSync(thumbDir, { recursive: true, force: true });
 });
 
+/** The frozen-baseline rubric stamp every fixture row shares unless overridden. */
+const RUBRIC = '0.2.1';
+
 /**
- * Insert one photo_current + one role='current' photo_score for a species.
- * `rubricVersion` defaults to the baseline's real provenance stamp ('0.2.1');
- * `rationale` defaults to an Opus-style sentence — pass the det-gate prefix
- * ('deterministic gate failed: …') to seed a heuristic (non-Opus) verdict.
+ * Insert one `photo_current` metadata row (the LOCAL review-store join the eval
+ * still reads species name/family/url from; the SCORE comes from the injected
+ * prod reader, #1073).
  */
 function seedCurrent(
   code: string,
-  fields: {
-    comName: string;
-    sciName: string;
-    family: string;
-    contentHash: string;
-    keep: number | null;
-    qualityScore: number | null;
-    overall: number;
-    rationale?: string | null;
-    rubricVersion?: string | null;
-    /** Stored R2 URL VERBATIM; defaults to a mixed-extension https URL. */
-    url?: string | null;
-    /** `criteria_json` blob; `null` to seed a row with no per-axis scores. */
-    criteriaJson?: string | null;
-  },
+  fields: { comName: string; sciName: string; family: string; url?: string | null },
 ): void {
   db.prepare(
     `INSERT INTO photo_current (species_code, com_name, sci_name, family, url, content_hash)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, NULL)`,
   ).run(
     code,
     fields.comName,
     fields.sciName,
     fields.family,
     fields.url === undefined ? `https://photos.bird-maps.com/${code}.jpg` : fields.url,
-    fields.contentHash,
-  );
-  db.prepare(
-    `INSERT INTO photo_score (species_code, role, content_hash, overall, verdict,
-                              criteria_json, flags_json, keep, quality_score, rationale,
-                              rubric_version, scored_at)
-     VALUES (?, 'current', ?, ?, 'good', ?, '[]', ?, ?, ?, ?, 'now')`,
-  ).run(
-    code,
-    fields.contentHash,
-    fields.overall,
-    fields.criteriaJson === undefined ? '{}' : fields.criteriaJson,
-    fields.keep,
-    fields.qualityScore,
-    fields.rationale === undefined ? 'sharp wild adult, diagnostic marks visible' : fields.rationale,
-    fields.rubricVersion === undefined ? '0.2.1' : fields.rubricVersion,
   );
 }
 
-/** Write a zero-byte image file `<code>.<ext>` into thumbDir. */
-function writeImage(code: string, ext = 'jpg'): void {
-  writeFileSync(join(thumbDir, `${code}.${ext}`), '');
+/**
+ * Write image bytes `<code>.<ext>` into thumbDir and RETURN their canonical
+ * content hash, so a fixture score row can be pinned to the exact local bytes
+ * (the same-bytes guarantee, #1073). Distinct `code` → distinct bytes → distinct
+ * hash, so a mismatch is engineered by pinning a score to a *different* hash.
+ */
+function writeImage(code: string, ext = 'jpg'): string {
+  const bytes = Buffer.from(`image-bytes-for-${code}.${ext}`);
+  writeFileSync(join(thumbDir, `${code}.${ext}`), bytes);
+  return contentHash(bytes);
+}
+
+/**
+ * Build a `PhotoScoreRow` for the prod baseline pin. `contentHash` defaults to a
+ * sentinel that will NOT match any local image — callers that want a hash match
+ * pass the value returned by {@link writeImage}.
+ */
+function scoreRow(
+  code: string,
+  fields: {
+    contentHash?: string;
+    keep: boolean;
+    qualityScore: number | null;
+    criteria?: Record<string, number> | null;
+    rationale?: string | null;
+    model?: string;
+    rubricVersion?: string;
+  },
+): PhotoScoreRow {
+  return {
+    speciesCode: code,
+    contentHash: fields.contentHash ?? `no-match-${code}`,
+    model: fields.model ?? DEFAULT_BASELINE_MODEL,
+    rubricVersion: fields.rubricVersion ?? RUBRIC,
+    keep: fields.keep,
+    qualityScore: fields.qualityScore,
+    criteria: fields.criteria ?? null,
+    fieldMarks: null,
+    rationale: fields.rationale ?? 'sharp wild adult, diagnostic marks visible',
+  };
+}
+
+/** An injected reader that returns the given fixture rows (no DB, no network). */
+function reader(rows: PhotoScoreRow[]): ScoreReader {
+  return () => Promise.resolve(rows);
 }
 
 describe('mulberry32 / shuffleInPlace', () => {
@@ -96,19 +122,52 @@ describe('mulberry32 / shuffleInPlace', () => {
   });
 });
 
-describe('buildEvalRows', () => {
-  // TDD #1: 4 currents (2 keep / 2 not, all keep non-null) + 4 images → 4 rows.
-  it('builds one row per current with correct input/expected and contentHash', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
-    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
-    writeImage('amerob');
-    writeImage('norcar', 'png');
-    writeImage('houspa', 'webp');
-    writeImage('rocpig');
+describe('resolveBaselinePin', () => {
+  it('defaults to the frozen Opus pin (claude-opus-4-8 / 0.2.1)', () => {
+    expect(resolveBaselinePin({})).toEqual({
+      model: 'claude-opus-4-8',
+      rubricVersion: '0.2.1',
+    });
+    expect(DEFAULT_BASELINE_MODEL).toBe('claude-opus-4-8');
+    expect(DEFAULT_BASELINE_RUBRIC).toBe('0.2.1');
+  });
 
-    const rows = buildEvalRows(db, { thumbDir });
+  it('respects BASELINE_MODEL / BASELINE_RUBRIC overrides', () => {
+    expect(
+      resolveBaselinePin({ BASELINE_MODEL: 'gemini-2.5-flash', BASELINE_RUBRIC: '0.3.0' }),
+    ).toEqual({ model: 'gemini-2.5-flash', rubricVersion: '0.3.0' });
+  });
+
+  it('falls back to defaults for empty-string env vars', () => {
+    expect(resolveBaselinePin({ BASELINE_MODEL: '', BASELINE_RUBRIC: '' })).toEqual({
+      model: 'claude-opus-4-8',
+      rubricVersion: '0.2.1',
+    });
+  });
+});
+
+describe('buildEvalRows', () => {
+  // The injected prod reader supplies the scores; the local store supplies the
+  // species metadata + image, hash-verified.
+  it('builds one row per baseline score with correct input/expected and contentHash', async () => {
+    const hRobin = writeImage('amerob');
+    const hCard = writeImage('norcar', 'png');
+    const hSparrow = writeImage('houspa', 'webp');
+    const hPigeon = writeImage('rocpig');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae' });
+    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae' });
+    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae' });
+
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: hCard, keep: true, qualityScore: 91 }),
+        scoreRow('houspa', { contentHash: hSparrow, keep: false, qualityScore: 40 }),
+        scoreRow('rocpig', { contentHash: hPigeon, keep: false, qualityScore: 30 }),
+      ]),
+    });
     expect(rows).toHaveLength(4);
 
     const robin = rows.find((r) => r.input.speciesCode === 'amerob')!;
@@ -120,9 +179,8 @@ describe('buildEvalRows', () => {
       sciName: 'Turdus migratorius',
       family: 'Turdidae',
     });
-    // `{}` criteria_json has no axes → no `criteria` key (undefined, not `{}`).
     expect(robin.expected).toEqual({ keep: true, qualityScore: 88 });
-    expect(robin.metadata).toEqual({ contentHash: 'h-amerob', expectedRubricVersion: '0.2.1' });
+    expect(robin.metadata).toEqual({ contentHash: hRobin, expectedRubricVersion: '0.2.1' });
 
     // Image resolved by extension glob, not hardcoded .jpg — readPath is LOCAL.
     expect(basename(rows.find((r) => r.input.speciesCode === 'norcar')!.input.readPath)).toBe('norcar.png');
@@ -132,47 +190,127 @@ describe('buildEvalRows', () => {
     expect(pigeon.expected).toEqual({ keep: false, qualityScore: 30 });
   });
 
-  // Coalesce rules mirror getScoreByHash (store.ts).
-  it('coalesces keep (null⇒true) and qualityScore (null⇒overall)', () => {
-    seedCurrent('coales', { comName: 'C', sciName: 'C c', family: 'Fam', contentHash: 'h-coales', keep: null, qualityScore: null, overall: 62 });
-    writeImage('coales');
+  // keep is a real boolean off the prod row; qualityScore is carried verbatim.
+  it('carries keep (boolean) and qualityScore straight off the prod score row', async () => {
+    const h = writeImage('coales');
+    seedCurrent('coales', { comName: 'C', sciName: 'C c', family: 'Fam' });
 
-    const rows = buildEvalRows(db, { thumbDir });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('coales', { contentHash: h, keep: true, qualityScore: 62 })]),
+    });
     expect(rows).toHaveLength(1);
     expect(rows[0].expected).toEqual({ keep: true, qualityScore: 62 });
   });
 
-  // TDD #2: one image missing → 3 rows, that one skipped + note logged.
-  it('skips a current whose image is missing and logs a note', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
-    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
-    writeImage('amerob');
-    writeImage('norcar');
+  // TDD: one image missing → that row skipped + note logged (the existing
+  // absent-image skip behaviour, preserved under the prod read).
+  it('skips a score whose image is missing and logs a note', async () => {
+    const hRobin = writeImage('amerob');
+    const hCard = writeImage('norcar');
+    const hPigeon = writeImage('rocpig');
     // houspa image deliberately absent.
-    writeImage('rocpig');
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) {
+      seedCurrent(c, { comName: c, sciName: `${c} s`, family: 'Fam' });
+    }
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const rows = buildEvalRows(db, { thumbDir });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: hCard, keep: true, qualityScore: 91 }),
+        scoreRow('houspa', { keep: false, qualityScore: 40 }),
+        scoreRow('rocpig', { contentHash: hPigeon, keep: false, qualityScore: 30 }),
+      ]),
+    });
     expect(rows).toHaveLength(3);
     expect(rows.map((r) => r.input.speciesCode).sort()).toEqual(['amerob', 'norcar', 'rocpig']);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0][0]).toContain('houspa');
+    expect(warn.mock.calls[0][0]).toContain('no cached image');
     warn.mockRestore();
   });
 
-  // TDD #3: sample:2 over 2-keep/2-not → exactly 1 keep + 1 not, exact codes pinned.
-  it('stratified sample:2 returns exactly 1 keep + 1 not with the pinned species_codes for the default seed', () => {
-    // Insertion order fixes the pre-shuffle stratum order:
-    //   keep = [amerob, norcar], not = [houspa, rocpig]
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
-    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
-    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
+  // #1073 same-bytes integrity: a local image whose hash ≠ the score's
+  // content_hash is skipped (logged), mirroring the absent-image skip — Gemini
+  // must never score different bytes than the Opus baseline did.
+  it('skips a score whose local image hash ≠ the baseline content_hash and logs a note', async () => {
+    const hRobin = writeImage('amerob'); // real local hash
+    writeImage('norcar'); // present, but the score below pins a DIFFERENT hash
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae' });
 
-    const rows = buildEvalRows(db, { thumbDir, sample: 2 });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        // contentHash deliberately does NOT match norcar's local bytes.
+        scoreRow('norcar', { contentHash: 'deadbeef', keep: true, qualityScore: 91 }),
+      ]),
+    });
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['amerob']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('norcar');
+    expect(warn.mock.calls[0][0]).toMatch(/hash|content_hash/i);
+    warn.mockRestore();
+  });
+
+  // A matching hash is kept (the positive half of the same-bytes test).
+  it('keeps a score whose local image hash matches the baseline content_hash', async () => {
+    const h = writeImage('amerob');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: h, keep: true, qualityScore: 88 })]),
+    });
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['amerob']);
+    expect(rows[0].metadata.contentHash).toBe(h);
+  });
+
+  // A score with no local photo_current metadata row can't be built → skipped.
+  it('skips a score with no local photo_current metadata row and logs a note', async () => {
+    const hRobin = writeImage('amerob');
+    writeImage('orphan'); // image exists but no photo_current row
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('orphan', { keep: true, qualityScore: 70 }),
+      ]),
+    });
+    expect(rows.map((r) => r.input.speciesCode)).toEqual(['amerob']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('orphan');
+    expect(warn.mock.calls[0][0]).toContain('photo_current');
+    warn.mockRestore();
+  });
+
+  // TDD: sample:2 over 2-keep/2-not → exactly 1 keep + 1 not, exact codes pinned.
+  it('stratified sample:2 returns exactly 1 keep + 1 not with the pinned species_codes for the default seed', async () => {
+    // Reader order fixes the pre-shuffle stratum order:
+    //   keep = [amerob, norcar], not = [houspa, rocpig]
+    const h: Record<string, string> = {};
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) {
+      h[c] = writeImage(c);
+      seedCurrent(c, { comName: c, sciName: `${c} s`, family: 'Fam' });
+    }
+
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      sample: 2,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: h.amerob, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: h.norcar, keep: true, qualityScore: 91 }),
+        scoreRow('houspa', { contentHash: h.houspa, keep: false, qualityScore: 40 }),
+        scoreRow('rocpig', { contentHash: h.rocpig, keep: false, qualityScore: 30 }),
+      ]),
+    });
     expect(rows).toHaveLength(2);
     expect(rows.filter((r) => r.expected.keep)).toHaveLength(1);
     expect(rows.filter((r) => !r.expected.keep)).toHaveLength(1);
@@ -185,15 +323,24 @@ describe('buildEvalRows', () => {
     expect(DEFAULT_SEED).toBe(0xb12d);
   });
 
-  // TDD #4: sample:3 (odd) over 2-keep/2-not → rounding rule keepTake=2, notTake=1.
-  it('stratified sample:3 applies the rounding rule (keepTake=round(3*2/4)=2, notTake=1)', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
-    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35 });
-    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
+  // TDD: sample:3 (odd) over 2-keep/2-not → rounding rule keepTake=2, notTake=1.
+  it('stratified sample:3 applies the rounding rule (keepTake=round(3*2/4)=2, notTake=1)', async () => {
+    const h: Record<string, string> = {};
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) {
+      h[c] = writeImage(c);
+      seedCurrent(c, { comName: c, sciName: `${c} s`, family: 'Fam' });
+    }
 
-    const rows = buildEvalRows(db, { thumbDir, sample: 3 });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      sample: 3,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: h.amerob, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: h.norcar, keep: true, qualityScore: 91 }),
+        scoreRow('houspa', { contentHash: h.houspa, keep: false, qualityScore: 40 }),
+        scoreRow('rocpig', { contentHash: h.rocpig, keep: false, qualityScore: 30 }),
+      ]),
+    });
     expect(rows).toHaveLength(3);
     expect(rows.filter((r) => r.expected.keep)).toHaveLength(2);
     expect(rows.filter((r) => !r.expected.keep)).toHaveLength(1);
@@ -201,127 +348,120 @@ describe('buildEvalRows', () => {
     expect(rows.map((r) => r.input.speciesCode)).toEqual(['norcar', 'amerob', 'houspa']);
   });
 
-  // C3 polish (#1015): when a species has two cached extensions, the chosen
-  // file must be DETERMINISTIC (readdir order is filesystem-dependent). The
-  // resolver sorts the listing, so `.jpg` (sorts before `.png`/`.webp`) wins.
-  it('deterministically resolves a two-extension species to the sort-first file', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
+  // When a species has two cached extensions, the chosen file must be
+  // DETERMINISTIC (readdir order is filesystem-dependent). The resolver sorts
+  // the listing, so `.jpg` (sorts before `.png`) wins — and the HASH-VERIFY
+  // pins to that sort-first file's bytes.
+  it('deterministically resolves a two-extension species to the sort-first file', async () => {
+    const hJpg = writeImage('amerob', 'jpg');
     writeImage('amerob', 'png');
-    writeImage('amerob', 'jpg');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
 
-    const rows = buildEvalRows(db, { thumbDir });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: hJpg, keep: true, qualityScore: 88 })]),
+    });
     expect(rows).toHaveLength(1);
     expect(basename(rows[0].input.readPath)).toBe('amerob.jpg');
   });
 
-  it('returns all rows unsampled when sample is omitted', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    writeImage('amerob');
-    expect(buildEvalRows(db, { thumbDir })).toHaveLength(1);
+  it('returns all rows unsampled when sample is omitted', async () => {
+    const h = writeImage('amerob');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: h, keep: true, qualityScore: 88 })]),
+    });
+    expect(rows).toHaveLength(1);
   });
 
-  // #1037 decision 2: det-gate rows are heuristic verdicts, not Opus findings —
-  // the judge must never be graded against them.
-  it('excludes deterministic-gate rows from the fetched set', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('detgat', {
-      comName: 'Det Gate', sciName: 'D g', family: 'Fam', contentHash: 'h-detgat',
-      keep: 0, qualityScore: 0, overall: 0,
-      rationale: 'deterministic gate failed: sharpness 0.00001 below floor 0.00005',
-    });
-    for (const c of ['amerob', 'norcar', 'detgat']) writeImage(c);
+  // #1037 decision 2 (now via the pin): det-gate rows carry
+  // model='deterministic-gate', so the pinned `getPhotoScores(..., model:opus)`
+  // never returns them — they cannot reach the dataset.
+  it('never sees deterministic-gate rows because the pin filters them out at the reader', async () => {
+    const hRobin = writeImage('amerob');
+    const hCard = writeImage('norcar');
+    for (const c of ['amerob', 'norcar']) seedCurrent(c, { comName: c, sciName: `${c} s`, family: 'Fam' });
 
-    const rows = buildEvalRows(db, { thumbDir });
+    // The injected reader stands in for `getPhotoScores(pool, {model:'claude-opus-4-8', …})`:
+    // it returns ONLY Opus rows (the det-gate rows don't match the model filter).
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: hCard, keep: false, qualityScore: 40 }),
+      ]),
+    });
     expect(rows.map((r) => r.input.speciesCode).sort()).toEqual(['amerob', 'norcar']);
   });
 
-  // #1067 (bot review): the per-axis null-skip keys on ABSENCE, but a det-gate
-  // row carries ZEROED-not-null criteria (`{framing:0,…}`) — which would score
-  // as real, harsh disagreement if it reached a scorer. The ONLY thing keeping
-  // it out is the existing `rationale NOT LIKE 'deterministic gate%'` query
-  // filter; this test couples the two mechanisms so neither can silently drift.
-  it('excludes a det-gate row even when it carries zeroed (non-null) criteria — so a scorer never sees fabricated 0s', () => {
-    const zeroed = { framing: 0, subjectClarity: 0, liveness: 0, naturalness: 0, pose: 0, background: 0, lighting: 0 };
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: JSON.stringify({ framing: 8, subjectClarity: 7, liveness: 9, naturalness: 6, pose: 7, background: 6, lighting: 8 }) });
-    seedCurrent('detgat', {
-      comName: 'Det Gate', sciName: 'D g', family: 'Fam', contentHash: 'h-detgat',
-      keep: 0, qualityScore: 0, overall: 0,
-      rationale: 'deterministic gate failed: sharpness below floor',
-      criteriaJson: JSON.stringify(zeroed),
+  // #1037 decision 1: every row carries the rubric version it was judged under.
+  it('populates metadata.expectedRubricVersion from the score row rubric_version', async () => {
+    const hRobin = writeImage('amerob');
+    const hCard = writeImage('norcar');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae' });
+
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: hCard, keep: false, qualityScore: 40 }),
+      ]),
     });
-    writeImage('amerob');
-    writeImage('detgat');
-
-    const rows = buildEvalRows(db, { thumbDir });
-    // The det-gate row is gone, so its zeroed criteria can never become an
-    // `expected.criteria` the per-axis scorer would grade as a 10-point miss.
-    expect(rows.map((r) => r.input.speciesCode)).toEqual(['amerob']);
-    expect(rows.every((r) => r.input.speciesCode !== 'detgat')).toBe(true);
-  });
-
-  // The exclusion predicate must be NULL-safe: `rationale NOT LIKE …` alone is
-  // NULL for a NULL rationale, which would silently drop Opus rows without one.
-  it('keeps a row whose rationale is NULL (not a det-gate verdict)', () => {
-    seedCurrent('norale', { comName: 'No Rationale', sciName: 'N r', family: 'Fam', contentHash: 'h-norale', keep: 1, qualityScore: 70, overall: 70, rationale: null });
-    writeImage('norale');
-
-    const rows = buildEvalRows(db, { thumbDir });
-    expect(rows.map((r) => r.input.speciesCode)).toEqual(['norale']);
-  });
-
-  // #1037 decision 1/3: every row carries the version the baseline was judged
-  // under, so the experiment can prove expected == judged criteria per row.
-  it('populates metadata.expectedRubricVersion from the DB rubric_version', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 0, qualityScore: 40, overall: 45 });
-    writeImage('amerob');
-    writeImage('norcar');
-
-    const rows = buildEvalRows(db, { thumbDir });
     expect(rows).toHaveLength(2);
     for (const row of rows) expect(row.metadata.expectedRubricVersion).toBe('0.2.1');
   });
 
-  // #1037 decision 1: the invariant is asserted over the FULL fetched set
-  // BEFORE sampling — a mixed-version DB fails deterministically, regardless of
-  // whether the odd row would have landed in the sample.
-  it('throws on a mixed rubric_version baseline even when sampling', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85 });
-    seedCurrent('houspa', { comName: 'House Sparrow', sciName: 'Passer domesticus', family: 'Passeridae', contentHash: 'h-houspa', keep: 0, qualityScore: 40, overall: 45 });
-    seedCurrent('rocpig', { comName: 'Rock Pigeon', sciName: 'Columba livia', family: 'Columbidae', contentHash: 'h-rocpig', keep: 0, qualityScore: 30, overall: 35, rubricVersion: '0.2.2' });
-    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) writeImage(c);
-
-    expect(() => buildEvalRows(db, { thumbDir, sample: 2 })).toThrow(/mixed rubric_version/i);
-    // The message names both versions so the operator knows what to re-score.
-    expect(() => buildEvalRows(db, { thumbDir, sample: 2 })).toThrow(/0\.2\.1.*0\.2\.2|0\.2\.2.*0\.2\.1/s);
+  // #1037 decision 1: the invariant is asserted over the FULL fetched set BEFORE
+  // sampling. With the prod pin it's trivially satisfied, but the guard still
+  // fails loud on a mixed-version reader fixture (a defensive backstop).
+  it('throws on a mixed rubric_version baseline even when sampling', async () => {
+    for (const c of ['amerob', 'norcar', 'houspa', 'rocpig']) {
+      writeImage(c);
+      seedCurrent(c, { comName: c, sciName: `${c} s`, family: 'Fam' });
+    }
+    const rows = [
+      scoreRow('amerob', { keep: true, qualityScore: 88 }),
+      scoreRow('norcar', { keep: true, qualityScore: 91 }),
+      scoreRow('houspa', { keep: false, qualityScore: 40 }),
+      scoreRow('rocpig', { keep: false, qualityScore: 30, rubricVersion: '0.2.2' }),
+    ];
+    await expect(buildEvalRows(db, { thumbDir, sample: 2, getScores: reader(rows) })).rejects.toThrow(
+      /mixed rubric_version/i,
+    );
+    await expect(buildEvalRows(db, { thumbDir, sample: 2, getScores: reader(rows) })).rejects.toThrow(
+      /0\.2\.1.*0\.2\.2|0\.2\.2.*0\.2\.1/s,
+    );
   });
 
-  it('throws when any fetched row has no rubric_version (unknown provenance)', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80 });
-    seedCurrent('unkver', { comName: 'Unknown Version', sciName: 'U v', family: 'Fam', contentHash: 'h-unkver', keep: 0, qualityScore: 40, overall: 45, rubricVersion: null });
-    writeImage('amerob');
-    writeImage('unkver');
-
-    expect(() => buildEvalRows(db, { thumbDir })).toThrow(/rubric_version/);
+  it('throws on an empty baseline (no version to pin the judge prompt to)', async () => {
+    await expect(buildEvalRows(db, { thumbDir, getScores: reader([]) })).rejects.toThrow(
+      /no scores returned/i,
+    );
   });
 
-  it('throws on an empty baseline (no version to pin the judge prompt to)', () => {
-    expect(() => buildEvalRows(db, { thumbDir })).toThrow(/no role='current' scores/i);
-  });
+  // #1067: the R2 URL is logged VERBATIM (mixed extensions) — distinct from the
+  // LOCAL readPath.
+  it('carries photo_current.url verbatim (mixed extensions) as imageUrl, distinct from readPath', async () => {
+    const hRobin = writeImage('amerob'); // local cache is .jpg even though the R2 URL is .jpeg
+    const hCard = writeImage('norcar', 'png');
+    seedCurrent('amerob', {
+      comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae',
+      url: 'https://photos.bird-maps.com/amerob.jpeg',
+    });
+    seedCurrent('norcar', {
+      comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae',
+      url: 'https://photos.bird-maps.com/norcar.png',
+    });
 
-  // #1067: the R2 URL is logged VERBATIM — extensions vary in the DB
-  // (.jpg/.jpeg/.png) and a reconstructed `<code>.jpeg` template 404s for
-  // hundreds of species, so the row must carry the stored column unchanged,
-  // distinct from the LOCAL readPath.
-  it('carries photo_current.url verbatim (mixed extensions) as imageUrl, distinct from readPath', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, url: 'https://photos.bird-maps.com/amerob.jpeg' });
-    seedCurrent('norcar', { comName: 'Northern Cardinal', sciName: 'Cardinalis cardinalis', family: 'Cardinalidae', contentHash: 'h-norcar', keep: 1, qualityScore: 91, overall: 85, url: 'https://photos.bird-maps.com/norcar.png' });
-    writeImage('amerob'); // local cache is .jpg even though the R2 URL is .jpeg
-    writeImage('norcar', 'png');
-
-    const rows = buildEvalRows(db, { thumbDir });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([
+        scoreRow('amerob', { contentHash: hRobin, keep: true, qualityScore: 88 }),
+        scoreRow('norcar', { contentHash: hCard, keep: true, qualityScore: 91 }),
+      ]),
+    });
     const robin = rows.find((r) => r.input.speciesCode === 'amerob')!;
     expect(robin.input.imageUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
     expect(robin.input.readPath).toBe(join(thumbDir, 'amerob.jpg'));
@@ -331,23 +471,38 @@ describe('buildEvalRows', () => {
     expect(card.input.imageUrl).toBe('https://photos.bird-maps.com/norcar.png');
   });
 
-  // #1067: the Opus per-axis sub-scores ride into expected.criteria.
-  it('populates expected.criteria from a real criteria_json blob', () => {
-    const criteria: CriteriaScores = { framing: 8, subjectClarity: 7, liveness: 10, naturalness: 4, pose: 6, background: 5, lighting: 9 };
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: JSON.stringify(criteria) });
-    writeImage('amerob');
+  // A NULL photo_current.url becomes '' (the verbatim contract carries no URL).
+  it('uses empty-string imageUrl when photo_current.url is NULL', async () => {
+    const h = writeImage('amerob');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', url: null });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: h, keep: true, qualityScore: 88 })]),
+    });
+    expect(rows[0].input.imageUrl).toBe('');
+  });
 
-    const rows = buildEvalRows(db, { thumbDir });
+  // #1067: the Opus per-axis sub-scores ride into expected.criteria (now from
+  // the prod JSONB `criteria`, already deserialized to an object).
+  it('populates expected.criteria from a prod criteria object', async () => {
+    const criteria: CriteriaScores = { framing: 8, subjectClarity: 7, liveness: 10, naturalness: 4, pose: 6, background: 5, lighting: 9 };
+    const h = writeImage('amerob');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: h, keep: true, qualityScore: 88, criteria })]),
+    });
     expect(rows[0].expected.criteria).toEqual(criteria);
   });
 
-  // #1067: a NULL criteria_json must yield `undefined` (an axis-skip), NOT `{}`
-  // — a fabricated empty object would be indistinguishable from a real score.
-  it('leaves expected.criteria undefined (not {}) for a NULL criteria_json', () => {
-    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae', contentHash: 'h-amerob', keep: 1, qualityScore: 88, overall: 80, criteriaJson: null });
-    writeImage('amerob');
-
-    const rows = buildEvalRows(db, { thumbDir });
+  // #1067: a NULL criteria must yield `undefined` (an axis-skip), NOT `{}`.
+  it('leaves expected.criteria undefined (not {}) for a NULL criteria', async () => {
+    const h = writeImage('amerob');
+    seedCurrent('amerob', { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' });
+    const rows = await buildEvalRows(db, {
+      thumbDir,
+      getScores: reader([scoreRow('amerob', { contentHash: h, keep: true, qualityScore: 88, criteria: null })]),
+    });
     expect(rows[0].expected.criteria).toBeUndefined();
     expect('criteria' in rows[0].expected).toBe(false);
   });
@@ -379,5 +534,27 @@ describe('parseCriteria', () => {
     expect(parseCriteria('{not json')).toBeUndefined();
     expect(parseCriteria('[1,2,3]')).toBeUndefined();
     expect(parseCriteria('"a string"')).toBeUndefined();
+  });
+});
+
+describe('criteriaFromRecord', () => {
+  it('coerces a full 7-axis record', () => {
+    const criteria: CriteriaScores = { framing: 8, subjectClarity: 7, liveness: 10, naturalness: 4, pose: 6, background: 5, lighting: 9 };
+    expect(criteriaFromRecord(criteria)).toEqual(criteria);
+  });
+
+  it('returns undefined for null', () => {
+    expect(criteriaFromRecord(null)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty object (no axes — never {})', () => {
+    expect(criteriaFromRecord({})).toBeUndefined();
+  });
+
+  it('returns undefined for a partial record missing an axis (skip, never fabricate)', () => {
+    const partial: Record<string, number> = {};
+    for (const k of CRITERIA_KEYS) partial[k] = 5;
+    delete partial.pose;
+    expect(criteriaFromRecord(partial)).toBeUndefined();
   });
 });

--- a/tools/photo-curation/src/eval/build-dataset.ts
+++ b/tools/photo-curation/src/eval/build-dataset.ts
@@ -1,10 +1,17 @@
-import { readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type Database from 'better-sqlite3';
-import { type CriteriaScores, CRITERIA_KEYS } from '@bird-watch/photo-quality';
+import { type CriteriaScores, CRITERIA_KEYS, contentHash } from '@bird-watch/photo-quality';
+import type { PhotoScoreRow } from '@bird-watch/shared-types';
 
 /**
- * One Braintrust eval row built from the Opus current-scores in review.sqlite.
+ * One Braintrust eval row built from the frozen Opus baseline that now lives in
+ * prod `species_photo_scores` (#1073/C4 — read via C2's `getPhotoScores`). The
+ * SCORE (`expected`, `metadata.contentHash`, …) comes from prod; the species
+ * METADATA (`com_name`/`sci_name`/`family`/`url`) and the image BYTES still come
+ * from the operator-local review store + thumb-cache, so the eval is portable
+ * across machines for the score yet reads the exact bytes the baseline scored.
+ *
  * `expected` is the Opus keep/score, used as proxy ground truth (#1010/#1013):
  * a later run compares a cheaper judge's output against it.
  *
@@ -18,10 +25,12 @@ import { type CriteriaScores, CRITERIA_KEYS } from '@bird-watch/photo-quality';
  *     and the experiment is portable across machines.
  *
  * `metadata.contentHash` ties the row back to the exact image bytes the Opus
- * pass scored. `expected.criteria` carries the Opus per-axis sub-scores
- * (`photo_score.criteria_json`) when present, so the per-axis scorers can
- * compare them against the candidate judge's; `undefined` when the baseline
- * row has no `criteria_json` (an axis-skip, never a fabricated zero).
+ * pass scored — and (#1073) is the value the local image is HASH-VERIFIED
+ * against before judging, so Gemini never scores different bytes than the
+ * baseline even though score and image now come from different stores.
+ * `expected.criteria` carries the Opus per-axis sub-scores when present, so the
+ * per-axis scorers can compare them against the candidate judge's; `undefined`
+ * when the baseline row has no criteria (an axis-skip, never a fabricated zero).
  */
 export interface EvalRow {
   input: {
@@ -53,8 +62,17 @@ export interface EvalRow {
   };
 }
 
+/**
+ * The injected prod-baseline reader (#1073): `getPhotoScores(pool, pin)` curried
+ * over the pool + pin, so `buildEvalRows` stays decoupled from `pg` and the unit
+ * test injects a fake returning fixture rows — no live DB in CI.
+ */
+export type ScoreReader = () => Promise<PhotoScoreRow[]>;
+
 /** Options for {@link buildEvalRows}. */
 export interface BuildEvalRowsOpts {
+  /** Injected prod-baseline reader (the pinned `getPhotoScores(pool, pin)`). */
+  getScores: ScoreReader;
   /** Directory holding the cached current thumbnails (`<code>.jpg|.png|.webp`). */
   thumbDir: string;
   /** When set, stratified-sample down to this many rows (keep=true / keep=false). */
@@ -72,15 +90,33 @@ export interface BuildEvalRowsOpts {
  */
 export const DEFAULT_SEED = 0xb12d;
 
-/** A row of the role='current' score join, before coalescing. */
-interface ScoreJoinRow {
-  species_code: string;
-  keep: number | null;
-  quality_score: number | null;
-  overall: number;
-  content_hash: string;
-  rubric_version: string | null;
-  criteria_json: string | null;
+/** Default frozen-baseline model pin (#1073). The 902-score Opus pass. */
+export const DEFAULT_BASELINE_MODEL = 'claude-opus-4-8';
+/** Default frozen-baseline rubric-version pin (#1073). */
+export const DEFAULT_BASELINE_RUBRIC = '0.2.1';
+
+/** The frozen-baseline pin `getPhotoScores` is queried with (#1073). */
+export interface BaselinePin {
+  model: string;
+  rubricVersion: string;
+}
+
+/**
+ * Resolve the frozen-baseline pin from the environment (#1073). `BASELINE_MODEL`
+ * defaults to {@link DEFAULT_BASELINE_MODEL} and `BASELINE_RUBRIC` to
+ * {@link DEFAULT_BASELINE_RUBRIC} — both overridable so a re-scored baseline
+ * under a new `(model, rubric)` can be evaluated without a code change. Pure +
+ * unit-tested; the eval entry passes the result straight to `getPhotoScores`.
+ */
+export function resolveBaselinePin(env: NodeJS.ProcessEnv): BaselinePin {
+  return {
+    model: env.BASELINE_MODEL || DEFAULT_BASELINE_MODEL,
+    rubricVersion: env.BASELINE_RUBRIC || DEFAULT_BASELINE_RUBRIC,
+  };
+}
+
+/** A `photo_current` metadata row keyed by species_code (LOCAL review store). */
+interface CurrentRow {
   url: string | null;
   com_name: string;
   sci_name: string;
@@ -88,11 +124,32 @@ interface ScoreJoinRow {
 }
 
 /**
- * Parse a baseline `criteria_json` blob into `CriteriaScores`, or `undefined`
- * when the column is NULL/empty (an axis-skip on the expected side — the
- * per-axis scorers never fabricate agreement from a missing baseline). Parse
- * failures and shape mismatches also yield `undefined` rather than throwing:
- * a malformed legacy blob must skip its axes, not abort the whole dataset.
+ * Coerce a prod `criteria` JSONB value (already deserialized by pg into a
+ * `Record<string, number> | null`) into `CriteriaScores`, or `undefined` when
+ * it is NULL or does not carry all seven axes. Mirrors {@link parseCriteria}'s
+ * skip-don't-fabricate posture: a missing/partial blob yields `undefined` (the
+ * per-axis scorers skip that axis), never a phantom `{}` that would read as a
+ * real all-zero score.
+ */
+export function criteriaFromRecord(criteria: Record<string, number> | null): CriteriaScores | undefined {
+  if (criteria === null) return undefined;
+  const out = {} as CriteriaScores;
+  for (const key of CRITERIA_KEYS) {
+    const v = criteria[key];
+    if (typeof v !== 'number') return undefined;
+    out[key] = v;
+  }
+  return out;
+}
+
+/**
+ * Parse a baseline `criteria_json` STRING blob into `CriteriaScores`, or
+ * `undefined` when the column is NULL/empty (an axis-skip on the expected side
+ * — the per-axis scorers never fabricate agreement from a missing baseline).
+ * Parse failures and shape mismatches also yield `undefined` rather than
+ * throwing: a malformed legacy blob must skip its axes, not abort the whole
+ * dataset. Retained as a pure helper (and re-used by {@link criteriaFromRecord}
+ * via the same per-axis contract) for callers that still hold a JSON string.
  */
 export function parseCriteria(criteriaJson: string | null): CriteriaScores | undefined {
   if (criteriaJson === null || criteriaJson === '') return undefined;
@@ -103,42 +160,33 @@ export function parseCriteria(criteriaJson: string | null): CriteriaScores | und
     return undefined;
   }
   if (typeof parsed !== 'object' || parsed === null) return undefined;
-  const obj = parsed as Record<string, unknown>;
-  const out = {} as CriteriaScores;
-  for (const key of CRITERIA_KEYS) {
-    const v = obj[key];
-    if (typeof v !== 'number') return undefined;
-    out[key] = v;
-  }
-  return out;
+  return criteriaFromRecord(parsed as Record<string, number>);
 }
 
 /**
  * Assert the single-rubric-version invariant (#1037 decision 1) over the FULL
- * fetched row set and return that version. Runs BEFORE image resolution and
- * BEFORE sampling, so a mixed-version or unknown-provenance baseline fails
- * deterministically — never depending on which rows a seed happens to sample.
- * The rubric version is part of the DATASET, not the live code: an
- * interchangeability eval must hold criteria constant at the version the
- * baseline was judged under, so anything else is a hard fail, never a silent
- * judge-under-different-criteria run.
+ * fetched score set and return that version. With the prod read (#1073) the pin
+ * `getPhotoScores(pool, {model, rubricVersion})` already filters to ONE
+ * rubric_version, so this is trivially satisfied for a real run — it stays as a
+ * cheap defensive guard (a mixed-version reader fixture, or an empty baseline,
+ * fails loud here BEFORE image resolution and sampling, never depending on
+ * which rows a seed happens to sample).
  */
-function assertSingleRubricVersion(joinRows: ScoreJoinRow[]): string {
-  if (joinRows.length === 0) {
+function assertSingleRubricVersion(scoreRows: PhotoScoreRow[]): string {
+  if (scoreRows.length === 0) {
     throw new Error(
-      "[build-dataset] no role='current' scores found — there is no baseline rubric version to pin the judge prompt to (is REVIEW_DB the scored baseline?)",
+      '[build-dataset] no scores returned for the baseline pin — there is no baseline rubric version to pin the judge prompt to (is BASELINE_MODEL/BASELINE_RUBRIC correct and has the C3 backfill run?)',
     );
   }
-  const missing = joinRows.filter((r) => r.rubric_version === null || r.rubric_version === '');
+  const missing = scoreRows.filter((r) => r.rubricVersion === null || r.rubricVersion === '');
   if (missing.length > 0) {
     throw new Error(
-      `[build-dataset] ${missing.length} of ${joinRows.length} fetched rows have no rubric_version — unknown provenance cannot be judged under pinned criteria (e.g. ${missing[0]!.species_code})`,
+      `[build-dataset] ${missing.length} of ${scoreRows.length} fetched rows have no rubric_version — unknown provenance cannot be judged under pinned criteria (e.g. ${missing[0]!.speciesCode})`,
     );
   }
   const counts = new Map<string, number>();
-  for (const r of joinRows) {
-    const v = r.rubric_version as string;
-    counts.set(v, (counts.get(v) ?? 0) + 1);
+  for (const r of scoreRows) {
+    counts.set(r.rubricVersion, (counts.get(r.rubricVersion) ?? 0) + 1);
   }
   if (counts.size > 1) {
     const breakdown = [...counts.entries()].map(([v, n]) => `${v} × ${n}`).join(', ');
@@ -201,79 +249,101 @@ function resolveImage(thumbDir: string, speciesCode: string): string | null {
 }
 
 /**
- * Build stratified eval rows from the role='current' Opus scores in `db`.
+ * Build stratified eval rows from the frozen Opus baseline in prod
+ * `species_photo_scores` (#1073), hash-verified against the local cache.
  *
- * Deterministic-gate rows are excluded at the query (#1037 decision 2), and
- * the single-rubric-version invariant is asserted over the full fetched set
- * before anything else (#1037 decision 1) — see
- * {@link assertSingleRubricVersion}. Every surviving row carries
- * `metadata.expectedRubricVersion` (the asserted version).
+ * The SCORE comes from `opts.getScores` (the injected, pinned
+ * `getPhotoScores(pool, {model, rubricVersion})`); the species METADATA
+ * (`url`/`com_name`/`sci_name`/`family`) and the image BYTES come from the
+ * LOCAL review store (`db.photo_current`) + `thumbDir`. The pin makes the
+ * single-rubric-version invariant (#1037 decision 1) trivially hold, and the
+ * det-gate rows (`model='deterministic-gate'`) simply do not match the Opus
+ * model pin — so they never reach the dataset (#1037 decision 2).
  *
- * Reads every current score joined to its `photo_current` metadata, coalesces
- * `keep`/`qualityScore` exactly as the review store does (`store.ts`
- * getScoreByHash: missing `keep` ⇒ kept, missing `quality_score` ⇒ `overall`),
- * resolves each image by extension glob, and skips (with a logged note) any
- * row whose image is absent from `thumbDir`.
+ * For each score row, in order, a row is SKIPPED (with a logged note) when:
+ *   1. the species has no `photo_current` row locally (no metadata to build it);
+ *   2. its image is absent from `thumbDir` (the existing absent-image skip); or
+ *   3. **the local image's content hash ≠ the score row's `contentHash`** — the
+ *      same-bytes guarantee (#1073): the judge must score the EXACT bytes the
+ *      baseline scored, even though score and image now come from different
+ *      stores, so a divergent local cache is dropped rather than mis-scored.
  *
- * When `opts.sample` is set, the surviving rows are split into keep=true /
- * keep=false strata, each shuffled by a seeded mulberry32 Fisher–Yates, and a
- * proportional allocation is taken from the front of each shuffled stratum
- * (clamp remainder pushed to the other stratum). Output is deterministic for a
- * fixed `seed`.
+ * `keep`/`qualityScore`/`criteria` come straight off the prod row. When
+ * `opts.sample` is set, the surviving rows are split into keep=true / keep=false
+ * strata, each shuffled by a seeded mulberry32 Fisher–Yates, and a proportional
+ * allocation is taken from the front of each shuffled stratum (clamp remainder
+ * pushed to the other stratum). Output is deterministic for a fixed `seed`.
  */
-export function buildEvalRows(
+export async function buildEvalRows(
   db: Database.Database,
   opts: BuildEvalRowsOpts,
-): EvalRow[] {
-  const { thumbDir, sample, seed = DEFAULT_SEED } = opts;
+): Promise<EvalRow[]> {
+  const { getScores, thumbDir, sample, seed = DEFAULT_SEED } = opts;
 
-  // Det-gate rows (`rationale LIKE 'deterministic gate%'`) are sharpness-
-  // heuristic verdicts with keep=0 / quality_score=0 — not Opus findings, so
-  // the judge must never be graded against them (#1037 decision 2). The
-  // predicate is NULL-safe: a bare `NOT LIKE` evaluates to NULL (row dropped)
-  // for a NULL rationale, which would silently exclude Opus rows without one.
-  const joinRows = db
-    .prepare(
-      `SELECT s.species_code, s.keep, s.quality_score, s.overall, s.content_hash,
-              s.rubric_version, s.criteria_json, c.url, c.com_name, c.sci_name, c.family
-         FROM photo_score s JOIN photo_current c USING(species_code)
-        WHERE s.role = 'current'
-          AND (s.rationale IS NULL OR s.rationale NOT LIKE 'deterministic gate%')`,
-    )
-    .all() as ScoreJoinRow[];
+  const scoreRows = await getScores();
+  const rubricVersion = assertSingleRubricVersion(scoreRows);
 
-  const rubricVersion = assertSingleRubricVersion(joinRows);
+  const currentStmt = db.prepare(
+    `SELECT url, com_name, sci_name, family FROM photo_current WHERE species_code = ?`,
+  );
 
   const rows: EvalRow[] = [];
-  for (const row of joinRows) {
-    const file = resolveImage(thumbDir, row.species_code);
-    if (file === null) {
+  for (const score of scoreRows) {
+    const current = currentStmt.get(score.speciesCode) as CurrentRow | undefined;
+    if (current === undefined) {
       console.warn(
-        `[build-dataset] skipping ${row.species_code}: no cached image in ${thumbDir}`,
+        `[build-dataset] skipping ${score.speciesCode}: no photo_current row in the local review store`,
       );
       continue;
     }
-    const criteria = parseCriteria(row.criteria_json);
+
+    const file = resolveImage(thumbDir, score.speciesCode);
+    if (file === null) {
+      console.warn(
+        `[build-dataset] skipping ${score.speciesCode}: no cached image in ${thumbDir}`,
+      );
+      continue;
+    }
+
+    // Same-bytes integrity (#1073): the score now comes from prod but the image
+    // from the local cache. Hash the local bytes and require they match the
+    // score row's content_hash — a mismatch means the cache diverged from what
+    // the baseline scored, so skip it (logged) rather than let Gemini score
+    // DIFFERENT bytes than Opus did. Mirrors the absent-image skip above.
+    const readPath = join(thumbDir, file);
+    const localHash = contentHash(readFileSync(readPath));
+    if (localHash !== score.contentHash) {
+      console.warn(
+        `[build-dataset] skipping ${score.speciesCode}: local image hash ${localHash} ≠ baseline content_hash ${score.contentHash} (cache diverged from the scored bytes)`,
+      );
+      continue;
+    }
+
+    const criteria = criteriaFromRecord(score.criteria);
     rows.push({
       input: {
-        readPath: join(thumbDir, file),
+        readPath,
         // The stored R2 URL VERBATIM (#1067): extensions vary in the DB
         // (.jpg/.jpeg/.png) and a reconstructed `<code>.jpeg` template 404s for
         // hundreds of species, so we never template — we log the column as-is.
-        imageUrl: row.url ?? '',
-        speciesCode: row.species_code,
-        comName: row.com_name,
-        sciName: row.sci_name,
-        family: row.family,
+        imageUrl: current.url ?? '',
+        speciesCode: score.speciesCode,
+        comName: current.com_name,
+        sciName: current.sci_name,
+        family: current.family,
       },
       expected: {
-        keep: row.keep === null ? true : row.keep === 1,
-        qualityScore: row.quality_score ?? row.overall,
-        // `undefined` (NOT `{}`) when the baseline has no criteria_json — the
+        keep: score.keep,
+        // The Opus baseline always carries a numeric quality_score; the only
+        // null-score rows are the det-gate verdicts, which don't match the Opus
+        // model pin and never reach here. Coalesce defensively to 0 so the type
+        // stays `number` — a real run never exercises this branch.
+        qualityScore: score.qualityScore ?? 0,
+        // `undefined` (NOT `{}`) when the baseline has no criteria — the
         // per-axis scorers skip a missing axis rather than scoring a phantom 0.
         ...(criteria !== undefined ? { criteria } : {}),
       },
-      metadata: { contentHash: row.content_hash, expectedRubricVersion: rubricVersion },
+      metadata: { contentHash: score.contentHash, expectedRubricVersion: rubricVersion },
     });
   }
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph PROD[Prod Postgres]
      SPS[(species_photo_scores)]
    end
    subgraph LOCAL[Operator-local run-worktree]
      RS[(review.sqlite<br/>photo_current)]
      TC["thumb-cache/[code].{jpg,png,webp}"]
    end

    SPS -- "getPhotoScores(pool,<br/>{model:claude-opus-4-8,<br/>rubricVersion:0.2.1})" --> BR{buildEvalRows}
    RS -- "url / com_name / sci_name / family" --> BR
    TC -- "image bytes" --> HASH[contentHash local bytes]
    HASH -- "== score.content_hash ?" --> BR
    HASH -- "mismatch -> skip (logged)" --> SKIP[dropped]
    BR -- "EvalRow[]" --> EVAL[bt eval -> Gemini judge<br/>vs Opus baseline]
```

## Summary

- **Why:** the frozen Opus baseline now lives in prod `species_photo_scores` (promoted by C3), so the eval must read it there instead of the operator-local `review.sqlite` — making the baseline a single shared source of truth rather than a file on one machine.
- **Same-bytes guarantee preserved:** score and image now come from *different* stores, so before judging we hash the local cache image and require it equals the score row's `content_hash`, skipping (logged) on mismatch exactly like an absent image. Gemini still scores the exact bytes Opus did — zero silent wrong-image scores.
- **Pinned + reproducible:** `buildEvalRows` reads via an injected `getPhotoScores(pool, {model, rubricVersion})` pinned to `claude-opus-4-8` / `0.2.1` (env-overridable `BASELINE_MODEL` / `BASELINE_RUBRIC`). The #1037 single-rubric-version invariant is trivially held by the pin; the det-gate exclusion falls out of the model pin (det-gate rows carry `model='deterministic-gate'`, never returned by the Opus-pinned read). The builder keeps a defensive single-version assertion as a backstop.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — green (321 passed, +8 net new)
- [x] New unit tests added: injected `getScores` fake (rows map to the eval shape; pin filters to the Opus baseline; det-gate rows never reach the dataset), hash-verify skip-on-mismatch + keep-on-match (mirrors the absent-image skip), `resolveBaselinePin` defaults + env overrides, `criteriaFromRecord` axis-skip coercion
- [x] `npm run build -w @bird-watch/photo-curation` — clean; eval entrypoint typechecked against the workspace (imports + top-level await + async builder resolve)
- [x] `npx knip` — exit 0
- [x] `npm run lint` — clean
- [ ] (UI only) N/A — not UI
- [x] Live eval RUN deferred: this is the code/test PR. A real run additionally needs the C3 data in prod + a `DATABASE_URL` and Gemini/Braintrust keys (operator-run from the run-worktree, per the runbook).

## Plan reference

Closes #1073. Child C4 (last) of epic #1074 (promote-scores-to-prod). Builds on C1 (migration), C2 (`getPhotoScores`), and C3 (backfill). Runbook updated: `docs/runbooks/photo-judge-eval.md` documents the `DATABASE_URL` requirement and the "baseline from prod, images from local cache, hash-verified" read path.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
