### PR TITLE
fix(elevation): migrate shadow/elevation tokens to the tier system (#1043)

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -6,8 +6,9 @@
  *
  * Architecture:
  *   - All values are resolved through Phase 1 semantic tokens (tokens.css).
- *     No raw hex codes. Custom properties from styles.css :root are also
- *     consumed where they carry the right semantic role.
+ *     No raw hex codes or raw shadow literals. Custom properties from
+ *     styles.css :root and tokens.css are consumed where they carry the
+ *     right semantic role. (#1043: popover shadows migrated to --card-elevation-2)
  *   - Shimmer animation respects prefers-reduced-motion via the global policy
  *     in styles/motion.css (animation-duration: 0ms !important). Components
  *     do NOT duplicate the media query.
@@ -896,14 +897,14 @@ button.adaptive-grid-marker__cell {
   position: absolute;
   z-index: var(--z-cell-popover);
   background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 6px;
+  border: 1px solid var(--color-border-ui);
+  border-radius: var(--card-radius);
   padding: var(--space-sm) var(--space-md);
   font: var(--text-body-sm);
   color: var(--color-text-strong);
   min-width: 240px;
-  max-width: 320px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: var(--card-maxw-popover);
+  box-shadow: var(--card-elevation-2);
 }
 
 .cell-popover__header {
@@ -997,12 +998,12 @@ button.adaptive-grid-marker__cell {
   border-radius: 2px;
 }
 
-/* Dark theme override. */
+/* Dark theme override — bg/text/border are mode-paired tokens; box-shadow
+   inherits from --card-elevation-2 (token is dark-aware, no override needed). */
 [data-theme="dark"] .cell-popover {
   background: var(--color-bg-surface);
-  border-color: var(--color-border-strong);
+  border-color: var(--color-border-ui);
   color: var(--color-text-strong);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
 
 /* Forced-colors fallback. */
@@ -1083,12 +1084,12 @@ button.adaptive-grid-marker__cell {
   max-height: 70vh;
   overflow-y: auto;
   background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 8px;
+  border: 1px solid var(--color-border-ui);
+  border-radius: var(--card-radius);
   padding: var(--space-md);
   font: var(--text-body-sm);
   color: var(--color-text-strong);
-  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--card-elevation-2);
 }
 
 .cluster-list-popover__header {
@@ -1228,12 +1229,12 @@ button.adaptive-grid-marker__cell {
   outline-offset: 2px;
 }
 
-/* Dark theme override. */
+/* Dark theme override — bg/text/border are mode-paired tokens; box-shadow
+   inherits from --card-elevation-2 (token is dark-aware, no override needed). */
 [data-theme="dark"] .cluster-list-popover {
   background: var(--color-bg-surface);
-  border-color: var(--color-border-strong);
+  border-color: var(--color-border-ui);
   color: var(--color-text-strong);
-  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.6);
 }
 
 /* Forced-colors fallback (matches existing styles.css:1696 pattern). */

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -2343,11 +2343,11 @@ describe('ObservationPopover anchoring — displaced silhouette regression (#718
     // obs projection).
     const distToEntry = Math.min(
       Math.abs(left - (expectedProjectedX + 12)),
-      Math.abs(left - (expectedProjectedX - 12 - 280)),
+      Math.abs(left - (expectedProjectedX - 12 - 300)),
     );
     const distToWrong = Math.min(
       Math.abs(left - (wrongProjectedX + 12)),
-      Math.abs(left - (wrongProjectedX - 12 - 280)),
+      Math.abs(left - (wrongProjectedX - 12 - 300)),
     );
     expect(distToEntry).toBeLessThan(distToWrong);
 

--- a/frontend/src/components/map/ObservationPopover.test.tsx
+++ b/frontend/src/components/map/ObservationPopover.test.tsx
@@ -162,7 +162,7 @@ describe('ObservationPopover', () => {
   });
 
   // Issue #718 — viewport-edge clamp: when a click lands too close to the
-  // right edge to fit POPOVER_W=280 + OFFSET=12, the popover flips to the
+  // right edge to fit POPOVER_W=300 + OFFSET=12, the popover flips to the
   // left of the click.
   it('flips to the left of the click when near the right edge', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1000, configurable: true });
@@ -176,11 +176,11 @@ describe('ObservationPopover', () => {
       />,
     );
     const dialog = screen.getByRole('dialog');
-    // 850 + 12 + 280 = 1142 > 1000 → flipX path.
+    // 850 + 12 + 300 = 1162 > 1000 → flipX path.
     const left = parseInt(dialog.style.left, 10);
     expect(left).toBeLessThan(850);
-    // 850 - 12 - 280 = 558.
-    expect(left).toBe(558);
+    // 850 - 12 - 300 = 538.
+    expect(left).toBe(538);
   });
 
   it('omits inline left/top when position is null (legacy harness path)', () => {

--- a/frontend/src/components/map/ObservationPopover.tsx
+++ b/frontend/src/components/map/ObservationPopover.tsx
@@ -37,10 +37,11 @@ export interface ObservationPopoverProps {
 
 // Pixel distance between the click point and the nearest popover edge.
 const OFFSET = 12;
-// Matches `max-width: 280px` in styles.css (.observation-popover). Single
-// source of truth lives in styles.css; the comment there flags that
-// POPOVER_W in this file must be updated alongside it.
-const POPOVER_W = 280;
+// Matches `max-width: var(--card-maxw-popover)` (300px) in styles.css
+// (.observation-popover). Single source of truth lives in styles.css;
+// the comment there flags that POPOVER_W in this file must be updated
+// alongside it. (#1043: bumped from 280 to 300 to match --card-maxw-popover)
+const POPOVER_W = 300;
 // First-paint fallback for height; replaced by the ResizeObserver-measured
 // real height after the first observe callback. A conservative 180px
 // matches the median content height at 1440×900 in the production app.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -54,9 +54,6 @@
   --dur-base: 250ms;
   --dur-slow: 350ms;
 
-  --shadow-panel: -2px 0 12px rgba(0, 0, 0, var(--opacity-subtle));
-  --shadow-listbox: 0 4px 12px rgba(0, 0, 0, var(--opacity-subtle));
-  --shadow-drawer: 0 -2px 12px rgba(0, 0, 0, var(--opacity-subtle));
 
   /* ── Colour tokens (styles.css-only) ───────────────────────────────────
      Tokens that have NO counterpart in tokens.css [data-theme] blocks.
@@ -1278,7 +1275,7 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
      round at --card-radius (12px) and the bottom-left legend caps at
      --card-maxw-legend (280px) — replaces the pre-contract 6px / 240px. */
   border-radius: var(--card-radius);
-  box-shadow: var(--shadow-listbox);
+  box-shadow: var(--card-elevation-1);
   font-size: var(--type-sm);
   color: var(--color-text-strong);
   max-width: var(--card-maxw-legend);
@@ -1549,7 +1546,7 @@ body:has(.species-detail-sheet--peek) .family-legend {
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
   border-radius: var(--card-radius);
-  box-shadow: var(--shadow-listbox);
+  box-shadow: var(--card-elevation-1);
   font-size: var(--type-xs);
   line-height: 1.4;
   color: var(--color-text-subtle);
@@ -1580,20 +1577,21 @@ body:has(.species-detail-sheet--peek) .family-legend {
    reachable via the MapMarkerHitLayer (which gives every observation
    marker a real tabindex).
 
-   max-width: 280px is duplicated as POPOVER_W in ObservationPopover.tsx
-   so the viewport-edge flipX decision can be made without forcing a
-   layout read on the popover DOM. Change both together. */
+   max-width: var(--card-maxw-popover) (300px) is duplicated as POPOVER_W
+   in ObservationPopover.tsx so the viewport-edge flipX decision can be
+   made without forcing a layout read on the popover DOM. Change both
+   together. (#1043) */
 .observation-popover {
   position: absolute;
   z-index: var(--z-popover);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
-  border-radius: 6px;
-  box-shadow: var(--shadow-listbox);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-elevation-2);
   padding: var(--space-sm) var(--space-md);
   font-size: var(--type-sm);
   color: var(--color-text-strong);
-  max-width: 280px;
+  max-width: var(--card-maxw-popover);
 }
 
 /* #950 — recipe-05 (menu-dropdown) origin-aware enter. Shared by the transient
@@ -1889,7 +1887,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   color: var(--color-text-strong);
   border-top-left-radius: var(--radius-lg, 12px);
   border-top-right-radius: var(--radius-lg, 12px);
-  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--card-elevation-sheet);
   /* Base z-index kept at 10 (below overlay band) — the snap modifier below
      overrides this at full snap. --peek (z-10) and --half (z-15) intentionally
      stay below the overlay band so map controls remain interactive when the
@@ -2081,7 +2079,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
 .sheet-fg-photo {
   grid-area: photo;
   overflow: hidden;
-  border-radius: 10px;
+  border-radius: var(--card-radius-inner);
   background: var(--color-bg-tint);
 }
 /* §1.2 inner-node sizing — make the <Photo> primitive fill the morphing frame
@@ -3101,8 +3099,8 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   padding: var(--space-xl);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
-  border-radius: var(--radius-lg, 12px);
-  box-shadow: var(--shadow-listbox);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-elevation-3);
 }
 
 /* #950 — recipe-06 (modal) enter on the landing card ONLY (never the scrim
@@ -3268,8 +3266,8 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   padding: var(--space-sm) var(--space-md);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
-  border-radius: var(--radius-lg, 12px);
-  box-shadow: var(--shadow-listbox);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-elevation-1);
 }
 
 /* Embedded mode (#800): inside .app-header-identity-card — no float, no

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -271,6 +271,10 @@
   --card-elevation-1: var(--elevation-1);   /* resting chrome          */
   --card-elevation-2: var(--elevation-2);   /* on-canvas transient     */
   --card-elevation-3: var(--elevation-3);   /* focused / modal         */
+  /* Sheet variant: upward-cast shadow for the bottom sheet edge (#1043).
+   * Direction is load-bearing (sheet rises from the bottom); mode-paired here
+   * so light and dark both have an explicit value — no single-mode literal. */
+  --card-elevation-sheet: 0 -4px 16px rgba(0,0,0,0.18);
 
   /* Undefined-token cleanup (spec §2.5, #761 #803) — these four tokens were
    * consumed by ds-primitives.css but never defined, causing cell/cluster
@@ -378,6 +382,8 @@
   --card-elevation-1: var(--elevation-1);
   --card-elevation-2: var(--elevation-2);
   --card-elevation-3: var(--elevation-3);
+  /* Sheet upward shadow — dark: stronger diffusion + bottom rim-light (#1043). */
+  --card-elevation-sheet: 0 -4px 20px rgba(0,0,0,0.6), inset 0 -1px 0 rgba(255,255,255,0.05);
 
   /* Undefined-token cleanup — dark overrides (spec §2.5, #761 #803). */
   --color-border-strong: #4a5a80;           /* stronger hairline on dark surfaces */

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -899,3 +899,127 @@ describe('B2 (#1041): color-scheme in both theme blocks', () => {
     expect(darkBlock).toMatch(/color-scheme:\s*dark/);
   });
 });
+
+// ── B4 (#1043): elevation / shadow token migration ───────────────────────────
+//
+// Guards that the legacy single-mode shadow tokens are deleted (styles.css :root
+// must no longer define them) and that the elevation tier system has coverage
+// across all three consumers mandated by the issue contract.
+describe('B4 (#1043): elevation/shadow token migration', () => {
+  // ── Deletion guards ───────────────────────────────────────────────────────
+
+  it('styles.css no longer defines --shadow-listbox (deleted — consumers migrated to --card-elevation-*)', () => {
+    expect(STYLES_CSS).not.toMatch(/--shadow-listbox\s*:/);
+  });
+
+  it('styles.css no longer defines --shadow-panel (deleted — stale vocabulary, zero consumers)', () => {
+    expect(STYLES_CSS).not.toMatch(/--shadow-panel\s*:/);
+  });
+
+  it('styles.css no longer defines --shadow-drawer (deleted — stale vocabulary, zero consumers)', () => {
+    expect(STYLES_CSS).not.toMatch(/--shadow-drawer\s*:/);
+  });
+
+  // Consumers must not reference the deleted tokens
+  it('no file references var(--shadow-listbox) after migration', () => {
+    expect(STYLES_CSS).not.toMatch(/var\(--shadow-listbox\)/);
+    expect(DS_PRIMITIVES_CSS).not.toMatch(/var\(--shadow-listbox\)/);
+  });
+
+  it('no file references var(--shadow-panel) after migration', () => {
+    expect(STYLES_CSS).not.toMatch(/var\(--shadow-panel\)/);
+    expect(DS_PRIMITIVES_CSS).not.toMatch(/var\(--shadow-panel\)/);
+  });
+
+  it('no file references var(--shadow-drawer) after migration', () => {
+    expect(STYLES_CSS).not.toMatch(/var\(--shadow-drawer\)/);
+    expect(DS_PRIMITIVES_CSS).not.toMatch(/var\(--shadow-drawer\)/);
+  });
+
+  // ── No raw box-shadow literals on migrated elements ───────────────────────
+  // AC: grep -nE "box-shadow: 0 -?4px" → zero matches (requires dark overrides deleted too)
+  it('styles.css has no raw "box-shadow: 0 4px" or "box-shadow: 0 -4px" literals (all migrated to tokens)', () => {
+    expect(STYLES_CSS).not.toMatch(/box-shadow:\s*0\s*-?4px/);
+  });
+
+  it('ds-primitives.css has no raw "box-shadow: 0 4px" or "box-shadow: 0 -4px" literals (all migrated to tokens)', () => {
+    expect(DS_PRIMITIVES_CSS).not.toMatch(/box-shadow:\s*0\s*-?4px/);
+  });
+
+  // ── Tier-2 coverage: at least 3 consumers of --card-elevation-2 ──────────
+  it('≥3 consumers of var(--card-elevation-2) across all files after migration', () => {
+    const allCss = STYLES_CSS + DS_PRIMITIVES_CSS + TOKENS_CSS;
+    // Count distinct var(--card-elevation-2) occurrences outside token definition lines
+    const matches = allCss.match(/var\(--card-elevation-2\)/g);
+    expect(
+      (matches ?? []).length,
+      'Expected ≥3 var(--card-elevation-2) usages: .cell-popover, .cluster-list-popover, .observation-popover',
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Sheet token present in both themes ───────────────────────────────────
+  it('--card-elevation-sheet is defined in the light [data-theme] block', () => {
+    const lightBlockMatch = TOKENS_CSS.match(
+      /:root\[data-theme="light"\]\s*\{([^}]*)\}/s,
+    );
+    expect(lightBlockMatch?.[1]).toMatch(/--card-elevation-sheet:/);
+  });
+
+  it('--card-elevation-sheet is defined in the dark [data-theme] block', () => {
+    const darkBlockMatch = TOKENS_CSS.match(
+      /:root\[data-theme="dark"\]\s*\{([^}]*)\}/s,
+    );
+    expect(darkBlockMatch?.[1]).toMatch(/--card-elevation-sheet:/);
+  });
+
+  it('styles.css .species-detail-sheet uses var(--card-elevation-sheet), not a raw shadow literal', () => {
+    const sheetBlockMatch = STYLES_CSS.match(
+      /\.species-detail-sheet\s*\{([^}]*)\}/s,
+    );
+    expect(sheetBlockMatch?.[1]).toMatch(/box-shadow:\s*var\(--card-elevation-sheet\)/);
+  });
+
+  // ── Radius / max-width migrations ─────────────────────────────────────────
+  it('ds-primitives.css .cell-popover uses var(--card-radius) for border-radius', () => {
+    const cellBlockMatch = DS_PRIMITIVES_CSS.match(
+      /\.cell-popover\s*\{([^}]*)\}/s,
+    );
+    expect(cellBlockMatch?.[1]).toMatch(/border-radius:\s*var\(--card-radius\)/);
+  });
+
+  it('ds-primitives.css .cluster-list-popover uses var(--card-radius) for border-radius', () => {
+    const clusterBlockMatch = DS_PRIMITIVES_CSS.match(
+      /\.cluster-list-popover\s*\{([^}]*)\}/s,
+    );
+    expect(clusterBlockMatch?.[1]).toMatch(/border-radius:\s*var\(--card-radius\)/);
+  });
+
+  it('styles.css .observation-popover uses var(--card-radius) for border-radius', () => {
+    const obsBlockMatch = STYLES_CSS.match(
+      /\.observation-popover\s*\{([^}]*)\}/s,
+    );
+    expect(obsBlockMatch?.[1]).toMatch(/border-radius:\s*var\(--card-radius\)/);
+  });
+
+  it('styles.css .observation-popover uses var(--card-maxw-popover) for max-width', () => {
+    const obsBlockMatch = STYLES_CSS.match(
+      /\.observation-popover\s*\{([^}]*)\}/s,
+    );
+    expect(obsBlockMatch?.[1]).toMatch(/max-width:\s*var\(--card-maxw-popover\)/);
+  });
+
+  it('ds-primitives.css .cell-popover uses var(--card-maxw-popover) for max-width', () => {
+    const cellBlockMatch = DS_PRIMITIVES_CSS.match(
+      /\.cell-popover\s*\{([^}]*)\}/s,
+    );
+    expect(cellBlockMatch?.[1]).toMatch(/max-width:\s*var\(--card-maxw-popover\)/);
+  });
+
+  it('styles.css .sheet-fg-photo uses var(--card-radius-inner) for border-radius (not 10px)', () => {
+    const photoBlockMatch = STYLES_CSS.match(
+      /\.sheet-fg-photo\s*\{([^}]*)\}/s,
+    );
+    expect(photoBlockMatch?.[1]).toMatch(/border-radius:\s*var\(--card-radius-inner\)/);
+    expect(photoBlockMatch?.[1]).not.toMatch(/border-radius:\s*10px/);
+  });
+});


### PR DESCRIPTION
## Summary

- Delete `--shadow-listbox`, `--shadow-panel`, `--shadow-drawer` from `styles.css :root` — all three were single-mode raw-alpha literals with no dark override; `--shadow-panel`/`--shadow-drawer` had zero consumers (dead vocabulary); `--shadow-listbox`'s five consumers migrate to the spec-assigned elevation tier token
- Wire every floating surface to its assigned elevation tier: `.family-legend` + `.map-attribution` + `.scope-control` → `var(--card-elevation-1)`; `.cell-popover` + `.cluster-list-popover` + `.observation-popover` → `var(--card-elevation-2)`; `.scope-chooser__card` → `var(--card-elevation-3)`; `.species-detail-sheet` → new `var(--card-elevation-sheet)` (mode-paired in both `[data-theme]` blocks — dark gets a rim-light instead of more black alpha that was invisible on the near-black basemap)
- Radius / border / max-width contract: all three map popovers → `var(--card-radius)` (retires 6px/8px) + `var(--color-border-ui)` (consistent hairline); `.observation-popover` + `.cell-popover` → `var(--card-maxw-popover)` (300px); `.sheet-fg-photo` → `var(--card-radius-inner)` (retires the 10px outlier)
- `POPOVER_W` in `ObservationPopover.tsx` bumped 280 → 300 to stay in sync with the CSS; flip-invariant tests in `ObservationPopover.test.tsx` and `MapCanvas.test.tsx` updated (TDD: RED first, then GREEN)
- `tokens.css.test.ts` gains a `B4 (#1043)` describe block: deletion guards, no-raw-4px-literal guards, ≥3 `--card-elevation-2` consumer assertion, `--card-elevation-sheet` both-themes assertion, radius/max-width token assertions

## Test plan

- [x] `npm test --workspace @bird-watch/frontend` — all pass; `tokens.css.test.ts` 120 pass (B1 + B2 + B4 blocks) after rebase over the merged B-stack
- [x] `npx tsc -b frontend` — clean
- [x] `npx knip` — no new findings
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] CI green at head `f88b8f2`: build, e2e, test, lint, knip, orphan-classname-check, perf-gate all SUCCESS
- [x] AC greps: `grep "shadow-listbox|shadow-panel|shadow-drawer" styles.css` → 0; `grep -nE "box-shadow: 0 -?4px" styles.css ds-primitives.css` → 0; `grep -rn "var(--card-elevation-2)" frontend/src | wc -l` → 6 (≥3)
- [x] Live Playwright verification (W.3) — 5 viewports × 2 themes (below)
- [x] Design QA: `ui-design:ui-designer` (opus), all 5 viewports

### Live computed-value verification (orchestrator, head `f88b8f2`)

Confirmed the migration resolves on the live app and legacy tokens are gone:

- `--card-elevation-1` → `0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.08)`; `--card-elevation-2` → `0 4px 12px rgba(0,0,0,.15)`; `--card-elevation-sheet` → `0 -4px 16px rgba(0,0,0,.18)`; `--card-radius` 12px; `--card-radius-inner` 8px; `--card-maxw-popover` 300px
- `--shadow-listbox` / `--shadow-panel` / `--shadow-drawer` → **all empty** (deleted)
- Consumer reads (light): `.cell-popover` box-shadow = `--card-elevation-2`, border-radius 12px, max-width 300px; `.species-detail-sheet` box-shadow = `--card-elevation-sheet` (0 -4px 16px rgba(0,0,0,.18)); `.sheet-fg-photo` border-radius 8px (not the old 10px)
- Dark `[data-theme]` override intact: `.cell-popover` dark box-shadow = `rgba(0,0,0,.55) 0 4px 14px + rgba(255,255,255,.06) 0 1px 0 inset` (rim-light idiom)
- Console: 0 errors / 0 warnings at all viewports (the sole `circle-11` dark-basemap warning is the pre-existing #947 item, reproduces on prod, not introduced here)

## Screenshots

Captured live (Playwright MCP) against head `f88b8f2`, **cell-popover open** (primary `--card-elevation-2` + `--card-radius` + `--card-maxw-popover` consumer) at all 5 canonical viewports × light/dark. This is an appearance-preserving token refactor — the popovers/cards retain their elevation, radius, and crispness.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![b4-390-light](https://github.com/user-attachments/assets/cc3bf95e-859c-4e92-affd-d293dc39bac1) | ![b4-390-dark](https://github.com/user-attachments/assets/37a364e4-c9e9-4402-a733-f81d0d3f564e) |
| 768×1024 (tablet) | ![b4-768-light](https://github.com/user-attachments/assets/f274fd15-35b8-423b-9746-5b0899d8f65c) | ![b4-768-dark](https://github.com/user-attachments/assets/0d901530-8ed3-49e4-bd54-32cdf8e47c60) |
| 1024×768 (laptop) | ![b4-1024-light](https://github.com/user-attachments/assets/95b4a0a0-8445-4515-92a5-c9512680ed8e) | ![b4-1024-dark](https://github.com/user-attachments/assets/9e047c6a-0950-4430-8b5c-af49c26b0107) |
| 1440×900 (desktop) | ![b4-1440-light](https://github.com/user-attachments/assets/13b52ef3-be25-4745-8c0d-3091ad7db48a) | ![b4-1440-dark](https://github.com/user-attachments/assets/6018d9b5-804e-405b-adfc-97e778257281) |
| 1920×1080 (wide) | ![b4-1920-light](https://github.com/user-attachments/assets/d9f2fde5-84d6-40a9-9b16-a46f9f886e75) | ![b4-1920-dark](https://github.com/user-attachments/assets/da3d0d42-91c7-4361-846f-0c916d6e3df2) |

## Notes

- `--card-elevation-sheet` is minted in `tokens.css` alongside the elevation scale — both `[data-theme="light"]` and `[data-theme="dark"]` blocks carry an explicit value, satisfying the B1 both-themes enforcement test. The dark value adds `inset 0 -1px 0 rgba(255,255,255,0.05)` (a bottom rim-light on the sheet top edge, matching the dark-elevation idiom used for tiers 1–3).
- `--shadow-panel` and `--shadow-drawer` were also slated for deletion by epic F (#1064) under its delete-if-present guard. B4 ships first per the epic dependency order and retires them here.
- Rebased over the merged B-stack (B1/B2/B3, `12f3233`). The only rebase conflict was in `tokens.css.test.ts` — B2's `--color-bg-inset` + `color-scheme` describe blocks and B4's `elevation/shadow` describe block both anchored at the same spot; resolved by keeping all three (120 tokens tests green).

Closes #1043. Closes #864. Part of #1039 (Wave 2 / B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
