### PR TITLE
fix(states): refetch busy dim, detail-error retry, landing CTA states, filters footer (#1051)

### DIFF
--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -168,15 +168,29 @@ describe('SpeciesDetailSurface', () => {
     expect(screen.getByText('Loading species details…')).toBeInTheDocument();
   });
 
-  it('shows error state on fetch failure', async () => {
+  it('shows error state on fetch failure, with a "Try again" action that recovers in place', async () => {
+    // C82 (#1051): the detail-rail error was a dead end (title-only StatusBlock).
+    // It now passes StatusBlock's first-class `action` prop so the user can
+    // recover without closing the rail and re-clicking the marker.
+    const getSpecies = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(VERMFLY);
     const client = makeClient({
-      getSpecies: vi.fn().mockRejectedValue(new Error('boom')),
+      getSpecies,
       getSilhouettes: vi.fn().mockResolvedValue([TYRANNIDAE_SILHOUETTE]),
     } as unknown as Partial<ApiClient>);
     render(<SpeciesDetailSurface speciesCode="vermfly" apiClient={client} />);
     await waitFor(() =>
       expect(screen.getByText('Could not load species details')).toBeInTheDocument()
     );
+    // The retry affordance is present (StatusBlock renders it as a button).
+    const retry = screen.getByRole('button', { name: 'Try again' });
+    // Clicking it refetches; on success the surface renders the species in place.
+    fireEvent.click(retry);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Vermilion Flycatcher' })).toBeInTheDocument()
+    );
+    expect(getSpecies).toHaveBeenCalledTimes(2);
   });
 
   // eBird API ToU §3 attribution moved to the app-level AttributionModal

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -48,7 +48,7 @@ export interface SpeciesDetailSurfaceProps {
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   const { speciesCode, apiClient, revealed = true } = props;
   const detail = useSpeciesDetail(apiClient, speciesCode);
-  const { loading, error, data } = detail;
+  const { loading, error, data, retry } = detail;
   // useSilhouettes provides the family-color payload. The data is cached at
   // module level so there is no second network call when other consumers
   // (App.tsx, AttributionModal) have already called the hook.
@@ -152,11 +152,16 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   }
 
   if (error) {
+    // C82 (#1051): give the detail-rail error a recovery path. `retry()`
+    // re-runs the fetch in place (no rail close + marker re-click). Mirrors
+    // the app-level data-error overlay, which already uses StatusBlock's
+    // first-class `action` prop.
     return (
       <StatusBlock
         state="error"
         title="Could not load species details"
         surface="panel"
+        action={{ label: 'Try again', onClick: retry }}
       />
     );
   }

--- a/frontend/src/data/use-species-detail.test.ts
+++ b/frontend/src/data/use-species-detail.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useSpeciesDetail, __resetSpeciesDetailCache } from './use-species-detail.js';
 import { ApiClient } from '../api/client.js';
 import type { SpeciesMeta } from '@bird-watch/shared-types';
@@ -30,7 +30,12 @@ describe('useSpeciesDetail', () => {
     const client = makeClient({ getSpecies } as unknown as Partial<ApiClient>);
 
     const { result } = renderHook(() => useSpeciesDetail(client, null));
-    expect(result.current).toEqual({ loading: false, error: null, data: null });
+    // C82 (#1051): the hook now also returns a `retry` callback so a failed
+    // detail fetch can be re-attempted in place. The state shape stays
+    // { loading, error, data }; assert those explicitly and assert `retry`
+    // is a function separately (a shape pin, not a behavior pin).
+    expect(result.current).toMatchObject({ loading: false, error: null, data: null });
+    expect(typeof result.current.retry).toBe('function');
     expect(getSpecies).not.toHaveBeenCalled();
   });
 
@@ -165,6 +170,29 @@ describe('useSpeciesDetail', () => {
     rerender({ code: null });
     rerender({ code: 'vermfly' });
     await waitFor(() => expect(result.current.data).toEqual(VERMFLY));
+    expect(getSpecies).toHaveBeenCalledTimes(2);
+  });
+
+  // C82 (#1051): calling the returned `retry()` re-runs the fetch in place —
+  // no close/reopen of the panel required. Failures are never cached
+  // (only `.set()` on success), so re-running the effect refetches.
+  it('retry() re-runs the fetch in place and recovers after a transient failure', async () => {
+    const getSpecies = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(VERMFLY);
+    const client = makeClient({ getSpecies } as unknown as Partial<ApiClient>);
+
+    const { result } = renderHook(() => useSpeciesDetail(client, 'vermfly'));
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    expect(result.current.data).toBeNull();
+    expect(getSpecies).toHaveBeenCalledTimes(1);
+
+    // Retry without changing speciesCode — the effect re-runs via the nonce.
+    act(() => {
+      result.current.retry();
+    });
+    await waitFor(() => expect(result.current.data).toEqual(VERMFLY));
+    expect(result.current.error).toBeNull();
     expect(getSpecies).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/data/use-species-detail.ts
+++ b/frontend/src/data/use-species-detail.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { ApiClient } from '../api/client.js';
 import type { SpeciesMeta } from '@bird-watch/shared-types';
 
@@ -6,6 +6,13 @@ export interface SpeciesDetailState {
   loading: boolean;
   error: Error | null;
   data: SpeciesMeta | null;
+  /**
+   * C82 (#1051): re-run the fetch in place for the current `speciesCode`
+   * without closing/reopening the panel. A no-op while `speciesCode` is null.
+   * Failures are never cached (the module cache is only `.set()` on success),
+   * so bumping the internal nonce re-runs the effect and refetches cleanly.
+   */
+  retry: () => void;
 }
 
 /**
@@ -48,11 +55,20 @@ export function useSpeciesDetail(
   client: ApiClient,
   speciesCode: string | null,
 ): SpeciesDetailState {
-  const [state, setState] = useState<SpeciesDetailState>({
+  const [state, setState] = useState<{
+    loading: boolean;
+    error: Error | null;
+    data: SpeciesMeta | null;
+  }>({
     loading: false,
     error: null,
     data: null,
   });
+
+  // C82 (#1051): retry nonce. Bumping it re-runs the effect (it's a dep)
+  // for the SAME speciesCode — recovering a failed detail fetch in place.
+  const [retryNonce, setRetryNonce] = useState(0);
+  const retry = useCallback(() => setRetryNonce((n) => n + 1), []);
 
   useEffect(() => {
     // Null code — panel closed / no selection. Surface a clean resting state.
@@ -96,7 +112,8 @@ export function useSpeciesDetail(
       });
 
     return () => { cancelled = true; };
-  }, [client, speciesCode]);
+    // `retryNonce` is a dep so retry() re-runs this effect for the same code.
+  }, [client, speciesCode, retryNonce]);
 
-  return state;
+  return { ...state, retry };
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -132,6 +132,22 @@ body {
   z-index: var(--z-map);
 }
 
+/* C80 (#1051): visible in-flight affordance for non-blocking refetches.
+   `#map-layer` carries aria-busy={observationsLoading} (App.tsx) — it stays
+   the SOLE aria-busy node (invariant). Before this rule the busy state was
+   invisible to sighted users (no [aria-busy] CSS existed anywhere): toggling
+   "Notable only" on a slow connection kept the full stale marker set with no
+   affordance. We dim ONLY the stale marker overlay (each react-map-gl <Marker>
+   is a `.maplibregl-marker` DOM element) — NOT the basemap canvas
+   (`.maplibregl-canvas`) — so the map reads as "refreshing" without going
+   blank, then the markers snap back to full opacity when the new data lands.
+   transition smooths both directions; the global motion.css reduced-motion
+   guard zeroes the duration so reduced-motion users get the end-state instantly. */
+#map-layer[aria-busy="true"] .maplibregl-marker {
+  opacity: 0.45;
+  transition: opacity var(--dur-fast) ease;
+}
+
 /* Main surface. The map chain was removed in the DISCARD wave (#113); the map
    was hoisted into `#map-layer` in the #761 (S2) shell inversion. `<main>` is
    retained as the e2e readiness gate (data-render-complete), the scroll-bypass
@@ -897,7 +913,11 @@ body {
   gap: var(--space-lg);
   padding: var(--space-md) var(--space-lg);
   background: var(--color-bg-surface);
-  border-bottom: 1px solid var(--color-border-ui);
+  /* V25 (#1051): the `border-bottom` was a vestige of the old in-flow top-bar
+     life. FiltersBar's sole consumer is now the floating `.filters-panel`
+     (App.tsx), where the hairline rendered full-width above ~20px of empty
+     card — reading as a cut-off footer slot. No rule may separate content
+     from empty space, so it's removed. */
   align-items: center;
   flex-wrap: wrap;
 }
@@ -3148,6 +3168,23 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border: 1px solid var(--color-text-strong);
   border-radius: 4px;
   cursor: pointer;
+  /* C83 (#1051): smooth the hover/active fill-shift. */
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+}
+/* C83 (#1051): the highest-intent click in the app had no hover/active — it
+   read as inert. The base fill is the dark `--color-text-strong` (#1a1a1a
+   light) with a white label, so the `.status-block__action` surface-tint hover
+   doesn't apply; these need explicit fill-shift hexes. Light-theme values
+   (label = #fff): hover #333333 → 12.63:1, active #000 → 21.0:1, both far past
+   AA. Dark-theme overrides (label flipped to --color-bg-surface) live in the
+   [data-theme="dark"] block below. */
+.zip-input__submit:hover {
+  background: #333333;
+  border-color: #333333;
+}
+.zip-input__submit:active {
+  background: #000000;
+  border-color: #000000;
 }
 .zip-input__submit:focus-visible {
   outline: 2px solid var(--color-text-strong);
@@ -3170,6 +3207,24 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    AA. :not(:disabled) leaves .scope-control__go:disabled's muted color alone. */
 [data-theme="dark"] .scope-control__go:not(:disabled) {
   color: var(--color-bg-surface);
+}
+/* C83 (#1051) dark-mode hover/active: the light-theme rules above set DARK
+   fills (#333333/#000000), correct for the light dark-on-white CTA but wrong
+   in dark mode, where the button is a LIGHT fill with a DARK label. Override
+   to LIGHTER fills so the flipped dark label (--color-bg-surface #1b2742)
+   stays readable: hover #e4e8f0 → 12.08:1, active #ffffff → 14.84:1, both far
+   past AA. Mirrors the label-flip above — one place covers both #827 buttons
+   so they can't drift. `:not(:disabled)` on the chooser keeps the muted
+   disabled state inert. */
+[data-theme="dark"] .zip-input__submit:hover,
+[data-theme="dark"] .scope-chooser__btn:not(:disabled):hover {
+  background: #e4e8f0;
+  border-color: #e4e8f0;
+}
+[data-theme="dark"] .zip-input__submit:active,
+[data-theme="dark"] .scope-chooser__btn:not(:disabled):active {
+  background: #ffffff;
+  border-color: #ffffff;
 }
 .zip-input__status {
   margin: 0;
@@ -3385,6 +3440,20 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border: 1px solid var(--color-text-strong);
   border-radius: 4px;
   cursor: pointer;
+  /* C83 (#1051): smooth the hover/active fill-shift. */
+  transition: background var(--dur-fast), border-color var(--dur-fast);
+}
+/* C83 (#1051): hover/active on the chooser commit CTA. Same fill-shift hexes
+   and ratios as .zip-input__submit (the two are duplicated-to-match, #827 AC).
+   `:not(:disabled)` keeps the muted .scope-chooser__btn:disabled state inert —
+   a disabled button must not respond to hover/active. */
+.scope-chooser__btn:not(:disabled):hover {
+  background: #333333;
+  border-color: #333333;
+}
+.scope-chooser__btn:not(:disabled):active {
+  background: #000000;
+  border-color: #000000;
 }
 .scope-chooser__btn:focus-visible {
   outline: 2px solid var(--color-text-strong);

--- a/frontend/src/styles.d3-state-polish.test.ts
+++ b/frontend/src/styles.d3-state-polish.test.ts
@@ -1,0 +1,136 @@
+/**
+ * D3 — visible-state polish CSS conformance (#1051, epic #1048)
+ *
+ * String-based assertions over styles.css (same pattern as
+ * styles/tokens.css.test.ts) pinning the three CSS-only fixes in D3:
+ *
+ *   - C80: a visible in-flight affordance keyed off the existing
+ *     `#map-layer[aria-busy="true"]` state. No `[aria-busy]` rule existed
+ *     before this change, so the non-blocking refetch was invisible to
+ *     sighted users. `#map-layer` stays the sole aria-busy node — the rule
+ *     dims the stale `.maplibregl-marker` overlay only (NOT the basemap
+ *     canvas), so the map reads as "refreshing" without going blank.
+ *   - C83: hover/active states on the two dark-fill landing CTAs
+ *     (`.zip-input__submit`, `.scope-chooser__btn`), light + dark. Hexes
+ *     are the issue-Contract values, each ≥4.5:1 AA in both themes
+ *     (verified in the contrast block below).
+ *   - V25: the trailing `border-bottom` on `.filters-bar` is gone — inside
+ *     the floating `.filters-panel` it rendered as a hairline above an
+ *     empty strip (a phantom cut-off footer).
+ *
+ * Issue: #1051. Part of #1048 (D3).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { contrastRatio } from './utils/wcag-contrast.js';
+
+const STYLES_CSS = readFileSync(
+  join(import.meta.dirname, 'styles.css'),
+  'utf8',
+);
+
+/** Pull the body of the FIRST `selector { ... }` block (no nested braces). */
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 's');
+  const m = css.match(re);
+  return m?.[1] ?? '';
+}
+
+describe('D3 state polish — styles.css conformance', () => {
+  describe('C80 — visible refetch busy affordance', () => {
+    it('defines a rule scoped to #map-layer[aria-busy="true"]', () => {
+      expect(STYLES_CSS).toMatch(/#map-layer\[aria-busy="true"\]/);
+    });
+
+    it('dims the marker overlay (.maplibregl-marker), not the basemap canvas', () => {
+      // The rule targets the marker layer so the stale markers fade during a
+      // refetch; the basemap (.maplibregl-canvas) must NOT be matched, else the
+      // whole map blinks.
+      const busyBlock = ruleBody(
+        STYLES_CSS,
+        '#map-layer[aria-busy="true"] .maplibregl-marker',
+      );
+      expect(busyBlock).not.toBe('');
+      // The affordance is an opacity dim.
+      expect(busyBlock).toMatch(/opacity:/);
+      // Never dim the basemap canvas directly.
+      expect(STYLES_CSS).not.toMatch(
+        /#map-layer\[aria-busy="true"\]\s+\.maplibregl-canvas\s*\{/,
+      );
+    });
+
+    it('transitions opacity so the dim is not an instant flash', () => {
+      const busyBlock = ruleBody(
+        STYLES_CSS,
+        '#map-layer[aria-busy="true"] .maplibregl-marker',
+      );
+      expect(busyBlock).toMatch(/transition:/);
+    });
+  });
+
+  describe('C83 — landing CTA hover/active states', () => {
+    for (const sel of ['.zip-input__submit', '.scope-chooser__btn']) {
+      const escaped = sel.replace('.', '\\.');
+      // The chooser button qualifies hover/active with :not(:disabled) so the
+      // muted disabled state stays inert; allow any pseudo-class chain between
+      // the base selector and :hover/:active.
+      it(`${sel} defines a :hover rule`, () => {
+        expect(STYLES_CSS).toMatch(new RegExp(`${escaped}(:[a-z-]+(\\([^)]*\\))?)*:hover`));
+      });
+      it(`${sel} defines an :active rule`, () => {
+        expect(STYLES_CSS).toMatch(new RegExp(`${escaped}(:[a-z-]+(\\([^)]*\\))?)*:active`));
+      });
+    }
+
+    it('uses the Contract light-theme hover/active fills (#333333, #000000)', () => {
+      const hover = ruleBody(STYLES_CSS, '.zip-input__submit:hover');
+      const active = ruleBody(STYLES_CSS, '.zip-input__submit:active');
+      expect(hover).toMatch(/#333333/i);
+      expect(active).toMatch(/#000000|#000\b/i);
+    });
+
+    it('uses the Contract dark-theme hover/active fills (#e4e8f0, #ffffff)', () => {
+      // Dark-mode overrides live under [data-theme="dark"] selectors.
+      expect(STYLES_CSS).toMatch(
+        /\[data-theme="dark"\][^{]*\.zip-input__submit:hover/,
+      );
+      expect(STYLES_CSS).toMatch(/#e4e8f0/i);
+      expect(STYLES_CSS).toMatch(
+        /\[data-theme="dark"\][^{]*\.zip-input__submit:active/,
+      );
+    });
+
+    it('every state label/fill pair clears the 4.5:1 AA floor in BOTH themes', () => {
+      // Light: label = #fff (--color-text-white). Dark: label = #1b2742
+      // (--color-bg-surface, the dark-mode flip).
+      const LIGHT_LABEL = '#ffffff';
+      const DARK_LABEL = '#1b2742';
+      // Light fills: base #1a1a1a, hover #333333, active #000000.
+      for (const fill of ['#1a1a1a', '#333333', '#000000']) {
+        expect(contrastRatio(fill, LIGHT_LABEL)).toBeGreaterThanOrEqual(4.5);
+      }
+      // Dark fills: base #f5f7fb, hover #e4e8f0, active #ffffff.
+      for (const fill of ['#f5f7fb', '#e4e8f0', '#ffffff']) {
+        expect(contrastRatio(fill, DARK_LABEL)).toBeGreaterThanOrEqual(4.5);
+      }
+    });
+
+    it(':disabled stays inert (no hover/active fill-shift overriding it)', () => {
+      // The chooser button keeps its muted :disabled rule. Hover/active must
+      // not clobber the disabled state — guard the source by asserting the
+      // :disabled rule still sets the muted color.
+      const disabled = ruleBody(STYLES_CSS, '.scope-chooser__btn:disabled');
+      expect(disabled).toMatch(/--color-text-muted/);
+    });
+  });
+
+  describe('V25 — filters panel trailing hairline removed', () => {
+    it('.filters-bar no longer carries a border-bottom', () => {
+      const bar = ruleBody(STYLES_CSS, '.filters-bar');
+      expect(bar).not.toBe('');
+      expect(bar).not.toMatch(/border-bottom:/);
+    });
+  });
+});


### PR DESCRIPTION
## Diagrams

State-flow for the two behavior-affecting fixes (C80 busy-dim, C82 detail-error retry). C83 and V25 are pure CSS resting-state changes.

```mermaid
sequenceDiagram
    participant U as User
    participant ML as "#map-layer (aria-busy)"
    participant M as "Markers (.maplibregl-marker)"
    participant H as useSpeciesDetail
    participant API as Read API

    Note over U,M: C80 — refetch (e.g. "Notable only" toggle)
    U->>ML: toggle filter
    ML->>ML: aria-busy="true" (observationsLoading)
    ML->>M: dim opacity 0.45 (stale markers fade)
    API-->>ML: fresh data
    ML->>ML: aria-busy="false"
    ML->>M: opacity 1 (snap back)

    Note over U,API: C82 — detail-rail error recovery
    U->>H: open species detail
    H->>API: GET /api/species/:code
    API-->>H: 500 (error, NOT cached)
    H-->>U: StatusBlock error + "Try again"
    U->>H: click "Try again" (retry nonce++)
    H->>API: GET /api/species/:code (re-run effect)
    API-->>H: 200
    H-->>U: species renders in place
```

## Summary

- **Why C80:** refetches are correctly non-blocking, but the only sighted signal was 13px of corner text — no `[aria-busy]` CSS existed anywhere. A `#map-layer[aria-busy="true"] .maplibregl-marker` opacity dim fades the *stale markers only* (never the basemap canvas), so the map reads as "refreshing." `#map-layer` stays the sole `aria-busy` node.
- **Why C82:** the desktop detail-rail error was a dead end (title-only `StatusBlock` — recovery meant closing the rail and re-clicking the marker). `useSpeciesDetail` now exposes `retry()` (a nonce in the effect deps; failures are never cached so re-running refetches), wired to the error `StatusBlock`'s first-class `action` prop as "Try again."
- **Why C83 / V25:** the two highest-intent landing CTAs had only `:focus-visible` (read as inert) — added `:hover`/`:active` fill-shifts, AA-clear in both themes; and the vestigial `.filters-bar` `border-bottom` rendered as a phantom cut-off footer inside the floating panel — removed.

## Screenshots

Captured live (Playwright MCP) against head `1bcd2b7`, **species detail open** (rail on desktop / sheet on mobile) at all 5 canonical viewports × light/dark. Console clean on normal load.

Live-verified at head `1bcd2b7`: **C82** — route-aborting the species-detail fetch surfaces "Could not load species details" + a **"Try again"** button; un-aborting + clicking it **recovers** (Bald Eagle detail loads). C80 (busy-dim scope), C83 (CTA `:hover`/`:active` fill-shifts, AA-clear both themes) and V25 (`.filters-bar` border removal) are pinned by the new `styles.d3-state-polish.test.ts` CSS-conformance test (hover/active hexes + computed AA ratios).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![d3-390-light](https://github.com/user-attachments/assets/79c649b6-c62b-4edd-826f-f4601da31f26) | ![d3-390-dark](https://github.com/user-attachments/assets/b35a51fa-d8e7-47be-9789-3fe994b2bdc5) |
| 768×1024 (tablet) | ![d3-768-light](https://github.com/user-attachments/assets/1b60bc11-a769-4722-940d-8172c20d248f) | ![d3-768-dark](https://github.com/user-attachments/assets/ff00c0d4-d85a-43f5-b735-f36a908ec930) |
| 1024×768 (laptop) | ![d3-1024-light](https://github.com/user-attachments/assets/28daf1eb-edd0-494b-a950-aac4726855b3) | ![d3-1024-dark](https://github.com/user-attachments/assets/2735a0e0-b5d7-4994-915f-7e9fed1730bf) |
| 1440×900 (desktop) | ![d3-1440-light](https://github.com/user-attachments/assets/aef830e5-79f5-4768-acfc-901f5cdbba28) | ![d3-1440-dark](https://github.com/user-attachments/assets/d3ad138d-107b-41b1-b2bd-95257cdfff46) |
| 1920×1080 (wide) | ![d3-1920-light](https://github.com/user-attachments/assets/5afae67f-8247-4ebc-84f5-935d84b3276d) | ![d3-1920-dark](https://github.com/user-attachments/assets/eca46dd0-cfb7-4b1c-839c-fd562decef7d) |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule — N/A: no new classNames; all changes are `:state` rules on existing classes (`.zip-input__submit`, `.scope-chooser__btn`) + library-owned `.maplibregl-marker`, plus one rule removal.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

**Design QA:** pending ui-design:ui-designer (W.3)

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — green (88 files / 1444 tests)
- [x] New/updated unit tests: `SpeciesDetailSurface.test.tsx` (error → "Try again" → recovers), `use-species-detail.test.ts` (retry behavior + updated shape pin), new `styles.d3-state-polish.test.ts` (busy-dim scope, hover/active hexes + AA ratios via `contrastRatio()`, filters-bar border removal)
- [x] `npm run build --workspace @bird-watch/frontend` — clean (pre-existing chunk-size warning only)
- [x] `npx knip` — clean (exit 0); `bash scripts/check-orphan-classnames.sh` — clean (exit 0)
- [x] e2e `species-detail.spec.ts` (17 passed, incl. detail error + zero console errors/warnings) + `filters.spec.ts` (9 passed) on `--project=dev-server`
- [x] (UI) Playwright MCP smoke — DONE at head `1bcd2b7`: C82 retry verified live (error → Try again → recovers); detail surface clean 5 viewports × 2 themes; console clean.

## Plan reference

Closes #1051. Part of #1048 (Wave 3 / D3).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

