### PR TITLE
fix(geometry): bottom-stack shared vars + z-ladder cleanup (#1054)

### DIFF
--- a/frontend/e2e/legend-attribution-overlap.spec.ts
+++ b/frontend/e2e/legend-attribution-overlap.spec.ts
@@ -169,4 +169,49 @@ test.describe('Legend ↔ attribution clearance (#837)', () => {
       await assertNoOverlapWhenExpanded(page, app);
     });
   });
+
+  // E2 (#1054): at ≥1440 the legend must adopt the wide corner gutter
+  // (--card-inset-wide = 24px) like the other four corners — it was the only
+  // corner missing the @media (min-width:1440px) block, leaving the bottom-left
+  // at 13px while the bottom-right attribution sat at 24-25px. Assert the legend
+  // sits ~24px from the left/bottom edges AND shares the attribution's bottom
+  // baseline (both bottom-anchored at --card-inset-wide). 1.5px tolerance for
+  // sub-pixel border/rounding.
+  test.describe('desktop 1440px — shared 24px corner gutter', () => {
+    test.use({ viewport: { width: 1440, height: 900 } });
+
+    test('the legend sits 24px from left/bottom and shares the attribution bottom baseline', async ({ page, apiStub }) => {
+      test.setTimeout(60_000);
+      await setupRoutes(page, apiStub);
+      const app = new AppPage(page);
+      await app.goto('state=US-AZ');
+      await app.waitForAppReady();
+      await expect(page.locator('[data-testid=map-canvas]')).toBeVisible({ timeout: 15_000 });
+      if (await skipIfMapHookAbsent(page, test)) return;
+
+      const m = await page.evaluate(() => {
+        const legend = document.querySelector('.family-legend');
+        const attr = document.querySelector('.map-attribution');
+        if (!legend || !attr) return null;
+        const lr = legend.getBoundingClientRect();
+        const ar = attr.getBoundingClientRect();
+        return {
+          legendLeft: lr.left,
+          legendBottomGap: window.innerHeight - lr.bottom,
+          attrBottomGap: window.innerHeight - ar.bottom,
+        };
+      });
+      expect(m, '.family-legend / .map-attribution not found').not.toBeNull();
+      // 24px = --card-inset-wide.
+      expect(m!.legendLeft, 'legend left gutter is the wide 24px inset').toBeLessThanOrEqual(25.5);
+      expect(m!.legendLeft).toBeGreaterThanOrEqual(22.5);
+      expect(m!.legendBottomGap, 'legend bottom gutter is the wide 24px inset').toBeLessThanOrEqual(25.5);
+      expect(m!.legendBottomGap).toBeGreaterThanOrEqual(22.5);
+      // The two bottom corners now share a baseline (both at --card-inset-wide).
+      expect(
+        Math.abs(m!.legendBottomGap - m!.attrBottomGap),
+        'legend and attribution share the bottom baseline',
+      ).toBeLessThanOrEqual(1.5);
+    });
+  });
 });

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -102,11 +102,17 @@ async function measureLegendVsSheet(
 ): Promise<{
   sheet: { left: number; top: number; right: number; bottom: number };
   legend: { left: number; top: number; right: number; bottom: number };
+  attr: { left: number; top: number; right: number; bottom: number } | null;
   intersectY: number;
+  // E2 (#1054): the bottom-right attribution must also yield above the peek strip
+  // (it rests at --z-overlay 40, above the peek sheet at --z-sheet-resting 10, so
+  // without a yield it paints over the sheet's family row). Full 2D overlap area.
+  attrSheetOverlap: number;
 } | null> {
   return page.evaluate(() => {
     const sheet = document.querySelector('.species-detail-sheet');
     const legend = document.querySelector('.family-legend');
+    const attr = document.querySelector('.map-attribution');
     if (!sheet || !legend) return null;
     const s = sheet.getBoundingClientRect();
     const l = legend.getBoundingClientRect();
@@ -114,10 +120,21 @@ async function measureLegendVsSheet(
       0,
       Math.min(s.bottom, l.bottom) - Math.max(s.top, l.top),
     );
+    let attrRect: { left: number; top: number; right: number; bottom: number } | null = null;
+    let attrSheetOverlap = 0;
+    if (attr) {
+      const a = attr.getBoundingClientRect();
+      attrRect = { left: a.left, top: a.top, right: a.right, bottom: a.bottom };
+      const ox = Math.max(0, Math.min(a.right, s.right) - Math.max(a.left, s.left));
+      const oy = Math.max(0, Math.min(a.bottom, s.bottom) - Math.max(a.top, s.top));
+      attrSheetOverlap = ox * oy;
+    }
     return {
       sheet: { left: s.left, top: s.top, right: s.right, bottom: s.bottom },
       legend: { left: l.left, top: l.top, right: l.right, bottom: l.bottom },
+      attr: attrRect,
       intersectY,
+      attrSheetOverlap,
     };
   });
 }
@@ -391,6 +408,17 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
       expect(
         m!.intersectY,
         `legend overlaps peek sheet vertically by ${m!.intersectY.toFixed(1)}px at 390×844`,
+      ).toBeLessThanOrEqual(0.5);
+
+      // E2 (#1054): the bottom-right attribution must also yield above the peek
+      // strip — it rests at --z-overlay (40), above the peek sheet at
+      // --z-sheet-resting (10), so without the peek-yield rule it paints over the
+      // sheet's bottom-right family row and clips its text. Assert zero 2D overlap.
+      expect(m!.attr, '.map-attribution must be present at peek').not.toBeNull();
+      expect(
+        m!.attrSheetOverlap,
+        `attribution (${JSON.stringify(m!.attr)}) overlaps peek sheet ` +
+          `(${JSON.stringify(m!.sheet)}) by ${m!.attrSheetOverlap.toFixed(1)}px² at 390×844`,
       ).toBeLessThanOrEqual(0.5);
     });
   });

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -278,6 +278,69 @@ describe('<SpeciesDetailSheet>', () => {
     });
   });
 
+  // ─── E2 (#1054) — published sheet-strip-height CSS var ──────────────────────
+  //
+  // The bottom-left legend's peek lift and the bottom-right attribution's
+  // peek-yield derive from a single CSS custom property the sheet publishes:
+  // `--sheet-strip-h` on document.body. At the peek detent it equals PEEK_PX
+  // (104px), retiring the stale hand-synced 120px literal in styles.css. The
+  // property MUST clear when the sheet leaves peek and on unmount (the sheet is
+  // conditionally mounted — a stale lift would survive close otherwise).
+  const PEEK_PX = 104;
+  describe('publishes --sheet-strip-h to body (#1054)', () => {
+    afterEach(() => {
+      document.body.style.removeProperty('--sheet-strip-h');
+    });
+
+    async function dragHalfToPeek(handle: HTMLElement) {
+      handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 400, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 600, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 740, pointerId: 1, bubbles: true }));
+      handle.dispatchEvent(new PointerEvent('pointerup', { clientY: 740, pointerId: 1, bubbles: true }));
+    }
+
+    it('at peek the published var equals PEEK_PX; not set at half', async () => {
+      render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'half'));
+      // Half/full stacking is intended — no lift, so no published strip height.
+      expect(document.body.style.getPropertyValue('--sheet-strip-h')).toBe('');
+
+      const handle = await screen.findByTestId('species-detail-sheet-handle');
+      await dragHalfToPeek(handle);
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+      expect(document.body.style.getPropertyValue('--sheet-strip-h')).toBe(`${PEEK_PX}px`);
+    });
+
+    it('clears the var on unmount (no stale lift survives close)', async () => {
+      const { unmount } = render(
+        <SpeciesDetailSheet
+          speciesCode="vermfly"
+          apiClient={makeClient()}
+          onClose={vi.fn()}
+          mainRef={{ current: mainEl }}
+        />,
+      );
+      const sheet = await screen.findByTestId('species-detail-sheet');
+      const handle = await screen.findByTestId('species-detail-sheet-handle');
+      await dragHalfToPeek(handle);
+      await waitFor(() => expect(sheet).toHaveAttribute('data-snap-state', 'peek'));
+      expect(document.body.style.getPropertyValue('--sheet-strip-h')).toBe(`${PEEK_PX}px`);
+
+      act(() => {
+        unmount();
+      });
+      expect(document.body.style.getPropertyValue('--sheet-strip-h')).toBe('');
+    });
+  });
+
   // ─── Escape — pinned predicate (#1026) ─────────────────────────────────────
   //
   // Escape now DISMISSES the sheet (closeWithRestore → onClose), matching the

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -344,6 +344,39 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
     [vh],
   );
 
+  // E2 (#1054) — publish the sheet's bottom-stack strip height as a single CSS
+  // custom property the bottom-left legend's peek lift and the bottom-right
+  // attribution's peek-yield derive from (styles.css). This retires the stale
+  // hand-synced 120px literal that drifted from PEEK_PX (now 104) after #912.
+  //
+  // The published value is the sheet's ACTUAL rendered strip height (offsetHeight),
+  // not the nominal PEEK_PX: the peek detent is content-driven (handle 44px +
+  // compact identity row) and carries env(safe-area-inset-bottom) padding, so the
+  // rendered strip is taller than PEEK_PX on real devices. Measuring the real box
+  // makes the legend/attribution lift land exactly one --space-md gap above the
+  // sheet top regardless of device safe-area — the prior 120px literal only cleared
+  // by luck. Falls back to PEEK_PX when offsetHeight is 0 (jsdom / pre-layout).
+  //
+  // Lift ONLY at peek: half/full stacking over the bottom corners is intended, and
+  // phones force-collapse the legend at half/full (App.tsx legendForceCollapsed),
+  // so a publish at peek alone is correct AND avoids a strobing lift mid-drag.
+  // useLayoutEffect so the measure reads post-commit layout (height inline style
+  // already applied). The sheet is conditionally mounted, so removeProperty on
+  // unmount (and on any non-peek snap) is load-bearing — a stale lift would
+  // otherwise survive close.
+  useLayoutEffect(() => {
+    if (snap === 'peek') {
+      const measured = sheetRef.current?.offsetHeight ?? 0;
+      const stripPx = measured > 0 ? measured : PEEK_PX;
+      document.body.style.setProperty('--sheet-strip-h', `${stripPx}px`);
+    } else {
+      document.body.style.removeProperty('--sheet-strip-h');
+    }
+    return () => {
+      document.body.style.removeProperty('--sheet-strip-h');
+    };
+  }, [snap]);
+
   // Inert sequencing — collapse side. When `snap` transitions away
   // from 'full', the React commit runs first (the new role="region"
   // attribute lands on the sheet), then this layout effect fires and

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -27,6 +27,11 @@
                                 detail surface: sheet peek (10), half (15), full (50) AND
                                 the rail (43). Lets hover-to-compare work with a detail
                                 open without the tooltip painting over it. */
+  --z-sheet-resting:  10;    /* E2 #1054: SpeciesDetailSheet at peek — above under-detail,
+                                BELOW the overlay band so legend/attribution/popovers stay
+                                interactive around it. Mirrors zIndex.sheetResting.        */
+  --z-sheet-raised:   15;    /* E2 #1054: SpeciesDetailSheet at half — one rank above peek,
+                                still below the overlay band. Mirrors zIndex.sheetRaised.  */
   --z-overlay:         40;   /* map-assist overlays: legend, scope-control             */
   --z-popover:         41;   /* on-canvas popovers above map-assist overlays           */
   --z-chrome:          42;   /* DEFINED for S2 (#775) — floating app-header chrome; NOT adopted in P1 */
@@ -825,12 +830,15 @@ body {
   filter: blur(0px);
 }
 
-/* Full-snap sheet: the identity card and controls pill become pointer-events:none
-   so the sheet's collapse handle receives the gesture. */
-body:has(.species-detail-sheet--full) .app-header-identity-card,
-body:has(.species-detail-sheet--full) .app-header-controls-pill {
-  pointer-events: none;
-}
+/* E2 (#1054): the full-snap `pointer-events: none` hack on the identity card +
+   controls pill is RETIRED (spec §5.3). It predated the named z-ladder: the full
+   sheet is now at --z-modal (50) via .species-detail-sheet--full, strictly above
+   the chrome band (--z-chrome 42) the cards ride, and the full sheet covers the
+   card regions (the cards anchor at --card-inset 12px from the top-left/top-right;
+   the only un-covered strip is the 8px FULL_INSET_PX gap above the sheet, which
+   sits ABOVE both cards). A higher-z element wins the hit test regardless of the
+   lower element's pointer-events, so the sheet's collapse handle already receives
+   the gesture at full snap without suppressing the cards. */
 
 .filters-bar {
   display: flex;
@@ -1267,7 +1275,11 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
 .family-legend {
   position: fixed;
   bottom: var(--card-inset);
-  left: var(--space-md);
+  /* E2 (#1054): anchor on --card-inset (the card-geometry gutter token), NOT
+     --space-md. They are the same 12px today, but --space-md would silently
+     detach if the corner gutter is retuned — and the legend is the bottom-left
+     four-corner anchor, so it must track the same token the other four corners do. */
+  left: var(--card-inset);
   z-index: var(--z-overlay);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui);
@@ -1279,6 +1291,17 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   font-size: var(--type-sm);
   color: var(--color-text-strong);
   max-width: var(--card-maxw-legend);
+}
+/* At ≥1440 the corner gutter widens to --card-inset-wide (24px), matching the
+   other four corners (identity card, controls pill, attribution, rail, filters
+   panel) which all carry this block. E2 (#1054): the legend was the only corner
+   missing it, leaving the bottom-left at 13px while the bottom-right attribution
+   sat at 24-25px — the two bottom corners did not share a baseline. */
+@media (min-width: 1440px) {
+  .family-legend {
+    bottom: var(--card-inset-wide);
+    left: var(--card-inset-wide);
+  }
 }
 .family-legend-toggle {
   display: flex;
@@ -1463,7 +1486,7 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
      line + 1px border, rounded up for headroom); keep it synced if the
      attribution grows a line. This rule's specificity (0,2,0) is below the
      peek-sheet lift below (0,2,1), so when a peek sheet is also up the larger
-     120px peek lift correctly wins. */
+     --sheet-strip-h (PEEK_PX = 104px) peek lift correctly wins. */
   .family-legend:has(.family-legend-entries) {
     bottom: calc(var(--card-inset) + 28px + var(--space-sm));
   }
@@ -1507,16 +1530,23 @@ body:has(.species-detail-sheet--full) .app-header-controls-pill {
   display: none;
 }
 
-/* Peek-snap sheet clearance (#830 item F). At the half/full snaps the legend is
-   already force-collapsed on phones (App.tsx legendForceCollapsed → entries
-   display:none above), so ONLY the peek snap leaves the un-collapsed legend
-   inside the bottom-sheet band. Lift the legend above the peek strip so the two
-   never overlap. This is a Layer-3 (transient-interaction) rule scoped to the
-   peek state — deliberately NOT a :root primitive and NOT applied at --half.
-   The 120px MUST stay synced to PEEK_PX in SpeciesDetailSheet.tsx (the peek
-   strip height); change both together. */
+/* Peek-snap sheet clearance (#830 item F; E2 #1054). At the half/full snaps the
+   legend is already force-collapsed on phones (App.tsx legendForceCollapsed →
+   entries display:none above), so ONLY the peek snap leaves the un-collapsed
+   legend inside the bottom-sheet band. Lift the legend above the peek strip so
+   the two never overlap. This is a Layer-3 (transient-interaction) rule scoped
+   to the peek state — deliberately NOT a :root primitive and NOT applied at --half.
+   The strip height now derives from --sheet-strip-h, which SpeciesDetailSheet.tsx
+   publishes on <body> at the peek detent as the sheet's ACTUAL rendered height
+   (offsetHeight, which already includes the env(safe-area-inset-bottom) padding
+   and the content-driven growth above PEEK_PX). This retires the prior hand-synced
+   120px literal, which had drifted from PEEK_PX (104 since #912) and only cleared
+   the true strip by luck. The lift is therefore card-inset gutter + the measured
+   strip + a space-md gap → legend bottom lands exactly one gap above the sheet top
+   on every device. The 104px fallback covers the paint between the peek class
+   landing and the publish layout-effect committing (and is the SSR/no-JS floor). */
 body:has(.species-detail-sheet--peek) .family-legend {
-  bottom: calc(var(--card-inset) + 120px + var(--space-md));
+  bottom: calc(var(--card-inset) + var(--sheet-strip-h, 104px) + var(--space-md));
 }
 
 /* Bottom-right always-visible attribution (#828 Option-A rebase over #830).
@@ -1567,6 +1597,20 @@ body:has(.species-detail-sheet--peek) .family-legend {
     bottom: var(--card-inset-wide);
     right: var(--card-inset-wide);
   }
+}
+
+/* Peek-snap attribution yield (E2 #1054, spec §5.3). The attribution island is
+   tier-1 resting chrome at --z-overlay (40); the peek sheet rests at --z-sheet-resting
+   (10), BELOW it — so without a yield the pill paints over the peek sheet's
+   bottom-right family row and clips its text (tier-1 chrome occluding tier-3
+   content). Lift the attribution above the peek strip exactly as the bottom-left
+   legend does, from the same published --sheet-strip-h (the sheet's measured
+   strip height, already inclusive of safe-area + content growth). ONLY at peek:
+   at half/full the bottom corners are intentionally covered by the sheet (and on
+   phones the legend is force-collapsed). Matches the legend lift's (0,2,1)
+   specificity. */
+body:has(.species-detail-sheet--peek) .map-attribution {
+  bottom: calc(var(--card-inset) + var(--sheet-strip-h, 104px) + var(--space-md));
 }
 
 /* Observation popover (#246, repositioned in #718). Anchored to the
@@ -1888,12 +1932,13 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   border-top-left-radius: var(--radius-lg, 12px);
   border-top-right-radius: var(--radius-lg, 12px);
   box-shadow: var(--card-elevation-sheet);
-  /* Base z-index kept at 10 (below overlay band) — the snap modifier below
-     overrides this at full snap. --peek (z-10) and --half (z-15) intentionally
-     stay below the overlay band so map controls remain interactive when the
-     sheet is partially open (peek/half). --full is elevated to --z-modal (50)
-     by the .species-detail-sheet--full modifier below. (O5 #783) */
-  z-index: 10;
+  /* Base z-index at --z-sheet-resting (10, below the overlay band) — the snap
+     modifier below overrides this at full snap. --peek (--z-sheet-resting) and
+     --half (--z-sheet-raised) intentionally stay below the overlay band so map
+     controls remain interactive when the sheet is partially open (peek/half).
+     --full is elevated to --z-modal (50) by the .species-detail-sheet--full
+     modifier below. (O5 #783; named in E2 #1054.) */
+  z-index: var(--z-sheet-resting);
   display: flex;
   flex-direction: column;
   /* The safe-area-inset-top clearance is only needed at FULL, when the sheet
@@ -2521,19 +2566,21 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    --half: mid-point snap; common for drill-down gesture contexts.
    --full: on --z-modal (50) via the .species-detail-sheet--full modifier (O5 #783). */
 .species-detail-sheet--peek {
-  /* Collapsed bar — intentionally BELOW the overlay band (z-10) so map
-     controls and the legend remain fully interactive at peek. Content is
-     clipped at the inline-driven 96px peek height. */
-  z-index: 10;
+  /* Collapsed bar — intentionally BELOW the overlay band (--z-sheet-resting 10)
+     so map controls and the legend remain fully interactive at peek. Content is
+     clipped at the PEEK_PX (104px) peek detent height
+     (SpeciesDetailSheet.tsx). */
+  z-index: var(--z-sheet-resting);
   overflow: hidden;
 }
 
 .species-detail-sheet--half {
-  /* Half-height state — above the map (z-15) but intentionally BELOW the
-     overlay band so map overlays remain interactive around the sheet.
-     Overflow hidden keeps the sheet clean at the snap boundary; .sheet-fg
-     inside handles scrollable content via its own touch-action. */
-  z-index: 15;
+  /* Half-height state — above the peek resting tier (--z-sheet-raised 15) but
+     intentionally BELOW the overlay band so map overlays remain interactive
+     around the sheet. Overflow hidden keeps the sheet clean at the snap
+     boundary; .sheet-fg inside handles scrollable content via its own
+     touch-action. */
+  z-index: var(--z-sheet-raised);
   overflow: hidden;
 }
 
@@ -2740,14 +2787,19 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
      (position: absolute) resolves against the panel, not the viewport. */
 .filters-panel {
   position: fixed;
-  /* Anchor top-right: clear the pill (--card-inset 12px + pill ~48px + 4px gap). */
-  inset-block-start: calc(var(--card-inset) + 64px);
+  /* Anchor top-right under the controls pill. The pill-clearance term now
+     derives from the SAME tokens the detail rail consumes (--controls-cluster-h
+     54px + --card-gap 8px = 62px) instead of a 64px literal (E2 #1054) — so a
+     pill-height retune moves both surfaces together. 12 + 62 = 74px top; pill
+     bottom = 12 + 54 = 66px → +8px gap, matching the rail's formula. */
+  inset-block-start: calc(var(--card-inset) + var(--controls-cluster-h) + var(--card-gap));
   inset-inline-end: var(--card-inset);
   /* Cap width — never full-bleed; same token as the detail rail. */
   inline-size: min(420px, calc(100vw - var(--card-inset) * 2));
   max-inline-size: var(--card-maxw-rail);
-  /* Scroll containment for overflowing filter controls on small viewports. */
-  max-block-size: calc(100dvh - var(--card-inset) - 64px - env(safe-area-inset-bottom, 0px));
+  /* Scroll containment for overflowing filter controls on small viewports — the
+     same pill-clearance term as the top inset (E2 #1054). */
+  max-block-size: calc(100dvh - var(--card-inset) - var(--controls-cluster-h) - var(--card-gap) - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
   /* Design-language surface — matches identity card / detail rail tier. */
   background: var(--color-bg-surface);
@@ -2756,26 +2808,34 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   box-shadow: var(--card-elevation-3);
   /* Modality z-tier (O4): sheet is modal-with-backdrop, above chrome (42). */
   z-index: var(--z-modal);
-  /* Padding: top padding generous to clear the close button; rest standard. */
-  padding-block-start: calc(var(--space-lg, 20px) + 8px);
-  padding-block-end: var(--space-lg, 20px);
+  /* Padding: top padding generous to clear the close button; rest standard.
+     --space-lg is 16px (styles.css :root), so the misleading 20px fallbacks
+     were removed (E2 #1054). */
+  padding-block-start: calc(var(--space-lg) + 8px);
+  padding-block-end: var(--space-lg);
   padding-inline: var(--space-md);
 }
 
 /* At ≥1440px the controls pill uses --card-inset-wide (24px instead of 12px),
-   so the panel position must track the wider gutter. */
+   so the panel position must track the wider gutter. The pill-clearance term is
+   the same token pair as the base rule (E2 #1054). */
 @media (min-width: 1440px) {
   .filters-panel {
-    inset-block-start: calc(var(--card-inset-wide) + 64px);
+    inset-block-start: calc(var(--card-inset-wide) + var(--controls-cluster-h) + var(--card-gap));
     inset-inline-end: var(--card-inset-wide);
     inline-size: min(420px, calc(100vw - var(--card-inset-wide) * 2));
   }
 }
 
-/* Mobile (compact ≤639px): bottom-anchored sheet instead of top-right drop.
+/* Mobile (compact ≤480px): bottom-anchored sheet instead of top-right drop.
    Respects env(safe-area-inset-bottom) for home-indicator clearance.
-   Max height limits the sheet to ~80vh so the map is still partly visible. */
-@media (max-width: 639px) {
+   Max height limits the sheet to ~80vh so the map is still partly visible.
+   E2 (#1054): switched 639→480 (program-wide breakpoint ruling #1060) so the
+   CSS card↔sheet switch converges with the ≤480 `legendForceCollapsed` signal
+   (App.tsx) — dissolving the 481-639 band where a sheet-mode panel coexisted
+   with an expanded, clickable legend. 480px is written as a literal because a
+   media query cannot consume a CSS var. */
+@media (max-width: 480px) {
   .filters-panel {
     inset-block-start: auto;
     inset-block-end: env(safe-area-inset-bottom, 0px);
@@ -2815,11 +2875,12 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   }
 }
 
-/* Mobile ≤639px: recipe-07 (panel-reveal) bottom-sheet — a short translateY
+/* Mobile ≤480px: recipe-07 (panel-reveal) bottom-sheet — a short translateY
    slide-up + opacity + cross-blur (the sheet's own height supplies the rest of
    the open distance, so a 24px travel reads as a full open). transform-origin
-   resets to the sheet's own box; transform/opacity/filter ONLY. */
-@media (max-width: 639px) {
+   resets to the sheet's own box; transform/opacity/filter ONLY. E2 (#1054):
+   639→480 to match the placement switch above (same #1060 ruling). */
+@media (max-width: 480px) {
   .filters-panel.t-filters-enter {
     transform-origin: bottom center;
     transition:
@@ -2841,25 +2902,31 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
    dismisses it (see App.tsx — onClick handler). It carries no role/label
    (presentational); data-testid="filters-backdrop" is the stable e2e hook.
 
-   z-index: --z-overlay - 1 (= 39) — below the filters sheet (--z-modal 50)
-   and below the chrome band (--z-chrome 42); the backdrop is the topmost
-   element over the map center at z-39, so click-outside-to-dismiss fires
-   reliably without an opaque scrim. pointer-events defaults to auto (inherited)
-   so the click handler works.
+   z-index: --z-modal - 1 (= 49) — directly below the filters sheet (--z-modal
+   50) and ABOVE the overlay band (legend/attribution 40, popovers 41) and the
+   chrome band (42). E2 (#1054) raised it from the prior z-39 (below the overlay
+   band): at z-39 the bottom-left legend sat ABOVE the backdrop, so a desktop
+   legend-entry click during filters-open mutated the family filter UNDER an open
+   "modal" — clicking outside the panel onto the legend should dismiss the panel,
+   not silently toggle a filter. At z-49 a legend click now hits the backdrop and
+   dismisses the panel (the panel at z-50 stays clickable above it). This is the
+   chosen resolution of the O5 (#783) deferral noted below — pointer interaction
+   with the legend during filters-open now dismisses, matching click-outside
+   semantics for the rest of the viewport. pointer-events defaults to auto
+   (inherited) so the click handler works.
 
    background: transparent — NO scrim dim. Modality is enforced by the `inert`
    attribute on #map-layer (set in App.tsx when the panel is open) plus the
    elevated floating panel itself. This matches the Google-Maps "panel over a
    live map" reference: opening a panel must not dim the map.
-   O2 (#770): .family-legend is now a `position:fixed` App-root sibling (not
-   inside #map-layer). The filters `inert` on #map-layer therefore no longer
-   covers the legend — keyboard focus is still contained by the focus-trap in
-   App.tsx's filters effect; pointer interaction with the legend during
-   filters-open is an accepted edge case deferred to O5 (#783). */
+   O2 (#770): .family-legend is a `position:fixed` App-root sibling (not inside
+   #map-layer), so the filters `inert` on #map-layer never covered it. The
+   backdrop raise above (z-49) is what now closes that gap for pointer input;
+   keyboard focus stays contained by the focus-trap in App.tsx's filters effect. */
 .filters-backdrop {
   position: fixed;
   inset: 0;
-  z-index: calc(var(--z-overlay) - 1);
+  z-index: calc(var(--z-modal) - 1);
   background: transparent;
   /* Backdrop click area is the full viewport; cursor shows it is interactive. */
   cursor: default;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -217,11 +217,12 @@
   --tt-scale:            0.96;
   --tt-delay:            120ms;
   --tt-in-ease:          ease-out;
-  /* Mobile (≤639px) Filters bottom-sheet travel for the recipe-07 slide-up;
+  /* Mobile (≤480px) Filters bottom-sheet travel for the recipe-07 slide-up;
      the sheet's own height supplies the rest of the open distance so a short
      translate reads as a full open (recipe-07 note). Named -filters so it
      doesn't collide with the canonical --panel-translate-y (100px) or the
-     field-guide sheet's --panel-translate-y-sheet (32px). */
+     field-guide sheet's --panel-translate-y-sheet (32px). (E2 #1054: the
+     consuming media query moved 639→480 per #1060.) */
   --panel-translate-y-filters: 24px;
 }
 

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -373,15 +373,21 @@ describe('styles.css — W1 conformance', () => {
       if (!m) throw new Error(`--${name} not found / not a literal in styles.css`);
       return Number(m[1]);
     };
-    // The sheet detents are literal z-index declarations in styles.css, NOT
-    // :root tokens — read them from their modifier rules so the guard tracks the
-    // values that actually render (styles.css:2310 / :2319).
+    // The sheet detents now reference NAMED z tiers (E2 #1054: peek →
+    // --z-sheet-resting, half → --z-sheet-raised, replacing the prior raw 10/15).
+    // Read the modifier rule's z-index — accept either a raw literal (legacy) or
+    // a var(--z-*) reference, resolving the var through the :root literal — so the
+    // guard tracks the value that actually renders.
     const sheetDetent = (modifier: string): number => {
       const m = STYLES_CSS.match(
-        new RegExp(`\\.species-detail-sheet--${modifier}\\s*\\{[^}]*z-index:\\s*(\\d+)\\b`, 's'),
+        new RegExp(
+          `\\.species-detail-sheet--${modifier}\\s*\\{[^}]*?z-index:\\s*(?:var\\(\\s*(--z-[a-z-]+)\\s*\\)|(\\d+)\\b)`,
+          's',
+        ),
       );
       if (!m) throw new Error(`.species-detail-sheet--${modifier} z-index not found`);
-      return Number(m[1]);
+      // m[1] = var name (e.g. "--z-sheet-resting"); m[2] = raw literal.
+      return m[1] ? z(m[1].replace(/^--/, '')) : Number(m[2]);
     };
 
     it('--z-under-detail sits BELOW the desktop rail (43)', () => {

--- a/frontend/src/tokens.test.ts
+++ b/frontend/src/tokens.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { iconSize, zIndex, opacity, spacing, duration, color } from './tokens.js';
 
@@ -40,6 +42,8 @@ describe('tokens', () => {
       const ranks = [
         zIndex.map,
         zIndex.underDetail,
+        zIndex.sheetResting,
+        zIndex.sheetRaised,
         zIndex.overlay,
         zIndex.popover,
         zIndex.chrome,
@@ -67,6 +71,28 @@ describe('tokens', () => {
       // #761 focus-order intent (AppHeader → … → detail rail/sheet),
       // token-enforced rather than DOM-order-dependent.
       expect(zIndex.chrome).toBeLessThan(zIndex.rail);
+    });
+    it('sheet-resting/raised tiers sit between under-detail and the overlay band', () => {
+      // E2 (#1054): the species-detail-sheet peek/half resting tiers are now
+      // NAMED (were raw 10/15 in styles.css). They sit ABOVE the under-detail
+      // hover preview (5) and BELOW the overlay band (40) so map overlays
+      // (legend, attribution, popovers) stay interactive around a peek/half sheet.
+      expect(zIndex.underDetail).toBeLessThan(zIndex.sheetResting);
+      expect(zIndex.sheetResting).toBeLessThan(zIndex.sheetRaised);
+      expect(zIndex.sheetRaised).toBeLessThan(zIndex.overlay);
+    });
+    it('new sheet tiers are numerically synced with styles.css :root', () => {
+      // The zIndex object mirrors the --z-* custom properties in styles.css :root
+      // (keep both sides in sync — the mirror comment in tokens.ts says so). This
+      // guard fails if the two new tiers drift between styles.css and tokens.ts.
+      const css = readFileSync(join(import.meta.dirname, './styles.css'), 'utf8');
+      const readTier = (name: string): number => {
+        const m = css.match(new RegExp(`--${name}:\\s*(\\d+)`));
+        if (!m) throw new Error(`--${name} not found in styles.css :root`);
+        return Number(m[1]);
+      };
+      expect(readTier('z-sheet-resting')).toBe(zIndex.sheetResting);
+      expect(readTier('z-sheet-raised')).toBe(zIndex.sheetRaised);
     });
   });
 

--- a/frontend/src/tokens.ts
+++ b/frontend/src/tokens.ts
@@ -79,6 +79,20 @@ export const zIndex = {
    * occluding it.
    */
   underDetail: 5,
+  /**
+   * SpeciesDetailSheet at the peek detent (collapsed identity bar). ABOVE the
+   * under-detail hover preview (5) and BELOW the overlay band (40) so the
+   * legend, attribution and on-canvas popovers stay interactive around a
+   * peek sheet. Named in E2 (#1054) — was a raw `z-index: 10` in styles.css.
+   */
+  sheetResting: 10,
+  /**
+   * SpeciesDetailSheet at the half detent. One rank above the peek resting
+   * tier, still BELOW the overlay band so map overlays remain interactive at
+   * half. Full snap is promoted to `modal` (50) by the --full modifier.
+   * Named in E2 (#1054) — was a raw `z-index: 15` in styles.css.
+   */
+  sheetRaised: 15,
   /** Map-assist overlays: family legend, scope-control. */
   overlay: 40,
   /** On-canvas popovers above map-assist overlays (observation popover). */


### PR DESCRIPTION
## Diagrams

Bottom-stack geometry now derives from shared variables and a fully-named z-ladder, instead of hand-synced literals scattered across `styles.css`.

```mermaid
flowchart TB
    subgraph tokens["shared tokens (single source)"]
        ci["--card-inset / --card-inset-wide"]
        cch["--controls-cluster-h + --card-gap"]
        strip["--sheet-strip-h (published by SpeciesDetailSheet at peek)"]
        zr["--z-sheet-resting (10) / --z-sheet-raised (15)"]
    end

    ci --> legend["family-legend (left/bottom + @1440 wide block)"]
    ci --> attr["map-attribution"]
    cch --> panel["filters-panel top + max-block (was 64px literal)"]
    strip --> liftL["legend peek lift"]
    strip --> liftA["attribution peek-yield (new — stops overpaint)"]
    zr --> sheet["sheet base / --peek / --half rules"]

    subgraph zladder["z-ladder (named, strict-monotonic)"]
        direction LR
        u["under-detail 5"] --> sr["sheet-resting 10"] --> sR["sheet-raised 15"] --> ov["overlay 40"] --> md["modal 50"]
    end

    bd["filters-backdrop: z-39 → calc(--z-modal - 1) = 49"] -. "legend click now dismisses, not filter-mutate" .-> ov
```

## Summary

- **Why:** the four-corner bottom stack was held together by hand-synced literals (one sync — the peek lift's `120px` — already broken vs `PEEK_PX` 104 since #912) and an unnamed sheet z-tier, so the contract drifted literal-by-literal. This is the Epic-E geometry hub; #1055/#1056 build on these shared vars.
- **What:** legend adopts the `@1440 → --card-inset-wide` block + anchors on `--card-inset` (shared bottom baseline with the attribution); `SpeciesDetailSheet` publishes its measured peek strip height as `--sheet-strip-h`, which the legend lift **and a new attribution peek-yield** consume (fixing tier-1 chrome over-painting the tier-3 peek sheet); the three `64px` pill-clearance literals become `calc(--card-inset[-wide] + --controls-cluster-h + --card-gap)`; the filters card↔sheet switch moves `639→480` (#1060); `--z-sheet-resting`/`--z-sheet-raised` are named + mirrored + test-guarded.
- **Also:** the filters backdrop is raised above the overlay band so a legend click during filters-open **dismisses** the panel (was: silently mutated the family filter under an open modal); the full-snap `pointer-events:none` hack is retired (the named z-ladder already routes the gesture to the collapse handle).

## Screenshots

Captured live (Playwright MCP) against head `3fc43f2`, **bottom-stack at `?scope=us`** (legend bottom-left + `OpenFreeMap · eBird` attribution bottom-right + scope/controls clusters) — the four-corner geometry this PR re-anchors. Console 0 errors / 0 warnings at every viewport (the lone dark-basemap `circle-11` warning is the pre-existing #947 item).

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e2-390-light](https://github.com/user-attachments/assets/5018d080-7a55-4636-9e95-52977cc141d4) | ![e2-390-dark](https://github.com/user-attachments/assets/9a73dcd3-4d8e-4333-9e5f-810b24a20179) |
| 768×1024 (tablet) | ![e2-768-light](https://github.com/user-attachments/assets/8639ccf3-9b0a-433c-bcad-18baf6622f78) | ![e2-768-dark](https://github.com/user-attachments/assets/329ae7ee-2a5e-437e-8820-bfe4c07bd173) |
| 1024×768 (laptop) | ![e2-1024-light](https://github.com/user-attachments/assets/def10ee6-647d-44dd-a0ea-b7c539062491) | ![e2-1024-dark](https://github.com/user-attachments/assets/849ee526-7216-4333-a523-df60a43ac366) |
| 1440×900 (desktop) | ![e2-1440-light](https://github.com/user-attachments/assets/503fac22-18aa-47d9-b8e1-852c27e8109a) | ![e2-1440-dark](https://github.com/user-attachments/assets/70219257-bb98-4de7-aa24-4395e3faa8cf) |
| 1920×1080 (wide) | ![e2-1920-light](https://github.com/user-attachments/assets/77d8b3af-07da-4ad3-971c-161543549b85) | ![e2-1920-dark](https://github.com/user-attachments/assets/e3409b75-5926-4df7-8977-ba89f432f865) |

Live geometry verification (head `3fc43f2`, 390 mobile, species sheet open at half detent): sheet `z-index` 15 sits below the persistent corner chrome (legend + attribution at `z-index` 40) — the chrome floats in the sheet's empty bottom margin with no content collision; at the full detent the sheet rises to the modal tier (50) over the chrome band (covered by the new `legend-attribution-overlap` + `map-root-geometry` e2e specs). `--sheet-strip-h` publish/clear and the z-ladder monotonicity are unit-guarded.

**Design QA:** `ui-design:ui-designer` (opus) — PASS, all 5 viewports (below).

- [x] Every new/renamed `className` — N/A, no new classNames (only token/geometry + z-index value changes on existing selectors); `orphan-classname-check` PASS.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above; orchestrator live-capture + ui-designer PASS complete.

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — **1435 passed (87 files)**, including new `SpeciesDetailSheet.test` strip-var (peek == `PEEK_PX`, cleared on unmount), `tokens.test` new z tiers (present + numerically synced with `styles.css :root`), and the updated `tokens.css.test` z-parser.
- [x] New unit tests added (sheet strip-var publish/clear; z-tier chain + CSS parity).
- [x] New Playwright e2e added: legend bbox 24px inset @1440 + shared bottom baseline (`legend-attribution-overlap`); attribution does **not** overlap the peek sheet @390 (`map-root-geometry`).
- [x] `npm run build --workspace @bird-watch/frontend` — clean.
- [x] `npx knip` — no new findings (only the pre-existing `map-v1-prototype` config hint). `bash scripts/check-orphan-classnames.sh` — PASS.
- [x] AC greps all empty: `grep -nE "[+-] 64px"`, `grep -n "120px + var"`, `grep -n "639px"` over `frontend/src/styles.css` (+ `tokens.css`).
- [x] e2e suite driven against the worktree head on a fresh dev server (the shared `:5173` plane serves a different worktree): **279 passed**, all `@coarse` touch tests pass under the coarse-pointer project, 0 real failures. (Live capture + console-zero sweep at all 5 viewports × 2 themes is the orchestrator's W.3 step.)

## Plan reference

Part of the 2026-06-11 design-review remediation program — Epic E (#1052), child **E2** (#1054). Plans live in issues, not `docs/plans/`.

Closes #1054. Part of #1052 (Wave 3 / E2).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

