### PR TITLE
fix(basemap): sanitize upstream null-prone z14 filters to clear console warnings (#1027)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -47,6 +47,7 @@ import { useSilhouetteCatalogue } from './use-silhouette-catalogue.js';
 import { useMapResize } from './use-map-resize.js';
 import { useScopeCamera } from './use-scope-camera.js';
 import { useStateArtboard } from './use-state-artboard.js';
+import { sanitizeNullNumericFilters } from './basemap-null-filter.js';
 import {
   aggregateClusterFamilies,
   aggregateClusterSpecies,
@@ -976,6 +977,28 @@ export function MapCanvas({
     map.on('style.load', onStyleLoad);
     return () => {
       map.off('style.load', onStyleLoad);
+    };
+  }, [mapReady]);
+
+  // ── #1027 [O8]: sanitize upstream null-prone basemap filters ──────────────
+  // The stock OpenFreeMap styles ship `[<,<=,>,>=]` comparisons over nullable
+  // data properties (`ref_length` on road shields, `admin_level` on
+  // boundaries) that log 4× "Expected value to be of type number, but found
+  // null instead." at z14 — upstream noise that trips the repo's zero-warning
+  // bar. `sanitizeNullNumericFilters` wraps each in `["all", ["has", prop],
+  // <original>]` (behaviour-preserving; see basemap-null-filter.ts). Runs once
+  // on the loaded style AND on every `style.load` (theme swap / Retry re-set
+  // the style and would otherwise drop the rewrite), mirroring the artboard's
+  // own `style.load` re-apply contract. Idempotent + fails open.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const apply = () => sanitizeNullNumericFilters(map);
+    apply(); // mapReady ⇒ first style already parsed; sanitize it now
+    map.on('style.load', apply);
+    return () => {
+      map.off('style.load', apply);
     };
   }, [mapReady]);
 

--- a/frontend/src/components/map/basemap-null-filter.test.ts
+++ b/frontend/src/components/map/basemap-null-filter.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isNullProneComparison,
+  nullSafeFilter,
+  sanitizeNullNumericFilters,
+} from './basemap-null-filter.js';
+
+/* ──────────────────────────────────────────────────────────────────────────
+   #1027 [O8] — the upstream OpenFreeMap positron style emits 4×
+   "Expected value to be of type number, but found null instead." at z14.
+
+   Root cause: 4 layers active at z14 filter on a numeric data property that is
+   NULL on many features —
+     - `highway-shield-non-us`, `highway-shield-us-interstate`, `road_shield_us`
+       → `["<=", ["get", "ref_length"], 6]` (roads with no `ref` carry no
+         `ref_length`),
+     - `boundary_3` → `[">=", ["get", "admin_level"], 3]` / `["<=", …, 6]`.
+   When the comparison's left operand evaluates to null, MapLibre logs the
+   warning once per layer per evaluation, dirtying a console the repo holds to a
+   zero-warning bar.
+
+   The fix is a STRUCTURAL, fail-open style transform (no hardcoded layer-id
+   list — the two basemaps use different id conventions): rewrite every filter
+   sub-expression of shape `[<numeric-op>, ["get", <prop>], <num>]` into
+   `["all", ["has", <prop>], <original>]`. `has` short-circuits the `all` to
+   `false` when the property is absent, so the null comparison is never
+   evaluated — and the visual outcome is IDENTICAL to today (a null operand
+   already resolved the comparison to false → no shield / no boundary). The
+   property-present branch runs the original comparison unchanged.
+   ────────────────────────────────────────────────────────────────────────── */
+
+describe('isNullProneComparison', () => {
+  it('flags a numeric comparison whose left operand is ["get", <prop>]', () => {
+    expect(isNullProneComparison(['<=', ['get', 'ref_length'], 6])).toBe(true);
+    expect(isNullProneComparison(['>=', ['get', 'admin_level'], 3])).toBe(true);
+    expect(isNullProneComparison(['>', ['get', 'rank'], 3])).toBe(true);
+    expect(isNullProneComparison(['<', ['get', 'rank'], 2])).toBe(true);
+  });
+
+  it('does NOT flag equality / membership ops (== / != tolerate null without warning)', () => {
+    expect(isNullProneComparison(['==', ['get', 'class'], 'city'])).toBe(false);
+    expect(isNullProneComparison(['!=', ['get', 'capital'], 2])).toBe(false);
+  });
+
+  it('does NOT flag a comparison whose operand is not a bare ["get", prop]', () => {
+    // a `zoom` comparison never reads a (nullable) feature property
+    expect(isNullProneComparison(['<=', ['zoom'], 6])).toBe(false);
+    // an already-guarded coalesce operand is not bare-get
+    expect(
+      isNullProneComparison(['<=', ['coalesce', ['get', 'ref_length'], 99], 6]),
+    ).toBe(false);
+  });
+
+  it('ignores non-arrays / short arrays', () => {
+    expect(isNullProneComparison(undefined)).toBe(false);
+    expect(isNullProneComparison(null)).toBe(false);
+    expect(isNullProneComparison(['<='])).toBe(false);
+    expect(isNullProneComparison('not-an-array')).toBe(false);
+  });
+});
+
+describe('nullSafeFilter', () => {
+  it('wraps a bare null-prone comparison in ["all", ["has", prop], <original>]', () => {
+    const original = ['<=', ['get', 'ref_length'], 6];
+    expect(nullSafeFilter(original)).toEqual([
+      'all',
+      ['has', 'ref_length'],
+      ['<=', ['get', 'ref_length'], 6],
+    ]);
+  });
+
+  it('rewrites null-prone comparisons NESTED inside an ["all", …] filter', () => {
+    const original = [
+      'all',
+      ['<=', ['get', 'ref_length'], 6],
+      ['match', ['get', 'network'], ['us-interstate'], true, false],
+    ];
+    expect(nullSafeFilter(original)).toEqual([
+      'all',
+      ['all', ['has', 'ref_length'], ['<=', ['get', 'ref_length'], 6]],
+      ['match', ['get', 'network'], ['us-interstate'], true, false],
+    ]);
+  });
+
+  it('rewrites BOTH comparisons in a two-sided range filter (boundary_3 shape)', () => {
+    const original = [
+      'all',
+      ['>=', ['get', 'admin_level'], 3],
+      ['<=', ['get', 'admin_level'], 6],
+      ['!=', ['get', 'maritime'], 1],
+    ];
+    expect(nullSafeFilter(original)).toEqual([
+      'all',
+      ['all', ['has', 'admin_level'], ['>=', ['get', 'admin_level'], 3]],
+      ['all', ['has', 'admin_level'], ['<=', ['get', 'admin_level'], 6]],
+      ['!=', ['get', 'maritime'], 1],
+    ]);
+  });
+
+  it('is a no-op for a filter with no null-prone comparison (returns null = unchanged)', () => {
+    const original = ['==', ['get', 'class'], 'city'];
+    expect(nullSafeFilter(original)).toBeNull();
+  });
+
+  it('returns null for an absent filter (nothing to rewrite)', () => {
+    expect(nullSafeFilter(undefined)).toBeNull();
+    expect(nullSafeFilter(null)).toBeNull();
+  });
+
+  it('is IDEMPOTENT — re-running over an already-guarded filter is a no-op', () => {
+    const once = nullSafeFilter(['<=', ['get', 'ref_length'], 6]);
+    expect(once).not.toBeNull();
+    // the guarded form has no BARE null-prone comparison left, so a second pass
+    // finds nothing to rewrite.
+    expect(nullSafeFilter(once)).toBeNull();
+  });
+});
+
+/* ── sanitizeNullNumericFilters (map-level pass) ──────────────────────────── */
+
+function makeMockMap(
+  layers: Array<{ id: string; type: string; filter?: unknown }>,
+) {
+  const byId = Object.fromEntries(layers.map((l) => [l.id, l]));
+  return {
+    layers,
+    getStyle: vi.fn(() => ({ layers })),
+    getFilter: vi.fn((id: string) => byId[id]?.filter),
+    setFilter: vi.fn((id: string, filter: unknown) => {
+      if (byId[id]) byId[id].filter = filter;
+    }),
+  };
+}
+
+describe('sanitizeNullNumericFilters (style-load pass — fails OPEN)', () => {
+  it('rewrites ONLY layers with a null-prone numeric comparison, by structure not id', () => {
+    const map = makeMockMap([
+      { id: 'background', type: 'background' },
+      {
+        id: 'road_shield_us',
+        type: 'symbol',
+        filter: ['all', ['<=', ['get', 'ref_length'], 6], ['==', ['get', 'class'], 'road']],
+      },
+      // hyphen-id variant — same structural rewrite, no id list
+      {
+        id: 'highway-shield-non-us',
+        type: 'symbol',
+        filter: ['<=', ['get', 'ref_length'], 6],
+      },
+      // a label layer with NO null-prone comparison — must be left untouched
+      { id: 'label_city', type: 'symbol', filter: ['==', ['get', 'class'], 'city'] },
+    ]);
+
+    sanitizeNullNumericFilters(map as never);
+
+    // both shield layers rewritten…
+    expect(map.setFilter).toHaveBeenCalledWith('road_shield_us', [
+      'all',
+      ['all', ['has', 'ref_length'], ['<=', ['get', 'ref_length'], 6]],
+      ['==', ['get', 'class'], 'road'],
+    ]);
+    expect(map.setFilter).toHaveBeenCalledWith('highway-shield-non-us', [
+      'all',
+      ['has', 'ref_length'],
+      ['<=', ['get', 'ref_length'], 6],
+    ]);
+    // …the unaffected label layer is NOT touched.
+    expect(
+      map.setFilter.mock.calls.some((c) => c[0] === 'label_city'),
+    ).toBe(false);
+    expect(map.setFilter.mock.calls.some((c) => c[0] === 'background')).toBe(false);
+  });
+
+  it('is idempotent at the map level — a second pass calls setFilter zero times', () => {
+    const map = makeMockMap([
+      { id: 'road_shield_us', type: 'symbol', filter: ['<=', ['get', 'ref_length'], 6] },
+    ]);
+    sanitizeNullNumericFilters(map as never);
+    map.setFilter.mockClear();
+    sanitizeNullNumericFilters(map as never);
+    expect(map.setFilter).not.toHaveBeenCalled();
+  });
+
+  it('fails OPEN: a getStyle/getFilter that throws does not propagate', () => {
+    const map = {
+      getStyle: vi.fn(() => {
+        throw new Error('style churn after swap');
+      }),
+      getFilter: vi.fn(),
+      setFilter: vi.fn(),
+    };
+    expect(() => sanitizeNullNumericFilters(map as never)).not.toThrow();
+  });
+
+  it('no-ops when the style has no layers (reconcile window)', () => {
+    const map = {
+      getStyle: vi.fn(() => ({})),
+      getFilter: vi.fn(),
+      setFilter: vi.fn(),
+    };
+    expect(() => sanitizeNullNumericFilters(map as never)).not.toThrow();
+    expect(map.setFilter).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/basemap-null-filter.ts
+++ b/frontend/src/components/map/basemap-null-filter.ts
@@ -1,0 +1,170 @@
+/**
+ * Basemap null-numeric-comparison filter sanitizer (#1027 · [O8]).
+ *
+ * The stock OpenFreeMap basemap styles ship filter expressions that compare a
+ * numeric DATA property with a `<`/`<=`/`>`/`>=` operator. When the property is
+ * absent on a feature (e.g. a road segment with no `ref` carries no
+ * `ref_length`), the comparison's left operand evaluates to `null` and MapLibre
+ * logs once per layer per evaluation:
+ *
+ *   "Expected value to be of type number, but found null instead."
+ *
+ * At z14 the positron (light) style has exactly four such layers active —
+ * `highway-shield-non-us`, `highway-shield-us-interstate`, `road_shield_us`
+ * (`["<=", ["get","ref_length"], 6]`) and `boundary_3`
+ * (`[">=", ["get","admin_level"], 3]` / `["<=", …, 6]`) — which is the 4×
+ * warning observed during a dblclick-zoom to z14 at the US-191 Morenci
+ * switchbacks. The warnings are UPSTREAM style content (they fire on the
+ * national map too, not just the state-artboard `within`-isolation path), and
+ * they are benign: a null operand resolves the comparison to `false`, so the
+ * feature simply renders no shield / no boundary — which is the correct visual
+ * outcome. But the repo holds the console to a zero-warning bar, so we patch the
+ * expression at `style.load` rather than accept the noise. This is NOT silent
+ * suppression — the rewrite is documented, tested, and behaviour-preserving.
+ *
+ * The transform is STRUCTURAL and FAILS OPEN — no hardcoded layer-id list (the
+ * two basemaps use different id conventions: underscore ids on dark,
+ * hyphenated/`label_*` on light). Every filter sub-expression of shape
+ * `[<numeric-op>, ["get", <prop>], <num>]` is rewritten to
+ * `["all", ["has", <prop>], <original-comparison>]`:
+ *
+ *   - When the feature LACKS `<prop>`, `["has", <prop>]` is `false` and the
+ *     `all` short-circuits — the original null comparison is NEVER evaluated, so
+ *     no warning fires. The whole expression is `false`, exactly matching the
+ *     pre-fix outcome (null → false → no render).
+ *   - When the feature HAS `<prop>`, the original comparison runs unchanged.
+ *
+ * So the rendered map is pixel-identical to today; only the console warning is
+ * removed. A future basemap release that adds a new null-prone comparison is
+ * sanitized automatically (structural match); a release that removes one is a
+ * no-op (nothing to rewrite). Equality / membership ops (`==`, `!=`, `match`,
+ * `in`) tolerate null without warning and are deliberately left untouched.
+ *
+ * Wired from MapCanvas's `style.load` listener (and the initial `load`), so the
+ * `[data-theme]` `setStyle` swap re-applies it on every theme flip — same
+ * re-apply contract as `applyLabelIsolation` (see use-state-artboard.ts).
+ */
+
+/** Numeric comparison operators that throw the null-number warning. */
+const NULL_PRONE_OPS = new Set(['<', '<=', '>', '>=']);
+
+/**
+ * True iff `expr` is a numeric comparison whose LEFT operand is a bare
+ * `["get", <prop>]` — i.e. it reads a (nullable) feature property and will warn
+ * when that property is absent. An already-guarded operand (`coalesce`, etc.)
+ * or a non-property operand (`["zoom"]`) is NOT flagged.
+ */
+export function isNullProneComparison(expr: unknown): boolean {
+  if (!Array.isArray(expr) || expr.length < 3) return false;
+  const [op, lhs] = expr;
+  if (typeof op !== 'string' || !NULL_PRONE_OPS.has(op)) return false;
+  return (
+    Array.isArray(lhs) &&
+    lhs[0] === 'get' &&
+    typeof lhs[1] === 'string'
+  );
+}
+
+/** The property name a null-prone comparison reads (caller pre-checks shape). */
+function comparisonProp(expr: unknown[]): string {
+  return (expr[1] as ['get', string])[1];
+}
+
+/**
+ * True iff `expr` is ALREADY the null-safe guard this module produces —
+ * `["all", ["has", <prop>], <null-prone-cmp-on-prop>]`. Recognizing it keeps the
+ * rewrite idempotent: a `style.load` re-apply (or a future pass) must NOT re-wrap
+ * a comparison we already guarded, which would nest `all`s without bound.
+ */
+function isAlreadyGuarded(expr: unknown): boolean {
+  if (!Array.isArray(expr) || expr.length !== 3 || expr[0] !== 'all') {
+    return false;
+  }
+  const [, hasExpr, cmp] = expr;
+  if (
+    !Array.isArray(hasExpr) ||
+    hasExpr[0] !== 'has' ||
+    typeof hasExpr[1] !== 'string'
+  ) {
+    return false;
+  }
+  return isNullProneComparison(cmp) && comparisonProp(cmp as unknown[]) === hasExpr[1];
+}
+
+/**
+ * Recursively rewrite a filter expression, wrapping every null-prone numeric
+ * comparison in `["all", ["has", prop], <original>]`. Returns the rewritten
+ * filter, or `null` when nothing changed (so the caller can skip `setFilter` —
+ * keeping the pass idempotent and avoiding needless repaints).
+ */
+export function nullSafeFilter(filter: unknown): unknown {
+  if (filter == null) return null;
+
+  // Already guarded by a prior pass — nothing to do (idempotency).
+  if (isAlreadyGuarded(filter)) return null;
+
+  // A bare null-prone comparison at the top level.
+  if (isNullProneComparison(filter)) {
+    const prop = comparisonProp(filter as unknown[]);
+    return ['all', ['has', prop], filter];
+  }
+
+  if (!Array.isArray(filter)) return null;
+
+  // Recurse into compound expressions (all/any/none/case/…). Rewrite each
+  // element; if any child changed, rebuild the array with the new children.
+  let changed = false;
+  const next = filter.map((child) => {
+    if (isAlreadyGuarded(child)) return child; // leave a prior guard intact
+    if (isNullProneComparison(child)) {
+      changed = true;
+      const prop = comparisonProp(child as unknown[]);
+      return ['all', ['has', prop], child];
+    }
+    if (Array.isArray(child)) {
+      const rewritten = nullSafeFilter(child);
+      if (rewritten !== null) {
+        changed = true;
+        return rewritten;
+      }
+    }
+    return child;
+  });
+
+  return changed ? next : null;
+}
+
+/**
+ * The minimal maplibre-map surface this pass needs. Structurally compatible with
+ * the real `map` from `mapRef.current.getMap()` and trivially mockable.
+ */
+export interface NullFilterMap {
+  getStyle: () => { layers?: Array<{ id: string }> } | undefined;
+  getFilter: (layerId: string) => unknown;
+  setFilter: (layerId: string, filter: unknown) => void;
+}
+
+/**
+ * Walk every layer in the current style, and for any whose filter contains a
+ * null-prone numeric comparison, replace it with the null-safe rewrite. Skips
+ * unaffected layers entirely (no `setFilter`), so it is idempotent — a second
+ * pass over an already-sanitized style is a no-op.
+ *
+ * **Fails OPEN.** Wrapped in try/catch (style churn after a `setStyle` swap can
+ * make `getStyle`/`getFilter`/`setFilter` throw); the worst case is the
+ * pre-fix console warning, never a thrown error or a blanked map.
+ */
+export function sanitizeNullNumericFilters(map: NullFilterMap): void {
+  try {
+    const layers = map.getStyle()?.layers ?? [];
+    for (const layer of layers) {
+      const original = map.getFilter(layer.id);
+      const rewritten = nullSafeFilter(original);
+      if (rewritten !== null) {
+        map.setFilter(layer.id, rewritten);
+      }
+    }
+  } catch {
+    /* defensive — style churn after a swap; QA detects any residual warning */
+  }
+}

--- a/frontend/src/components/map/use-state-artboard.test.ts
+++ b/frontend/src/components/map/use-state-artboard.test.ts
@@ -406,3 +406,128 @@ describe('useStateArtboard — ordering invariants (P2 backfill, #884 · U13)', 
     expect(result.current.maskTheme).toBe('dark');
   });
 });
+
+/* ──────────────────────────────────────────────────────────────────────────
+   #1124 [S1] regression — restore-path re-sanitization on scope round-trip.
+
+   The S1 deliverable (basemap-null-filter.ts · #1027) clears the z14
+   "Expected value to be of type number, but found null instead." warning by
+   rewriting upstream `["<=", ["get","ref_length"], 6]` road-shield filters into
+   `["all", ["has","ref_length"], <original>]` at `style.load`.
+
+   But `useStateArtboard`'s label-isolation capture (`applyLabelIsolation` in the
+   `style.load` handler / mask-change effect) records each isolatable symbol
+   layer's RAW filter into `savedFiltersRef` — and the road-shield layers ARE
+   isolatable (the `shield` token in SYMBOL_NAME_PATTERN), so what is captured is
+   the RAW, un-sanitized `["<=", ["get","ref_length"], 6]`. The capture runs
+   BEFORE the sanitizer effect in MapCanvas, so the saved filter is never the
+   guarded shape.
+
+   On a state → us scope round-trip the teardown (`restoreLabelIsolation`) writes
+   those RAW filters back via `setFilter`. That transition fires NO `style.load`,
+   so the sanitizer never re-runs — re-introducing the warning on the national
+   map and silently undoing S1's deliverable.
+
+   The fix re-runs `sanitizeNullNumericFilters(map)` after the restore so the
+   filter written back ends up guarded again.
+   ────────────────────────────────────────────────────────────────────────── */
+
+const SHIELD_RAW_FILTER = ['<=', ['get', 'ref_length'], 6];
+const SHIELD_GUARDED_FILTER = [
+  'all',
+  ['has', 'ref_length'],
+  ['<=', ['get', 'ref_length'], 6],
+];
+
+/**
+ * A minimal stateful fake map for the restore-path test: a single isolatable
+ * road-shield symbol layer (matches SYMBOL_NAME_PATTERN via the `shield` token)
+ * pre-seeded with the RAW null-prone filter, plus the mask fill + a cluster
+ * layer so the float/sink half can run without throwing. Backs `getFilter`/
+ * `setFilter` with a real store so the round-trip's net filter is observable.
+ */
+function makeShieldFakeMap() {
+  const layers: StyleLayer[] = [
+    { id: 'road_shield_us', type: 'symbol' },
+    MASK_LAYER,
+    CLUSTER_LAYER,
+  ];
+  const filters: Record<string, unknown> = {
+    road_shield_us: SHIELD_RAW_FILTER,
+  };
+  const handlers: Record<string, Array<() => void>> = {};
+
+  const map = {
+    getStyle: () => ({ layers: layers.slice() }),
+    getFilter: vi.fn((layerId: string) => filters[layerId]),
+    setFilter: vi.fn((layerId: string, filter: unknown) => {
+      filters[layerId] = filter;
+    }),
+    getLayer: vi.fn((layerId: string) => layers.find((l) => l.id === layerId) ?? null),
+    getSource: vi.fn(() => null),
+    addSource: vi.fn(),
+    removeSource: vi.fn(),
+    moveLayer: vi.fn(),
+    addLayer: vi.fn((layer: Record<string, unknown>) => {
+      layers.push({
+        id: String(layer.id),
+        type: String(layer.type),
+        source: layer.source as string | undefined,
+      });
+    }),
+    removeLayer: vi.fn((layerId: string) => {
+      const i = layers.findIndex((l) => l.id === layerId);
+      if (i !== -1) layers.splice(i, 1);
+    }),
+    triggerRepaint: vi.fn(),
+    getRenderWorldCopies: vi.fn(() => false),
+    setRenderWorldCopies: vi.fn(),
+    setStyle: vi.fn(),
+    on: vi.fn((type: string, cb: () => void) => {
+      (handlers[type] ??= []).push(cb);
+    }),
+    off: vi.fn((type: string, cb: () => void) => {
+      handlers[type] = (handlers[type] ?? []).filter((h) => h !== cb);
+    }),
+  };
+
+  return { map, filters };
+}
+
+describe('useStateArtboard — restore-path re-sanitization (#1124 · S1)', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+  });
+
+  it('re-guards the restored road-shield filter on a state → us scope round-trip (does NOT write back the raw null-prone shape)', () => {
+    const fake = makeShieldFakeMap();
+    const ref = makeRef(fake.map);
+
+    // Enter a state scope: applyLabelIsolation captures the RAW shield filter
+    // into savedFiltersRef and merges in the within expression.
+    const { rerender } = renderHook(
+      ({ poly }: { poly: MultiPolygon | null }) => useStateArtboard(ref, true, poly),
+      { initialProps: { poly: AZ_POLYGON as MultiPolygon | null } },
+    );
+
+    // While isolated, the live filter is the merged ['all', RAW, within] shape.
+    expect(Array.isArray(fake.filters['road_shield_us'])).toBe(true);
+
+    // Leave the state scope (state → us): poly → null tears down isolation, which
+    // calls restoreLabelIsolation to write the captured RAW filter back. No
+    // style.load fires on this transition, so the MapCanvas sanitizer never
+    // re-runs — the restore path itself must re-guard the filter.
+    act(() => {
+      rerender({ poly: null });
+    });
+
+    // The net filter on the shield layer MUST be the guarded shape, NOT the raw
+    // null-prone comparison that re-introduces the z14 warning.
+    expect(fake.filters['road_shield_us']).toEqual(SHIELD_GUARDED_FILTER);
+    expect(fake.filters['road_shield_us']).not.toEqual(SHIELD_RAW_FILTER);
+  });
+});

--- a/frontend/src/components/map/use-state-artboard.ts
+++ b/frontend/src/components/map/use-state-artboard.ts
@@ -11,6 +11,7 @@ import {
   MASK_LAYER_ID,
 } from './artboard-layers.js';
 import type { ArtboardMap } from './artboard-layers.js';
+import { sanitizeNullNumericFilters } from './basemap-null-filter.js';
 
 /**
  * State-artboard hook (the #884 · U13 / #898 nerve-center consolidation;
@@ -325,6 +326,15 @@ export function useStateArtboard(
         if (savedFiltersRef.current) {
           restoreLabelIsolation(liveMap, savedFiltersRef.current);
           savedFiltersRef.current = null;
+          // #1124 [S1]: the filters captured for isolation were the RAW upstream
+          // shapes (capture runs BEFORE MapCanvas's style.load sanitizer, so the
+          // saved road-shield filters are the un-guarded `["<=", ["get",
+          // "ref_length"], 6]`). restoreLabelIsolation just wrote those raw
+          // filters back, and this scope → us transition fires NO style.load —
+          // so the MapCanvas sanitizer never re-runs and the z14 null-expression
+          // warning returns. Re-guard the restored filters here. Idempotent +
+          // fails OPEN (own try/catch); a no-op for already-guarded filters.
+          sanitizeNullNumericFilters(liveMap);
         }
         removeFloatLayers(liveMap);
       } catch {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["style.load (initial + every theme setStyle swap)"] --> B["sanitizeNullNumericFilters(map)"]
    B --> C{"layer filter has<br/>[op, get(prop), n]<br/>op in {&lt;, &lt;=, &gt;, &gt;=}?"}
    C -- no --> D["leave untouched<br/>(no setFilter)"]
    C -- yes --> E["rewrite to:<br/>all( has(prop), original )"]
    E --> F["feature lacks prop → has=false → all short-circuits<br/>(null comparison never evaluated, result false = unchanged render)"]
    E --> G["feature has prop → original comparison runs unchanged"]
```

```mermaid
flowchart LR
    subgraph "z14 positron — 4 null-prone layers (the 4x warning)"
      H1["highway-shield-non-us<br/>(&lt;= ref_length 6)"]
      H2["highway-shield-us-interstate<br/>(&lt;= ref_length 6)"]
      H3["road_shield_us<br/>(&lt;= ref_length 6)"]
      B3["boundary_3<br/>(&gt;= / &lt;= admin_level)"]
    end
    H1 & H2 & H3 & B3 --> W["MapLibre logs<br/>Expected value to be of type number, but found null"]
    W --> X["sanitized at style.load → 0 warnings"]
```

## Summary

- **Audit verdict (O8 null-expression warning): UPSTREAM, now fixed in our config.** The 4x `"Expected value to be of type number, but found null instead."` at z14 traces to four stock OpenFreeMap **positron** layers active at z14 whose filters compare a *nullable* numeric data property: the three road-shield layers (`highway-shield-non-us`, `highway-shield-us-interstate`, `road_shield_us` — all `["<=", ["get","ref_length"], 6]`; a road with no `ref` carries no `ref_length`) and `boundary_3` (`[">=" / "<=", ["get","admin_level"], …]`). Four active layers = the observed 4x. It is **not** introduced by our state-artboard `within`-isolation (the merge puts the original filter first; the comparison fires regardless, and it also fires on the national/no-scope map), and it is **benign** (null resolves the comparison to false → no shield/boundary, the correct visual outcome). But the repo holds the console to a zero-warning bar, so — per the issue's "patch the expression at style load" path, **not** silent suppression — we sanitize it.
- **Fix: a structural, fail-open style transform** (`frontend/src/components/map/basemap-null-filter.ts`). At `style.load` (and the initial load) it rewrites every `[<numeric-op>, ["get", prop], n]` sub-expression to `["all", ["has", prop], <original>]`. `["has", prop]` short-circuits the `all` to false when the property is absent, so the null comparison is never evaluated — **the rendered map is pixel-identical; only the warning is removed.** No hardcoded layer-id list (the two basemaps use different id conventions), idempotent (recognizes its own guard form), and re-applied on every theme `setStyle` swap via the same `style.load` re-apply contract the artboard machinery uses.
- **z14 legibility verdict (V34 / V39): deferred as upstream-style work, documented, investigate-only.** The two styles we load are asymmetric: **positron has 3 road-shield layers + `highway-name-major/minor/path` road-name labels; the dark style has zero shields and only `highway_name_motorway`/`highway_name_other`**, plus a stricter `place_city` gate (`rank > 3`, `maxzoom 14`). So at z14 over rural terrain (Morenci, US-191) dark legitimately renders fewer road names/shields than light — a structural upstream difference, not our isolation suppressing interior labels (the isolation matches shields via `SYMBOL_NAME_PATTERN` and the buffered polygon admits interior anchors; V39's light sparsity is also stock positron). **Closing the parity gap means injecting shield layers / relaxing rank+zoom filters into a third-party basemap — a basemap re-style, materially larger and riskier than this null-filter fix (it touches the recurrent blank-map class), so it is explicitly NOT done here.** A scoped follow-up should be filed (I attempted to but issue-creation was out of this task's permitted scope) covering: (1) lift dark road/label color+width at `style.load`, (2) port shields to dark, or (3) relax dark's `place_city` gate — verified zoomed-in at an AZ interior point AND a border, both themes.
- **#947 (`circle-11` dark sprite) is a separate, unshared root cause** — a missing maki POI icon in the shared sprite, not a null-number expression. Confirmed `circle-11` appears only in the dark style and the canonical fix is a `styleimagemissing`/`addImage` handler (out of scope here; #1027 carves it out as a permitted AC exception).

## Screenshots

N/A — not UI (basemap style-expression audit; the null-filter rewrite is behaviour-preserving and produces no rendered app change — `has`-guarded comparisons resolve to the identical result the null comparison already produced).

- [x] No new/renamed `className` in this PR — `N/A — no CSS touched`
- [x] Multi-viewport design QA — `N/A — not UI (no rendered change)`

## Test plan

- [x] `npx tsc -b frontend` — green
- [x] `npm test --workspace @bird-watch/frontend -- --run` — green (89 files / 1525 tests; includes 14 new tests for the null-filter sanitizer)
- [x] New unit tests added — `frontend/src/components/map/basemap-null-filter.test.ts` covers: comparison detection, the `all(has, original)` rewrite (bare, nested, two-sided range), idempotency at both the expression and map level, structural-not-id-based rewriting (hyphen + underscore ids), and fail-open (throwing `getStyle`, empty style).
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx knip` — exit 0 (only the pre-existing prototype-dir config hint; no new dead code/unused export)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] `npm run lint` — exit 0
- [ ] (UI only) Playwright MCP smoke — `N/A — not UI`. The warning's repro requires real WebGL + live tiles at z14 (headless skips it). Recommend the orchestrator verify live on the PR head: `?state=US-AZ`, dblclick-zoom to z14 at ≈33.05,-109.33, confirm DevTools console shows **zero** of the null-number warnings (the documented #947 `circle-11` may still appear) — on the national map too.

## Plan reference

Out of plan — design-review remediation child S1 (#1027), standalone alongside #947. Related: #947 (`circle-11` dark sprite; separate unshared root cause), and a deferred follow-up for the V34/V39 dark-theme legibility parity (see Summary).

Closes #1027.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**Orchestrator live console-check (head `cc78fb8`, the recommended verification):** at `?state=US-AZ` jumped to z14 at the rural Morenci coords (≈33.05, −109.33). **Light z14: console fully clean (0 errors / 0 warnings) — the null-expression warnings are gone.** Dark z14: 0 errors, 1 warning — `Image "wood-pattern" could not be loaded`, a `styleimagemissing` warning of the SAME class as #947's `circle-11` (a missing dark-basemap sprite icon, NOT a null-expression warning), which S1 explicitly scopes out / leaves to #947. So S1's deliverable — clearing the upstream null-prone filter warnings at z14 — is confirmed live; the remaining dark warning is the out-of-scope missing-image class. Map renders unchanged (behavior-preserving).


---
**Round-trip regression fix (head `74424c2`, addresses bot review IMPORTANT).** The first review flagged that `restoreLabelIsolation` wrote back the *raw* (pre-sanitizer) road-shield filters on a `state → us` scope round-trip — and since that transition fires no `style.load`, the sanitizer never re-ran, so the z14 null-expression warning returned (×3) on the national map. Fixed by re-running `sanitizeNullNumericFilters(map)` after `restoreLabelIsolation` in the artboard teardown (`use-state-artboard.ts`), with a new unit test that FAILS before / PASSES after (drives the real state→us teardown and asserts the restored filter is the guarded shape, not the raw shape). **Orchestrator live re-verify of the exact flagged path:** `?state=US-AZ` (label-isolation captured) → click "Whole US" (in-app teardown, no `style.load`) → jump to z14 at rural AZ. All three shield layers' restored filters are now GUARDED (`["has", …]` present), and the console is **0 errors / 0 warnings** — the round-trip warning is gone. Full frontend suite green (1509 tests).