### PR TITLE
fix(legend): usability pass — chevron, label wrap, per-tier persistence, empty/overflow states (#1055)

### DIFF
--- a/frontend/e2e/family-legend-collapse-visibility.spec.ts
+++ b/frontend/e2e/family-legend-collapse-visibility.spec.ts
@@ -193,6 +193,9 @@ test.describe('Collapsed legend chip visibility — P0 regression from #471', ()
         try {
           window.localStorage.removeItem('family-legend-expanded');
           window.localStorage.removeItem('family-legend-expanded.v2');
+          window.localStorage.removeItem('family-legend-expanded.v3.compact');
+          window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+          window.localStorage.removeItem('family-legend-expanded.v3.wide');
         } catch { /* noop */ }
       });
       await app.goto('view=map');
@@ -229,6 +232,9 @@ test.describe('Collapsed legend chip visibility — P0 regression from #471', ()
         try {
           window.localStorage.removeItem('family-legend-expanded');
           window.localStorage.removeItem('family-legend-expanded.v2');
+          window.localStorage.removeItem('family-legend-expanded.v3.compact');
+          window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+          window.localStorage.removeItem('family-legend-expanded.v3.wide');
         } catch { /* noop */ }
       });
       await app.goto('view=map');

--- a/frontend/e2e/family-legend-viewport.spec.ts
+++ b/frontend/e2e/family-legend-viewport.spec.ts
@@ -329,6 +329,9 @@ test.describe('FamilyLegend viewport-aware counts (mobile, #351)', () => {
       try {
         window.localStorage.removeItem('family-legend-expanded');
         window.localStorage.removeItem('family-legend-expanded.v2');
+        window.localStorage.removeItem('family-legend-expanded.v3.compact');
+        window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+        window.localStorage.removeItem('family-legend-expanded.v3.wide');
       } catch {
         /* noop */
       }

--- a/frontend/e2e/family-legend.spec.ts
+++ b/frontend/e2e/family-legend.spec.ts
@@ -24,6 +24,9 @@ test.describe('FamilyLegend (desktop)', () => {
       try {
         window.localStorage.removeItem('family-legend-expanded');
         window.localStorage.removeItem('family-legend-expanded.v2');
+        window.localStorage.removeItem('family-legend-expanded.v3.compact');
+        window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+        window.localStorage.removeItem('family-legend-expanded.v3.wide');
       } catch { /* noop */ }
     });
     await app.goto('view=map');
@@ -39,6 +42,9 @@ test.describe('FamilyLegend (desktop)', () => {
       try {
         window.localStorage.removeItem('family-legend-expanded');
         window.localStorage.removeItem('family-legend-expanded.v2');
+        window.localStorage.removeItem('family-legend-expanded.v3.compact');
+        window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+        window.localStorage.removeItem('family-legend-expanded.v3.wide');
       } catch { /* noop */ }
     });
     await app.goto('view=map');
@@ -104,12 +110,12 @@ test.describe('FamilyLegend (mobile)', () => {
     // Resolves analysis Theme 3 — on mobile with empty localStorage (or
     // after a clear), the first paint must start collapsed.
     //
-    // The legacy key migration (family-legend-expanded → .v2) is covered
-    // by unit tests in FamilyLegend.test.tsx. This e2e test covers the
-    // viewport-driven default at the integration level.
+    // The key migration (family-legend-expanded → .v2 → per-tier .v3.<tier>,
+    // E3 #1055) is covered by unit tests in FamilyLegend.test.tsx. This e2e
+    // test covers the viewport-driven default at the integration level.
     //
     // Use addInitScript to clear localStorage BEFORE any React code runs.
-    // localStorage.clear() also removes any .v2 value left by a prior
+    // localStorage.clear() also removes any stored value left by a prior
     // desktop test in the same Playwright BrowserContext worker.
     await page.addInitScript(() => {
       window.localStorage.clear();

--- a/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
+++ b/frontend/e2e/legend-o5-cap-force-collapse.spec.ts
@@ -3,6 +3,18 @@ import { AppPage } from './pages/app-page.js';
 import type { Observation } from '@bird-watch/shared-types';
 
 /**
+ * E3 (#1055): the legend expansion preference is now per-breakpoint-class —
+ * `family-legend-expanded.v3.<tier>` where tier ∈ {compact (<480), roomy
+ * (480–1023), wide (≥1024)}. A seed that sets the wrong tier's key silently
+ * tests nothing (the active tier reads its own key), so map the viewport width
+ * to its tier here and seed that exact key.
+ */
+function legendKeyFor(width: number): string {
+  const tier = width < 480 ? 'compact' : width < 1024 ? 'roomy' : 'wide';
+  return `family-legend-expanded.v3.${tier}`;
+}
+
+/**
  * O5 (#783) — FamilyLegend mobile width cap (R6) + force-collapsed behaviour.
  *
  * Covers:
@@ -98,11 +110,15 @@ test.describe('R6 — legend width cap at 390px (O5 #783)', () => {
 
   test('collapsed legend at 390px is ≤280px wide', async ({ page, apiStub }) => {
     await setupRoutes(page, apiStub);
-    // Start collapsed (clear localStorage so responsive default applies)
+    // Start collapsed (clear localStorage so responsive default applies).
+    // E3 (#1055): clear every legacy + per-tier key so no stored pref survives.
     await page.addInitScript(() => {
       try {
         window.localStorage.removeItem('family-legend-expanded');
         window.localStorage.removeItem('family-legend-expanded.v2');
+        window.localStorage.removeItem('family-legend-expanded.v3.compact');
+        window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+        window.localStorage.removeItem('family-legend-expanded.v3.wide');
       } catch { /* noop */ }
     });
     const app = new AppPage(page);
@@ -133,7 +149,7 @@ test.describe('R6 — legend width cap at 390px (O5 #783)', () => {
     // localStorage says expanded=true. At 390px the cap must still hold.
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.compact', 'true');
       } catch { /* noop */ }
     });
     const app = new AppPage(page);
@@ -156,7 +172,7 @@ test.describe('R6 — legend width cap at 390px (O5 #783)', () => {
 
     // Verify the stored preference was NOT mutated (the cap is CSS-only)
     const stored = await page.evaluate(() =>
-      window.localStorage.getItem('family-legend-expanded.v2'),
+      window.localStorage.getItem('family-legend-expanded.v3.compact'),
     );
     expect(stored).toBe('true');
   });
@@ -177,7 +193,7 @@ test.describe('force-collapsed — detail sheet at half/full (O5 #783)', () => {
     // Expanded legend in localStorage so it would show entries without force-collapse
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.compact', 'true');
       } catch { /* noop */ }
     });
     const app = new AppPage(page);
@@ -221,7 +237,7 @@ test.describe('force-collapsed — detail sheet at half/full (O5 #783)', () => {
 
     // The stored preference must be intact (not mutated to false)
     const stored = await page.evaluate(() =>
-      window.localStorage.getItem('family-legend-expanded.v2'),
+      window.localStorage.getItem('family-legend-expanded.v3.compact'),
     );
     expect(stored).toBe('true');
   });
@@ -252,11 +268,13 @@ for (const { width, height, label } of [
       await setupRoutes(page, apiStub);
       await apiStub.stubSpecies('vermfly', VERMFLY_WITH_PHOTO);
       await apiStub.stubPhotoImage();
-      await page.addInitScript(() => {
+      // E3 (#1055): seed THIS viewport's tier key (1024→wide, 768→roomy).
+      const legendKey = legendKeyFor(width);
+      await page.addInitScript((key) => {
         try {
-          window.localStorage.setItem('family-legend-expanded.v2', 'true');
+          window.localStorage.setItem(key, 'true');
         } catch { /* noop */ }
-      });
+      }, legendKey);
       const app = new AppPage(page);
       // At these widths isCompact=true so the sheet renders (not the rail).
       await app.goto('detail=vermfly&view=detail');
@@ -275,8 +293,9 @@ for (const { width, height, label } of [
       await expect(page.locator('.family-legend-entries')).not.toBeVisible();
 
       // The stored expanded preference is NOT mutated by force-collapse.
-      const stored = await page.evaluate(() =>
-        window.localStorage.getItem('family-legend-expanded.v2'),
+      const stored = await page.evaluate(
+        (key) => window.localStorage.getItem(key),
+        legendKey,
       );
       expect(stored).toBe('true');
     });
@@ -286,11 +305,11 @@ for (const { width, height, label } of [
       apiStub,
     }) => {
       await setupRoutes(page, apiStub);
-      await page.addInitScript(() => {
+      await page.addInitScript((key) => {
         try {
-          window.localStorage.setItem('family-legend-expanded.v2', 'true');
+          window.localStorage.setItem(key, 'true');
         } catch { /* noop */ }
-      });
+      }, legendKeyFor(width));
       const app = new AppPage(page);
       await app.goto('view=map');
       await app.waitForAppReady();
@@ -317,7 +336,7 @@ test.describe('force-collapsed — filters sheet open (O5 #783)', () => {
     await setupRoutes(page, apiStub);
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.compact', 'true');
       } catch { /* noop */ }
     });
     const app = new AppPage(page);

--- a/frontend/e2e/legend-roomy-band-cap.spec.ts
+++ b/frontend/e2e/legend-roomy-band-cap.spec.ts
@@ -10,8 +10,9 @@ import type { Observation } from '@bird-watch/shared-types';
  *   - #810: ≤480px width/height cap (styles.css @media max-width:480px).
  *
  * The surviving bug this spec guards: on the 481–1023px band a user with a
- * stored `family-legend-expanded.v2=true` preference (e.g. expanded on a prior
- * desktop session) sees the legend render expanded — and because the ≤480px cap
+ * stored `family-legend-expanded.v3.roomy=true` preference (E3 #1055 re-keyed
+ * the per-breakpoint pref; pre-#1055 this was the breakpoint-blind `.v2`)
+ * sees the legend render expanded — and because the ≤480px cap
  * media query does NOT apply above 480px, `.family-legend-entries` falls back to
  * the desktop `max-height: 400px`. The resulting ~440px-tall panel anchored at
  * the bottom-left occludes the lower-left of the framed state.
@@ -102,10 +103,11 @@ test.describe('#853 — legend cap on the roomy band (500×844, stored-expanded)
   }) => {
     await setupRoutes(page, apiStub);
     // Simulate the bug-reporting user: expanded on a prior (desktop) session, so
-    // the stored .v2 preference overrides the <1024px collapse-default (#809).
+    // the stored roomy-tier preference overrides the <1024px collapse-default
+    // (#809). 500px maps to the 'roomy' tier (E3 #1055 per-breakpoint keys).
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.roomy', 'true');
       } catch {
         /* noop */
       }
@@ -147,7 +149,7 @@ test.describe('#853 — legend cap on the roomy band (500×844, stored-expanded)
     // Sanity: the cap is a CSS display bound only — the stored preference is
     // not mutated (#809/#810 invariant carried forward).
     const stored = await page.evaluate(() =>
-      window.localStorage.getItem('family-legend-expanded.v2'),
+      window.localStorage.getItem('family-legend-expanded.v3.roomy'),
     );
     expect(stored).toBe('true');
   });
@@ -159,7 +161,7 @@ test.describe('#853 — legend cap on the roomy band (500×844, stored-expanded)
     await setupRoutes(page, apiStub);
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.roomy', 'true');
       } catch {
         /* noop */
       }
@@ -193,7 +195,7 @@ test.describe('#853 — legend cap on the roomy band (768×1024, stored-expanded
     await setupRoutes(page, apiStub);
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        window.localStorage.setItem('family-legend-expanded.v3.roomy', 'true');
       } catch {
         /* noop */
       }
@@ -229,7 +231,8 @@ test.describe('#853 counter-case — desktop ≥1024px keeps the 400px fallback'
     await setupRoutes(page, apiStub);
     await page.addInitScript(() => {
       try {
-        window.localStorage.setItem('family-legend-expanded.v2', 'true');
+        // E3 (#1055): 1440px → the 'wide' tier key.
+        window.localStorage.setItem('family-legend-expanded.v3.wide', 'true');
       } catch {
         /* noop */
       }

--- a/frontend/e2e/legend-usability-e3.spec.ts
+++ b/frontend/e2e/legend-usability-e3.spec.ts
@@ -147,17 +147,34 @@ for (const { width, height, tier, label } of [
       await expect(labelEl).toBeVisible();
       // The full text (incl. the final noun) is present in the DOM…
       await expect(labelEl).toHaveText(LONG_LABEL);
-      // …and is NOT clipped by single-line ellipsis: a two-line wrap means the
-      // rendered box is taller than one line. Assert ≥ ~2 lines tall.
-      const box = await labelEl.boundingBox();
-      const lineHeightPx = await labelEl.evaluate(
-        (el) => parseFloat(getComputedStyle(el).lineHeight),
-      );
-      expect(box, 'label box missing').not.toBeNull();
+      // V3/V7: the long name must NOT be single-line-ellipsis-truncated (which drops
+      // the head noun). Prove it font-independently — works whether the CI font fits
+      // it on one line or wraps it to two:
+      const metrics = await labelEl.evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return {
+          lineClamp: cs.webkitLineClamp,            // '2' = multi-line clamp, not single-line ellipsis
+          whiteSpace: cs.whiteSpace,                 // must NOT be 'nowrap'
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          clientHeight: el.clientHeight,
+          lineHeight: parseFloat(cs.lineHeight),
+        };
+      });
+      // (a) multi-line clamp, not a single-line nowrap+ellipsis:
+      expect(metrics.lineClamp, 'label uses 2-line clamp (not single-line ellipsis)').toBe('2');
+      expect(metrics.whiteSpace, 'label is allowed to wrap').not.toBe('nowrap');
+      // (b) the full label is not horizontally clipped — scrollWidth never exceeds the
+      //     box width whether it sits on one line (fits) or wraps to two (each line fits):
       expect(
-        box!.height,
-        `label height ${box!.height.toFixed(1)}px should span ~2 lines (lineHeight ${lineHeightPx}px) — the long name must wrap, not single-line-ellipsis`,
-      ).toBeGreaterThan(lineHeightPx * 1.5);
+        metrics.scrollWidth,
+        `label not horizontally ellipsis-clipped (scrollWidth ${metrics.scrollWidth} ≤ clientWidth ${metrics.clientWidth})`,
+      ).toBeLessThanOrEqual(metrics.clientWidth + 1);
+      // (c) clamped at MOST two lines tall (never a 3+ line overflow):
+      expect(
+        metrics.clientHeight,
+        `label clamped to ≤2 lines (${metrics.clientHeight}px ≤ ${metrics.lineHeight * 2 + 2}px)`,
+      ).toBeLessThanOrEqual(metrics.lineHeight * 2 + 2);
     });
   });
 }

--- a/frontend/e2e/legend-usability-e3.spec.ts
+++ b/frontend/e2e/legend-usability-e3.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect } from './fixtures.js';
+import { AppPage } from './pages/app-page.js';
+import type { Observation } from '@bird-watch/shared-types';
+
+/**
+ * E3 (#1055) — family-legend usability pass.
+ *
+ * Locks the new affordances at the integration level:
+ *   - the chevron is a ≥16px SVG (not the near-invisible --type-xs ▸ glyph),
+ *   - long colloquial family names keep their final (distinguishing) noun
+ *     instead of single-line-ellipsis dropping it,
+ *   - the entries list shows a bottom fade cue at rest when it overflows,
+ *   - an expanded-but-empty viewport shows a muted row (aria-expanded stays
+ *     true), and a collapsed empty viewport shows a non-interactive pill.
+ *
+ * Repo e2e conventions: page.goto() via the POM; LIFO route stubs; no DB
+ * writes; no per-spec retries. All silhouettes/observations are stubbed so the
+ * assertions are deterministic and don't depend on the seeded DB.
+ */
+
+// A long colloquial name whose FINAL noun ("Parrots") is exactly what the old
+// single-line ellipsis cut. Named explicitly so the wrap assertion can't pass
+// vacuously on a short-name payload (reviewer addendum, #1055 finding 5).
+const LONG_LABEL = 'African & New World Parrots';
+const LONG_LABEL_FINAL_NOUN = 'Parrots';
+
+function silhouette(familyCode: string, commonName: string, color = '#3B7A57') {
+  return {
+    familyCode,
+    color,
+    colorDark: color,
+    // A trivially valid path; the swatch render is not under test here.
+    svgData: 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+    svgUrl: null,
+    source: null,
+    license: null,
+    commonName,
+    creator: null,
+  };
+}
+
+function obs(subId: string, familyCode: string): Observation {
+  return {
+    subId,
+    speciesCode: 'vermfly',
+    comName: 'X',
+    familyCode,
+    lat: 32.2217,
+    lng: -110.9265,
+    locId: `L-${subId}`,
+    locName: 'Tucson, AZ',
+    obsDt: '2026-05-30T12:00:00Z',
+    howMany: 1,
+    isNotable: false,
+    silhouetteId: null,
+  };
+}
+
+/** Register LIFO-safe stubs with a caller-supplied silhouette + observation set. */
+async function setupRoutes(
+  page: import('@playwright/test').Page,
+  apiStub: import('./fixtures.js').ApiStub,
+  silhouettes: ReturnType<typeof silhouette>[],
+  observations: Observation[],
+): Promise<void> {
+  await apiStub.stubEmpty();
+  await apiStub.stubObservations(observations);
+  await page.route('**/api/silhouettes', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(silhouettes),
+    });
+  });
+}
+
+/** Seed the active tier's expanded key so the legend mounts expanded. */
+async function seedExpanded(
+  page: import('@playwright/test').Page,
+  tier: 'compact' | 'roomy' | 'wide',
+): Promise<void> {
+  await page.addInitScript((key) => {
+    try {
+      window.localStorage.setItem(key, 'true');
+    } catch {
+      /* noop */
+    }
+  }, `family-legend-expanded.v3.${tier}`);
+}
+
+// ─── chevron affordance ───────────────────────────────────────────────────────
+for (const { width, height, tier, label } of [
+  { width: 390, height: 844, tier: 'compact' as const, label: 'mobile' },
+  { width: 1440, height: 900, tier: 'wide' as const, label: 'desktop' },
+]) {
+  test.describe(`E3 (#1055): chevron is a ≥16px SVG (${label} ${width}×${height})`, () => {
+    test.use({ viewport: { width, height } });
+
+    test('the toggle chevron renders as a 16×16 SVG', async ({ page, apiStub }) => {
+      await setupRoutes(
+        page,
+        apiStub,
+        [silhouette('tyrannidae', 'Tyrant Flycatchers')],
+        [obs('S1', 'tyrannidae')],
+      );
+      await seedExpanded(page, tier);
+      const app = new AppPage(page);
+      await app.goto('view=map');
+      await app.waitForAppReady();
+
+      const chevron = page.locator('svg.family-legend-chevron');
+      await expect(chevron).toBeVisible();
+      const box = await chevron.boundingBox();
+      expect(box, 'chevron SVG not found').not.toBeNull();
+      // The rendered glyph is at least 16px in both dimensions (the contract
+      // floor; the old --type-xs ▸ was well under that).
+      expect(box!.width).toBeGreaterThanOrEqual(16);
+      expect(box!.height).toBeGreaterThanOrEqual(16);
+    });
+  });
+}
+
+// ─── long-label wrap: the final noun survives ─────────────────────────────────
+for (const { width, height, tier, label } of [
+  { width: 390, height: 844, tier: 'compact' as const, label: 'mobile' },
+  { width: 1440, height: 900, tier: 'wide' as const, label: 'desktop' },
+]) {
+  test.describe(`E3 (#1055): long family label keeps its final noun (${label} ${width}×${height})`, () => {
+    test.use({ viewport: { width, height } });
+
+    test(`"${LONG_LABEL}" renders its final noun "${LONG_LABEL_FINAL_NOUN}" (no head-noun ellipsis loss)`, async ({
+      page,
+      apiStub,
+    }) => {
+      await setupRoutes(
+        page,
+        apiStub,
+        [silhouette('psittacidae', LONG_LABEL)],
+        [obs('S1', 'psittacidae')],
+      );
+      await seedExpanded(page, tier);
+      const app = new AppPage(page);
+      await app.goto('view=map');
+      await app.waitForAppReady();
+
+      const labelEl = page.locator('.family-legend-entry-label');
+      await expect(labelEl).toBeVisible();
+      // The full text (incl. the final noun) is present in the DOM…
+      await expect(labelEl).toHaveText(LONG_LABEL);
+      // …and is NOT clipped by single-line ellipsis: a two-line wrap means the
+      // rendered box is taller than one line. Assert ≥ ~2 lines tall.
+      const box = await labelEl.boundingBox();
+      const lineHeightPx = await labelEl.evaluate(
+        (el) => parseFloat(getComputedStyle(el).lineHeight),
+      );
+      expect(box, 'label box missing').not.toBeNull();
+      expect(
+        box!.height,
+        `label height ${box!.height.toFixed(1)}px should span ~2 lines (lineHeight ${lineHeightPx}px) — the long name must wrap, not single-line-ellipsis`,
+      ).toBeGreaterThan(lineHeightPx * 1.5);
+    });
+  });
+}
+
+// ─── overflow cue at rest ─────────────────────────────────────────────────────
+test.describe('E3 (#1055): overflow cue is visible at rest when the list overflows', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('data-overflow=true paints a bottom fade when scrollHeight > clientHeight', async ({
+    page,
+    apiStub,
+  }) => {
+    // Many families → the entries list exceeds the ≤480px 240px cap → overflow.
+    const many = Array.from({ length: 30 }, (_, i) => {
+      const code = `fam${i.toString().padStart(2, '0')}`;
+      return { sil: silhouette(code, `Family Number ${i}`), ob: obs(`S${i}`, code) };
+    });
+    await setupRoutes(
+      page,
+      apiStub,
+      many.map((m) => m.sil),
+      many.map((m) => m.ob),
+    );
+    await seedExpanded(page, 'compact');
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const list = page.locator('.family-legend-entries');
+    await expect(list).toBeVisible();
+    // The component measured an overflow and stamped the flag…
+    await expect(list).toHaveAttribute('data-overflow', 'true');
+    // …and the ::after fade pseudo-element is painted (non-zero height) at rest.
+    const fadeHeight = await list.evaluate((el) =>
+      parseFloat(getComputedStyle(el, '::after').height),
+    );
+    expect(
+      fadeHeight,
+      'the overflow ::after fade must have a non-zero height at rest',
+    ).toBeGreaterThan(0);
+  });
+
+  test('no overflow flag when the list fits', async ({ page, apiStub }) => {
+    await setupRoutes(
+      page,
+      apiStub,
+      [silhouette('tyrannidae', 'Tyrant Flycatchers')],
+      [obs('S1', 'tyrannidae')],
+    );
+    await seedExpanded(page, 'compact');
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const list = page.locator('.family-legend-entries');
+    await expect(list).toBeVisible();
+    await expect(list).toHaveAttribute('data-overflow', 'false');
+  });
+});
+
+// ─── empty / zero-in-view honesty ─────────────────────────────────────────────
+test.describe('E3 (#1055): empty-viewport honesty', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('expanded with zero in-view families shows the muted row and keeps aria-expanded=true', async ({
+    page,
+    apiStub,
+  }) => {
+    // Silhouettes exist (so the legend mounts), but NO observations → zero
+    // entries to count. Expanded preference seeded for the wide tier.
+    await setupRoutes(
+      page,
+      apiStub,
+      [silhouette('tyrannidae', 'Tyrant Flycatchers')],
+      [],
+    );
+    await seedExpanded(page, 'wide');
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const toggle = page.getByRole('button', { name: /bird families in view/i });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    // aria-expanded stays truthful (the legend IS expanded).
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    // The muted empty row is shown rather than a bare header.
+    await expect(page.locator('.family-legend-empty')).toBeVisible();
+    await expect(page.locator('.family-legend-empty')).toContainText(/no birds in this view/i);
+    // No entry rows.
+    await expect(page.getByTestId('family-legend-entry')).toHaveCount(0);
+  });
+
+  test('collapsed with zero in-view families shows a non-interactive "No families in view" pill', async ({
+    page,
+    apiStub,
+  }) => {
+    await setupRoutes(
+      page,
+      apiStub,
+      [silhouette('tyrannidae', 'Tyrant Flycatchers')],
+      [],
+    );
+    // Seed COLLAPSED so the zero-state pill (not the muted row) is exercised.
+    await page.addInitScript((key) => {
+      try {
+        window.localStorage.setItem(key, 'false');
+      } catch {
+        /* noop */
+      }
+    }, 'family-legend-expanded.v3.wide');
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    const pill = page.getByRole('button', { name: /no families in view/i });
+    await expect(pill).toBeVisible({ timeout: 10_000 });
+    await expect(pill).toBeDisabled();
+    await expect(page.locator('.family-legend')).toHaveAttribute('data-empty', 'true');
+  });
+});

--- a/frontend/e2e/map-root-geometry.spec.ts
+++ b/frontend/e2e/map-root-geometry.spec.ts
@@ -359,6 +359,9 @@ test.describe('#761 (S2): full-viewport map root geometry', () => {
         try {
           window.localStorage.removeItem('family-legend-expanded');
           window.localStorage.removeItem('family-legend-expanded.v2');
+          window.localStorage.removeItem('family-legend-expanded.v3.compact');
+          window.localStorage.removeItem('family-legend-expanded.v3.roomy');
+          window.localStorage.removeItem('family-legend-expanded.v3.wide');
         } catch {
           /* noop */
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -127,8 +127,9 @@ const LEDE_LOADING_PLACEHOLDER = 'Updating…';
  * 768×1024 (iPad portrait) the expanded legend covers the only visible marker
  * on first paint. Lift the JS threshold to 1024 so tablet-portrait (and
  * narrower) start collapsed; tablet-landscape and desktop still default
- * expanded. localStorage `family-legend-expanded.v2` still overrides the
- * default once the user toggles.
+ * expanded. The per-breakpoint `family-legend-expanded.v3.<tier>` storage key
+ * (E3 #1055) still overrides the default once the user toggles — for that tier
+ * only, so a desktop expand never leaks into the phone tier.
  */
 const LEGEND_EXPAND_MIN_WIDTH = 1024;
 

--- a/frontend/src/components/FamilyLegend.test.tsx
+++ b/frontend/src/components/FamilyLegend.test.tsx
@@ -1,8 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import { FamilyLegend } from './FamilyLegend.js';
+import { setMatchMedia, getMockMediaQuery } from '../test-setup.js';
+
+// useBreakpoint's two matchMedia queries (see use-breakpoint.ts). A matcher for
+// a given viewport width lets these tests drive a specific tier and simulate a
+// live mid-session resize via getMockMediaQuery(...).dispatchChange().
+const Q_COMPACT = '(max-width: 479px)';
+const Q_ROOMY = '(max-width: 1023px)';
+function matcherForWidth(width: number) {
+  return (query: string): boolean => {
+    if (query === Q_COMPACT) return width <= 479;
+    if (query === Q_ROOMY) return width <= 1023;
+    return false;
+  };
+}
 
 const baseSilhouettes: FamilySilhouette[] = [
   {
@@ -68,12 +82,24 @@ const baseObservations: Observation[] = [
   obs('S4', 'unknownidae'),
 ];
 
-const STORAGE_KEY = 'family-legend-expanded.v2';
+// E3 (#1055): the preference key is now per-breakpoint tier
+// (`family-legend-expanded.v3.<tier>`). These unit tests do NOT install a
+// matchMedia mock (no setMatchMedia call), so useBreakpoint() falls back to
+// 'wide' — STORAGE_KEY therefore targets the wide tier's key, the active tier
+// under jsdom. Tests that need a specific tier install setMatchMedia.
+const STORAGE_KEY = 'family-legend-expanded.v3.wide';
+const STORAGE_KEY_COMPACT = 'family-legend-expanded.v3.compact';
+const STORAGE_KEY_ROOMY = 'family-legend-expanded.v3.roomy';
+// Superseded breakpoint-blind key — only referenced by the migration cases.
+const V2_STORAGE_KEY = 'family-legend-expanded.v2';
 const LEGACY_STORAGE_KEY = 'family-legend-expanded';
 
 function clearLegendStorage() {
   try {
     window.localStorage.removeItem(STORAGE_KEY);
+    window.localStorage.removeItem(STORAGE_KEY_COMPACT);
+    window.localStorage.removeItem(STORAGE_KEY_ROOMY);
+    window.localStorage.removeItem(V2_STORAGE_KEY);
     window.localStorage.removeItem(LEGACY_STORAGE_KEY);
   } catch { /* jsdom only */ }
 }
@@ -421,8 +447,10 @@ describe('Phase 3: mobile-collapsed default', () => {
     expect(window.localStorage.getItem('family-legend-expanded')).toBeNull();
   });
 
-  it('persistence under the new .v2 key wins on subsequent mounts', () => {
-    window.localStorage.setItem('family-legend-expanded.v2', 'true');
+  it('persistence under the per-tier .v3 key wins on subsequent mounts', () => {
+    // jsdom has no matchMedia mock here → useBreakpoint() = 'wide', so the
+    // active tier key is .v3.wide.
+    window.localStorage.setItem(STORAGE_KEY, 'true');
     render(
       <FamilyLegend
         silhouettes={baseSilhouettes}
@@ -438,16 +466,12 @@ describe('Phase 3: mobile-collapsed default', () => {
     );
   });
 
-  // #853: on the 481–1023px 'roomy' band, App passes defaultExpanded=false
-  // (the <1024px collapse-default, #809). A stored .v2='true' preference still
-  // overrides that default and renders the entries expanded — this behaviour is
-  // intentional and must be preserved; the occlusion is bounded in CSS (a
-  // shorter scrollable entries max-height on the band, NOT a forced collapse).
-  // jsdom does not evaluate media queries, so the height cap itself is asserted
-  // by legend-roomy-band-cap.spec.ts; this case guards the component contract
-  // that the stored-expanded path keeps rendering entries on the band.
-  it('#853: stored .v2=true keeps entries expanded on the roomy band (defaultExpanded=false)', () => {
-    window.localStorage.setItem('family-legend-expanded.v2', 'true');
+  // E3 (#1055): one-shot .v2 → .v3.<active-tier> migration. A non-null .v2 seeds
+  // ONLY the tier the user is on right now (wide under jsdom), then .v2 is
+  // deleted. Seeding all three tiers would re-create the cross-breakpoint leak
+  // this issue kills.
+  it('#1055: a stored .v2=true migrates into the ACTIVE tier key, then .v2 is deleted', () => {
+    window.localStorage.setItem(V2_STORAGE_KEY, 'true');
     render(
       <FamilyLegend
         silhouettes={baseSilhouettes}
@@ -457,14 +481,87 @@ describe('Phase 3: mobile-collapsed default', () => {
         defaultExpanded={false}
       />,
     );
-    // The stored preference wins over the roomy-band collapse-default: entries
-    // render, and the toggle reports expanded. The bounding cap is CSS-only and
-    // does NOT collapse the legend or mutate the stored preference.
+    // The migrated value wins over defaultExpanded=false: entries render.
+    expect(screen.getByRole('button', { name: /Bird families in view/i })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    // .v2 is consumed and removed; the active tier (wide) carries the value.
+    expect(window.localStorage.getItem(V2_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+    // CRITICAL: the OTHER tiers are NOT seeded — that would re-create the leak.
+    expect(window.localStorage.getItem(STORAGE_KEY_COMPACT)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY_ROOMY)).toBeNull();
+  });
+
+  it('#1055: an already-set tier key wins over a stale .v2 (no overwrite), and .v2 is still cleared', () => {
+    // A fresher per-tier write must not be clobbered by a leftover .v2.
+    window.localStorage.setItem(STORAGE_KEY, 'false');
+    window.localStorage.setItem(V2_STORAGE_KEY, 'true');
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    // The tier key 'false' wins (collapsed), NOT the stale .v2 'true'.
+    expect(screen.getByRole('button', { name: /Bird families in view/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false');
+    expect(window.localStorage.getItem(V2_STORAGE_KEY)).toBeNull();
+  });
+
+  it('#1055: absent .v2 leaves defaultExpanded untouched (no seed)', () => {
+    // No .v2 and no tier key → defaultExpanded governs; nothing is written
+    // until the user toggles.
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Bird families in view/i })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(window.localStorage.getItem(V2_STORAGE_KEY)).toBeNull();
+  });
+
+  // #853: on the 481–1023px 'roomy' band, App passes defaultExpanded=false
+  // (the <1024px collapse-default, #809). A stored tier preference still
+  // overrides that default and renders the entries expanded — this behaviour is
+  // intentional and must be preserved; the occlusion is bounded in CSS (a
+  // shorter scrollable entries max-height on the band, NOT a forced collapse).
+  // jsdom does not evaluate media queries, so the height cap itself is asserted
+  // by legend-roomy-band-cap.spec.ts; this case guards the component contract
+  // that the stored-expanded path keeps rendering entries.
+  it('#853: stored tier=true keeps entries expanded over a collapse-default', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'true');
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    // The stored preference wins over the collapse-default: entries render,
+    // and the toggle reports expanded. The bounding cap is CSS-only and does
+    // NOT collapse the legend or mutate the stored preference.
     expect(screen.getAllByTestId('family-legend-entry')).toHaveLength(3);
     expect(
       screen.getByRole('button', { name: /Bird families in view/i }),
     ).toHaveAttribute('aria-expanded', 'true');
-    expect(window.localStorage.getItem('family-legend-expanded.v2')).toBe('true');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
   });
 });
 
@@ -755,5 +852,263 @@ describe('O5 (#783): forceCollapsed prop', () => {
     const aside = container.querySelector('.family-legend');
     expect(aside).not.toBeNull();
     expect(aside!.getAttribute('data-force-collapsed')).toBeNull();
+  });
+});
+
+/**
+ * E3 (#1055) — per-breakpoint-class persistence.
+ *
+ * The preference key is `family-legend-expanded.v3.<tier>` where the tier comes
+ * from useBreakpoint(). A desktop (wide) expand must NOT pre-open the phone
+ * (compact) legend, and a live mid-session tier change must NOT clobber the new
+ * tier's key with the old tier's value (the reviewer's IMPORTANT, an explicit
+ * AC).
+ */
+describe('E3 (#1055): per-breakpoint persistence', () => {
+  beforeEach(() => {
+    try { window.localStorage.clear(); } catch { /* jsdom only */ }
+  });
+  afterEach(() => {
+    try { window.localStorage.clear(); } catch { /* jsdom only */ }
+  });
+
+  it('writes the toggle under the ACTIVE tier key — a wide write does not pre-open compact', async () => {
+    // Mount at the wide tier (≥1024px).
+    setMatchMedia(matcherForWidth(1440));
+    const user = userEvent.setup();
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    // Toggle collapses at wide → writes .v3.wide='false'.
+    await user.click(screen.getByRole('button', { name: /bird families in view/i }));
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false');
+    // The compact tier key was never touched — no cross-breakpoint leak.
+    expect(window.localStorage.getItem(STORAGE_KEY_COMPACT)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY_ROOMY)).toBeNull();
+  });
+
+  it('reading a compact preference does not consult the wide key', () => {
+    // A compact-only stored preference (collapsed) must govern at compact even
+    // when a wide preference exists and says expanded.
+    setMatchMedia(matcherForWidth(390));
+    window.localStorage.setItem(STORAGE_KEY_COMPACT, 'false');
+    window.localStorage.setItem(STORAGE_KEY, 'true'); // wide says expanded
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    // At compact the compact key ('false') wins, NOT the wide key.
+    expect(
+      screen.getByRole('button', { name: /bird families in view/i }),
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('a live tier change (compact → wide) does NOT write the old expanded value into the new tier key', () => {
+    // Reviewer IMPORTANT / explicit AC: toggle at compact, then drag to wide.
+    // The wide key must remain untouched (read-only re-key on resize).
+    setMatchMedia(matcherForWidth(390)); // start compact
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    // Expand at compact → writes .v3.compact='true'.
+    act(() => {
+      screen.getByRole('button', { name: /bird families in view/i }).click();
+    });
+    expect(window.localStorage.getItem(STORAGE_KEY_COMPACT)).toBe('true');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull(); // wide untouched
+
+    // Live resize to wide: move the matcher then fire both queries' change.
+    act(() => {
+      setMatchMedia(matcherForWidth(1440));
+      getMockMediaQuery(Q_COMPACT)!.dispatchChange(false);
+      getMockMediaQuery(Q_ROOMY)!.dispatchChange(false);
+    });
+
+    // The wide key must NOT have been clobbered with the compact 'true' value.
+    // It adopts wide's own preference instead — here none, so defaultExpanded
+    // (false) governs and nothing is written for wide.
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    // And the compact preference the user actually set is intact.
+    expect(window.localStorage.getItem(STORAGE_KEY_COMPACT)).toBe('true');
+  });
+
+  it('a live tier change adopts the new tier stored preference (read-only re-key)', () => {
+    // wide has its own stored 'false'; expanding at compact then resizing to
+    // wide must adopt wide's 'false' (collapsed), not carry compact's 'true'.
+    setMatchMedia(matcherForWidth(390)); // start compact
+    window.localStorage.setItem(STORAGE_KEY, 'false'); // wide pref: collapsed
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false} // start collapsed at compact, then expand
+      />,
+    );
+    act(() => {
+      screen.getByRole('button', { name: /bird families in view/i }).click();
+    });
+    // Expanded at compact (writes .v3.compact='true').
+    expect(
+      screen.getByRole('button', { name: /bird families in view/i }),
+    ).toHaveAttribute('aria-expanded', 'true');
+
+    act(() => {
+      setMatchMedia(matcherForWidth(1440));
+      getMockMediaQuery(Q_COMPACT)!.dispatchChange(false);
+      getMockMediaQuery(Q_ROOMY)!.dispatchChange(false);
+    });
+
+    // Adopts wide's stored 'false' → collapsed, and wide's key is unchanged.
+    expect(
+      screen.getByRole('button', { name: /bird families in view/i }),
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+});
+
+/**
+ * E3 (#1055) — empty / zero-in-view honesty.
+ */
+describe('E3 (#1055): empty and zero-in-view states', () => {
+  beforeEach(() => {
+    try { window.localStorage.clear(); } catch { /* jsdom only */ }
+  });
+  afterEach(() => {
+    try { window.localStorage.clear(); } catch { /* jsdom only */ }
+  });
+
+  it('expanded + zero entries renders one muted row and keeps aria-expanded=true', () => {
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={[]} // silhouettes present, but nothing in view to count
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={true}
+      />,
+    );
+    // No entry rows…
+    expect(screen.queryAllByTestId('family-legend-entry')).toHaveLength(0);
+    // …but a muted empty row, not a bare header.
+    expect(screen.getByText(/no birds in this view/i)).toBeInTheDocument();
+    // aria-expanded stays truthful (the legend IS expanded).
+    expect(
+      screen.getByRole('button', { name: /bird families in view/i }),
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapsed + zero entries renders a non-interactive "No families in view" pill', () => {
+    render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={[]}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    // The zero-state pill reads "No families in view" and is disabled — it must
+    // not advertise an expand whose only result is an empty card.
+    const toggle = screen.getByRole('button', { name: /no families in view/i });
+    expect(toggle).toBeDisabled();
+    const aside = document.querySelector('.family-legend');
+    expect(aside!.getAttribute('data-empty')).toBe('true');
+    // No muted empty row while collapsed (the pill itself carries the message).
+    expect(screen.queryByText(/no birds in this view/i)).not.toBeInTheDocument();
+  });
+
+  it('zero-state pill restores to a live toggle when entries return', () => {
+    const { rerender } = render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={[]}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /no families in view/i }),
+    ).toBeDisabled();
+
+    // Observations return → the pill becomes a live, enabled toggle again.
+    rerender(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    const toggle = screen.getByRole('button', { name: /bird families in view/i });
+    expect(toggle).toBeEnabled();
+    expect(document.querySelector('.family-legend')!.getAttribute('data-empty')).toBeNull();
+  });
+});
+
+/**
+ * E3 (#1055) — chevron affordance: ≥16px, points up when collapsed, down (180°
+ * via data-expanded) when expanded.
+ */
+describe('E3 (#1055): chevron affordance', () => {
+  beforeEach(() => {
+    try { window.localStorage.clear(); } catch { /* jsdom only */ }
+  });
+
+  it('renders a ≥16px SVG chevron (not the old --type-xs glyph)', () => {
+    const { container } = render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    const chevron = container.querySelector('svg.family-legend-chevron');
+    expect(chevron).not.toBeNull();
+    expect(chevron!.getAttribute('width')).toBe('16');
+    expect(chevron!.getAttribute('height')).toBe('16');
+    // aria-hidden — it is decorative; the toggle's accessible name carries state.
+    expect(chevron!.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it("chevron data-expanded='false' when collapsed (points up) and 'true' when expanded", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <FamilyLegend
+        silhouettes={baseSilhouettes}
+        observations={baseObservations}
+        familyCode={null}
+        onFamilyToggle={vi.fn()}
+        defaultExpanded={false}
+      />,
+    );
+    const chevron = () => container.querySelector('svg.family-legend-chevron')!;
+    // Collapsed at rest: data-expanded='false' (CSS leaves it pointing up).
+    expect(chevron().getAttribute('data-expanded')).toBe('false');
+    await user.click(screen.getByRole('button', { name: /bird families in view/i }));
+    // Expanded: data-expanded='true' (CSS rotates 180° to point down).
+    expect(chevron().getAttribute('data-expanded')).toBe('true');
   });
 });

--- a/frontend/src/components/FamilyLegend.tsx
+++ b/frontend/src/components/FamilyLegend.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import type { FamilySilhouette as FamilySilhouetteData, Observation } from '@bird-watch/shared-types';
 import { prettyFamily } from '../derived.js';
 import { FamilySilhouette } from './ds/FamilySilhouette.js';
@@ -6,10 +6,26 @@ import { getFamilyChannel } from '../config/family-palette.js';
 import type { FamilyCode, ShapeVariant } from '../config/family-palette.js';
 import { FAMILY_PALETTE } from '../config/family-palette.js';
 import { useTheme } from '../hooks/use-theme.js';
+import { useBreakpoint } from '../hooks/use-breakpoint.js';
+import type { Breakpoint } from '../hooks/use-breakpoint.js';
 import { countNoun, formatCount } from '../lib/format-count.js';
 
-const STORAGE_KEY = 'family-legend-expanded.v2';
+// E3 (#1055): the expansion preference is now per-breakpoint-CLASS, not a
+// single global key. A desktop expand must not force the phone legend open over
+// ~40% of the map on the next visit (the cross-breakpoint leak this fixes).
+// `useBreakpoint()` supplies the 'compact' | 'roomy' | 'wide' tier and we key
+// the stored preference by it: `family-legend-expanded.v3.<tier>`.
+const STORAGE_KEY_PREFIX = 'family-legend-expanded.v3';
+// Superseded breakpoint-blind key (#783-era). A non-null .v2 is migrated into
+// the ACTIVE tier's key only — seeding all three tiers would re-create the
+// exact cross-breakpoint leak this issue exists to kill — then .v2 is deleted.
+const V2_STORAGE_KEY = 'family-legend-expanded.v2';
+// Original (pre-.v2) key. The existing legacy-v1 drop is preserved verbatim.
 const LEGACY_STORAGE_KEY = 'family-legend-expanded';
+
+function storageKeyFor(tier: Breakpoint): string {
+  return `${STORAGE_KEY_PREFIX}.${tier}`;
+}
 
 export interface FamilyLegendProps {
   /** All known family→silhouette rows (mounted by App via useSilhouettes). */
@@ -37,9 +53,10 @@ export interface FamilyLegendProps {
   /**
    * Default expansion state on first paint when localStorage is empty.
    * Driven by the responsive @media query in MapSurface (mobile collapsed,
-   * desktop expanded). Once the user toggles, the new .v2 storage key
-   * wins on subsequent mounts — the responsive default is a first-visit
-   * hint, not a sticky rule.
+   * desktop expanded). Once the user toggles, the per-breakpoint
+   * `family-legend-expanded.v3.<tier>` storage key wins on subsequent mounts
+   * for that tier — the responsive default is a first-visit hint, not a
+   * sticky rule, and a desktop expand never leaks into the phone tier.
    */
   defaultExpanded: boolean;
   /**
@@ -53,15 +70,28 @@ export interface FamilyLegendProps {
   forceCollapsed?: boolean;
 }
 
-function readStoredExpanded(): boolean | null {
+function readStoredExpanded(tier: Breakpoint): boolean | null {
   try {
-    // Migration: drop the legacy key so it can't clobber the mobile
+    // Migration: drop the legacy v1 key so it can't clobber the mobile
     // viewport hint on first paint. This runs on every mount; effectively
     // free since the key is absent after first migration.
     if (window.localStorage.getItem(LEGACY_STORAGE_KEY) !== null) {
       window.localStorage.removeItem(LEGACY_STORAGE_KEY);
     }
-    const v = window.localStorage.getItem(STORAGE_KEY);
+    const tierKey = storageKeyFor(tier);
+    // One-shot .v2 → .v3.<active-tier> migration. A non-null .v2 seeds ONLY the
+    // tier the user is on right now, then .v2 is deleted. Seeding all three
+    // tiers would re-create the cross-breakpoint leak this issue kills; .v2
+    // absent ⇒ no seed (defaultExpanded path is untouched). Don't overwrite an
+    // already-set tier key (a fresher per-tier write wins over the stale .v2).
+    const v2 = window.localStorage.getItem(V2_STORAGE_KEY);
+    if (v2 !== null) {
+      if (window.localStorage.getItem(tierKey) === null && (v2 === 'true' || v2 === 'false')) {
+        window.localStorage.setItem(tierKey, v2);
+      }
+      window.localStorage.removeItem(V2_STORAGE_KEY);
+    }
+    const v = window.localStorage.getItem(tierKey);
     if (v === 'true') return true;
     if (v === 'false') return false;
     return null;
@@ -70,9 +100,9 @@ function readStoredExpanded(): boolean | null {
   }
 }
 
-function writeStoredExpanded(value: boolean): void {
+function writeStoredExpanded(tier: Breakpoint, value: boolean): void {
   try {
-    window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false');
+    window.localStorage.setItem(storageKeyFor(tier), value ? 'true' : 'false');
   } catch {
     // Storage failures (private mode, quota) are non-fatal — the legend
     // simply forgets the preference next mount.
@@ -134,34 +164,102 @@ function FamilyLegendImpl({
   defaultExpanded,
   forceCollapsed = false,
 }: FamilyLegendProps) {
-  // Initial state precedence: localStorage .v2 > defaultExpanded prop.
-  // The function-form initializer means readStoredExpanded only runs once
-  // at mount, not on every render. The legacy .v1 key is deleted inside
-  // readStoredExpanded so it can never clobber a mobile first-paint.
+  // E3 (#1055): the active breakpoint tier keys the stored preference. Reacts
+  // to live matchMedia resizes — a mid-session tier change re-reads the new
+  // tier's preference (read-only re-key below), never clobbers it.
+  const tier = useBreakpoint();
+
+  // Initial state precedence: stored tier key (.v3.<tier>, seeded from a one-shot
+  // .v2 migration) > defaultExpanded prop. The function-form initializer means
+  // readStoredExpanded only runs once at mount, not on every render. The legacy
+  // .v1 key is deleted inside readStoredExpanded so it can never clobber a
+  // mobile first-paint.
   const [expanded, setExpanded] = useState<boolean>(() => {
-    const stored = readStoredExpanded();
+    const stored = readStoredExpanded(tier);
     return stored ?? defaultExpanded;
   });
 
-  // Persist on every change. The write is idempotent; cost is trivial.
-  // Only written after a manual toggle — first paints defer to defaultExpanded.
-  // forceCollapsed does NOT trigger this effect — it is a transient display
-  // override and must NOT mutate the user's stored preference. (O5 #783)
+  // Track the tier the current `expanded` value belongs to so we can detect a
+  // live tier transition (compact→wide drag). The write itself happens in the
+  // toggle handler (a user action), NOT in an effect — that is what keeps the
+  // re-key on resize strictly READ-ONLY. (#1055 reviewer AC: a tier change must
+  // NOT write the old `expanded` into the new tier's key — the intra-session
+  // form of the cross-breakpoint leak.)
+  const tierRef = useRef(tier);
+
+  // On a live tier transition, adopt the NEW tier's stored preference (or its
+  // responsive default), writing nothing. This is the per-breakpoint
+  // persistence boundary: a compact expand does not leak into the wide tier,
+  // and resizing never clobbers a tier key. forceCollapsed is irrelevant here —
+  // it is a transient display override, not a stored preference. (O5 #783)
   useEffect(() => {
-    writeStoredExpanded(expanded);
-  }, [expanded]);
+    if (tierRef.current === tier) return;
+    tierRef.current = tier;
+    const stored = readStoredExpanded(tier);
+    setExpanded(stored ?? defaultExpanded);
+  }, [tier, defaultExpanded]);
+
+  // The toggle is the ONLY writer: it persists to the current tier's key at
+  // write time. Writing here (not in an effect keyed on `expanded`) means a
+  // tier-change-induced state update never persists — the leak the reviewer
+  // flagged. First paints defer to defaultExpanded and write nothing, as
+  // before. forceCollapsed is a transient override and never advances or
+  // persists the stored preference. (O5 #783)
+  const handleToggle = () => {
+    if (forceCollapsed) return;
+    setExpanded(prev => {
+      const next = !prev;
+      writeStoredExpanded(tier, next);
+      return next;
+    });
+  };
 
   const entries = useMemo(
     () => buildEntries(silhouettes, observations, familyCounts),
     [silhouettes, observations, familyCounts],
   );
 
+  // E3 (#1055): overflow cue. macOS overlay scrollbars are invisible at rest,
+  // so a half-hidden family list gave no signal that more rows lie below the
+  // fold. CSS cannot detect overflow, so measure it here and stamp
+  // data-overflow on the <ul>; the CSS paints a bottom fade gradient when set.
+  // The flag is recomputed on entries/expand change (via the effect dep), on
+  // scroll (clear it at the bottom so the fade doesn't sit over the final row),
+  // and on resize. Guarded so it never runs while the list isn't mounted.
+  const entriesRef = useRef<HTMLUListElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const measureOverflow = () => {
+    const el = entriesRef.current;
+    if (!el) {
+      setOverflowing(false);
+      return;
+    }
+    // A 1px slack avoids a flickering fade from sub-pixel rounding, and clear
+    // the cue once scrolled to the end (nothing more to reveal below).
+    const atBottom = el.scrollHeight - el.clientHeight - el.scrollTop <= 1;
+    setOverflowing(el.scrollHeight > el.clientHeight + 1 && !atBottom);
+  };
+
+  // Recompute the overflow flag when the rendered set or expansion changes, and
+  // keep it current across viewport resizes (the entries max-height steps down
+  // on the compact/roomy bands, changing what overflows). The <ul> may be
+  // unmounted (collapsed/empty) — measureOverflow no-ops via its null guard.
+  useEffect(() => {
+    measureOverflow();
+    if (typeof window === 'undefined') return;
+    window.addEventListener('resize', measureOverflow);
+    return () => window.removeEventListener('resize', measureOverflow);
+    // entries identity + the gating booleans drive a remeasure; measureOverflow
+    // reads live DOM so it needs no deps of its own.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entries, expanded, forceCollapsed]);
+
   // Phase 1 contrast (#578, F3): read [data-theme] so legend swatches use the
-  // correct palette column. The legend card surface is #131C30 in dark mode —
-  // a different (lighter) background than the light basemap (#f4f1ea), so the
-  // light `color` (darkened for contrast on cream) fails ≥3:1 against the dark
-  // card. `colorDark` is the original lighter/brighter hex that passes both
-  // #0E1116 (Phase 3 dark basemap) and #131C30 (legend card).
+  // correct palette column. The legend card surface is --color-bg-surface
+  // (#1b2742) in dark mode — a different (lighter) background than the light
+  // basemap (#f4f1ea), so the light `color` (darkened for contrast on cream)
+  // fails ≥3:1 against the dark card. `colorDark` is the original
+  // lighter/brighter hex that passes both the dark basemap and the legend card.
   const isDark = useTheme() === 'dark';
 
   // Render nothing when the legend has no useful content. Covers two
@@ -178,12 +276,26 @@ function FamilyLegendImpl({
   // preference. (O5 #783 — AC: "aria-expanded accurate to effective state")
   const effectiveExpanded = forceCollapsed ? false : expanded;
 
+  // E3 (#1055): zero-in-view honesty. When there are silhouettes (so we don't
+  // hit the hard `return null` above) but zero entries to show, the collapsed
+  // pill must not advertise an expand whose only result is an empty card. While
+  // collapsed-and-empty the toggle becomes non-interactive ("No families in
+  // view"); it restores to a live toggle the moment entries return. While
+  // expanded-and-empty we keep aria-expanded truthful and render one muted row
+  // ("No birds in this view") rather than a bare header. forceCollapsed is a
+  // transient overlay state, not a true empty-view, so it is excluded.
+  const isEmpty = entries.length === 0;
+  const zeroStateCollapsed = isEmpty && !forceCollapsed && !effectiveExpanded;
+  const expandedEmpty = effectiveExpanded && isEmpty;
+  const titleText = zeroStateCollapsed ? 'No families in view' : 'Bird families in view';
+
   return (
     <aside
       className="family-legend"
       role="complementary"
       aria-labelledby={toggleId}
       data-expanded={expanded ? 'true' : 'false'}
+      {...(zeroStateCollapsed ? { 'data-empty': 'true' } : {})}
       {...(forceCollapsed ? { 'data-force-collapsed': 'true' } : {})}
     >
       <button
@@ -191,32 +303,53 @@ function FamilyLegendImpl({
         type="button"
         className="family-legend-toggle"
         aria-expanded={effectiveExpanded}
+        {...(zeroStateCollapsed ? { disabled: true } : {})}
         {...(effectiveExpanded && entries.length > 0 ? { 'aria-controls': 'family-legend-entries' } : {})}
-        onClick={() => {
-          // forceCollapsed is a transient display override — the toggle
-          // click still advances the stored preference if forceCollapsed
-          // is true (the stored preference persists; the force-collapsed
-          // visual is driven by the parent prop, not by expanded state).
-          if (!forceCollapsed) setExpanded(prev => !prev);
-        }}
+        onClick={handleToggle}
       >
-        <span className="family-legend-title">Bird families in view</span>
-        {/* Single glyph + rotate transition — chevron rotate only.
-            data-expanded drives the CSS rotate(90deg) on .family-legend-chevron.
-            List mount behavior is byte-identical (hard guard: no always-mount). */}
-        <span
-          className="family-legend-chevron"
-          data-expanded={effectiveExpanded ? 'true' : 'false'}
-          aria-hidden="true"
-        >
-          ▸
-        </span>
+        <span className="family-legend-title">{titleText}</span>
+        {/* E3 (#1055): a ≥16px SVG chevron replaces the near-invisible
+            --type-xs ▸ glyph. At rest (collapsed) it points UP — the pill
+            expands upward, so "up" reads as "expand", not "navigate right".
+            data-expanded drives the CSS rotate(180deg) → points down to read
+            as "collapse downward". CHEVRON ROTATE ONLY — do NOT animate the
+            entries <ul> (hard guard: always-mounted/animated list reintroduces
+            the #837 corner overlap). The zero-state pill hides the chevron — a
+            non-interactive pill has nothing to expand. */}
+        {!zeroStateCollapsed && (
+          <svg
+            className="family-legend-chevron"
+            data-expanded={effectiveExpanded ? 'true' : 'false'}
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M3.5 10.5 8 6l4.5 4.5"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
       </button>
+      {expandedEmpty && (
+        <p className="family-legend-empty" role="status">
+          No birds in this view — pan or zoom out.
+        </p>
+      )}
       {effectiveExpanded && entries.length > 0 && (
         <ul
+          ref={entriesRef}
           id="family-legend-entries"
           className="family-legend-entries"
           role="list"
+          data-overflow={overflowing ? 'true' : 'false'}
+          onScroll={measureOverflow}
         >
           {entries.map(entry => {
             const active = entry.familyCode === familyCode;
@@ -225,8 +358,9 @@ function FamilyLegendImpl({
             // fall back to the null-channel shape (circle). The fill color,
             // however, now comes from the DB silhouettes payload — using
             // `colorDark` in dark mode so the swatch passes ≥3:1 against the
-            // dark legend card surface (#131C30), and `color` in light mode for
-            // the light basemap (#f4f1ea). Mirrors AdaptiveGridMarker's pattern.
+            // dark legend card surface (--color-bg-surface, #1b2742), and `color`
+            // in light mode for the light basemap (#f4f1ea). Mirrors
+            // AdaptiveGridMarker's pattern.
             const paletteCode = (entry.familyCode in FAMILY_PALETTE)
               ? (entry.familyCode as FamilyCode)
               : null;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1416,11 +1416,13 @@ body {
   text-align: left;
   border-radius: var(--card-radius);
 }
-/* Square the toggle's bottom corners only when an entries list actually
-   follows it, so header + list read as one continuous card. :has() tracks the
-   real presence of entries — correct for expanded-but-empty and
-   force-collapsed states without needing a JS-driven class. */
-.family-legend-toggle:has(+ .family-legend-entries) {
+/* Square the toggle's bottom corners only when a body (entries list OR the
+   expanded-empty muted row) actually follows it, so header + body read as one
+   continuous card. :has() tracks the real presence of a sibling — correct for
+   the expanded-but-empty muted row and force-collapsed states without needing a
+   JS-driven class. */
+.family-legend-toggle:has(+ .family-legend-entries),
+.family-legend-toggle:has(+ .family-legend-empty) {
   border-radius: var(--card-radius) var(--card-radius) 0 0;
 }
 .family-legend-toggle:hover {
@@ -1435,17 +1437,40 @@ body {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
+/* E3 (#1055): zero-in-view honesty. When there are no families to show, the
+   collapsed pill is non-interactive (the component sets `disabled` + the
+   <aside> carries data-empty) — there is nothing to expand. Drop the pointer
+   affordance and mute the label so it reads as a status, not a control. The
+   hover lift is suppressed too. */
+.family-legend[data-empty='true'] .family-legend-toggle {
+  cursor: default;
+}
+.family-legend[data-empty='true'] .family-legend-toggle:hover {
+  background: transparent;
+}
+.family-legend[data-empty='true'] .family-legend-title {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
 .family-legend-title {
   flex: 1;
+  min-width: 0;
   font-weight: 600;
 }
 .family-legend-chevron {
-  font-size: var(--type-xs);
+  /* E3 (#1055): a 16×16 SVG chevron replaces the near-invisible --type-xs ▸.
+     The glyph keeps --color-text-muted (currentColor) — 7.46:1 light (#555 on
+     #fff) / 5.07:1 dark (#8a98ad on #1b2742), both clear the WCAG 1.4.11 3:1
+     non-text-contrast floor; do NOT downgrade to --color-text-subtle (3.99:1
+     dark, a thinner margin). flex:0 0 auto keeps it square next to the
+     flex-grow title. */
+  flex: 0 0 auto;
   color: var(--color-text-muted);
-  /* Chevron rotate: ▸ stays as the single glyph; data-expanded drives
-     rotate(90deg). CHEVRON ROTATE ONLY — do NOT animate the entries <ul>
-     (hard guard: always-mounted list reintroduces the #837 corner overlap,
-     breaks e2e not.toBeVisible(), drifts toward FLIP pattern).
+  /* Chevron rotate: the SVG points UP at rest (collapsed reads "expand
+     upward", NOT "navigate right"); data-expanded drives rotate(180deg) so it
+     points down to read as "collapse downward". CHEVRON ROTATE ONLY — do NOT
+     animate the entries <ul> (hard guard: always-mounted list reintroduces the
+     #837 corner overlap, breaks e2e not.toBeVisible(), drifts toward FLIP).
      The global motion.css guard zeroes transition-duration for
      prefers-reduced-motion so the chevron snaps instantly to end-state. */
   transform: rotate(0deg);
@@ -1453,7 +1478,7 @@ body {
   display: inline-block;
 }
 .family-legend-chevron[data-expanded='true'] {
-  transform: rotate(90deg);
+  transform: rotate(180deg);
 }
 .family-legend-entries {
   list-style: none;
@@ -1473,6 +1498,47 @@ body {
   gap: 2px;
   max-height: 400px;
   overflow-y: auto;
+  border-top: 1px solid var(--color-border-subtle);
+  border-radius: 0 0 var(--card-radius) var(--card-radius);
+  /* E3 (#1055): the entries list is the relative anchor for the overflow fade
+     pseudo-element below — it must clip to the rounded bottom corners. */
+  position: relative;
+}
+/* E3 (#1055): overflow cue. macOS overlay scrollbars are invisible at rest, so
+   a half-hidden family list gave no signal that more rows lie below the fold.
+   FamilyLegend.tsx measures scrollHeight > clientHeight and sets
+   data-overflow="true" on the <ul>; this paints a bottom fade gradient that is
+   visible at rest (not only while scrolling) and disappears once the user
+   scrolls to the end (the component clears the flag at the bottom). The
+   gradient is a sticky pseudo-element inside the scroll container so it tracks
+   the viewport edge of the list, not the scrolled content. pointer-events:none
+   keeps clicks falling through to the rows beneath. */
+.family-legend-entries[data-overflow='true']::after {
+  content: '';
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  /* Pull the strip up over the last rows without consuming layout height. */
+  margin-top: -28px;
+  display: block;
+  height: 28px;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    var(--color-bg-surface)
+  );
+  border-radius: 0 0 var(--card-radius) var(--card-radius);
+}
+/* E3 (#1055): expanded-but-empty muted row. Keeps aria-expanded truthful (the
+   header still reports expanded) while telling the user why the card is empty,
+   instead of showing a bare header. Mirrors the entries padding/border so the
+   header + row read as one continuous card. */
+.family-legend-empty {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
   border-top: 1px solid var(--color-border-subtle);
   border-radius: 0 0 var(--card-radius) var(--card-radius);
 }
@@ -1528,12 +1594,32 @@ body {
 .family-legend-entry-label {
   flex: 1;
   min-width: 0;
+  /* E3 (#1055): wrap to TWO lines instead of single-line ellipsis. The old
+     `white-space: nowrap` + ellipsis cut the distinguishing head noun off the
+     long colloquial names #924 introduced — "African & New World P…" dropped
+     "Parrots", "Blackbirds, Orioles &…" dropped "Allies". Two-line clamp keeps
+     the final noun visible within the 280px --card-maxw-legend cap (which is
+     NOT raised — the rows are already 36px+ and grow to fit a second line). A
+     name longer than two lines still ellipsizes, but that is rare and never
+     drops the head noun on the current colloquial set. line-height tightened so
+     two lines stay compact. */
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  line-height: 1.25;
+  /* Preserve the word that follows the wrap (don't break mid-word). */
+  overflow-wrap: anywhere;
 }
 .family-legend-entry-count {
   flex-shrink: 0;
+  /* E3 (#1055): tighten the count gutter — the count was set off by the row's
+     12px --space-md gap, which read as a wide gulf next to a wrapped two-line
+     label. A dedicated 8px left margin (the count keeps its own padding/pill)
+     pulls it closer to the label column while staying clear of the wrap. */
+  margin-left: var(--space-sm);
+  align-self: center;
   font-variant-numeric: tabular-nums;
   font-size: var(--type-xs);
   color: var(--color-text-body);
@@ -1590,8 +1676,9 @@ body {
 
 /* #853: bound the legend on the 481–1023px 'roomy' band (useBreakpoint's
    `'roomy'` tier; --overlay-bp-compact 480px → --overlay-bp-wide 1024px). On
-   this band a user with a stored `family-legend-expanded.v2=true` preference
-   (e.g. expanded on a prior desktop session) sees the legend render expanded —
+   this band a user with a stored `family-legend-expanded.v3.roomy=true`
+   preference (E3 #1055 re-keyed the per-breakpoint pref; was the breakpoint-
+   blind `.v2`) sees the legend render expanded —
    the <1024px collapse-default (#809) is correctly overridden by the stored
    preference — but the ≤480px height cap above (#810) does NOT apply here, so
    `.family-legend-entries` fell back to the desktop `max-height: 400px`


### PR DESCRIPTION
## Diagrams

Storage key migration + per-tier write/read boundary (the core of this change):

```mermaid
flowchart TD
    mount["FamilyLegend mount (tier = useBreakpoint)"] --> readv1{"legacy v1 key present?"}
    readv1 -- yes --> dropv1["delete v1"]
    readv1 -- no --> readv2
    dropv1 --> readv2{"v2 key present?"}
    readv2 -- "yes &amp; active-tier key empty" --> seed["seed .v3.&lt;tier&gt; only, delete .v2"]
    readv2 -- "yes &amp; active-tier key set" --> dropv2["keep tier key, delete .v2"]
    readv2 -- no --> readtier
    seed --> readtier["read .v3.&lt;tier&gt;"]
    dropv2 --> readtier
    readtier --> init["expanded = stored ?? defaultExpanded"]

    toggle["user toggles (only writer)"] --> writetier["write .v3.&lt;current tier&gt;"]
    resize["live tier change (resize)"] --> reread["re-read NEW tier key (READ-ONLY, no write)"]
```

## Summary

- **Why:** the legend was hard to operate and dishonest — a near-invisible `--type-xs` chevron, single-line ellipsis that dropped the head noun of long colloquial names (`African & New World P…`), a breakpoint-blind storage key that leaked a desktop expand onto the phone, bare-header empty states, and an invisible-at-rest overflow.
- **What:** 16×16 SVG chevron (up at rest → down when expanded, contrast lock kept on `--color-text-muted`); two-line label wrap inside the unchanged 280px cap; per-tier persistence (`.v3.<compact|roomy|wide>`) with a one-shot `.v2`→active-tier migration and a **read-only** re-key on live resize (toggle is the sole writer — the reviewer's explicit AC); muted "No birds in this view" row + non-interactive "No families in view" pill; a measured `data-overflow` bottom-fade cue.
- **Hard guard honored:** the entries `<ul>` is still conditionally mounted and unanimated — no #837 corner-overlap regression.

## Screenshots

Captured live (Playwright MCP) against head `1d778b8`, **family legend expanded** at all 5 canonical viewports × light/dark (`?scope=us` — 96 families, exercising the overflow cue). Console clean.

Live-verified at head `1d778b8`: `.family-legend-toggle` chevron is now a 16×16 **SVG** (V8/V24, was a `--type-xs ▸`); `.family-legend-entries` is scrollable with `data-overflow="true"` (V40 bottom-fade); long colloquial names wrap to two lines inside the 280px cap (V3/V7 — "Blackbirds, Orioles & Allies" no longer truncated); 96 entries render. Per-tier persistence (O11) + empty-state row/pill (C81/V38) are pinned by the 45 FamilyLegend unit tests + 8 e2e cases.

| Viewport | Light | Dark |
|---|---|---|
| 390×844 (mobile) | ![e3-390-light](https://github.com/user-attachments/assets/805dbfc8-b756-4ad4-a7c5-c02cddc7ed67) | ![e3-390-dark](https://github.com/user-attachments/assets/8191872f-4722-4b45-80c1-1015833d45d7) |
| 768×1024 (tablet) | ![e3-768-light](https://github.com/user-attachments/assets/f22ba9b4-fb3f-43a7-99d7-e331927eaac8) | ![e3-768-dark](https://github.com/user-attachments/assets/2f22d706-241b-4632-9353-c25c0f3c90d0) |
| 1024×768 (laptop) | ![e3-1024-light](https://github.com/user-attachments/assets/acc3ae5b-218d-4b62-aaa0-f403445eb284) | ![e3-1024-dark](https://github.com/user-attachments/assets/9396921e-cdd1-4de0-9726-d6622d4cf223) |
| 1440×900 (desktop) | ![e3-1440-light](https://github.com/user-attachments/assets/71db51a7-b7bd-4649-89ff-e387bd0f4422) | ![e3-1440-dark](https://github.com/user-attachments/assets/3d9d4365-8567-41f7-91db-27cd889b7904) |
| 1920×1080 (wide) | ![e3-1920-light](https://github.com/user-attachments/assets/69b8d35f-3825-4a51-9c84-3732bc27fe80) | ![e3-1920-dark](https://github.com/user-attachments/assets/e5b7b2ad-9649-4b66-8602-042b9cb7e929) |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule (`family-legend-empty` added with rule; `family-legend-chevron`/`family-legend-title` pre-existing — orphan-classname-check PASS)
- [x] Multi-viewport design QA: 10 `user-attachments` URLs above (5 viewports × 2 themes).

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 1447 passed (87 files); FamilyLegend.test.tsx 45 passed (new: per-tier write isolation, live tier-change no-clobber, expanded-empty muted row, zero-state disabled pill, chevron size/direction, .v2→.v3.<tier> migration shape incl. no-overwrite + no-cross-tier-seed)
- [x] New unit tests added (TDD: failing-first)
- [x] New Playwright e2e spec added — `legend-usability-e3.spec.ts` (chevron ≥16px, long-label final-noun wrap at 390 & 1440 with a **named** family so it can't pass vacuously, overflow cue at rest, both empty states)
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — exit 0; `bash scripts/check-orphan-classnames.sh` — PASS
- [x] All legend e2e specs green against this worktree's Vite (5273; shared :5173 belonged to another worktree): `family-legend`, `family-legend-viewport`, `family-legend-collapse-visibility`, `legend-o5-cap-force-collapse`, `legend-roomy-band-cap`, `legend-usability-e3`, `map-root-geometry` — 36 passed
- [x] (UI) Playwright MCP smoke — DONE at head `1d778b8`: SVG chevron + label-wrap + data-overflow fade verified; 96 entries; console clean.

## Design QA

`ui-design:ui-designer` (opus) — PASS (all 5 viewports).

## Plan reference

Out of plan — design-review remediation epic. Closes #1055. Part of #1052 (Wave 3 / E3). Builds on the merged E2 geometry hub #1054.

## Notes

- **Key-rename blast radius (all .v2 call sites re-keyed to the per-tier .v3.<tier> matching each spec's viewport):** `legend-o5-cap-force-collapse.spec.ts` (390→compact, 1024→wide, 768→roomy via a `legendKeyFor(width)` helper), `legend-roomy-band-cap.spec.ts` (500/768→roomy, 1440→wide), and the `removeItem` cleanup sites in `family-legend.spec.ts`, `family-legend-viewport.spec.ts`, `family-legend-collapse-visibility.spec.ts`, `map-root-geometry.spec.ts` (E2-owned; key-string only) now clear all three tier keys. `FamilyLegend.test.tsx` `STORAGE_KEY` re-pointed to `.v3.wide` (the active tier under jsdom, where matchMedia is unmocked).
- **Stale doc refs corrected on the touched files** (per R7, since the PR already edits them): the legend-card surface comment `#131C30` → `#1b2742` (`--color-bg-surface`); `.v2` references in `App.tsx`, `styles.css`, and the e2e comments → `.v3.<tier>`.
- **Findings — all reproduced at `origin/main` (bcd3c61, post-#1054)** before changing anything: chevron `styles.css` glyph + size, label `white-space: nowrap` ellipsis, breakpoint-blind `STORAGE_KEY`, entries gate `effectiveExpanded && entries.length > 0` vs independent `aria-expanded`, and `max-height`+`overflow-y:auto` with no fade. None were non-repro.
- **Legend-dismiss guard fold-in: NOT taken.** The E2 review's adjacent SUGGESTION (a legend-entry click while the filters panel is open dismissing the panel via the raised `.filters-backdrop`) sits in filters/backdrop pointer-events territory, not legend usability — verifying it cleanly would expand scope beyond E3, and nothing here touches that interaction. Flagged for a separate follow-up rather than gold-plated in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

