### PR TITLE
fix(filters): species search never-silent contract + un-narrow option lists (#1050)

### DIFF
--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, VERMFLY_OBS } from './fixtures.js';
+import { test, expect, VERMFLY_OBS, SPECIES_DICT_FIXTURE } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 test.describe('filter flows', () => {
@@ -13,6 +13,11 @@ test.describe('filter flows', () => {
     // per-observation payload to resolve "Vermilion Flycatcher" → "vermfly";
     // stub before navigation.
     await apiStub.stubObservations(VERMFLY_OBS);
+    // D2 (#1050): the FiltersBar species index is now dictionary-backed (bare
+    // GET /api/species). Stub it so the datalist + typeahead stay hermetic —
+    // without it these specs would silently hit the live seeded DB. The one
+    // fixture row resolves "Vermilion Flycatcher" → "vermfly".
+    await apiStub.stubSpeciesDictionary(SPECIES_DICT_FIXTURE);
     app = new AppPage(page);
     await app.goto();
     await app.waitForAppReady();
@@ -41,9 +46,15 @@ test.describe('filter flows', () => {
     await expect.poll(() => app.getUrlParams().get('family'), { timeout: 5_000 }).toBeNull();
   });
 
-  test('species input does not commit on keystroke (draft isolation + no-match blur)', async () => {
+  test('species input does not commit on keystroke (draft isolation + no-match blur)', async ({ page }) => {
     await app.filters.species.focus();
-    await app.filters.setSpecies('Vermilio'); // partial, no match
+    // Wait for the dictionary-backed datalist to populate before committing —
+    // a no-match verdict is deliberately DEFERRED while the dictionary is still
+    // loading (#1050: a verdict against an empty index would be a false hint),
+    // so the visible-hint assertion below requires the settled state. Mirrors
+    // the exact-match specs' datalist-attached gate.
+    await expect(page.locator('datalist#species-options option').first()).toBeAttached({ timeout: 10_000 });
+    await app.filters.setSpecies('Vermilio'); // partial, no exact match
 
     // Draft only — URL should not have species param yet.
     await expect.poll(() => app.getUrlParams().get('species'), { timeout: 3_000 }).toBeNull();
@@ -51,6 +62,14 @@ test.describe('filter flows', () => {
     await app.filters.species.blur();
     // After blur with no exact match, URL still has no species param.
     await expect.poll(() => app.getUrlParams().get('species'), { timeout: 5_000 }).toBeNull();
+
+    // D2 (#1050) C78: the no-match commit must NOT be silent — a visible inline
+    // status hint appears, scoped to the (national) dictionary index, and the
+    // typed value is kept in the field (never a silent clear).
+    const hint = page.getByRole('status').filter({ hasText: /No species matching/i });
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText('No species matching "Vermilio"');
+    await expect(app.filters.species).toHaveValue('Vermilio');
   });
 
   test('species input commits exact match on blur', async ({ page }) => {

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,5 +1,10 @@
 import { test as base } from '@playwright/test';
-import type { Observation, SpeciesMeta, StateSummary } from '@bird-watch/shared-types';
+import type {
+  Observation,
+  SpeciesDictEntry,
+  SpeciesMeta,
+  StateSummary,
+} from '@bird-watch/shared-types';
 
 /**
  * Read API endpoints that can be stubbed. Keep in sync with
@@ -70,6 +75,20 @@ export const VERMFLY_OBS: Observation[] = [
     familyCode: 'tyrannidae',
     taxonOrder: 4400,
   },
+];
+
+/**
+ * Species-dictionary fixture for the bare `GET /api/species` endpoint (#859,
+ * `client.ts:168-170`). D2 (#1050) re-pointed the FiltersBar species index at
+ * this dictionary (national, filter-independent) so search works at every zoom.
+ * fixtures.ts previously stubbed only observations/hotspots/silhouettes/states/
+ * zip-index — NOT this endpoint — so without `stubSpeciesDictionary` the
+ * dictionary-backed datalist would silently re-point the species specs at the
+ * live seeded DB. One row (Vermilion Flycatcher) is enough to resolve
+ * "Vermilion Flycatcher" → "vermfly" in the exact-match specs.
+ */
+export const SPECIES_DICT_FIXTURE: SpeciesDictEntry[] = [
+  { code: 'vermfly', comName: 'Vermilion Flycatcher', familyCode: 'tyrannidae' },
 ];
 
 /**
@@ -144,6 +163,17 @@ export interface ApiStub {
   stubEmpty(): Promise<void>;
   /** Stubs `/api/observations` to return `200` with the provided list. */
   stubObservations(obs: Observation[]): Promise<void>;
+  /**
+   * D2 (#1050) — stubs the BARE `GET /api/species` species dictionary (#859)
+   * to return `200` with the provided rows (default `SPECIES_DICT_FIXTURE`).
+   * Matched by a URL PREDICATE (pathname ends in exactly `/api/species`, no
+   * trailing code segment) — NOT a `**\/api/species**` glob — so it never
+   * swallows the per-species detail route `**\/api/species/{code}` that
+   * `stubSpecies` and the live dev-server own. The FiltersBar species index
+   * (and its datalist) is dictionary-backed post-#1050, so every spec that
+   * exercises the species typeahead must register this to stay hermetic.
+   */
+  stubSpeciesDictionary(entries?: SpeciesDictEntry[]): Promise<void>;
   /**
    * #847 — state-aware, bbox-intersecting `/api/observations` stub. Models the
    * server's `stateCode AND bbox` clip (packages/db-client/src/observations.ts:
@@ -235,6 +265,22 @@ export const test = base.extend<{ apiStub: ApiStub }>({
             }),
           });
         });
+      },
+      async stubSpeciesDictionary(entries = SPECIES_DICT_FIXTURE) {
+        // URL PREDICATE (not a glob): match ONLY the bare dictionary endpoint
+        // (pathname ending in `/api/species`), so `/api/species/{code}` (the
+        // per-species detail route) falls through to stubSpecies / the live
+        // dev-server. A `**/api/species**` glob would wrongly capture both.
+        await page.route(
+          (url) => url.pathname.endsWith('/api/species'),
+          async route => {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(entries),
+            });
+          },
+        );
       },
       async stubStateAwareObservations(rowsByState) {
         // [w,s,e,n] envelope per state, from STATES_FIXTURE.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2756,3 +2756,91 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     expect(lede).toHaveTextContent('2,000 sightings');
   });
 });
+
+// D2 (#1050) C79: filter option lists must NOT self-narrow to the filtered
+// result. Family options derive from the STABLE silhouettes catalogue
+// (`useSilhouettes`), not from the active fetch — so a family→family direct
+// switch works without first resetting to "All families".
+describe('D2 (#1050) C79: Family select lists the full family universe under an active filter', () => {
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetSpeciesDictionaryCache();
+    __resetStatesCache();
+    __resetZipIndexCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetStates.mockResolvedValue([]);
+    mapSurfaceRef.renderCount = 0;
+    // The silhouettes catalogue is the stable family universe. It carries
+    // MULTIPLE families even when the active fetch (familyCode=tyrannidae) has
+    // been narrowed to one. familyCode keys are lowercase (#921) — the option
+    // `value` must match the lowercase family code the URL carries.
+    mockGetSilhouettes.mockResolvedValue([
+      {
+        familyCode: 'tyrannidae', color: '#C77A2E', colorDark: '#C77A2E',
+        svgData: 'M0 0L1 1Z', svgUrl: null, source: 'placeholder', license: 'CC0',
+        commonName: 'Tyrant Flycatchers', creator: null,
+      },
+      {
+        familyCode: 'accipitridae', color: '#3E7CB1', colorDark: '#3E7CB1',
+        svgData: 'M0 0L1 1Z', svgUrl: null, source: 'placeholder', license: 'CC0',
+        commonName: 'Hawks, Eagles & Kites', creator: null,
+      },
+      {
+        familyCode: 'corvidae', color: '#5A6B7B', colorDark: '#5A6B7B',
+        svgData: 'M0 0L1 1Z', svgUrl: null, source: 'placeholder', license: 'CC0',
+        commonName: 'Crows & Jays', creator: null,
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Family select still lists the full family universe with a familyCode active', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: 'tyrannidae',
+      view: 'map', scope: { kind: 'state', stateCode: 'US-AZ' },
+    };
+    // The narrowed fetch carries ONLY the active family's rows (what the live
+    // server returns under `familyCode=tyrannidae`). Pre-fix, the select
+    // derived from THIS and collapsed to tyrannidae + "All families".
+    mockGetObservations.mockResolvedValue({
+      data: [
+        {
+          subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+          lat: 32.2, lng: -110.9, obsDt: new Date().toISOString(), locId: 'L1',
+          locName: 'Tucson', howMany: 1, isNotable: false,
+          silhouetteId: 'tyrannidae', familyCode: 'tyrannidae', taxonOrder: 4400,
+        },
+      ],
+      meta: { freshestObservationAt: new Date().toISOString() },
+    });
+
+    render(<App />);
+    await screen.findByRole('banner');
+    await userEvent.click(screen.getByRole('button', { name: /Filters/i }));
+    const familySelect = screen.getByLabelText('Family') as HTMLSelectElement;
+
+    // The full catalogue universe is listed — NOT collapsed to the active family.
+    // "All families" + 3 catalogue families = 4 options.
+    const optionValues = within(familySelect)
+      .getAllByRole('option')
+      .map(o => (o as HTMLOptionElement).value);
+    expect(optionValues).toContain('');           // "All families"
+    expect(optionValues).toContain('tyrannidae'); // active family (lowercase)
+    expect(optionValues).toContain('accipitridae'); // a DIFFERENT family to switch to
+    expect(optionValues).toContain('corvidae');
+
+    // The active family is the selected value — its lowercase option value must
+    // match the URL's lowercase familyCode (reviewer addendum: a casing mismatch
+    // would silently de-select the active family).
+    expect(familySelect.value).toBe('tyrannidae');
+
+    // A direct family→family switch works without first resetting to "All families".
+    await userEvent.selectOptions(familySelect, 'accipitridae');
+    expect(mockUrlState.set).toHaveBeenCalledWith(
+      expect.objectContaining({ familyCode: 'accipitridae' }),
+    );
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,6 @@ import { useSpeciesDictionary } from './data/use-species-dictionary.js';
 import { useStates } from './data/use-states.js';
 import {
   familyCountsFromBuckets,
-  deriveFamiliesFromBuckets,
   totalCountFromBuckets,
 } from './data/bucket-aggregates.js';
 import { useStatePolygon } from './data/state-polygons.js';
@@ -26,6 +25,7 @@ import { useSpeciesDetail } from './data/use-species-detail.js';
 // the entry bundle — App owns the scope→clampPad derivation (#760/#762).
 import { ARTBOARD_PAD } from './components/map/mask.js';
 import { FiltersBar } from './components/FiltersBar.js';
+import type { FamilyOption, SpeciesOption } from './components/FiltersBar.js';
 import { FamilyLegend } from './components/FamilyLegend.js';
 import { MapSurface } from './components/MapSurface.js';
 import { ScopeChooser } from './components/ScopeChooser.js';
@@ -36,7 +36,7 @@ import { AppHeader } from './components/AppHeader.js';
 import { useIsCompact } from './lib/use-is-compact.js';
 import { useIsPhone } from './lib/use-is-phone.js';
 import { AttributionModal } from './components/AttributionModal.js';
-import { deriveFamilies, deriveSpeciesIndex } from './derived.js';
+import { resolveFamilyName } from './derived.js';
 import { filterObservationsByBounds, filterBucketsByBounds } from './lib/viewport-filter.js';
 import { regionLabelFor } from './config/region.js';
 import { prefetchMapCanvas } from './prefetch.js';
@@ -524,31 +524,31 @@ export function App() {
     error: silhouettesError,
   } = useSilhouettes(apiClient);
 
-  // #921: familyCode → curated colloquial name, from the `/api/silhouettes`
-  // catalogue the app already fetches. Threaded into both derive functions so
-  // the FiltersBar `<select>` options AND the count lede read `Tyrant
-  // Flycatchers` instead of the scientific `Tyrannidae`. Keys are lowercased to
-  // match the server's lowercase family_code on both the observation and bucket
-  // paths. A cold catalogue yields an empty map → both functions fall back to
-  // `prettyFamily` (never a blank label).
-  const familyNamesByCode = useMemo(() => {
-    const map = new Map<string, string | null>();
-    for (const s of silhouettes) map.set(s.familyCode.toLowerCase(), s.commonName);
-    return map;
+  // D2 (#1050) C79 — the Family filter options derive from the STABLE
+  // silhouettes catalogue (`useSilhouettes`), NOT from the active fetch result.
+  // Pre-#1050 the options came from the fetch (deriveFamilies/FromBuckets), which
+  // carries the active `familyCode` — so once a family was selected the select
+  // collapsed to "that family + All families", forcing a reset-to-all before a
+  // family→family switch. The catalogue is the filter-independent universe of
+  // every observed family (95 today) and is already in scope here, so the select
+  // lists all families while one is active. `familyCode` is lowercased server-side
+  // (#921) and the catalogue keys it lowercase too — the option `value` MUST stay
+  // lowercase so the controlled `<select value={familyCode}>` keeps the active
+  // family highlighted (reviewer addendum: a casing mismatch silently de-selects
+  // it — a subtler form of the exact bug being fixed). A cold catalogue yields an
+  // empty list; the select degrades to "All families" only (never a blank label).
+  const families = useMemo<FamilyOption[]>(() => {
+    const seen = new Set<string>();
+    const opts: FamilyOption[] = [];
+    for (const s of silhouettes) {
+      const code = s.familyCode.toLowerCase();
+      if (seen.has(code)) continue;
+      seen.add(code);
+      opts.push({ code, name: resolveFamilyName(code, { commonName: s.commonName }) });
+    }
+    // Sort by RESOLVED display name (matches the prior derive's ordering).
+    return opts.sort((a, b) => a.name.localeCompare(b.name));
   }, [silhouettes]);
-
-  // #859: in aggregated mode the per-observation array is empty, so the family
-  // filter options derive from the buckets' families instead (the species
-  // autocomplete index has no aggregated analogue — codes carry no names on the
-  // wire — so it stays observation-only and is simply empty at low zoom).
-  const families = useMemo(
-    () =>
-      mode === 'aggregated'
-        ? deriveFamiliesFromBuckets(buckets, familyNamesByCode)
-        : deriveFamilies(observations, familyNamesByCode),
-    [mode, buckets, observations, familyNamesByCode],
-  );
-  const speciesIndex = useMemo(() => deriveSpeciesIndex(observations), [observations]);
 
   // #738/C5: runtime region label for the active scope (#735). `null` ⟺
   // unscoped (the chooser landing) — every consumer degrades to no region
@@ -684,12 +684,19 @@ export function App() {
     { center: [number, number]; zoom: number; key: string } | undefined
   >(undefined);
 
-  // Resolve human-readable family name when a familyCode filter is active.
-  // Derived from families (prettyFamily-capitalised code from deriveFamilies).
-  const familyName = useMemo(
-    () => (state.familyCode ? families.find(f => f.code === state.familyCode)?.name : undefined),
-    [families, state.familyCode],
-  );
+  // Resolve human-readable family name for the count lede when a familyCode
+  // filter is active. Resolved directly via the unified `resolveFamilyName`
+  // chain against the active code — NOT by looking the code up in the filter
+  // `families` options (#1050 decoupled those from the fetch). The catalogue
+  // (`silhouettes`) supplies the curated colloquial name; `resolveFamilyName`
+  // falls back to `prettyFamily(code)` so a real code never yields a blank label
+  // even with a cold catalogue. The first matching silhouette's commonName wins.
+  const familyName = useMemo(() => {
+    if (!state.familyCode) return undefined;
+    const code = state.familyCode.toLowerCase();
+    const commonName = silhouettes.find(s => s.familyCode.toLowerCase() === code)?.commonName;
+    return resolveFamilyName(code, { commonName });
+  }, [silhouettes, state.familyCode]);
 
   // Issue #351: viewport-aware FamilyLegend counts. MapCanvas reports
   // the current bounds on each `idle` (camera-change settle) via
@@ -884,7 +891,33 @@ export function App() {
   // aggregated low-zoom popovers can resolve the real common names carried (as
   // codes) in the buckets. A cold dictionary is tolerated everywhere (rows fall
   // back to the bare code) so this never gates the map render.
-  const { dictionary } = useSpeciesDictionary(apiClient);
+  //
+  // D2 (#1050) C78/C79: the SAME dictionary backs the Species filter index. It
+  // is national and filter-independent, so the species search resolves names at
+  // EVERY zoom — including aggregated low-zoom mode, where the per-observation
+  // array is empty (#859) and the old observation-derived index was silently
+  // inert — and the species datalist no longer self-narrows under an active
+  // species filter (the dictionary doesn't carry the active filter). `loading`
+  // and `error` are threaded to FiltersBar so it can classify a no-match commit
+  // correctly: defer the no-match verdict while loading (a verdict against a
+  // not-yet-populated index would be a false hint), and surface a fetch-error
+  // outcome on error — both honoring the "never silent" contract.
+  const {
+    dictionary,
+    loading: dictionaryLoading,
+    error: dictionaryError,
+  } = useSpeciesDictionary(apiClient);
+
+  // Dictionary-backed Species filter index: `{ code, comName }` per entry,
+  // common-name-sorted to match the prior observation-derived ordering. Memoized
+  // on the dictionary identity (stable once resolved, per the hook's tab cache).
+  const speciesIndex = useMemo<SpeciesOption[]>(() => {
+    const opts: SpeciesOption[] = [];
+    for (const [code, { comName, familyCode }] of dictionary) {
+      opts.push({ code, comName, familyCode });
+    }
+    return opts.sort((a, b) => a.comName.localeCompare(b.comName));
+  }, [dictionary]);
 
   // Active species meta for the detail view (issue #327 task-11). The
   // hook fires only when state.view === 'detail' AND state.detail is set
@@ -1355,6 +1388,8 @@ export function App() {
               familyCode={state.familyCode}
               families={families}
               speciesIndex={speciesIndex}
+              speciesIndexLoading={dictionaryLoading}
+              speciesIndexError={dictionaryError !== null}
               onChange={set}
             />
           </div>

--- a/frontend/src/components/FiltersBar.test.tsx
+++ b/frontend/src/components/FiltersBar.test.tsx
@@ -94,6 +94,141 @@ describe('FiltersBar', () => {
     expect(input.value).toBe('Amer');
   });
 
+  // D2 (#1050) C78: committing unmatched text must NOT silently no-op. It
+  // renders a role="status" hint, KEEPS the typed value, and does not change
+  // speciesCode (no onChange to a different code; a null commit only fires if
+  // a code was previously set — see the "clears" case below).
+  it('no-match commit renders a status hint, keeps the value, and does not change speciesCode', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const idx = [{ code: 'amerob', comName: 'American Robin' }];
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={idx}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByLabelText('Species') as HTMLInputElement;
+    await user.type(input, 'Zzzzz not a bird');
+    await user.keyboard('{Enter}');
+
+    // Value KEPT (never a silent clear of the field).
+    expect(input.value).toBe('Zzzzz not a bird');
+    // Visible inline status hint, scoped to the (national) dictionary index —
+    // NOT "in the current view".
+    const hint = screen.getByRole('status');
+    expect(hint).toHaveTextContent('No species matching "Zzzzz not a bird"');
+    // speciesCode was already null; a no-match must not push a (redundant) null
+    // commit that would round-trip the URL. onChange is not called for species.
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ speciesCode: expect.anything() })
+    );
+  });
+
+  // D2 (#1050) C78: a dictionary-backed index (aggregated/low-zoom mode) still
+  // resolves a valid common name → an exact-match commit fires onChange.
+  it('commits a valid common name from a dictionary-backed index (aggregated mode)', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    // Dictionary-derived index — present even though observations are empty.
+    const idx = [{ code: 'vermfly', comName: 'Vermilion Flycatcher' }];
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={idx}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByLabelText('Species') as HTMLInputElement;
+    await user.type(input, 'Vermilion Flycatcher');
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith({ speciesCode: 'vermfly' });
+    // No false no-match hint on a clean match.
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  // D2 (#1050): while the dictionary is still loading, a commit must NOT render
+  // a no-match hint — a no-match verdict during that window is a false hint (a
+  // new silent-failure class the contract explicitly guards against).
+  it('renders NO no-match hint while the dictionary is loading', async () => {
+    const user = userEvent.setup();
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        speciesIndexLoading
+        onChange={() => {}}
+      />
+    );
+    const input = screen.getByLabelText('Species') as HTMLInputElement;
+    await user.type(input, 'Vermilion Flycatcher');
+    await user.keyboard('{Enter}');
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+    // Value kept — still never silent in the destructive sense.
+    expect(input.value).toBe('Vermilion Flycatcher');
+  });
+
+  // D2 (#1050): on dictionary error, a commit renders ZipInput's fetchError-style
+  // outcome (role="alert").
+  it('renders a role=alert outcome when the dictionary failed to load', async () => {
+    const user = userEvent.setup();
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        speciesIndexError
+        onChange={() => {}}
+      />
+    );
+    const input = screen.getByLabelText('Species') as HTMLInputElement;
+    await user.type(input, 'Vermilion Flycatcher');
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  // D2 (#1050): typing again after a no-match hint clears the stale hint (no
+  // lingering false feedback while the user edits toward a match).
+  it('clears the no-match hint when the user edits the field again', async () => {
+    const user = userEvent.setup();
+    const idx = [{ code: 'amerob', comName: 'American Robin' }];
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={idx}
+        onChange={() => {}}
+      />
+    );
+    const input = screen.getByLabelText('Species') as HTMLInputElement;
+    await user.type(input, 'Zzz');
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    await user.type(input, 'a');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
   it('clears species draft when speciesCode goes null (popstate)', () => {
     const idx = [{ code: 'amerob', comName: 'American Robin' }];
     const { rerender } = render(

--- a/frontend/src/components/FiltersBar.tsx
+++ b/frontend/src/components/FiltersBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useId } from 'react';
 import type { Since } from '../state/url-state.js';
 
 export interface FamilyOption { code: string; name: string; }
@@ -27,11 +27,37 @@ export interface FiltersBarProps {
   familyCode: string | null;
   families: FamilyOption[];
   speciesIndex: SpeciesOption[];
+  /**
+   * D2 (#1050): the species index is dictionary-backed (`useSpeciesDictionary`),
+   * so a commit can only be classified as a no-match once that index is settled.
+   * While `speciesIndexLoading`, defer the no-match verdict — a verdict against a
+   * still-empty index would be a FALSE hint (the new silent-failure class the
+   * "never silent" contract guards against). Mirrors ZipInput's index-warm window.
+   */
+  speciesIndexLoading?: boolean;
+  /**
+   * D2 (#1050): when the species dictionary failed to load, a commit renders
+   * ZipInput's `fetchError` outcome (`role="alert"`) instead of a no-match
+   * `role="status"` — the field can't be trusted to recognize anything.
+   */
+  speciesIndexError?: boolean;
   onChange: (partial: Partial<{
     since: Since; notable: boolean;
     speciesCode: string | null; familyCode: string | null;
   }>) => void;
 }
+
+/**
+ * D2 (#1050) — the surfaced feedback for a Species commit, mirroring ZipInput's
+ * "never silent" contract (`ZipInput.tsx:14-25`). `none` is the no-message state
+ * — both a successful exact-match commit and an empty-field clear leave it
+ * `none` (the change itself is the feedback). `notRecognized` and `fetchError`
+ * are the two cases that would otherwise have been a silent no-op.
+ */
+type SpeciesFeedback =
+  | { kind: 'none' }
+  | { kind: 'notRecognized'; query: string }
+  | { kind: 'fetchError' };
 
 export function FiltersBar(props: FiltersBarProps) {
   // Draft state so users can type multi-character species without URL updating on every keystroke.
@@ -39,6 +65,15 @@ export function FiltersBar(props: FiltersBarProps) {
   const [speciesDraft, setSpeciesDraft] = useState<string>(
     () => props.speciesIndex.find(s => s.code === props.speciesCode)?.comName ?? ''
   );
+
+  // D2 (#1050): the surfaced outcome of the last Species commit (the "never
+  // silent" feedback). Cleared whenever the user edits the field again so a
+  // stale no-match hint never lingers while typing toward a match.
+  const [speciesFeedback, setSpeciesFeedback] = useState<SpeciesFeedback>({ kind: 'none' });
+
+  // Stable id so the Species input can `aria-describedby` its feedback message —
+  // assistive tech announces the no-match/error hint as the field's description.
+  const speciesHintId = useId();
 
   // Store speciesIndex in a ref so the sync effect below doesn't re-run on
   // identity churn (new array reference with identical content after every
@@ -54,11 +89,54 @@ export function FiltersBar(props: FiltersBarProps) {
     setSpeciesDraft(comName);
   }, [props.speciesCode, props.speciesIndex.length]);
 
+  // D2 (#1050) — never-silent species commit. Four outcomes mirror ZipInput:
+  //   - exact match            → commit the code, clear any feedback.
+  //   - empty field            → clear the active species filter (KEPT behavior).
+  //   - dictionary loading     → defer; surface NO no-match verdict (would be
+  //                              a false hint against a not-yet-populated index).
+  //   - dictionary error       → role="alert" (the field can't recognize names).
+  //   - no match (settled)     → role="status" hint, KEEP the typed value, and
+  //                              do NOT push a redundant null commit (that would
+  //                              round-trip the URL for no reason). Only an
+  //                              explicit clear (empty field) commits null.
   function commitSpeciesDraft(value: string) {
+    const trimmed = value.trim();
+
+    // Empty field is an explicit "clear the species filter" — commit null only
+    // when a code was actually set, otherwise it's a no-op (and never a hint).
+    if (trimmed === '') {
+      if (props.speciesCode !== null) props.onChange({ speciesCode: null });
+      setSpeciesFeedback({ kind: 'none' });
+      return;
+    }
+
     const match = props.speciesIndex.find(
-      s => s.comName.toLowerCase() === value.toLowerCase()
+      s => s.comName.toLowerCase() === trimmed.toLowerCase()
     );
-    props.onChange({ speciesCode: match?.code ?? null });
+    if (match) {
+      props.onChange({ speciesCode: match.code });
+      setSpeciesFeedback({ kind: 'none' });
+      return;
+    }
+
+    // No match. Classify against the dictionary state BEFORE verdicting.
+    if (props.speciesIndexError) {
+      setSpeciesFeedback({ kind: 'fetchError' });
+      return;
+    }
+    if (props.speciesIndexLoading) {
+      // Index not settled yet — defer. A no-match verdict here would be false.
+      setSpeciesFeedback({ kind: 'none' });
+      return;
+    }
+    // Settled + no match → surface the national-scope no-match hint, keep value.
+    setSpeciesFeedback({ kind: 'notRecognized', query: trimmed });
+  }
+
+  function handleSpeciesInput(value: string) {
+    setSpeciesDraft(value);
+    // Editing clears a stale hint so feedback never lags the field's content.
+    if (speciesFeedback.kind !== 'none') setSpeciesFeedback({ kind: 'none' });
   }
 
   return (
@@ -105,7 +183,10 @@ export function FiltersBar(props: FiltersBarProps) {
           list="species-options"
           placeholder="Common name"
           value={speciesDraft}
-          onChange={e => setSpeciesDraft(e.target.value)}
+          aria-describedby={
+            speciesFeedback.kind === 'none' ? undefined : speciesHintId
+          }
+          onChange={e => handleSpeciesInput(e.target.value)}
           onBlur={e => commitSpeciesDraft(e.target.value)}
           onKeyDown={e => {
             if (e.key === 'Enter') {
@@ -118,6 +199,29 @@ export function FiltersBar(props: FiltersBarProps) {
             <option key={s.code} value={s.comName} />
           )}
         </datalist>
+        {/* D2 (#1050) never-silent feedback. The no-match copy is scoped to the
+            dictionary-backed (national) index — 'No species matching "X"', NOT
+            "…in the current view", which would be false at low zoom where the
+            index is the whole-US dictionary. */}
+        {speciesFeedback.kind === 'notRecognized' && (
+          <p
+            id={speciesHintId}
+            className="filters-bar__species-status"
+            role="status"
+            aria-live="polite"
+          >
+            No species matching &quot;{speciesFeedback.query}&quot;
+          </p>
+        )}
+        {speciesFeedback.kind === 'fetchError' && (
+          <p
+            id={speciesHintId}
+            className="filters-bar__species-error"
+            role="alert"
+          >
+            Could not load the species list — try again
+          </p>
+        )}
       </label>
     </div>
   );

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -85,7 +85,8 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
   // the detail surface shows the curated #924 colloquial name ("Hawks,
   // Eagles & Kites") instead of the raw eBird family_name ("Hawks, Eagles,
   // and Kites"). Keys are lowercased to match the server's lowercase
-  // family_code — same convention as App.tsx familyNamesByCode (l.533-536).
+  // family_code — same lowercase-keyed silhouettes convention App.tsx uses for
+  // its catalogue-derived Family filter options (#1050 C79).
   const resolveCommonName = useMemo(() => {
     const byCode = new Map<string, string | null>();
     for (const s of silhouettes) byCode.set(s.familyCode.toLowerCase(), s.commonName);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -913,6 +913,30 @@ body {
   border: 1px solid var(--color-border-ui);
   border-radius: 4px;
 }
+/* D2 (#1050) — never-silent Species feedback. The status (no-match) and error
+   (dictionary-load failure) messages sit BELOW the input inside its <label>
+   (which is `display:flex` with a 6px gap), so `flex-basis:100%` drops them to
+   their own full-width row instead of crowding the field. Mirrors the
+   muted-status / error-box split ZipInput uses (.zip-input__status /
+   .zip-input__error). */
+.filters-bar__species-status {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: var(--type-xs);
+  color: var(--color-text-muted);
+  line-height: 1.3;
+}
+.filters-bar__species-error {
+  flex-basis: 100%;
+  margin: 0;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--type-xs);
+  color: var(--color-error-text);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: 4px;
+  line-height: 1.3;
+}
 
 /* Species detail surface (#151). In-flow surface inside <main>, replaces the
    old position:fixed SpeciesPanel sidebar/drawer. Styled consistently with


### PR DESCRIPTION
## Diagrams

Species commit now follows ZipInput's four-outcome "never silent" contract, classifying against the dictionary state before verdicting:

```mermaid
flowchart TD
    Commit["Species commit (blur / Enter)"] --> Empty{"empty field?"}
    Empty -->|yes| Clear["clear filter if a code was set; no hint"]
    Empty -->|no| Match{"exact match in<br/>dictionary index?"}
    Match -->|yes| Fire["onChange(speciesCode); clear hint"]
    Match -->|no| Err{"dictionary error?"}
    Err -->|yes| Alert["role=alert: 'Could not load the species list'"]
    Err -->|no| Loading{"dictionary loading?"}
    Loading -->|yes| Defer["defer — NO hint (false-verdict guard)"]
    Loading -->|no| Status["role=status: 'No species matching X'; value KEPT"]
```

Option lists now read from a stable universe instead of the filtered fetch:

```mermaid
flowchart LR
    Cat["silhouettes catalogue<br/>(all observed families)"] --> Fam["Family select options"]
    Dict["species dictionary<br/>(national, filter-independent)"] --> Spec["Species index + datalist"]
    Fetch["active /api/observations result"] -.->|"no longer feeds"| Fam
    Fetch -.->|"no longer feeds"| Spec
```

## Summary

- **C78 — species filter no longer fails silently.** A no-match commit kept committing `speciesCode: null` with zero feedback (and was fully inert at low zoom, where the observation-derived index was empty). It now mirrors ZipInput: a settled no-match shows an inline `role="status"` hint and KEEPS the typed value; a commit while the dictionary loads defers the verdict (a no-match against an unpopulated index would be a *false* hint — a new silent-failure class); a dictionary load error renders a `role="alert"` outcome.
- **Search works at every zoom.** The Species index is now backed by the already-mounted national species dictionary (`useSpeciesDictionary`) instead of the per-fetch observations, so names resolve in whole-US and zoomed-out state views too — and the datalist stops self-narrowing under an active species filter (C79's species half).
- **C79 — option lists stop self-narrowing.** Family options derive from the stable silhouettes catalogue (the filter-independent universe of all observed families), not the active fetch, so a family→family switch works without first resetting to "All families". Option values stay lowercase to match the URL's `familyCode` (reviewer addendum — a casing mismatch would silently de-select the active family).

## Screenshots

Captured live (Playwright MCP) against head `6719b68`, **filters open with a no-match species search** at `?scope=us`, 5 viewports × light/dark. Console clean.

Live-verified at head `6719b68`: typing a non-matching species (`zzzznotarealbird`) + commit shows the inline `role="status"` hint **"No species matching \"zzzznotarealbird\""** (visible, `aria-describedby` wired) and KEEPS the typed value — never silent (C78 ✓). The Family `<select>` lists the full catalogue universe (**97 options**: "All families" + 96 families, lowercase values matching the URL `familyCode`) instead of self-narrowing to active+all (C79 ✓).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![d2-390-light](https://github.com/user-attachments/assets/bc42be0a-8585-4b3e-8fc5-a0e187a9bfa1) | ![d2-390-dark](https://github.com/user-attachments/assets/7087df37-279d-4e63-b08b-2ef953771a01) |
| 768×1024 (tablet) | ![d2-768-light](https://github.com/user-attachments/assets/c5aaa1a6-6d40-4335-95f1-34f9206acd31) | ![d2-768-dark](https://github.com/user-attachments/assets/88d13186-9fc9-46f9-8a64-f3709821f545) |
| 1024×768 (laptop) | ![d2-1024-light](https://github.com/user-attachments/assets/7b667267-6231-4d85-aa15-36ae6751b0ea) | ![d2-1024-dark](https://github.com/user-attachments/assets/746cabfc-87fb-4883-8339-1cf28fdc4853) |
| 1440×900 (desktop) | ![d2-1440-light](https://github.com/user-attachments/assets/5f7cdc9b-27f8-4115-870d-cf3889362107) | ![d2-1440-dark](https://github.com/user-attachments/assets/02ac6378-559d-4b08-ba79-c09411258ad8) |
| 1920×1080 (wide) | ![d2-1920-light](https://github.com/user-attachments/assets/eeaa9ef0-6bf2-4c68-865b-6837264d2a12) | ![d2-1920-dark](https://github.com/user-attachments/assets/3c19b011-a188-4862-8629-fe588a703d8a) |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` — **done**: `.filters-bar__species-status` + `.filters-bar__species-error` added; `scripts/check-orphan-classnames.sh` PASS.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — green (1437 passed)
- [x] New unit tests added: 5 `FiltersBar.test.tsx` cases (no-match hint + value-kept + no-commit; dictionary-backed exact match; loading defers hint; error → `role=alert`; edit clears stale hint) and 1 `App.test.tsx` case (Family select lists the full catalogue universe + lowercase value + direct family→family switch).
- [x] E2E: extended `filters.spec.ts` no-match-blur to assert the visible status hint; added a hermetic `stubSpeciesDictionary` (URL-predicate on bare `/api/species`, never swallows `/api/species/{code}`). 9/9 filters specs green against the PR-head worktree (dev-server project).
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` clean; `scripts/check-orphan-classnames.sh` PASS
- [x] (UI) Playwright MCP multi-viewport smoke — DONE at head `6719b68`: no-match status visible + value-kept, Family list 97 options, console clean. Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Plan reference

Out of plan — design-review remediation (Epic D #1048, Wave 3 / D2). Findings M-13 / C78 / C79 from the 2026-06-11 full-app design review.

Closes #1050. Part of #1048 (Wave 3 / D2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

