### PR TITLE
fix(lede): same scope reports the same metric at every viewport — unify on sightings (#1047)

### DIFF
--- a/frontend/e2e/map-cold-load.spec.ts
+++ b/frontend/e2e/map-cold-load.spec.ts
@@ -117,9 +117,10 @@ test.describe('Map cold load — issue #716', () => {
     await expect(lede).toBeVisible({ timeout: 10_000 });
     // #828: the lede is count-only — no region, no time-window. The misleading
     // filter-empty copy must still never appear after a successful cold load.
+    // #1047: lede always reports sightings.
     await expect(lede).not.toHaveText(/No matches for these filters/i);
     await expect(lede).not.toHaveText(/No sightings match your current filters/i);
-    await expect(lede).toHaveText(/^\d+ species$/);
+    await expect(lede).toHaveText(/^\d+ sightings$/);
   });
 
   /**
@@ -187,7 +188,7 @@ test.describe('Map cold load — issue #716', () => {
     // Release observations; the real lede now renders.
     releaseObservations?.();
     await expect(lede).toBeVisible({ timeout: 10_000 });
-    // #828: count-only lede — no region, no time-window.
-    await expect(lede).toHaveText(/^\d+ species$/);
+    // #828: count-only lede — no region, no time-window. #1047: sightings.
+    await expect(lede).toHaveText(/^\d+ sightings$/);
   });
 });

--- a/frontend/e2e/scope-disclosure.spec.ts
+++ b/frontend/e2e/scope-disclosure.spec.ts
@@ -84,7 +84,8 @@ test.describe('Scope disclosure (#828)', () => {
     const app = await setup(page, apiStub);
 
     // The count-only lede is visible (region + window dropped, #828).
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    // #1047: lede always reports sightings.
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     // The visible region rides in the wordmark line exactly once.
     await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
 

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -308,8 +308,9 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // #828: the region moved to the wordmark headline; the lede is count-only.
     // The region ("Arizona", resolved from the /api/states name table) now reads
     // in the wordmark line, and the lede is just the count.
+    // #1047: lede always reports sightings regardless of aggregation mode.
     await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
 
     // O9 (#781): the scope-pick warmed the MapCanvas/maplibre chunk — at least
     // one chunk request fired on the scoped path (the prefetch on click + the
@@ -331,10 +332,12 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // species"), NOT the region name. The div is visually hidden (.sr-only) but
     // present in the a11y tree (#741 copy-lockstep — this contract mirrors the
     // displayed lede, so it moves in lockstep with App.tsx's ledeText).
-    await expect(page.locator('div[role="status"].sr-only')).toHaveText(/^\d+ species$/, { timeout: 3_000 });
+    // #1047: the sr-only settle live region reuses ledeText — it now carries
+    // "N sightings" in lockstep with the visible lede.
+    await expect(page.locator('div[role="status"].sr-only')).toHaveText(/^\d+ sightings$/, { timeout: 3_000 });
     // #828 a11y (no regression): the REGION is still announced — by the AppHeader
     // scope-change live region ("Showing Arizona."), so a screen-reader user
-    // hears "Showing Arizona." then "N species" with no duplication.
+    // hears "Showing Arizona." then "N sightings" with no duplication.
     await expect(
       app.appHeader.locator('span[role="status"][aria-live="polite"]'),
     ).toHaveText('Showing Arizona.');
@@ -495,9 +498,10 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await apiStub.stubStateAwareObservations(ROWS_BY_STATE);
 
     // Land scoped to NY (a non-empty Template lede).
+    // #1047: lede always reports sightings.
     await app.goto('state=US-NY');
     await app.waitForAppReady();
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
 
     // In-app switch to FL via the in-card scope control — NO resize/drag/reload.
     await app.openScopeDisclosure();
@@ -506,7 +510,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // (a) The camera flips to FL.
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-FL');
     // (b) The lede repopulates and NEVER sticks on the empty copy.
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
     await expect(app.appHeader.locator('.brand-region')).toHaveText('· Florida');
 
@@ -532,15 +536,16 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     const { app, obsRequests } = await setup(page, apiStub);
     await apiStub.stubStateAwareObservations(ROWS_BY_STATE);
 
+    // #1047: lede always reports sightings.
     await app.goto('state=US-FL');
     await app.waitForAppReady();
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
 
     await app.openScopeDisclosure();
     await app.switchStateViaScopeControl('US-NY');
 
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-NY');
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
     await expect(app.appHeader.locator('.brand-region')).toHaveText('· New York');
 
@@ -569,8 +574,9 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await app.openScopeDisclosure();
     await app.switchStateViaScopeControl('US-AZ');
 
+    // #1047: lede always reports sightings.
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
-    await expect(app.mapLede).toHaveText(/^\d+ species$/);
+    await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
     await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
 

--- a/frontend/e2e/zip-scope.spec.ts
+++ b/frontend/e2e/zip-scope.spec.ts
@@ -124,7 +124,8 @@ test.describe('ZIP scope round-trip + empty-region + error paths (D6, #741)', ()
     }
     // AZ has data → the count-only lede reads a populated region (#828: the
     // region moved to the wordmark headline, so the lede no longer names it).
-    await expect(app.mapLede).toHaveText(/^\d+ (species|sightings of .+)$/);
+    // #1047: lede always reports sightings in both aggregation modes.
+    await expect(app.mapLede).toHaveText(/^\d+ sightings( of .+)?$/);
     await expect(app.mapLede).not.toContainText('No recent sightings');
   });
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2487,7 +2487,7 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     vi.restoreAllMocks();
   });
 
-  it('Default (T4): "{N} species" — no region, no window', async () => {
+  it('Default (T4): "{N} sightings" — no region, no window', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
@@ -2498,7 +2498,9 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     });
     render(<App />);
     const lede = await screen.findByTestId('map-lede');
-    expect(lede).toHaveTextContent('2 species');
+    // #1047: lede always reports sightings regardless of aggregation mode.
+    expect(lede).toHaveTextContent('2 sightings');
+    expect(lede).not.toHaveTextContent(/species/i);
     expect(lede).not.toHaveTextContent(/seen across/i);
     expect(lede).not.toHaveTextContent(/Arizona/i);
     expect(lede).not.toHaveTextContent(/in the last/i);
@@ -2544,7 +2546,30 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     expect(lede).not.toHaveTextContent(/species/i);
   });
 
-  it('Family filter (T3): "{N} species of {familyName}" — no region, no window', async () => {
+  // #1047 — cross-mode invariance: the SAME scope in per-observation mode must
+  // also report sightings, not species, so both modes carry the same label.
+  it('#1047: per-observation mode reports "N sightings" (same label as aggregated mode)', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    // Per-observation payload — data array, no buckets (mode = 'per-observation').
+    mockGetObservations.mockResolvedValue({
+      data: [
+        obs({ speciesCode: 'vermfly' }),
+        obs({ speciesCode: 'gilwoo', comName: 'Gila Woodpecker' }),
+        obs({ speciesCode: 'vermfly' }),
+      ],
+      meta: { freshestObservationAt: new Date().toISOString() },
+    });
+    render(<App />);
+    const lede = await screen.findByTestId('map-lede');
+    // 3 observations → "3 sightings"; the "species" label must never appear.
+    expect(lede).toHaveTextContent('3 sightings');
+    expect(lede).not.toHaveTextContent(/species/i);
+  });
+
+  it('Family filter (T3): "{N} sightings of {familyName}" — no region, no window', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: 'picidae',
       view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
@@ -2561,10 +2586,11 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     });
     render(<App />);
     const lede = await screen.findByTestId('map-lede');
-    // familyName is resolved from the family taxonomy; assert the count + "species of"
-    // shape and the absence of region/window. (The exact family label is owned by
-    // the family-name lookup; the dedupe contract is the count + no region/window.)
-    expect(lede).toHaveTextContent(/^2 species of .+$/);
+    // #1047: family-filter branch now reports sightings count, not species count.
+    // familyName is resolved from the family taxonomy; the exact label is owned by
+    // the family-name lookup; assert count + "sightings of" shape.
+    expect(lede).toHaveTextContent(/^2 sightings of .+$/);
+    expect(lede).not.toHaveTextContent(/species/i);
     expect(lede).not.toHaveTextContent(/seen across/i);
     expect(lede).not.toHaveTextContent(/Arizona/i);
     expect(lede).not.toHaveTextContent(/in the last/i);
@@ -2663,7 +2689,8 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     });
     const { rerender } = render(<App />);
     const lede = await screen.findByTestId('map-lede');
-    expect(lede).toHaveTextContent('2 species');
+    // #1047: default template now reports sightings, not species count.
+    expect(lede).toHaveTextContent('2 sightings');
 
     // Transition to a new state whose observations fetch never resolves —
     // observationsLoading flips true while the prior (nonzero) observations are
@@ -2681,7 +2708,7 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     await waitFor(() => {
       const ledeNow = screen.queryByTestId('map-lede');
       // Either the row is gone OR it shows a count-free placeholder — never the
-      // stale "2 species".
+      // stale "2 sightings".
       if (ledeNow) {
         expect(ledeNow).not.toHaveTextContent(/\d+\s+species/i);
         expect(ledeNow).not.toHaveTextContent(/\d+\s+sightings/i);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1135,21 +1135,19 @@ export function App() {
     // #852/#859: in aggregated (low-zoom / whole-state) mode there are no
     // per-observation rows to count distinct species from — the buckets carry an
     // EXACT total sightings count but only a capped per-family species sample.
-    // So aggregated mode reports the exact SIGHTINGS count (sum of bucket.count)
-    // rather than a species count (which would require the full distinct-species
-    // set the wire intentionally omits). The per-observation (z >= 6) "{N}
-    // species" / "{N} species of {family}" copy below is unchanged.
-    if (mode === 'aggregated') {
-      return `${observationCount} sightings`;
-    }
+    // #1047 (locked product call): the lede metric follows SCOPE, not aggregation
+    // mode. An exact species count does not exist in aggregated mode (the wire
+    // intentionally omits the distinct-species set), so ALL non-zero lede
+    // templates unify on the sightings count. "N species" copy is removed from
+    // both the aggregated and the per-observation paths.
     const speciesCommonName =
       speciesCount === 1 ? (observations[0]?.comName ?? null) : null;
     if (speciesCommonName) {
       return `${observationCount} sightings of ${speciesCommonName}`;
     } else if (familyName) {
-      return `${speciesCount} species of ${familyName}`;
+      return `${observationCount} sightings of ${familyName}`;
     }
-    return `${speciesCount} species`;
+    return `${observationCount} sightings`;
   }, [
     region,
     observations,


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    state "Per-observation mode (z ≥ 6)" as PO
    state "Aggregated mode (z < 6)" as AGG

    PO --> [*]: "${observationCount} sightings" (was: "${speciesCount} species")
    PO --> FamilyFilter: familyName set
    PO --> SingleSpecies: speciesCount == 1
    FamilyFilter --> [*]: "${observationCount} sightings of ${familyName}" (was: "species of")
    SingleSpecies --> [*]: "${observationCount} sightings of ${commonName}" (unchanged)
    AGG --> [*]: "${observationCount} sightings" (unchanged)
```

## Summary

- The lede branched on aggregation mode, and mode is zoom-coupled — so the
  same AZ scope showed "340 species" on 1440px desktop (z ≥ 6 → per-obs)
  and "7371 sightings" on 390px mobile (z < 6 → aggregated). Locked product
  call: the metric follows scope, not zoom.
- An exact distinct-species count is structurally absent from the aggregated
  wire (AggregatedBucket.speciesCount is per-cell and cannot be unioned), so
  the only scope-stable metric is sightings. All non-zero templates now report
  the sightings count in both modes.
- TDD: inverted T4/T3/#872 unit-test assertions from "species" to "sightings";
  added cross-mode invariance test; updated 11 e2e assertion sites across 4
  spec files (including the sr-only settle live-region at state-scope.spec.ts).

## Screenshots

Live-verified at the rebased head `699f411` (over the merged A5 #1091) on the dev server — the AZ identity-card lede at all 5 canonical viewports x light/dark.

**The fix:** AZ scope reads **"N sightings"** at EVERY viewport — confirmed live `"22 sightings"` (390/768/1920, aggregated z~5) and `"16 sightings"` (1024/1440, per-observation z>=6). Previously the same scope flipped to **"N species"** in per-observation mode (the desktop/zoomed-in case), so the metric label changed with screen size. It never says "species" now. (The count itself differs slightly by viewport because the fitBounds bbox aspect ratio differs — that is viewport-honest and acceptable per the locked product call; the LABEL is what is now scope-stable.) US scope unchanged ("N sightings"). The sr-only settle live region reuses `ledeText`, so SR copy follows automatically.

The family-filter sub-template (`N sightings of <Family>`, was `N species of <Family>`) is the same one-word change on the adjacent line and is covered by the inverted unit test (T3); the live AC is the default-template viewport-consistency, verified above.

Console clean on a clean single load (only the pre-existing #1027/S1 basemap warning); C3 touches no map-render code.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile, z~5 aggregated) | <img width="260" alt="c3-390-light" src="https://github.com/user-attachments/assets/f1a23a14-29d8-4865-ade7-7e68c6f75514" /> | <img width="260" alt="c3-390-dark" src="https://github.com/user-attachments/assets/65303878-bddf-4e1e-bec0-8ffd75b89e5d" /> |
| 768×1024 (tablet) | <img width="260" alt="c3-768-light" src="https://github.com/user-attachments/assets/03930ed3-9f6e-44a5-b32c-b42917e8cbc7" /> | <img width="260" alt="c3-768-dark" src="https://github.com/user-attachments/assets/16fccfe4-8ac8-42da-b0c5-ef86f53ee0d3" /> |
| 1024×768 (z~6 per-obs) | <img width="260" alt="c3-1024-light" src="https://github.com/user-attachments/assets/11c62b77-3de1-4a87-9bb6-05b5944de297" /> | <img width="260" alt="c3-1024-dark" src="https://github.com/user-attachments/assets/7b0556e1-024d-4df4-b413-5500bd89744a" /> |
| 1440×900 (desktop) | <img width="260" alt="c3-1440-light" src="https://github.com/user-attachments/assets/552936ba-94f0-4424-87f7-8abd51d2166e" /> | <img width="260" alt="c3-1440-dark" src="https://github.com/user-attachments/assets/1bd72127-0ecc-4c74-9694-0e8d95eb5e5d" /> |
| 1920×1080 (wide) | <img width="260" alt="c3-1920-light" src="https://github.com/user-attachments/assets/e23490c0-aa08-47bf-9c5a-f7090ea75c33" /> | <img width="260" alt="c3-1920-dark" src="https://github.com/user-attachments/assets/6261e0db-e65d-4a60-a986-188d4c3346e2" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no className change; lede copy only
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs — 10 published (5 viewports x light/dark)


## Test plan

- [x] `npx tsc -b frontend` — clean (no output)
- [x] `npm test --workspace @bird-watch/frontend` — 86 files, 1343 tests passing
- [x] New unit tests added: cross-mode invariance test (#1047); T4/T3/#872
      assertions inverted from "species" to "sightings" (not deleted)
- [x] E2e specs updated: 11 sites across zip-scope, map-cold-load,
      scope-disclosure, state-scope (including sr-only live region at :337)
- [x] `npm run build` — clean production build (515 ms)
- [x] `npm run lint` — no errors or warnings
- [x] `npx knip` — no new findings (one pre-existing configuration hint)
- [x] `npx playwright test --list` — all 4 touched spec files compile and are listed
- [x] (UI only) Playwright MCP smoke — orchestrator live verify: AZ lede = "N sightings" at 390 AND 1440 (no "species" at any viewport), 5 viewports x both themes, console clean (only #1027/S1)

## Plan reference

Closes #1047. Part of #1044 (design-review remediation, Wave 1 / C3).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

