### PR TITLE
fix(identity-card): scope auto-collapse + nowrap links + ::before middot (#1057)

### DIFF
--- a/frontend/e2e/scope-disclosure.spec.ts
+++ b/frontend/e2e/scope-disclosure.spec.ts
@@ -86,8 +86,15 @@ test.describe('Scope disclosure (#828)', () => {
     // The count-only lede is visible (region + window dropped, #828).
     // #1047: lede always reports sightings.
     await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
-    // The visible region rides in the wordmark line exactly once.
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
+    // The visible region rides in the wordmark line exactly once. #1057: the
+    // "· " separator is painted by `.brand-region::before` (CSS) so the element
+    // text node is JUST the region name; the visible dot is asserted via the
+    // pseudo-element's resolved `content` (textContent excludes ::before).
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('Arizona');
+    const dotContent = await app.appHeader
+      .locator('.brand-region')
+      .evaluate((el) => getComputedStyle(el, '::before').content);
+    expect(dotContent).toContain('·');
 
     // The disclosure trigger is present and collapsed.
     await expect(app.scopeDisclosureTrigger).toBeVisible();
@@ -255,5 +262,40 @@ test.describe('Scope disclosure (#828)', () => {
     // The URL round-trips to the new scope (the persisted action — unlike the
     // disclosure open/closed state, which is component-local, not in the URL).
     await expect(page).toHaveURL(/[?&]state=US-FL\b/);
+  });
+
+  // ── E5 (#1057): auto-collapse on surface-takeover / commit ───────────────
+  // Spec §5.1 COMPACT: at most one expanded surface. The disclosure collapses
+  // when the state selection COMMITS (the user is done choosing) and when the
+  // Filters sheet takes over. The PRESERVED no-click-outside rule (a stray map
+  // click keeps it open, asserted above) is a different intent than these.
+
+  test('#1057: the disclosure auto-collapses after a successful state commit', async ({ page, apiStub }) => {
+    const app = await setup(page, apiStub);
+
+    await app.openScopeDisclosure();
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Commit a state switch via the #1035 explicit-Go path (POM helper).
+    await app.switchStateViaScopeControl('US-FL');
+
+    // The scope round-trips AND the disclosure collapses (the commit is "done").
+    await expect(page).toHaveURL(/[?&]state=US-FL\b/);
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(app.scopeControlStateSelect).toBeHidden();
+  });
+
+  test('#1057: the disclosure auto-collapses when the Filters sheet opens', async ({ page, apiStub }) => {
+    const app = await setup(page, apiStub);
+
+    await app.openScopeDisclosure();
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Opening Filters is a surface-takeover intent (≠ a stray map click): the
+    // scope disclosure collapses so two expanded surfaces are never up at once.
+    await app.filtersTrigger.click();
+
+    await expect(app.scopeDisclosureTrigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(app.scopeControlStateSelect).toBeHidden();
   });
 });

--- a/frontend/e2e/state-scope.spec.ts
+++ b/frontend/e2e/state-scope.spec.ts
@@ -309,7 +309,9 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // The region ("Arizona", resolved from the /api/states name table) now reads
     // in the wordmark line, and the lede is just the count.
     // #1047: lede always reports sightings regardless of aggregation mode.
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
+    // #1057: the "· " separator is now a `.brand-region::before` (CSS), so the
+    // element's text node is JUST the resolved region name (no literal dot).
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('Arizona');
     await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
 
     // O9 (#781): the scope-pick warmed the MapCanvas/maplibre chunk — at least
@@ -357,7 +359,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.mapCanvas).toBeVisible();
 
     // #828: region "USA" now reads in the wordmark line; the lede is count-only.
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· USA');
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('USA');
 
     // Data invariant (#735): ?scope=us sends NO state= — byte-for-byte the
     // unscoped national query. Every observations request must omit state=.
@@ -420,7 +422,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // ?state wins; the ?zip is not a scope and is dropped from the resolution.
     expect(app.getUrlParams().get('state')).toBe('US-AZ');
     // #828: AZ rendered → region in the wordmark line; lede is count-only.
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('Arizona');
     expect(obsRequests.length).toBeGreaterThan(0);
     for (const url of obsRequests) {
       expect(new URL(url).searchParams.get('state')).toBe('US-AZ');
@@ -512,7 +514,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     // (b) The lede repopulates and NEVER sticks on the empty copy.
     await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Florida');
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('Florida');
 
     // (c) The LAST /api/observations carrying state=US-FL has a bbox tightly
     // matching the FL envelope (the render-phase reseed value) — NOT the stale
@@ -547,7 +549,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-NY');
     await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· New York');
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('New York');
 
     await expect.poll(() => lastBboxForState(obsRequests, 'US-NY') !== null).toBe(true);
     const nyBbox = lastBboxForState(obsRequests, 'US-NY')!;
@@ -578,7 +580,7 @@ test.describe('Scope chooser + state/whole-US scope (C9, #741)', () => {
     await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
     await expect(app.mapLede).toHaveText(/^\d+ sightings$/);
     await expect(app.mapLede).not.toHaveText(/No recent sightings/);
-    await expect(app.appHeader.locator('.brand-region')).toHaveText('· Arizona');
+    await expect(app.appHeader.locator('.brand-region')).toHaveText('Arizona');
 
     await expect.poll(() => lastBboxForState(obsRequests, 'US-AZ') !== null).toBe(true);
     const azBbox = lastBboxForState(obsRequests, 'US-AZ')!;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1522,7 +1522,8 @@ describe('#740 (C6): scope wiring end-to-end', () => {
     render(<App />);
     // The AppHeader wordmark / region-name row names the region — the resolved
     // "Arizona" name, not the bare "US-AZ" code. Check the identity card.
-    // .brand-region contains " · Arizona" (note space + dot); use a regex match.
+    // #1057: the "· " separator now lives in `.brand-region::before` (CSS), so
+    // the element's text node is just the region name ("Arizona").
     await screen.findByText(/Arizona/i, { selector: '.brand-region' });
     expect(screen.queryByText(/US-AZ/, { selector: '.brand-region' })).toBeNull();
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1261,6 +1261,11 @@ export function App() {
         filterCount={filterCount}
         onOpenFilters={() => setFiltersOpen(true)}
         filtersOpen={filtersOpen}
+        // E5 (#1057): the `?detail=` presence boolean — drives the scope
+        // disclosure's auto-collapse when a species-detail surface takes over
+        // (spec §5.1 COMPACT: at most one expanded surface). Same derivation
+        // (`!!state.detail`) used for the compact sheet-open signal above.
+        detailOpen={!!state.detail}
         filtersTriggerRef={filtersTriggerRef}
         onOpenAttribution={onOpenAttribution}
         ledeText={ledeText}

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -11,6 +11,10 @@ const baseProps = {
   // O4 (#780): filtersOpen drives aria-expanded on the trigger;
   // filtersTriggerRef is forwarded to the button for focus restoration.
   filtersOpen: false,
+  // E5 (#1057): detail-open signal (App derives it from `?detail=` presence).
+  // Drives the scope-disclosure auto-collapse so at most one expanded surface
+  // is up at a time (spec §5.1 COMPACT).
+  detailOpen: false,
   filtersTriggerRef: createRef<HTMLButtonElement>(),
   onOpenAttribution: vi.fn(),
   ledeText: null as string | null,
@@ -212,6 +216,85 @@ describe('<AppHeader>', () => {
     await userEvent.click(screen.getByRole('button', { name: 'outside' }));
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
     expect(document.querySelector('.app-header-scope-rows')).toHaveAttribute('data-open', 'true');
+  });
+
+  // ── Scope-disclosure auto-collapse (E5 #1057) ────────────────────────────
+  // Spec §5.1 COMPACT: at most one expanded surface. The disclosure collapses
+  // when another surface takes over (Filters opens, a detail sheet opens) or
+  // when a state selection commits. The deliberate no-click-outside rule is
+  // PRESERVED (a Filters tap is a different intent than a stray map click).
+
+  it('collapses the disclosure on the RISING edge of filtersOpen (#1057)', async () => {
+    const { rerender } = render(<AppHeader {...baseProps} {...stateProps} filtersOpen={false} />);
+    const trigger = screen.getByRole('button', { name: /change region/i });
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Filters opens (e.g. a Filters tap) → the scope disclosure collapses so the
+    // two surfaces are never up simultaneously.
+    rerender(<AppHeader {...baseProps} {...stateProps} filtersOpen={true} />);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('.app-header-scope-rows')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('does NOT slam shut a fresh re-open while filtersOpen stays true (rising edge only) (#1057)', async () => {
+    // Only the rising edge collapses. Once filtersOpen is already true, the user
+    // can re-open the disclosure (e.g. Filters got dismissed then re-tapped, or
+    // the user deliberately re-opens scope) without it being yanked shut on the
+    // next unrelated re-render.
+    const { rerender } = render(<AppHeader {...baseProps} {...stateProps} filtersOpen={true} />);
+    const trigger = screen.getByRole('button', { name: /change region/i });
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    // An unrelated re-render with filtersOpen STILL true must not collapse it.
+    rerender(<AppHeader {...baseProps} {...stateProps} filtersOpen={true} filterCount={2} />);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses the disclosure on the RISING edge of detailOpen (#1057)', async () => {
+    const { rerender } = render(<AppHeader {...baseProps} {...stateProps} detailOpen={false} />);
+    const trigger = screen.getByRole('button', { name: /change region/i });
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // A detail sheet/rail opens (?detail= appears) → the scope disclosure collapses.
+    rerender(<AppHeader {...baseProps} {...stateProps} detailOpen={true} />);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('.app-header-scope-rows')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('collapses the disclosure after a successful state selection (onPickState) (#1057)', async () => {
+    const onPickState = vi.fn();
+    render(<AppHeader {...baseProps} {...stateProps} onPickState={onPickState} />);
+    const trigger = screen.getByRole('button', { name: /change region/i });
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Stage a different state and commit via Go (the #1035 explicit-commit path).
+    // Scope the Go button to the state form (the ZipInput also renders a "Go").
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: /switch state/i }),
+      'US-AZ',
+    );
+    const stateGo = document.querySelector<HTMLButtonElement>('.scope-control__go')!;
+    await userEvent.click(stateGo);
+
+    // The commit still flows to the parent…
+    expect(onPickState).toHaveBeenCalledWith('US-AZ');
+    // …and the disclosure collapses (the commit is the user's "done" signal).
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('.app-header-scope-rows')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('renders exactly one middot in the wordmark — the brand-region carries no literal "·" text node (#1057)', () => {
+    // The separator is painted via `.brand-region::before` (CSS), so the JSX
+    // text node must NOT also carry a literal "· " (else the dot doubles). The
+    // visible "·" comes from CSS content, invisible to textContent.
+    render(<AppHeader {...baseProps} region="Arizona" />);
+    const brandRegion = document.querySelector('.brand-region')!;
+    // The DOM text node is just the region name — no literal middot.
+    expect(brandRegion.textContent).toBe('Arizona');
+    expect(brandRegion.textContent).not.toContain('·');
   });
 
   // ── Filters trigger ─────────────────────────────────────────────────────

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -94,6 +94,13 @@ export interface AppHeaderProps {
    */
   filtersOpen: boolean;
   /**
+   * Whether a species detail surface (sheet/rail) is open — App derives this
+   * from `?detail=` presence (`!!state.detail`). E5 (#1057): drives the scope
+   * disclosure's auto-collapse so a detail surface taking over closes the
+   * expanded scope card (spec §5.1 COMPACT — at most one expanded surface).
+   */
+  detailOpen: boolean;
+  /**
    * Ref forwarded to the Filters trigger button. App.tsx holds this so it can
    * restore focus to the trigger when the filters sheet is dismissed (O4 #780).
    * The button is always mounted (in the persistent controls pill), so `.current`
@@ -135,6 +142,7 @@ export function AppHeader({
   filterCount,
   onOpenFilters,
   filtersOpen,
+  detailOpen,
   filtersTriggerRef,
   onOpenAttribution,
   ledeText,
@@ -183,6 +191,44 @@ export function AppHeader({
     if (!scopeActive) setScopeOpen(false);
   }, [scopeActive]);
 
+  // E5 (#1057): auto-collapse the disclosure when ANOTHER surface takes over —
+  // the Filters sheet opening or a species-detail surface opening. Spec §5.1
+  // COMPACT requires at most one expanded surface; on a ≤480 phone an open
+  // scope card + an open Filters/detail sheet violated that. We collapse only
+  // on the RISING EDGE of each signal (false→true) — NOT whenever the signal
+  // is true — so the user can deliberately re-open the scope form while the
+  // other surface is still up without it being slammed shut on the next
+  // unrelated re-render. This is the SURFACE-TAKEOVER intent, deliberately
+  // distinct from the PRESERVED no-click-outside rule: a stray map click must
+  // still not discard a half-typed ZIP, but a Filters/detail tap is a clear
+  // "switch surfaces" intent. Source signals are pinned (per the issue's
+  // reviewer addenda) to the existing `filtersOpen` prop and the `detailOpen`
+  // boolean App derives from `?detail=` presence — no new context.
+  const prevFiltersOpen = useRef(filtersOpen);
+  const prevDetailOpen = useRef(detailOpen);
+  useEffect(() => {
+    const filtersRising = filtersOpen && !prevFiltersOpen.current;
+    const detailRising = detailOpen && !prevDetailOpen.current;
+    prevFiltersOpen.current = filtersOpen;
+    prevDetailOpen.current = detailOpen;
+    if (filtersRising || detailRising) setScopeOpen(false);
+  }, [filtersOpen, detailOpen]);
+
+  // E5 (#1057): a successful state COMMIT collapses the disclosure — the user
+  // is "done" choosing a scope. We hook the COMMIT path (`onPickState`), NOT
+  // the raw `change` event: sibling #1035 moved that commit from
+  // change-navigates to an explicit Go/Enter submit, so wrapping `onPickState`
+  // here composes with #1035 in either merge order (in both worlds it stays the
+  // commit callback). The wrapped handler forwards to the real `onPickState`
+  // and then collapses.
+  const handlePickState = useCallback(
+    (stateCode: string) => {
+      onPickState(stateCode);
+      setScopeOpen(false);
+    },
+    [onPickState],
+  );
+
   // Esc collapses + restores focus to the trigger (spec §7). NO click-outside:
   // a stray map click must not discard a half-typed ZIP. Handler lives on the
   // identity card so Esc closes from any field inside the form OR from the
@@ -219,9 +265,14 @@ export function AppHeader({
             Bird Maps
             {/* #828: the visible region rides in the wordmark line at EVERY
                 breakpoint (the resting card is two lines everywhere). The
-                matching <h1> below is sr-only so the region isn't read twice. */}
+                matching <h1> below is sr-only so the region isn't read twice.
+                #1057: the " · " separator is painted by `.brand-region::before`
+                (CSS), NOT a literal text node, so "· {region}" wraps as one
+                unbreakable unit and never orphans a hanging "·" at a line end.
+                The JSX MUST NOT also carry the literal "· " here (it would
+                double-render the dot). */}
             {region && (
-              <span className="brand-region" aria-hidden="true"> · {region}</span>
+              <span className="brand-region" aria-hidden="true">{region}</span>
             )}
           </a>
 
@@ -340,7 +391,7 @@ export function AppHeader({
                 ref={firstScopeFieldRef}
                 scope={scope as ScopedView}
                 states={states}
-                onPickState={onPickState}
+                onPickState={handlePickState}
                 onPickWholeUs={onPickWholeUs}
                 onExit={onExitScope}
                 onResolve={onResolveZip}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -470,10 +470,25 @@ body {
   border-radius: 4px;
 }
 
-/* " · Arizona" suffix in the wordmark (at roomy/wide; hidden at compact). */
+/* "· Arizona" suffix in the wordmark, painted at EVERY breakpoint (#828 — the
+   resting card is two lines everywhere; there is no compact-hiding rule). #1057:
+   the leading "· " separator is rendered via `::before` (NOT a literal JSX text
+   node) so the dot and the region name are ONE element's content and wrap as an
+   unbreakable unit — the line can no longer break between the "·" and the
+   region, which previously orphaned a hanging "·" at the end of line one on a
+   390px wordmark. The literal "· " was dropped from the JSX in tandem (see
+   AppHeader.tsx) to avoid double-rendering the dot. */
 .app-header-wordmark .brand-region {
   font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
+}
+.app-header-wordmark .brand-region::before {
+  /* Leading normal space = the (breakable) gap after "Bird Maps"; then the
+     middot + a NO-BREAK space (\00a0) bind the "·" to the region name so they
+     never split across a line. The NO-BREAK space does the binding on its own —
+     no `white-space` override needed (which would also kill the leading break
+     opportunity). */
+  content: ' \00b7\00a0';
 }
 
 /* Region name — the page's single <h1>, kept for heading structure but ALWAYS
@@ -3503,6 +3518,13 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border-radius: 4px;
   text-decoration: underline;
   cursor: pointer;
+  /* #1057: keep each label ("Whole US", "Change scope") on a single line. With
+     no nowrap they broke mid-phrase at 390 into stacked, per-line-underlined
+     "Whole / US" — the primary scope-change affordances read as a layout bug and
+     lost tap width despite free card width. The exit-group stays flex-with-gap
+     (.scope-control__exit-group); if space is ever genuinely tight the card may
+     grow toward --card-maxw-identity (360px) rather than wrapping these labels. */
+  white-space: nowrap;
 }
 .scope-control__wholeus:hover,
 .scope-control__exit:hover {


### PR DESCRIPTION
## Diagrams

State machine for the scope disclosure's open/closed lifecycle — E5 adds the three new collapse transitions on top of the existing trigger / Esc / unscope edges.

```mermaid
stateDiagram-v2
    [*] --> Closed
    Closed --> Open: click search trigger
    Open --> Closed: click close trigger
    Open --> Closed: Esc, restores focus to trigger
    Open --> Closed: scope goes unscoped
    Open --> Closed: filtersOpen rising edge -- E5
    Open --> Closed: detailOpen rising edge -- E5
    Open --> Closed: onPickState commit -- E5
    Open --> Open: click OUTSIDE card -- preserved
```

Wordmark middot: the separator moves from a literal JSX text node to a CSS pseudo-element so the dot binds to the region name.

```mermaid
flowchart LR
    A["span.brand-region (text node = region only)"] --> B[".brand-region::before (content is middot + NBSP)"]
    B --> C["renders 'Bird Maps · Arizona'; the dot and region wrap as one unbreakable unit"]
```

## Summary

- **Why:** three minor identity-card bugs from the 2026-06-11 design review (C29+O13, V29, V5): an open scope card could coexist with an open Filters/detail sheet on a 480px phone (violating spec §5.1 COMPACT "at most one expanded surface"); the scope links wrapped mid-phrase at 390 into stacked, per-line-underlined fragments; and the wordmark middot could orphan at the end of line one when the region wrapped.
- **Auto-collapse:** `AppHeader` collapses `scopeOpen` on the rising edge of `filtersOpen` and of a new `detailOpen` prop (App derives it from `?detail=` presence, `!!state.detail`), and after a state commit — hooked on the `onPickState` COMMIT path so it composes with #1035 in either merge order, never the raw change event. Rising-edge-only so a deliberate re-open is not slammed shut; the no-click-outside rule is PRESERVED (a stray map click must not discard a half-typed ZIP).
- **CSS:** `white-space: nowrap` on `.scope-control__wholeus` / `.scope-control__exit`; the middot separator moves to `.brand-region::before` (NBSP binds dot to region) and the literal middot is dropped from the JSX to avoid a double-dot. Corrected the stale `styles.css` comment claiming the suffix is "hidden at compact".

## Screenshots

Captured live (Playwright MCP) against head `114e580`, **top-left identity + scope cluster** at `?state=US-AZ` (5 viewports × light/dark). Console 0 errors / 0 warnings at every viewport (lone dark-basemap `circle-11` warning is pre-existing #947).

Live-verified computed values (head `114e580`): `.brand-region` textContent = `"Arizona"` (the literal middot is gone from the text node); `.brand-region::before` content = `" · "` (single CSS middot, unbreakable with the region — V5 ✓); `.scope-control__wholeus` and `.scope-control__exit` both `white-space: nowrap` (V29 ✓). Auto-collapse on filters-open / detail-open / commit (C29+O13) is covered by 5 RTL cases + 2 e2e cases (all green).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e5-390-light](https://github.com/user-attachments/assets/e3d12947-7edb-44e5-858f-7a165d6629a9) | ![e5-390-dark](https://github.com/user-attachments/assets/a66a7d57-a5b9-443b-b035-487287ad9940) |
| 768×1024 (tablet) | ![e5-768-light](https://github.com/user-attachments/assets/44b4abd4-22fa-4d7d-a2b4-69b13ba43099) | ![e5-768-dark](https://github.com/user-attachments/assets/6c86a2e5-7a76-4145-86be-3c8bc66f7239) |
| 1024×768 (laptop) | ![e5-1024-light](https://github.com/user-attachments/assets/261061c1-2320-4beb-b417-e91523a9d689) | ![e5-1024-dark](https://github.com/user-attachments/assets/bff36250-dd09-4f98-83ff-b0d2a9e0293a) |
| 1440×900 (desktop) | ![e5-1440-light](https://github.com/user-attachments/assets/95264168-8bb1-41f3-a3b8-b3042d696fd4) | ![e5-1440-dark](https://github.com/user-attachments/assets/6ab67812-376e-4574-9bae-f61ee845f953) |
| 1920×1080 (wide) | ![e5-1920-light](https://github.com/user-attachments/assets/50cce8a1-f188-4cd7-bbec-7fed275a63c4) | ![e5-1920-dark](https://github.com/user-attachments/assets/f2f09740-5513-41c7-8303-292d8b38c779) |

- [x] Every new/renamed `className` — no new classNames (`::before` on existing `.brand-region`); `check-orphan-classnames.sh` green.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend` — green (87 files / 1436 tests)
- [x] New unit tests added: filters-rising, detail-rising, commit-collapse, rising-edge-only, single-middot (AppHeader.test.tsx)
- [x] New e2e cases added: auto-collapse-after-commit + auto-collapse-on-filters (scope-disclosure.spec.ts); discovered + compile under the Playwright loader
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — exit 0; `bash scripts/check-orphan-classnames.sh` — exit 0
- [x] (UI) Live Playwright drive + console check at the 5 canonical viewports × 2 themes — DONE at head `114e580`: V5 middot + V29 nowrap computed-verified, console clean.

Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Plan reference

Out of plan — design-review remediation program (issue-driven, not a `docs/plans/` file). Closes #1057. Part of #1052 (Wave 3 / E5).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

