### PR TITLE
feat(photo-curation): eval-comparison viewer (read path, PR2 of 2) (#1095)

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -322,6 +322,20 @@ const config: KnipConfig = {
       //             confirm public/pending-swaps.html still references it (grep
       //             `src="/pending-swaps.js"`).
       //
+      // 2026-06-12 (#1095): public/eval.js — the model-comparison viewer (PR2),
+      //             a browser ES module loaded at runtime via eval.html's
+      //             `<script type="module" src="/eval.js">` (it `import`s
+      //             /theme.js + ./safe.js), never imported by any TS/JS module
+      //             knip can trace, so it is flagged as an unused file — exactly
+      //             the overview.js/swap.js/pending-swaps.js precedent above. Its
+      //             percent-rendering is inline (no exported helper), so unlike
+      //             safe.js it has no test sibling to make knip trace it; the
+      //             gate correctness it depends on is tested server-side in
+      //             src/server/eval-queries.test.ts + index.test.ts. Risk: masks
+      //             a genuinely orphaned public asset if the screen is deleted but
+      //             its script left on disk. Re-audit 2026-07-27 — confirm
+      //             public/eval.html still references it (grep `src="/eval.js"`).
+      //
       // 2026-06-12 (#1094): the prior eval/photo-judge.eval.ts ignore was
       //             REMOVED here when that Braintrust harness was deleted in
       //             #1094 — knip flags a configured-but-unused ignore entry, so
@@ -341,7 +355,7 @@ const config: KnipConfig = {
       ignore: [
         'workflows/score-current.mjs', 'workflows/source-candidates.mjs',
         'public/overview.js', 'public/swap.js', 'public/theme.js',
-        'public/pending-swaps.js',
+        'public/pending-swaps.js', 'public/eval.js',
       ],
     },
   },

--- a/tools/photo-curation/public/app.css
+++ b/tools/photo-curation/public/app.css
@@ -114,3 +114,29 @@ button.alt { font: inherit; color: inherit; padding: 0; text-align: inherit; -we
   .compare.arrow-between { grid-template-columns: 1fr; }
   .swap-arrow { transform: rotate(90deg); padding: 4px 0; }
 }
+
+/* ── Eval viewer (#1095): model-comparison table + falseKeep gallery ── */
+.eval-wrap { max-width: 1100px; margin: 0 auto; padding: 24px; }
+.eval-table-section { overflow-x: auto; }
+.eval-table { width: 100%; border-collapse: collapse; font-size: var(--type-sm); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); overflow: hidden; }
+.eval-table th, .eval-table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+.eval-table thead th { font-weight: 600; color: var(--text-dim); background: var(--surface-2); }
+.eval-table tbody tr:last-child td { border-bottom: none; }
+.eval-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.run-row { cursor: pointer; }
+.run-row:hover { background: var(--surface-2); }
+.run-row.selected { box-shadow: inset 4px 0 0 var(--status-good); }
+.run-row.selected td:first-child { font-weight: 600; }
+.run-model { font-weight: 600; }
+.run-baseline { color: var(--text-dim); }
+.gate-badge { display: inline-block; font-weight: 700; font-size: var(--type-xs); padding: 2px 10px; border-radius: 999px; color: #fff; }
+.gate-badge.gate-pass { background: var(--status-great); }
+.gate-badge.gate-fail { background: var(--status-good); }
+.eval-gallery-section { margin-top: 28px; }
+.eval-gallery-title { font-size: var(--type-md); font-weight: 600; margin: 0 0 12px; }
+.eval-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; }
+.fk-figure { margin: 0; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); overflow: hidden; }
+.fk-img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; display: block; background: var(--surface-2); }
+.fk-caption { padding: 10px 12px; display: flex; flex-direction: column; gap: 4px; }
+.fk-name { font-size: var(--type-sm); font-weight: 600; }
+.fk-scores { font-size: var(--type-xs); color: var(--text-dim); }

--- a/tools/photo-curation/public/eval.html
+++ b/tools/photo-curation/public/eval.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Photo Curation — Model Comparison</title>
+  <link rel="stylesheet" href="/app.css" />
+</head>
+<body>
+  <header class="app-header">
+    <a class="back-link" href="/">← Overview</a>
+    <h1 class="app-title">Model Comparison</h1>
+    <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
+    <span class="staged-indicator" id="summary">…</span>
+  </header>
+  <p class="readout-note">
+    Each row is one local eval run (<code>npm run eval</code>): the candidate
+    judge against the frozen Opus baseline. The gate is <em>keep-agreement ≥
+    90%</em>. The gallery below shows the run's <strong>falseKeeps</strong> —
+    images the candidate judge KEPT that the Opus baseline REPLACED (the
+    dangerous disagreement). Pick a run from the table to inspect its falseKeeps.
+  </p>
+  <main class="eval-wrap">
+    <section class="eval-table-section">
+      <table class="eval-table" id="runs-table">
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Baseline</th>
+            <th class="num">Rows</th>
+            <th class="num">Keep agree</th>
+            <th class="num">falseKeep</th>
+            <th class="num">falseReplace</th>
+            <th class="num">Score MAE</th>
+            <th class="num">Cost</th>
+            <th>Gate</th>
+          </tr>
+        </thead>
+        <tbody id="runs-body"></tbody>
+      </table>
+    </section>
+    <section class="eval-gallery-section">
+      <h2 class="eval-gallery-title" id="gallery-title">falseKeeps</h2>
+      <div class="eval-gallery" id="gallery"></div>
+    </section>
+  </main>
+  <script type="module" src="/eval.js"></script>
+</body>
+</html>

--- a/tools/photo-curation/public/eval.js
+++ b/tools/photo-curation/public/eval.js
@@ -1,0 +1,99 @@
+import { initTheme, toggleTheme } from '/theme.js';
+import { esc, safeImg } from './safe.js';
+initTheme();
+document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+// UNIT CONTRACT (#1094): the server stores `agreement` and `scoreMae` as 0–1
+// FRACTIONS — the gate (`PASS`/`fail`) is derived server-side (see
+// src/server/eval-queries.ts), so this page only renders. The `%` columns
+// multiply by 100 for display; never re-derive the gate here.
+function pct(fraction) {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+function usd(cost) {
+  return `$${Number(cost).toFixed(2)}`;
+}
+
+let selectedRun = new URLSearchParams(location.search).get('run');
+
+function runRow(run, isSelected) {
+  const tr = document.createElement('tr');
+  tr.className = 'run-row' + (isSelected ? ' selected' : '');
+  tr.dataset.id = run.id;
+  const gateClass = run.gate === 'PASS' ? 'gate-pass' : 'gate-fail';
+  tr.innerHTML = `
+    <td class="run-model">${esc(run.model)}</td>
+    <td class="run-baseline">${esc(run.baselineModel)} · ${esc(run.baselineRubric)}</td>
+    <td class="num">${esc(run.sampleSize)}</td>
+    <td class="num">${esc(pct(run.agreement))}</td>
+    <td class="num">${esc(run.falseKeep)}</td>
+    <td class="num">${esc(run.falseReplace)}</td>
+    <td class="num">${esc(pct(run.scoreMae))}</td>
+    <td class="num">${esc(usd(run.totalCost))}</td>
+    <td><span class="gate-badge ${gateClass}">${esc(run.gate)}</span></td>`;
+  tr.addEventListener('click', () => selectRun(run.id));
+  return tr;
+}
+
+function figure(fk) {
+  return `
+    <figure class="fk-figure">
+      <img class="fk-img" src="${safeImg(fk.sourceUrl)}" alt="${esc(fk.comName)}" loading="lazy" />
+      <figcaption class="fk-caption">
+        <span class="fk-name">${esc(fk.comName)}</span>
+        <span class="fk-scores">Gemini keep@${esc(fk.geminiQuality)} · Opus replace@${esc(fk.opusQuality)}</span>
+      </figcaption>
+    </figure>`;
+}
+
+async function loadFalseKeeps(runId) {
+  const gallery = document.getElementById('gallery');
+  const title = document.getElementById('gallery-title');
+  const res = await fetch(`/api/eval/false-keeps?run=${encodeURIComponent(runId)}`);
+  if (!res.ok) {
+    gallery.innerHTML = '<p class="empty">Could not load falseKeeps for this run.</p>';
+    return;
+  }
+  const data = await res.json();
+  title.textContent = `falseKeeps · ${data.falseKeeps.length}`;
+  if (data.falseKeeps.length === 0) {
+    gallery.innerHTML = '<p class="empty">No falseKeeps — the candidate judge kept nothing the baseline replaced.</p>';
+    return;
+  }
+  gallery.innerHTML = data.falseKeeps.map(figure).join('');
+}
+
+function renderRuns(runs) {
+  const body = document.getElementById('runs-body');
+  body.innerHTML = '';
+  for (const run of runs) body.appendChild(runRow(run, run.id === selectedRun));
+}
+
+function selectRun(runId) {
+  selectedRun = runId;
+  document.querySelectorAll('.run-row').forEach((tr) => tr.classList.toggle('selected', tr.dataset.id === runId));
+  const url = new URL(location.href);
+  url.searchParams.set('run', runId);
+  history.replaceState(null, '', url);
+  loadFalseKeeps(runId);
+}
+
+async function load() {
+  const res = await fetch('/api/eval/runs');
+  const data = await res.json();
+  document.getElementById('summary').textContent = `${data.runs.length} run${data.runs.length === 1 ? '' : 's'}`;
+  if (data.runs.length === 0) {
+    document.getElementById('runs-body').innerHTML = '<tr><td colspan="9" class="empty">No eval runs yet — run <code>npm run eval</code>.</td></tr>';
+    document.getElementById('gallery').innerHTML = '';
+    document.getElementById('gallery-title').textContent = 'falseKeeps';
+    return;
+  }
+  // Default to the newest run (the API returns newest-first) unless ?run= named
+  // a run that actually exists.
+  const known = data.runs.some((r) => r.id === selectedRun);
+  if (!known) selectedRun = data.runs[0].id;
+  renderRuns(data.runs);
+  loadFalseKeeps(selectedRun);
+}
+
+load();

--- a/tools/photo-curation/public/index.html
+++ b/tools/photo-curation/public/index.html
@@ -10,6 +10,7 @@
   <header class="app-header">
     <h1 class="app-title">Photo Curation</h1>
     <a class="nav-link" href="/pending-swaps">Pending swaps →</a>
+    <a class="nav-link" href="/eval">Model comparison →</a>
     <button class="theme-toggle" id="theme-toggle" type="button">Theme</button>
     <span class="staged-indicator" id="staged">staged: 0 approved</span>
   </header>

--- a/tools/photo-curation/src/server/eval-queries.test.ts
+++ b/tools/photo-curation/src/server/eval-queries.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { openDb } from '../db.js';
+import { insertEvalRun, insertEvalResult, type EvalResultRecord } from '../eval/store.js';
+import { evalRuns, evalFalseKeeps } from './eval-queries.js';
+
+// Seed an in-memory store (the PR1 #1094 schema + helpers) — no network, no
+// fixtures on disk. The unit contract that load-bears here: `agreement` and
+// `score_mae` are 0–1 FRACTIONS, so the derived gate is `agreement >= 0.90`.
+
+function baseResult(over: Partial<EvalResultRecord> = {}): EvalResultRecord {
+  return {
+    runId: 'r1',
+    speciesCode: 'houspa',
+    comName: 'House Sparrow',
+    contentHash: 'h1',
+    sourceUrl: 'https://photos.bird-maps.com/houspa.webp',
+    geminiKeep: true,
+    geminiQuality: 80,
+    geminiCriteriaJson: null,
+    opusKeep: true,
+    opusQuality: 78,
+    cost: 0.01,
+    promptTokens: 100,
+    completionTokens: 20,
+    ...over,
+  };
+}
+
+describe('evalRuns', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = openDb(':memory:'); });
+  afterEach(() => db.close());
+
+  it('returns one row per run, newest started_at first, with a derived gate', () => {
+    insertEvalRun(db, {
+      id: 'old', model: 'gemini-2.0', baselineModel: 'opus-4', baselineRubric: 'v0.2.2',
+      sampleSize: 150, startedAt: '2026-06-10T00:00:00Z',
+      agreement: 0.9, falseKeep: 5, falseReplace: 27, scoreMae: 0.12, totalCost: 4.2,
+    });
+    insertEvalRun(db, {
+      id: 'new', model: 'gemini-2.5', baselineModel: 'opus-4', baselineRubric: 'v0.2.2',
+      sampleSize: 150, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.7867, falseKeep: 5, falseReplace: 27, scoreMae: 0.2, totalCost: 4.0,
+    });
+
+    const runs = evalRuns(db);
+    expect(runs.map((r) => r.id)).toEqual(['new', 'old']); // newest first
+
+    const newest = runs[0];
+    expect(newest.model).toBe('gemini-2.5');
+    expect(newest.baselineModel).toBe('opus-4');
+    expect(newest.baselineRubric).toBe('v0.2.2');
+    expect(newest.sampleSize).toBe(150);
+    expect(newest.agreement).toBe(0.7867);
+    expect(newest.falseKeep).toBe(5);
+    expect(newest.falseReplace).toBe(27);
+    expect(newest.scoreMae).toBe(0.2);
+    expect(newest.totalCost).toBe(4.0);
+    expect(newest.startedAt).toBe('2026-06-12T00:00:00Z');
+  });
+
+  // Gate boundary — both sides of 0.90, with the value in FRACTION units so a
+  // percent-vs-fraction slip cannot pass silently.
+  it('gates PASS at exactly agreement = 0.90 (fraction)', () => {
+    insertEvalRun(db, {
+      id: 'boundary', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 10, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.9, falseKeep: 0, falseReplace: 0, scoreMae: 0.1, totalCost: 0,
+    });
+    expect(evalRuns(db)[0].gate).toBe('PASS');
+  });
+
+  it('gates fail at agreement = 0.89 (fraction)', () => {
+    insertEvalRun(db, {
+      id: 'boundary', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 10, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.89, falseKeep: 0, falseReplace: 0, scoreMae: 0.1, totalCost: 0,
+    });
+    expect(evalRuns(db)[0].gate).toBe('fail');
+  });
+
+  it('returns an empty array when no runs exist', () => {
+    expect(evalRuns(db)).toEqual([]);
+  });
+});
+
+describe('evalFalseKeeps', () => {
+  let db: Database.Database;
+  beforeEach(() => { db = openDb(':memory:'); });
+  afterEach(() => db.close());
+
+  it('returns only the gemini_keep=1 ∧ opus_keep=0 rows for the run', () => {
+    insertEvalRun(db, {
+      id: 'r1', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 4, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.5, falseKeep: 1, falseReplace: 1, scoreMae: 0.2, totalCost: 0,
+    });
+    // The one true falseKeep: Gemini keeps (1), Opus replaces (0).
+    insertEvalResult(db, baseResult({
+      speciesCode: 'falsekeep', comName: 'False Keeper',
+      geminiKeep: true, geminiQuality: 72, opusKeep: false, opusQuality: 30,
+    }));
+    // Agreement (both keep) — excluded.
+    insertEvalResult(db, baseResult({ speciesCode: 'agree', geminiKeep: true, opusKeep: true }));
+    // False replace (Gemini replaces, Opus keeps) — excluded.
+    insertEvalResult(db, baseResult({ speciesCode: 'falsereplace', geminiKeep: false, opusKeep: true }));
+    // Both replace — excluded.
+    insertEvalResult(db, baseResult({ speciesCode: 'bothreplace', geminiKeep: false, opusKeep: false }));
+
+    const fks = evalFalseKeeps(db, 'r1');
+    expect(fks).toHaveLength(1);
+    const fk = fks[0];
+    expect(fk.speciesCode).toBe('falsekeep');
+    expect(fk.comName).toBe('False Keeper');
+    expect(fk.sourceUrl).toBe('https://photos.bird-maps.com/houspa.webp');
+    expect(fk.geminiQuality).toBe(72);
+    expect(fk.opusQuality).toBe(30);
+  });
+
+  it('scopes to the given run only', () => {
+    insertEvalRun(db, {
+      id: 'r1', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 1, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.5, falseKeep: 1, falseReplace: 0, scoreMae: 0.2, totalCost: 0,
+    });
+    insertEvalRun(db, {
+      id: 'r2', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 1, startedAt: '2026-06-11T00:00:00Z',
+      agreement: 0.5, falseKeep: 1, falseReplace: 0, scoreMae: 0.2, totalCost: 0,
+    });
+    insertEvalResult(db, baseResult({ runId: 'r1', speciesCode: 'a', geminiKeep: true, opusKeep: false }));
+    insertEvalResult(db, baseResult({ runId: 'r2', speciesCode: 'b', geminiKeep: true, opusKeep: false }));
+
+    expect(evalFalseKeeps(db, 'r1').map((f) => f.speciesCode)).toEqual(['a']);
+    expect(evalFalseKeeps(db, 'r2').map((f) => f.speciesCode)).toEqual(['b']);
+  });
+
+  it('returns an empty array for a run with no false keeps', () => {
+    insertEvalRun(db, {
+      id: 'clean', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 1, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 1, falseKeep: 0, falseReplace: 0, scoreMae: 0, totalCost: 0,
+    });
+    insertEvalResult(db, baseResult({ runId: 'clean', geminiKeep: true, opusKeep: true }));
+    expect(evalFalseKeeps(db, 'clean')).toEqual([]);
+  });
+});

--- a/tools/photo-curation/src/server/eval-queries.ts
+++ b/tools/photo-curation/src/server/eval-queries.ts
@@ -1,0 +1,122 @@
+// Read-path queries for the model-comparison viewer (#1095, PR2 of 2). These
+// read the `eval_run` + `eval_result` tables that #1094 created (see ../db.ts)
+// and the store helpers in ../eval/store.ts.
+//
+// UNIT CONTRACT (load-bearing): #1094 stores `eval_run.agreement` and
+// `score_mae` as 0–1 FRACTIONS — `agreement` is the mean of the per-row
+// keepAgreement scores. So the gate is a DIRECT `agreement >= 0.90` (NOT
+// `>= 90`); a stored percent would make every run gate PASS silently. The viewer
+// (`public/eval.js`) renders `× 100` for the `%` columns.
+
+import type Database from 'better-sqlite3';
+
+/** Pass-or-fail headline gate for a run. */
+export type Gate = 'PASS' | 'fail';
+
+/** The 90% keep-agreement gate as a 0–1 fraction (the #1094 unit contract). */
+export const AGREEMENT_GATE = 0.9;
+
+/**
+ * One row per eval RUN for the comparison table. Mirrors `EvalRunRecord` (the
+ * store helper) plus a derived `gate`. `agreement` / `scoreMae` stay 0–1
+ * fractions — the viewer multiplies by 100 for display.
+ */
+export interface EvalRunSummary {
+  id: string;
+  model: string;
+  baselineModel: string;
+  baselineRubric: string;
+  sampleSize: number;
+  agreement: number;
+  falseKeep: number;
+  falseReplace: number;
+  scoreMae: number;
+  totalCost: number;
+  startedAt: string;
+  gate: Gate;
+}
+
+/** One falseKeep judgment: Gemini kept what the Opus baseline replaced. */
+export interface FalseKeep {
+  sourceUrl: string;
+  comName: string;
+  speciesCode: string;
+  geminiQuality: number;
+  opusQuality: number;
+}
+
+interface EvalRunSummaryDbRow {
+  id: string;
+  model: string;
+  baseline_model: string;
+  baseline_rubric: string;
+  sample_size: number;
+  agreement: number;
+  false_keep: number;
+  false_replace: number;
+  score_mae: number;
+  total_cost: number;
+  started_at: string;
+}
+
+/** Derive the headline gate from the 0–1 fraction agreement. */
+function gateFor(agreement: number): Gate {
+  return agreement >= AGREEMENT_GATE ? 'PASS' : 'fail';
+}
+
+/** Every eval run, newest `started_at` first, each with its derived gate. */
+export function evalRuns(db: Database.Database): EvalRunSummary[] {
+  const rows = db
+    .prepare(
+      `SELECT id, model, baseline_model, baseline_rubric, sample_size,
+              agreement, false_keep, false_replace, score_mae, total_cost, started_at
+         FROM eval_run
+        ORDER BY started_at DESC`,
+    )
+    .all() as EvalRunSummaryDbRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    model: r.model,
+    baselineModel: r.baseline_model,
+    baselineRubric: r.baseline_rubric,
+    sampleSize: r.sample_size,
+    agreement: r.agreement,
+    falseKeep: r.false_keep,
+    falseReplace: r.false_replace,
+    scoreMae: r.score_mae,
+    totalCost: r.total_cost,
+    startedAt: r.started_at,
+    gate: gateFor(r.agreement),
+  }));
+}
+
+interface FalseKeepDbRow {
+  source_url: string;
+  com_name: string;
+  species_code: string;
+  gemini_quality: number;
+  opus_quality: number;
+}
+
+/**
+ * The dangerous-disagreement set for a run: judgments where Gemini KEPT
+ * (`gemini_keep = 1`) what the Opus baseline REPLACED (`opus_keep = 0`).
+ * Ordered by `species_code` for stable gallery output.
+ */
+export function evalFalseKeeps(db: Database.Database, runId: string): FalseKeep[] {
+  const rows = db
+    .prepare(
+      `SELECT source_url, com_name, species_code, gemini_quality, opus_quality
+         FROM eval_result
+        WHERE run_id = ? AND gemini_keep = 1 AND opus_keep = 0
+        ORDER BY species_code`,
+    )
+    .all(runId) as FalseKeepDbRow[];
+  return rows.map((r) => ({
+    sourceUrl: r.source_url,
+    comName: r.com_name,
+    speciesCode: r.species_code,
+    geminiQuality: r.gemini_quality,
+    opusQuality: r.opus_quality,
+  }));
+}

--- a/tools/photo-curation/src/server/index.test.ts
+++ b/tools/photo-curation/src/server/index.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import Database from 'better-sqlite3';
 import { createServer } from './index.js';
+import { openDb } from '../db.js';
+import { insertEvalRun, insertEvalResult, type EvalResultRecord } from '../eval/store.js';
 
 function seedDb(): Database.Database {
   const db = new Database(':memory:');
@@ -277,5 +279,120 @@ describe('review-server API', () => {
     expect((await request(app).post('/api/select-swap').send({ speciesCode: 'houspa', inatId: 'nope' })).status).toBe(400);
     // missing inatId key entirely is rejected (must be a number or explicit null)
     expect((await request(app).post('/api/select-swap').send({ speciesCode: 'houspa' })).status).toBe(400);
+  });
+});
+
+// ── #1095 PR2: the eval-comparison read routes ──
+// These read the eval_run/eval_result tables #1094 added; the canonical openDb
+// schema carries them, so seed with openDb + the PR1 store helpers (no network).
+describe('review-server eval API', () => {
+  let db: Database.Database;
+  afterEach(() => db.close());
+  beforeEach(() => { db = openDb(':memory:'); });
+
+  function evalResult(over: Partial<EvalResultRecord> = {}): EvalResultRecord {
+    return {
+      runId: 'r1',
+      speciesCode: 'houspa',
+      comName: 'House Sparrow',
+      contentHash: 'h1',
+      sourceUrl: 'https://photos.bird-maps.com/houspa.webp',
+      geminiKeep: true,
+      geminiQuality: 80,
+      geminiCriteriaJson: null,
+      opusKeep: true,
+      opusQuality: 78,
+      cost: 0.01,
+      promptTokens: 100,
+      completionTokens: 20,
+      ...over,
+    };
+  }
+
+  it('GET /api/eval/runs returns runs newest-first with the derived gate', async () => {
+    insertEvalRun(db, {
+      id: 'old', model: 'gemini-2.0', baselineModel: 'opus-4', baselineRubric: 'v0.2.2',
+      sampleSize: 150, startedAt: '2026-06-10T00:00:00Z',
+      agreement: 0.95, falseKeep: 2, falseReplace: 10, scoreMae: 0.1, totalCost: 4.2,
+    });
+    insertEvalRun(db, {
+      id: 'new', model: 'gemini-2.5', baselineModel: 'opus-4', baselineRubric: 'v0.2.2',
+      sampleSize: 150, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.7867, falseKeep: 5, falseReplace: 27, scoreMae: 0.2, totalCost: 4.0,
+    });
+    const app = createServer(db);
+    const res = await request(app).get('/api/eval/runs');
+    expect(res.status).toBe(200);
+    expect(res.body.runs.map((r: { id: string }) => r.id)).toEqual(['new', 'old']);
+    expect(res.body.runs[0].model).toBe('gemini-2.5');
+    expect(res.body.runs[0].gate).toBe('fail');   // 0.7867 < 0.90
+    expect(res.body.runs[1].gate).toBe('PASS');   // 0.95 >= 0.90
+  });
+
+  // Gate boundary — both sides of 0.90 in FRACTION units, so a percent-vs-
+  // fraction slip (which would make 0.89 read as PASS) can't pass green.
+  it('GET /api/eval/runs gates PASS at agreement = 0.90 and fail at 0.89 (fractions)', async () => {
+    insertEvalRun(db, {
+      id: 'pass', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 10, startedAt: '2026-06-12T00:00:01Z',
+      agreement: 0.9, falseKeep: 0, falseReplace: 0, scoreMae: 0.1, totalCost: 0,
+    });
+    insertEvalRun(db, {
+      id: 'fail', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 10, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.89, falseKeep: 0, falseReplace: 0, scoreMae: 0.1, totalCost: 0,
+    });
+    const app = createServer(db);
+    const res = await request(app).get('/api/eval/runs');
+    const byId = Object.fromEntries(res.body.runs.map((r: { id: string; gate: string }) => [r.id, r.gate]));
+    expect(byId.pass).toBe('PASS');
+    expect(byId.fail).toBe('fail');
+  });
+
+  it('GET /api/eval/false-keeps filters to gemini_keep=1 ∧ opus_keep=0 for the run', async () => {
+    insertEvalRun(db, {
+      id: 'r1', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 4, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.5, falseKeep: 1, falseReplace: 1, scoreMae: 0.2, totalCost: 0,
+    });
+    insertEvalResult(db, evalResult({
+      speciesCode: 'falsekeep', comName: 'False Keeper',
+      geminiKeep: true, geminiQuality: 72, opusKeep: false, opusQuality: 30,
+    }));
+    insertEvalResult(db, evalResult({ speciesCode: 'agree', geminiKeep: true, opusKeep: true }));
+    insertEvalResult(db, evalResult({ speciesCode: 'falsereplace', geminiKeep: false, opusKeep: true }));
+
+    const app = createServer(db);
+    const res = await request(app).get('/api/eval/false-keeps?run=r1');
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBe('r1');
+    expect(res.body.falseKeeps).toHaveLength(1);
+    expect(res.body.falseKeeps[0].speciesCode).toBe('falsekeep');
+    expect(res.body.falseKeeps[0].geminiQuality).toBe(72);
+    expect(res.body.falseKeeps[0].opusQuality).toBe(30);
+  });
+
+  it('GET /api/eval/false-keeps 400s on a missing run param', async () => {
+    const app = createServer(db);
+    const res = await request(app).get('/api/eval/false-keeps');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /api/eval/false-keeps 400s on an unknown run id', async () => {
+    insertEvalRun(db, {
+      id: 'r1', model: 'm', baselineModel: 'b', baselineRubric: 'rb',
+      sampleSize: 1, startedAt: '2026-06-12T00:00:00Z',
+      agreement: 0.5, falseKeep: 0, falseReplace: 0, scoreMae: 0.2, totalCost: 0,
+    });
+    const app = createServer(db);
+    const res = await request(app).get('/api/eval/false-keeps?run=nope');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /eval serves the comparison page', async () => {
+    const app = createServer(db);
+    const res = await request(app).get('/eval');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('eval.js');
   });
 });

--- a/tools/photo-curation/src/server/index.ts
+++ b/tools/photo-curation/src/server/index.ts
@@ -6,6 +6,8 @@ import {
   listOverview, getSwapView, writeDecision, denyAndAdvance,
   type SortMode, type FilterMode,
 } from './queries.js';
+import { evalRuns, evalFalseKeeps } from './eval-queries.js';
+import { readEvalRun } from '../eval/store.js';
 import { selectSwaps } from '../swaps.js';
 import { setSwapSelection, getSwapSelection, clearSwapSelection } from '../store.js';
 
@@ -38,6 +40,11 @@ export function createServer(db: Database.Database): Express {
   // comes from GET /api/pending-swaps below.
   app.get('/pending-swaps', (_req: Request, res: Response) => {
     res.sendFile('pending-swaps.html', { root: publicDir });
+  });
+  // The model-comparison page (#1095): a comparison table of eval runs + a
+  // falseKeep gallery. Served verbatim; data comes from GET /api/eval/* below.
+  app.get('/eval', (_req: Request, res: Response) => {
+    res.sendFile('eval.html', { root: publicDir });
   });
 
   // ── JSON API ──
@@ -161,6 +168,22 @@ export function createServer(db: Database.Database): Express {
       excludeIds: Array.isArray(excludeIds) ? (excludeIds as number[]) : [],
     });
     return res.json({ proposed: result.next, resourceQueued: result.resourceRequested });
+  });
+
+  // ── #1095 eval-comparison read API ──
+  // One row per eval run for the comparison table (newest-first, gate derived).
+  app.get('/api/eval/runs', (_req: Request, res: Response) => {
+    return res.json({ runs: evalRuns(db) });
+  });
+
+  // The falseKeep gallery for a run: gemini_keep=1 ∧ opus_keep=0. `?run=<id>`
+  // is required and must name a real run — mirror the swap routes' 400/validate
+  // idiom (a missing or unknown run is a bad request, not an empty gallery).
+  app.get('/api/eval/false-keeps', (req: Request, res: Response) => {
+    const run = req.query.run;
+    if (typeof run !== 'string' || !run) return res.status(400).json({ error: 'run required' });
+    if (!readEvalRun(db, run)) return res.status(400).json({ error: `unknown run: ${run}` });
+    return res.json({ runId: run, falseKeeps: evalFalseKeeps(db, run) });
   });
 
   return app;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Browser as eval.js browser
    participant Server as express review server
    participant DB as SQLite eval_run and eval_result

    Note over Browser,DB: GET /eval serves eval.html
    Browser->>Server: GET /api/eval/runs
    Server->>DB: SELECT all eval_run ORDER BY started_at DESC
    Server-->>Browser: returns runs, gate derived agreement at least 0.90
    Note over Browser: render comparison table, pick newest run or run param
    Browser->>Server: GET /api/eval/false-keeps for a run
    Server->>DB: SELECT where gemini_keep is 1 and opus_keep is 0
    Server-->>Browser: returns runId and falseKeeps, 400 on missing run
    Note over Browser: render falseKeep gallery, lazy R2 thumbnails
```

## Summary

- **Why:** PR2 of 2 (read path) for the local eval store #1094 landed — turns the throwaway Python comparison report into a permanent page in the existing photo-curation review server, so model-vs-baseline runs are inspectable without re-running a one-off script.
- Adds two read queries (`evalRuns` with a server-derived PASS/fail gate, `evalFalseKeeps` filtered to the dangerous `gemini_keep=1 ∧ opus_keep=0` set), three routes (`GET /api/eval/runs`, `GET /api/eval/false-keeps?run=<id>`, `GET /eval`), and a `public/eval.html` + `public/eval.js` page reusing `theme.js` + `safe.js`.
- **Unit contract (load-bearing):** #1094 stores `agreement` / `score_mae` as **0–1 fractions**, so the gate is `agreement >= 0.90` (derived server-side, never in the client) and `eval.js` renders the `%` columns `× 100`. The supertest asserts the gate at **both sides of 0.90** in fraction units (`0.90 ⇒ PASS`, `0.89 ⇒ fail`) so a percent-vs-fraction slip can't pass green.

## Screenshots

N/A — local tooling UI (tools/photo-curation/public/, not frontend/**)

## Test plan

- [x] `npm run test --workspace @bird-watch/photo-curation` — green (27 files, 365 tests; +13 new)
- [x] New unit / integration tests added — `src/server/eval-queries.test.ts` (queries + gate boundary) and new `review-server eval API` block in `src/server/index.test.ts` (route shapes, gate at both sides of 0.90, falseKeep filter, 400 on missing/unknown run, `/eval` serves the page)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx knip` — clean (new `public/eval.js` follows the existing `public/*.js` browser-ESM precedent in `knip.ts`)
- [x] e2e unaffected — no `frontend/**` touched

## Plan reference

Closes #1095. Out of plan (file-based) — plans live in issues for this repo; #1095 is the self-contained spec (PR2 of 2; PR1 = #1096/#1094).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
