### PR TITLE
fix(detail): family-name drift — detail surface uses the #924 colloquial names (#1046)

### DIFF
--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -5,8 +5,9 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SpeciesDetailSheet, resolveContentTier } from './SpeciesDetailSheet.js';
 import { ApiClient } from '../api/client.js';
-import type { SpeciesMeta } from '@bird-watch/shared-types';
+import type { SpeciesMeta, FamilySilhouette } from '@bird-watch/shared-types';
 import { __resetSpeciesDetailCache } from '../data/use-species-detail.js';
+import { __resetSilhouettesCache } from '../data/use-silhouettes.js';
 import { analytics } from '../analytics.js';
 
 const VERMFLY_WITH_PHOTO: SpeciesMeta = {
@@ -1498,6 +1499,150 @@ describe('<SpeciesDetailSheet> — photoless silhouette fallback (#908 T2)', () 
     );
     // No silhouette on the photo branch.
     expect(silhouetteInFrame(sheet)).toBeNull();
+  });
+});
+
+// ─── C2 #1046: colloquial family-name resolution in Sheet ─────────────────
+//
+// The Sheet renders the family name at four sites across the MID and FULL
+// tiers.  Fixtures are DESYNCED (raw eBird name ≠ colloquial) so the tests
+// prove the resolution chain rather than accidentally passing because both
+// sources carry the same text.
+describe('<SpeciesDetailSheet> — C2 colloquial family-name resolution (#1046)', () => {
+  let mainEl: HTMLElement;
+
+  beforeEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
+    mainEl = document.createElement('main');
+    mainEl.id = 'main-surface';
+    document.body.appendChild(mainEl);
+    __resetSpeciesDetailCache();
+    // Must also reset the silhouettes cache because this describe block
+    // overrides getSilhouettes to inject colloquial names — without the
+    // reset each test's silhouettes mock would bleed into the next one.
+    __resetSilhouettesCache();
+  });
+
+  // DESYNCED fixtures: raw eBird "and" vs colloquial "&".
+  const HAWK_META: SpeciesMeta = {
+    speciesCode: 'coohaw',
+    comName: "Cooper's Hawk",
+    sciName: 'Accipiter cooperii',
+    familyCode: 'accipitridae',
+    familyName: 'Hawks, Eagles, and Kites',
+    taxonOrder: 2200,
+    photoUrl: 'https://photos.bird-maps.com/coohaw.jpg',
+    photoAttribution: 'Test',
+    photoLicense: 'CC-BY-4.0',
+  };
+
+  const HAWK_SILHOUETTE: FamilySilhouette = {
+    familyCode: 'accipitridae',
+    color: '#7A2EC7',
+    colorDark: '#7A2EC7',
+    svgData: 'M0 0L1 1Z',
+    svgUrl: null,
+    source: 'https://www.phylopic.org/i/y',
+    license: 'CC0-1.0',
+    commonName: 'Hawks, Eagles & Kites',
+    creator: 'Test Creator',
+  };
+
+  function makeHawkClient(): ApiClient {
+    const client = new ApiClient({ baseUrl: '' });
+    client.getSpecies = vi.fn().mockResolvedValue(HAWK_META);
+    client.getSilhouettes = vi.fn().mockResolvedValue([HAWK_SILHOUETTE]);
+    return client;
+  }
+
+  function makeHawkClientNoSilhouette(): ApiClient {
+    const client = new ApiClient({ baseUrl: '' });
+    client.getSpecies = vi.fn().mockResolvedValue(HAWK_META);
+    // No accipitridae entry — exercises the fallback branch.
+    client.getSilhouettes = vi.fn().mockResolvedValue([]);
+    return client;
+  }
+
+  it('C2 MID tier: family name shows colloquial, not raw eBird name (card page, compact↔mid)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="coohaw"
+        apiClient={makeHawkClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // Sheet opens at half → MID content tier.
+    await waitFor(() => expect(sheet).toHaveAttribute('data-content', 'mid'));
+    // Both the identity-row p and the <dd> on the card page must show colloquial.
+    // The card page is in the DOM at MID.
+    const cardPage = sheet.querySelector('[data-page-id="card"]') as HTMLElement;
+    expect(cardPage).not.toBeNull();
+    // Identity row: .sheet-fg-family text
+    const familyRows = cardPage.querySelectorAll('.sheet-fg-family');
+    const familyText = Array.from(familyRows).map(el => el.textContent?.trim());
+    expect(familyText.some(t => t?.includes('Hawks, Eagles & Kites'))).toBe(true);
+    expect(familyText.every(t => !t?.includes('Hawks, Eagles, and Kites'))).toBe(true);
+    // Record dl Family <dd>
+    const dts = Array.from(cardPage.querySelectorAll('dt'));
+    const familyDt = dts.find(el => el.textContent?.trim() === 'Family');
+    expect(familyDt).toBeDefined();
+    const familyDd = familyDt!.nextElementSibling;
+    expect(familyDd?.textContent?.trim()).toBe('Hawks, Eagles & Kites');
+  });
+
+  it('C2 FULL tier: family name shows colloquial, not raw eBird name (entry page)', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="coohaw"
+        apiClient={makeHawkClient()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    // Advance to full snap so the entry page is active.
+    const expandBtn = await screen.findByRole('button', { name: /expand/i });
+    act(() => { expandBtn.click(); });
+    await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'full'));
+    const entryPage = sheet.querySelector('[data-page-id="entry"]') as HTMLElement;
+    expect(entryPage).not.toBeNull();
+    // Identity row on entry page
+    const familyRows = entryPage.querySelectorAll('.sheet-fg-family');
+    const familyText = Array.from(familyRows).map(el => el.textContent?.trim());
+    expect(familyText.some(t => t?.includes('Hawks, Eagles & Kites'))).toBe(true);
+    expect(familyText.every(t => !t?.includes('Hawks, Eagles, and Kites'))).toBe(true);
+    // Taxonomy dl Family <dd> on entry page
+    const dts = Array.from(entryPage.querySelectorAll('dt'));
+    const familyDt = dts.find(el => el.textContent?.trim() === 'Family');
+    expect(familyDt).toBeDefined();
+    const familyDd = familyDt!.nextElementSibling;
+    expect(familyDd?.textContent?.trim()).toBe('Hawks, Eagles & Kites');
+  });
+
+  it('C2 fallback: when silhouettes has no entry for the family, renders raw eBird familyName', async () => {
+    render(
+      <SpeciesDetailSheet
+        speciesCode="coohaw"
+        apiClient={makeHawkClientNoSilhouette()}
+        onClose={vi.fn()}
+        mainRef={{ current: mainEl }}
+      />
+    );
+    const sheet = await screen.findByTestId('species-detail-sheet');
+    await waitFor(() => expect(sheet).toHaveAttribute('data-content', 'mid'));
+    const cardPage = sheet.querySelector('[data-page-id="card"]') as HTMLElement;
+    expect(cardPage).not.toBeNull();
+    // Falls back to raw eBird name, never Accipitridae.
+    const familyDts = Array.from(cardPage.querySelectorAll('dt'));
+    const familyDt = familyDts.find(el => el.textContent?.trim() === 'Family');
+    expect(familyDt).toBeDefined();
+    const familyDd = familyDt!.nextElementSibling;
+    expect(familyDd?.textContent?.trim()).toBe('Hawks, Eagles, and Kites');
+    expect(familyDd?.textContent?.trim()).not.toBe('Accipitridae');
   });
 });
 

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -206,6 +206,23 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   const resolvePath = useMemo(() => buildFamilyPathResolver(silhouettes), [silhouettes]);
   const resolveImgUrl = useMemo(() => buildFamilyImgUrlResolver(silhouettes), [silhouettes]);
 
+  // Build the familyCode → colloquial name resolver once per silhouettes
+  // identity change (#1046 / C2). Mirrors the server's
+  // COALESCE(family_silhouettes.common_name, species_meta.family_name) so
+  // all four family-name render sites on the sheet show the curated #924
+  // colloquial name ("Hawks, Eagles & Kites") instead of the raw eBird
+  // familyName ("Hawks, Eagles, and Kites"). Keys are lowercased to match
+  // the server's lowercase family_code (same convention as App.tsx l.533-536).
+  const resolveCommonName = useMemo(() => {
+    const byCode = new Map<string, string | null>();
+    for (const s of silhouettes) byCode.set(s.familyCode.toLowerCase(), s.commonName);
+    return (familyCode: string | null | undefined, rawName: string | undefined): string | undefined => {
+      if (!familyCode) return rawName;
+      const hit = byCode.get(familyCode.toLowerCase());
+      return hit ?? rawName;
+    };
+  }, [silhouettes]);
+
   // ── Analytics (T3 #909) ──────────────────────────────────────────────────
   // Re-wired off SpeciesDetailSurface (SpeciesDetailSurface.tsx:73-115): T1
   // (#907) stopped composing the surface inside this sheet and silently dropped
@@ -861,7 +878,7 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
                 aria-hidden="true"
                 style={{ background: famColor }}
               />
-              {data?.familyName}
+              {resolveCommonName(data?.familyCode, data?.familyName)}
             </p>
           </div>
 
@@ -871,7 +888,7 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
           <dl className="sheet-fg-record">
             <div className="sheet-fg-cell">
               <dt className="sheet-fg-label">Family</dt>
-              <dd className="sheet-fg-value">{data?.familyName ?? '—'}</dd>
+              <dd className="sheet-fg-value">{resolveCommonName(data?.familyCode, data?.familyName) ?? '—'}</dd>
             </div>
             <div className="sheet-fg-cell">
               <dt className="sheet-fg-label">eBird taxonomic order</dt>
@@ -943,7 +960,7 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
                 aria-hidden="true"
                 style={{ background: famColor }}
               />
-              {data?.familyName}
+              {resolveCommonName(data?.familyCode, data?.familyName)}
             </p>
           </div>
 
@@ -957,7 +974,7 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
             </div>
             <div className="sheet-fg-taxrow">
               <dt>Family</dt>
-              <dd>{data?.familyName}</dd>
+              <dd>{resolveCommonName(data?.familyCode, data?.familyName)}</dd>
             </div>
             <div className="sheet-fg-taxrow">
               <dt>eBird taxonomic order</dt>

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -346,6 +346,106 @@ describe('SpeciesDetailSurface', () => {
     expect(body!.lastElementChild).toBe(sentinel);
   });
 
+  // ─── C2 #1046: colloquial family-name resolution ─────────────────────────
+  //
+  // Both render sites (identity row + taxonomy <dl>) must show the curated
+  // #924 colloquial name from the silhouettes payload, NOT the raw eBird
+  // familyName from SpeciesMeta.  Fixtures are DESYNCED (different strings)
+  // to prove the resolution chain rather than accidentally passing because
+  // both sources happen to carry the same text.
+
+  it('C2: identity row and taxonomy <dl> show the colloquial name, not the raw eBird name', async () => {
+    // DESYNCED: raw eBird name uses "and"; colloquial uses "&".
+    const HAWK_META: SpeciesMeta = {
+      speciesCode: 'coohaw',
+      comName: "Cooper's Hawk",
+      sciName: 'Accipiter cooperii',
+      familyCode: 'accipitridae',
+      familyName: 'Hawks, Eagles, and Kites',
+      taxonOrder: 2200,
+    };
+    const HAWK_SILHOUETTE: FamilySilhouette = {
+      familyCode: 'accipitridae',
+      color: '#7A2EC7',
+      colorDark: '#7A2EC7',
+      svgData: 'M0 0L1 1Z',
+      svgUrl: null,
+      source: 'https://www.phylopic.org/i/y',
+      license: 'CC0-1.0',
+      commonName: 'Hawks, Eagles & Kites',
+      creator: 'Test Creator',
+    };
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(HAWK_META),
+      getSilhouettes: vi.fn().mockResolvedValue([HAWK_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="coohaw" apiClient={client} />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: "Cooper's Hawk" })).toBeInTheDocument()
+    );
+    // Colloquial name appears at both sites (identity row + taxonomy dl).
+    expect(screen.getAllByText('Hawks, Eagles & Kites')).toHaveLength(2);
+    // Raw eBird name must NOT appear at either site.
+    expect(screen.queryByText('Hawks, Eagles, and Kites')).toBeNull();
+  });
+
+  it('C2 fallback: when silhouettes payload has no entry for the family, renders raw eBird familyName', async () => {
+    const HAWK_META: SpeciesMeta = {
+      speciesCode: 'coohaw',
+      comName: "Cooper's Hawk",
+      sciName: 'Accipiter cooperii',
+      familyCode: 'accipitridae',
+      familyName: 'Hawks, Eagles, and Kites',
+      taxonOrder: 2200,
+    };
+    const client = makeClient({
+      // Silhouettes payload carries a DIFFERENT family — no accipitridae entry.
+      getSpecies: vi.fn().mockResolvedValue(HAWK_META),
+      getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="coohaw" apiClient={client} />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: "Cooper's Hawk" })).toBeInTheDocument()
+    );
+    // Falls back to the raw eBird name at both sites.
+    expect(screen.getAllByText('Hawks, Eagles, and Kites')).toHaveLength(2);
+    // Must NOT render the Latin family name as a fallback.
+    expect(screen.queryByText('Accipitridae')).toBeNull();
+  });
+
+  it('C2 null-commonName fallback: when silhouette.commonName is null, renders raw eBird familyName', async () => {
+    const HAWK_META: SpeciesMeta = {
+      speciesCode: 'coohaw',
+      comName: "Cooper's Hawk",
+      sciName: 'Accipiter cooperii',
+      familyCode: 'accipitridae',
+      familyName: 'Hawks, Eagles, and Kites',
+      taxonOrder: 2200,
+    };
+    const NULL_COMMON_SILHOUETTE: FamilySilhouette = {
+      familyCode: 'accipitridae',
+      color: '#7A2EC7',
+      colorDark: '#7A2EC7',
+      svgData: 'M0 0L1 1Z',
+      svgUrl: null,
+      source: 'https://www.phylopic.org/i/y',
+      license: 'CC0-1.0',
+      commonName: null,
+      creator: 'Test Creator',
+    };
+    const client = makeClient({
+      getSpecies: vi.fn().mockResolvedValue(HAWK_META),
+      getSilhouettes: vi.fn().mockResolvedValue([NULL_COMMON_SILHOUETTE]),
+    } as unknown as Partial<ApiClient>);
+    render(<SpeciesDetailSurface speciesCode="coohaw" apiClient={client} />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: "Cooper's Hawk" })).toBeInTheDocument()
+    );
+    // null commonName → falls back to raw eBird name, not Latin family code.
+    expect(screen.getAllByText('Hawks, Eagles, and Kites')).toHaveLength(2);
+    expect(screen.queryByText('Accipitridae')).toBeNull();
+  });
+
   // ─── Phase 4 heading + Photo contracts ──────────────────────────────────
   //
   // Sky Atlas Phase 4 promotes SpeciesDetailSurface to a presentational body

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -79,6 +79,23 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
     [silhouettes],
   );
 
+  // Build the familyCode → colloquial name resolver once per silhouettes
+  // identity change (#1046 / C2). Mirrors the server's
+  // COALESCE(family_silhouettes.common_name, species_meta.family_name) so
+  // the detail surface shows the curated #924 colloquial name ("Hawks,
+  // Eagles & Kites") instead of the raw eBird family_name ("Hawks, Eagles,
+  // and Kites"). Keys are lowercased to match the server's lowercase
+  // family_code — same convention as App.tsx familyNamesByCode (l.533-536).
+  const resolveCommonName = useMemo(() => {
+    const byCode = new Map<string, string | null>();
+    for (const s of silhouettes) byCode.set(s.familyCode.toLowerCase(), s.commonName);
+    return (familyCode: string | null | undefined, rawName: string): string => {
+      if (!familyCode) return rawName;
+      const hit = byCode.get(familyCode.toLowerCase());
+      return hit ?? rawName;
+    };
+  }, [silhouettes]);
+
   // Analytics: panel_opened / panel_dwell_ms (preserved from pre-Phase-4).
   useEffect(() => {
     if (!data?.speciesCode) return;
@@ -188,7 +205,7 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
             aria-hidden="true"
             style={{ background: famColor }}
           />
-          {data.familyName}
+          {resolveCommonName(data.familyCode, data.familyName)}
         </p>
       </div>
 
@@ -209,7 +226,7 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
         </div>
         <div className="detail-fg-taxrow">
           <dt>Family</dt>
-          <dd>{data.familyName}</dd>
+          <dd>{resolveCommonName(data.familyCode, data.familyName)}</dd>
         </div>
         <div className="detail-fg-taxrow">
           <dt>eBird taxonomic order</dt>


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  A["useSilhouettes()"] --> B["resolveCommonName(familyCode, rawName)"]
  C["useSpeciesDetail()"] --> D["data.familyName (raw eBird)"]
  B --> E["colloquial name\n(e.g. 'Hawks, Eagles & Kites')"]
  D --> B
  E --> F["identity row"]
  E --> G["taxonomy dl dd"]
```

## Summary

- The species detail card (desktop) and sheet (mobile) rendered the raw eBird `family_name` ("Hawks, Eagles, and Kites") at all six sites, while the legend, popovers, and filters all showed the curated #924 colloquial name — a different noun, not just ampersand style.
- Adds a `resolveCommonName(familyCode, rawName)` memoized resolver (per-silhouettes-identity, same pattern as `resolveColor`/`resolvePath`/`resolveImgUrl` already in both components) that does `silhouette.commonName ?? data.familyName`, mirroring the server's `COALESCE(family_silhouettes.common_name, species_meta.family_name)` (#927).
- Applied at all 2 Surface sites (`:191`/`:212`) and all 4 Sheet sites (`:881`/`:891`/`:963`/`:977`).

## Screenshots

Live-verified at head `f768c96` on the dev server. Opened the **Bald Eagle** detail (`?state=US-CA&detail=devseed-baleag`); the family label reads **"Hawks, Eagles & Kites"** at the hero family row AND the FAMILY taxonomy row, on BOTH the desktop rail (`SpeciesDetailSurface`, 1440/1920) and the mobile/tablet sheet (`SpeciesDetailSheet`, 1024/768/390) — matching the legend string exactly. Wood Duck (`devseed-wooduc`) renders "Ducks, Geese & Swans" the same way.

**Fixture-trap note (live-confirmed — why dev can't show a before/after):** the dev seed's `species_meta.family_name` is ALREADY the colloquial form — `/api/species/devseed-baleag` returns `familyName: "Hawks, Eagles & Kites"`, identical to the curated `family_silhouettes.common_name`. So in dev the raw and curated sources carry the SAME string and the bug is invisible (exactly the trap the issue flags at the existing assertions). The distinguishing behavior — raw `family_name` in, curated name out — is proven by the **desynced unit tests** (new fixtures where raw ≠ colloquial; both render the colloquial). The species detail is cached by code, so an in-page `fetch`-rewrite to simulate production didn't re-hit the network — the unit tests are the authoritative proof; the live pass confirms correct rendering + the no-regression invariant.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile — Sheet) | <img width="260" alt="c2-390-light" src="https://github.com/user-attachments/assets/54f6c093-04dc-4389-a344-76b920eed85d" /> | <img width="260" alt="c2-390-dark" src="https://github.com/user-attachments/assets/9e03a40a-c78c-4533-969f-1c7cb4a90fc7" /> |
| 768×1024 (tablet — Sheet) | <img width="260" alt="c2-768-light" src="https://github.com/user-attachments/assets/85e55c19-6ba6-4483-80f7-43b448beff4a" /> | <img width="260" alt="c2-768-dark" src="https://github.com/user-attachments/assets/9c72ab35-5d42-4412-aaf8-adbd2685b7a9" /> |
| 1024×768 (Sheet) | <img width="260" alt="c2-1024-light" src="https://github.com/user-attachments/assets/91ca0d86-4b76-45db-833f-3ff6e9bc1048" /> | <img width="260" alt="c2-1024-dark" src="https://github.com/user-attachments/assets/20e5ca26-2a55-495e-b16b-4258b51ed399" /> |
| 1440×900 (desktop — rail) | <img width="260" alt="c2-1440-light" src="https://github.com/user-attachments/assets/a7a85521-6502-4e28-8023-0bc9f9af41cb" /> | <img width="260" alt="c2-1440-dark" src="https://github.com/user-attachments/assets/77ef13d1-9044-4cf7-b34e-65317d250e70" /> |
| 1920×1080 (wide — rail) | <img width="260" alt="c2-1920-light" src="https://github.com/user-attachments/assets/3c8d711f-5957-4f7a-b739-ceadd09a637f" /> | <img width="260" alt="c2-1920-dark" src="https://github.com/user-attachments/assets/760c2069-d9fb-41ce-971e-41bc11b03f44" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no new className; text-resolution change only
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — 10 published (5 viewports × light/dark; rail + sheet)


## Test plan

- [x] `npx tsc -b frontend` — clean (zero errors)
- [x] `npm test --workspace @bird-watch/frontend` — 86/86 files, 1348/1348 tests green
- [x] New unit tests added: 6 new tests (3 Surface, 3 Sheet) with DESYNCED fixtures so the raw eBird name ≠ colloquial name — fixture trap closed
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build (566ms)
- [x] `npx knip` — no new findings
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] Playwright MCP smoke — orchestrator live verify: family label = legend string on rail + sheet, 5 viewports × both themes, console clean (only the pre-existing #1027/S1 basemap warning)

## Plan reference

Closes #1046. Part of #1044 (design-review remediation, Wave 1 / C2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

