### PR TITLE
fix(markers): badge-in-tile anchoring, displaced-twin collision pass, pixelRatio:2 silhouette scale (#1058)

### DIFF
--- a/frontend/e2e/badge-anchor.spec.ts
+++ b/frontend/e2e/badge-anchor.spec.ts
@@ -1,25 +1,27 @@
 /**
- * badge-anchor.spec.ts — badge anchors to cell, not grid corner (bugfix)
+ * badge-anchor.spec.ts — badge anchors INSIDE its own cell, not the grid corner
  *
- * User-reported bug: the count badge on AdaptiveGridMarker cells rendered as
- * `<button>` was visually anchored at the GRID corner rather than the per-cell
- * corner, so multiple count>1 cells in one cluster all stacked badges at the
- * same offset from the grid origin.
+ * Original bug (fixed PR #563): the count badge on AdaptiveGridMarker cells
+ * rendered as `<button>` was visually anchored at the GRID corner rather than
+ * the per-cell corner, so multiple count>1 cells in one cluster all stacked
+ * badges at the same offset from the grid origin. Root cause: inline
+ * `style={{ all: 'unset' }}` reset `position` to `static`, so the absolutely-
+ * positioned badge fell through to the grid (also `position: relative`).
  *
- * Root cause: inline `style={{ all: 'unset' }}` on the button reset `position`
- * to `static`, overriding the class-level `position: relative`. The absolutely-
- * positioned badge then fell through to the nearest positioned ancestor — the
- * grid element (also `position: relative`) — instead of anchoring to the cell.
+ * E6 / #1058 (M-15 "Yuma clump"): the badge was anchored `bottom:-3px;
+ * right:-3px`, OVERHANGING the 22px tile across the 2px grid gap into the
+ * neighbouring cell — so at a dense border a "3" read as belonging to two
+ * birds at once. The fix moves the badge to the top-right INSIDE the tile
+ * (`top:0; right:0`; the 14px badge fits within the 22px cell), keeping the
+ * existing 1px white box-shadow ring (the WCAG 1.4.11 contrast floor). Every
+ * badge bbox must now sit fully WITHIN its owner cell's bbox and intersect no
+ * neighbour.
  *
- * Fix: remove `all: 'unset'` from the inline style; add a
- * `button.adaptive-grid-marker__cell` CSS rule (specificity 0,1,1) to supply
- * the necessary browser chrome-reset properties (background, border, padding,
- * font) without touching `position`.
- *
- * This spec asserts the real-browser layout contract: for every cell that has a
- * badge, the badge's right/bottom edges must be within 5px of the cell's
- * right/bottom edges. jsdom does not have a layout engine and cannot catch this
- * regression — this Playwright test is the load-bearing AC verification.
+ * This spec asserts the real-browser layout contract: for every badged cell,
+ * the badge bbox is contained within the cell bbox (right edge ≈ cell right
+ * edge, top edge ≈ cell top edge, no left/bottom overhang). jsdom has no
+ * layout engine and cannot catch this — this Playwright test is the
+ * load-bearing AC verification.
  *
  * Test strategy:
  *   - Stubs /api/silhouettes with 4 families (3 with svgData → rendered branch,
@@ -28,8 +30,8 @@
  *   - Stubs /api/observations with enough co-located points that supercluster
  *     aggregation produces one cluster with ≥3 count>1 cells.
  *   - Flies to the cluster at zoom=14 where the grid marker is visible.
- *   - Asserts badge.getBoundingClientRect().right ≈ cell.getBoundingClientRect().right
- *     and badge.bottom ≈ cell.bottom for each badged cell (±5px tolerance).
+ *   - Asserts the badge bbox is inside its cell bbox (top-right anchored), with
+ *     a small tolerance for the box-shadow ring / subpixel rounding.
  *
  * WebGL guard: same skip-pattern as forced-colors.spec.ts and
  * basemap-dark-flip.spec.ts. Headless Chromium in some CI environments has no
@@ -187,11 +189,11 @@ async function flyTo(
   await page.waitForTimeout(800);
 }
 
-test.describe('Badge anchor (bugfix: badge must anchor to cell, not grid corner)', () => {
+test.describe('Badge anchor (badge bbox must sit inside its own cell, top-right)', () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
   test(
-    'each cell badge is positioned within 5px of its own cell right/bottom edges',
+    'each cell badge bbox is contained within its own cell (top-right anchored, no neighbour overhang)',
     async ({ page }) => {
       // Route stubs must be registered before page.goto.
       await page.route('**/api/hotspots', async route => {
@@ -238,7 +240,9 @@ test.describe('Badge anchor (bugfix: badge must anchor to cell, not grid corner)
       // aggregate as expected (e.g. different zoom breakpoint on this runner).
       test.skip(badgeCount < 2, `Only ${badgeCount} badge(s) found — cluster did not produce ≥2 count>1 cells at this zoom`);
 
-      // For each badge, verify it is anchored to its own cell and not to the grid.
+      // For each badge, verify its bbox is contained within its own cell's bbox
+      // (top-right anchored), not overhanging into a neighbour. The box-shadow
+      // ring is NOT part of getBoundingClientRect, so the rects compare cleanly.
       const results = await page.evaluate(() => {
         const badges = Array.from(
           document.querySelectorAll('[data-testid="adaptive-grid-marker-badge"]'),
@@ -255,30 +259,49 @@ test.describe('Badge anchor (bugfix: badge must anchor to cell, not grid corner)
           const cRect = ancestor.getBoundingClientRect();
 
           return {
+            badgeTop: bRect.top,
             badgeRight: bRect.right,
             badgeBottom: bRect.bottom,
+            badgeLeft: bRect.left,
+            cellTop: cRect.top,
             cellRight: cRect.right,
             cellBottom: cRect.bottom,
+            cellLeft: cRect.left,
+            // Top-right anchor deltas.
+            deltaTop: Math.abs(bRect.top - cRect.top),
             deltaRight: Math.abs(bRect.right - cRect.right),
-            deltaBottom: Math.abs(bRect.bottom - cRect.bottom),
+            // Overhang past the cell on the bottom / left edges (positive = overhang).
+            bottomOverhang: bRect.bottom - cRect.bottom,
+            leftOverhang: cRect.left - bRect.left,
             cellTestId: ancestor.getAttribute('data-testid') ?? '',
           };
         });
       });
 
-      // Every badge must anchor within 5px of its cell (not the grid).
+      // Every badge must be top-right anchored INSIDE its cell, with no
+      // bottom/left overhang into a neighbour. 2px tolerance absorbs subpixel
+      // rounding and the box-shadow ring's optical (non-layout) bleed.
+      const TOL = 2;
       for (const result of results) {
         if ('error' in result) {
           throw new Error(`Badge anchor check failed: ${result.error}`);
         }
         expect(
           result.deltaRight,
-          `Badge right edge (+${result.badgeRight.toFixed(0)}) must be within 5px of cell right edge (${result.cellRight.toFixed(0)}) — got delta ${result.deltaRight.toFixed(1)}px. Bug: badge anchored to grid corner, not cell corner.`,
-        ).toBeLessThanOrEqual(5);
+          `Badge right edge (${result.badgeRight.toFixed(0)}) must be within ${TOL}px of cell right edge (${result.cellRight.toFixed(0)}) — got delta ${result.deltaRight.toFixed(1)}px. Badge must anchor top-right INSIDE its cell.`,
+        ).toBeLessThanOrEqual(TOL);
         expect(
-          result.deltaBottom,
-          `Badge bottom edge (+${result.badgeBottom.toFixed(0)}) must be within 5px of cell bottom edge (${result.cellBottom.toFixed(0)}) — got delta ${result.deltaBottom.toFixed(1)}px. Bug: badge anchored to grid corner, not cell corner.`,
-        ).toBeLessThanOrEqual(5);
+          result.deltaTop,
+          `Badge top edge (${result.badgeTop.toFixed(0)}) must be within ${TOL}px of cell top edge (${result.cellTop.toFixed(0)}) — got delta ${result.deltaTop.toFixed(1)}px. Badge must anchor top-right INSIDE its cell.`,
+        ).toBeLessThanOrEqual(TOL);
+        expect(
+          result.bottomOverhang,
+          `Badge must NOT overhang its cell's bottom edge (badge bottom ${result.badgeBottom.toFixed(0)} vs cell bottom ${result.cellBottom.toFixed(0)}) — that overhang crosses the 2px grid gap into the neighbouring cell (E6 #1058).`,
+        ).toBeLessThanOrEqual(TOL);
+        expect(
+          result.leftOverhang,
+          `Badge must NOT overhang its cell's left edge (badge left ${result.badgeLeft.toFixed(0)} vs cell left ${result.cellLeft.toFixed(0)}).`,
+        ).toBeLessThanOrEqual(TOL);
       }
     },
   );

--- a/frontend/e2e/marker-overlap.spec.ts
+++ b/frontend/e2e/marker-overlap.spec.ts
@@ -83,6 +83,12 @@ interface OverlapResult {
    *  what O5 governs (legend width-widening is @media max-width:760px-gated; at 1440px the
    *  legend is content-sized regardless of O5 status, giving a clean O5-independent control). */
   marker_legend_overlap_area: number;
+  /** E6 (#1058): worst pairwise overlap RATIO among displaced-silhouette twins,
+   *  as intersectionArea / min(bboxA, bboxB) area (denominator pinned to the
+   *  smaller bbox per #1058 reviewer addendum #2). The collision/spiral pass
+   *  (`resolveDisplacedCollisions`) must keep this ≤ 0.25 — twins from adjacent
+   *  groups may no longer pile into the "Yuma clump". 0 when <2 twins. */
+  worst_twin_overlap_ratio: number;
 }
 
 // NOTE: the top-level `pairwiseArea` helper that used to live here was removed
@@ -217,12 +223,37 @@ async function measureOverlap(page: Page): Promise<OverlapResult> {
     // marker_legend_overlap_area: legend-only (O5-governed desktop control at 1440px).
     const markerLegendOverlapArea  = pairArea(items, legendBoxes);
 
+    // ── Displaced-twin pairwise overlap RATIO (E6 / #1058) ───────────────────
+    // Among the displaced-silhouette twins ONLY, find the worst pairwise overlap
+    // ratio = intersectionArea / min(areaA, areaB). The collision/spiral pass
+    // must keep this ≤ 0.25 (denominator pinned to the smaller bbox). Uses the
+    // displaced-silhouette DOM rects collected above.
+    const twinRects = displacedSils.map((el) => {
+      const r = el.getBoundingClientRect();
+      return { x: r.left, y: r.top, w: r.width, h: r.height };
+    });
+    let worstTwinRatio = 0;
+    for (let i = 0; i < twinRects.length; i++) {
+      for (let j = i + 1; j < twinRects.length; j++) {
+        const a = twinRects[i]!;
+        const b = twinRects[j]!;
+        const ox = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x));
+        const oy = Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+        if (ox <= 0 || oy <= 0) continue;
+        const inter = ox * oy;
+        const minArea = Math.min(a.w * a.h, b.w * b.h);
+        if (minArea <= 0) continue;
+        worstTwinRatio = Math.max(worstTwinRatio, inter / minArea);
+      }
+    }
+
     return {
       marker_count: items.length,
       total_overlap_area: total,
       worst_overlap_area: worst,
       marker_overlay_overlap_area: markerOverlayOverlapArea,
       marker_legend_overlap_area:  markerLegendOverlapArea,
+      worst_twin_overlap_ratio: worstTwinRatio,
     };
   });
 }
@@ -274,6 +305,19 @@ for (const viewport of VIEWPORTS) {
         result.total_overlap_area,
         `marker_count=${result.marker_count}, worst_overlap=${result.worst_overlap_area}px²`,
       ).toBe(0);
+
+      // ── Displaced-twin overlap-ratio assertion (E6 / #1058) ──────────────────
+      // No pair of displaced-silhouette twins may overlap by more than 25% of
+      // the smaller bbox area. `resolveDisplacedCollisions` (the collision/spiral
+      // post-step) enforces this so twins from adjacent groups stop piling into
+      // the "Yuma clump". A 0.01 epsilon absorbs subpixel projection rounding;
+      // do NOT relax further — a higher value IS the signal the pass regressed.
+      expect(
+        result.worst_twin_overlap_ratio,
+        `[${viewport.name} z${zoom}] worst displaced-twin overlap ratio must be ≤ 0.25 ` +
+        `(intersection / smaller-bbox area) — got ${result.worst_twin_overlap_ratio.toFixed(3)}. ` +
+        `The collision/spiral pass (resolveDisplacedCollisions) must split overlapping twins (E6 #1058).`,
+      ).toBeLessThanOrEqual(0.25 + 0.01);
 
       // ── Exclusion-zone assertions (V1 / #788) ────────────────────────────────
       // See the header doc block above for the full contract rationale.

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -643,13 +643,20 @@ button.adaptive-grid-marker__cell {
 }
 
 .adaptive-grid-marker__badge {
-  /* Per-cell observation-count badge — bottom-right, 14px tall, tabular
-     digits. The 1px white box-shadow is the WCAG 1.4.11 contrast guarantee
-     against any basemap tile underneath (spec §4.3). The inline style on
-     the React node duplicates this for jsdom test environments. */
+  /* Per-cell observation-count badge — top-right INSIDE the 22px cell tile,
+     14px tall, tabular digits. The 1px white box-shadow is the WCAG 1.4.11
+     contrast guarantee against any basemap tile underneath (spec §4.3). The
+     inline style on the React node duplicates this for jsdom test environments.
+
+     E6 / #1058 (M-15 "Yuma clump"): the badge was previously anchored
+     `bottom:-3px; right:-3px`, overhanging the tile across the 2px grid gap
+     into the neighbouring cell — so a "3" read as belonging to two birds at a
+     dense border. Anchoring top-right INSIDE the tile (14px badge ≤ 22px cell)
+     keeps every badge bbox fully within its owner cell. The 1px white ring
+     stays — it is the contrast floor, not decoration. */
   position: absolute;
-  bottom: -3px;
-  right: -3px;
+  top: 0;
+  right: 0;
   background: #1a1a1a;
   color: #fff;
   font-size: 9px;

--- a/frontend/src/components/map/deconflict.test.ts
+++ b/frontend/src/components/map/deconflict.test.ts
@@ -6,9 +6,12 @@ import {
   bucketKey,
   buildGroups,
   displaceSilhouettes,
+  resolveDisplacedCollisions,
+  pairwiseOverlapRatio,
   hashSubId,
   SILHOUETTE_PX,
   type DeconflictInput,
+  type DisplacedSilhouette,
 } from './deconflict.js';
 
 // Shared fixtures
@@ -424,5 +427,125 @@ describe('deconflict', () => {
     // Both clamped ≤ 20.
     expect(Math.hypot(offE.dx, offE.dy)).toBeLessThanOrEqual(20);
     expect(Math.hypot(offW.dx, offW.dy)).toBeLessThanOrEqual(20);
+  });
+});
+
+/**
+ * Displaced-twin collision/spiral pass (E6 / #1058, M-15 "Yuma clump").
+ *
+ * `displaceSilhouettes` shifts each silhouette only away from ITS OWN group's
+ * cluster anchor — it never compares two silhouettes' final positions. At a
+ * dense border, twins displaced out of adjacent groups land on top of each
+ * other. `resolveDisplacedCollisions` is a pure post-step that nudges those
+ * overlapping twins apart so no pair overlaps by more than 25% of the smaller
+ * silhouette's bbox area (denominator pinned per #1058 reviewer addendum #2).
+ */
+describe('resolveDisplacedCollisions', () => {
+  // Pinned overlap metric: intersection / min(areaA, areaB). All silhouette
+  // bboxes are SILHOUETTE_PX squares, so min-area = SILHOUETTE_PX².
+  const SIL = SILHOUETTE_PX;
+
+  function disp(subId: string, px: number, py: number): DisplacedSilhouette {
+    return { subId, px, py };
+  }
+
+  /** Worst-case pairwise overlap ratio after applying the extra offsets. */
+  function worstRatioAfter(
+    items: ReadonlyArray<DisplacedSilhouette>,
+    extra: Map<string, { dx: number; dy: number }>,
+  ): number {
+    const resolved = items.map((it) => {
+      const e = extra.get(it.subId) ?? { dx: 0, dy: 0 };
+      return { subId: it.subId, px: it.px + e.dx, py: it.py + e.dy };
+    });
+    let worst = 0;
+    for (let i = 0; i < resolved.length; i++) {
+      for (let j = i + 1; j < resolved.length; j++) {
+        const a = resolved[i]!;
+        const b = resolved[j]!;
+        worst = Math.max(worst, pairwiseOverlapRatio(a.px, a.py, b.px, b.py));
+      }
+    }
+    return worst;
+  }
+
+  it('pairwiseOverlapRatio pins the metric: intersection / smaller bbox area', () => {
+    // Coincident centers → full overlap → ratio 1.
+    expect(pairwiseOverlapRatio(100, 100, 100, 100)).toBeCloseTo(1, 5);
+    // Disjoint (≥ SIL apart on an axis) → ratio 0.
+    expect(pairwiseOverlapRatio(100, 100, 100 + SIL, 100)).toBeCloseTo(0, 5);
+    // Half-overlap on x, full on y → (SIL/2 · SIL) / SIL² = 0.5.
+    expect(pairwiseOverlapRatio(100, 100, 100 + SIL / 2, 100)).toBeCloseTo(0.5, 5);
+  });
+
+  it('is a no-op for an empty input (silhouette-only group: zero displaced twins)', () => {
+    expect(resolveDisplacedCollisions([]).size).toBe(0);
+  });
+
+  it('is a no-op for a single displaced twin (≤1 → nothing to deconflict)', () => {
+    const out = resolveDisplacedCollisions([disp('OBS1', 100, 100)]);
+    expect(out.size).toBe(0);
+  });
+
+  it('two displaced twins landing exactly on top of each other → split apart, ≤25% overlap, bounded', () => {
+    // The Yuma failure mode: twins from adjacent groups displaced onto the
+    // same pixel. coincident → full overlap (ratio 1) before the pass.
+    const items = [disp('OBS_A', 200, 200), disp('OBS_B', 200, 200)];
+    expect(worstRatioAfter(items, new Map())).toBeCloseTo(1, 5);
+
+    const extra = resolveDisplacedCollisions(items);
+    // Worst pairwise overlap now ≤ 25% of the smaller bbox.
+    expect(worstRatioAfter(items, extra)).toBeLessThanOrEqual(0.25 + 1e-6);
+    // Offsets stay bounded (no runaway spiral).
+    for (const off of extra.values()) {
+      expect(Math.hypot(off.dx, off.dy)).toBeLessThanOrEqual(SIL * 2);
+    }
+  });
+
+  it('two adjacent-group twins overlapping ~80% → resolved to ≤25%', () => {
+    // Centers 6px apart on x → overlap (SIL-6)·SIL / SIL² = 22/28 ≈ 0.786.
+    const items = [disp('OBS_A', 200, 200), disp('OBS_B', 206, 200)];
+    expect(worstRatioAfter(items, new Map())).toBeGreaterThan(0.7);
+    const extra = resolveDisplacedCollisions(items);
+    expect(worstRatioAfter(items, extra)).toBeLessThanOrEqual(0.25 + 1e-6);
+  });
+
+  it('already-separated twins (>SIL apart) → no offsets emitted (pass is a no-op)', () => {
+    const items = [disp('OBS_A', 100, 100), disp('OBS_B', 100 + SIL + 5, 100)];
+    const extra = resolveDisplacedCollisions(items);
+    // Nothing to do — either empty map or all-zero offsets.
+    for (const off of extra.values()) {
+      expect(off.dx).toBeCloseTo(0, 5);
+      expect(off.dy).toBeCloseTo(0, 5);
+    }
+    expect(worstRatioAfter(items, extra)).toBeCloseTo(0, 5);
+  });
+
+  it('clump of 13 coincident twins (Yuma scale) → every pair ≤25% overlap, all bounded', () => {
+    const items = Array.from({ length: 13 }, (_, i) => disp(`OBS_${i}`, 300, 300));
+    expect(worstRatioAfter(items, new Map())).toBeCloseTo(1, 5);
+    const extra = resolveDisplacedCollisions(items);
+    expect(worstRatioAfter(items, extra)).toBeLessThanOrEqual(0.25 + 1e-6);
+    for (const off of extra.values()) {
+      expect(Number.isFinite(off.dx)).toBe(true);
+      expect(Number.isFinite(off.dy)).toBe(true);
+      expect(Math.hypot(off.dx, off.dy)).toBeLessThanOrEqual(SIL * 3);
+    }
+  });
+
+  it('is deterministic — same input yields identical offsets', () => {
+    const items = [
+      disp('OBS_A', 200, 200),
+      disp('OBS_B', 200, 200),
+      disp('OBS_C', 203, 201),
+    ];
+    const a = resolveDisplacedCollisions(items);
+    const b = resolveDisplacedCollisions(items);
+    for (const it of items) {
+      const oa = a.get(it.subId) ?? { dx: 0, dy: 0 };
+      const ob = b.get(it.subId) ?? { dx: 0, dy: 0 };
+      expect(oa.dx).toBe(ob.dx);
+      expect(oa.dy).toBe(ob.dy);
+    }
   });
 });

--- a/frontend/src/components/map/deconflict.ts
+++ b/frontend/src/components/map/deconflict.ts
@@ -417,6 +417,192 @@ export function displaceSilhouettes(
 }
 
 /**
+ * A displaced silhouette's FINAL pixel center (input position + the offset
+ * `displaceSilhouettes` already applied), keyed by subId. Input to the
+ * collision/spiral pass below.
+ */
+export interface DisplacedSilhouette {
+  subId: string;
+  /** Final pixel x after `displaceSilhouettes` (input px + offset dx). */
+  px: number;
+  /** Final pixel y after `displaceSilhouettes` (input py + offset dy). */
+  py: number;
+}
+
+/**
+ * Pairwise overlap ratio for two SILHOUETTE_PX-square bboxes centered at the
+ * given pixel positions, as `intersectionArea / min(areaA, areaB)`.
+ *
+ * The denominator is PINNED to the smaller bbox's area (#1058 reviewer addendum
+ * #2) — both silhouette bboxes are identical squares today, so `min` equals
+ * `SILHOUETTE_PX²`, but pinning the metric here means the AC's "≤25% overlap"
+ * is encoded in one place rather than re-derived per test. Returns a value in
+ * `[0, 1]`: 1 when the centers coincide, 0 when the boxes are disjoint.
+ */
+export function pairwiseOverlapRatio(
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const ox = Math.max(0, SILHOUETTE_PX - Math.abs(ax - bx));
+  const oy = Math.max(0, SILHOUETTE_PX - Math.abs(ay - by));
+  const intersection = ox * oy;
+  const minArea = SILHOUETTE_PX * SILHOUETTE_PX; // both bboxes are equal squares
+  return intersection / minArea;
+}
+
+/**
+ * Collision/spiral layout pass for displaced silhouette twins (E6 / #1058,
+ * M-15 "Yuma clump"). PURE and unit-testable: no React, no MapLibre.
+ *
+ * `displaceSilhouettes` shifts each silhouette away from ITS OWN group's
+ * cluster anchor and never compares two silhouettes' final positions, so at a
+ * dense border, twins displaced out of adjacent groups land on top of each
+ * other (the count badges then read as belonging to two birds at once). This
+ * post-step nudges overlapping twins apart along their center-to-center vector
+ * until no pair overlaps by more than 25% of the smaller bbox area (the
+ * `pairwiseOverlapRatio` metric), returning ONLY the EXTRA per-subId pixel
+ * offset to apply on top of `displaceSilhouettes`' offset.
+ *
+ * Contract (per #1058):
+ *  - no-op for ≤1 twin (`items.length <= 1` → empty map) — nothing to deconflict;
+ *  - empty input → empty map, so the silhouette-only-group early-exit upstream
+ *    (zero displaced twins) is preserved untouched;
+ *  - already-separated twins (every pair ≥ `TWIN_MIN_SEPARATION` apart) → no
+ *    offsets emitted, so the common no-collision case is a true no-op;
+ *  - offsets stay BOUNDED — the spiral seed places the k-th clump member at
+ *    radius ≈ `TWIN_MIN_SEPARATION·√k`, so cumulative displacement grows only as
+ *    √(clump size); the spiral relaxes `displaceSilhouettes`' 20px `maxOffsetPx`
+ *    cap without becoming unbounded;
+ *  - deterministic — fixed iteration count + a stable subId-hash phase for the
+ *    spiral seed (so a clump radiates evenly instead of all pushing one axis).
+ *
+ * Algorithm (two phases):
+ *  1. SPIRAL SEED. Connected clumps of mutually-overlapping twins are found via
+ *     Union-Find on the `< TWIN_MIN_SEPARATION` graph; each clump's members are
+ *     placed on a deterministic sunflower (phyllotaxis) spiral around the clump
+ *     centroid, ordered by subId hash. This alone separates exactly-coincident
+ *     twins (which a pure pairwise push cannot, having no gradient).
+ *  2. RELAXATION. A fixed budget of pairwise passes nudges any remaining
+ *     sub-`TWIN_MIN_SEPARATION` pair apart by half the shortfall each — cleans
+ *     up near-coincident (not exactly equal) seeds the spiral didn't fully clear.
+ *  O(passes·N²), bounded by twin count (<20 in practice).
+ */
+// Center separation that guarantees ≤25% overlap for two equal SILHOUETTE_PX
+// squares in ANY direction. Worst case is axis-aligned with full perpendicular
+// overlap: area = SIL·(SIL−d). Setting that ≤ 0.25·SIL² gives d ≥ 0.75·SIL = 21
+// at SIL=28. We target a hair above 0.75·SILHOUETTE_PX (a 0.5px epsilon) so
+// floating-point relaxation lands strictly inside the ≤25% AC, not exactly on it.
+const TWIN_MIN_SEPARATION = SILHOUETTE_PX * 0.75 + 0.5;
+
+export function resolveDisplacedCollisions(
+  items: ReadonlyArray<DisplacedSilhouette>,
+): Map<string, { dx: number; dy: number }> {
+  const extra = new Map<string, { dx: number; dy: number }>();
+  if (items.length <= 1) return extra;
+
+  // Mutable working positions (start at the already-displaced centers).
+  const pos = items.map((it) => ({ x: it.px, y: it.py }));
+  const origin = items.map((it) => ({ x: it.px, y: it.py }));
+
+  // ── Phase 1: spiral-seed each connected clump of overlapping twins ──────────
+  // Build the overlap graph (pairs closer than TWIN_MIN_SEPARATION) and group
+  // by connected component, so an isolated already-separated twin is its own
+  // singleton clump (untouched) and a pile becomes one clump.
+  const edges: Array<[number, number]> = [];
+  for (let i = 0; i < pos.length; i++) {
+    for (let j = i + 1; j < pos.length; j++) {
+      if (Math.hypot(pos[i]!.x - pos[j]!.x, pos[i]!.y - pos[j]!.y) < TWIN_MIN_SEPARATION) {
+        edges.push([i, j]);
+      }
+    }
+  }
+  const reps = unionFind(pos.length, edges);
+  const clumps = new Map<number, number[]>();
+  for (let i = 0; i < reps.length; i++) {
+    const r = reps[i] as number;
+    if (!clumps.has(r)) clumps.set(r, []);
+    clumps.get(r)!.push(i);
+  }
+
+  // Golden-angle sunflower: the k-th point sits at angle k·137.5° and radius
+  // proportional to √k, which keeps neighbors ≈ a constant distance apart while
+  // the whole pattern stays compact (radius ~ √k, not k). Scale so adjacent
+  // ring members clear TWIN_MIN_SEPARATION.
+  const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5)); // ≈ 137.5° in radians
+  const RADIAL_STEP = TWIN_MIN_SEPARATION; // r(k) = RADIAL_STEP · √k
+  for (const indices of clumps.values()) {
+    if (indices.length <= 1) continue; // singleton clump — already clear
+    // Centroid of the clump's CURRENT positions — the spiral re-centers here so
+    // the seeded ring stays near the twins' true border location.
+    let cx = 0;
+    let cy = 0;
+    for (const i of indices) {
+      cx += pos[i]!.x;
+      cy += pos[i]!.y;
+    }
+    cx /= indices.length;
+    cy /= indices.length;
+    // Deterministic order by subId hash so the seed is pan-stable.
+    const ordered = [...indices].sort(
+      (a, b) => hashSubId(items[a]!.subId) - hashSubId(items[b]!.subId),
+    );
+    ordered.forEach((idx, k) => {
+      const radius = RADIAL_STEP * Math.sqrt(k);
+      const angle = k * GOLDEN_ANGLE;
+      pos[idx] = { x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) };
+    });
+  }
+
+  // ── Phase 2: relaxation cleanup for any residual sub-separation pairs ───────
+  const PASSES = 24;
+  for (let pass = 0; pass < PASSES; pass++) {
+    let movedThisPass = false;
+    for (let i = 0; i < pos.length; i++) {
+      for (let j = i + 1; j < pos.length; j++) {
+        const a = pos[i]!;
+        const b = pos[j]!;
+        let vx = b.x - a.x;
+        let vy = b.y - a.y;
+        let dist = Math.hypot(vx, vy);
+        if (dist >= TWIN_MIN_SEPARATION) continue; // already far enough apart
+        if (dist < 1e-6) {
+          // Still coincident after the seed (identical subId hash collision is
+          // the only way) — pick a stable direction from the pair's subIds.
+          const seed = hashSubId(items[i]!.subId + '|' + items[j]!.subId);
+          const angle = (seed % 360) * (Math.PI / 180);
+          vx = Math.cos(angle);
+          vy = Math.sin(angle);
+          dist = 1; // unit vector; full shortfall applied below
+        } else {
+          vx /= dist;
+          vy /= dist;
+        }
+        const shortfall = TWIN_MIN_SEPARATION - dist;
+        const half = shortfall / 2;
+        a.x -= vx * half;
+        a.y -= vy * half;
+        b.x += vx * half;
+        b.y += vy * half;
+        movedThisPass = true;
+      }
+    }
+    if (!movedThisPass) break;
+  }
+
+  // Derive the extra offset (final working pos − origin). Only emit non-zero
+  // offsets so already-clear twins contribute nothing (true no-op case).
+  for (let i = 0; i < pos.length; i++) {
+    const dx = pos[i]!.x - origin[i]!.x;
+    const dy = pos[i]!.y - origin[i]!.y;
+    if (dx !== 0 || dy !== 0) extra.set(items[i]!.subId, { dx, dy });
+  }
+
+  return extra;
+}
+
+/**
  * Stable string hash for observation subIds (issue #554 silhouette
  * deconflict). Used to derive a NEGATIVE pseudo-`cluster_id` (callers negate
  * the result, e.g. `-hashSubId(subId)`) so silhouette inputs can be carried

--- a/frontend/src/components/map/observation-layers.ts
+++ b/frontend/src/components/map/observation-layers.ts
@@ -340,8 +340,14 @@ export function buildUnclusteredPointLayerSpec(): LayerProps {
     filter: ['!', ['has', 'point_count']],
     layout: {
       'icon-image': ['get', 'silhouetteId'],
-      // 0.85 keeps a 32-viewBox SDF roughly in the 24-28px range on the
-      // map — same visual scale as the FamilyLegend chip preview.
+      // Scale chain (E6 / #1058): the sprite SVG has a 24-unit viewBox
+      // rastered into a 64px shell (silhouette-sprite.ts), registered with
+      // `pixelRatio: 2` so maplibre lays it down at 32 CSS px; ×0.85 here ≈
+      // 27px on the map — inside the documented 24-28px band and ≈ the
+      // React-marker SILHOUETTE_PX (28), so the same visual scale as the
+      // FamilyLegend chip preview. (Before the pixelRatio fix the 64px raster
+      // rendered ≈54px — ~2× the badged markers, the M-15 "oversized canvas
+      // silhouette" finding.)
       'icon-size': 0.85,
       // Without these two, MapLibre drops icons that overlap each other
       // or text labels from the basemap. At ≥CLUSTER_MAX_ZOOM zoom levels

--- a/frontend/src/components/map/reconcile-viewport.ts
+++ b/frontend/src/components/map/reconcile-viewport.ts
@@ -1,8 +1,10 @@
 import {
   buildGroups,
   displaceSilhouettes,
+  resolveDisplacedCollisions,
   type DeconflictGroup,
   type DeconflictInput,
+  type DisplacedSilhouette,
 } from './deconflict.js';
 
 /**
@@ -117,15 +119,37 @@ export function reconcileToGroups(
   for (const inp of inputs) {
     if (inp.subId) inputBySubId.set(inp.subId, inp);
   }
+
+  // E6 / #1058: collision/spiral cleanup. `displaceSilhouettes` only shifts each
+  // twin away from its OWN cluster anchor, never against other displaced twins,
+  // so at a dense border (the "Yuma clump") twins from adjacent groups land on
+  // top of each other. `resolveDisplacedCollisions` is a pure post-step over the
+  // ALREADY-DISPLACED px positions (input px + the offset above) that returns
+  // EXTRA per-subId offsets so no displaced pair overlaps by more than 25% of
+  // the smaller bbox. It is a no-op for ≤1 displaced twin and for any set whose
+  // twins are already separated — so the silhouette-only-group early-exit
+  // upstream (pxOffsets has no entry for those) is preserved untouched.
+  const displaced: DisplacedSilhouette[] = [];
+  for (const [subId, off] of pxOffsets) {
+    const inp = inputBySubId.get(subId);
+    if (!inp) continue;
+    displaced.push({ subId, px: inp.px + off.dx, py: inp.py + off.dy });
+  }
+  const collisionOffsets = resolveDisplacedCollisions(displaced);
+
   for (const [subId, off] of pxOffsets) {
     const inp = inputBySubId.get(subId);
     if (!inp || inp.longitude === undefined || inp.latitude === undefined) continue;
-    const displacedPx = inp.px + off.dx;
-    const displacedPy = inp.py + off.dy;
+    // Total offset = displaceSilhouettes' base + the collision/spiral extra.
+    const extra = collisionOffsets.get(subId) ?? { dx: 0, dy: 0 };
+    const dx = off.dx + extra.dx;
+    const dy = off.dy + extra.dy;
+    const displacedPx = inp.px + dx;
+    const displacedPy = inp.py + dy;
     const ll = unproject([displacedPx, displacedPy]);
     offsets.set(subId, {
-      dx: off.dx,
-      dy: off.dy,
+      dx,
+      dy,
       longitude: ll.lng,
       latitude: ll.lat,
     });

--- a/frontend/src/components/map/silhouette-sprite.test.ts
+++ b/frontend/src/components/map/silhouette-sprite.test.ts
@@ -74,7 +74,7 @@ describe('silhouettePathToSvg', () => {
 function makeSpriteMap(preregistered: string[] = []) {
   const registered = new Set<string>(preregistered);
   const addImage = vi.fn(
-    (id: string, _img: HTMLImageElement, _opts?: { sdf?: boolean }) => {
+    (id: string, _img: HTMLImageElement, _opts?: { sdf?: boolean; pixelRatio?: number }) => {
       registered.add(id);
     },
   );
@@ -84,7 +84,7 @@ function makeSpriteMap(preregistered: string[] = []) {
 }
 
 describe('registerSilhouetteSprite', () => {
-  it('registers the sprite via addImage with { sdf: true }', async () => {
+  it('registers the sprite via addImage with { sdf: true, pixelRatio: 2 }', async () => {
     const { map, addImage, hasImage } = makeSpriteMap();
     await registerSilhouetteSprite(map, 'tyrannidae', 'M12 4 L20 20 Z');
     expect(hasImage).toHaveBeenCalledWith('tyrannidae');
@@ -94,7 +94,13 @@ describe('registerSilhouetteSprite', () => {
     expect(img).toBeInstanceOf(FakeImage);
     // sdf:true is the whole point — the sprite is a colorless alpha mask the
     // layer tints later. Registration must never bake in a color.
-    expect(opts).toEqual({ sdf: true });
+    //
+    // pixelRatio:2 (E6 / #1058, M-15 suggestion) treats the 64px SVG raster
+    // as a 2× hi-DPI image so it lays down at 32 CSS px, not 64; ×icon-size
+    // 0.85 ≈ 27px on the map — inside the documented 24-28px band and ≈ the
+    // React-marker SILHOUETTE_PX (28). Without it the SDF rendered ≈54px,
+    // ~2× the badged markers (the "oversized canvas silhouette" finding).
+    expect(opts).toEqual({ sdf: true, pixelRatio: 2 });
   });
 
   it('short-circuits (no addImage) when the sprite id is already registered', async () => {

--- a/frontend/src/components/map/silhouette-sprite.ts
+++ b/frontend/src/components/map/silhouette-sprite.ts
@@ -14,9 +14,11 @@ import { isValidSvgPathData } from './silhouette-fallback.js';
  *      minimal structural {@link SpriteMap}, never maplibre's full `Map`, so it
  *      unit-tests against a tiny spy with no WebGL (exemplar: `artboard-layers.ts`).
  *
- * Registration is COLORLESS: `addImage(id, img, { sdf: true })` registers a
- * single-channel alpha mask; tinting happens later via the symbol layer's
- * `icon-color` paint property, not at sprite-register time.
+ * Registration is COLORLESS: `addImage(id, img, { sdf: true, pixelRatio: 2 })`
+ * registers a single-channel alpha mask; tinting happens later via the symbol
+ * layer's `icon-color` paint property, not at sprite-register time. The
+ * `pixelRatio: 2` halves the 64px raster to 32 CSS px so the on-map scale
+ * matches the documented 24-28px band (E6 / #1058).
  */
 
 /**
@@ -26,17 +28,19 @@ import { isValidSvgPathData } from './silhouette-fallback.js';
  * keeps the helper unit-testable against a spy object and documents the exact
  * dependency surface.
  *
- * `addImage`'s 3-arg overload (`id`, `image`, `options`) with `{ sdf: true }`
- * is the maplibre-gl 5.x shape (verified against 5.x docs — the options object
- * carries `sdf`/`pixelRatio`/`stretchX`/etc.); `HTMLImageElement` is an accepted
- * `image` type.
+ * `addImage`'s 3-arg overload (`id`, `image`, `options`) with
+ * `{ sdf: true, pixelRatio: 2 }` is the maplibre-gl 5.x shape (verified against
+ * 5.x docs — the options object carries `sdf`/`pixelRatio`/`stretchX`/etc.);
+ * `HTMLImageElement` is an accepted `image` type. `pixelRatio` is part of the
+ * production interface (not just the test mock) so the `{ sdf: true,
+ * pixelRatio: 2 }` call below typechecks (E6 / #1058).
  */
 export interface SpriteMap {
   hasImage: (id: string) => boolean;
   addImage: (
     id: string,
     image: HTMLImageElement,
-    options?: { sdf?: boolean },
+    options?: { sdf?: boolean; pixelRatio?: number },
   ) => void;
 }
 
@@ -108,7 +112,11 @@ export async function registerSilhouetteSprite(
       });
     }
     if (!map.hasImage(id)) {
-      map.addImage(id, img, { sdf: true });
+      // pixelRatio:2 (E6 / #1058): the SVG shell rasters at 64px; tagging it
+      // 2× hi-DPI makes maplibre lay it down at 32 CSS px. ×icon-size 0.85
+      // (observation-layers.ts) ≈ 27px — the documented 24-28px band and ≈
+      // the React-marker SILHOUETTE_PX. Without it the SDF rendered ≈54px.
+      map.addImage(id, img, { sdf: true, pixelRatio: 2 });
     }
   } finally {
     URL.revokeObjectURL(url);


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    QRF[MapCanvas shell: queryRenderedFeatures + map.project] -->|already-projected px/py| RV[reconcileToGroups]
    RV --> BG[buildGroups: Union-Find overlap groups]
    RV --> DS["displaceSilhouettes: shift each twin away from ITS OWN anchor (≤20px)"]
    DS -->|displaced px positions| RDC["resolveDisplacedCollisions (NEW, E6)<br/>sunflower-spiral seed + pairwise relaxation"]
    RDC -->|extra per-subId offset| SUM[base offset + collision offset]
    SUM --> UNP[unproject px → lng/lat]
    UNP --> RENDER[DisplacedSilhouetteLayer twins]

    subgraph sprite [Silhouette sprite scale]
        SVG["silhouettePathToSvg: 24-viewBox → 64px shell"] --> ADD["addImage(id, img, {sdf:true, pixelRatio:2})<br/>64px raster → 32 CSS px → ×0.85 ≈ 27px"]
    end

    subgraph badge [Badge anchoring]
        OLD["before: bottom:-3px right:-3px → overhangs neighbour"] --> NEW["after: top:0 right:0 → bbox inside 22px tile"]
    end
```

## Summary

- **Why:** at a dense border (the "Yuma clump", finding M-15) ~13 displaced silhouettes piled into an ambiguous grid — count badges sat *between* silhouettes (a "3" read as two birds' badge), and canvas silhouettes rendered ~2× the badged markers. E6 makes every badge unambiguously owned by one tile, stops displaced twins piling, and restores the documented 24-28px silhouette scale.
- **What (3 fixes):** (1) badge anchored top-right INSIDE its 22px tile (was overhanging into the neighbour across the 2px gap), keeping the 1px white WCAG-1.4.11 ring; (2) a pure, unit-testable `resolveDisplacedCollisions` post-step keeps no displaced-twin pair overlapping >25% of the smaller bbox (denominator pinned per the issue's addendum #2), wired between `displaceSilhouettes` and the unproject loop; (3) sprites register with `pixelRatio: 2` so the 64px raster lays down at 32 CSS px → ×0.85 ≈ 27px (was ≈54px), plus the `SpriteMap` interface widening and the corrected stale `observation-layers.ts` comment.
- The optional connector/leader dot (contract item 3, "preferred", not tested by the AC) was deliberately dropped to keep the PR minimal — the three load-bearing, test-inverting changes are complete and independently mergeable.

## Screenshots

Captured live (Playwright MCP) against head `f10c9e7`, **AZ marker field** at all 5 canonical viewports × light/dark (`?state=US-AZ`). Console clean. Silhouettes render at the restored ~24–28px scale (the pixelRatio:2 fix — no longer ~2× the badged markers); markers cluster cleanly with no overlapping/piled twins.

Live-verified at head `f10c9e7`: marker field renders 18 adaptive-grid markers at the AZ framing + 35 at a Phoenix-metro z9 jump, silhouettes correctly sized, badges within tiles. Deconfliction math (`resolveDisplacedCollisions`, ≤25% twin overlap) + sprite `pixelRatio:2` + badge-in-tile anchoring are pinned by 49 unit tests (deconflict + silhouette-sprite) and the e2e `badge-anchor` / `marker-overlap` specs.

> **Rebase note:** this branch's original head (`a2383b9`) was based on a divergent git history (its parent `b95fd21`, the dispatch-time origin/main, is not an ancestor of the squash-merged current main). The E6 change was re-applied onto the current origin/main via `git cherry-pick` → `f10c9e7` (clean, `ds-primitives.css` auto-merged); the net diff is byte-identical to the original (9 files, +481/−54). tsc clean, 49 E6 unit tests pass on the new base.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e6-390-light](https://github.com/user-attachments/assets/cbec4215-f676-4868-89ef-506e2cb1a638) | ![e6-390-dark](https://github.com/user-attachments/assets/eb0f2a68-1e2b-46fd-abf9-2cc9c536f4b1) |
| 768×1024 (tablet) | ![e6-768-light](https://github.com/user-attachments/assets/9464e9bb-416d-44c2-af86-2382e07b01fe) | ![e6-768-dark](https://github.com/user-attachments/assets/6d2646c2-037d-43fb-bdb4-1f379a223bd0) |
| 1024×768 (laptop) | ![e6-1024-light](https://github.com/user-attachments/assets/04cf2c8a-58e2-4539-b668-f69fd6c40f01) | ![e6-1024-dark](https://github.com/user-attachments/assets/517efbc1-c433-49d1-9397-db1d4fab4db0) |
| 1440×900 (desktop) | ![e6-1440-light](https://github.com/user-attachments/assets/462f3c41-3427-42b9-a5e1-1fb7b62a8809) | ![e6-1440-dark](https://github.com/user-attachments/assets/a7430dbd-8b97-4922-874d-bdec5e8f297c) |
| 1920×1080 (wide) | ![e6-1920-light](https://github.com/user-attachments/assets/54c1b54a-e955-48bf-8c08-8a95e363b596) | ![e6-1920-dark](https://github.com/user-attachments/assets/01a66316-0fc4-421e-9d0f-b483d97312a2) |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule — N/A, no new classNames (badge fix is a property change on the existing `.adaptive-grid-marker__badge` rule; `bash scripts/check-orphan-classnames.sh` → PASS)
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 1439 passed (87 files)
- [x] New unit tests added: `deconflict.test.ts` (8 new `resolveDisplacedCollisions` + `pairwiseOverlapRatio` cases incl. 2-coincident, 13-coincident "Yuma scale", already-separated no-op, determinism); `silhouette-sprite.test.ts` (inverted to `{ sdf: true, pixelRatio: 2 }`)
- [x] e2e specs updated: `badge-anchor.spec.ts` (inverted bottom-right → top-right-inside containment); `marker-overlap.spec.ts` (extended with the ≤25% twin-overlap-ratio rule; existing zero-overlap asserts unchanged)
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — exit 0
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [ ] (UI) Playwright MCP smoke at the 5 canonical viewports × 2 themes — **pending orchestrator live-capture (W.3)**; subagents do not drive Playwright in this repo.

Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Plan reference

Closes #1058. Part of #1052 (Wave 3 / E6). Design-review remediation program (2026-06-11), findings M-15 + V9.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

