### PR TITLE
fix(controls): dark-mode controls + chip contrast/legibility (#1041)

### DIFF
--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -113,4 +113,28 @@ test.describe('filter flows', () => {
 
     await expect(page.getByRole('dialog', { name: 'Filters' })).not.toBeVisible();
   });
+
+  // B2 (#1041): dark-mode filter controls must render themed — not native UA white.
+  // Asserts that the time-window <select> background is the themed --color-bg-surface
+  // (#1b2742 = rgb(27, 39, 66)) rather than the browser's default white/lightgray.
+  // Pattern after basemap-dark-flip.spec.ts:264 — setAttribute, not prefers-color-scheme
+  // emulation (the repo uses [data-theme] which overrides the media query).
+  test('dark mode: time-window select has themed background (not native white UA chrome)', async ({ page }) => {
+    // Panel is already open from beforeEach.
+    // Flip theme to dark.
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    const select = app.filters.timeWindow;
+    await expect(select).toBeVisible();
+
+    const bg = await select.evaluate((el) =>
+      window.getComputedStyle(el).backgroundColor,
+    );
+
+    // --color-bg-surface dark = #1b2742 = rgb(27, 39, 66).
+    // Any browser-default white (rgb(255, 255, 255)) or lightgray would fail here.
+    expect(bg).toBe('rgb(27, 39, 66)');
+  });
 });

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -260,6 +260,33 @@
   opacity: 0.9;
 }
 
+/*
+ * B2 (#1041): dark-legend silhouette visibility floor.
+ *
+ * Some families (e.g. Anhingas near-black #1a1a2e, Bulbuls dark red-brown
+ * #4a1a1a) are nearly invisible on the dark legend card (#1b2742). The DB
+ * hex is used directly as --family-fill / --family-silhouette-color with no
+ * dark-mode lightening, so the silhouettes look like the missing-icon bug.
+ *
+ * Fix: scope a color-mix() lightening to the legend context only — map SDF
+ * markers are untouched (the .family-legend scoping rule keeps this inert
+ * everywhere else). 70% original + 30% white lifts near-blacks into the
+ * clearly visible range while leaving already-bright families (cardinals,
+ * goldfinches) only slightly muted.
+ *
+ * Both render paths covered:
+ *   1. Inline-SVG path (.family-legend .family-silhouette svg) — overrides fill.
+ *   2. CSS-mask-img path (.family-legend .family-silhouette-img) — overrides
+ *      background-color (the mask's tint source, ds-primitives.css:239).
+ */
+[data-theme="dark"] .family-legend .family-silhouette svg {
+  fill: color-mix(in oklab, var(--family-fill) 70%, white);
+}
+
+[data-theme="dark"] .family-legend .family-silhouette-img {
+  background-color: color-mix(in oklab, var(--family-silhouette-color, var(--color-text-muted)) 70%, white);
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    <Photo>
    CLS-safe: aspect-ratio reserves space before the image decodes.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -404,15 +404,22 @@ body {
   min-width: 36px;
 }
 .app-header-scope-toggle:hover {
-  background: var(--color-bg-tint);
+  /* B2 (#1041): was --color-bg-tint (#1c2640 dark), which only lifts 1.01:1
+     vs the navy card and is invisible in dark. --color-bg-inset is #253050
+     in dark — 1.14:1 lift, visible affordance. Light value is unchanged
+     (#f0ebe0, same resolved hex as the old --color-bg-tint #f0ebe0). */
+  background: var(--color-bg-inset);
   color: var(--color-text-strong);
 }
 .app-header-scope-toggle:focus-visible {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
-/* Expanded: the trigger reads as active (the ✕ that collapses the form). */
+/* Expanded: the trigger reads as active (the ✕ that collapses the form).
+   B2 (#1041): also fill the background so the ✕ keeps its hit-target
+   affordance in dark mode at rest (not just on hover). */
 .app-header-scope-toggle[aria-expanded='true'] {
+  background: var(--color-bg-inset);
   color: var(--color-text-strong);
 }
 .app-header-wordmark:hover {
@@ -838,7 +845,17 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   flex-wrap: wrap;
 }
 .filters-bar label { display: flex; gap: 6px; align-items: center; font-size: var(--type-sm); }
-.filters-bar select, .filters-bar input { padding: 4px 8px; }
+/* B2 (#1041): adopt the identity-card control trio so dark mode renders
+   themed controls instead of native white UA widgets on the navy panel.
+   .scope-control__select and .zip-input__field use the same three properties.
+   border-radius: 4px = the inner-input radius contract. */
+.filters-bar select, .filters-bar input {
+  padding: 4px 8px;
+  color: var(--color-text-strong);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border-ui);
+  border-radius: 4px;
+}
 
 /* Species detail surface (#151). In-flow surface inside <main>, replaces the
    old position:fixed SpeciesPanel sidebar/drawer. Styled consistently with
@@ -1404,7 +1421,11 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   font-variant-numeric: tabular-nums;
   font-size: var(--type-xs);
   color: var(--color-text-body);
-  background: var(--color-bg-tint);
+  /* B2 (#1041): was --color-bg-tint, which in dark mode resolves to #1c2640
+     — a 1.01:1 lift vs the navy card #1b2742, i.e. invisible. --color-bg-inset
+     resolves to #253050 in dark (1.14:1 lift, 9.60:1 text contrast) and to
+     #f0ebe0 in light (same value as the old --color-bg-tint, pixel-unchanged). */
+  background: var(--color-bg-inset);
   padding: 1px 5px;
   border-radius: 8px;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -240,11 +240,21 @@
  *   --color-density-text. These can use the spec values directly.
  */
 :root[data-theme="light"] {
+  /* B2 (#1041): native form-control widget internals (dropdown list, checkbox
+     glyph) follow the theme when color-scheme is set. Without this, UA widgets
+     always render with light-chrome regardless of [data-theme]. */
+  color-scheme: light;
+
   --color-bg-page:    #f4f1ea;  /* preserve existing — warm cream page bg */
   --color-bg-surface: #ffffff;  /* preserve existing */
   --color-bg-tint:    #f0ebe0;  /* preserve existing */
   --color-bg-skeleton: #f0ebe0; /* alias of bg-tint initially (NEW) */
   --color-bg-skeleton-highlight: #f0ebe0; /* shimmer mid-stop — matches bg-tint in light */
+  /* B2 (#1041): chip background for counts + scope-toggle hover. Preserves
+     the existing .family-legend-entry-count bg value so the resolved colour
+     is pixel-identical in light — only dark gains a new value (#253050).
+     --color-text-body (#444 → #444444) on #f0ebe0 = 8.19:1 (AA). */
+  --color-bg-inset:   #f0ebe0;
 
   --color-text-strong: #1a1a1a; /* preserve existing */
   --color-text-body:   #444;    /* preserve existing — AA-tuned */
@@ -321,6 +331,9 @@
  * fixed in styles.css in this same PR (#454 W1).
  */
 :root[data-theme="dark"] {
+  /* B2 (#1041): dark-mode widget chrome. */
+  color-scheme: dark;
+
   --color-bg-page:    var(--c-navy-900);
   /* Lifted from #131c30 → #1b2742 (spec §2.2, #761 #803): a card sitting only
    * ~6 luminance points off the #0d1424 basemap cannot separate by shadow alone
@@ -329,6 +342,11 @@
   --color-bg-tint:    #1c2640;
   --color-bg-skeleton: #1c2640;
   --color-bg-skeleton-highlight: #253050;
+  /* B2 (#1041): lifted navy chip background (#253050 = skeleton-highlight).
+     --color-text-body (#d8dee8) on #253050 = 9.60:1 (AA).
+     Card-vs-chip lift: #253050 / #1b2742 = 1.14:1 (visible separation).
+     Invisible predecessor was --color-bg-tint #1c2640 vs card #1b2742 = 1.01:1. */
+  --color-bg-inset:   #253050;
 
   --color-text-strong: #f5f7fb;
   --color-text-body:   #d8dee8;

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -840,3 +840,62 @@ describe('B1 (#1040): undefined/unpaired-token enforcement', () => {
     expect(contrastRatio('#f5f7fb', '#1c2640')).toBeGreaterThanOrEqual(4.5);
   });
 });
+
+// ── B2 (#1041): dark-mode controls + chip contrast/legibility ────────────────
+//
+// 1. --color-bg-inset: a mode-paired chip-background token.
+//    light: #f0ebe0 (current .family-legend-entry-count bg value — preserves resolved color)
+//    dark:  #253050 (skeleton-highlight: 9.60:1 chip text contrast + 1.14:1 lift vs card #1b2742)
+//
+// 2. color-scheme: feeds native widget internals (select dropdown, checkbox
+//    glyph) so they follow the theme rather than staying UA-light in dark mode.
+//
+// 3. The B1 both-themes enforcement test already guards that --color-bg-inset
+//    appears in BOTH [data-theme] blocks — these tests pin the exact values.
+describe('B2 (#1041): --color-bg-inset token pairing', () => {
+  const lightBlockMatch = TOKENS_CSS.match(
+    /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+  );
+  const lightBlock = lightBlockMatch?.[1] ?? '';
+
+  const darkBlockMatch = TOKENS_CSS.match(
+    /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+  );
+  const darkBlock = darkBlockMatch?.[1] ?? '';
+
+  it('--color-bg-inset is defined in the light block', () => {
+    expect(lightBlock).toMatch(/--color-bg-inset:/);
+  });
+
+  it('--color-bg-inset light value is #f0ebe0 (preserves chip-vs-card lift + 8.19:1 text contrast)', () => {
+    expect(lightBlock).toMatch(/--color-bg-inset:\s*#f0ebe0/);
+  });
+
+  it('--color-bg-inset is defined in the dark block', () => {
+    expect(darkBlock).toMatch(/--color-bg-inset:/);
+  });
+
+  it('--color-bg-inset dark value is #253050 (skeleton-highlight: 9.60:1 text contrast, 1.14:1 card lift)', () => {
+    expect(darkBlock).toMatch(/--color-bg-inset:\s*#253050/);
+  });
+});
+
+describe('B2 (#1041): color-scheme in both theme blocks', () => {
+  const lightBlockMatch = TOKENS_CSS.match(
+    /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+  );
+  const lightBlock = lightBlockMatch?.[1] ?? '';
+
+  const darkBlockMatch = TOKENS_CSS.match(
+    /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+  );
+  const darkBlock = darkBlockMatch?.[1] ?? '';
+
+  it('light block declares color-scheme: light (native widget internals use light UA chrome)', () => {
+    expect(lightBlock).toMatch(/color-scheme:\s*light/);
+  });
+
+  it('dark block declares color-scheme: dark (native widget internals use dark UA chrome)', () => {
+    expect(darkBlock).toMatch(/color-scheme:\s*dark/);
+  });
+});

--- a/frontend/src/utils/wcag-contrast.test.ts
+++ b/frontend/src/utils/wcag-contrast.test.ts
@@ -45,4 +45,42 @@ describe('contrastRatio', () => {
     expect(ratio).toBeGreaterThan(6.0);
     expect(ratio).toBeLessThan(6.4);
   });
+
+  // B2 (#1041): short-hex expansion — #444 expands to #444444 before slicing.
+  // Without the fix, hexToSRGB('#444') slices h='444' to h.slice(0,2)='44',
+  // h.slice(2,4)='4' (length 1), parseInt('4x', 16) — the last channel was
+  // being read from h.slice(4,6) = '' → parseInt('', 16) → NaN → luminance NaN.
+  it('3-digit short hex (#444) expands correctly — no NaN', () => {
+    // #444 → #444444: R=G=B=68/255.  Luminance must be a finite number > 0.
+    const lum = relativeLuminance('#444');
+    expect(Number.isFinite(lum)).toBe(true);
+    expect(lum).toBeGreaterThan(0);
+  });
+
+  it('3-digit short hex matches its 6-digit equivalent', () => {
+    // #444 and #444444 must produce identical luminance and contrast.
+    expect(relativeLuminance('#444')).toBeCloseTo(relativeLuminance('#444444'), 10);
+    expect(contrastRatio('#444', '#ffffff')).toBeCloseTo(
+      contrastRatio('#444444', '#ffffff'),
+      10,
+    );
+  });
+
+  // B2 (#1041): chip contrast assertions — --color-text-body on --color-bg-inset.
+  // Resolved hex constants (pinned for auditability; match tokens.css values):
+  //   light: text-body #444 (→ #444444) on bg-inset #f0ebe0 — must ≥ 4.5:1
+  //   dark:  text-body #d8dee8 on bg-inset #253050          — must ≥ 4.5:1
+  it('B2 chip light: --color-text-body (#444444) on --color-bg-inset (#f0ebe0) ≥ 4.5:1', () => {
+    // light: #444444 on cream chip #f0ebe0
+    // Contrast ≈ 8.19:1 (WAI WCAG calculator verified)
+    const ratio = contrastRatio('#444444', '#f0ebe0');
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('B2 chip dark: --color-text-body (#d8dee8) on --color-bg-inset (#253050) ≥ 4.5:1', () => {
+    // dark: #d8dee8 on skeleton-highlight #253050
+    // Contrast ≈ 9.60:1 (WAI WCAG calculator verified)
+    const ratio = contrastRatio('#d8dee8', '#253050');
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
 });

--- a/frontend/src/utils/wcag-contrast.ts
+++ b/frontend/src/utils/wcag-contrast.ts
@@ -17,7 +17,12 @@ export function contrastRatio(hexA: string, hexB: string): number {
 }
 
 function hexToSRGB(hex: string): [number, number, number] {
-  const h = hex.replace('#', '');
+  let h = hex.replace('#', '');
+  // Expand 3-digit shorthand (#abc → #aabbcc) so callers can pass either form
+  // without silently producing NaN from a 6-char slice on a 3-char string.
+  if (h.length === 3) {
+    h = h.replace(/(.)/g, '$1$1');
+  }
   return [
     parseInt(h.slice(0, 2), 16),
     parseInt(h.slice(2, 4), 16),


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    A["tokens.css: mint --color-bg-inset (both themes)"] --> B["styles.css: .filters-bar controls themed"]
    A --> C["styles.css: .family-legend-entry-count themed"]
    A --> D["styles.css: scope-toggle hover/expanded filled"]
    E["tokens.css: add color-scheme light/dark"] --> B
    E --> F["Native widget internals follow theme"]
    G["ds-primitives.css: dark legend silhouette floor"] --> H["Near-black families visible on dark card"]
    I["wcag-contrast.ts: expand 3-digit short hex"] --> J["contrastRatio('#444', ...) returns real number not NaN"]
```

## Summary

- Dark filters panel shipped native white UA controls (select, input, checkbox) on the `#1b2742` navy card because `.filters-bar select/input` had only `padding` — no background, color, or border. Two different control treatments in one viewport; the white rectangles were the brightest elements on a dark screen.
- Family legend count chips and the scope-toggle hover/expanded state used `--color-bg-tint` (`#1c2640` dark), which is only 1.01:1 contrast against the card (`#1b2742`) — functionally invisible. Mints `--color-bg-inset` (`#253050` dark = 1.14:1 lift, 9.60:1 text contrast; `#f0ebe0` light = pixel-unchanged).
- Near-black legend silhouettes (Anhingas, Bulbuls) were invisible on the dark card. Adds a `color-mix(in oklab, <fill> 70%, white)` floor scoped to `.family-legend` — covers both SVG fill and CSS-mask render paths; map SDF markers untouched.

## Screenshots

Live-verified at head `18b5f73` on the dev server — the **Filters panel open** in BOTH themes (the dark shots are the load-bearing ones).

Verified live (orchestrator computed-value probe in DARK):
- **Filters `<select>`/`<input>` no longer UA-white:** background `rgb(27,39,66)` = #1b2742 (--color-bg-surface), text `rgb(245,247,251)` = #f5f7fb (--color-text-strong), border `rgb(58,70,104)` = #3a4668 (--color-border-ui).
- **`color-scheme: dark`** applied at the root in dark (native dropdown/checkbox chrome renders dark, not UA-light).
- **--color-bg-inset (new, both-themes paired per B1's enforcement test):** dark = #253050; the legend count chip computes `rgb(37,48,80)` = #253050 (was --color-bg-tint #1c2640 at a 1.01:1 lift = invisible). Scope-toggle hover/expanded also use it.
- Dark legend silhouettes for near-black families are lifted via `color-mix(... 70%, white)` so they're visible on the dark card.
- Console clean on a clean single load (only the pre-existing #1027/S1 basemap warning). B2 also fixed a `hexToSRGB` short-hex NaN bug in wcag-contrast.ts (reviewer-addendum prerequisite for the chip-contrast assertions).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | <img width="260" alt="b2-390-light" src="https://github.com/user-attachments/assets/19b32be1-a51f-4d12-a752-95437a6bda8d" /> | <img width="260" alt="b2-390-dark" src="https://github.com/user-attachments/assets/853b256a-bdbe-4674-947d-26b3fc25b7f1" /> |
| 768×1024 (tablet) | <img width="260" alt="b2-768-light" src="https://github.com/user-attachments/assets/64555f4e-5070-46b1-8320-1d7bef958081" /> | <img width="260" alt="b2-768-dark" src="https://github.com/user-attachments/assets/822475fc-8c15-40af-a9a4-65009a4725d1" /> |
| 1024×768 | <img width="260" alt="b2-1024-light" src="https://github.com/user-attachments/assets/b90c24b5-d700-4ffd-9a10-d1aed5c45203" /> | <img width="260" alt="b2-1024-dark" src="https://github.com/user-attachments/assets/b3dcdafc-2016-48cb-bfa6-08a8e521695c" /> |
| 1440×900 (desktop) | <img width="260" alt="b2-1440-light" src="https://github.com/user-attachments/assets/ae63047d-cf24-4f78-92f7-9a821694dac5" /> | <img width="260" alt="b2-1440-dark" src="https://github.com/user-attachments/assets/18120b26-b4af-4c93-a65b-22d7bec44946" /> |
| 1920×1080 (wide) | <img width="260" alt="b2-1920-light" src="https://github.com/user-attachments/assets/41013b85-37e8-4427-8cb1-d7b7923720ee" /> | <img width="260" alt="b2-1920-dark" src="https://github.com/user-attachments/assets/ad5c8f2e-ff7e-48b6-a183-066fb8e7e882" /> |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — verified (orphan-classname-check PASS)
- [x] Multi-viewport design QA: PR body has >=10 `user-attachments` URLs — 10 published (5 viewports x light/dark)


## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend` — 87 files / 1413 tests green (10 new)
- [x] New unit tests added: `wcag-contrast.test.ts` — short-hex expansion + B2 chip contrast ratios pinned
- [x] `tokens.css.test.ts` — B2 `--color-bg-inset` pairing + `color-scheme` assertions (6 new, RED before token change, GREEN after)
- [x] New e2e assertion added: `filters.spec.ts` — dark-theme time-window select computed background must equal `rgb(27, 39, 66)` (`--color-bg-surface` dark)
- [x] `npm run build --workspace @bird-watch/frontend` — clean vite build, no new warnings
- [x] `npx knip` — no new findings (1 pre-existing config hint)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] (UI only) Playwright MCP smoke — orchestrator live verify in DARK: Filters select/input bg=#1b2742 + border (not UA white), color-scheme:dark, --color-bg-inset #253050 chip visible. 5 viewports x both themes; console clean (only #1027/S1)

## Plan reference

Closes #1041. Part of #1039 (Wave 2 / B2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

