### PR TITLE
feat(photo-curation): render thumbnails in Braintrust — wrap judge-span sourceUrl as image_url

### DIFF
--- a/tools/photo-curation/src/judges/traced.test.ts
+++ b/tools/photo-curation/src/judges/traced.test.ts
@@ -105,6 +105,11 @@ describe('tracedJudge', () => {
     expect(inputLog!.input.judgedRubricVersion).toBe('0.2.1');
     expect(inputLog!.input.judgedRubricVersion).not.toBe(PROMPT);
 
+    // image_url nests the SAME R2 URL in Braintrust's recognized render shape
+    // (#1086) so the tree viewer force-renders the thumbnail inline. It rides
+    // ALONGSIDE the unchanged sourceUrl string (the queryable provenance field).
+    expect(inputLog!.input.image_url).toEqual({ url: 'https://example.test/amerob.jpg' });
+
     // output span-log: the full JudgeOutput.
     const outputLog = span.logs.find((l) => 'output' in l) as { output: JudgeOutput } | undefined;
     expect(outputLog).toBeTruthy();
@@ -119,6 +124,22 @@ describe('tracedJudge', () => {
     expect(typeof metaLog!.metadata.latencyMs).toBe('number');
     // metrics.latency is the same measurement in SECONDS (Braintrust aggregation).
     expect(metaLog!.metrics.latency).toBeCloseTo(metaLog!.metadata.latencyMs / 1000);
+  });
+
+  it('omits image_url (no {url: undefined}) when the image has no sourceUrl', async () => {
+    // A judgment whose image carries no public URL (sourceUrl absent) must NOT
+    // log image_url at all — logging { url: undefined } would surface a broken
+    // render hint in Braintrust (#1086). sourceUrl itself is allowed to be
+    // undefined; it stays a queryable field, image_url is the render-only hint.
+    const noUrlImg: ImageInput = { buffer: Buffer.from('bytes'), mime: 'image/jpeg' };
+    const logger = makeRecordingLogger();
+    const judge = tracedJudge(new FakeJudge(), { project: 'bird-maps', model: 'gemini-2.5-flash', rubricVersion: '0.2.1', logger });
+
+    await judge.judge(noUrlImg, ctx, PROMPT);
+
+    const inputLog = logger.spans[0]!.logs.find((l) => 'input' in l) as { input: Record<string, unknown> } | undefined;
+    expect(inputLog).toBeTruthy();
+    expect(inputLog!.input).not.toHaveProperty('image_url');
   });
 
   it('propagates an inner error and still closes the span', async () => {

--- a/tools/photo-curation/src/judges/traced.ts
+++ b/tools/photo-curation/src/judges/traced.ts
@@ -147,7 +147,18 @@ export function tracedJudge(inner: VisionJudge, opts: TracedJudgeOptions): Visio
             family: ctx.family,
             judgedRubricVersion: rubricVersion,
             model,
+            // `sourceUrl` stays the queryable provenance string (`bt sql`, the
+            // analysis script). `image_url` nests the SAME URL in Braintrust's
+            // recognized render shape (#1086) — per the BT docs
+            // (`instrument/attachments.md` → "Inline attachments → Simple URLs"),
+            // `{ image_url: { url } }` FORCES the tree viewer to render the
+            // thumbnail inline, independent of its image-extension heuristic, so
+            // disagreement review happens in the BT UI instead of out-of-band.
+            // Spread-guard the empty case: an image with no public URL logs NO
+            // `image_url` key (never `{ url: undefined }`, which would surface a
+            // broken render hint).
             sourceUrl: img.sourceUrl,
+            ...(img.sourceUrl ? { image_url: { url: img.sourceUrl } } : {}),
             project,
           },
         });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph judge["tracedJudge.judge()"]
        src["img.sourceUrl<br/>(R2 URL or undefined)"]
    end
    src -->|always| prov["sourceUrl: &lt;url&gt;<br/>(queryable provenance — bt sql / analysis)"]
    src -->|"only when truthy<br/>(spread-guard)"| rend["image_url: { url: &lt;url&gt; }<br/>(forces inline thumbnail render)"]
    prov --> log["span.log({ input })"]
    rend --> log
    log --> bt["Braintrust tree viewer<br/>(thumbnail renders inline)"]
```

## Summary

- Braintrust auto-renders image-extension URLs via a heuristic; per the BT docs (`instrument/attachments.md` → "Inline attachments → Simple URLs"), nesting the URL as `{ image_url: { url } }` is the **guaranteed** way to force inline thumbnail rendering — so photo-judge disagreement review happens in the BT UI instead of fetching images out-of-band.
- `sourceUrl` is left unchanged (queryable provenance for `bt sql` and the analysis script); `image_url` is a pure render hint, **spread-guarded** so an absent `sourceUrl` logs no `image_url` key (never `{ url: undefined }`).
- Scope is the `traced.ts` wrapper only — `@bird-watch/photo-quality` stays SDK-free; `JudgeOutput`, the gate, and the scorers are untouched.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/photo-curation` — green (23 files, 322 tests). New TDD pair in `traced.test.ts`: (1) input span carries `image_url: { url }` alongside the unchanged `sourceUrl`; (2) an image with no `sourceUrl` omits `image_url` entirely.
- [x] New unit tests added (behavior changed)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior
- [x] `npm run build -w @bird-watch/photo-curation` — clean
- [x] `npx knip` — exit 0
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

## Plan reference

Out of plan — small docs-grounded polish on the photo-judge Braintrust eval epic (#1010). Closes #1086.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)