### PR TITLE
fix(filters): mobile sheet form layout — stacked labels, 44px fields, toggle row (#1056)

### DIFF
--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -133,6 +133,81 @@ test.describe('filter flows', () => {
     await expect(page.getByRole('dialog', { name: 'Filters' })).not.toBeVisible();
   });
 
+  // E4 (#1056): at the 390px mobile sheet breakpoint the filters form must read
+  // and tap like a mobile form — each field full-width and ≥44px tall, the
+  // "Notable only" control its own full-width tappable toggle row — instead of
+  // a shrunken desktop inline form. The panel switches to the bottom sheet at
+  // ≤480px (E2 #1054), so 390×844 is squarely in sheet mode.
+  test.describe('mobile sheet form layout (390×844)', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    // The four interactive controls (the close button and datalist are not
+    // measured). Each is scoped to the open panel via the FiltersBar POM.
+    function controls() {
+      return [app.filters.timeWindow, app.filters.family, app.filters.species];
+    }
+
+    test('every field is full-width and ≥44px tall, radius preserved', async ({ page }) => {
+      const panel = page.getByRole('dialog', { name: 'Filters' });
+      await expect(panel).toBeVisible();
+
+      // Inner content width = the .filters-bar content box (panel inner minus the
+      // panel's padding minus the bar's own padding) — the box the stacked fields
+      // should span. Read padding off the live computed style so the assertion
+      // tracks the tokens, not hard-coded literals.
+      const bar = panel.locator('.filters-bar');
+      const innerWidth = await bar.evaluate((el) => {
+        const cs = window.getComputedStyle(el);
+        return el.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+      });
+
+      for (const field of controls()) {
+        await expect(field).toBeVisible();
+        const box = await field.boundingBox();
+        expect(box).not.toBeNull();
+        // ≥44px coarse-pointer floor (WCAG 2.5.5 / Apple HIG).
+        expect(box!.height).toBeGreaterThanOrEqual(44);
+        // Full-width: spans the panel inner content width (allow 1px rounding).
+        expect(box!.width).toBeGreaterThanOrEqual(innerWidth - 1);
+        // #1041/#1043 radius ladder: inner inputs keep 4px — must NOT drift to
+        // --card-radius-inner (8px) at mobile.
+        const radius = await field.evaluate((el) =>
+          window.getComputedStyle(el).borderRadius,
+        );
+        expect(radius).toBe('4px');
+      }
+    });
+
+    test('the Notable only row is its own ≥44px tappable toggle row', async ({ page }) => {
+      const panel = page.getByRole('dialog', { name: 'Filters' });
+      await expect(panel).toBeVisible();
+
+      // The toggle ROW is the <label> wrapping the checkbox.
+      const row = panel.locator('label.filters-bar__toggle-row');
+      await expect(row).toBeVisible();
+      const rowBox = await row.boundingBox();
+      expect(rowBox).not.toBeNull();
+      expect(rowBox!.height).toBeGreaterThanOrEqual(44);
+      // Full-width row within the .filters-bar content box.
+      const bar = panel.locator('.filters-bar');
+      const innerWidth = await bar.evaluate((el) => {
+        const cs = window.getComputedStyle(el);
+        return el.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+      });
+      expect(rowBox!.width).toBeGreaterThanOrEqual(innerWidth - 1);
+
+      // Tapping the ROW (not just the ~14px glyph) flips notable in the URL.
+      expect(app.getUrlParams().get('notable')).toBeNull();
+      // Click near the row's right edge — away from the checkbox glyph — to
+      // prove the whole row is the tap target.
+      await row.click({ position: { x: rowBox!.width - 12, y: rowBox!.height / 2 } });
+      await expect.poll(() => app.getUrlParams().get('notable'), { timeout: 5_000 }).toBe('true');
+      // The POM's check/uncheck path stays green — round-trip back to default.
+      await app.filters.toggleNotable(false);
+      await expect.poll(() => app.getUrlParams().get('notable'), { timeout: 5_000 }).toBeNull();
+    });
+  });
+
   // B2 (#1041): dark-mode filter controls must render themed — not native UA white.
   // Asserts that the time-window <select> background is the themed --color-bg-surface
   // (#1b2742 = rgb(27, 39, 66)) rather than the browser's default white/lightgray.

--- a/frontend/src/components/FiltersBar.test.tsx
+++ b/frontend/src/components/FiltersBar.test.tsx
@@ -56,6 +56,35 @@ describe('FiltersBar', () => {
     expect(onChange).toHaveBeenCalledWith({ notable: true });
   });
 
+  // E4 (#1056): at the mobile sheet breakpoint the "Notable only" control
+  // becomes its own full-width tappable toggle ROW. The whole row must remain a
+  // <label> wrapping a REAL <input type="checkbox"> with the "Notable only"
+  // accessible name — NOT a button/switch — so getByRole('checkbox') and the
+  // POM's getByLabel('Notable only').check()/.uncheck() stay green. The
+  // .filters-bar__toggle-row class is the CSS hook the mobile @media block
+  // targets to give the row its ≥44px tap area; the desktop layout is unchanged.
+  it('renders the notable control as a full-row toggle with role + label preserved', () => {
+    render(
+      <FiltersBar
+        since="14d"
+        notable={false}
+        speciesCode={null}
+        familyCode={null}
+        families={[]}
+        speciesIndex={[]}
+        onChange={() => {}}
+      />
+    );
+    // The accessible control is still a real checkbox reachable by role + name.
+    const checkbox = screen.getByRole('checkbox', { name: /Notable/ });
+    expect(checkbox).toHaveProperty('type', 'checkbox');
+    // It is wrapped by a <label> carrying the toggle-row hook the mobile CSS
+    // targets — so tapping anywhere on the row flips the checkbox.
+    const row = checkbox.closest('label');
+    expect(row).not.toBeNull();
+    expect(row).toHaveClass('filters-bar__toggle-row');
+  });
+
   it('species draft survives a speciesIndex identity change', async () => {
     const user = userEvent.setup();
     const idx1 = [{ code: 'amerob', comName: 'American Robin' }];

--- a/frontend/src/components/FiltersBar.tsx
+++ b/frontend/src/components/FiltersBar.tsx
@@ -153,7 +153,14 @@ export function FiltersBar(props: FiltersBarProps) {
           <option value="14d">14 days</option>
         </select>
       </label>
-      <label>
+      {/* E4 (#1056): the "Notable only" control is its own row. The
+          .filters-bar__toggle-row hook lets the mobile sheet @media block turn
+          the whole <label> into a full-width ≥44px tappable toggle row — the
+          checkbox glyph stays ~14px but the tap target is the row. The element
+          remains a <label> wrapping a REAL <input type="checkbox"> with the
+          "Notable only" aria-label so getByRole('checkbox') and the POM's
+          getByLabel('Notable only').check()/.uncheck() stay green. */}
+      <label className="filters-bar__toggle-row">
         <input
           type="checkbox"
           aria-label="Notable only"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3030,13 +3030,26 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   }
   /* The toggle row is the exception to the stacked layout: caption sits BESIDE
      the checkbox, the whole row is full-width and ≥44px so the entire band is
-     tappable (the wrapping <label> forwards the click to the checkbox). */
-  .filters-bar__toggle-row {
+     tappable (the wrapping <label> forwards the click to the checkbox).
+     Selector is `label.filters-bar__toggle-row` (0,2,1) so it BEATS the stacked
+     `.filters-bar label { flex-direction: column }` (0,1,1) above — a bare
+     `.filters-bar__toggle-row` (0,1,0) lost on specificity and the row computed
+     `column`, stacking the glyph above its caption. */
+  label.filters-bar__toggle-row {
     flex-direction: row;
     align-items: center;
     gap: var(--space-sm);
     min-block-size: 44px;
     inline-size: 100%;
+  }
+  /* And constrain the checkbox itself back to its natural ~14px glyph: the
+     generic `.filters-bar input { inline-size:100%; min-block-size:44px }` above
+     (0,1,1) would otherwise stretch this checkbox to a full-width 44px box. The
+     `input[type="checkbox"]` element+attr selector here is (0,2,1) so it wins. */
+  .filters-bar__toggle-row input[type="checkbox"] {
+    inline-size: auto;
+    min-block-size: auto;
+    flex: 0 0 auto;
   }
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2987,6 +2987,57 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
     border-radius: var(--card-radius) var(--card-radius) 0 0;
     overflow-y: auto;
   }
+
+  /* E4 (#1056): inside the bottom sheet, restyle the FiltersBar form so it
+     reads and taps like a mobile form instead of the shrunken desktop inline
+     layout. The desktop anchored-card layout (>480px) is untouched — these
+     rules live only in the sheet-mode media query, the SAME 480px breakpoint
+     the .filters-panel card↔sheet switch uses (E2 #1054, ruling #1060).
+
+     Three coupled changes:
+       1. The bar stacks its rows full-width (gap = --space-md) — no more
+          horizontal flex-wrap producing three different field x-positions
+          (ragged left rail). [M-18]
+       2. Each label stacks its caption ABOVE a full-width field, and every
+          select/input gets min-height: 44px (coarse-pointer floor, WCAG 2.5.5)
+          while KEEPING border-radius: 4px — the #1041/#1043 inner-input radius
+          contract; do NOT drift to --card-radius-inner (8px). [M-18]
+       3. "Notable only" becomes its own full-width ≥44px tappable toggle row:
+          the whole <label> row is the tap target (checkbox glyph + caption laid
+          out horizontally, glyph stays ~14px). It already wraps a real
+          <input type="checkbox" aria-label="Notable only">, so role/label and
+          the .check()/.uncheck() POM path are preserved. [M-18] */
+  .filters-bar {
+    flex-direction: column;
+    align-items: stretch;
+    flex-wrap: nowrap;
+    gap: var(--space-md);
+  }
+  .filters-bar label {
+    /* Caption stacked above its field, full-width. */
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+  }
+  .filters-bar select,
+  .filters-bar input {
+    inline-size: 100%;
+    /* Coarse-pointer floor. Keep 4px inner-input radius (set unconditionally at
+       :857-863); restated here only because some UA select resets re-derive it
+       from the box — the property value is identical, never 8px. */
+    min-block-size: 44px;
+    border-radius: 4px;
+  }
+  /* The toggle row is the exception to the stacked layout: caption sits BESIDE
+     the checkbox, the whole row is full-width and ≥44px so the entire band is
+     tappable (the wrapping <label> forwards the click to the checkbox). */
+  .filters-bar__toggle-row {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-sm);
+    min-block-size: 44px;
+    inline-size: 100%;
+  }
 }
 
 /* #950 — Filters panel enter. The panel is conditionally mounted (App.tsx:


### PR DESCRIPTION
## Diagrams

The change is purely a sheet-mode CSS restyle plus one markup hook. At >480px nothing changes; at ≤480px the FiltersBar layout switches from desktop-inline to mobile-form.

```mermaid
flowchart TB
    subgraph desktop["&gt;480px (untouched anchored card)"]
        d1["row of horizontal-flex labels (ragged left rail)"]
        d2["fields ~24px tall, checkbox shares Time-window row"]
    end
    subgraph mobile["&le;480px sheet mode (new @media block)"]
        m1["filters-bar stacks column, full-width"]
        m2["each label: caption ABOVE full-width field"]
        m3["select/input: min-height 44px, border-radius 4px"]
        m4["Notable only: own full-width &ge;44px tappable toggle row"]
    end
    sw{"viewport &le; 480px?"} -->|no| desktop
    sw -->|yes| mobile
```

## Summary

- **Why:** at the ≤480px sheet breakpoint (the card↔sheet switch E2 #1054 moved here) the FiltersBar still rendered the desktop inline `<label>X<select></label>` form — horizontal-flex labels producing a ragged left rail, ~24px-tall fields, and a ~14px checkbox glyph sharing the Time-window visual row, all below the 44px coarse-pointer floor on the app's most-used phone surface (finding M-18, major).
- **What:** a new `@media (max-width: 480px)` block (same literal `.filters-panel` uses) stacks the bar full-width, stacks each label's caption above its field, gives `select`/`input` `min-height: 44px` while keeping `border-radius: 4px` (the #1041/#1043 inner-input radius contract — NOT `--card-radius-inner` 8px), and turns "Notable only" into its own full-width ≥44px tappable toggle row via a new `.filters-bar__toggle-row` class on the existing `<label>`. The desktop anchored-card layout is untouched.
- **Contract preserved:** the toggle still wraps a real `<input type="checkbox" aria-label="Notable only">`, so `getByRole('checkbox', { name: /Notable/ })` and the POM's `getByLabel('Notable only').check()/.uncheck()` stay green; all `aria-label`s and the `onChange` URL-state contract are unchanged.

## Screenshots

Captured live (Playwright MCP) against head `71d0267`, **filters open** at all 5 canonical viewports × light/dark. At 390 the mobile sheet form shows the stacked full-width fields + the inline `[checkbox] Notable only` toggle row; at ≥768 the desktop inline layout is unchanged (no regression). Console clean.

Live-verified at head `71d0267` (390px): every field full-width (332px = bar inner width) and 44px tall; `.filters-bar__toggle-row` computes `flex-direction: row`, 44px tall × 332px full-width, checkbox natural 13×13px (M-18 ✓). **2nd commit `71d0267` fixed a specificity bug** found in W.3 live-verify: `.filters-bar label { flex-direction: column }` (0,1,1) had outranked the toggle-row override (0,1,0) so the checkbox stacked above its label as a full-width box — raised the selector to `label.filters-bar__toggle-row` + constrained the checkbox to natural size, so it now reads as an inline tappable row.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e4-390-light](https://github.com/user-attachments/assets/37d41a8e-fb41-4984-9a89-8b2419da81ac) | ![e4-390-dark](https://github.com/user-attachments/assets/a67e5a90-4254-4b4a-8c29-651691806641) |
| 768×1024 (tablet) | ![e4-768-light](https://github.com/user-attachments/assets/738faea5-6b53-41de-a6a3-ece0c130c91c) | ![e4-768-dark](https://github.com/user-attachments/assets/593f4c9e-79ce-4a3e-a86b-104f807b8bc5) |
| 1024×768 (laptop) | ![e4-1024-light](https://github.com/user-attachments/assets/ee67d0ec-a57f-43af-83bf-f936ad0b3ad4) | ![e4-1024-dark](https://github.com/user-attachments/assets/b2152b74-f875-4f41-b165-6bf2d9eca3c9) |
| 1440×900 (desktop) | ![e4-1440-light](https://github.com/user-attachments/assets/c6d7e9c5-6fe8-4531-b8af-f88f62a7b341) | ![e4-1440-dark](https://github.com/user-attachments/assets/febf87b3-7d5b-48a0-a0e2-66ba16403f54) |
| 1920×1080 (wide) | ![e4-1920-light](https://github.com/user-attachments/assets/ebf00838-b3a9-4e22-a579-4519fcd9ffa0) | ![e4-1920-dark](https://github.com/user-attachments/assets/1b832dae-0e66-436f-824d-411384dc3c3e) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule in `frontend/src/styles.css` — `.filters-bar__toggle-row` is defined in the new `@media (max-width: 480px)` block; `bash scripts/check-orphan-classnames.sh` passes.
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — green (1436 tests, incl. new `FiltersBar.test.tsx` toggle-row case)
- [x] New unit test added — `FiltersBar.test.tsx`: notable control renders as a full-row toggle with role + label preserved
- [x] New Playwright e2e added — `filters.spec.ts` 390×844 block: every field spans the bar inner width and is ≥44px tall with `border-radius: 4px`; tapping the toggle row (away from the glyph) flips `notable` in the URL and round-trips back. Ran green against a worktree-local Vite; `map-root-geometry.spec.ts` also re-run green (no geometry disturbance).
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` (exit 0) and `bash scripts/check-orphan-classnames.sh` — pass
- [x] (UI) Playwright MCP smoke — DONE at head `71d0267`: mobile form full-width 44px fields + inline toggle row verified; desktop unchanged; console clean. Design QA: `ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Plan reference

Closes #1056. Part of #1052 (Wave 3 / E4).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

