### PR TITLE
fix(landing): initial focus placement + §4.8 scrim opacity (#1034)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1466,12 +1466,13 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     expect(mockGetHotspots).not.toHaveBeenCalled();
   });
 
-  // #761 (S1) focus-trap (task #5a): initial focus is moved into the chooser
-  // scrim on mount. The focus LANDING TARGET task #5a chose is the
-  // `.scope-chooser-scrim` wrapper element (it carries `tabIndex={-1}`); App's
-  // inert/focus-trap useLayoutEffect calls `.focus()` on it after mount. Assert
-  // that wrapper holds focus on the unscoped render.
-  it('moves initial focus into the chooser scrim on the unscoped landing', async () => {
+  // A5 (#1034): initial focus moves to the ZIP input on the unscoped landing,
+  // not the scrim wrapper. The scrim wrapper carries `outline:none` and must
+  // NOT hold focus (a UA blue full-viewport ring on the app's first impression
+  // was V14 major finding). After this fix the focus LANDING TARGET is the
+  // `.zip-input__field` input inside <ZipInput>; the scrim wrapper stays in the
+  // DOM as a focus-trap boundary but is no longer the ACTIVE focus target.
+  it('moves initial focus to the ZIP input on the unscoped landing, not the scrim wrapper', async () => {
     mockUrlState.state = {
       since: '14d', notable: false, speciesCode: null, familyCode: null,
       view: 'map', scope: { kind: 'unscoped' },
@@ -1480,7 +1481,11 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     await screen.findByRole('region', { name: /Choose where to look at birds/i });
     const scrim = container.querySelector('.scope-chooser-scrim');
     expect(scrim).not.toBeNull();
-    expect(scrim).toHaveFocus();
+    // Focus must be on the ZIP input, not the scrim wrapper itself.
+    const zipInput = screen.getByRole('textbox', { name: /ZIP code/i });
+    expect(zipInput).toHaveFocus();
+    // Guard: scrim wrapper must NOT hold focus (that painted the UA blue ring).
+    expect(scrim).not.toHaveFocus();
   });
 
   // Region label: state scope resolves to the state NAME from /api/states.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1015,10 +1015,11 @@ export function App() {
   //       of the wrapper. Replicates the attribute-toggle pattern that
   //       SpeciesDetailSheet.tsx uses via the mapLayerRef prop (O1 unified target).
   //   (5a) Move initial focus into the scrim on mount — `inert` alone does NOT
-  //       move focus, it only removes a subtree from the tab order. The focus
-  //       landing target is the scrim wrapper itself (it carries `tabIndex={-1}`
-  //       in the JSX below); the focus unit test keys off `scrimRef`/that
-  //       wrapper holding focus.
+  //       move focus, it only removes a subtree from the tab order. A5 (#1034):
+  //       focus target is the ZIP input (first field), not the scrim wrapper.
+  //       Focusing the wrapper painted a UA blue full-viewport outline (V14
+  //       major). The wrapper carries `tabIndex={-1}` as a fallback escape
+  //       hatch only (the Tab-trap still uses scrim.focus() as last resort).
   //   (5b) Trap Tab/Shift+Tab so focus cycles within the chooser and never
   //       escapes. `inert` on #map-layer covers the map subtree, but the
   //       ALWAYS-rendered shell now also mounts the <AppHeader> (wordmark,
@@ -1047,11 +1048,16 @@ export function App() {
     const focusables = (): HTMLElement[] =>
       Array.from(scrim.querySelectorAll<HTMLElement>(focusableSelector));
 
-    // (5a) Move initial focus onto the scrim wrapper (the tabIndex={-1}
-    // landing element). Keeping it on the wrapper rather than the first control
-    // avoids stealing focus into the ZIP <input> on every render and matches
-    // the focus unit test's target.
-    scrim.focus();
+    // (5a) Move initial focus to the ZIP input — the first interactive field
+    // on the landing. A5 (#1034): previously focused the scrim wrapper itself
+    // (tabIndex={-1}), which painted a UA blue full-viewport outline (V14
+    // major). Focus the ZIP input directly so the ring appears on the field
+    // (correct a11y: focus belongs on the first field). Falls back to the
+    // first focusable inside the scrim, and then to the scrim itself if the
+    // ZIP input is not yet mounted.
+    const zipInput = scrim.querySelector<HTMLElement>('input[aria-label="ZIP code"]');
+    const initialTarget = zipInput ?? focusables()[0] ?? scrim;
+    initialTarget.focus();
 
     // (5b) Wrap Tab / Shift+Tab between the first and last focusable controls.
     const onKeyDown = (e: KeyboardEvent): void => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1040,6 +1040,23 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   inset: 0;
 }
 
+/* A5 (#1034): MapLibre canvas focus indicator — V35 fix.
+   The `.maplibregl-canvas` element carries `tabindex="0"` so keyboard users
+   can pan/tilt after a Tab; after any MOUSE interaction it also holds focus
+   but a plain `:focus` UA ring painted a full-viewport blue outline (V35).
+   Fix: suppress the outline on plain `:focus` (covers pointer/touch paths),
+   then restore a styled ring on `:focus-visible` (keyboard / sequential nav
+   only — exactly the paths that benefit from a ring).
+   Ring style: inset-offset + token colour keeps it within the canvas bounds
+   and matches the rest of the app's focus language. */
+.maplibregl-canvas:focus {
+  outline: none;
+}
+.maplibregl-canvas:focus-visible {
+  outline: 2px solid var(--color-border-ui);
+  outline-offset: -2px;
+}
+
 /* #830 item D: the internal `.attribution-trigger` button (and its CSS) was
    removed — the modal is controlled via the `open` prop, opened by the
    top-right AppHeader ⓘ button. */
@@ -2946,8 +2963,8 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    mounted-but-idle map (epic OQ1 option (a)), NOT a full-tree unmount. App
    renders `<ScopeChooser>` inside this `.scope-chooser-scrim` wrapper as a
    floating sibling of <main> (the #663 floating-overlay pattern). The wrapper
-   is the full-viewport fixed backdrop + the focus-trap landing element
-   (`tabIndex={-1}`, focused by App's inert/focus-trap effect).
+   carries `tabIndex={-1}` as a focus-trap boundary; initial focus lands on
+   the ZIP input inside it (A5 #1034 — see App.tsx step 5a).
 
    Z-tier: `--z-modal` (50, the named modal tier from #761 P1 / #778). The scrim
    must PAINT above the highest currently-rendered overlay — the detail rail at
@@ -2959,15 +2976,32 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    order. The scrim only needs to win the PAINT layering, which 50 does over
    43/41/40.
 
-   Backdrop: a near-opaque cream wash (`color-mix` over the page color) so the
-   idle map is faintly visible behind the chooser card without competing with
-   it — a true scrim, not the old opaque full-surface unmount. */
+   Backdrop: a ~65% wash (`color-mix` over the page color) so the idle map is
+   legible behind the chooser card — spec §4.8 (#1034, A5). One rule serves
+   both themes: `--color-bg-page` adapts per-theme so no override needed.
+   The old #794 value (~92%) made city labels and basemap functionally
+   invisible in dark mode (V12/V13 review findings).
+
+   `outline: none` suppresses the UA blue full-viewport focus ring that the
+   `tabIndex={-1}` wrapper would otherwise paint when App's useLayoutEffect
+   falls back to focusing the wrapper (A5 #1034 V14 major). Focus lands on
+   the ZIP input by default (see App.tsx 5a); this rule covers the fallback
+   edge case and permanently kills the perimeter ring.
+
+   Optional `backdrop-filter: blur(2px)`: soft-focuses the map behind the
+   chooser card without competing with it visually (spec §4.8). */
 .scope-chooser-scrim {
   position: fixed;
   inset: 0;
   z-index: var(--z-modal);
   display: flex;
-  background: color-mix(in srgb, var(--color-bg-page) 92%, transparent);
+  /* A5 (#1034): §4.8 opacity — was 92% (#794), reduced to 65% so city labels
+     and the basemap read behind the card in both themes. */
+  background: color-mix(in srgb, var(--color-bg-page) 65%, transparent);
+  backdrop-filter: blur(2px);
+  /* Suppress the UA outline: the wrapper is a tabIndex={-1} focus-trap anchor,
+     not a user-facing interactive element — it must never show a focus ring. */
+  outline: none;
   /* The scrim is the scroll container for a tall card on short viewports. */
   overflow: auto;
 }

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -432,4 +432,83 @@ describe('styles.css — W1 conformance', () => {
       );
     });
   });
+
+  // ── A5 (#1034): scrim opacity + focus-ring fixes ──────────────────────────
+  describe('A5 (#1034): .scope-chooser-scrim — §4.8 opacity + focus-ring contract', () => {
+    // Extract the .scope-chooser-scrim rule block for scoped assertions.
+    const scrimBlockMatch = STYLES_CSS.match(
+      /\.scope-chooser-scrim\s*\{([^}]*)\}/s,
+    );
+    const scrimBlock = scrimBlockMatch?.[1] ?? '';
+
+    it('.scope-chooser-scrim block exists in styles.css', () => {
+      expect(scrimBlock).not.toBe('');
+    });
+
+    // C12/V13 (#1034): spec §4.8 directs ~60-70% opacity — replace the ~92%
+    // wash from #794. One color-mix rule, consumed by both themes (structural
+    // theme parity: no per-theme override needed because --color-bg-page
+    // already adapts per theme).
+    it('uses ~65% color-mix (not the old 92%) for the scrim background — spec §4.8', () => {
+      // Guard the old value is gone.
+      expect(scrimBlock).not.toMatch(/color-mix[^;]*92%/);
+      // Assert the new value is present (65% ± 1 tolerance = 64–66% acceptable).
+      expect(scrimBlock).toMatch(/color-mix\(in srgb,\s*var\(--color-bg-page\)\s*6[45]%,\s*transparent\)/);
+    });
+
+    // V14 (#1034): the scrim wrapper must suppress its own UA outline so it
+    // never paints a full-viewport blue ring on the landing's first impression.
+    // Note: scrimBlock extraction uses [^}]* which stops at the `}` inside the
+    // comment text "tabIndex={-1}" — assert against the full CSS instead,
+    // anchored to the .scope-chooser-scrim rule neighbourhood.
+    it('has outline: none to suppress the UA focus ring on the wrapper itself', () => {
+      // Match outline:none anywhere in the .scope-chooser-scrim rule block.
+      // Use a two-step check: the property must appear AFTER the selector and
+      // BEFORE the next top-level selector (a line starting with a dot/hash/
+      // element after a newline).
+      const scrimRuleStart = STYLES_CSS.indexOf('.scope-chooser-scrim {');
+      expect(scrimRuleStart).toBeGreaterThan(-1);
+      // Find the closing brace of the rule (the one that terminates the block,
+      // not those embedded in comments). Walk forward counting comment depth.
+      let depth = 0;
+      let inComment = false;
+      let ruleEnd = -1;
+      for (let i = scrimRuleStart; i < STYLES_CSS.length - 1; i++) {
+        if (!inComment && STYLES_CSS[i] === '/' && STYLES_CSS[i + 1] === '*') {
+          inComment = true; i++; continue;
+        }
+        if (inComment && STYLES_CSS[i] === '*' && STYLES_CSS[i + 1] === '/') {
+          inComment = false; i++; continue;
+        }
+        if (inComment) continue;
+        if (STYLES_CSS[i] === '{') { depth++; continue; }
+        if (STYLES_CSS[i] === '}') {
+          depth--;
+          if (depth === 0) { ruleEnd = i; break; }
+        }
+      }
+      expect(ruleEnd).toBeGreaterThan(scrimRuleStart);
+      const ruleText = STYLES_CSS.slice(scrimRuleStart, ruleEnd + 1);
+      expect(ruleText).toMatch(/outline:\s*none/);
+    });
+  });
+
+  // ── A5 (#1034): MapLibre canvas `:focus-visible` gate ────────────────────
+  describe('A5 (#1034): MapLibre canvas focus indicator — :focus-visible gate', () => {
+    // V35 (#1034): the canvas holds focus after mouse pan/zoom with the UA
+    // ring unstyled. The fix: suppress the default outline on :focus, only
+    // show a styled indicator on :focus-visible (keyboard / sequential nav).
+    it('.maplibregl-canvas:focus has outline: none (pointer interactions paint nothing)', () => {
+      expect(STYLES_CSS).toMatch(
+        /\.maplibregl-canvas:focus\s*\{[^}]*outline:\s*none[^}]*\}/s,
+      );
+    });
+
+    it('.maplibregl-canvas:focus-visible shows a token-styled outline instead of UA blue', () => {
+      // Must use --color-border-ui token, not a hardcoded colour.
+      expect(STYLES_CSS).toMatch(
+        /\.maplibregl-canvas:focus-visible\s*\{[^}]*outline:[^}]*var\(--color-border-ui\)[^}]*\}/s,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant App (useLayoutEffect)
    participant ZIP input
    participant Scrim wrapper (tabIndex=-1)

    Note over App (useLayoutEffect): landing mount (scopeActive = false)
    App (useLayoutEffect)->>ZIP input: zipInput.focus()
    Note over ZIP input: focus ring on first field (correct a11y)
    Note over Scrim wrapper (tabIndex=-1): outline: none — never shows UA ring
    Note over App (useLayoutEffect): Tab/Shift-Tab trap unchanged (scrim = boundary)
```

## Summary

- **V14 major (A5):** `useLayoutEffect` was calling `scrim.focus()` on landing mount — the `tabIndex={-1}` scrim wrapper painted a UA blue full-viewport focus ring on the app's first impression. Fix: focus the `input[aria-label="ZIP code"]` directly; the scrim stays as a focus-trap boundary (no visual ring thanks to `outline: none`).
- **C12/V12/V13 (A5):** `.scope-chooser-scrim` background was `92% color-mix` (#794); spec §4.8 directs ~60-70%. Reduced to `65%` so city labels and the basemap are legible in both themes — one rule, no per-theme override needed (`--color-bg-page` adapts). Added `backdrop-filter: blur(2px)` per spec §4.8.
- **V35 (A5):** `.maplibregl-canvas` held focus after mouse pan/zoom with the UA blue ring unstyled. Fix: `outline: none` on `:focus`; token-styled ring (`2px solid var(--color-border-ui)`, inset `-2px`) on `:focus-visible` (keyboard/sequential nav only).

## Screenshots

Live-verified at the rebased head `0a602dc` (over the merged C2 #1092) on the dev server — the **landing** at all 5 canonical viewports x light/dark.

Verified live (orchestrator-driven Playwright):
- **V14 — no perimeter ring:** on landing mount `document.activeElement` is the **ZIP input** (`input[aria-label="ZIP code"]`, `.zip-input__field`), never the scrim wrapper. The scrim wrapper computes `outline: none`. No saturated-blue viewport-edge ring in any shot.
- **C12/V13/V12 — scrim 65%, both themes:** the scrim background is one `color-mix(... 65%, transparent)` consumed by both themes (light `color(srgb .957 .945 .918 / 0.65)`, dark `color(srgb .051 .078 .141 / 0.65)`) + `backdrop-filter: blur(2px)`; the US basemap and city labels read THROUGH the scrim behind the chooser card in BOTH themes (dark is no longer a flat navy void). The card stays opaque so its AA is unaffected.
- **V35 — canvas focus indicator gated + token-styled:** the CSS is `.maplibregl-canvas:focus` -> `outline: none` (so mouse pan/zoom paints nothing) and `.maplibregl-canvas:focus-visible` -> `outline: 2px solid var(--color-border-ui)` (keyboard Tab paints a token ring, computed `rgb(216,211,195) solid 2px` — not UA blue `rgb(0,95,204)`).
- Console clean on a clean single load. The only ambient noise is the pre-existing #1027/S1 basemap `null`-expression warning (reproduces on prod); A5 touches no map-render code.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="260" alt="a5-390-light" src="https://github.com/user-attachments/assets/343f8fea-bc15-4f56-b6cc-78ba2956cff6" /> | <img width="260" alt="a5-390-dark" src="https://github.com/user-attachments/assets/29feb7d0-446f-4f2e-862f-8ad459592ed4" /> |
| 768×1024 (tablet) | <img width="260" alt="a5-768-light" src="https://github.com/user-attachments/assets/0db5f109-342e-48ca-9e38-aa03b83c2c24" /> | <img width="260" alt="a5-768-dark" src="https://github.com/user-attachments/assets/846fe1b3-204e-4e1e-975e-0757f6fd03e5" /> |
| 1024×768 | <img width="260" alt="a5-1024-light" src="https://github.com/user-attachments/assets/5bb201ce-de86-48d8-bcfd-6d35a3d1bf7e" /> | <img width="260" alt="a5-1024-dark" src="https://github.com/user-attachments/assets/ea824de3-8879-43cf-b7eb-2fc84a8c75f2" /> |
| 1440×900 (desktop) | <img width="260" alt="a5-1440-light" src="https://github.com/user-attachments/assets/233c4c41-aac1-4a58-9c77-d49d679a78cb" /> | <img width="260" alt="a5-1440-dark" src="https://github.com/user-attachments/assets/408311a8-e5f8-439b-bc4f-445944d0402b" /> |
| 1920×1080 (wide) | <img width="260" alt="a5-1920-light" src="https://github.com/user-attachments/assets/49a6d28a-7723-491c-95b9-3da898a92f10" /> | <img width="260" alt="a5-1920-dark" src="https://github.com/user-attachments/assets/dec92555-248c-4856-a281-db161dbc5b82" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no new className; existing `.scope-chooser-scrim` / canvas rules retuned only
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs — 10 published (5 viewports x light/dark)


## Test plan

- [x] TDD: test → RED → impl → GREEN for each of the 2 AC items
  - RTL: `document.activeElement` is ZIP input on landing mount (App.test.tsx)
  - CSS assertions: `65%` color-mix, `outline: none` on scrim block, `:focus`/`:focus-visible` canvas rules (tokens.css.test.ts — 6 new assertions)
- [x] Pre-existing failures (`App.seed.test.ts`, `url-state.test.ts`) are pre-existing `@bird-watch/shared-types` build artifact absence — resolved by `npm run build -w @bird-watch/shared-types`; unrelated to this PR
- [x] `npx tsc -b frontend` — clean
- [x] `npm test --workspace @bird-watch/frontend` — 86 files / 1347 tests all green (after shared-types build)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx knip` — 1 pre-existing configuration hint (stale ignore rule for prototype path), no new findings
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] (UI only) Playwright MCP smoke — orchestrator live verify: focus->ZIP (no perimeter ring), 65% scrim both themes (basemap reads through), canvas focus=none / focus-visible=token ring; 5 viewports x both themes; console clean (only #1027/S1)

## Plan reference

Closes #1034. Part of #1029 (design-review remediation, Wave 1 / A5).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
