### PR TITLE
fix(controls): filters-dialog semantics, theme-toggle targets/state, Filters-first order (#1033)

### DIFF
--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -4,8 +4,9 @@ import { AppPage } from './pages/app-page.js';
 /**
  * AttributionModal — #830 update: the modal is controlled-open. The internal
  * `.attribution-trigger` button was removed; the only Credits affordance is the
- * AppHeader ⓘ "Credits & attribution" button (`app.attributionTrigger`), which
+ * AppHeader ⓘ "Credits" button (`app.attributionTrigger`), which
  * sets the modal's `open` prop. Every test opens via that button.
+ * (#1033 V1/V18: label shortened from "Credits & attribution" to "Credits")
  *
  * Covers:
  *   - Credits trigger (AppHeader ⓘ) reachable from every view (map, detail).

--- a/frontend/e2e/axe.spec.ts
+++ b/frontend/e2e/axe.spec.ts
@@ -458,10 +458,11 @@ test.describe('axe-core WCAG scans', () => {
     const app = new AppPage(page);
     await app.goto('view=map');
     await app.waitForAppReady();
-    // #830: open via the AppHeader ⓘ "Credits & attribution" button — the
+    // #830: open via the AppHeader ⓘ "Credits" button — the
     // documented real affordance, which sets the controlled `open` prop on
     // AttributionModal (item D). The header is fixed chrome on `--z-chrome`
     // (always clickable). No internal shim is involved any more.
+    // (#1033 V1/V18: label shortened from "Credits & attribution" to "Credits")
     await app.attributionTrigger.click();
     // Wait on the [open] attribute commit — observable contract that
     // showModal() has run, focus-delegation is settled, and the dialog
@@ -484,8 +485,8 @@ test.describe('axe-core WCAG scans', () => {
       const app = new AppPage(page);
       await app.goto('view=map');
       await app.waitForAppReady();
-      // #830: open via the AppHeader ⓘ "Credits & attribution" button (the
-      // controlled-open trigger, item D). See the desktop test for the rationale.
+      // #830: open via the AppHeader ⓘ "Credits" button (the
+      // controlled-open trigger, item D; #1033: label shortened). See the desktop test for the rationale.
       await app.attributionTrigger.click();
       await expect(page.locator('dialog.attribution-modal[open]')).toBeVisible();
       const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -81,7 +81,7 @@ test.describe('filter flows', () => {
 
     // Close via close button, re-check dimensions.
     await page.getByRole('button', { name: /Close filters/i }).click();
-    await expect(page.getByRole('region', { name: 'Filters' })).not.toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Filters' })).not.toBeVisible();
     const boxClosed = await mapLayer.boundingBox();
     expect(boxClosed).not.toBeNull();
 
@@ -94,23 +94,23 @@ test.describe('filter flows', () => {
 
   test('backdrop click dismisses the filters panel', async ({ page }) => {
     // Panel is open from beforeEach.
-    await expect(page.getByRole('region', { name: 'Filters' })).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Filters' })).toBeVisible();
 
     // Click the backdrop (data-testid="filters-backdrop").
     await app.filtersBackdrop.click();
 
     // Panel should no longer be visible.
-    await expect(page.getByRole('region', { name: 'Filters' })).not.toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Filters' })).not.toBeVisible();
     // Backdrop should also be gone (conditionally rendered).
     await expect(app.filtersBackdrop).not.toBeAttached();
   });
 
   test('Escape key dismisses the filters panel', async ({ page }) => {
     // Panel is open from beforeEach.
-    await expect(page.getByRole('region', { name: 'Filters' })).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Filters' })).toBeVisible();
 
     await page.keyboard.press('Escape');
 
-    await expect(page.getByRole('region', { name: 'Filters' })).not.toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Filters' })).not.toBeVisible();
   });
 });

--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -167,7 +167,8 @@ test.describe('MOB-N1 — .filters-panel-close touch target ≥ 44×44pt', () =>
     // block opening the panel (the panel-open behaviour itself is covered by
     // the desktop reachability specs). Then assert the close button's size.
     await app.filtersTrigger.dispatchEvent('click');
-    await page.getByRole('region', { name: 'Filters' }).waitFor({ state: 'visible' });
+    // #1033 C51: upgraded from role="region" to role="dialog"
+    await page.getByRole('dialog', { name: 'Filters' }).waitFor({ state: 'visible' });
 
     const closeBtn = page.locator('.filters-panel-close');
     const box = await closeBtn.boundingBox();

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -19,7 +19,7 @@ export class AppPage {
   readonly filtersTrigger: Locator;
   /** Theme toggle button in the controls pill. */
   readonly themeToggle: Locator;
-  /** Credits & attribution trigger in the controls pill. */
+  /** Credits trigger (ⓘ icon-only button) in the controls pill. */
   readonly attributionTrigger: Locator;
 
   // --- Scope chooser (landing surface, #742) accessors (C9/D6, #741) ---

--- a/frontend/e2e/pages/app-page.ts
+++ b/frontend/e2e/pages/app-page.ts
@@ -138,7 +138,8 @@ export class AppPage {
     // #800: appHeaderTabs removed — no tablist in the new corner-card header.
     this.filtersTrigger = this.appHeader.getByRole('button', { name: /^Filters/ });
     this.themeToggle = this.appHeader.getByRole('button', { name: /Switch to (light|dark) theme/ });
-    this.attributionTrigger = this.appHeader.getByRole('button', { name: /Credits & attribution/ });
+    // #1033 V1/V18: label shortened to "Credits" (was "Credits & attribution")
+    this.attributionTrigger = this.appHeader.getByRole('button', { name: /Credits/ });
 
     // Chooser (#742) — region accessible name "Choose where to look at birds".
     this.chooser = page.getByRole('region', { name: 'Choose where to look at birds' });
@@ -207,7 +208,8 @@ export class AppPage {
    * until the test ends or the Close button is clicked.
    */
   async openFilters(): Promise<void> {
-    const panel = this.page.getByRole('region', { name: 'Filters' });
+    // #1033 C51: filters panel upgraded from role="region" to role="dialog"
+    const panel = this.page.getByRole('dialog', { name: 'Filters' });
     // Guard: if the panel is already visible (e.g., test parallelism left it
     // open from a prior interaction in the same browser context), skip the
     // trigger click to avoid a double-open no-op that could race on slow CI.

--- a/frontend/e2e/pages/filters-bar.ts
+++ b/frontend/e2e/pages/filters-bar.ts
@@ -9,7 +9,7 @@ export class FiltersBar {
 
   constructor(page: Page) {
     // Phase 3: FiltersBar is rendered inside a filters panel
-    // (`<div class="filters-panel" role="region" aria-label="Filters">`)
+    // (`<div class="filters-panel" role="dialog" aria-label="Filters">`)
     // that is only mounted when the user opens the Filters drawer via the
     // AppHeader trigger. Scope every locator to that panel so locators
     // resolve only when the panel is open, giving a clear "element not
@@ -17,7 +17,9 @@ export class FiltersBar {
     // every getByLabel call is preserved as a belt-and-braces precaution
     // against ambient label collisions (header buttons, modal contents,
     // future tablist entries).
-    const panel = page.getByRole('region', { name: 'Filters' });
+    // #1033 C51: upgraded from role="region" to role="dialog" so that
+    // aria-haspopup="dialog" on the trigger is truthful.
+    const panel = page.getByRole('dialog', { name: 'Filters' });
     this.timeWindow = panel.getByLabel('Time window', { exact: true });
     this.notableOnly = panel.getByLabel('Notable only', { exact: true });
     this.family = panel.getByLabel('Family', { exact: true });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -550,8 +550,8 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
       };
       render(<App />);
       await screen.findByRole('banner');
-      // AppHeader carries the "Credits & attribution" button
-      const trigger = screen.getByRole('button', { name: /Credits & attribution/i });
+      // AppHeader carries the "Credits" button
+      const trigger = screen.getByRole('button', { name: /Credits/i });
       expect(trigger).toBeInTheDocument();
     },
   );
@@ -570,7 +570,7 @@ describe('Phase 6: Footer removal + Attribution via AppHeader (issue #250 → Ph
     // onOpenAttribution sets attributionOpen → the modal's open prop opens the
     // native dialog. (No leftover .attribution-trigger shim — it was deleted.)
     expect(document.querySelector('.attribution-trigger')).toBeNull();
-    await userEvent.click(screen.getByRole('button', { name: /Credits & attribution/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Credits/i }));
     expect(dialog?.hasAttribute('open')).toBe(true);
   });
 
@@ -655,12 +655,12 @@ describe('Phase 3: AppHeader + Filters panel', () => {
     await screen.findByRole('banner');
     const trigger = screen.getByRole('button', { name: /Filters/i });
     // Closed initially: the FiltersBar region should not be in the DOM
-    expect(screen.queryByRole('region', { name: /Filters/i })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: /Filters/i })).toBeNull();
     await userEvent.click(trigger);
-    expect(screen.getByRole('region', { name: /Filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /Filters/i })).toBeInTheDocument();
     // Close button inside the panel dismisses it
     await userEvent.click(screen.getByRole('button', { name: /Close filters/i }));
-    expect(screen.queryByRole('region', { name: /Filters/i })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: /Filters/i })).toBeNull();
   });
 
   it('Filters badge count reflects active filters (notable + family = 2)', async () => {
@@ -713,6 +713,19 @@ describe('O4 (#780): Filters floating sheet — modality, dismiss, inert, aria',
     expect(trigger).not.toHaveAttribute('aria-controls');
   });
 
+  // C51 (#1033): filters surface must be role=dialog (was role=region) so that
+  // aria-haspopup="dialog" on the trigger is truthful. aria-modal="true" marks
+  // it as a modal dialog (inert on #map-layer already enforces the boundary).
+  it('filters surface is role=dialog named "Filters" with aria-modal=true (#1033 C51)', async () => {
+    render(<App />);
+    await screen.findByRole('banner');
+    await userEvent.click(screen.getByRole('button', { name: /Filters/i }));
+    const panel = screen.getByRole('dialog', { name: 'Filters' });
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    expect(panel).toHaveAttribute('aria-label', 'Filters');
+  });
+
   it('aria-expanded on trigger flips false→true on open, true→false on close', async () => {
     render(<App />);
     await screen.findByRole('banner');
@@ -750,11 +763,11 @@ describe('O4 (#780): Filters floating sheet — modality, dismiss, inert, aria',
     const mapLayer = container.querySelector('#map-layer');
 
     await userEvent.click(trigger);
-    expect(screen.getByRole('region', { name: /Filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /Filters/i })).toBeInTheDocument();
     expect(mapLayer).toHaveAttribute('inert');
 
     await userEvent.keyboard('{Escape}');
-    expect(screen.queryByRole('region', { name: /Filters/i })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: /Filters/i })).toBeNull();
     expect(mapLayer).not.toHaveAttribute('inert');
   });
 
@@ -765,13 +778,13 @@ describe('O4 (#780): Filters floating sheet — modality, dismiss, inert, aria',
     const mapLayer = container.querySelector('#map-layer');
 
     await userEvent.click(trigger);
-    expect(screen.getByRole('region', { name: /Filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /Filters/i })).toBeInTheDocument();
     expect(mapLayer).toHaveAttribute('inert');
 
     const backdrop = container.querySelector('[data-testid="filters-backdrop"]');
     expect(backdrop).not.toBeNull();
     await userEvent.click(backdrop!);
-    expect(screen.queryByRole('region', { name: /Filters/i })).toBeNull();
+    expect(screen.queryByRole('dialog', { name: /Filters/i })).toBeNull();
     expect(mapLayer).not.toHaveAttribute('inert');
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1313,9 +1313,10 @@ export function App() {
           The backdrop covers the viewport at `--z-modal - 1` so it is below the
           sheet but above map overlays; clicking it dismisses the sheet.
           `inert` on #map-layer is managed by the useLayoutEffect above.
-          The `role="region" aria-label="Filters"` accessible name is preserved
-          exactly — the POM and history-nav.spec.ts resolve via
-          `getByRole('region', { name: 'Filters' })`. */}
+          The panel is `role="dialog" aria-modal="true" aria-label="Filters"`
+          (#1033 C51 — was role="region", upgraded so aria-haspopup="dialog"
+          on the trigger is truthful). The POM and e2e specs resolve via
+          `getByRole('dialog', { name: 'Filters' })`. */}
       {filtersOpen && (
         <>
           <div
@@ -1326,8 +1327,9 @@ export function App() {
           <div
             ref={filtersPanelRef}
             className="filters-panel t-filters-enter"
-            role="region"
+            role="dialog"
             aria-label="Filters"
+            aria-modal="true"
           >
             {/* Shared sheet-header × (#1026): the same bare-× affordance the
                 detail sheet now uses. No grabber — the filters surface is a

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -242,7 +242,8 @@ describe('<AppHeader>', () => {
   it('clicking the Attribution link calls onOpenAttribution', async () => {
     const onOpenAttribution = vi.fn();
     render(<AppHeader {...baseProps} onOpenAttribution={onOpenAttribution} />);
-    await userEvent.click(screen.getByRole('button', { name: /Credits & attribution/i }));
+    // #1033 V1: attribution demoted to icon-only; label shortened to "Credits"
+    await userEvent.click(screen.getByRole('button', { name: /^Credits$/i }));
     expect(onOpenAttribution).toHaveBeenCalledTimes(1);
   });
 
@@ -251,9 +252,23 @@ describe('<AppHeader>', () => {
     // inline disclosure — so it carries aria-haspopup but deliberately NOT
     // aria-expanded (a divergence from the Filters trigger, which is inline).
     render(<AppHeader {...baseProps} />);
-    const trigger = screen.getByRole('button', { name: /Credits & attribution/i });
+    // #1033 V1/V18: attribution label shortened to "Credits"
+    const trigger = screen.getByRole('button', { name: /^Credits$/i });
     expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
     expect(trigger).not.toHaveAttribute('aria-expanded');
+  });
+
+  // ── Controls order (V1/V18 #1033): Filters · ⓘ Credits · ThemeToggle ────
+
+  it('controls pill orders Filters first, then Credits (ⓘ), then ThemeToggle (#1033 V1/V18)', () => {
+    render(<AppHeader {...baseProps} />);
+    const pill = document.querySelector('.app-header-controls-pill')!;
+    const buttons = Array.from(pill.querySelectorAll('button'));
+    // Three buttons: Filters → ⓘ Credits → ThemeToggle (Toggle color theme)
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toHaveAttribute('aria-label', expect.stringMatching(/^Filters/));
+    expect(buttons[1]).toHaveAttribute('aria-label', 'Credits');
+    expect(buttons[2]).toHaveAttribute('aria-label', 'Toggle color theme');
   });
 
   // ── ThemeToggle ─────────────────────────────────────────────────────────

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -348,39 +348,12 @@ export function AppHeader({
         )}
       </div>
 
-      {/* TOP-RIGHT: controls pill (Filters · Attribution · Theme toggle) */}
+      {/* TOP-RIGHT: controls pill (Filters · ⓘ Credits · Theme toggle).
+          Order: Filters first per spec §3/§5.2 (#1033 V1/V18); attribution
+          demoted to icon-only ⓘ at all widths, label shortened to "Credits"
+          (the always-visible bottom-right pill already shows eBird/OpenFreeMap
+          so the full "Credits & attribution" prose is redundant here). */}
       <div className="app-header-controls-pill">
-        <button
-          type="button"
-          className="app-header-attribution"
-          onClick={onOpenAttribution}
-          aria-label="Credits & attribution"
-          // #830 item E: this opens a showModal() dialog rendered in the top
-          // layer, so it carries aria-haspopup="dialog" but INTENTIONALLY omits
-          // aria-expanded — a deliberate divergence from .app-header-filters
-          // (an inline disclosure). Do NOT "fix" to match filters.
-          aria-haspopup="dialog"
-        >
-          <svg
-            className="app-header-btn-icon"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <path d="M12 16v-4M12 8h.01" />
-          </svg>
-          {filtersLabeled && (
-            <span className="app-header-btn-label">Attribution</span>
-          )}
-        </button>
-
         <button
           ref={filtersTriggerRef}
           type="button"
@@ -412,6 +385,38 @@ export function AppHeader({
               {filterCount}
             </span>
           )}
+        </button>
+
+        <button
+          type="button"
+          className="app-header-attribution"
+          onClick={onOpenAttribution}
+          aria-label="Credits"
+          // #830 item E: this opens a showModal() dialog rendered in the top
+          // layer, so it carries aria-haspopup="dialog" but INTENTIONALLY omits
+          // aria-expanded — a deliberate divergence from .app-header-filters
+          // (an inline disclosure). Do NOT "fix" to match filters.
+          // #1033 V1/V18: icon-only at all widths (no text label rendered even
+          // at wide breakpoints) — the "Credits & attribution" prose was moved
+          // to the bottom-right attribution pill which already carries the
+          // always-visible eBird/OpenFreeMap credit.
+          aria-haspopup="dialog"
+        >
+          <svg
+            className="app-header-btn-icon"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 16v-4M12 8h.01" />
+          </svg>
         </button>
 
         <ThemeToggle />

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -30,8 +30,11 @@
  *        attribution and recency isn't worth a permanent line on a minimized card.
  *
  *   TOP-RIGHT controls pill (.app-header-controls-pill) — compact content-width card:
- *     Filters trigger (+ active-count badge) · Attribution · Theme toggle.
- *     Filters is a labeled button at ≥1024, icon-only below.
+ *     Filters trigger (+ active-count badge) · ⓘ Credits · Theme toggle.
+ *     Order: Filters first per spec §3/§5.2 (#1033 V1/V18).
+ *     Filters shows a text label at ≥1024, icon-only below.
+ *     ⓘ Credits is icon-only at ALL widths (#1033 V1/V18 — the always-visible
+ *     bottom-right pill already carries eBird/OpenFreeMap credit).
  *
  * The old `role="tablist"` / `TABS` / `activeView` / `onSelectView` machinery is
  * entirely removed — the map is the always-mounted sole surface post-#688/#777.
@@ -41,8 +44,8 @@
  *   in the wordmark line and the scope form is collapsed behind the disclosure —
  *   so the layout is near-identical across the canonical viewport set. The only
  *   per-breakpoint variation is in the top-right controls pill:
- *   wide (≥1024): Filters/Attribution show text labels; corner insets use --card-inset-wide.
- *   roomy/compact (<1024): Filters/Attribution are icon-only; standard --card-inset gutters.
+ *   wide (≥1024): Filters shows text label; corner insets use --card-inset-wide.
+ *   roomy/compact (<1024): Filters is icon-only; standard --card-inset gutters.
  *
  * Lede prop (O3 #779 / #828) — carried from MapSurface into AppHeader so the
  * formerly invisible context-strip content renders in the identity card:
@@ -97,7 +100,7 @@ export interface AppHeaderProps {
    * is reliably non-null whenever the useLayoutEffect close path fires.
    */
   filtersTriggerRef: RefObject<HTMLButtonElement>;
-  /** Open the Credits & Attribution modal. */
+  /** Open the Credits modal (ⓘ trigger in the controls pill). */
   onOpenAttribution: () => void;
   // ── Lede / context-strip props (O3 #779 / #828) ─────────────────────────
   /**

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -740,10 +740,52 @@ body {
   }
 }
 
-/* ThemeToggle button inside the controls pill (plain <button> via ThemeToggle). */
+/* ThemeToggle button inside the controls pill (plain <button> via ThemeToggle).
+   #1033 C52: shared baseline sizing + focus ring to match pill siblings;
+   coarse-pointer 44px floor replaces the old max-width:480px floor so iPad
+   portrait/landscape also get a reachable target on touch-primary devices. */
 .app-header-controls-pill button {
-  /* touch targets set in @media (max-width: 480px) block */
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--card-radius-inner);
+  padding: var(--space-xs) var(--space-sm);
+  font: inherit;
+  color: var(--color-text-body);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  min-width: 36px;
 }
+.app-header-controls-pill button:hover {
+  background: var(--color-bg-tint);
+}
+.app-header-controls-pill button:focus-visible {
+  outline: 2px solid var(--color-text-strong);
+  outline-offset: 2px;
+}
+/* #1033 V10: active-theme treatment — subtle bg tint, no border (was a
+   boxed style that made the toggle look permanently pressed). Uses
+   aria-pressed so the visual state is anchored to the semantic state.
+   In dark mode (V37): ghost treatment — card-fill bg + light icon, no
+   solid-inverted fill. --color-bg-tint is slightly lighter than the card
+   in both modes and provides enough contrast without being the brightest
+   element in the dark frame. */
+.app-header-controls-pill button[aria-pressed="true"] {
+  background: var(--color-bg-tint);
+  border-color: transparent;
+}
+/* C52: coarse-pointer 44px floor (covers iPad touch, not just ≤480px phones). */
+@media (pointer: coarse) {
+  .app-header-controls-pill button {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+/* Keep the old max-width:480px floor as a fallback for fine-pointer small
+   screens (e.g. a resized desktop window) — belt-and-braces. */
 @media (max-width: 480px) {
   .app-header-controls-pill button {
     min-height: 44px;


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    direction LR

    state "Controls pill (before)" as Before {
        ⓘCredits --> Filters
        Filters --> ☀Toggle
    }

    state "Controls pill (after)" as After {
        Filters2: Filters
        ⓘ2: ⓘ Credits
        Toggle2: ☀ Toggle
        Filters2 --> ⓘ2
        ⓘ2 --> Toggle2
    }

    state "Filters panel role (before)" as PanelBefore {
        roleBefore: role="region" aria-label="Filters"
    }

    state "Filters panel role (after)" as PanelAfter {
        roleAfter: role="dialog" aria-label="Filters" aria-modal="true"
    }
```

## Summary

- **C51**: Filters floating sheet upgraded from `role="region"` to `role="dialog" aria-modal="true"` — the trigger already carried `aria-haspopup="dialog"` and the behavioural modal contract (inert, Escape, Tab-wrap, focus restore) was already in place; only the ARIA role was wrong. All 8 e2e call sites updated accordingly.
- **V1/V18**: Controls pill reordered to **Filters · ⓘ · ☀** per spec §3/§5.2; attribution demoted to icon-only ⓘ at all widths, `aria-label` shortened to `'Credits'` (the always-visible bottom-right `OpenFreeMap · eBird` pill already carries the license credit).
- **C52/O14/V10/V37**: ThemeToggle gets shared 36px min-size + 2px `--color-text-strong` focus ring at all widths; 44px floor moved to `@media (pointer: coarse)` covering iPad touch; active-theme treatment is a subtle `--color-bg-tint` background (no border) anchored to `aria-pressed="true"`; dark-mode ghost treatment eliminates the solid white square.

## Screenshots

Live-verified at the rebased head `e9fb49c` (over the merged C3 #1090) on the dev server — the top-right controls cluster at all 5 canonical viewports x light/dark.

Verified live (orchestrator-driven Playwright):
- **V1/V18 — order + Credits relabel:** the controls pill reads **Filters - Credits(ⓘ) - Toggle** at every viewport (probed `aria-label` order = `["Filters","Credits","Toggle color theme"]`). The attribution trigger is icon-only ⓘ with accessible name **"Credits"** (was "Credits & attribution"); the always-visible `OpenFreeMap - eBird` credit stays bottom-right.
- **C51 — truthful filters semantics:** opening Filters yields `<div class="filters-panel" role="dialog" aria-modal="true" aria-label="Filters">`; the trigger announces `aria-haspopup="dialog"` + `aria-expanded`. (trap/inert/Escape/focus-restore already matched.)
- **C52/O14 — toggle targets + focus ring:** all three pill buttons compute `height: 36px` at desktop widths (the shared min); the 44px floor is keyed on `@media (pointer: coarse)`. The toggle's keyboard focus ring computes `2px solid` `--color-text-strong` (`rgb(245,247,251)` in dark) via `:focus-visible` — was UA default.
- **V10/V37 — toggle treatment:** the toggle background is `transparent` and MATCHES its Filters sibling (no boxed/permanently-pressed look); in **dark** it is the ghost treatment (transparent fill + light sun icon), no longer the solid white square that was the brightest element in the frame. `aria-pressed` already tracks the active theme (#475, verify-only).
- Console clean on a clean single load (only the pre-existing #1027/S1 basemap warning); A4 touches no map-render code.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="260" alt="a4-390-light" src="https://github.com/user-attachments/assets/833aca22-4896-48ed-a9cc-6a1116893ac2" /> | <img width="260" alt="a4-390-dark" src="https://github.com/user-attachments/assets/c20b7242-7e64-4c04-a577-48163f751624" /> |
| 768×1024 (tablet) | <img width="260" alt="a4-768-light" src="https://github.com/user-attachments/assets/cd971973-1c91-45a0-b997-0568d6aee9c5" /> | <img width="260" alt="a4-768-dark" src="https://github.com/user-attachments/assets/ca15406d-49ef-430b-a67d-85f164d61959" /> |
| 1024×768 | <img width="260" alt="a4-1024-light" src="https://github.com/user-attachments/assets/ba7cbdb0-dce0-4ed6-888b-41d54e42ae04" /> | <img width="260" alt="a4-1024-dark" src="https://github.com/user-attachments/assets/44148518-3fe9-4402-a297-fdc4a7ba6325" /> |
| 1440×900 (desktop) | <img width="260" alt="a4-1440-light" src="https://github.com/user-attachments/assets/d4b48023-3d1b-4529-9a68-26d9be3be4b9" /> | <img width="260" alt="a4-1440-dark" src="https://github.com/user-attachments/assets/00b3c705-3b96-4465-b090-4dbdc694223f" /> |
| 1920×1080 (wide) | <img width="260" alt="a4-1920-light" src="https://github.com/user-attachments/assets/a9fbe822-37d3-4fbf-98cd-0cb60f39ed7d" /> | <img width="260" alt="a4-1920-dark" src="https://github.com/user-attachments/assets/fe04fb1f-d2c9-47da-b824-4d412014ae26" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule (toggle/controls-pill rules verified; orphan-classname-check PASS)
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs — 10 published (5 viewports x light/dark)


## Test plan

- [x] `npx tsc -b frontend` — clean (0 errors)
- [x] `npm test --workspace @bird-watch/frontend` — 1344 passed across 86 files
- [x] New RTL tests added: `filters surface is role=dialog named "Filters" with aria-modal=true` in `App.test.tsx`; `controls pill orders Filters first, then Credits (ⓘ), then ThemeToggle` in `AppHeader.test.tsx`; updated attribution label assertions in both files
- [x] e2e blast radius updated: 8 `getByRole('region', 'Filters')` → `getByRole('dialog', 'Filters')` across 4 files; `attributionTrigger` POM regex `/Credits & attribution/` → `/Credits/`; `npx playwright test --list` confirms 292 tests compile
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] (UI only) Playwright MCP smoke — orchestrator live verify: order Filters-ⓘ-toggle, Filters role=dialog+aria-modal, dark toggle ghost (not white square), toggle focus ring, 36px min; 5 viewports x both themes; console clean (only #1027/S1)

## Plan reference

Closes #1033. Part of #1029 (design-review remediation, Wave 1 / A4).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

