### PR TITLE
fix(map): basemap-failure watchdog + retry card (#1049)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -39,6 +39,11 @@ let bareHandlersAll: Record<string, Array<() => void | Promise<void>>> = {};
 // existing tests keep their synchronous-load behavior.
 let deferMapLoad = false;
 let deferredOnLoad: (() => void) | null = null;
+// #1049 (M-12) basemap watchdog: capture the `<MapView onError>` prop so the
+// watchdog tests can drive maplibre `error` events (the M-consecutive-failure
+// path) through the component's stateful handler. Reset in beforeEach.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedOnError: ((e: any) => void) | null = null;
 
 function makeFakeMap() {
   const canvas = { style: { cursor: '' }, clientWidth: 1440, clientHeight: 900 };
@@ -231,11 +236,14 @@ function makeFakeMap() {
 
 const MockMap = forwardRef(function MockMap(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  { children, onLoad, ...rest }: any,
+  { children, onLoad, onError, ...rest }: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ref: any,
 ) {
   useImperativeHandle(ref, () => ({ getMap: () => fakeMap }), []);
+  // #1049 (M-12): expose the live `onError` prop so the watchdog tests can fire
+  // maplibre `error` events at the component's stateful handler.
+  capturedOnError = onError ?? null;
   useEffect(() => {
     if (!onLoad) return;
     if (deferMapLoad) {
@@ -3554,5 +3562,177 @@ describe('handleMapError (#854 console hygiene)', () => {
 
     errorSpy.mockRestore();
     debugSpy.mockRestore();
+  });
+});
+
+/* ── basemap-failure watchdog (#1049 / finding M-12) ─────────────────────────
+   OpenFreeMap CDN flakiness (ERR_CONNECTION_CLOSED/429 on tiles.openfreemap.org)
+   can blank the basemap with NO `load` / `style.load` and no error/warning
+   console signal. Pre-#1049 the app set no state on that path — floating chrome
+   over a silent void, no recovery affordance. The watchdog detects the
+   condition two ways — (a) a style-load timeout, (b) M consecutive basemap-
+   source errors — and surfaces a `StatusBlock` retry card; Retry calls
+   `map.setStyle()` with the current-theme URL.
+
+   These tests use FAKE timers (the rest of the suite runs real timers, so a
+   ~10 s default watchdog cannot fire inside them — exactly the contract).
+   `__resetAdaptiveGridCacheForTesting()` is NOT used here (no reconciler work);
+   each test installs its own fakeMap + resets the captured onError prop. */
+describe('basemap watchdog (#1049 / M-12)', () => {
+  let modConsts: {
+    BASEMAP_WATCHDOG_MS: number;
+    BASEMAP_ERROR_THRESHOLD: number;
+    BASEMAP_LIGHT: string;
+    BASEMAP_DARK: string;
+  };
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    registeredHandlers = {};
+    bareHandlers = {};
+    bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
+    capturedOnError = null;
+    fakeMap = makeFakeMap();
+    document.documentElement.removeAttribute('data-theme');
+    modConsts = await import('./MapCanvas.js');
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function basemapErr(sourceId?: string, name?: string): any {
+    const error = new Error(name === 'AbortError' ? 'aborted' : 'Failed to fetch');
+    if (name) error.name = name;
+    return { type: 'error', target: fakeMap, error, sourceId };
+  }
+
+  it('1. no `load` within the watchdog window → renders the "Basemap unavailable" retry card', () => {
+    deferMapLoad = true; // hold onLoad so the basemap never reports healthy
+    render(<MapCanvas observations={[]} />);
+
+    // Before the window elapses: no card.
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(modConsts.BASEMAP_WATCHDOG_MS + 100);
+    });
+
+    expect(screen.getByText('Basemap unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Retry' }),
+    ).toBeInTheDocument();
+  });
+
+  it('2a. M consecutive basemap-source errors → renders the retry card', () => {
+    render(<MapCanvas observations={[]} />);
+    expect(capturedOnError).toBeTypeOf('function');
+
+    act(() => {
+      for (let i = 0; i < modConsts.BASEMAP_ERROR_THRESHOLD; i++) {
+        capturedOnError!(basemapErr(BASEMAP_SOURCE_ID));
+      }
+    });
+
+    expect(screen.getByText('Basemap unavailable')).toBeInTheDocument();
+  });
+
+  it('2b. M AbortErrors do NOT count → no card (clause-i benign swallow is never tallied)', () => {
+    render(<MapCanvas observations={[]} />);
+    expect(capturedOnError).toBeTypeOf('function');
+
+    act(() => {
+      // AbortError carries the basemap sourceId too, but name === 'AbortError'
+      // is clause (i) — debug-swallowed and NEVER counted.
+      for (let i = 0; i < modConsts.BASEMAP_ERROR_THRESHOLD + 3; i++) {
+        capturedOnError!(basemapErr(BASEMAP_SOURCE_ID, 'AbortError'));
+      }
+    });
+
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+  });
+
+  it('2c. a non-basemap source error does NOT count toward the basemap threshold', () => {
+    render(<MapCanvas observations={[]} />);
+    act(() => {
+      for (let i = 0; i < modConsts.BASEMAP_ERROR_THRESHOLD + 3; i++) {
+        capturedOnError!(basemapErr('observations'));
+      }
+    });
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+  });
+
+  it('3. Retry click → calls map.setStyle() with the current style URL and clears the card', () => {
+    deferMapLoad = true;
+    render(<MapCanvas observations={[]} />);
+    act(() => {
+      vi.advanceTimersByTime(modConsts.BASEMAP_WATCHDOG_MS + 100);
+    });
+    expect(screen.getByText('Basemap unavailable')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+
+    // Default (no data-theme) → light basemap URL.
+    expect(fakeMap.setStyle).toHaveBeenCalledWith(
+      modConsts.BASEMAP_LIGHT,
+    );
+    // Card is cleared on retry (the watchdog restarts; it hasn't elapsed again).
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+  });
+
+  it('3b. Retry uses the DARK style URL when [data-theme]="dark"', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    deferMapLoad = true;
+    render(<MapCanvas observations={[]} />);
+    act(() => {
+      vi.advanceTimersByTime(modConsts.BASEMAP_WATCHDOG_MS + 100);
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+    expect(fakeMap.setStyle).toHaveBeenCalledWith(modConsts.BASEMAP_DARK);
+  });
+
+  it('4. happy path: `load` fires → watchdog cancelled, no card ever renders', () => {
+    render(<MapCanvas observations={[]} />); // deferMapLoad false → onLoad fires on mount
+
+    act(() => {
+      vi.advanceTimersByTime(modConsts.BASEMAP_WATCHDOG_MS * 2);
+    });
+
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+  });
+
+  it('5. a `style.load` after a deferred mount cancels the watchdog (retry-success keys on style.load, not load)', () => {
+    deferMapLoad = true;
+    render(<MapCanvas observations={[]} />);
+    // Fire the first load so mapReady flips and the style.load listener registers.
+    act(() => {
+      deferredOnLoad?.();
+    });
+    // Simulate the basemap recovering via a style reload BEFORE the window ends.
+    act(() => {
+      (bareHandlersAll['style.load'] ?? []).forEach((cb) => cb());
+    });
+    act(() => {
+      vi.advanceTimersByTime(modConsts.BASEMAP_WATCHDOG_MS * 2);
+    });
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
+  });
+
+  it('6. one basemap error short of the threshold does NOT render the card', () => {
+    render(<MapCanvas observations={[]} />);
+    act(() => {
+      for (let i = 0; i < modConsts.BASEMAP_ERROR_THRESHOLD - 1; i++) {
+        capturedOnError!(basemapErr(BASEMAP_SOURCE_ID));
+      }
+    });
+    expect(screen.queryByText('Basemap unavailable')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -34,6 +34,7 @@ import { mergeLeafBuckets } from '../../data/bucket-aggregates.js';
 import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
 import { ObservationPopover } from './ObservationPopover.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
+import { StatusBlock } from '../ds/StatusBlock.js';
 // Marker render-tree dispatch extracted to two presentational layers
 // (epic #884 · U11 / #896). MapCanvas keeps every handler + derived state and
 // threads them as props; the layers hold no map ref and render only.
@@ -158,6 +159,32 @@ export function __resetAdaptiveGridCacheForTesting(): void {
  * `state-mask`) is never silenced.
  */
 export const BASEMAP_SOURCE_ID = 'openmaptiles';
+
+// #1049 (M-12) basemap-failure watchdog tuning.
+//
+// `BASEMAP_WATCHDOG_MS` — how long after mount (or a Retry) the basemap has to
+// report healthy (the maplibre `load` on first paint, `style.load` thereafter)
+// before the watchdog concludes the OpenFreeMap CDN has stalled and surfaces
+// the retry card. Kept at ~10 s deliberately: it must be comfortably longer
+// than a cold style+first-tile fetch on a slow connection (so a healthy-but-
+// slow load never false-positives), and — load-bearing for the test suite —
+// it must stay multi-second so the 3.5k-line MapCanvas suite (which runs REAL
+// timers) can never trip it. The watchdog tests use FAKE timers to advance it.
+export const BASEMAP_WATCHDOG_MS = 10_000;
+
+// `BASEMAP_ERROR_THRESHOLD` — M consecutive clause-(ii) basemap-source errors
+// (a flaky-CDN tile/network hiccup keyed on BASEMAP_SOURCE_ID) before the card
+// is surfaced. AbortErrors (clause i) are NEVER counted, and any successful
+// `style.load` resets the run to zero. A small M ride-throughs the odd
+// transient 429 but still reacts to a persistently-down CDN within a few
+// failed tile batches.
+export const BASEMAP_ERROR_THRESHOLD = 5;
+
+// Re-exported so the watchdog's Retry test can assert `setStyle` was called with
+// the exact current-theme URL without re-literaling the OpenFreeMap endpoints
+// (single source of truth = basemap-style.ts). These are pass-through aliases of
+// the basemap-style.ts exports already imported above.
+export { BASEMAP_LIGHT, BASEMAP_DARK } from './basemap-style.js';
 
 /**
  * The maplibre `error` event payload as react-map-gl surfaces it
@@ -374,6 +401,32 @@ export function MapCanvas({
    * can fire before the ref is live).
    */
   const [mapReady, setMapReady] = useState(false);
+
+  // ── #1049 (M-12) basemap-failure watchdog ────────────────────────────────
+  // OpenFreeMap CDN flakiness (ERR_CONNECTION_CLOSED/429 on tiles.openfreemap.org)
+  // can leave the basemap blank with NO `load`/`style.load` and no console
+  // error/warning — floating chrome over a silent void. `basemapFailed` drives
+  // the transient-layer tier-2 retry card (the four-corner anchor contract's
+  // transient surface — it mirrors the `.map-error-overlay` precedent). It is
+  // set by (a) a style-load timeout (neither `load` nor `style.load` within
+  // BASEMAP_WATCHDOG_MS of mount/Retry) or (b) BASEMAP_ERROR_THRESHOLD
+  // consecutive clause-(ii) basemap-source errors. AbortErrors (clause i) are
+  // NEVER counted (the #854 benign swallow is preserved verbatim).
+  const [basemapFailed, setBasemapFailed] = useState(false);
+  // `basemapHealthyRef` flips true the moment the basemap reports healthy — the
+  // first `load` (via handleLoad) and every `style.load` thereafter. The
+  // watchdog timer reads it on expiry so a healthy-but-slow load never trips
+  // the card. A ref (not state) because the timer closure must see the LIVE
+  // value without re-arming on every render.
+  const basemapHealthyRef = useRef(false);
+  // Consecutive clause-(ii) basemap-error tally. A ref so incrementing it does
+  // not re-render; it crosses the threshold → setBasemapFailed(true). Reset to
+  // zero on any successful `style.load` (the CDN recovered).
+  const basemapErrorCountRef = useRef(0);
+  // Bumped on each Retry to re-arm the watchdog effect (its dep). Starting the
+  // timer is idempotent w.r.t. mount; the epoch is the explicit re-trigger.
+  const [watchdogEpoch, setWatchdogEpoch] = useState(0);
+
   // State-artboard machinery (#760/#762/#763/#765/#849/#850 blank-map class) is
   // consolidated into `useStateArtboard` (`use-state-artboard.ts`, epic #884 ·
   // U13 / #898): the four mask/label-isolation effects, the `[data-theme]`
@@ -669,6 +722,12 @@ export function MapCanvas({
     if (!map) return;
     // Signal the reconciler effect that the map is mounted + ref-live.
     setMapReady(true);
+    // #1049: the first `load` IS the basemap reporting healthy — mark it so the
+    // watchdog timer (which reads this ref on expiry) cancels. `load` fires only
+    // once per map lifetime; subsequent recovery is signalled by `style.load`
+    // (wired in the dedicated effect below), per the #854 / load-once contract.
+    basemapHealthyRef.current = true;
+    basemapErrorCountRef.current = 0;
 
     // Test hook (Spider v2 e2e): exposes the maplibre instance for Playwright
     // to drive easeTo and inspect sources. Not relied on by production code.
@@ -839,6 +898,87 @@ export function MapCanvas({
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps -- obsLookupRef is a
   // stable ref; the click handler reads .current at call time, not capture time.
+  }, []);
+
+  // ── #1049 (M-12) watchdog timer ──────────────────────────────────────────
+  // Arms on mount and re-arms on each Retry (watchdogEpoch). If the basemap has
+  // not reported healthy (`basemapHealthyRef`) by BASEMAP_WATCHDOG_MS, surface
+  // the card. Real-timer-safe: the multi-second default never fires inside the
+  // suite's real-timer tests; the watchdog tests advance fake timers.
+  useEffect(() => {
+    // A prior success (or a Retry that already recovered) means nothing to watch.
+    if (basemapHealthyRef.current) return;
+    const timer = setTimeout(() => {
+      if (!basemapHealthyRef.current) {
+        setBasemapFailed(true);
+      }
+    }, BASEMAP_WATCHDOG_MS);
+    return () => clearTimeout(timer);
+  }, [watchdogEpoch]);
+
+  // ── #1049: `style.load` health signal ────────────────────────────────────
+  // `load` fires once per map lifetime (handleLoad), so basemap RECOVERY after a
+  // Retry's `setStyle` is signalled by `style.load` instead (reviewer addendum
+  // (2)). Registered once after mapReady (ref-read deps, like the artboard's own
+  // style.load listener); on each style reload it marks the basemap healthy,
+  // zeroes the error tally, and clears any showing failure card.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const onStyleLoad = () => {
+      basemapHealthyRef.current = true;
+      basemapErrorCountRef.current = 0;
+      setBasemapFailed(false);
+    };
+    map.on('style.load', onStyleLoad);
+    return () => {
+      map.off('style.load', onStyleLoad);
+    };
+  }, [mapReady]);
+
+  // ── #1049: error-counting handler ────────────────────────────────────────
+  // Wraps the exported `handleMapError` (which is UNCHANGED — same #854 console
+  // hygiene) with consecutive-failure counting. Only clause-(ii) basemap-source
+  // errors that are NOT AbortErrors tally; an AbortError (clause i) is benign
+  // camera-move noise and is never counted. Crossing BASEMAP_ERROR_THRESHOLD
+  // surfaces the card.
+  const handleMapErrorWithWatchdog = useCallback((e: MapErrorEvent) => {
+    const isBasemapTileFailure =
+      e.error?.name !== 'AbortError' && e.sourceId === BASEMAP_SOURCE_ID;
+    if (isBasemapTileFailure) {
+      basemapErrorCountRef.current += 1;
+      if (basemapErrorCountRef.current >= BASEMAP_ERROR_THRESHOLD) {
+        setBasemapFailed(true);
+      }
+    }
+    // Delegate logging verbatim to the unchanged #854 handler.
+    handleMapError(e);
+  }, []);
+
+  // ── #1049: Retry ─────────────────────────────────────────────────────────
+  // Re-fetch the basemap by re-setting the current-theme style. `setStyle` fires
+  // a fresh `style.load` — the artboard's own style.load listener
+  // (use-state-artboard.ts) re-applies label isolation + bumps styleEpoch, and
+  // our style.load health listener above marks the basemap healthy + clears the
+  // card. So Retry coordinates with the existing setStyle/styleEpoch machinery
+  // rather than racing it (reviewer addendum (1)): it routes through the SAME
+  // `style.load` re-apply path the [data-theme] swap uses. We optimistically
+  // clear the card and re-arm the watchdog so a still-dead CDN re-surfaces it.
+  const handleBasemapRetry = useCallback(() => {
+    const map = mapRef.current?.getMap();
+    const style =
+      typeof document !== 'undefined' &&
+      document.documentElement.getAttribute('data-theme') === 'dark'
+        ? BASEMAP_DARK
+        : BASEMAP_LIGHT;
+    basemapHealthyRef.current = false;
+    basemapErrorCountRef.current = 0;
+    setBasemapFailed(false);
+    // Guarded: if the map ref is somehow gone, the watchdog re-arm below still
+    // re-surfaces the card after the window (no silent dead-end).
+    map?.setStyle(style);
+    setWatchdogEpoch((n) => n + 1);
   }, []);
 
   /* Sprite registration (issue #246).
@@ -1721,7 +1861,12 @@ export function MapCanvas({
         // scope `fitBounds` fly. Passing this handler diverts that fallback, so
         // `handleMapError` re-surfaces genuine errors itself. See the handler's
         // doc comment + isBenignMapError for the narrow swallow predicate.
-        onError={handleMapError}
+        //
+        // #1049 (M-12): `handleMapErrorWithWatchdog` WRAPS that handler — it
+        // counts consecutive clause-(ii) basemap-source failures toward the
+        // retry-card threshold, then delegates logging to the UNCHANGED
+        // `handleMapError` (so the #854 console-hygiene contract is preserved).
+        onError={handleMapErrorWithWatchdog}
         attributionControl={false}
         // Fix 3b (PR #582 bot review): preserve the WebGL backbuffer when running
         // e2e tests so `readCanvasPixel` in basemap-dark-flip.spec.ts can sample
@@ -1918,6 +2063,31 @@ export function MapCanvas({
             ? { onDrillIn: () => handleDrillInToCenter(clusterList.drillCenter) }
             : {})}
         />
+      )}
+      {/* #1049 (M-12): basemap-failure retry card. Transient-layer tier-2
+          surface per the four-corner anchor contract — it mirrors the
+          `.map-error-overlay` precedent (App.tsx data-error overlay): a focused,
+          recoverable card floating over the still-mounted map, NOT a blocking
+          modal. Surfaced when the watchdog times out or M consecutive basemap-
+          source errors land. Retry re-sets the current-theme style and re-arms
+          the watchdog. Uses StatusBlock's first-class `action` prop — no
+          hand-rolled retry button. */}
+      {basemapFailed && (
+        <div
+          className="map-basemap-error"
+          role="dialog"
+          aria-modal="false"
+          aria-label="Basemap error"
+          data-testid="basemap-error-overlay"
+        >
+          <StatusBlock
+            state="error"
+            title="Basemap unavailable"
+            body="The map background failed to load. Your connection or the tile provider may be temporarily unavailable."
+            surface="overlay"
+            action={{ label: 'Retry', onClick: handleBasemapRetry }}
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -259,6 +259,43 @@ body {
   }
 }
 
+/* #1049 (M-12): basemap-failure retry card. Mirrors the .map-error-overlay
+   precedent above (same transient-layer tier-2 placement, same --z-rail tier,
+   same top/center inset and width cap) so a basemap failure and a data-fetch
+   failure read as the same recoverable affordance. Distinct class (not shared)
+   because the two can coexist (data error + basemap error) and because the
+   basemap card carries no dismiss button — there is nothing to dismiss to (a
+   blank map is not a usable state), only Retry. */
+.map-basemap-error {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(var(--card-maxw-identity, 360px), calc(100vw - 2 * var(--card-inset, 12px)));
+  background: var(--color-bg-surface);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-elevation-3);
+  z-index: var(--z-rail);
+  display: flex;
+  align-items: flex-start;
+}
+
+.map-basemap-error .status-block {
+  flex: 1;
+}
+
+/* On narrow phone viewports (≤ 440px) fill edge-to-edge with inset margins
+   while keeping true vertical center (translateY(-50%) from top:50%). */
+@media (max-width: 440px) {
+  .map-basemap-error {
+    left: var(--card-inset, 12px);
+    right: var(--card-inset, 12px);
+    top: 50%;
+    transform: translateY(-50%);
+    width: auto;
+  }
+}
+
 /* Skip-link (issue #247). WCAG 2.4.1 (Bypass Blocks) — keyboard users
    skip past the map canvas (which is intentionally NOT in the global tab
    order — a 344-marker tab sequence is hostile per UX/a11y review) to


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    [*] --> Watching: mount / Retry (arm 10s watchdog)
    Watching --> Healthy: load (first) OR style.load (recovery)
    Watching --> Failed: 10s elapse with no load/style.load
    Watching --> Failed: 5 consecutive basemap-source errors
    Healthy --> [*]
    Failed --> Watching: Retry — setStyle(theme URL), re-arm
    note right of Failed
        Retry card (StatusBlock action prop)
        "Basemap unavailable" + Retry
        transient tier-2, --z-rail
    end note
    note right of Watching
        AbortError (clause i) never tallies;
        any style.load zeroes the run
    end note
```

## Summary

- **Why:** a basemap failure (flaky OpenFreeMap CDN — `ERR_CONNECTION_CLOSED` / 429 on `tiles.openfreemap.org`) previously set no state — floating chrome over a silent blank void, nothing even at console-warning level, no recovery (finding M-12 / C76). The data-fetch path got a retry overlay (O7 #786); the basemap path — the dependency this repo documents as flaky — got nothing.
- **What:** a `basemapFailed` watchdog in `MapCanvas` fires (a) on a ~10s style-load timeout (neither `load` nor `style.load`) or (b) after 5 consecutive clause-(ii) basemap-source errors, and surfaces a transient tier-2 retry card. `AbortError` (clause i) is never counted — the #854 benign swallow and the exported `isBenignMapError`/`handleMapError` predicate are unchanged; counting **wraps** the `onError` wiring.
- **Recovery:** Retry re-sets the current-theme style (`BASEMAP_LIGHT`/`BASEMAP_DARK`), clears the card, and re-arms the watchdog. It routes through the same `style.load` re-apply path the `[data-theme]` swap uses (`use-state-artboard`'s setStyle/styleEpoch) rather than racing it; recovery keys on `style.load`, **not** `load` (which fires once per map lifetime). Per the two reviewer addenda on the issue.

## Screenshots

Captured live (Playwright MCP) against head `a1f9825`, **basemap-failure retry card** at all 5 canonical viewports × light/dark. Triggered by route-aborting `tiles.openfreemap.org`; after the ~10s style-load watchdog the `.map-basemap-error` card ("Basemap unavailable" + Retry, z-index 43) appears over the failed basemap while all four-corner chrome stays intact. **Recovery verified live:** un-aborting + clicking Retry clears the card and recovers the map without reload (`clicked:true, recovered:true`). Healthy load shows NO card (no false-fire) and console is clean.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![d1-390-light](https://github.com/user-attachments/assets/287bf915-bf50-4fd1-ae86-bdd89e711aad) | ![d1-390-dark](https://github.com/user-attachments/assets/2988098a-54f5-4541-8449-ae5577423638) |
| 768×1024 (tablet) | ![d1-768-light](https://github.com/user-attachments/assets/1fc65620-7607-4e3b-8f38-e2daa269d172) | ![d1-768-dark](https://github.com/user-attachments/assets/7a90061e-aba2-45e4-8fb9-1238fd377097) |
| 1024×768 (laptop) | ![d1-1024-light](https://github.com/user-attachments/assets/b15305c0-2955-4c69-8925-285c93d3bcc2) | ![d1-1024-dark](https://github.com/user-attachments/assets/73a8cd6c-dceb-444a-aedb-f3663d8e7624) |
| 1440×900 (desktop) | ![d1-1440-light](https://github.com/user-attachments/assets/ed427cf4-88ef-49d0-b03a-5e59d20ed88a) | ![d1-1440-dark](https://github.com/user-attachments/assets/d917fa90-9f8d-4371-8b12-3ea20aa1eb14) |
| 1920×1080 (wide) | ![d1-1920-light](https://github.com/user-attachments/assets/e9f8a72b-4b43-4c59-8070-3165e6073ad1) | ![d1-1920-dark](https://github.com/user-attachments/assets/0281307e-bd6a-4d48-beb5-ad04394b9a88) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule (`.map-basemap-error` added to `frontend/src/styles.css`; `scripts/check-orphan-classnames.sh` exits 0). `.status-block*` is owned by the `StatusBlock` primitive.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Test plan

- [x] `npx tsc -b frontend` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 1440 pass / 87 files (incl. 9 new watchdog cases + the untouched `#854` console-hygiene describe)
- [x] New unit tests added: timeout card, M-error card, AbortError-never-counts, non-basemap-source-never-counts, Retry `setStyle` (light + dark) + clear, happy-path cancel, `style.load`-recovery cancel, below-threshold no-card (fake timers; the rest of the suite runs real timers so the multi-second watchdog can never trip it)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx knip` — clean; `bash scripts/check-orphan-classnames.sh` — exit 0
- [x] (UI) Playwright MCP smoke — DONE: route-abort `tiles.openfreemap.org` → retry card appears after the watchdog; unblock + Retry recovers without reload; verified 390×844 + 1440×900 (+ 768/1024/1920), light + dark; healthy-load console clean.

## Plan reference

Part of Epic D (#1048), Wave 3 / D1. Finding M-12 (C76) from the 2026-06-11 full-app design review.

Closes #1049. Part of #1048 (Wave 3 / D1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

