### PR TITLE
chore(typography): unify font-stack + --type-sm leading + ramp/weight/tracking tokens (#1061)

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -445,6 +445,12 @@
   border-radius: 999px;
   font-family: var(--font-stack);
   font-weight: var(--font-weight-semibold);
+  /* F1 #1061: tabular digits. pillDimensions() in ClusterPill.tsx predicts the
+     deconflict AABB from a fixed per-digit advance (~8/9/10px per tier) — that
+     formula only holds if every digit is the same width. Every other count
+     surface already sets this (.app-header-lede, observation count, grid
+     badges); the pill was the lone omission. */
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
   transition: transform var(--dur-fast), box-shadow var(--dur-fast);
   /* WCAG 2.5.8 Target Size (Minimum) — 24×24px floor. Audit measured
@@ -672,8 +678,16 @@ button.adaptive-grid-marker__cell {
   right: 0;
   background: #1a1a1a;
   color: #fff;
+  /* MAP-MARKER-GRAPHICS RAMP EXCEPTION (F1 #1061, 2026-06-13): this 9px count
+     glyph sits BELOW the --type-xs (11px) ramp floor. Promoting it to
+     --type-xs would force a re-tune of the 14px badge box + the E6/#1058
+     "badge bbox fully within its 22px owner cell" anchoring invariant — a real
+     geometry change that exceeds value-preserving hygiene. The badge is a
+     map-graphic, not running prose; contrast is ~17:1 and bold. Excluded from
+     ramp audits here (and at __overflow below). Re-audit: if the marker box is
+     ever re-sized, fold the glyph back onto --type-xs at that time. */
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   min-width: 14px;
   height: 14px;
   padding: 0 3px;
@@ -699,8 +713,13 @@ button.adaptive-grid-marker__cell {
      than another silhouette tile. */
   background: rgba(0, 0, 0, 0.78);
   color: #fff;
+  /* MAP-MARKER-GRAPHICS RAMP EXCEPTION (F1 #1061, 2026-06-13): 10px sub-ramp
+     count glyph — same exclusion rationale as .adaptive-grid-marker__badge
+     above (map graphic in a fixed cell box, not prose; ~17:1 contrast, bold).
+     Excluded from ramp audits; re-fold onto --type-xs only if the cell box is
+     re-sized. */
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   font-variant-numeric: tabular-nums;
 }
 
@@ -833,7 +852,7 @@ button.adaptive-grid-marker__cell {
 }
 
 .cell-hover-preview__footer {
-  font-size: 11px;
+  font-size: var(--type-xs);
   color: var(--color-text-muted);
   margin-top: var(--space-xxs);
   font-style: italic;
@@ -1037,7 +1056,7 @@ button.adaptive-grid-marker__cell {
 }
 
 .cell-popover__footer {
-  font-size: 11px;
+  font-size: var(--type-xs);
   color: var(--color-text-muted);
   margin-top: var(--space-xs);
   font-style: italic;
@@ -1056,7 +1075,7 @@ button.adaptive-grid-marker__cell {
   border: none;
   background: none;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--type-xs);
   cursor: pointer;
   color: var(--color-text-link);
   text-decoration: underline;
@@ -1224,6 +1243,9 @@ button.adaptive-grid-marker__cell {
    state-hidden trap; only the caret animates here. */
 .cluster-list-popover__family-toggle::before {
   content: "▶ ";
+  /* GLYPH RAMP EXCEPTION (F1 #1061, 2026-06-13): decorative ▶ disclosure caret,
+     not running text — sized to the rotation box, not the type ramp. Excluded
+     from ramp audits (same class as the map-marker badge glyphs above). */
   font-size: 10px;
   display: inline-block;
   width: 12px;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -99,7 +99,15 @@
 *, *::before, *::after { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, sans-serif;
+  /* F1 #1061, spec §2.5: resolve through the single --font-stack token. Before
+     #1061 body hardcoded the legacy scaffold stack (no "Segoe UI Variable",
+     no "Inter") with NO line-height, so surfaces inheriting body's font — most
+     notably .observation-popover — rendered in a different family/leading than
+     the --text-body-sm consumers (.cell-popover). On Windows the two map
+     popovers a user toggles between resolved to different fonts. A line-height
+     baseline of 1.5 matches the --leading-sm small-body leading. */
+  font-family: var(--font-stack);
+  line-height: 1.5;
   background: var(--color-bg-page);
   color: var(--color-text-strong);
 }
@@ -238,14 +246,18 @@ body {
   top: 8px;
   right: 8px;
   /* Touch target ≥44×44 (WCAG 2.5.5 / design-review finding).
-     The visible × glyph stays at font-size:18px; padding + flex-centering
+     The visible × glyph is sized by font-size; padding + flex-centering
      expand the hit area without enlarging the visual mark. */
   min-width: 44px;
   min-height: 44px;
   border: none;
   background: transparent;
   color: var(--color-text-muted);
-  font-size: 18px;
+  /* ICON-GLYPH EXCEPTION (F1 #1061, 2026-06-13): the × is a 20×20 close
+     affordance, not type-ramp text — unified with the sibling close glyph
+     (.species-detail-rail-close) and the header's 20×20 stroke-SVG icon scale.
+     The 44×44 hit area above is unchanged. */
+  font-size: 20px;
   line-height: 1;
   cursor: pointer;
   border-radius: 4px;
@@ -791,7 +803,7 @@ body {
   background: transparent;
   border: 1.5px solid var(--color-text-strong);
   color: var(--color-text-strong);
-  font-size: 11px;
+  font-size: var(--type-xs);
   font-weight: var(--font-weight-semibold);
   line-height: 1;
   /* Recipe #03 — notification-badge: one-shot @keyframes entrance on mount.
@@ -1140,7 +1152,7 @@ body {
   margin: 0;
   font-size: var(--type-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--color-text-muted);
 }
 .detail-fg-taxrow dd {
@@ -1159,7 +1171,7 @@ body {
   font-size: var(--type-xs);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-eyebrow);
   color: var(--color-text-muted);
 }
 .species-detail-loading { color: var(--color-text-muted); font-size: var(--type-sm); margin: 8px 0 0 0; }
@@ -1274,7 +1286,10 @@ body {
 .attribution-modal-header h2 {
   margin: 0;
   font-size: var(--type-md);
-  font-weight: 700;
+  /* F1 #1061: §2.4 card/resting-surface titles are semibold. This modal title
+     was the only resting title shipping at bold; dropped to semibold to match
+     the contract (and tokenized off the raw 700). */
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-strong);
 }
 .attribution-modal-close {
@@ -1302,7 +1317,10 @@ body {
 .attribution-modal-section h3 {
   margin: 0 0 var(--space-xs) 0;
   font-size: var(--type-sm);
-  font-weight: 700;
+  /* F1 #1061: §2.4 — resting subheading follows the card-title semibold voice
+     (matches the h2 above; differentiated by size, not weight). Tokenized off
+     the raw 700. */
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-strong);
 }
 .attribution-modal-section p {
@@ -1456,12 +1474,12 @@ body {
 }
 .family-legend[data-empty='true'] .family-legend-title {
   color: var(--color-text-muted);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 .family-legend-title {
   flex: 1;
   min-width: 0;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 .family-legend-chevron {
   /* E3 (#1055): a 16×16 SVG chevron replaces the near-invisible --type-xs ▸.
@@ -1822,7 +1840,14 @@ body:has(.species-detail-sheet--peek) .map-attribution {
   border-radius: var(--card-radius);
   box-shadow: var(--card-elevation-2);
   padding: var(--space-sm) var(--space-md);
+  /* F1 #1061, spec §2.5: must read identically to its sibling map popover
+     .cell-popover (which sets `font: var(--text-body-sm)` = --font-stack @
+     --type-sm / --leading-sm). This rule keeps font-size as the token but
+     previously relied on body for family + UA-normal for leading, which
+     diverged from the shorthand. Pin the same stack + leading here. */
+  font-family: var(--font-stack);
   font-size: var(--type-sm);
+  line-height: var(--leading-sm);
   color: var(--color-text-strong);
   max-width: var(--card-maxw-popover);
 }
@@ -1908,7 +1933,7 @@ body:has(.species-detail-sheet--peek) .map-attribution {
 }
 .observation-popover-name {
   flex: 1;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 .observation-popover-badge {
   background: var(--color-accent-notable-fg);
@@ -1920,7 +1945,7 @@ body:has(.species-detail-sheet--peek) .map-attribution {
   align-items: center;
   justify-content: center;
   font-size: var(--type-xs);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 .observation-popover-close {
   appearance: none;
@@ -2041,6 +2066,10 @@ aside.species-detail-rail .species-detail-rail-close {
   display: block;
   width: 32px;
   height: 32px;
+  /* ICON-GLYPH EXCEPTION (F1 #1061, 2026-06-13): the × is a 20×20 close
+     affordance unified with .map-error-overlay__dismiss and the header's
+     20×20 stroke-SVG icon scale — not type-ramp text. The 32×32 hit area
+     above is unchanged. */
   font-size: 20px;
   line-height: 1;
   background: transparent;
@@ -2459,7 +2488,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   margin: 0;
   font-size: var(--type-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--color-text-muted);
 }
 .sheet-fg-value {
@@ -2519,7 +2548,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   margin: 0;
   font-size: var(--type-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-label);
   color: var(--color-text-muted);
 }
 .sheet-fg-taxrow dd { margin: 0; font-size: var(--type-sm); color: var(--color-text-strong); }
@@ -2533,7 +2562,7 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   font-size: var(--type-xs);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: var(--tracking-eyebrow);
   color: var(--color-text-muted);
 }
 .sheet-fg-prose {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -49,6 +49,15 @@
   --type-lg:   22px;  /* surface section titles */
   --type-hero: 34px;  /* lede, detail-surface species name */
 
+  /* The single --type-sm leading (F1 #1061, spec §2.5). Before #1061 the
+     small-body leading was half a system — 1.4 (.app-header-lede), 1.2
+     (filters reset), 1.5 (--text-body-sm). Unified to 1.5 (the value the
+     --text-body-sm consumers already carry) and encoded here next to the ramp
+     so the two map popovers (.cell-popover via --text-body-sm, .observation-
+     popover via this token) resolve to identical leading. Consumed by
+     --text-body-sm below and by .observation-popover in styles.css. */
+  --leading-sm: 1.5;
+
   --font-stack:
     -apple-system, BlinkMacSystemFont, "Segoe UI Variable",
     "Helvetica Neue", "Inter", sans-serif;
@@ -57,6 +66,18 @@
   --font-weight-medium:   500;
   --font-weight-semibold: 600;
   --font-weight-bold:     700;
+
+  /* Letter-spacing scale (F1 #1061, spec §2.4). The uppercase meta surfaces
+     hand-rolled their tracking: 0.06em on label rows (.detail-fg-taxrow dt,
+     .sheet-fg-label, .sheet-fg-taxrow dt) and 0.08em on section eyebrows
+     (.detail-fg-about-eyebrow, .sheet-fg-about-eyebrow). Promoted to tokens so
+     the two label/eyebrow voices are single-sourced. The 0.04em
+     (.scope-chooser__divider) and 0.01em (.sort-label) outliers are one-off
+     micro-tracking on unique surfaces, kept as literals (no second consumer to
+     justify a token). NOT consumed by the dead .map-freshness 0.05em rule —
+     that whole rule is deleted by #1064. */
+  --tracking-label:   0.06em;
+  --tracking-eyebrow: 0.08em;
 
   /* Corner radius (#761 P1, issue #778). --radius-lg retires the missing-token
      inline fallback var(--radius-lg, 12px) consumed at styles.css (sheet top
@@ -217,7 +238,7 @@
    * themes resolve to the 13px/1.5 and 17px/1.3 contract values.
    * The [data-theme="light"] definitions and the false "inherits the
    * :root definition above" dark comment are removed. */
-  --text-body-sm:    var(--font-weight-regular) var(--type-sm) / 1.5 var(--font-stack);
+  --text-body-sm:    var(--font-weight-regular) var(--type-sm) / var(--leading-sm) var(--font-stack);
   --text-heading-sm: var(--font-weight-medium) var(--type-md) / 1.3 var(--font-stack);
 
   /* ── transient-popover enter family (#950) ──────────────────────────────

--- a/frontend/src/styles/tokens.css.test.ts
+++ b/frontend/src/styles/tokens.css.test.ts
@@ -1016,3 +1016,85 @@ describe('B4 (#1043): elevation/shadow token migration', () => {
     expect(photoBlockMatch?.[1]).not.toMatch(/border-radius:\s*10px/);
   });
 });
+
+// F1 (#1061) — typography unification: one font stack, one --type-sm leading,
+// ramp/weight/tracking values consumed as tokens. Guards pin the unified
+// values so a future regression (re-typed literal, divergent body stack)
+// reddens here, not only at live-verify.
+describe('F1 #1061 — typography unification', () => {
+  describe('tokens.css — leading + tracking tokens', () => {
+    it('defines --leading-sm next to the type ramp (the single --type-sm leading)', () => {
+      // Contract: ONE --type-sm leading, encoded next to the ramp. We pick 1.5
+      // to match the --text-body-sm consumers (.cell-popover et al.), so the
+      // two map popovers resolve identically.
+      expect(TOKENS_CSS).toMatch(/--leading-sm:\s*1\.5\s*;/);
+    });
+    it('--text-body-sm consumes --leading-sm (no re-typed 1.5 literal in the shorthand)', () => {
+      expect(TOKENS_CSS).toMatch(
+        /--text-body-sm:\s*var\(--font-weight-regular\)\s*var\(--type-sm\)\s*\/\s*var\(--leading-sm\)\s*var\(--font-stack\)/,
+      );
+    });
+    it('defines --tracking-label: 0.06em in Layer 1', () => {
+      expect(TOKENS_CSS).toMatch(/--tracking-label:\s*0\.06em\s*;/);
+    });
+    it('defines --tracking-eyebrow: 0.08em in Layer 1', () => {
+      expect(TOKENS_CSS).toMatch(/--tracking-eyebrow:\s*0\.08em\s*;/);
+    });
+  });
+
+  describe('styles.css — body font + popover parity', () => {
+    it('body resolves font-family through var(--font-stack) (not the legacy scaffold stack)', () => {
+      const bodyBlock = STYLES_CSS.match(/\bbody\s*\{([^}]*)\}/s);
+      expect(bodyBlock?.[1]).toMatch(/font-family:\s*var\(--font-stack\)/);
+      // The legacy scaffold stack must be gone from body.
+      expect(bodyBlock?.[1]).not.toMatch(/-apple-system,\s*BlinkMacSystemFont,\s*"Helvetica Neue"/);
+    });
+    it('body sets a line-height baseline', () => {
+      const bodyBlock = STYLES_CSS.match(/\bbody\s*\{([^}]*)\}/s);
+      expect(bodyBlock?.[1]).toMatch(/line-height:/);
+    });
+    it('.observation-popover sets the same font + leading as the --text-body-sm consumers', () => {
+      const popBlock = STYLES_CSS.match(/\.observation-popover\s*\{([^}]*)\}/s);
+      // Must pin the token stack and the unified --type-sm leading so it is
+      // visually identical to .cell-popover (font: var(--text-body-sm)).
+      expect(popBlock?.[1]).toMatch(/font-family:\s*var\(--font-stack\)/);
+      expect(popBlock?.[1]).toMatch(/line-height:\s*var\(--leading-sm\)/);
+    });
+  });
+
+  describe('mechanical token swaps — no re-typed literals', () => {
+    it('no raw font-size: 11px in styles.css (use var(--type-xs))', () => {
+      expect(STYLES_CSS).not.toMatch(/font-size:\s*11px/);
+    });
+    it('no raw font-size: 11px in ds-primitives.css (use var(--type-xs))', () => {
+      expect(DS_PRIMITIVES_CSS).not.toMatch(/font-size:\s*11px/);
+    });
+    it('no raw numeric font-weight in styles.css (use var(--font-weight-*))', () => {
+      expect(STYLES_CSS).not.toMatch(/font-weight:\s*[0-9]/);
+    });
+    it('no raw numeric font-weight in ds-primitives.css (use var(--font-weight-*))', () => {
+      expect(DS_PRIMITIVES_CSS).not.toMatch(/font-weight:\s*[0-9]/);
+    });
+    it('no literal weight smuggled into a font: shorthand', () => {
+      expect(STYLES_CSS).not.toMatch(/font:\s*[0-9]{3}/);
+      expect(DS_PRIMITIVES_CSS).not.toMatch(/font:\s*[0-9]{3}/);
+    });
+    it('the uppercase label rows consume --tracking-label (not the 0.06em literal)', () => {
+      // .detail-fg-taxrow dt / .sheet-fg-label / .sheet-fg-taxrow dt
+      // (the dead .map-freshness 0.05em is deleted by #1064 — not touched here).
+      expect(STYLES_CSS).not.toMatch(/letter-spacing:\s*0\.06em/);
+    });
+    it('the uppercase eyebrows consume --tracking-eyebrow (not the 0.08em literal)', () => {
+      expect(STYLES_CSS).not.toMatch(/letter-spacing:\s*0\.08em/);
+    });
+    it('.cluster-pill sets font-variant-numeric: tabular-nums (its width formula assumes tabular digits)', () => {
+      const pillBlock = DS_PRIMITIVES_CSS.match(/\.cluster-pill\s*\{([^}]*)\}/s);
+      expect(pillBlock?.[1]).toMatch(/font-variant-numeric:\s*tabular-nums/);
+    });
+    it('the two × close glyphs are unified at one shared size (20px), not 18px/20px split', () => {
+      // Either SVG migration (no font-size:18|20) or one shared size with an
+      // icon-glyph exception comment at both sites — we take the latter at 20px.
+      expect(STYLES_CSS).not.toMatch(/font-size:\s*18px/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

One typographic voice across every surface (Wave 4 / F1 of the 2026-06-11 design-review hygiene epic #1060). Before this change `body` hardcoded a legacy scaffold stack (`-apple-system, BlinkMacSystemFont, "Helvetica Neue"…` — no `"Segoe UI Variable"`, no `"Inter"`) with **no** `line-height`, so any surface inheriting body's font rendered in a different family/leading than the `--text-body-sm` consumers. Most visibly, `.observation-popover` (font-size token only) diverged from its sibling map popover `.cell-popover` (`font: var(--text-body-sm)`) — on Windows the two map popovers a user toggles between resolved to different fonts, the exact failure spec §2.5 names.

What this PR does:

- **tokens.css** — add `--leading-sm: 1.5` (the single `--type-sm` leading) next to the ramp; rewire `--text-body-sm` to consume it; add `--tracking-label: 0.06em` + `--tracking-eyebrow: 0.08em` in Layer 1.
- **styles.css** — `body` resolves through `var(--font-stack)` + a `line-height: 1.5` baseline; `.observation-popover` pins the same `font-family` + `--leading-sm` as `.cell-popover` so the two are identical.
- **Mechanical token swaps (zero visual change):** 4× `font-size: 11px` → `var(--type-xs)`; raw `font-weight` literals → `var(--font-weight-*)`; `0.06/0.08em` tracking → tokens; `.cluster-pill += font-variant-numeric: tabular-nums` (its `pillDimensions()` deconflict AABB assumes a fixed per-digit advance).
- **§2.4 conformance (intended deltas):** attribution-modal `h2`/`h3` drop `bold` → `semibold` (resting-surface titles are semibold) — the only intended pixel delta beyond leading normalization.
- **× close glyphs** unified at one shared `20px` size (was 18px/20px split), each carrying a one-line icon-glyph ramp-exception comment; the `44×44` / `32×32` hit areas are unchanged.
- **Map-marker graphics** — the 9px/10px count glyphs and the `▶` disclosure caret carry dated map-marker-graphics ramp-exception comments (promoting them to `--type-xs` would force a badge-box re-tune that breaks the E6/#1058 anchoring invariant — exceeds value-preserving hygiene).
- **tokens.css.test.ts** — 15 guards pinning the unified stack/leading/tracking values and the no-re-typed-literal invariants.

```mermaid
flowchart LR
  A["body (legacy stack, no leading)"] -.diverged.-> P1[".observation-popover"]
  B["--text-body-sm (token stack / 1.5)"] --> P2[".cell-popover"]
  A2["body (var(--font-stack), 1.5)"] --> P1b[".observation-popover (font-stack / --leading-sm)"]
  B --> P2
  P1b -. identical .- P2
```

## Test plan

- TDD: 15 `tokens.css.test.ts` guards written first (Red, 15 failing), then implementation (Green).
- `npx tsc -b frontend` — clean (exit 0).
- `npm test --workspace @bird-watch/frontend -- --run` — **1527 passed (88 files)**; `tokens.css.test.ts` 136 passed incl. the 15 new F1 guards.
- `npm run build --workspace @bird-watch/frontend` — built (exit 0; only the pre-existing maplibre-gl chunk-size note).
- `npx knip` — exit 0 (only a pre-existing unrelated ignore-rule hint).
- `bash scripts/check-orphan-classnames.sh` — PASS.
- AC grep audits all clean: `font-size: 11px` → 0 per file; no raw `font-weight: [0-9]`; no `font: NNN` shorthand smuggling; `font-size: (18|20)px` → exactly the two × sites at one shared 20px with exception comments.
- e2e: `map-root-geometry.spec.ts` + `marker-overlap.spec.ts` compile and enumerate cleanly (`--list`, 37 tests). Both assert *relations* (relative `getBoundingClientRect` / AABB intersection), not exact px, and there are **zero** `toHaveCSS`/`font-family`/`line-height` assertions anywhere under `frontend/e2e/`, so the leading change pins no guard. Full live e2e run deferred to the orchestrator live-verify pass (the shared `:5173` dev plane is held by a parallel-worktree's code; running here would silently reuse the wrong build).

## Screenshots

**Live verification (W.3 — orchestrator, head `37ee008`).** Confirmed the intended typographic deltas live against the loaded CSS + computed styles at `?state=US-CA`:

1. **Two map popovers now identical (the §2.5 headline fix) ✓** — from the loaded stylesheet: `.observation-popover` resolves `font-family: var(--font-stack)` / `font-size: var(--type-sm)` / `line-height: var(--leading-sm)`, and `.cell-popover` resolves `font: var(--text-body-sm)` which expands to `400 13px / 1.5 <same --font-stack>`. Same family + 13px + 1.5 leading. The live `.cell-popover` computed to `13px / 19.5px` (= 13×1.5) — both popovers now share one voice.
2. **Body baseline ✓** — `body` computes the token stack (`-apple-system, system-ui, "Segoe UI Variable", "Helvetica Neue", Inter…`) at `16px / 24px` (line-height 1.5), replacing the legacy no-leading scaffold stack.
3. **attribution-modal h2/h3 bold→semibold ✓** — Credits modal: h2 "Credits" and h3 "Bird Sightings Data" both compute `font-weight: 600` (semibold per §2.4), down from bold.
4. **Mechanical swaps value-preserving** — 4× `font-size:11px`→`--type-xs`, font-weight/tracking literals→tokens, `.cluster-pill` tabular-nums: byte-identical, confirmed by the 15 `tokens.css.test.ts` guards + the static-regression captures below.

**Static-appearance pass:** 10 captures (5 viewports × 2 themes), `?state=US-CA`. Console **0 errors / 0 warnings** at every light viewport; dark shows only the known `circle-11` #947 dark-basemap missing-image noise (not introduced here).

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="f1-390-light" src="https://github.com/user-attachments/assets/ba82c00f-878f-4ab0-8799-d31558e485a1" /> | <img width="360" alt="f1-390-dark" src="https://github.com/user-attachments/assets/90a31a11-f355-4795-99fb-a96950bedd03" /> |
| **768×1024 (tablet)** | <img width="360" alt="f1-768-light" src="https://github.com/user-attachments/assets/c310bd36-8a93-44d0-9ad1-2d2ddd9f3eb4" /> | <img width="360" alt="f1-768-dark" src="https://github.com/user-attachments/assets/7a100fec-9e8e-42f4-9458-c18269a7075f" /> |
| **1024×768 (laptop)** | <img width="360" alt="f1-1024-light" src="https://github.com/user-attachments/assets/56e50215-2c46-48f0-abad-59631114b4c4" /> | <img width="360" alt="f1-1024-dark" src="https://github.com/user-attachments/assets/ee2d3227-8acd-4de3-a219-2476e3312d61" /> |
| **1440×900 (desktop)** | <img width="360" alt="f1-1440-light" src="https://github.com/user-attachments/assets/20657b23-554c-422c-ae4b-65c13345386c" /> | <img width="360" alt="f1-1440-dark" src="https://github.com/user-attachments/assets/3f421ffe-3f8a-4895-aa38-d0e3e8c3572d" /> |
| **1920×1080 (wide)** | <img width="360" alt="f1-1920-light" src="https://github.com/user-attachments/assets/c0afbb46-6a35-4771-b92e-98a44644dde6" /> | <img width="360" alt="f1-1920-dark" src="https://github.com/user-attachments/assets/50b0c1ab-386d-47e2-9a82-da8c5c1d1d01" /> |

## Design QA

**ui-design:ui-designer (opus) — OVERALL PASS** (head `37ee008`). Per-viewport: 390×844 PASS · 768×1024 PASS · 1024×768 PASS · 1440×900 PASS · 1920×1080 PASS. One consistent sans family + 1.5 leading across wordmark/heading/lede/legend at every size; no overflow, clipping, misalignment, or broken wrapping from the line-height/stack change; identity card auto-heights for the slightly taller leading; four-corner contract intact both themes.

## Notes

- **Scope discipline:** touches only the four files the issue names (tokens.css, styles.css, ds-primitives.css, tokens.css.test.ts). No breakpoint values (F2 #1062), no motion/easing (F3 #1063), no dead-code deletion (F4 #1064), no shadow tokenization (#1043). The dead `.map-freshness` `0.05em` tracking is left untouched for #1064.
- **Leading choice = 1.5** (vs 1.4): matches the `--text-body-sm` consumers the popover-parity AC requires, so `.observation-popover` and `.cell-popover` resolve to identical `line-height`.
- **Outlier tracking kept as literals:** `0.04em` (`.scope-chooser__divider`) and `0.01em` (`.sort-label`) are one-off micro-tracking with no second consumer — documented in the `--tracking-*` token comment rather than over-tokenized.
- **Intended pixel deltas** (everything else is value-preserving): (1) `.observation-popover` taller under 1.5 vs UA-normal leading; (2) attribution-modal `h2`/`h3` bold → semibold per §2.4; (3) `.map-error-overlay__dismiss` × glyph 18px → 20px. Orchestrator live-verify should confirm these read correctly at all 5 viewports × 2 themes.

Closes #1061. Part of #1060 (Wave 4 / F1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


