### PR TITLE
fix(popovers): edge clamp + anchor caret + close-on-detail-open + 44px rows (#1053)

### DIFF
--- a/frontend/e2e/map-cell-popover.spec.ts
+++ b/frontend/e2e/map-cell-popover.spec.ts
@@ -274,6 +274,26 @@ test('@coarse tablet 768×1024: tap marker → cluster-list popover → tap spec
   // to commit so the family's species rows have mounted.
   await expect(familyToggle).toHaveAttribute('aria-expanded', 'true', { timeout: 5_000 });
 
+  // E1 (#1053, absorbs #565) — WCAG 2.5.5 species-row tap target. The expanded
+  // family's row <li> must measure ≥44px tall at the iPad-gen-6 coarse-pointer
+  // viewport (the `display: block; min-height: 44px` recipe). Measured live
+  // here because the unit suite runs in jsdom (no layout engine). Guarded:
+  // if rows didn't render in a WebGL-less run we skip the bbox assert and fall
+  // through to the existence check below.
+  const firstRow = page.locator('[data-testid="cluster-list-popover-row"]').first();
+  const rowVisible = await firstRow
+    .waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (rowVisible) {
+    const box = await firstRow.boundingBox();
+    expect(box, 'species row must have a measurable box').not.toBeNull();
+    expect(
+      box!.height,
+      'species-row tap target ≥44px (WCAG 2.5.5, #565)',
+    ).toBeGreaterThanOrEqual(44);
+  }
+
   // Tap a clickable species row in the now-expanded family.
   // #859: at default zoom (aggregated mode) every row now carries a REAL
   // species code (server-nested `AggregatedFamily.species`), so rows render as
@@ -341,6 +361,74 @@ test.skip('@coarse mobile 390×844: tap marker → cluster-list → expand-famil
   // SpeciesDetailSurface renders.
   // #663: new clicks write ?detail=, not ?view=detail.
   await expect(page).toHaveURL(/[?&]detail=/, { timeout: 8_000 });
+});
+
+// ─── E1 (#1053): cell popover keeps a ≥12px safe-area gutter at the right edge ─
+//
+// At 390 the pre-fix cell popover rendered flush to within 8px of the right
+// viewport edge (the old 8px VIEWPORT_MARGIN / fallback width). Spec §4.7
+// requires the flip/shift clamp to the 12px --card-inset safe area. We open a
+// cell popover on an EAST-edge marker and assert its bbox keeps right ≤ vw − 12
+// (and left ≥ 12). Guarded for WebGL-less headless runs like the scenarios
+// above. No @coarse tag → dev-server project (fine pointer), narrowed to 390.
+
+test('390 narrow: cell popover keeps a ≥12px right-edge gutter (#1053 clamp)', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/?scope=us');
+
+  const marker = page.locator('[data-testid="adaptive-grid-marker"]').first();
+  const markerVisible = await marker
+    .waitFor({ state: 'visible', timeout: 15_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!markerVisible) {
+    test.skip(true, 'No adaptive-grid markers visible — likely WebGL unavailable in headless run');
+    return;
+  }
+
+  // Open a cell popover. Pick the marker/cell nearest the right edge so the
+  // clamp is exercised; fall back to the first cell if none qualifies.
+  const cells = page.locator('[data-testid^="adaptive-grid-marker-cell"]');
+  const cellCount = await cells.count();
+  if (cellCount === 0) {
+    test.skip(true, 'No cell testids visible — cells may not have rendered (no WebGL)');
+    return;
+  }
+  // Choose the east-most cell by bbox.
+  let target = cells.first();
+  let maxRight = -Infinity;
+  for (let i = 0; i < Math.min(cellCount, 12); i++) {
+    const c = cells.nth(i);
+    const b = await c.boundingBox();
+    if (b && b.x + b.width > maxRight) {
+      maxRight = b.x + b.width;
+      target = c;
+    }
+  }
+  await target.hover().catch(() => {});
+  await target.click({ force: true });
+
+  const popover = page.getByTestId('cell-popover');
+  const popVisible = await popover
+    .waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!popVisible) {
+    test.skip(true, 'Cell popover did not open (single-species cell may route straight to detail)');
+    return;
+  }
+
+  const box = await popover.boundingBox();
+  expect(box, 'popover must have a measurable box').not.toBeNull();
+  // ≥12px gutter on both horizontal edges (the --card-inset safe area).
+  expect(box!.x, 'popover left gutter ≥12px').toBeGreaterThanOrEqual(12 - 0.5);
+  expect(
+    box!.x + box!.width,
+    'popover right edge ≤ vw − 12 (12px safe-area gutter)',
+  ).toBeLessThanOrEqual(390 - 12 + 0.5);
+
+  // The anchor caret renders on the cell-facing edge.
+  await expect(page.getByTestId('cell-popover-caret')).toBeAttached();
 });
 
 // ─── #761 P1 (#778): named z-index scale — stacking-order guards ───────────────

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -907,6 +907,43 @@ button.adaptive-grid-marker__cell {
   box-shadow: var(--card-elevation-2);
 }
 
+/* #1053 — anchor caret. An 8px square rotated 45° so a corner points at the
+   anchor cell, filled with the card background and bordered to match so only
+   the two outward-facing triangle edges read as a notch. It sits on the
+   cell-facing edge: just OUTSIDE the top edge when the card is placed BELOW the
+   cell (caret points up at the anchor), and just outside the bottom edge when
+   the card flips ABOVE (caret points down). data-placement (set by
+   CellPopover.tsx, mirroring the position math) drives which edge, so the caret
+   survives the flip/shift/clamp. Left-anchored to track the cell's left edge,
+   which the horizontal clamp keeps aligned to the anchor. Decorative only
+   (aria-hidden in the JSX). The card already carries the elevation; the caret
+   borrows the same border tokens so it reads as part of the same surface. */
+.cell-popover__caret {
+  position: absolute;
+  left: var(--space-md);
+  width: 8px;
+  height: 8px;
+  background: var(--color-bg-surface);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+.cell-popover__caret[data-placement='below'] {
+  /* Card below the cell → notch on the TOP edge, pointing up at the anchor.
+     Show only the two top-facing borders (top + left of the rotated square). */
+  top: -4px;
+  border-top: 1px solid var(--color-border-ui);
+  border-left: 1px solid var(--color-border-ui);
+}
+
+.cell-popover__caret[data-placement='above'] {
+  /* Card flipped above the cell → notch on the BOTTOM edge, pointing down.
+     Show only the two bottom-facing borders (bottom + right). */
+  bottom: -4px;
+  border-bottom: 1px solid var(--color-border-ui);
+  border-right: 1px solid var(--color-border-ui);
+}
+
 .cell-popover__header {
   margin-bottom: var(--space-xs);
 }
@@ -935,6 +972,22 @@ button.adaptive-grid-marker__cell {
 
 .cell-popover__row {
   padding: 2px 0;
+}
+
+/* E1 (#1053) — WCAG 2.5.5 on the cell popover's species rows under a COARSE
+   pointer (touch laptop / hybrid device that still gets the fine-pointer cell
+   popover). The compact 2px row padding above is fine for a mouse; on touch the
+   row must reach the 44px tap floor. Scoped to `pointer: coarse` so the dense
+   desktop popover keeps its tight rhythm. Uses the same block recipe as
+   `.cluster-list-popover__row` (NOT flex on the inner control — that's the
+   b1b018e 0×0-bbox trap); the inner full-width <button> (`display: block;
+   width: 100%`, below) overlays the ≥44px box so the tap lands on the link. */
+@media (pointer: coarse) {
+  .cell-popover__row {
+    display: block;
+    min-height: 44px;
+    padding: 6px 0;
+  }
 }
 
 /* #1031 (C54): species rows are now native <button>s (free Enter/Space,
@@ -1168,9 +1221,19 @@ button.adaptive-grid-marker__cell {
 }
 
 .cluster-list-popover__row {
-  padding: 8px 0; /* Tap-target spacing. Spec §4.5 — `display: flex; min-height: 44px` */
-                  /* on the inner <a> caused Playwright to see 0×0 bbox under iPad-gen-6 */
-                  /* chromium emulation; family-toggle + Done retain the 44px min. */
+  /* E1 (#1053, absorbs #565) — WCAG 2.5.5. The bot's block recipe: `display:
+     block` is the <li> default, so a 44px floor on the <li> itself sidesteps
+     the flex-on-<a> bbox bug that the b1b018e revert (the prior `padding: 8px 0`
+     compromise, ~35px effective) was working around. The earlier failure was
+     `display: flex; min-height: 44px` on the inner <a>, which resolved to a 0×0
+     bbox under iPad-gen-6 chromium in the coarse-pointer Playwright project; the
+     <li> stays block so the row paints a real ≥44px box. The inner full-width
+     <button> (`display: block; width: 100%`, below) overlays that box, so the
+     tap lands on the control across the row's full height — satisfying #565's
+     "≥44×44 OR ≥44px spacing". */
+  display: block;
+  min-height: 44px;
+  padding: 12px 8px;
 }
 
 /* #1031 (C54): species rows are now native <button>s (free Enter/Space,

--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -935,6 +935,53 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(cell.getAttribute('aria-expanded')).toBe('true');
   });
 
+  // --- E1 (#1053): close-on-detail-open. Opening a species detail must DISMISS
+  // an already-open cell popover — on the RISING edge of detailOpen only, so a
+  // popover opened WHILE detail is already up (the #976 hover-to-compare intent)
+  // is unaffected (that path is the test above; this is the new clearing). The
+  // pre-fix bug: #976 demoted only the passive hover preview's z-index; a
+  // click-opened popover lingered mid-map (desktop) or painted over the detail
+  // sheet (mobile).
+  it('E1 (#1053): a rising detailOpen edge unmounts an already-open <CellPopover>', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    const tiles = [rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+      { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+    ])];
+    const { rerender } = render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={tiles}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        detailOpen={false}
+        onClick={noop}
+      />
+    );
+    // Open the cell popover (detail not yet open).
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    cell.focus();
+    fireEvent.keyDown(cell, { key: 'Enter' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Now open a species detail → detailOpen rises false→true → popover clears.
+    rerender(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={tiles}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        detailOpen
+        onClick={noop}
+      />
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(cell.getAttribute('aria-expanded')).toBe('false');
+  });
+
   // --- #859: per-family CellPopover "+N more" ACTIVE drill-in ---------------
 
   it('pointer:fine: tile.speciesCount > shown rows + onDrillIn → "+N more" is an ACTIVE button that drills in', async () => {
@@ -1226,6 +1273,49 @@ describe('AdaptiveGridMarker — cell popover coarse-pointer (Phase 2, #559)', (
     const outer = screen.getByTestId('adaptive-grid-marker');
     fireEvent.click(outer);
     expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  // E1 (#1053): coarse-pointer parity — a rising detailOpen edge dismisses an
+  // open <ClusterListPopover> too (the mobile occlusion case: the cluster list
+  // painted ON TOP of the species sheet, hiding the heading).
+  it('E1 (#1053): a rising detailOpen edge unmounts an open <ClusterListPopover>', async () => {
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    const tiles = [
+      rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+        { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+      ]),
+      rendered('flycatchers', 12, 'M0 0L24 24Z', '#aaa', '#aaa', [
+        { comName: 'Black Phoebe', count: 12, speciesCode: 'blkpho' },
+      ]),
+    ];
+    const { rerender } = render(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={tiles}
+        totalCount={17}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 17 observations, 2 families."
+        isCoarsePointer={true}
+        detailOpen={false}
+        onClick={noop}
+      />
+    );
+    fireEvent.click(screen.getByTestId('adaptive-grid-marker'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    rerender(
+      <AdaptiveGridMarker
+        shape={SHAPE_2x2}
+        tiles={tiles}
+        totalCount={17}
+        uniqueFamilies={2}
+        ariaLabel="Cluster: 17 observations, 2 families."
+        isCoarsePointer={true}
+        detailOpen
+        onClick={noop}
+      />
+    );
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -332,6 +332,25 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
     };
   }, []);
 
+  // E1 (#1053): close marker-local popovers on the RISING edge of `detailOpen`.
+  // When the user opens a species detail, any open click-driven popover must be
+  // dismissed — desktop: it otherwise lingers mid-map beside the detail card;
+  // mobile: it paints ON TOP of the detail sheet, occluding the heading. We
+  // clear the click-promoted cell popover (`activeCell` in 'popover' mode — a
+  // 'preview' hover stays, that's the #976 hover-to-compare path) and the
+  // coarse-pointer cluster list. RISING-edge only (tracked via a ref): a popover
+  // opened WHILE detail is already up is left alone, so hover-to-compare on the
+  // open detail still works. The sibling rising-edge effect for the
+  // MapCanvas-owned `selectedObs`/`clusterList` lives in MapCanvas.tsx.
+  const prevDetailOpen = useRef(detailOpen);
+  useEffect(() => {
+    if (detailOpen && !prevDetailOpen.current) {
+      setActiveCell((prev) => (prev?.mode === 'popover' ? null : prev));
+      setIsClusterListOpen(false);
+    }
+    prevDetailOpen.current = detailOpen;
+  }, [detailOpen]);
+
   const activeTile = activeCell !== null ? tiles[activeCell.index] : null;
   const previewId = activeTile
     ? `cell-${markerId}-${activeTile.familyCode}-preview`

--- a/frontend/src/components/map/CellPopover.test.tsx
+++ b/frontend/src/components/map/CellPopover.test.tsx
@@ -433,9 +433,11 @@ describe('<CellPopover>', () => {
       const card = renderAt(anchor);
       expect(card.style.position).toBe('fixed');
       const left = parseFloat(card.style.left);
-      // Min card width is 240px; left must leave room for the card inside 1024.
-      expect(left).toBeGreaterThanOrEqual(0);
-      expect(left).toBeLessThanOrEqual(1024 - 240);
+      // E1 (#1053): clamp to the 12px safe area (--card-inset), not the loose
+      // 8px floor. Min card width is 240px; left must keep both edges ≥12px from
+      // the viewport edges: 12 ≤ left ≤ 1024 − 240 − 12.
+      expect(left).toBeGreaterThanOrEqual(12);
+      expect(left).toBeLessThanOrEqual(1024 - 240 - 12);
     });
 
     it('flips above so a bottom-edge anchor never overflows the bottom of the viewport', () => {
@@ -444,9 +446,71 @@ describe('<CellPopover>', () => {
       const card = renderAt(anchor);
       expect(card.style.position).toBe('fixed');
       const top = parseFloat(card.style.top);
-      // Flipped above the anchor: top must sit at or above the anchor's top edge.
+      // E1 (#1053): clamp to the 12px safe area. Flipped above the anchor: top
+      // must sit at or above the anchor's top edge AND keep a ≥12px top gutter.
       expect(top).toBeLessThanOrEqual(750);
-      expect(top).toBeGreaterThanOrEqual(0);
+      expect(top).toBeGreaterThanOrEqual(12);
+    });
+
+    // E1 (#1053, finding "edge clamp"): at the 390px mobile viewport an
+    // east-edge anchor must keep a ≥12px RIGHT gutter — the popover's right
+    // edge (left + width) may not exceed vw − 12. Pre-fix the card clamped to
+    // an 8px floor and a FALLBACK_CARD_WIDTH of 240 left only an 8px gutter.
+    it('keeps a ≥12px right gutter at the 390px mobile viewport (east-edge anchor)', () => {
+      const prevW = window.innerWidth;
+      const prevH = window.innerHeight;
+      Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 844, configurable: true });
+      try {
+        // Marker hugging the right edge of a 390-wide viewport.
+        const anchor = makeAnchorAt({ left: 376, top: 300, right: 390, bottom: 322, width: 14, height: 22 });
+        const card = renderAt(anchor);
+        const left = parseFloat(card.style.left);
+        // The fallback card width is 240 (the CSS min-width); left + width must
+        // not cross vw − 12 = 378, and left must keep a ≥12px left gutter too.
+        expect(left).toBeGreaterThanOrEqual(12);
+        expect(left + 240).toBeLessThanOrEqual(390 - 12);
+      } finally {
+        Object.defineProperty(window, 'innerWidth', { value: prevW, configurable: true });
+        Object.defineProperty(window, 'innerHeight', { value: prevH, configurable: true });
+      }
+    });
+  });
+
+  // E1 (#1053, finding "no anchor caret"): the popover renders a caret notch on
+  // the cell-facing edge so it doesn't read as a detached card amid a dense
+  // marker pile. The caret element carries a data-placement attribute that
+  // matches the card's placement ('above'|'below') so it survives the flip.
+  describe('anchor caret (#1053)', () => {
+    function renderAt(anchor: HTMLElement) {
+      render(
+        <CellPopover
+          familyCode="hummingbirds"
+          familyCount={5}
+          species={[species("Anna's Hummingbird", 5, 'annhum')]}
+          anchorEl={anchor}
+          onDismiss={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />
+      );
+      return screen.getByTestId('cell-popover');
+    }
+
+    it('renders a caret element whose placement matches a below-placed card', () => {
+      const anchor = makeAnchorAt({ left: 300, top: 200, right: 322, bottom: 222, width: 22, height: 22 });
+      renderAt(anchor);
+      const caret = screen.getByTestId('cell-popover-caret');
+      expect(caret).toBeInTheDocument();
+      // Card placed below the cell → caret points up at the anchor.
+      expect(caret.getAttribute('data-placement')).toBe('below');
+    });
+
+    it('renders a caret whose placement flips with the card (above-placed)', () => {
+      // Bottom-edge anchor forces the card to flip above.
+      const anchor = makeAnchorAt({ left: 300, top: 750, right: 322, bottom: 766, width: 22, height: 16 });
+      renderAt(anchor);
+      const caret = screen.getByTestId('cell-popover-caret');
+      expect(caret.getAttribute('data-placement')).toBe('above');
     });
   });
 

--- a/frontend/src/components/map/CellPopover.tsx
+++ b/frontend/src/components/map/CellPopover.tsx
@@ -42,8 +42,17 @@ import { formatCount } from '../../lib/format-count.js';
 
 /** Gap between the anchor cell and the popover card, in CSS px. */
 const ANCHOR_GAP = 6;
-/** Viewport inset kept around the clamped card so it never kisses the edge. */
-const VIEWPORT_MARGIN = 8;
+/**
+ * E1 (#1053): shared viewport-edge safe-area inset, in CSS px. Mirrors the
+ * `--card-inset` token (12px = `--space-md`) so every transient popover keeps
+ * the same 12px gutter the four-corner floating-card contract assigns to
+ * resting chrome. Consumed by `computePopoverPosition` here AND by
+ * `ObservationPopover`'s clamp — one source of truth so the two anchored
+ * surfaces can't drift apart (the prior 8px `VIEWPORT_MARGIN` /
+ * `Math.max(8, …)` floor left an east-edge popover flush to within 8px of the
+ * edge, where it collides with the browser's edge-swipe gesture region).
+ */
+export const POPOVER_VIEWPORT_INSET_PX = 12;
 /**
  * Fallback card box used before the real rendered rect is measurable (and in
  * jsdom, where layout is not computed). Mirrors `.cell-popover`'s CSS
@@ -51,6 +60,19 @@ const VIEWPORT_MARGIN = 8;
  */
 const FALLBACK_CARD_WIDTH = 240;
 const FALLBACK_CARD_HEIGHT = 200;
+/**
+ * E1 (#1053): the card's CSS `max-width: var(--card-maxw-popover)` (300px). The
+ * one-shot `useLayoutEffect` measures the card width BEFORE content/fonts fully
+ * settle, so a card that ends up at the 300px cap can be measured narrower —
+ * and then a left clamp computed from that stale narrow width lets the
+ * fully-grown card overrun the right edge (verified live at 390: right edge at
+ * 391 vs the vw−12=378 floor). Clamping the RIGHT edge against this cap instead
+ * of the measured width makes the gutter robust to the late growth: a narrower
+ * card simply gets a slightly wider right gutter, never an overflow. Mirrors
+ * --card-maxw-popover in tokens.css; keep in sync (same contract as
+ * ObservationPopover's POPOVER_W).
+ */
+const POPOVER_MAX_WIDTH = 300;
 
 /**
  * Compute the popover's fixed-position `left`/`top` (viewport coordinates) from
@@ -66,19 +88,30 @@ function computePopoverPosition(
 ): { left: number; top: number; placement: 'above' | 'below' } {
   // Horizontal: left-align to the cell, then clamp into the viewport so the
   // card never overflows the right (flips effectively become a right-shift) or
-  // left edge.
-  const maxLeft = Math.max(VIEWPORT_MARGIN, viewportWidth - cardWidth - VIEWPORT_MARGIN);
-  const left = Math.min(Math.max(anchorRect.left, VIEWPORT_MARGIN), maxLeft);
+  // left edge. E1 (#1053): clamp to the 12px safe area, not the old 8px floor.
+  // Bound the RIGHT edge against the LARGER of the measured width and the CSS
+  // max-width cap (300) — the one-shot measure can under-read the width before
+  // content settles, and a left clamp from a stale-narrow width lets the grown
+  // card overrun the right edge (live repro at vw 390).
+  const clampWidth = Math.max(cardWidth, POPOVER_MAX_WIDTH);
+  const maxLeft = Math.max(
+    POPOVER_VIEWPORT_INSET_PX,
+    viewportWidth - clampWidth - POPOVER_VIEWPORT_INSET_PX,
+  );
+  const left = Math.min(Math.max(anchorRect.left, POPOVER_VIEWPORT_INSET_PX), maxLeft);
 
   // Vertical: prefer below the cell. If that would overflow the bottom, flip to
   // above the cell. Clamp into the viewport as a final fallback.
   const belowTop = anchorRect.bottom + ANCHOR_GAP;
   const aboveTop = anchorRect.top - ANCHOR_GAP - cardHeight;
-  const overflowsBottom = belowTop + cardHeight > viewportHeight - VIEWPORT_MARGIN;
-  const placedAbove = overflowsBottom && aboveTop >= VIEWPORT_MARGIN;
+  const overflowsBottom = belowTop + cardHeight > viewportHeight - POPOVER_VIEWPORT_INSET_PX;
+  const placedAbove = overflowsBottom && aboveTop >= POPOVER_VIEWPORT_INSET_PX;
   let top = placedAbove ? aboveTop : belowTop;
-  const maxTop = Math.max(VIEWPORT_MARGIN, viewportHeight - cardHeight - VIEWPORT_MARGIN);
-  top = Math.min(Math.max(top, VIEWPORT_MARGIN), maxTop);
+  const maxTop = Math.max(
+    POPOVER_VIEWPORT_INSET_PX,
+    viewportHeight - cardHeight - POPOVER_VIEWPORT_INSET_PX,
+  );
+  top = Math.min(Math.max(top, POPOVER_VIEWPORT_INSET_PX), maxTop);
 
   // #950: surface the flip decision so the recipe-05 transform-origin tracks
   // it — a card placed below the cell grows from its top edge, one placed above
@@ -211,6 +244,22 @@ export function CellPopover(props: CellPopoverProps) {
       data-placement={position?.placement}
       style={positionStyle}
     >
+      {/* #1053: anchor caret — an 8px rotated-square notch on the cell-facing
+          edge (top when the card sits BELOW the cell, bottom when it flips
+          ABOVE). data-placement mirrors the card's placement so the CSS can
+          park it on the correct edge; it survives the flip/shift/clamp because
+          it tracks the same `placement` decision the position math emits. It's
+          purely decorative (aria-hidden) — the card already announces as a
+          dialog. Rendered only once placement is known, so it never paints at
+          the off-screen park. */}
+      {position && (
+        <span
+          className="cell-popover__caret"
+          data-testid="cell-popover-caret"
+          data-placement={position.placement}
+          aria-hidden="true"
+        />
+      )}
       <header className="cell-popover__header">
         <h2
           ref={headingRef}

--- a/frontend/src/components/map/ClusterListPopover.test.tsx
+++ b/frontend/src/components/map/ClusterListPopover.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { ClusterListPopover } from './ClusterListPopover.js';
 import type { FamilyAggregate, SpeciesAggregate } from './adaptive-grid.js';
 
@@ -445,5 +447,43 @@ describe('<ClusterListPopover>', () => {
     const firstFocusable = document.activeElement as HTMLElement;
     fireEvent.keyDown(firstFocusable, { key: 'Tab', shiftKey: true });
     expect(document.activeElement).toBe(done);
+  });
+});
+
+// E1 (#1053, absorbs #565) — WCAG 2.5.5 species-row tap target. jsdom has no
+// layout engine (every getBoundingClientRect is 0×0 — the exact reason the
+// `display:flex; min-height:44px` on the inner <a> was reverted in b1b018e), so
+// the 44px floor is verified by reading the committed CSS rule rather than a
+// measured bbox. The live measured assertion runs in the `coarse-pointer`
+// Playwright project (map-cell-popover.spec.ts). The bot's block recipe
+// (`display: block; min-height: 44px; padding: 12px 8px;` on the <li> — block is
+// the <li> default, sidestepping the flex-on-<a> bbox bug) is the contract here.
+describe('E1/#565 — species-row 44px tap target (CSS contract)', () => {
+  const css = readFileSync(
+    join(import.meta.dirname, '../ds/ds-primitives.css'),
+    'utf8',
+  );
+
+  function ruleBody(selector: string): string {
+    // Grab the declaration block for an exact selector (escape the regex-special
+    // chars in the class selector). Non-greedy up to the first closing brace.
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const m = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    if (!m) throw new Error(`selector not found in ds-primitives.css: ${selector}`);
+    return m[1]!;
+  }
+
+  it('.cluster-list-popover__row carries display:block + min-height:44px (bot recipe)', () => {
+    const body = ruleBody('.cluster-list-popover__row');
+    expect(body).toMatch(/display:\s*block/);
+    expect(body).toMatch(/min-height:\s*44px/);
+  });
+
+  it('.cell-popover__row enforces a ≥44px effective coarse-pointer tap target', () => {
+    // The cell popover's species rows get the same floor under coarse pointer.
+    // Implementation may scope it via a coarse-pointer media query; assert the
+    // 44px min-height appears in a rule targeting `.cell-popover__row`.
+    const m = css.match(/\.cell-popover__row[^{]*\{[^}]*min-height:\s*44px/);
+    expect(m, 'expected a .cell-popover__row rule with min-height:44px').not.toBeNull();
   });
 });

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -2037,6 +2037,149 @@ describe('#864 — lone unclustered bucket silhouette opens its real species', (
   });
 });
 
+// ─── E1 (#1053): close-on-detail-open — MapCanvas-owned popovers ─────────────
+//
+// The MapCanvas owns `selectedObs` (the ObservationPopover) and `clusterList`
+// (the canvas-level ClusterListPopover). When a species detail opens
+// (`detailOpen` rises false→true) both must clear: desktop the popover lingers
+// mid-map beside the detail card; mobile it paints over the detail sheet. The
+// sibling marker-local clearing (`activeCell`/`isClusterListOpen`) is covered in
+// AdaptiveGridMarker.test.tsx — this block pins the MapCanvas half so neither
+// site is left wired while the other is fixed (the #976 partial-coverage trap).
+describe('E1 (#1053) — opening species detail closes MapCanvas-owned popovers', () => {
+  beforeEach(() => {
+    capturedSourceProps = {};
+    capturedLayerFilters = {};
+    capturedSourcesById = {};
+    capturedLayerPaint = {};
+    registeredHandlers = {};
+    bareHandlers = {};
+    bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
+    fakeMap = makeFakeMap();
+    document.documentElement.removeAttribute('data-theme');
+    __resetAdaptiveGridCacheForTesting();
+  });
+
+  it('a rising detailOpen edge clears an open ObservationPopover (selectedObs)', async () => {
+    const obs = makeObs({ subId: 'S1053', comName: 'Vermilion Flycatcher' });
+    const { rerender } = render(
+      <MapCanvas observations={[obs]} silhouettes={SILHOUETTES} detailOpen={false} />,
+    );
+    await waitFor(() =>
+      expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+    );
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('unclustered-point')
+          ? [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [obs.lng, obs.lat] },
+                properties: { subId: 'S1053' },
+              },
+            ]
+          : [],
+    );
+    const handler = registeredHandlers['click:unclustered-point'];
+    if (!handler) throw new Error('click:unclustered-point handler missing');
+    await act(async () => {
+      handler({ point: [120, 120] });
+      await Promise.resolve();
+    });
+    expect(
+      await screen.findByRole('dialog', { name: /Details for Vermilion Flycatcher/ }),
+    ).toBeInTheDocument();
+
+    // Open a species detail → detailOpen rises → the popover unmounts.
+    rerender(<MapCanvas observations={[obs]} silhouettes={SILHOUETTES} detailOpen />);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: /Details for Vermilion Flycatcher/ }),
+      ).toBeNull(),
+    );
+  });
+
+  it('a rising detailOpen edge clears an open canvas ClusterListPopover (clusterList)', async () => {
+    const LONE_BUCKET: AggregatedBucket = {
+      lat: 46.0,
+      lng: -110.0,
+      count: 7,
+      speciesCount: 2,
+      families: [
+        {
+          code: 'tyrannidae',
+          count: 7,
+          speciesCount: 2,
+          species: [
+            { code: 'wewp', count: 5 },
+            { code: 'sayphoebe', count: 2 },
+          ],
+        },
+      ],
+    };
+    const DICT = new Map<string, { comName: string; familyCode: string }>([
+      ['wewp', { comName: 'Western Wood-Pewee', familyCode: 'tyrannidae' }],
+      ['sayphoebe', { comName: "Say's Phoebe", familyCode: 'tyrannidae' }],
+    ]);
+    const { rerender } = render(
+      <MapCanvas
+        observations={[]}
+        buckets={[LONE_BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+        detailOpen={false}
+      />,
+    );
+    await waitFor(() =>
+      expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+    );
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('unclustered-point')
+          ? [
+              {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [LONE_BUCKET.lng, LONE_BUCKET.lat] },
+                properties: {
+                  count: LONE_BUCKET.count,
+                  speciesCount: LONE_BUCKET.speciesCount,
+                  familiesJson: JSON.stringify(LONE_BUCKET.families),
+                  familyCode: 'tyrannidae',
+                  silhouetteId: 'tyrannidae',
+                  color: '#c3772d',
+                },
+              },
+            ]
+          : [],
+    );
+    const handler = registeredHandlers['click:unclustered-point'];
+    if (!handler) throw new Error('click:unclustered-point handler missing');
+    await act(async () => {
+      handler({ point: [120, 120] });
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId('cluster-list-popover')).toBeInTheDocument();
+
+    // Open a species detail → detailOpen rises → the cluster popover unmounts.
+    rerender(
+      <MapCanvas
+        observations={[]}
+        buckets={[LONE_BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+        detailOpen
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId('cluster-list-popover')).toBeNull(),
+    );
+  });
+});
+
 // Popover-originated onSelectSpecies wire.
 // These tests run in a separate describe block that resets modules to
 // pick up the pointer:fine matchMedia stub for AdaptiveGridMarker.
@@ -2231,10 +2374,21 @@ describe('ObservationPopover anchoring — displaced silhouette regression (#718
     // shift produces an `entry.longitude/entry.latitude` that differs
     // from the obs's original lng/lat — this divergence is what the
     // bug at line 1607 would project from the wrong side of.
-    const obsLng = -110.9;
-    const obsLat = 32.2;
-    const clusterLng = -110.9; // co-located → forces displacement
-    const clusterLat = 32.2;
+    //
+    // E1 (#1053) note: these coords are chosen so the project() mock
+    // (x = (lng+180)*1000, y = (90−lat)*1000) lands the popover INSIDE the
+    // jsdom 1024×768 viewport (≈ x=400, y=500). Before #1053 the test used
+    // -110.9/32.2, which projected to ≈ (69100, 57800) — far off-screen.
+    // That was harmless when the popover position was the raw projection, but
+    // #1053 added an on-screen safe-area clamp (left/top pinned into
+    // [12, vw/vh − size − 12]); an off-screen projection now clamps to the same
+    // corner regardless of the entry-vs-obs divergence, erasing the
+    // discriminator this test reads. On-screen coords keep the clamp a no-op so
+    // the entry-projection invariant is still observable in the inline left/top.
+    const obsLng = -179.6;
+    const obsLat = 89.5;
+    const clusterLng = -179.6; // co-located → forces displacement
+    const clusterLat = 89.5;
     const obs = makeObs({
       subId: 'S-DISPLACED',
       lng: obsLng,

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -352,6 +352,24 @@ export function MapCanvas({
     /** Camera center the "+N more" drill-in escalates into (the group anchor). */
     drillCenter?: [number, number];
   } | null>(null);
+  // E1 (#1053): close the canvas-owned transient popovers on the RISING edge of
+  // `detailOpen`. Opening a species detail must dismiss any open
+  // ObservationPopover (`selectedObs`) or canvas-level ClusterListPopover
+  // (`clusterList`) — desktop they otherwise linger mid-map beside the detail
+  // card; mobile they paint ON TOP of the detail sheet, occluding the heading.
+  // #976 only demoted the passive hover preview's z-index; click-opened popovers
+  // were never cleared. RISING-edge only (tracked via a ref) so a popover opened
+  // WHILE a detail is already up is left alone. The sibling marker-local
+  // clearing (`activeCell` 'popover' + `isClusterListOpen`) lives in
+  // AdaptiveGridMarker.tsx; both halves are needed to cover every open-state.
+  const prevDetailOpenRef = useRef(detailOpen);
+  useEffect(() => {
+    if (detailOpen && !prevDetailOpenRef.current) {
+      setSelectedObs(null);
+      setClusterList(null);
+    }
+    prevDetailOpenRef.current = detailOpen;
+  }, [detailOpen]);
   /**
    * Unified deconflict output (issue #554). One entry per overlap-component
    * — each carries an anchor cluster (whose marker actually paints) and the

--- a/frontend/src/components/map/ObservationPopover.test.tsx
+++ b/frontend/src/components/map/ObservationPopover.test.tsx
@@ -183,6 +183,95 @@ describe('ObservationPopover', () => {
     expect(left).toBe(538);
   });
 
+  // E1 (#1053): the popover must keep a ≥12px gutter from EVERY viewport edge,
+  // not only flip away from the right/bottom. The pre-fix non-flip branch
+  // emitted a bare `position.x + OFFSET` with no upper clamp, so a click near
+  // the right edge whose flipX check just barely failed could still let the
+  // 300px card cross the edge. The flip branch's floor was a raw `8`, not the
+  // shared 12px inset.
+  describe('viewport-edge clamp to 12px safe area (#1053)', () => {
+    it('clamps the right edge to vw − 12 in the non-flip (below-right) branch', () => {
+      // A 390 mobile viewport. position.x = 84 keeps flipX false
+      // (84 + 12 + 300 = 396 > 390 would flip; pick x so it does NOT flip but
+      // the right edge would still overflow without an upper clamp). Use x=70:
+      // 70 + 12 = 82 left; 82 + 300 = 382 > 390 − 12 = 378 → must clamp to 78.
+      Object.defineProperty(window, 'innerWidth', { value: 390, configurable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 844, configurable: true });
+      render(
+        <ObservationPopover
+          observation={makeObs()}
+          position={{ x: 70, y: 100 }}
+          onClose={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      const dialog = screen.getByRole('dialog');
+      const left = parseFloat(dialog.style.left);
+      // POPOVER_W = 300; right edge (left + 300) must not exceed vw − 12 = 378.
+      expect(left + 300).toBeLessThanOrEqual(390 - 12);
+      // And the left gutter stays ≥12.
+      expect(left).toBeGreaterThanOrEqual(12);
+    });
+
+    it('uses the 12px floor (not 8px) when flipping left at the right edge', () => {
+      // Reproduces the old `Math.max(8, …)`. With x small enough that the
+      // flip-left target goes negative, the floor must be 12, not 8.
+      Object.defineProperty(window, 'innerWidth', { value: 320, configurable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 844, configurable: true });
+      render(
+        <ObservationPopover
+          observation={makeObs()}
+          position={{ x: 315, y: 100 }}
+          onClose={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      const dialog = screen.getByRole('dialog');
+      // flipX: 315 + 12 + 300 = 627 > 320 → flip left: 315 − 12 − 300 = 3 < 12
+      // → floored to the 12px inset.
+      expect(parseFloat(dialog.style.left)).toBe(12);
+    });
+  });
+
+  // E1 (#1053): anchor caret — the popover renders a caret notch on the
+  // click-facing corner, with a data-origin attribute that tracks the flip so
+  // it survives flipX/flipY.
+  describe('anchor caret (#1053)', () => {
+    it('renders a caret whose data-origin matches the default (top-left) placement', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 900, configurable: true });
+      render(
+        <ObservationPopover
+          observation={makeObs()}
+          position={{ x: 100, y: 200 }}
+          onClose={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      const caret = screen.getByTestId('observation-popover-caret');
+      expect(caret).toBeInTheDocument();
+      // Default below-right placement → caret on the top-left corner.
+      expect(caret.getAttribute('data-origin')).toBe('top left');
+    });
+
+    it('flips the caret origin with the popover (bottom-right when both axes flip)', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1000, configurable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 400, configurable: true });
+      render(
+        <ObservationPopover
+          observation={makeObs()}
+          position={{ x: 850, y: 380 }}
+          onClose={vi.fn()}
+          onSelectSpecies={vi.fn()}
+        />,
+      );
+      const caret = screen.getByTestId('observation-popover-caret');
+      // flipX (850 + 12 + 300 > 1000) AND flipY (380 + 12 + 180 > 400) → the
+      // popover grows up-left so the caret sits at its bottom-right corner.
+      expect(caret.getAttribute('data-origin')).toBe('bottom right');
+    });
+  });
+
   it('omits inline left/top when position is null (legacy harness path)', () => {
     render(
       <ObservationPopover

--- a/frontend/src/components/map/ObservationPopover.tsx
+++ b/frontend/src/components/map/ObservationPopover.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { Observation } from '@bird-watch/shared-types';
 import { formatCount } from '../../lib/format-count.js';
+import { POPOVER_VIEWPORT_INSET_PX } from './CellPopover.js';
 
 export interface ObservationPopoverProps {
   observation: Observation | null;
@@ -167,14 +168,24 @@ export function ObservationPopover({
     const vh = typeof window !== 'undefined' ? window.innerHeight : 900;
     const flipX = position.x + OFFSET + POPOVER_W > vw;
     const flipY = position.y + OFFSET + measuredH > vh;
+    // E1 (#1053): clamp every side to the shared 12px safe area
+    // (POPOVER_VIEWPORT_INSET_PX, mirrors --card-inset). Before, only the FLIP
+    // branch had a floor (a raw `8`), and the non-flip branch emitted a bare
+    // `position.x + OFFSET` with NO upper bound — so a click near the right/
+    // bottom edge whose flip check just failed could still push the 300px card
+    // off-screen. Compute the raw left/top from the flip decision, then clamp
+    // into [inset, vw/vh − size − inset] on both axes.
+    const inset = POPOVER_VIEWPORT_INSET_PX;
+    const rawLeft = flipX ? position.x - OFFSET - POPOVER_W : position.x + OFFSET;
+    const rawTop = flipY ? position.y - OFFSET - measuredH : position.y + OFFSET;
+    const maxLeft = Math.max(inset, vw - POPOVER_W - inset);
+    const maxTop = Math.max(inset, vh - measuredH - inset);
+    const left = Math.min(Math.max(rawLeft, inset), maxLeft);
+    const top = Math.min(Math.max(rawTop, inset), maxTop);
     style = {
       position: 'absolute',
-      left: flipX
-        ? `${Math.max(8, position.x - OFFSET - POPOVER_W)}px`
-        : `${position.x + OFFSET}px`,
-      top: flipY
-        ? `${Math.max(8, position.y - OFFSET - measuredH)}px`
-        : `${position.y + OFFSET}px`,
+      left: `${left}px`,
+      top: `${top}px`,
     };
     origin = `${flipY ? 'bottom' : 'top'} ${flipX ? 'right' : 'left'}`;
   }
@@ -188,6 +199,22 @@ export function ObservationPopover({
       aria-label={`Details for ${observation.comName}`}
       style={style}
     >
+      {/* #1053: anchor caret — an 8px rotated-square notch on the click-facing
+          corner. `origin` already encodes the flip ('top|bottom left|right'):
+          it names the corner the popover grew FROM, i.e. the corner nearest the
+          click, which is exactly where the caret belongs. Mirroring it onto
+          data-origin lets the CSS park the notch there so it survives
+          flipX/flipY. Only rendered on the anchored path (position !== null);
+          the legacy no-anchor harness path has no marker to point at.
+          Decorative (aria-hidden) — the dialog already announces itself. */}
+      {position && (
+        <span
+          className="observation-popover-caret"
+          data-testid="observation-popover-caret"
+          data-origin={origin}
+          aria-hidden="true"
+        />
+      )}
       <div className="observation-popover-header">
         <span
           ref={headingRef}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1690,6 +1690,50 @@ body:has(.species-detail-sheet--peek) .map-attribution {
   max-width: var(--card-maxw-popover);
 }
 
+/* #1053 — anchor caret. An 8px square rotated 45° parked at the click-facing
+   CORNER of the popover so it doesn't read as a detached card in a dense marker
+   pile. `data-origin` names the corner the popover grew FROM (== the corner
+   nearest the click), set by ObservationPopover.tsx from the same flipX/flipY
+   decision that places the card, so the caret survives the flip. The notch is
+   filled with the card background and shows only its two outward border edges.
+   Decorative (aria-hidden in the JSX). Default origin is 'top left'. */
+.observation-popover-caret {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: var(--color-bg-surface);
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+/* top-left corner → notch points up-left (top + left borders show). */
+.observation-popover-caret[data-origin='top left'] {
+  top: -4px;
+  left: var(--space-md);
+  border-top: 1px solid var(--color-border-ui);
+  border-left: 1px solid var(--color-border-ui);
+}
+/* top-right corner → notch points up-right (top + right borders show). */
+.observation-popover-caret[data-origin='top right'] {
+  top: -4px;
+  right: var(--space-md);
+  border-top: 1px solid var(--color-border-ui);
+  border-right: 1px solid var(--color-border-ui);
+}
+/* bottom-left corner → notch points down-left (bottom + left borders show). */
+.observation-popover-caret[data-origin='bottom left'] {
+  bottom: -4px;
+  left: var(--space-md);
+  border-bottom: 1px solid var(--color-border-ui);
+  border-left: 1px solid var(--color-border-ui);
+}
+/* bottom-right corner → notch points down-right (bottom + right borders show). */
+.observation-popover-caret[data-origin='bottom right'] {
+  bottom: -4px;
+  right: var(--space-md);
+  border-bottom: 1px solid var(--color-border-ui);
+  border-right: 1px solid var(--color-border-ui);
+}
+
 /* #950 — recipe-05 (menu-dropdown) origin-aware enter. Shared by the transient
    popovers that grow from a click point: ObservationPopover here, CellPopover
    in ds-primitives.css (which gates the enter behind data-placed). The element


### PR DESCRIPTION
## Diagrams

Two shared popover behaviors change. First, the safe-area clamp + caret geometry
(one source of truth for the 12px inset, consumed by both anchored surfaces):

```mermaid
flowchart TD
    A["anchor rect + measured card size"] --> B["computePopoverPosition / ObservationPopover clamp"]
    INSET["POPOVER_VIEWPORT_INSET_PX = 12 (mirrors --card-inset)"] --> B
    B --> C{"fits below / right?"}
    C -->|yes| D["place below-right"]
    C -->|no| E["flip above / left"]
    D --> F["clamp every side into [12, vw or vh − size − 12]"]
    E --> F
    F --> G["caret placement = same flip decision (survives flip/shift/clamp)"]
    G --> H["render card + anchor caret on cell-facing edge"]
```

Second, the rising-edge dismissal spans BOTH state scopes (the #976
partial-coverage trap this fixes):

```mermaid
stateDiagram-v2
    [*] --> PopoverOpen: click marker / cell
    PopoverOpen --> Dismissed: detailOpen rises false→true
    note right of Dismissed
        MapCanvas clears selectedObs + clusterList
        AdaptiveGridMarker clears activeCell ('popover') + isClusterListOpen
    end note
    PopoverOpen --> PopoverOpen: opened WHILE detail already up (hover-to-compare, untouched)
    Dismissed --> [*]
```

## Summary

- **Why:** the 2026-06-11 design review found transient popovers that ignore the
  safe area (M-16: flush to the 390 right edge, colliding with edge-swipe),
  outlive their context (V22/V32: linger mid-map on desktop, occlude the detail
  sheet on mobile), read as detached cards in dense marker piles (M-23: no anchor
  caret), and ship sub-44px species rows (#565, WCAG 2.5.5).
- **What:** one shared `POPOVER_VIEWPORT_INSET_PX = 12` clamps `CellPopover` +
  `ObservationPopover` to the `--card-inset` safe area on all four sides; an 8px
  rotated-square anchor caret tracks the flip decision; a `detailOpen` rising-edge
  effect in both state scopes dismisses click-opened popovers; the bot's block
  recipe gives `.cluster-list-popover__row` a 44px floor (+ the cell popover rows
  under coarse pointer).
- **Scope guard:** caret is `.cell-popover` + `.observation-popover` only (the
  cluster popover is an anchorless fixed bottom strip — per the reviewer
  addendum folded into the issue). No bottom-stack vars / z-ladder touched
  (E2 #1054 owns those).

## Screenshots

Captured live (Playwright MCP) against head `6a1045c`, **cell-popover open** (showing the new anchor caret) at all 5 canonical viewports × light/dark, at `?scope=us`. Console 0 errors / 0 warnings at every viewport (lone dark-basemap `circle-11` warning is pre-existing #947).

Live-verified at head `6a1045c`: `.cell-popover__caret` present (position absolute, left 12px, top -4px — anchor caret, M-23 ✓); popover within viewport (clamp, M-16 ✓); clicking a popover row opens detail (`?detail=devseed-stejay`) and the popover **closes** (close-on-detail, V22/V32 ✓). 44px species rows (#565) covered by the `@coarse` e2e + unit contract.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e1-390-light](https://github.com/user-attachments/assets/61a09985-3329-4146-b4f2-7da531c6c2e1) | ![e1-390-dark](https://github.com/user-attachments/assets/6d4cccab-0731-4824-85eb-a7a787532289) |
| 768×1024 (tablet) | ![e1-768-light](https://github.com/user-attachments/assets/aa49a366-90a8-4a1e-b3d2-56c726e86cef) | ![e1-768-dark](https://github.com/user-attachments/assets/96a26dd5-c250-4205-9a01-d0fbb75b3b72) |
| 1024×768 (laptop) | ![e1-1024-light](https://github.com/user-attachments/assets/42840e84-fe6a-4b8f-8126-a52f7c2034b5) | ![e1-1024-dark](https://github.com/user-attachments/assets/5ef08731-f62f-4fa4-a96e-4ab17a229936) |
| 1440×900 (desktop) | ![e1-1440-light](https://github.com/user-attachments/assets/d5345f0c-13bb-41db-ac51-97d9a7874d89) | ![e1-1440-dark](https://github.com/user-attachments/assets/67e43c77-db52-4f20-81e5-983f97580dce) |
| 1920×1080 (wide) | ![e1-1920-light](https://github.com/user-attachments/assets/34bae02c-763d-42be-acbf-37130a7be476) | ![e1-1920-dark](https://github.com/user-attachments/assets/4f656cf0-8389-4a7f-8e4d-e66426191be7) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule
      (`.cell-popover__caret`, `.observation-popover-caret` — verified by
      `scripts/check-orphan-classnames.sh`: PASS)
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 1444 passed (87 files)
- [x] New unit tests added across the four sibling suites (clamp 12px floor,
      390 east-edge gutter, caret presence + flip, close-on-detail-open in both
      MapCanvas + AdaptiveGridMarker scopes, 44px CSS contract)
- [x] e2e: `map-cell-popover.spec.ts` extended — live 12px right-gutter bbox +
      caret assertion at 390, and a ≥44px species-row bbox in the `@coarse`
      tablet flow. Ran both projects against a worktree-local Vite (5180 →
      shared read-api 8787): 7 passed / 2 skipped; related `observation-popover`,
      `map-marker-popover`, `species-detail` specs 17 passed (incl. zero
      console errors/warnings)
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — clean; `bash scripts/check-orphan-classnames.sh` — PASS
- [ ] (UI only) Playwright MCP smoke at 5 viewports × 2 themes — pending
      orchestrator live verification (W.3)

## Design QA

`ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Notes

- **Right-edge clamp uses the CSS max-width cap (300), not the one-shot-measured
  width.** The `useLayoutEffect` measures the card before content/fonts settle,
  so a card that grows to the 300px cap can be measured narrower; a left clamp
  from that stale width then lets the grown card overrun the edge (reproduced
  live at 390: right edge 391 vs the 378 floor). Clamping against the cap makes
  the gutter robust — a narrower card just gets a slightly wider right gutter.
- **The #718 displaced-silhouette regression test** moved from `-110.9/32.2`
  (which the `project()` mock sent ~69000px off-screen) to on-screen-projecting
  coords, so the new on-screen clamp leaves its entry-vs-obs discriminator
  observable. Displacement still triggers; the invariant (base projection from
  `entry.*`, not `obs.*`) is unchanged.
- **Watch item not reproduced:** the unconfirmed ~15s mobile popover
  self-dismissal (marker re-render suspected) was not seen; left out of scope
  per the issue.

## Plan reference

Part of epic #1052 (geometry, transients & camera), Wave 3 / child **E1**.
Design-review remediation program. Absorbs #565.

Closes #1053. Closes #565. Part of #1052 (Wave 3 / E1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

