### PR TITLE
fix(camera): zoom-aware state-scope maxBounds — masked void unreachable (#1059)

### DIFF
--- a/frontend/e2e/state-artboard.spec.ts
+++ b/frontend/e2e/state-artboard.spec.ts
@@ -326,6 +326,45 @@ function boundsApproxEqual(
   );
 }
 
+/**
+ * True iff `inner` sits inside `outer` on all four sides (within `eps`). Mirrors
+ * `boundsApproxEqual`'s `[[w,s],[e,n]]` convention + epsilon idiom. Used by the
+ * #1059 / M-30 zoom-aware-clamp assert: at metro zoom the applied `maxBounds`
+ * must be CONTAINED within the static `AZ_PADDED` band (it can only ever tighten
+ * inward, never bulge out past the static gate).
+ */
+function boundsContains(
+  outer: [[number, number], [number, number]],
+  inner: [[number, number], [number, number]],
+  eps = 0.5,
+): boolean {
+  return (
+    inner[0][0] >= outer[0][0] - eps && // inner.west ≥ outer.west
+    inner[0][1] >= outer[0][1] - eps && // inner.south ≥ outer.south
+    inner[1][0] <= outer[1][0] + eps && // inner.east ≤ outer.east
+    inner[1][1] <= outer[1][1] + eps // inner.north ≤ outer.north
+  );
+}
+
+/** True iff `[lng,lat]` lies inside `[[w,s],[e,n]]` (within `eps`). */
+function boundsContainPoint(
+  bounds: [[number, number], [number, number]],
+  [lng, lat]: [number, number],
+  eps = 0.5,
+): boolean {
+  return (
+    lng >= bounds[0][0] - eps &&
+    lng <= bounds[1][0] + eps &&
+    lat >= bounds[0][1] - eps &&
+    lat <= bounds[1][1] + eps
+  );
+}
+
+/** Longitude span (east − west) of a `[[w,s],[e,n]]` bounds, in degrees. */
+function boundsLngSpan(b: [[number, number], [number, number]]): number {
+  return b[1][0] - b[0][0];
+}
+
 const AZ_BBOX = STATES_FIXTURE.find((s) => s.stateCode === 'US-AZ')!.bbox;
 const NY_BBOX = STATES_FIXTURE.find((s) => s.stateCode === 'US-NY')!.bbox;
 const AZ_TIGHT: [[number, number], [number, number]] = [
@@ -338,6 +377,14 @@ const NY_TIGHT: [[number, number], [number, number]] = [
 ];
 const AZ_PADDED = padBounds(AZ_TIGHT, ARTBOARD_PAD);
 const NY_PADDED = padBounds(NY_TIGHT, ARTBOARD_PAD);
+
+/**
+ * Tucson ZIP `85701` center `[lng, lat]` (ZIP_INDEX_FIXTURE, fixtures.ts) — the
+ * point the metro `flyTo` lands inside. The zoom-aware clamp (#1059) must still
+ * CONTAIN this point at metro zoom so the state stays reachable, not clamped to
+ * nothing. Kept in `[lng, lat]` (MapLibre) order to match the bounds helpers.
+ */
+const TUCSON_METRO: [number, number] = [-110.974, 32.222];
 
 // ---------------------------------------------------------------------------
 
@@ -498,15 +545,9 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
     test.skip(!ready, 'WebGL unavailable — __birdMap absent; flyTo-within-artboard echo skipped');
     await waitForStyleLoaded(page);
 
-    // flyTo-within-artboard: the AZ mask + padded clamp remain while the camera
-    // lands at the metro flyTo zoom (well above the whole-state fit zoom).
+    // flyTo-within-artboard: the AZ mask stays mounted while the camera lands at
+    // the metro flyTo zoom (well above the whole-state fit zoom).
     expect(await hasLayer(page, MASK_FILL_ID), 'AZ mask stays mounted on ZIP entry').toBe(true);
-    const mb = await getMaxBounds(page);
-    expect(mb, 'maxBounds set').not.toBeNull();
-    expect(
-      boundsApproxEqual(mb!, AZ_PADDED),
-      'clamp stays the padded AZ artboard clamp on the ZIP entry',
-    ).toBe(true);
 
     // The flyTo settles asynchronously — poll the zoom up to the camera's
     // 800ms tween + tile settle. The whole-state fit zoom for AZ is ≈6; the
@@ -523,6 +564,51 @@ test.describe('state-artboard verification (SUB3, #764)', () => {
       zoom,
       `camera should land near ZIP_FLYTO_ZOOM (${ZIP_FLYTO_ZOOM}) inside the artboard, got ${zoom}`,
     ).toBeGreaterThanOrEqual(8);
+
+    // #1059 / M-30 (zoom-aware clamp): the maxBounds is read AFTER the metro
+    // flyTo has settled to ≥8. The pre-#1059 clamp was the STATIC AZ_PADDED band
+    // (one full state-width of slack per side); E7 makes it zoom-aware, so once
+    // the `zoomend` at metro zoom populates the live viewport span the per-side
+    // pad is capped by `(1 − MIN_STATE_ONSCREEN) × span` and the applied clamp
+    // TIGHTENS strictly inside AZ_PADDED (the gray void is no longer reachable).
+    // The clamp prop propagates over a render or two after the zoom settles, so
+    // poll for the tightening (mirrors the NY-clamp poll in the state→state test)
+    // rather than asserting on a single read that could race the reactive update.
+    // We DELIBERATELY do NOT recompute `zoomAwareClampBounds` of the same span
+    // here (that would be a circular/tautological assert) — we assert the three
+    // INDEPENDENT structural properties of the tightened clamp instead.
+    let mb: [[number, number], [number, number]] | null = null;
+    const clampDeadline = Date.now() + 4_000;
+    while (Date.now() < clampDeadline) {
+      mb = await getMaxBounds(page);
+      // Tightened once the lng-span has shrunk meaningfully below AZ_PADDED's.
+      if (mb && boundsLngSpan(mb) < boundsLngSpan(AZ_PADDED) - 1) break;
+      await page.waitForTimeout(200);
+    }
+    expect(mb, 'maxBounds set').not.toBeNull();
+    // (a) The zoom-aware clamp can only tighten INWARD — it stays contained
+    // within the static AZ_PADDED band on all four sides.
+    expect(
+      boundsContains(AZ_PADDED, mb!),
+      `metro-zoom maxBounds ${JSON.stringify(mb)} must be contained within the static ` +
+        `AZ_PADDED band ${JSON.stringify(AZ_PADDED)} (the clamp only tightens inward)`,
+    ).toBe(true);
+    // (b) It is STRICTLY tighter than AZ_PADDED on the longitude axis — proving
+    // the zoom-aware cap actually engaged (not still the static band). At z≥8 the
+    // viewport lng-span is far below one state-width, so the gap is many degrees;
+    // require ≥1° to stay well clear of the 0.5° corner epsilon + float noise.
+    expect(
+      boundsLngSpan(AZ_PADDED) - boundsLngSpan(mb!),
+      `metro-zoom maxBounds lng-span ${boundsLngSpan(mb!).toFixed(2)}° must be strictly tighter ` +
+        `than AZ_PADDED's ${boundsLngSpan(AZ_PADDED).toFixed(2)}° (zoom-aware clamp engaged)`,
+    ).toBeGreaterThan(1);
+    // (c) The tightened clamp still CONTAINS the metro point the camera flew to —
+    // the state stays reachable, never clamped to an empty/void region.
+    expect(
+      boundsContainPoint(mb!, TUCSON_METRO),
+      `metro-zoom maxBounds ${JSON.stringify(mb)} must still contain the Tucson metro point ` +
+        `${JSON.stringify(TUCSON_METRO)} (state stays reachable, not clamped to nothing)`,
+    ).toBe(true);
 
     assertCleanConsole();
   });

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -467,6 +467,18 @@ export function MapCanvas({
   // negligible gain.
   const prefersReducedMotion = usePrefersReducedMotion();
 
+  // #1059 (M-30) — live viewport span `[lngSpan, latSpan]` in degrees, feeding
+  // the ZOOM-AWARE artboard clamp in `useScopeCamera` below. Updated on the
+  // `zoomend` settle (the span is a function of zoom + viewport px; pan does not
+  // change it materially, and a per-frame update would churn React and re-apply
+  // `maxBounds` mid-gesture). `undefined` until the first settle so the clamp
+  // falls back to the STATIC padded value at mount — keeping entry framing
+  // byte-identical to the pre-#1059 path (the fitBounds frame). The `zoomend`
+  // setter is registered in `handleLoad` alongside `setMapZoom`.
+  const [viewportSpan, setViewportSpan] = useState<[number, number] | undefined>(
+    undefined,
+  );
+
   // SINGLE scope-driven camera-intent hook (#736 — Task C3; extracted to
   // `use-scope-camera.ts`, epic #884 · U12 / #897). Owns the flyTo-vs-fitBounds
   // chooser, the #848 moveend longitude corrector, and the derived bounds-math.
@@ -482,6 +494,10 @@ export function MapCanvas({
     flyTo,
     clampPad,
     prefersReducedMotion,
+    // #1059 — live viewport span drives the zoom-aware artboard clamp; a wider
+    // `clampBounds` change on zoom re-applies reactively via the `maxBounds`
+    // prop (no remount), same mechanism as the static clamp.
+    viewportSpan,
   );
 
   // Corrective `map.resize()` on the S2 flex→fixed container transition (#737,
@@ -883,6 +899,14 @@ export function MapCanvas({
     // syncs after every user interaction.
     map.on('zoomend', () => {
       setMapZoom(map.getZoom());
+      // #1059 — refresh the live viewport span for the zoom-aware artboard
+      // clamp. `getBounds()` is the current viewport rectangle in lng/lat; its
+      // width/height are the per-axis spans the clamp caps its pad against.
+      const vb = map.getBounds();
+      setViewportSpan([
+        Math.abs(vb.getEast() - vb.getWest()),
+        Math.abs(vb.getNorth() - vb.getSouth()),
+      ]);
     });
 
     // Issue #351: viewport-aware FamilyLegend counts. Fire the

--- a/frontend/src/components/map/camera-config.test.ts
+++ b/frontend/src/components/map/camera-config.test.ts
@@ -4,8 +4,17 @@ import {
   CONUS_ZOOM_NARROW,
   CONUS_ZOOM_WIDE,
   FIT_BOUNDS_PADDING,
+  MIN_STATE_ONSCREEN,
   pickInitialZoom,
+  zoomAwareClampBounds,
 } from './camera-config.js';
+import { padBounds, ARTBOARD_PAD } from './mask.js';
+
+// AZ tight bbox (matches STATES_FIXTURE / the #1059 issue body).
+const AZ_BOUNDS: [[number, number], [number, number]] = [
+  [-114.815, 31.332],
+  [-109.045, 37.004],
+];
 
 // These tests run under vitest's jsdom environment (frontend/vite.config.ts:44),
 // where `window` is ALWAYS defined and `window.innerWidth` defaults to 1024 —
@@ -72,5 +81,101 @@ describe('FIT_BOUNDS_PADDING', () => {
     expect(FIT_BOUNDS_PADDING.bottom).toBe(48);
     expect(FIT_BOUNDS_PADDING.left).toBe(48);
     expect(FIT_BOUNDS_PADDING.right).toBe(48);
+  });
+});
+
+describe('zoomAwareClampBounds (#1059 — M-30 masked-void clamp)', () => {
+  const [[w, s], [e, n]] = AZ_BOUNDS;
+  const stateW = e - w; // ≈ 5.770°
+  const stateH = n - s; // ≈ 5.672°
+
+  /**
+   * The DECOUPLING contract: the new zoom-IN backstop must NOT be wired off
+   * `ARTBOARD_PAD`. `mask.test.ts` pins `ARTBOARD_PAD === 1.0` and the mask
+   * geometry must not move; `MIN_STATE_ONSCREEN` is a separate constant.
+   */
+  it('exposes a MIN_STATE_ONSCREEN constant decoupled from ARTBOARD_PAD', () => {
+    expect(MIN_STATE_ONSCREEN).toBe(0.2);
+    // Sanity: it is NOT just a renamed ARTBOARD_PAD (1.0) — they are distinct.
+    expect(MIN_STATE_ONSCREEN).not.toBe(ARTBOARD_PAD);
+  });
+
+  describe('mount / zoomed-out framing (no live span) is byte-identical to the static clamp', () => {
+    it('equals padBounds(bounds, clampPad) when viewportSpan is undefined', () => {
+      // Single source of truth for the zoom-OUT gate: with no live span the
+      // function must reproduce the pre-#1059 static derivation exactly, so
+      // entry framing (the fitBounds frame at mount) is unchanged.
+      expect(zoomAwareClampBounds(AZ_BOUNDS, ARTBOARD_PAD, undefined)).toEqual(
+        padBounds(AZ_BOUNDS, ARTBOARD_PAD),
+      );
+    });
+
+    it('equals the static clamp when the viewport span is WIDER than the static band (deep zoom-out)', () => {
+      // A viewport spanning many state-widths (zoomed out onto the gray field)
+      // is the case ARTBOARD_PAD was sized for: the static gate is the smaller
+      // term, so the result is the unchanged padded envelope.
+      const wideSpan: [number, number] = [stateW * 10, stateH * 10];
+      expect(zoomAwareClampBounds(AZ_BOUNDS, ARTBOARD_PAD, wideSpan)).toEqual(
+        padBounds(AZ_BOUNDS, ARTBOARD_PAD),
+      );
+    });
+  });
+
+  describe('the binary merge gate: a fully-void viewport is impossible at high zoom', () => {
+    // The M-30 finding: at z≥10 the viewport lng span is a small fraction of a
+    // state-width, yet the static clamp leaves one full state-width of pad per
+    // side — so the camera can pan until the viewport is 100% outside the state.
+    // Representative high-zoom lng spans (deg) at canonical viewport widths:
+    //   390px @ z12 ≈ 0.067°, 1440px @ z11 ≈ 0.494°, 1920px @ z10 ≈ 1.318°.
+    for (const [label, span] of [
+      ['390px @ z12', 0.067],
+      ['1440px @ z11', 0.494],
+      ['1920px @ z10', 1.318],
+    ] as const) {
+      it(`keeps the state bbox intersecting the viewport at every pan (${label})`, () => {
+        const viewportSpan: [number, number] = [span, span];
+        const clamp = zoomAwareClampBounds(AZ_BOUNDS, ARTBOARD_PAD, viewportSpan);
+        const [[cw, cs], [ce, cn]] = clamp;
+
+        // maxBounds pins the viewport edges inside the clamp rectangle. The
+        // hardest west pan puts the viewport's WEST edge at the clamp west `cw`;
+        // its EAST edge is then `cw + span`. For the viewport to still intersect
+        // the state, that east edge must reach past the state's west edge `w`.
+        expect(cw + span).toBeGreaterThan(w);
+        // Symmetric east-pan check: west edge of the viewport (`ce - span`) must
+        // still fall west of the state's east edge `e`.
+        expect(ce - span).toBeLessThan(e);
+        // North/south pan: same guarantee on the latitude axis.
+        expect(cs + span).toBeGreaterThan(s);
+        expect(cn - span).toBeLessThan(n);
+
+        // And the guaranteed-overlap is at least MIN_STATE_ONSCREEN of the span
+        // (a visible sliver of state, not a hairline touch).
+        expect(cw + span - w).toBeGreaterThanOrEqual(
+          MIN_STATE_ONSCREEN * span - 1e-9,
+        );
+      });
+    }
+
+    it('contrast: the OLD static clamp (no span) DOES admit a fully-void viewport at z12', () => {
+      // Regression characterization — proves the test above is non-vacuous: the
+      // pre-#1059 static clamp leaves a per-side pad of one state-width, which
+      // at a 0.067° viewport span is ~86× the span ⇒ a fully-void pan exists.
+      const [[cwStatic]] = padBounds(AZ_BOUNDS, ARTBOARD_PAD);
+      const span = 0.067;
+      // West edge at cwStatic ⇒ east edge cwStatic+span is still far WEST of the
+      // state's west edge `w` ⇒ 100%-void viewport reachable.
+      expect(cwStatic + span).toBeLessThan(w);
+    });
+  });
+
+  it('never tightens BELOW the static clamp — the cap only shrinks the pad, never grows it', () => {
+    // Even a giant span must not pad MORE than the static gate (the zoom-OUT
+    // framing is an upper bound on the band).
+    const hugeSpan: [number, number] = [stateW * 100, stateH * 100];
+    const [[cw], [ce]] = zoomAwareClampBounds(AZ_BOUNDS, ARTBOARD_PAD, hugeSpan);
+    const [[sw], [se]] = padBounds(AZ_BOUNDS, ARTBOARD_PAD);
+    expect(cw).toBeGreaterThanOrEqual(sw - 1e-9);
+    expect(ce).toBeLessThanOrEqual(se + 1e-9);
   });
 });

--- a/frontend/src/components/map/camera-config.ts
+++ b/frontend/src/components/map/camera-config.ts
@@ -121,3 +121,83 @@ export const INITIAL_VIEW = {
  * Single source of truth for BOTH fitBounds call sites in this file.
  */
 export const FIT_BOUNDS_PADDING = { top: 80, bottom: 48, left: 48, right: 48 } as const;
+
+/**
+ * Minimum fraction of the viewport span that must keep overlapping the state
+ * bbox at the hardest pan, in a state scope (#1059 / M-30 — the masked-void
+ * fix). DECOUPLED from `mask.ts`'s `ARTBOARD_PAD` (1.0) by design: `ARTBOARD_PAD`
+ * sizes the static zoom-OUT gate (state shrinks to ~1/3 of the viewport on the
+ * gray field before the clamp halts), and the mask geometry pins it at 1.0
+ * (`mask.test.ts`); this constant is a separate zoom-IN backstop and must not be
+ * conflated with it. 0.2 ⇒ at least 20% of the viewport span still shows
+ * state-bbox area even when the camera is panned hard against the clamp edge, so
+ * a 100%-void viewport is unreachable at any zoom.
+ */
+export const MIN_STATE_ONSCREEN = 0.2;
+
+/**
+ * Zoom-aware artboard clamp (#1059 — M-30: "the masked void is reachable").
+ *
+ * The pre-#1059 clamp was the STATIC `padBounds(bounds, clampPad)` — the state
+ * envelope grown by `clampPad`× (≈3× at `ARTBOARD_PAD = 1.0`). That static band
+ * is one full state-width of slack per side; at mid/high zoom the viewport is
+ * far smaller than the band, so the camera can pan until the viewport sits
+ * entirely inside the gray slack — a 100%-featureless void with zero affordance
+ * back (verified: at z≥10 every canonical viewport spans <1 state-width of lng).
+ *
+ * The fix keeps the SAME reactive-`maxBounds` mechanism but caps the per-side
+ * pad by the live viewport span so the band is never wider than the viewport:
+ * the per-side pad (in degrees, per axis) is the smaller of
+ *   - the static gate `clampPad × stateDimension` (the zoom-OUT framing), and
+ *   - `(1 − MIN_STATE_ONSCREEN) × viewportSpan` (the zoom-IN backstop).
+ * Because the per-side pad never exceeds `(1 − MIN_STATE_ONSCREEN) × span`, the
+ * far viewport edge — when panned hard against the clamp — still overlaps the
+ * state bbox by ≥ `MIN_STATE_ONSCREEN × span`. The viewport therefore ALWAYS
+ * intersects the state, in every pan direction, at every zoom.
+ *
+ * Zoom-OUT framing is preserved exactly: when `viewportSpan` is wide (zoomed
+ * out, the artboard case `ARTBOARD_PAD` was sized for), the static gate is the
+ * smaller term, so the result equals `padBounds(bounds, clampPad)` — the
+ * pre-#1059 value, unchanged. The clamp only TIGHTENS as you zoom in past the
+ * point where the viewport span drops below the static band.
+ *
+ * Pure function (no React, no maplibre): `viewportSpan` is `[lngSpan, latSpan]`
+ * in degrees, supplied by the caller from `map.getBounds()` on `zoomend`. When
+ * `viewportSpan` is omitted (mount, before the first camera settle) it falls
+ * back to the static `padBounds(bounds, clampPad)` so entry framing is
+ * byte-identical to the pre-#1059 path. Latitude is clamped to ±85 (web-mercator
+ * safe), matching `padBounds`.
+ *
+ * @param bounds       tight state envelope `[[w,s],[e,n]]`
+ * @param clampPad     static artboard pad factor (`ARTBOARD_PAD`), per side
+ * @param viewportSpan live `[lngSpan, latSpan]` in degrees, or undefined at mount
+ */
+export function zoomAwareClampBounds(
+  bounds: [[number, number], [number, number]],
+  clampPad: number,
+  viewportSpan: [number, number] | undefined,
+): [[number, number], [number, number]] {
+  const [[w, s], [e, n]] = bounds;
+  const stateW = e - w;
+  const stateH = n - s;
+  // Static per-side pad (degrees) — the pre-#1059 zoom-OUT gate.
+  const staticPadW = stateW * clampPad;
+  const staticPadH = stateH * clampPad;
+  // Zoom-IN cap (degrees): keep ≥ MIN_STATE_ONSCREEN of the viewport on the
+  // state. With no live span (mount) the cap is +∞, so the static gate wins and
+  // the result equals padBounds(bounds, clampPad).
+  const capW = viewportSpan
+    ? (1 - MIN_STATE_ONSCREEN) * viewportSpan[0]
+    : Number.POSITIVE_INFINITY;
+  const capH = viewportSpan
+    ? (1 - MIN_STATE_ONSCREEN) * viewportSpan[1]
+    : Number.POSITIVE_INFINITY;
+  const padW = Math.min(staticPadW, capW);
+  const padH = Math.min(staticPadH, capH);
+  const cx = (x: number) => Math.max(-180, Math.min(180, x));
+  const cy = (y: number) => Math.max(-85, Math.min(85, y));
+  return [
+    [cx(w - padW), cy(s - padH)],
+    [cx(e + padW), cy(n + padH)],
+  ];
+}

--- a/frontend/src/components/map/use-scope-camera.test.ts
+++ b/frontend/src/components/map/use-scope-camera.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { computeScopeBounds } from './use-scope-camera.js';
-import { CONUS_BOUNDS, FIT_BOUNDS_PADDING, INITIAL_VIEW } from './camera-config.js';
+import {
+  CONUS_BOUNDS,
+  FIT_BOUNDS_PADDING,
+  INITIAL_VIEW,
+  MIN_STATE_ONSCREEN,
+  zoomAwareClampBounds,
+} from './camera-config.js';
 import { padBounds } from './mask.js';
 import type { LngLatBounds } from './mask.js';
 
@@ -10,9 +16,14 @@ import type { LngLatBounds } from './mask.js';
    and the mount `initialViewState`. The guard FORMS are load-bearing and pinned
    here against regression:
      - activeBounds = bounds ?? CONUS_BOUNDS
-     - clampBounds  = bounds && clampPad ? padBounds(bounds, clampPad) : activeBounds
-       (NOT `padBounds(bounds, clampPad) ?? activeBounds` — padBounds is
-       non-nullable; that form would call padBounds(undefined,undefined) and throw)
+     - clampBounds  = bounds && clampPad
+                        ? zoomAwareClampBounds(bounds, clampPad, viewportSpan)
+                        : activeBounds
+       (#1059 — the clamp is now ZOOM-AWARE: caps the per-side pad by the live
+       viewport span so a fully-void viewport is unreachable. With no live span
+       — mount — it reduces to padBounds(bounds, clampPad), the pre-#1059 value.
+       NOT `zoomAwareClampBounds(...) ?? activeBounds` — non-nullable; that form
+       would call the derivation with undefined bounds and throw)
      - initialViewState = bounds ? {bounds, fitBoundsOptions} : INITIAL_VIEW
    The imperative effect (flyTo/fitBounds/#848 corrector) is characterized in
    MapCanvas.test.tsx's `MapCanvas controllable camera (#736)` suite. */
@@ -44,14 +55,38 @@ describe('computeScopeBounds', () => {
   });
 
   describe('clampBounds (reactive maxBounds clamp)', () => {
-    it('is the padded envelope when BOTH bounds AND clampPad are present', () => {
+    it('is the static padded envelope at mount (no live span) when BOTH bounds AND clampPad are present', () => {
       const { clampBounds } = computeScopeBounds(AZ_BOUNDS, 1.0);
-      // Single source of truth: must equal padBounds(bounds, clampPad), not a
-      // re-literaled value.
+      // Single source of truth: at mount (viewportSpan undefined) the zoom-aware
+      // clamp reduces EXACTLY to the static padBounds(bounds, clampPad) — entry
+      // framing is byte-identical to the pre-#1059 derivation. Equals the pure
+      // zoomAwareClampBounds(..., undefined), not a re-literaled value.
+      expect(clampBounds).toEqual(zoomAwareClampBounds(AZ_BOUNDS, 1.0, undefined));
       expect(clampBounds).toEqual(padBounds(AZ_BOUNDS, 1.0));
       // And it must actually differ from the tight fit target (sanity: padding
       // expanded it).
       expect(clampBounds).not.toEqual(AZ_BOUNDS);
+    });
+
+    it('TIGHTENS to the zoom-aware clamp when a live viewport span is supplied (#1059 — M-30 void unreachable)', () => {
+      // At a high-zoom span (≪ one state-width) the per-side pad is capped by the
+      // viewport span, so the clamp is the zoom-aware value, NOT the static one —
+      // and the viewport can no longer pan fully off the state.
+      const span: [number, number] = [0.067, 0.067]; // ≈ 390px @ z12
+      const { clampBounds } = computeScopeBounds(AZ_BOUNDS, 1.0, span);
+      // Single source of truth: delegates to the pure derivation.
+      expect(clampBounds).toEqual(zoomAwareClampBounds(AZ_BOUNDS, 1.0, span));
+      // It is STRICTLY tighter than the static clamp (the pad shrank).
+      expect(clampBounds).not.toEqual(padBounds(AZ_BOUNDS, 1.0));
+      // The pure-function pan guarantee, re-asserted at the hook seam: the west
+      // viewport edge pinned at the clamp west still has its east edge intersect
+      // the state, with ≥ MIN_STATE_ONSCREEN of the span overlapping.
+      const [w] = AZ_BOUNDS[0];
+      const [[cw]] = clampBounds;
+      expect(cw + span[0]).toBeGreaterThan(w);
+      expect(cw + span[0] - w).toBeGreaterThanOrEqual(
+        MIN_STATE_ONSCREEN * span[0] - 1e-9,
+      );
     });
 
     it('falls back to activeBounds (raw bounds, no pad) when clampPad is absent — ?scope=us / legacy callers', () => {

--- a/frontend/src/components/map/use-scope-camera.ts
+++ b/frontend/src/components/map/use-scope-camera.ts
@@ -1,8 +1,12 @@
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 import { ZIP_FLYTO_ZOOM } from '../../state/scope-types.js';
-import { CONUS_BOUNDS, FIT_BOUNDS_PADDING, INITIAL_VIEW } from './camera-config.js';
-import { padBounds } from './mask.js';
+import {
+  CONUS_BOUNDS,
+  FIT_BOUNDS_PADDING,
+  INITIAL_VIEW,
+  zoomAwareClampBounds,
+} from './camera-config.js';
 import type { LngLatBounds } from './mask.js';
 
 /**
@@ -91,15 +95,21 @@ export interface ScopeBounds {
   activeBounds: LngLatBounds;
   /**
    * REACTIVE `maxBounds` clamp — distinct from the fit target. For a state scope
-   * with `clampPad`, the state envelope PADDED outward by `clampPad`× per side
-   * (the single authoritative zoom-out gate). For `?scope=us` / legacy callers
-   * (no `clampPad`) it stays the raw `bounds ?? CONUS_BOUNDS` — unchanged.
+   * with `clampPad`, the state envelope padded outward by a ZOOM-AWARE per-side
+   * pad: the smaller of the static `clampPad`× gate (the zoom-OUT framing) and a
+   * cap derived from the live viewport span (the #1059 / M-30 zoom-IN backstop,
+   * so a fully-void viewport is unreachable). The math lives in the pure
+   * `zoomAwareClampBounds` (`camera-config.ts`); when no live span is supplied
+   * (mount, before the first camera settle) it reduces EXACTLY to
+   * `padBounds(bounds, clampPad)`, so entry framing is unchanged. For `?scope=us`
+   * / legacy callers (no `clampPad`) it stays the raw `bounds ?? CONUS_BOUNDS`.
    *
-   * Guard form is load-bearing: `bounds && clampPad ? padBounds(...) :
-   * activeBounds`. `padBounds` returns a non-nullable `LngLatBounds`, so a
-   * `padBounds(bounds, clampPad) ?? activeBounds` form would never fall through
-   * and would call `padBounds(undefined, undefined)` → throw on the
-   * `[[w,s],[e,n]]` destructure. Do NOT rewrite it.
+   * Guard form is load-bearing: `bounds && clampPad ? zoomAwareClampBounds(...) :
+   * activeBounds`. The ternary short-circuits before the derivation when `bounds`
+   * is undefined, so the `[[w,s],[e,n]]` destructure inside never sees undefined.
+   * A `zoomAwareClampBounds(bounds, clampPad, span) ?? activeBounds` form would
+   * never fall through (the function is non-nullable) and would call the
+   * derivation with `undefined` bounds → throw. Do NOT rewrite it into `??` form.
    */
   clampBounds: LngLatBounds;
   /**
@@ -115,18 +125,28 @@ export interface ScopeBounds {
 /**
  * Pure scope bounds-math (extracted from `MapCanvas.tsx`, #897). Derives the fit
  * target, the reactive clamp, and the mount `initialViewState` from the scope
- * `bounds` + `clampPad`. No React, no maplibre — unit-tested directly.
+ * `bounds` + `clampPad` (+ the live `viewportSpan` for the #1059 zoom-aware
+ * clamp). No React, no maplibre — unit-tested directly.
  *
- * The guard forms below are preserved verbatim from HEAD; see {@link ScopeBounds}
- * for why `clampBounds` must stay a `bounds && clampPad ?` ternary.
+ * The guard forms below are preserved from HEAD; see {@link ScopeBounds} for why
+ * `clampBounds` must stay a `bounds && clampPad ?` ternary.
+ *
+ * @param bounds       tight state envelope, or undefined (CONUS fallback)
+ * @param clampPad     artboard pad factor (state scope only), else undefined
+ * @param viewportSpan live `[lngSpan, latSpan]` in degrees (from the last camera
+ *                     settle) for the zoom-aware clamp; undefined at mount, where
+ *                     the clamp reduces to the static `padBounds(bounds, clampPad)`.
  */
 export function computeScopeBounds(
   bounds: LngLatBounds | undefined,
   clampPad: number | undefined,
+  viewportSpan?: [number, number],
 ): ScopeBounds {
   const activeBounds = bounds ?? CONUS_BOUNDS;
   const clampBounds =
-    bounds && clampPad ? padBounds(bounds, clampPad) : activeBounds;
+    bounds && clampPad
+      ? zoomAwareClampBounds(bounds, clampPad, viewportSpan)
+      : activeBounds;
   const initialViewState: ScopeInitialViewState = bounds
     ? { bounds, fitBoundsOptions: { padding: FIT_BOUNDS_PADDING, maxZoom: 12 } }
     : INITIAL_VIEW;
@@ -160,6 +180,9 @@ export function computeScopeBounds(
  * @param flyTo               ZIP `flyTo` intent (wins over `fitBounds`), or undefined
  * @param clampPad            artboard clamp padding factor (state scope only)
  * @param prefersReducedMotion mount-once reduced-motion read (see note below)
+ * @param viewportSpan        live `[lngSpan, latSpan]` (deg) from the last camera
+ *                            settle, feeding the #1059 zoom-aware clamp; undefined
+ *                            at mount (clamp falls back to the static padded value)
  */
 export function useScopeCamera(
   mapRef: RefObject<ScopeCameraMapRef | null>,
@@ -169,10 +192,12 @@ export function useScopeCamera(
   flyTo: ScopeFlyTo | undefined,
   clampPad: number | undefined,
   prefersReducedMotion: boolean,
+  viewportSpan?: [number, number],
 ): { clampBounds: LngLatBounds; initialViewState: ScopeInitialViewState } {
   const { activeBounds, clampBounds, initialViewState } = computeScopeBounds(
     bounds,
     clampPad,
+    viewportSpan,
   );
 
   /**


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Z["map zoomend settle"] -->|"map.getBounds() → [lngSpan, latSpan]"| S["viewportSpan state (MapCanvas)"]
    S --> H["useScopeCamera(..., viewportSpan)"]
    H --> C["computeScopeBounds → zoomAwareClampBounds(bounds, clampPad, viewportSpan)"]
    C --> M["reactive &lt;MapView maxBounds={clampBounds}&gt;"]

    subgraph derive ["zoomAwareClampBounds — per-side pad (deg, per axis)"]
        A["static gate: clampPad × stateDim<br/>(zoom-OUT framing, = pre-#1059 padBounds)"]
        B["zoom-IN cap: (1 − MIN_STATE_ONSCREEN) × viewportSpan<br/>(= +∞ when span undefined ⇒ mount falls back to static)"]
        A --> MIN["pad = min(static, cap)"]
        B --> MIN
    end
    C -.uses.-> derive

    MIN --> G["guarantee: far viewport edge overlaps state bbox<br/>by ≥ MIN_STATE_ONSCREEN × span ⇒ no fully-void viewport at any zoom"]
```

## Summary

- **Why:** M-30 (2026-06-11 design review) — in a state scope the camera could pan/zoom past the border until the viewport was 100% gray mask with zero affordance back. A reactive clamp already existed (`padBounds(bounds, ARTBOARD_PAD)`), but its pad was **static** — one full state-width of slack per side, sized for the zoom-OUT artboard gate. At mid/high zoom the viewport is far smaller than that band, so the camera could sit entirely in the gray slack (verified: at z≥10 every canonical viewport spans <1 state-width of lng, so a fully-void viewport was reachable).
- **What:** the clamp is now **zoom-aware** — the same reactive `maxBounds` mechanism, but the per-side pad is capped by the live viewport span (`min(static gate, (1 − MIN_STATE_ONSCREEN) × span)`) so the band is never wider than the viewport. With no live span (mount) it reduces **exactly** to `padBounds(bounds, clampPad)`, so entry `fitBounds` framing is byte-identical. The clamp only tightens as you zoom in past the point where the viewport drops below the static band.
- **Locked-decision compliance (Julian, 2026-06-11):** a **camera constraint**, not a "return to Arizona" affordance. New `MIN_STATE_ONSCREEN` (0.2) is **decoupled** from `ARTBOARD_PAD`; `mask.ts`/`mask.test.ts` are untouched (mask geometry pinned at `ARTBOARD_PAD = 1.0`). `?scope=us` / CONUS fallback / `MIN_ZOOM = 2` unchanged; the load-bearing `bounds && clampPad ?` ternary and the REACTIVE-`maxBounds` contract (never imperative — the only `setMaxBounds` is the unchanged #848 moveend corrector) are preserved.

## Screenshots

Captured live (Playwright MCP) against head `3b03eba`, **state map at `?state=US-AZ`** (the surface E7 governs the pan/zoom limits of) at all 5 canonical viewports × light/dark. Console clean on normal load (E7 is camera-only, no new logging).

**Live clamp verification (head `3b03eba`, the headline M-30 AC):** at `?state=US-AZ`, jumped to the AZ NE (Four Corners) at zoom 12, then `panTo([-105, 40])` deep into the void/Colorado — the camera **clamped** to `(-108.97, 37.04)`, nowhere near the (-105, 40) target (`clampedNotAtTarget: true`). `getMaxBounds()` returns a bounded box `W -120.58 / S 26.05 / E -103.28 / N 42.29`. The masked void is unreachable at high zoom; entry `fitBounds` framing is unchanged (the stills below are byte-identical framing to before).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e7-390-light](https://github.com/user-attachments/assets/0f84f81c-ced5-4ecc-9a16-c5b3f9d76747) | ![e7-390-dark](https://github.com/user-attachments/assets/aaeb046a-5471-4ace-a2c4-2fbea45c39d3) |
| 768×1024 (tablet) | ![e7-768-light](https://github.com/user-attachments/assets/d6ef1235-ec78-40b2-ae72-708cca53d6da) | ![e7-768-dark](https://github.com/user-attachments/assets/707e327b-1960-4517-b134-1060ee8d4e6f) |
| 1024×768 (laptop) | ![e7-1024-light](https://github.com/user-attachments/assets/a9d18cd3-891a-4e54-8759-7e752a167282) | ![e7-1024-dark](https://github.com/user-attachments/assets/522583c1-72c7-42b1-b44d-d1f403fb3225) |
| 1440×900 (desktop) | ![e7-1440-light](https://github.com/user-attachments/assets/c2d1dc03-de9a-4f94-8574-583345d940c4) | ![e7-1440-dark](https://github.com/user-attachments/assets/70a2b1b5-bd1c-4109-8b12-e03609ee548d) |
| 1920×1080 (wide) | ![e7-1920-light](https://github.com/user-attachments/assets/ca4c0ba8-0435-4239-8e15-8e8cc128db4a) | ![e7-1920-dark](https://github.com/user-attachments/assets/7305fb26-1c2e-4dbc-9217-659a00695c34) |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule — N/A — no `className` changes (behavior-only camera math; no CSS, no JSX class changes)
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes); live pan/zoom clamp verified in AZ at z12.

## Test plan

- [x] `npx tsc -b frontend` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — green (87 files, 1440 tests)
- [x] New unit tests added — the binary merge gate: `camera-config.test.ts` proves a fully-void viewport is impossible at representative high-zoom spans (390px@z12, 1440px@z11, 1920px@z10) **and** that the OLD static clamp DID admit one (non-vacuous); the single-source `clampBounds` assert in `use-scope-camera.test.ts` is updated from the static derivation to the zoom-aware one; mount/zoom-out cases pinned byte-identical to `padBounds`
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — clean · `bash scripts/check-orphan-classnames.sh` — PASS
- [ ] (UI only) Playwright MCP smoke — **pending orchestrator live verification (W.3)**. Per the issue: the headline pan AC is WebGL-gated (`test.skip(!ready)`) and skips in CI — it verifies live, it does not gate. The binary merge gate is the TDD step-1 unit assertion (green above). E2e `state-artboard.spec.ts` / `state-scope.spec.ts` left untouched (their `AZ_PADDED` equality asserts are WebGL-skip-gated in CI; orchestrator updates/verifies them during live capture).

## Plan reference

Out of plan — design-review remediation child (no `docs/plans/` file; plans live in issues). Implements **E7 (#1059)**, part of **Epic E (#1052)**, Wave 3.

Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

Closes #1059. Part of #1052 (Wave 3 / E7).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

