### PR TITLE
fix(ui): scrollbar styling + credits (#1042)

### DIFF
--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -305,3 +305,101 @@ test.describe('AttributionModal — iNat photo credit (#327 task-11)', () => {
     });
   }
 });
+
+/**
+ * B3 (#1042 M-11): single-scroller assertion — the Credits modal must have
+ * exactly ONE scroll container. The native <dialog> previously had both
+ * UA overflow:auto AND the inner .attribution-modal-content with
+ * overflow-y:auto + max-height:80vh, producing two side-by-side tracks.
+ * After the fix (.attribution-modal { overflow: hidden }), only the inner
+ * content div scrolls.
+ *
+ * B3 (#1042 M-10): scrollbar-color token resolution — .family-legend-entries
+ * must compute a non-"auto" scrollbar-color under both light and dark themes,
+ * confirming the --scrollbar-* token pair resolves in both [data-theme] blocks.
+ */
+test.describe('B3 (#1042): single-scroller + scrollbar tokens', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('M-11: only .attribution-modal-content scrolls — dialog itself does not', async ({ page }) => {
+    const app = new AppPage(page);
+    await app.goto('scope=us');
+    await app.waitForAppReady();
+    await app.attributionTrigger.click();
+    const dialog = page.locator('dialog.attribution-modal');
+    await expect(dialog).toHaveAttribute('open', '');
+    // Wait for the Phylopic data to load so the content is as tall as possible.
+    await dialog.locator('[data-testid=attribution-phylopic-row]').first()
+      .waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Force the inner content taller than 80vh so both containers would scroll
+    // if both had overflow-y:auto.  We inject a tall sentinel div.
+    await page.evaluate(() => {
+      const content = document.querySelector('.attribution-modal-content');
+      if (!content) throw new Error('.attribution-modal-content not found');
+      const sentinel = document.createElement('div');
+      sentinel.style.height = '2000px';
+      sentinel.setAttribute('data-testid', 'scroll-sentinel');
+      content.appendChild(sentinel);
+    });
+
+    const { contentScrolls, dialogScrolls } = await page.evaluate(() => {
+      const content = document.querySelector('.attribution-modal-content');
+      const dlg     = document.querySelector('dialog.attribution-modal');
+      if (!content || !dlg) throw new Error('Elements not found');
+      return {
+        contentScrolls: content.scrollHeight > content.clientHeight,
+        dialogScrolls:  dlg.scrollHeight    > dlg.clientHeight,
+      };
+    });
+
+    expect(contentScrolls, '.attribution-modal-content must have scrollHeight > clientHeight').toBe(true);
+    expect(dialogScrolls,  'dialog.attribution-modal must NOT scroll (overflow:hidden)').toBe(false);
+  });
+
+  test('M-10: scrollbar-color on .family-legend-entries resolves (not "auto") in both themes', async ({ page }) => {
+    const app = new AppPage(page);
+    await app.goto('scope=us');
+    await app.waitForAppReady();
+
+    // Light theme.
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'light');
+    });
+    const lightScrollbarColor = await page.evaluate(() => {
+      const el = document.querySelector('.family-legend-entries');
+      if (!el) return null;
+      return window.getComputedStyle(el).scrollbarColor;
+    });
+    expect(
+      lightScrollbarColor,
+      '.family-legend-entries scrollbar-color must not be null in light theme',
+    ).not.toBeNull();
+    expect(
+      lightScrollbarColor,
+      '.family-legend-entries scrollbar-color must not be "auto" in light theme (token not resolving)',
+    ).not.toBe('auto');
+
+    // Dark theme.
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+    const darkScrollbarColor = await page.evaluate(() => {
+      const el = document.querySelector('.family-legend-entries');
+      if (!el) return null;
+      return window.getComputedStyle(el).scrollbarColor;
+    });
+    expect(
+      darkScrollbarColor,
+      '.family-legend-entries scrollbar-color must not be null in dark theme',
+    ).not.toBeNull();
+    expect(
+      darkScrollbarColor,
+      '.family-legend-entries scrollbar-color must not be "auto" in dark theme (token not resolving)',
+    ).not.toBe('auto');
+
+    // The dark theme thumb must differ from the light theme thumb,
+    // confirming the per-theme token values actually differ.
+    expect(darkScrollbarColor).not.toBe(lightScrollbarColor);
+  });
+});

--- a/frontend/e2e/attribution-modal.spec.ts
+++ b/frontend/e2e/attribution-modal.spec.ts
@@ -343,24 +343,48 @@ test.describe('B3 (#1042): single-scroller + scrollbar tokens', () => {
       content.appendChild(sentinel);
     });
 
-    const { contentScrolls, dialogScrolls } = await page.evaluate(() => {
+    // `overflow:hidden` clips overflowing content but does NOT collapse
+    // scrollHeight to clientHeight, so `scrollHeight > clientHeight` is still
+    // true on the (non-scrolling) dialog. The faithful "exactly one scroll
+    // container" oracle is: the inner content actually scrolls AND is the
+    // scroller (overflow-y auto|scroll), while the dialog's overflow-y is
+    // hidden (so it cannot scroll).
+    const { contentScrolls, contentOverflowY, dialogOverflowY } = await page.evaluate(() => {
       const content = document.querySelector('.attribution-modal-content');
       const dlg     = document.querySelector('dialog.attribution-modal');
       if (!content || !dlg) throw new Error('Elements not found');
       return {
-        contentScrolls: content.scrollHeight > content.clientHeight,
-        dialogScrolls:  dlg.scrollHeight    > dlg.clientHeight,
+        contentScrolls:   content.scrollHeight > content.clientHeight,
+        contentOverflowY: getComputedStyle(content).overflowY,
+        dialogOverflowY:  getComputedStyle(dlg).overflowY,
       };
     });
 
-    expect(contentScrolls, '.attribution-modal-content must have scrollHeight > clientHeight').toBe(true);
-    expect(dialogScrolls,  'dialog.attribution-modal must NOT scroll (overflow:hidden)').toBe(false);
+    expect(contentScrolls, '.attribution-modal-content must scroll (scrollHeight > clientHeight)').toBe(true);
+    expect(['auto', 'scroll'], 'inner content is the scroll container').toContain(contentOverflowY);
+    expect(dialogOverflowY, 'dialog.attribution-modal must NOT scroll (overflow-y:hidden)').toBe('hidden');
   });
 
   test('M-10: scrollbar-color on .family-legend-entries resolves (not "auto") in both themes', async ({ page }) => {
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();
+
+    // .family-legend-entries mounts only when the legend is expanded AND
+    // families have derived from observations (FamilyLegend.tsx ~L215). On the
+    // 1440×900 desktop viewport the legend defaults to expanded, so the element
+    // appears once families load — wait for it before reading computed styles.
+    // If this run defaults to collapsed, expand it first.
+    const legendEntries = page.locator('.family-legend-entries');
+    const toggle = page.locator('.family-legend-toggle');
+    try {
+      await legendEntries.waitFor({ state: 'attached', timeout: 15_000 });
+    } catch {
+      if ((await toggle.getAttribute('aria-expanded')) === 'false') {
+        await toggle.click();
+      }
+      await legendEntries.waitFor({ state: 'attached', timeout: 15_000 });
+    }
 
     // Light theme.
     await page.evaluate(() => {

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -1263,3 +1263,24 @@ button.adaptive-grid-marker__cell {
     /* No-op currently; reserved for future slide-in. */
   }
 }
+
+/* ── B3 (#1042 M-10): themed scrollbar on .cluster-list-popover ─────────────
+ * The cluster-list popover has overflow-y:auto and max-height:70vh. Without
+ * themed scrollbars the UA-default light chrome paints on the dark navy card.
+ * Uses the same mode-paired --scrollbar-* tokens as styles.css (see comment
+ * there); this rule lives here because the selector lives in ds-primitives.css.
+ */
+.cluster-list-popover {
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  scrollbar-width: thin;
+}
+.cluster-list-popover::-webkit-scrollbar {
+  width: 6px;
+}
+.cluster-list-popover::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+.cluster-list-popover::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 3px;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3450,3 +3450,71 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
     justify-content: flex-end;
   }
 }
+
+/* ── B3 (#1042 M-10/M-11): themed scrollbars on all card scroll regions ─────
+ *
+ * Without this, UA-default light chrome (solid white/grey track + grey thumb)
+ * paints over every dark card that has overflow-y:auto, producing a stark
+ * seam on the near-black basemap. The six affected regions:
+ *
+ *   .family-legend-entries     — styles.css:1342 (max-height:400px, legend list)
+ *   .attribution-modal-content — styles.css:1141 (Credits modal inner scroll)
+ *   aside.species-detail-rail  — styles.css:1729 (right-side detail rail)
+ *   .filters-panel             — styles.css:2742 (filters drop panel)
+ *   .sheet-fg                  — styles.css:2053 (mobile species sheet)
+ *
+ * The sixth region (.cluster-list-popover) lives in ds-primitives.css and
+ * receives the same rule there.
+ *
+ * Token values per [data-theme] block:
+ *   light: thumb #d8d3c3 (=--color-border-ui) on transparent — 1.50:1 vs #fff
+ *   dark:  thumb #3a4668 (=--color-border-ui) on transparent — 1.59:1 vs #1b2742
+ * Both are parity-of-affordance with the UA default thumb (~1.5–1.7:1);
+ * scrollbar thumbs carry no WCAG text contrast floor.
+ */
+.family-legend-entries,
+.attribution-modal-content,
+aside.species-detail-rail,
+.filters-panel,
+.sheet-fg {
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  scrollbar-width: thin;
+}
+.family-legend-entries::-webkit-scrollbar,
+.attribution-modal-content::-webkit-scrollbar,
+aside.species-detail-rail::-webkit-scrollbar,
+.filters-panel::-webkit-scrollbar,
+.sheet-fg::-webkit-scrollbar {
+  width: 6px;
+}
+.family-legend-entries::-webkit-scrollbar-track,
+.attribution-modal-content::-webkit-scrollbar-track,
+aside.species-detail-rail::-webkit-scrollbar-track,
+.filters-panel::-webkit-scrollbar-track,
+.sheet-fg::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+.family-legend-entries::-webkit-scrollbar-thumb,
+.attribution-modal-content::-webkit-scrollbar-thumb,
+aside.species-detail-rail::-webkit-scrollbar-thumb,
+.filters-panel::-webkit-scrollbar-thumb,
+.sheet-fg::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 3px;
+}
+
+/* ── B3 (#1042 M-11): single-scroller in the Credits modal ──────────────────
+ *
+ * The native <dialog> carries UA overflow:auto, and .attribution-modal-content
+ * also has overflow-y:auto with max-height:80vh — two nested 80vh-capped
+ * scrollers paint side-by-side full-height tracks. Fix: make the dialog
+ * itself non-scrolling; the inner .attribution-modal-content is the sole
+ * scroll container.
+ *
+ * The inner element already has max-height:80vh, but the dialog's 80vh cap
+ * clips the OUTER box; after setting overflow:hidden the dialog defers
+ * entirely to its child for overflow management.
+ */
+.attribution-modal {
+  overflow: hidden;
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -313,6 +313,14 @@
      Single-sourced with src/config/family-dot-ring.ts, which the falsifiable
      contrast audit (family-dot-ring-contrast.test.ts) iterates. */
   --sheet-dot-ring: #767676;
+
+  /* Scrollbar theming (#1042 M-10/M-11): thumb on --color-border-ui register,
+   * track transparent so the card background shows through.
+   * Light thumb #d8d3c3 on card #ffffff = 1.50:1 — parity-of-affordance
+   * with UA default (#c1c1c1 on white = 1.66:1). No WCAG text floor applies.
+   * Consumed by the shared scrollbar rule in styles.css + ds-primitives.css. */
+  --scrollbar-thumb: #d8d3c3;   /* = --color-border-ui light value */
+  --scrollbar-track: transparent;
 }
 
 /* ── Layer 2: Semantic — dark mode ──────────────────────────────────── */
@@ -408,6 +416,13 @@
      well past the 3:1 SC 1.4.11 floor. Single-sourced with
      src/config/family-dot-ring.ts (SHEET_DOT_RING.dark). */
   --sheet-dot-ring: #aeb6c2;
+
+  /* Scrollbar theming (#1042 M-10/M-11) — dark override.
+   * Dark thumb #3a4668 on card #1b2742 = 1.59:1 — parity-of-affordance
+   * with UA default. Track transparent so the navy card surface shows through,
+   * eliminating the solid-white gutter on dark legend/modal/rail. */
+  --scrollbar-thumb: #3a4668;   /* = --color-border-ui dark value */
+  --scrollbar-track: transparent;
 }
 
 /* ── Layer 3: Component aliases ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- Mint `--scrollbar-thumb` / `--scrollbar-track` in BOTH `[data-theme]` blocks in `tokens.css` (B1 both-themes resolution test stays green; the `--scrollbar-` prefix was already in the enforcement regex)
- Apply `scrollbar-color` + `::-webkit-scrollbar` rules to all six card scroll regions: `.family-legend-entries`, `.attribution-modal-content`, `aside.species-detail-rail`, `.filters-panel`, `.sheet-fg` (in `styles.css`), and `.cluster-list-popover` (in `ds-primitives.css`)
- Add `.attribution-modal { overflow: hidden }` so the native `<dialog>`'s UA `overflow:auto` no longer competes with the inner `.attribution-modal-content` scroller — one scroll container, one scrollbar track

## Test plan

- [x] `npx tsc -b frontend` — clean (zero errors)
- [x] `npm test --workspace @bird-watch/frontend -- --run` — B1 both-themes enforcement test green with new `--scrollbar-*` pair
- [x] `npx playwright test attribution-modal --project=dev-server` — 18 passed, incl. both B3 oracles (M-10 token resolution, M-11 single-scroller)
- [x] `npx knip` — only pre-existing findings (node-pg-migrate, knip binary), no new dead code
- [x] `bash scripts/check-orphan-classnames.sh` — PASS, all JSX classNames matched
- [x] Screenshots: orchestrator live-capture, 5 canonical viewports × 2 themes (below)
- [x] Design QA: orchestrator `ui-design:ui-designer` (opus) dispatch — all 5 viewports PASS

### e2e oracle fix (2nd commit, spec-only)

The first e2e run surfaced two **test-logic** defects in the new `attribution-modal.spec.ts` (the shipped CSS was correct):

- **M-11** asserted the dialog does not scroll via `dlg.scrollHeight > dlg.clientHeight === false`. But `overflow:hidden` *clips* overflowing content without collapsing `scrollHeight` — so that oracle reads `true` even when the dialog correctly presents no scrollbar. Replaced with a computed-overflow assertion: content `overflow-y` ∈ {auto, scroll} and scrolls; `getComputedStyle(dialog).overflowY === 'hidden'`.
- **M-10** read `.family-legend-entries` before it mounted. That element renders only once the legend is expanded **and** families have derived from observations (`FamilyLegend.tsx`), so it was `null` in cold CI. Added a `locator('.family-legend-entries').waitFor({ state: 'attached' })` (with an expand-toggle fallback) before reading `scrollbar-color`.

Both fixes are spec-only; no production CSS or component changed in the 2nd commit.

## Screenshots

Captured live (Playwright MCP) against the PR head, **Credits modal open** at all 5 canonical viewports × light/dark — the surface that exercises both M-11 (single inner scroller, no doubled track) and the themed-thumb token pair. Console clean (0 errors / 0 warnings) at every viewport.

Live-verified computed values: legend scroll region `scrollbar-color` resolves light `rgb(216,211,195)` = `#d8d3c3` vs dark `rgb(58,70,104)` = `#3a4668` (theme-paired, differ — M-10); `.attribution-modal` computes `overflow: hidden` while `.attribution-modal-content` computes `overflow-y: auto` (single scroller — M-11).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![b3-390-light](https://github.com/user-attachments/assets/943a329f-c395-4c19-b3a7-3aa6daa26747) | ![b3-390-dark](https://github.com/user-attachments/assets/1f5b48ee-8644-4224-bf05-1ffabad4fd3b) |
| 768×1024 (tablet) | ![b3-768-light](https://github.com/user-attachments/assets/7c943d8c-f780-4f5b-a791-75faef932f50) | ![b3-768-dark](https://github.com/user-attachments/assets/00eda880-d763-4abd-b3cc-7e0b54b9c8c4) |
| 1024×768 (laptop) | ![b3-1024-light](https://github.com/user-attachments/assets/62545237-ddf6-4ce6-9632-21921eec9679) | ![b3-1024-dark](https://github.com/user-attachments/assets/f81f9cf4-e806-4457-a62b-a9467a3b5de1) |
| 1440×900 (desktop) | ![b3-1440-light](https://github.com/user-attachments/assets/7bb36ae8-1170-4c97-bc90-b7d383cec8cf) | ![b3-1440-dark](https://github.com/user-attachments/assets/fa0abc9d-6967-42b3-95b3-cf524be2ec44) |
| 1920×1080 (wide) | ![b3-1920-light](https://github.com/user-attachments/assets/f8e3589a-5a2d-4cf7-a53f-d6759abf50be) | ![b3-1920-dark](https://github.com/user-attachments/assets/742cac0e-2ca0-459b-8b0b-eab900cd0133) |

## Notes

- File scope strictly limited to: `frontend/src/styles/tokens.css`, `frontend/src/styles.css`, `frontend/src/components/ds/ds-primitives.css`, `frontend/e2e/attribution-modal.spec.ts` — exactly the files named in the issue contract. No selector, role, or label changes. No POM updates.
- Token values: light thumb `#d8d3c3` (= `--color-border-ui` light) on transparent; dark thumb `#3a4668` (= `--color-border-ui` dark) on transparent. Both are parity-of-affordance with the UA default (~1.5–1.6:1 vs card surface); scrollbar thumbs carry no WCAG text-contrast floor.
- Rebased over B2 (#1101, `e577977`). The scrollbar group rule + the modal `overflow` rule sit at distinct lines from the B2/B4 targets.

Closes #1042. Part of #1039 (Wave 2 / B3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
