### PR TITLE
docs: spec/comment drift sweep + region amendment (#1065)

### DIFF
--- a/docs/design/2026-05-30-floating-ui-design-spec.md
+++ b/docs/design/2026-05-30-floating-ui-design-spec.md
@@ -46,7 +46,7 @@ Every floating surface consumes **one** vocabulary. No element invents its own r
 | Token | Light | Dark | Role |
 |---|---|---|---|
 | `--card-bg` → `--color-bg-surface` | `#ffffff` | **`#1b2742`** (lift from today's `#131c30`) | card fill |
-| `--card-border` → `--color-border-ui` | `#d8d3c3` | **`#3a4straints` → `#3a4668`** (lift from `#283354`) | 1px hairline edge |
+| `--card-border` → `--color-border-ui` | `#d8d3c3` | **`#3a4668`** (lift from `#283354`) | 1px hairline edge |
 | text → existing `--color-text-*` | unchanged | unchanged | unchanged |
 
 The dark fill and border are **deliberately lifted** (`#131c30 → #1b2742`, `#283354 → #3a4668`). A card sitting only ~6 luminance points off the `#0d1424` basemap cannot separate by shadow alone on a near-black ground — the fill itself must read as "lifted." This is the primary mechanism that fixes dark-mode separation; elevation is secondary.
@@ -73,8 +73,8 @@ Three tiers, **mode-paired**. Dark elevation is **not** "more black alpha" (invi
 | Tier | Surfaces | Token |
 |---|---|---|
 | **1** — resting chrome | header clusters, scope control, family legend, context card | `--card-elevation-1: var(--elevation-1)` |
-| **2** — on-canvas transient | observation / cell / cluster popovers, anchored filters panel | `--card-elevation-2: var(--elevation-2)` |
-| **3** — focused / modal | detail card, bottom sheet, attribution modal, scope chooser | `--card-elevation-3: var(--elevation-3)` |
+| **2** — on-canvas transient | observation / cell / cluster popovers | `--card-elevation-2: var(--elevation-2)` |
+| **3** — focused / modal | detail card, bottom sheet, attribution modal, scope chooser, filters panel | `--card-elevation-3: var(--elevation-3)` |
 
 The header gains real elevation (it has **none** today) by adopting tier 1. The `border-bottom` survives only as the light-mode hairline.
 
@@ -83,7 +83,9 @@ The header gains real elevation (it has **none** today) by adopting tier 1. The 
 - Card title: `--type-md` 17px / `--font-weight-semibold`.
 - Card body & rows: `--type-sm` 13px / regular.
 - Meta / freshness / attribution: `--type-xs` 11px / `--color-text-subtle`.
-- **Lede (the scope-identity sentence): `--type-lg` 22px** semibold for the region name, `--type-sm` for the "N species · updated" line. The lede must be the strongest text on a scoped view (see §5 hierarchy).
+- **Wordmark + region suffix (AMENDED — see ruling note below): `--type-md` bold** for the "Bird Maps" brand, with the region riding as a muted `--font-weight-medium` ` · Arizona` suffix on the same line (`--color-text-muted`). The "N species · updated" line is `--type-sm`. The brand/region wordmark is the resting identity row of the top-left card.
+
+  > **Amendment (Julian, 2026-06-11):** *"we got rid of the concept of region — this is drift."* The original §2.4/§5.2 mandate — a `--type-lg` 22px region name asserted as the loudest text on a scoped view — was never shipped. #828 shipped a two-line wordmark instead: the brand at `--type-md` bold, the region as a quiet muted suffix, and an `.sr-only` `<h1>` that carries the page's heading structure without painting. The spec is amended here to describe that shipped reality; the matching "whispered-region" visual finding closes **by-design**. No typography change ships from this amendment.
 
 ### 2.5 Token-debt cleanup that ships *with* this language
 
@@ -186,7 +188,7 @@ When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to 
 ### 4.3 Context strip / lede → the top-left card's identity rows *(currently INVISIBLE — blocker)*
 
 - **Today:** authored as an in-flow opaque `border-bottom` band rendered *before* `.map-surface`; because `.map-surface` is `absolute; inset: 0` it paints over the strip → the app's primary orientation sentence is **not visible at any width**.
-- **Target:** Stop rendering it in flow. Fold the lede + freshness into the **top-left identity card** as its headline rows: region name at `--type-lg`, then `331 species · updated 20 min ago · eBird` at `--type-sm`/`--type-xs`. Drop the opaque band / `border-bottom` entirely — it was built for a document-flow layout that no longer exists.
+- **Target:** Stop rendering it in flow. Fold the lede + freshness into the **top-left identity card** as its headline rows: the `--type-md` bold wordmark with its muted ` · region` suffix (per §2.4 as amended — the original `--type-lg` region mandate was never shipped; #828's two-line wordmark is the shipped design), then `331 species · updated 20 min ago · eBird` at `--type-sm`/`--type-xs`. Drop the opaque band / `border-bottom` entirely — it was built for a document-flow layout that no longer exists.
 - This is the single highest-value content fix: it makes the lede exist again **and** makes it the primary text (see §5).
 
 ### 4.4 FamilyLegend → keep (the one correct island), formalize
@@ -200,14 +202,14 @@ When a **bottom sheet** (detail or filters) is up, the legend auto-collapses to 
 - **Today:** `position: fixed; top:0; right:0; bottom:0; width: min(560px,100vw); border-left` — a 3-edge wall that slices the viewport into "map | panel," passes *under* the header (`z-rail 43 > z-chrome 42`, top:0), and its close button collides with the header band.
 - **Target (desktop):** an **inset floating card** — `top: calc(var(--card-inset) + controls-cluster-height + var(--card-gap)); right/bottom: var(--card-inset); width: clamp(360px, 38vw, 420px)`; `--card-radius` on all four corners, `--card-elevation-3`, **drop `border-left` for a floating shadow**. The map visibly wraps it on all sides — preserving the "map stays interactive beside detail" intent (#663) and never slicing the top-right controls.
 - **Target (mobile):** keep the bottom **sheet** (Apple-Maps idiom) with peek/half/full snaps, `--card-radius` top corners, `--card-elevation-3`. Reconcile its raw z (10/15/20) onto `--z-modal` (50) at full snap so the `pointer-events:none` header hack can be retired.
-- **Responsive:** anchored card ≥`--overlay-bp-roomy` region; bottom sheet below.
+- **Responsive:** anchored card ≥`--overlay-bp-compact` (480); bottom sheet below.
 
 ### 4.6 Filters → anchored floating panel / bottom sheet
 
 - **Today:** a full-bleed flow band (`display:flex; border-bottom`, no position/radius/shadow) that **displaces the map downward** on open.
 - **Target (desktop):** an **anchored panel** under the Filters trigger in the top-right cluster — `--card-radius`, `--card-elevation-2`, a close affordance, never a top band; the map never jumps.
 - **Target (mobile):** promote to a **bottom sheet** reusing the detail-sheet snap mechanics.
-- **Responsive:** switch anchored-card ↔ sheet at `--overlay-bp-compact` (480) / `--overlay-bp-roomy` (600) — the tokens that exist but nothing consumes yet.
+- **Responsive:** switch anchored-card ↔ sheet at `--overlay-bp-compact` (480) — the shipped single switch boundary.
 
 ### 4.7 Popovers (observation / cell / cluster) → one primitive with edge-collision
 
@@ -234,9 +236,9 @@ Build the layer the tokens already name; **delete every per-component @media** (
 
 ### 5.2 Visual hierarchy (fix the inversion)
 
-Today the loudest element is a utility (scope control, top-center) and the quietest is the identity (whispered ` · Arizona`, occluded lede). Correct ranking, loudest → quietest:
+The pre-redesign inversion put a utility (scope control, top-center) loudest. Correct ranking, loudest → quietest (amended per the §2.4 region ruling — the region rides as a muted wordmark suffix by design, NOT as a `--type-lg` headline):
 
-1. **Identity / lede** — region name + `N species · updated` (top-left card headline, `--type-lg`). *Primary.*
+1. **Identity** — the `--type-md` bold wordmark with its muted ` · region` suffix, plus the `N species · updated` line. *Primary.* (Amended #828: the region is a quiet suffix on the wordmark line, not a `--type-lg` headline — see §2.4's amendment note.)
 2. **Filters** — what's shown; labeled control at ≥1024, not a 20px icon. *Primary-secondary.*
 3. **Scope control** — de-emphasized "change where" rows under the lede. *Secondary.*
 4. **Legend / attribution.** *Tertiary.*
@@ -258,7 +260,7 @@ Today the loudest element is a utility (scope control, top-center) and the quiet
 
 A **`feat(tokens): floating-card design language` PR** must land before #800/#801/#779/#780/#783, or the elements will diverge again. It adds to `tokens.css`: the `--card-*` geometry family (§2.1), the mode-paired **`--elevation-1/2/3`** scale (§2.3), the **lifted dark `--color-bg-surface` / `--color-border-ui`** (§2.2), and resolves/replaces the four undefined `ds-primitives.css` tokens (§2.5). It writes the **four-corner anchor contract** into `tokens.css` comments + CLAUDE.md. No visual element moves in this PR — it's pure foundation so every downstream PR is a token-consumption change, not a restyle.
 
-A second small foundation PR, **`feat(overlay): placement breakpoint engine`**, wires `--overlay-bp-compact/roomy/wide` to real rules and deletes the divergent per-component thresholds (§5.1). This unblocks the responsive behavior every element depends on.
+A second small foundation PR, **`feat(overlay): placement breakpoint engine`**, wires `--overlay-bp-compact/wide` to real rules and deletes the divergent per-component thresholds (§5.1). This unblocks the responsive behavior every element depends on.
 
 ### 6.1 Existing epic #761 issues — retargeted per this spec
 

--- a/frontend/src/components/SpeciesDetailSheet.test.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.test.tsx
@@ -624,8 +624,8 @@ describe('<SpeciesDetailSheet>', () => {
   it('unmounting at full snap cleans up inert on <main> (viewport-flip regression)', async () => {
     // Simulate: mobile user opens sheet (at half), advances to full snap (inert
     // set), then rotates device. App.tsx's viewport router unmounts
-    // SpeciesDetailSheet and mounts SpeciesDetailModal. Without the cleanup
-    // function the inert attribute leaks onto <main> and blocks all pointer
+    // SpeciesDetailSheet and mounts the desktop SpeciesDetailRail. Without the
+    // cleanup function the inert attribute leaks onto <main> and blocks all pointer
     // events + tab order.
     const { unmount } = render(
       <SpeciesDetailSheet

--- a/frontend/src/components/SpeciesDetailSheet.tsx
+++ b/frontend/src/components/SpeciesDetailSheet.tsx
@@ -384,8 +384,8 @@ export function SpeciesDetailSheet(props: SpeciesDetailSheetProps) {
   //
   // The cleanup function is the load-bearing fix for the viewport-flip bug:
   // if the user rotates the device mid-snap, App.tsx swaps SpeciesDetailSheet
-  // for SpeciesDetailModal and this sheet unmounts without ever reaching the
-  // snap !== 'full' branch above. Without cleanup, `inert` leaks onto #map-layer
+  // for the desktop SpeciesDetailRail and this sheet unmounts without ever
+  // reaching the snap !== 'full' branch above. Without cleanup, `inert` leaks onto #map-layer
   // indefinitely — pointer events blocked, tab order broken.
   //
   // Cleanup closure mechanics: `snap` is captured at effect-run time. When the

--- a/frontend/src/components/SpeciesDetailSurface.test.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.test.tsx
@@ -463,9 +463,9 @@ describe('SpeciesDetailSurface', () => {
   // ─── Phase 4 heading + Photo contracts ──────────────────────────────────
   //
   // Sky Atlas Phase 4 promotes SpeciesDetailSurface to a presentational body
-  // component consumed by SpeciesDetailModal (desktop) and SpeciesDetailSheet
+  // component consumed by SpeciesDetailRail (desktop) and SpeciesDetailSheet
   // (mobile). The heading becomes <h1 id="detail-title" tabIndex={-1}> so
-  // the modal/sheet wrappers can set aria-labelledby="detail-title" and
+  // the rail/sheet wrappers can set aria-labelledby="detail-title" and
   // call #detail-title.focus() on open. The photo masthead uses <Photo
   // priority={true}> so LCP is served by loading="eager" fetchpriority="high".
 

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -25,7 +25,7 @@ export interface SpeciesDetailSurfaceProps {
 
 /**
  * Presentational body of the detail surface (Phase 4). Composed inside
- * <SpeciesDetailModal> (desktop) and <SpeciesDetailSheet> (mobile);
+ * <SpeciesDetailRail> (desktop) and <SpeciesDetailSheet> (mobile);
  * never rendered directly in <main> after Phase 4 ships. The component
  * does not own scroll, dismiss, or focus-capture — those belong to its
  * wrappers.

--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -5,10 +5,18 @@
  *   StatusBlock, FamilySilhouette, Photo, ClusterPill, FilterSentence, SortLabel
  *
  * Architecture:
- *   - All values are resolved through Phase 1 semantic tokens (tokens.css).
- *     No raw hex codes or raw shadow literals. Custom properties from
- *     styles.css :root and tokens.css are consumed where they carry the
- *     right semantic role. (#1043: popover shadows migrated to --card-elevation-2)
+ *   - Values are resolved through Phase 1 semantic tokens (tokens.css) wherever
+ *     a token carries the right semantic role; no raw shadow literals remain.
+ *     (#1043: popover shadows migrated to --card-elevation-2.) The only
+ *     deliberate raw hex are the cross-basemap contrast guarantees, which must
+ *     read identically over ANY basemap tile and so cannot follow the themed
+ *     token: the count badge's `background:#1a1a1a; color:#fff` + 1px white
+ *     ring (`.adaptive-grid-marker__badge`, including its dark-theme override —
+ *     the WCAG 1.4.11 contrast floor against arbitrary map tiles, spec §4.3),
+ *     and the photo-attribution focus ring `outline:2px solid #fff`
+ *     (`.photo__attribution-link:focus-visible` — guaranteed-visible over photo
+ *     imagery). Custom properties from styles.css :root and tokens.css are
+ *     consumed everywhere else.
  *   - Shimmer animation respects prefers-reduced-motion via the global policy
  *     in styles/motion.css (animation-duration: 0ms !important). Components
  *     do NOT duplicate the media query.
@@ -761,12 +769,12 @@ button.adaptive-grid-marker__cell {
      shares or contests the --z-modal (50) tier with a detail surface — the safety
      is preserved by DEMOTION now, not suppression.
 
-     ORDERING CONTRACT vs the detail rail (handoff to O5 / #783):
+     ORDERING CONTRACT vs the detail rail (finalized by O5 / #783):
      P1's `--z-cell-popover`/`--z-cluster-popover` (44/45) resolve ABOVE the
-     rail's current `--z-rail` (43), so the click-driven popovers temporarily
-     paint over the rail. Re-tiering the rail/sheet ABOVE the popovers (into the
-     --z-modal band with the compensating #663 inert work) is O5's job (report R3);
-     O6 does NOT move the rail's z value. This tooltip at --z-modal (50) is the
+     rail's `--z-rail` (43), so the click-driven popovers paint over the rail.
+     This rail < popovers ordering is the FINAL §5.3 ladder: O5 (#783) decided
+     AGAINST re-tiering the rail/sheet above the popovers, so the ladder stays
+     rail 43 < cell 44 < cluster 45. O6 does NOT move the rail's z value. This tooltip at --z-modal (50) is the
      RESTING tier (no detail open): the cursor tooltip can still float over an
      open cell/cluster popover. While a detail IS open, the `--under-detail`
      modifier below demotes it (see #976). */
@@ -894,11 +902,11 @@ button.adaptive-grid-marker__cell {
      body origin / bottom-left, which #863 fixes.)
      #761 P1, #778 — above the rail, below the cluster popover.
      #761 O6 (#782) ORDERING CONTRACT vs the detail rail: --z-cell-popover (44)
-     resolves ABOVE the rail's current --z-rail (43), so this click-driven popover
-     temporarily paints over an open SpeciesDetailRail. Re-tiering the rail ABOVE
-     the popovers (into --z-modal with the #663 inert work) is O5's job (report R3);
-     O6 does NOT move the rail's z value and leaves the temporary popover-over-rail
-     state as expected. Verified live (O6): this popover escapes to a higher
+     resolves ABOVE the rail's --z-rail (43), so this click-driven popover
+     paints over an open SpeciesDetailRail. This rail < popovers ordering is the
+     FINAL §5.3 ladder — O5 (#783) kept it (decided AGAINST re-tiering the rail
+     above the popovers), so the ladder stays rail 43 < cell 44 < cluster 45.
+     O6 does NOT move the rail's z value. Verified live (O6): this popover escapes to a higher
      stacking context (via the #859 portal) and paints above the map-assist overlays
      (legend/scope at --z-overlay 40, observation-popover at --z-popover 41). */
   position: absolute;
@@ -1129,9 +1137,11 @@ button.adaptive-grid-marker__cell {
   bottom: var(--space-md);
   /* #761 P1, #778 — topmost popover, above cell popover + rail.
      #761 O6 (#782) ORDERING CONTRACT vs the detail rail: --z-cluster-popover (45)
-     resolves ABOVE the rail's current --z-rail (43); this coarse-pointer popover
-     temporarily paints over an open SpeciesDetailRail. Re-tiering the rail ABOVE
-     the popovers is O5's job (report R3); O6 does NOT move the rail's z value.
+     resolves ABOVE the rail's --z-rail (43); this coarse-pointer popover
+     paints over an open SpeciesDetailRail. This rail < popovers ordering is the
+     FINAL §5.3 ladder — O5 (#783) kept it (decided AGAINST re-tiering the rail
+     above the popovers), so the ladder stays rail 43 < cell 44 < cluster 45.
+     O6 does NOT move the rail's z value.
      CONTAINING BLOCK NOTE: this rule is `position: fixed`, but on coarse pointers
      it is anchored to the viewport edges (left/right/bottom = --space-md), so even
      if the transformed MapLibre marker container traps the fixed positioning to the

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2979,7 +2979,9 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
      same pill-clearance term as the top inset (E2 #1054). */
   max-block-size: calc(100dvh - var(--card-inset) - var(--controls-cluster-h) - var(--card-gap) - env(safe-area-inset-bottom, 0px));
   overflow-y: auto;
-  /* Design-language surface — matches identity card / detail rail tier. */
+  /* Design-language surface — matches detail rail / attribution modal tier
+     (tier 3: --card-elevation-3 + --z-modal; NOT the identity card, which is
+     tier 1). */
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-ui, rgba(0,0,0,0.08));
   border-radius: var(--card-radius);

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -83,10 +83,12 @@
    *   TOP-RIGHT   Controls cluster: Filters · Attribution · theme toggle
    *               — compact pill group, content-width.
    *   BOTTOM-LEFT Family legend — --card-maxw-legend.
-   *   BOTTOM-RIGHT Reserved for future zoom/locate — safe-zone. (Attribution
-   *               consolidated #830: always-visible eBird source credit in the
-   *               identity-card freshness line; full credits in the top-right
-   *               ⓘ Credits modal.)
+   *   BOTTOM-RIGHT Minimal always-visible attribution island: `OpenFreeMap ·
+   *               eBird` (license floor, --type-xs) as the `.map-attribution`
+   *               pill. (#828 relocated the always-visible eBird credit here
+   *               after deleting the identity-card freshness line #830 had
+   *               parked it in; full credits stay in the top-right ⓘ Credits
+   *               modal.) Future zoom/locate shares this corner.
    *   TRANSIENT   Popovers (flip/shift/clamp to stay on-screen), detail
    *               card (insets into top-right region), filters panel
    *               (anchored under its trigger) — per-element caps.


### PR DESCRIPTION
## Summary

Docs/spec/comment drift sweep (F5, #1065) — make the design-authority artifacts describe what shipped so the next implementer does not "fix" production back to a superseded design. No rendered-output change; comments and spec markdown only.

**Spec** (`docs/design/2026-05-30-floating-ui-design-spec.md`):
- **§2.4 / §5.2 / §4.3 region amendment** — the spec mandated a `--type-lg` 22px region name as the loudest text on a scoped view. That was never shipped; #828 shipped a two-line wordmark (brand `--type-md` bold + muted ` · region` suffix + `.sr-only` `<h1>`). Amended to that shipped reality with a quoted ruling note. No typography change ships; the matching whispered-region visual finding closes by-design.
- **§2.3 tier table** — filters panel moved tier 2 → tier 3 (ships `--card-elevation-3` + `--z-modal`).
- **§4.5 / §4.6 / §6.0** — the filters anchored↔sheet switch amended off the deleted `--overlay-bp-roomy` (600) boundary to the shipped 480-only switch.
- **§2.2** — corrupted `#3a4straints` cell fixed to `#3a4668`.

**Code comments** (no behavior / CSS-value change):
- `ds-primitives.css` header — names the deliberate badge-hex / outline raw values (cross-basemap contrast guarantees) instead of the false "No raw hex codes" absolute. #1043 (merged) already corrected the shadow half; its wording is preserved.
- `ds-primitives.css` ×3 "O5's job" comments → the final §5.3 ladder (rail 43 < cell 44 < cluster 45; O5 #783 kept it).
- `tokens.css` four-corner BOTTOM-RIGHT row → the shipped `.map-attribution` island (now matches spec §3 / CLAUDE.md).
- `styles.css` filters-panel tier comment → "detail rail / attribution modal tier" (identity card is tier 1).
- `SpeciesDetailModal` → `SpeciesDetailRail` in 4 stale comments.

```mermaid
flowchart LR
  A["spec mandate (--type-lg region)"] -->|"never shipped"| B["#828 two-line wordmark"]
  B -->|"this PR amends spec to match"| C["spec = shipped reality"]
```

## Test plan

- `npx tsc -b frontend` → clean (comment edits in `.tsx`/`.test.tsx` still compile).
- `npm test --workspace @bird-watch/frontend -- --run` → 88 files / 1511 tests pass.
- `npm run build --workspace @bird-watch/frontend` → built.
- `npx knip` → clean.
- `bash scripts/check-orphan-classnames.sh` → PASS.
- ACs: `grep -rn SpeciesDetailModal frontend/src` empty; `grep -c "O5's job" ds-primitives.css` = 0; `grep -n "3a4straints|strongest text|overlay-bp-roomy" spec` all empty.

## Screenshots

N/A — not UI (docs/spec/comment drift; no rendered change)

## Design QA

N/A — not UI

## Notes

**Julian's region ruling (2026-06-11, load-bearing amendment rationale):** *"we got rid of the concept of region — this is drift."* The §2.4/§5.2 `--type-lg` region-typography mandate is therefore stale; the spec amends to the shipped two-line wordmark, and the V2 region-typography finding closes by-design. No code change to the region's type treatment ships.

**Ownership coordination:**
- `styles.css:431` (stale brand-region comment) is **owned by E5 #1057** (merged earlier). Verified at pickup that #1057 landed the rewrite — the `.brand-region` block now correctly documents the shipped wordmark — so F5 dropped it from scope, touching only `styles.css` tier comment (`:3031`).
- ds-primitives header **shadow half** is #1043's (B4, merged): its "popover shadows migrated to --card-elevation-2" wording is left intact; F5 extended only the badge-hex/outline half.
- §4.6 `--overlay-bp-roomy`/600 spec prose is F5's; the tokens.css comment-block + token deletion is **#1064's (F4, open)**. F5 is scheduled to merge at/before #1064 so F4's deletion never strands the spec. `--overlay-bp-roomy` is currently still defined (F4 unmerged) — that is expected; F5's AC is about the spec/docs, not the token.

Closes #1065. Part of #1060 (Wave 4 / F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
