### PR TITLE
chore(motion): tokenize tunings, hoist settle clock, fix mis-attributed tween, live PRM listener (#1063)

### DIFF
--- a/frontend/src/components/ds/ds-primitives.css
+++ b/frontend/src/components/ds/ds-primitives.css
@@ -349,6 +349,11 @@
   height: 100%;
   object-fit: cover;
   border-radius: var(--photo-radius);
+  /* Bare UA `ease` is a DELIBERATE departure (#1063; the enter motion was
+     reviewed in #957): a symmetric photo cross-fade reads correctly on the
+     gentle default ease, and swapping in the house ease-out bezier would change
+     the visible curve (this child preserves shipped appearance). Duration is
+     tokenized (--dur-base); only the curve is intentionally the UA keyword. */
   transition: opacity var(--dur-base) ease;
 }
 
@@ -1338,12 +1343,12 @@ button.adaptive-grid-marker__cell {
   }
 }
 
-/* Reduced-motion: no slide-in animation in v1. Reserved for future. */
-@media (prefers-reduced-motion: reduce) {
-  .cluster-list-popover {
-    /* No-op currently; reserved for future slide-in. */
-  }
-}
+/* #1063: removed the empty reduced-motion media block that read "Reserved for
+   future slide-in." The #07 slide-up for this popover is DEFERRED (#950, see the
+   .cluster-list-popover and __family-toggle::before comments above) — an empty
+   guard reserving for it implied motion that #950 explicitly does not ship. The
+   only motion here (the caret rotate) is covered by the global motion.css guard;
+   no per-element block is needed. */
 
 /* ── B3 (#1042 M-10): themed scrollbar on .cluster-list-popover ─────────────
  * The cluster-list popover has overflow-y:auto and max-height:70vh. Without

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -461,12 +461,19 @@ export function MapCanvas({
      reactive — reads on mount and listens for `change`. */
   const isCoarsePointer = useCoarsePointer();
 
-  // Phase 0: read prefers-reduced-motion once at mount. Extracted to a generic
-  // mount-once sensor hook in #889 (epic #884). It deliberately captures the
-  // value once (no `change` listener) — the user must reload to fully apply
-  // other reduced-motion changes anyway, and re-checking adds complexity for
-  // negligible gain.
+  // #1063: `usePrefersReducedMotion` is a LIVE sensor — it tracks the OS
+  // reduce-motion preference across the session (CSS already responded live via
+  // motion.css; this aligns the JS camera-flight gate so the two no longer
+  // split-brain for vestibular-sensitive users). The camera flights below read
+  // the preference through `prefersReducedMotionRef.current` rather than the
+  // value directly: the `clusters` click handler is registered ONCE in
+  // `handleLoad` (it would otherwise capture the mount-time value forever), and
+  // the scope-reframe effect (`useScopeCamera`) must NOT take a live value as a
+  // dep or an OS toggle would spuriously re-fire the reframe (#848/#736). The ref
+  // mirrors the live value every render; flights read `.current` at dispatch time.
   const prefersReducedMotion = usePrefersReducedMotion();
+  const prefersReducedMotionRef = useRef(prefersReducedMotion);
+  prefersReducedMotionRef.current = prefersReducedMotion;
 
   // #1059 (M-30) — live viewport span `[lngSpan, latSpan]` in degrees, feeding
   // the ZOOM-AWARE artboard clamp in `useScopeCamera` below. Updated on the
@@ -494,7 +501,7 @@ export function MapCanvas({
     boundsKey,
     flyTo,
     clampPad,
-    prefersReducedMotion,
+    prefersReducedMotionRef,
     // #1059 — live viewport span drives the zoom-aware artboard clamp; a wider
     // `clampBounds` change on zoom re-applies reactively via the `maxBounds`
     // prop (no remount), same mechanism as the static clamp.
@@ -884,7 +891,9 @@ export function MapCanvas({
               map.easeTo({
                 center,
                 zoom,
-                ...(prefersReducedMotion ? { duration: 0 } : {}),
+                // Read via ref: this handler is registered once in handleLoad,
+                // so a captured value would freeze at mount; .current is live.
+                ...(prefersReducedMotionRef.current ? { duration: 0 } : {}),
               });
             }
           })
@@ -1694,7 +1703,7 @@ export function MapCanvas({
               map.easeTo({
                 center: [anchor.longitude!, anchor.latitude!],
                 zoom: targetZoom,
-                ...(prefersReducedMotion ? { duration: 0 } : {}),
+                ...(prefersReducedMotionRef.current ? { duration: 0 } : {}),
               });
               return;
             }
@@ -1776,7 +1785,7 @@ export function MapCanvas({
           map.easeTo({
             center: [anchor.longitude!, anchor.latitude!],
             zoom: targetZoom,
-            ...(prefersReducedMotion ? { duration: 0 } : {}),
+            ...(prefersReducedMotionRef.current ? { duration: 0 } : {}),
           });
         } else if (anchorEl) {
           // Camera already at the zoom where this cluster bottoms out
@@ -1792,7 +1801,10 @@ export function MapCanvas({
         // the prior err-swallow pattern.
       }
     },
-    [aggregated, observations, prefersReducedMotion, openClusterListFromGroup],
+    // prefersReducedMotion is read through the stable ref (`.current`), so it is
+    // intentionally NOT a dep — the callback need not be re-created on an OS
+    // reduce-motion toggle; the flight `duration` picks up the live value anyway.
+    [aggregated, observations, openClusterListFromGroup],
   );
 
   const handleClosePopover = useCallback(() => setSelectedObs(null), []);
@@ -1843,10 +1855,12 @@ export function MapCanvas({
       map.easeTo({
         center,
         zoom: targetZoom,
-        ...(prefersReducedMotion ? { duration: 0 } : {}),
+        // Live preference via the stable ref — see prefersReducedMotionRef above.
+        ...(prefersReducedMotionRef.current ? { duration: 0 } : {}),
       });
     },
-    [prefersReducedMotion],
+    // prefersReducedMotion read through the ref (`.current`); not a dep.
+    [],
   );
 
   /* Hit-target layer: render hit targets at zoom >= CLUSTER_MAX_ZOOM

--- a/frontend/src/components/map/use-scope-camera.ts
+++ b/frontend/src/components/map/use-scope-camera.ts
@@ -179,7 +179,15 @@ export function computeScopeBounds(
  * @param boundsKey           identity key for `bounds`; a change is the reframe trigger
  * @param flyTo               ZIP `flyTo` intent (wins over `fitBounds`), or undefined
  * @param clampPad            artboard clamp padding factor (state scope only)
- * @param prefersReducedMotion mount-once reduced-motion read (see note below)
+ * @param prefersReducedMotionRef ref tracking the LIVE reduced-motion preference
+ *                            (#1063: `usePrefersReducedMotion` is now a live
+ *                            sensor). Passed as a REF, not a value, on purpose:
+ *                            the flight `duration` reads `.current` at call time
+ *                            (so an OS toggle takes effect on the NEXT reframe)
+ *                            while the effect dep array stays inert — a live VALUE
+ *                            in the deps would re-fire the reframe on a mid-session
+ *                            toggle, the exact #848/#736 spurious-recenter class the
+ *                            exhaustive-deps disable below guards against.
  * @param viewportSpan        live `[lngSpan, latSpan]` (deg) from the last camera
  *                            settle, feeding the #1059 zoom-aware clamp; undefined
  *                            at mount (clamp falls back to the static padded value)
@@ -191,7 +199,7 @@ export function useScopeCamera(
   boundsKey: string | undefined,
   flyTo: ScopeFlyTo | undefined,
   clampPad: number | undefined,
-  prefersReducedMotion: boolean,
+  prefersReducedMotionRef: RefObject<boolean>,
   viewportSpan?: [number, number],
 ): { clampBounds: LngLatBounds; initialViewState: ScopeInitialViewState } {
   const { activeBounds, clampBounds, initialViewState } = computeScopeBounds(
@@ -225,7 +233,7 @@ export function useScopeCamera(
         center: flyTo.center,
         zoom: flyTo.zoom,
         essential: true,
-        duration: prefersReducedMotion ? 0 : 800,
+        duration: prefersReducedMotionRef.current ? 0 : 800,
       });
       // The ZIP `flyTo` branch is IMMUNE to the #848 mid-flight longitude bug:
       // flyTo's easeFunc snaps to the exact targetCenter at `k===1`, so an
@@ -328,7 +336,7 @@ export function useScopeCamera(
       padding: FIT_BOUNDS_PADDING,
       maxZoom: 12,
       essential: true,
-      duration: prefersReducedMotion ? 0 : 600,
+      duration: prefersReducedMotionRef.current ? 0 : 600,
     });
     // fitBounds has returned: any synchronous cancellation moveend it fired
     // (while stopping the in-flight easeTo) is now past. From here, the next
@@ -343,17 +351,18 @@ export function useScopeCamera(
     // eslint-disable-next-line react-hooks/exhaustive-deps -- boundsKey +
     // flyTo?.key are the intentional triggers; `activeBounds` identity derives
     // from boundsKey and re-running on its reference churn is undesirable
-    // (prototype documents this exact disable). `prefersReducedMotion` is the
-    // mount-once read from `usePrefersReducedMotion` (`useMemo([])`, NO `change`
-    // listener — `use-prefers-reduced-motion.ts` is contractually a mount-once
-    // sensor, "do not convert it into one"), so its presence here is inert: an
-    // OS reduced-motion toggle mid-session does NOT re-fire this effect, so the
-    // camera intent cannot spuriously recenter on an unchanged scope (the
-    // #848/#736 "camera moves when it shouldn't" class this unit guards). Only an
-    // in-flight `duration` reads the live value — exactly the desired behaviour.
-    // The dep is kept (not dropped) to satisfy the lint rule and to remain
-    // correct-by-construction if the sensor's mount-once contract ever changes.
-  }, [mapReady, boundsKey, flyTo?.key, prefersReducedMotion]);
+    // (prototype documents this exact disable). The reduced-motion preference is
+    // read through `prefersReducedMotionRef.current` at flight-dispatch time, NOT
+    // from a value dep: #1063 made `usePrefersReducedMotion` a LIVE sensor, and a
+    // live VALUE in this array would re-fire the reframe the instant a user
+    // toggles OS reduce-motion mid-session — a spurious recenter on an unchanged
+    // scope, the exact #848/#736 "camera moves when it shouldn't" class this unit
+    // guards. A stable ref carries the live value into the flight `duration`
+    // without participating in the trigger set: the duration tracks the live
+    // preference on the NEXT reframe while the effect stays keyed only on real
+    // scope changes. The ref is intentionally NOT listed (refs are stable; ESLint
+    // would not require it anyway).
+  }, [mapReady, boundsKey, flyTo?.key]);
 
   return { clampBounds, initialViewState: initialViewStateRef.current };
 }

--- a/frontend/src/lib/use-prefers-reduced-motion.test.ts
+++ b/frontend/src/lib/use-prefers-reduced-motion.test.ts
@@ -1,27 +1,35 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { usePrefersReducedMotion } from './use-prefers-reduced-motion.js';
 
 /**
- * usePrefersReducedMotion is a deliberately mount-once read (`useMemo`, empty
- * deps, NO change listener — the source captures the value once and the user
- * must reload to apply other reduced-motion changes anyway). The spec therefore
- * asserts seed-once + SSR-`false` fallback ONLY. There is intentionally no
- * change-event-update or unmount-removal case: adding one would silently
- * convert this mount-once read into a reactive hook.
+ * usePrefersReducedMotion is a LIVE sensor (#1063): it seeds from matchMedia on
+ * mount and subscribes to the `change` event so flipping OS reduce-motion
+ * mid-session updates the value without a reload (mirrors use-coarse-pointer).
+ * The spec asserts seed-once, SSR-`false` fallback, change-event update, AND
+ * unmount removal. (Before #1063 this was a deliberate mount-once `useMemo` with
+ * NO listener; that contract was retired so CSS and MapLibre camera flights
+ * agree on the live preference for vestibular-sensitive users.)
  */
 describe('usePrefersReducedMotion', () => {
+  let listeners: Array<(e: MediaQueryListEvent) => void>;
   let mql: MediaQueryList;
   let capturedQuery: string | null;
 
   beforeEach(() => {
+    listeners = [];
     capturedQuery = null;
     mql = {
       matches: false,
       media: '(prefers-reduced-motion: reduce)',
       onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === 'change') listeners.push(listener as (e: MediaQueryListEvent) => void);
+      }),
+      removeEventListener: vi.fn((type: string, listener: EventListener) => {
+        const idx = listeners.indexOf(listener as (e: MediaQueryListEvent) => void);
+        if (idx >= 0) listeners.splice(idx, 1);
+      }),
       dispatchEvent: vi.fn(),
       addListener: vi.fn(),
       removeListener: vi.fn(),
@@ -41,7 +49,7 @@ describe('usePrefersReducedMotion', () => {
     expect(capturedQuery).toBe('(prefers-reduced-motion: reduce)');
   });
 
-  it('returns matchMedia.matches as the mount-once value', () => {
+  it('returns matchMedia.matches as the initial value', () => {
     (mql as { matches: boolean }).matches = true;
     const { result } = renderHook(() => usePrefersReducedMotion());
     expect(result.current).toBe(true);
@@ -53,9 +61,23 @@ describe('usePrefersReducedMotion', () => {
     expect(result.current).toBe(false);
   });
 
-  it('does NOT register a change listener (mount-once read, not reactive)', () => {
-    renderHook(() => usePrefersReducedMotion());
-    expect(mql.addEventListener).not.toHaveBeenCalled();
+  it('updates when the media query changes (live OS reduce-motion toggle)', () => {
+    (mql as { matches: boolean }).matches = false;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      (mql as { matches: boolean }).matches = true;
+      listeners.forEach(l => l({ matches: true } as MediaQueryListEvent));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('removes the change listener on unmount', () => {
+    const { unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(mql.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
   });
 
   it('returns false in an SSR context (no window.matchMedia)', () => {

--- a/frontend/src/lib/use-prefers-reduced-motion.ts
+++ b/frontend/src/lib/use-prefers-reduced-motion.ts
@@ -1,25 +1,36 @@
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
 const QUERY = '(prefers-reduced-motion: reduce)';
 
 /**
- * Phase 0: read `prefers-reduced-motion` once at mount. `useMemo` with an empty
- * dep array captures the value once — intentional. The user must reload to fully
- * apply other reduced-motion changes anyway, and re-checking adds complexity for
- * negligible gain. This deliberately registers NO `change` listener; it is a
- * mount-once read, not a reactive sensor — do not convert it into one.
+ * Live `prefers-reduced-motion` sensor (#1063). Seeds from `matchMedia` on mount
+ * and subscribes to the `change` event so flipping the OS reduce-motion setting
+ * mid-session updates the value WITHOUT a reload. CSS already responds live
+ * (motion.css zeroes durations the instant the media query flips), so the prior
+ * mount-once read left MapLibre camera flights — which gate `duration: 0` on
+ * this value — at full motion until a reload: a split-brain for vestibular-
+ * sensitive users. This makes the JS gate track the live preference too.
  *
- * SSR-safe: returns `false` when `window`/`matchMedia` is undefined.
+ * SSR-safe: returns `false` when `window`/`matchMedia` is undefined. The first
+ * client render reads matchMedia and re-renders if reduce-motion is set.
  *
- * Extracted verbatim from `MapCanvas.tsx` in #889 (epic #884) — behaviour-
- * preserving; the no-listener semantics are preserved exactly.
+ * Mirrors the `use-coarse-pointer.ts` sensor idiom (useState seed + a `change`
+ * listener torn down on unmount). Originally extracted from `MapCanvas.tsx` in
+ * #889 (epic #884) as a mount-once `useMemo`; #1063 made it reactive.
  */
 export function usePrefersReducedMotion(): boolean {
-  return useMemo(
-    () =>
-      typeof window !== 'undefined' && typeof window.matchMedia === 'function'
-        ? window.matchMedia(QUERY).matches
-        : false,
-    [],
-  );
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return prefersReducedMotion;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -612,10 +612,12 @@ body {
    But `visibility:hidden` keeps the element IN FLOW: a closed in-flow flex child
    of the vertical-column `.app-header-identity-card` still reserves the full
    ScopeControl box, so the card froze at its OPEN height — an empty band below
-   the lede (#975). This wrapper animates `grid-template-rows: 0fr → 1fr` (the
-   catalog-only, JS-free "tween to content height" technique — the concrete
-   answer to #01's "can't tween to auto"); closed → a 0-height track, so the
-   inner form contributes ZERO layout height. The inner .t-panel-slide keeps the
+   the lede (#975). This wrapper animates `grid-template-rows: 0fr → 1fr` — a
+   documented HOUSE EXTENSION (#1063), NOT a transitions-dev catalog recipe: the
+   18-recipe catalog has no grid-template-rows tween. It is the JS-free "tween to
+   content height" technique (the concrete answer to #01's "can't tween to auto",
+   reviewed live in #975/#979); closed → a 0-height track, so the inner form
+   contributes ZERO layout height. The inner .t-panel-slide keeps the
    UNCHANGED #07 transform/opacity/blur reveal on the SAME clock
    (--panel-open-dur / --panel-ease), so both the height collapse and the visible
    slide play together. No new per-element prefers-reduced-motion query — the
@@ -624,7 +626,14 @@ body {
 .app-header-scope-clip {
   display: grid;
   grid-template-rows: 1fr;
-  transition: grid-template-rows var(--panel-open-dur) var(--panel-ease);
+  /* #1063: tween BOTH the row track AND the closed-state gap-compensation
+     margin on the same panel clock. The negative margin-block-start below
+     (cancels the card gap while collapsed) was previously absent from this
+     list, so it stepped discretely at the edges of the 400ms grid-rows tween —
+     a visible ~8px jump. Animating it here keeps the collapse continuous. */
+  transition:
+    grid-template-rows var(--panel-open-dur) var(--panel-ease),
+    margin-block-start var(--panel-open-dur) var(--panel-ease);
 }
 .app-header-scope-clip[data-open='false'] {
   grid-template-rows: 0fr;
@@ -793,8 +802,10 @@ body {
      Digit changes stay instant hard-cuts (no animation on value change).
      The global motion.css guard sets animation-duration: 0ms for
      prefers-reduced-motion, resolving instantly to the end-state — no
-     stuck-hidden risk because the end-state is fully visible. */
-  animation: badge-pop 200ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+     stuck-hidden risk because the end-state is fully visible.
+     Tunings (incl. the dated catalog-#03 back-out deviation) live in
+     tokens.css: --badge-pop-dur / --badge-pop-ease. */
+  animation: badge-pop var(--badge-pop-dur) var(--badge-pop-ease) both;
 }
 
 @keyframes badge-pop {
@@ -882,9 +893,9 @@ body {
   transform: scale(0.85);
   filter: blur(4px);
   transition:
-    opacity   160ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 160ms cubic-bezier(0.22, 1, 0.36, 1),
-    filter    160ms cubic-bezier(0.22, 1, 0.36, 1);
+    opacity   var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--icon-swap-ease),
+    filter    var(--icon-swap-dur) var(--icon-swap-ease);
   will-change: opacity, transform, filter;
 }
 .theme-toggle-glyph[data-active] {
@@ -1469,7 +1480,7 @@ body {
      The global motion.css guard zeroes transition-duration for
      prefers-reduced-motion so the chevron snaps instantly to end-state. */
   transform: rotate(0deg);
-  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform var(--chevron-dur) var(--icon-swap-ease);
   display: inline-block;
 }
 .family-legend-chevron[data-expanded='true'] {
@@ -2091,10 +2102,13 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
 /* The catalog snippet sets pointer-events on the resting/open states to gate
    interaction during a full panel reveal. The rail is keyboard-focused on
    mount (close button) and the entrance is short, so pointer-events stay
-   default here — gating them would briefly swallow clicks on the open card. */
-@media (prefers-reduced-motion: reduce) {
-  aside.species-detail-rail.t-panel-slide { transition: none !important; }
-}
+   default here — gating them would briefly swallow clicks on the open card.
+   No per-element reduced-motion guard: the rail's transitions carry NO
+   transition-delay, so the global motion.css duration-zeroing already lands
+   them at the end-state instantly — a per-element `transition: none` here would
+   be byte-for-byte redundant (#1063 deleted it; motion.css:6-10 single-source
+   policy, the same "house policy / owned globally by motion.css" convention the
+   compliant siblings in this file cite at the scope-clip and sheet-settle rules). */
 
 /* Recipe #18 — texts-reveal (verbatim CSS) on the identity block. Lines:
    name=--1, sci=--2, family-row=--3 (the --3 delay is added below). */
@@ -2130,6 +2144,16 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
   transform: translateY(0);
   filter: blur(0);
 }
+/* This per-element guard genuinely qualifies under the motion.css single-source
+   policy (motion.css:6-10 permits a per-element override "when needed"): the
+   stagger lines DO carry transition-delays (:--1/--2/--3 above, up to
+   --stagger-stagger * 2 ≈ 80ms). The global guard zeroes transition-DURATION
+   only, NOT transition-DELAY — so without this `transition: none !important`,
+   reduced-motion users would still see the three identity lines flip in a
+   staggered 80ms cascade. `transition: none` kills the delay too, landing all
+   three at the end-state on the same frame. (Contrast the rail above: no delay
+   there, so the global duration-zeroing suffices and a per-element guard is
+   redundant — #1063.) */
 @media (prefers-reduced-motion: reduce) {
   .detail-fg-identity.t-stagger .t-stagger-line { transition: none !important; }
 }
@@ -2179,11 +2203,12 @@ aside.species-detail-rail.t-panel-slide[data-open='true'] {
      01-card-resize). The transition is gated OFF during an active drag via
      [data-dragging='true'] below so the drag tracks the finger 1:1.
      Reduced-motion is owned globally by motion.css (collapses this to 0ms);
-     no per-element guard here, per repo convention. */
-  --sheet-settle-dur: 240ms;
-  --sheet-settle-ease: cubic-bezier(0.22, 1, 0.36, 1);
+     no per-element guard here, per repo convention.
+     --sheet-settle-dur / --sheet-settle-ease are the ONE settle clock, defined
+     in tokens.css beside --page-slide-dur/--page-fade-dur (the must-stay-synced
+     half of the same clock — #1063 hoisted them so #954's split-definition
+     desync class can't recur). Consumed here, NOT defined. */
   transition: height var(--sheet-settle-dur) var(--sheet-settle-ease);
-  will-change: height;
 }
 
 .species-detail-sheet[data-dragging='true'] {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -166,6 +166,40 @@
   --page-slide-ease:     cubic-bezier(0.22, 1, 0.36, 1);
   --page-fade-ease:      cubic-bezier(0.22, 1, 0.36, 1);
 
+  /* ── ONE settle clock (#1063) ────────────────────────────────────────────
+     The field-guide sheet's settle tween (recipe-01 card-resize: the
+     height/width snap between detents) MUST stay synchronized with the
+     recipe-08 page cross-dissolve above (--page-slide-dur/--page-fade-dur):
+     the page cross-fade, the in-page #07 reveals, and the #01 container-height
+     tween all start+finish on one frame (no two-stage desync — #954 chased a
+     desync that arose precisely because this clock was defined inline on the
+     component, split from the --page-* values). Hoisted here so the two halves
+     of the one-clock contract sit together and a future retune of one is an
+     obvious cue to retune the other. styles.css CONSUMES these; it no longer
+     defines them. Reduced-motion is owned globally by motion.css. */
+  --sheet-settle-dur:    240ms;
+  --sheet-settle-ease:   cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* ── Chrome micro-motion tunings (#1063) ─────────────────────────────────
+     Previously raw literals in styles.css; tokenized so a global motion retune
+     reaches them. Reduced-motion is owned globally by motion.css. */
+  /* Filters-button numeric badge entrance (recipe-03 notification-badge, a
+     @keyframes pop on mount). DEVIATION (2026-06-11, #1063): catalog #03 uses a
+     1.36 back-out overshoot at 500ms; this badge keeps the codebase's only
+     stronger 1.56 back-out at 200ms — a tighter, snappier pop tuned for the
+     small chrome badge rather than the catalog's larger surface. Kept as a
+     deliberate, dated departure rather than normalized to the catalog value. */
+  --badge-pop-dur:       200ms;
+  --badge-pop-ease:      cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Theme-toggle glyph cross-fade (opacity/transform/filter swap between sun &
+     moon). House bezier; short because it is an in-place icon swap. */
+  --icon-swap-dur:       160ms;
+  --icon-swap-ease:      cubic-bezier(0.22, 1, 0.36, 1);
+  /* Family-legend chevron rotate (rotate ONLY — never the entries list). House
+     bezier (shared via --icon-swap-ease); named for its own surface so a
+     chevron-specific retune does not perturb the theme-toggle swap. */
+  --chevron-dur:         200ms;
+
   /* ds-shimmer duration — shared by .status-block__skeleton + .photo__skeleton
      (both use the same ds-shimmer keyframe; #948). adaptive-grid-pending-shimmer
      (1.4s, reverse-direction) and skeleton-shimmer (opacity-pulse technique) are


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph tokens["tokens.css (single source)"]
        SC["--sheet-settle-dur / -ease (HOISTED, beside --page-* one clock)"]
        BP["--badge-pop-dur / -ease (dated catalog-#03 deviation note)"]
        IS["--icon-swap-dur / -ease"]
        CH["--chevron-dur"]
    end
    subgraph styles["styles.css (consumes only)"]
        BADGE["badge-pop @keyframes"]
        TOGGLE["theme-toggle glyph swap"]
        CHEV["legend chevron rotate"]
        SHEET["sheet settle (will-change: height dropped)"]
        CLIP["scope-clip: grid-rows + margin-block-start on one clock"]
    end
    BP --> BADGE
    IS --> TOGGLE
    IS --> CHEV
    CH --> CHEV
    SC --> SHEET

    subgraph prm["live reduced-motion (PRM)"]
        HOOK["usePrefersReducedMotion (useState + change listener)"]
        REF["prefersReducedMotionRef (.current = live value)"]
        FLIGHTS["MapLibre flights read .current at dispatch"]
        EFFECT["scope-reframe effect deps stay inert (no live value)"]
        HOOK --> REF
        REF --> FLIGHTS
        REF -.->|"NOT a dep — avoids #848/#736 spurious recenter"| EFFECT
    end
```

## Summary

- **Why:** motion hygiene with zero visual change at default settings — every tuning is a token or a claimed exception, the ONE settle clock lives in one file, the reduced-motion guards follow the motion.css single-source policy, and the OS reduce-motion toggle takes effect live (CSS already did; the JS camera-flight gate did not — split-brain for vestibular-sensitive users).
- **Tokenized** the three hardcoded chrome tunings (badge pop, theme-toggle swap, legend chevron) into the tokens.css motion block, byte-identical values; **hoisted** `--sheet-settle-dur/-ease` beside `--page-slide-dur/--page-fade-dur` so the one-clock contract's halves sit together (the split definition is the #954 desync class).
- **Fixed** the mis-attributed scope-clip tween (grid-rows 0fr↔1fr is a documented house extension, not a catalog recipe), added the gap-comp `margin-block-start` to the scope-clip transition list (was a discrete ~8px step), deleted the redundant rail PRM guard + annotated why the stagger guard genuinely qualifies, dropped the inert `will-change: height`, deleted the dead "Reserved for future slide-in" PRM block (contradicted #950's deferral), and documented `.photo__img`'s deliberate UA `ease`.

## Screenshots

**Live motion verification (W.3 — orchestrator, head `48af44c`).** Stills can't show motion, so each load-bearing delta was driven live (camera flights instrumented by spying the `duration` passed to `flyTo`/`easeTo`; reduce-motion toggled via `emulateMedia({reducedMotion})`, which fires the real `matchMedia` change the new live sensor listens to):

1. **Live PRM toggle (headline) ✓** — motion ON: scope change (US-AZ→US-CA) dispatched `flyTo` **duration 600**. Toggled reduce-motion **ON mid-session** (no reload): next scope change (→US-TX) dispatched `flyTo` **duration 0** (instant). Toggled **OFF**: next change (→US-NY) dispatched `flyTo` **duration 600** again. The JS camera gate now tracks the live OS preference — the split-brain is gone.
2. **No spurious recenter on toggle ✓** — toggling reduce-motion while a scope was active fired **zero** camera calls and left center/zoom byte-identical (−119.272, 37.581, z5.81 before == after). The ref-not-dep design holds (#848/#736 class).
3. **Scope-clip continuous collapse ✓** — `.app-header-scope-clip` computed `transition-property: grid-template-rows, margin-block-start` both at `0.4s`; the gap-comp margin now tweens on the same clock (no discrete ~8px step).
4. **Chrome micro-motion unchanged ✓** — computed tokens byte-identical: `--badge-pop-dur` 200ms / back-out bezier, `--icon-swap-dur` 160ms, `--chevron-dur` 200ms.
5. **Sheet settle unchanged ✓** — `--sheet-settle-dur` 240ms, hoisted beside `--page-slide-dur`/`--page-fade-dur` (240ms), values unchanged.
6. **Reduced-motion stagger ✓** — desktop detail rail, reduce-motion ON: all three identity lines (`t-stagger-line--1/2/3`) compute `transition: none` / `transition-delay: 0s` (land same frame, no 80ms cascade).

**Static-appearance regression pass:** 10 captures below (5 viewports × 2 themes), `?state=US-CA`. Console **0 errors / 0 warnings** at every light viewport; dark shows only the known `circle-11` #947 dark-basemap missing-image noise (not introduced here).

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="f3-390-light" src="https://github.com/user-attachments/assets/de0f26f6-ec7c-44d0-9ab7-b3b7ea81dc0a" /> | <img width="360" alt="f3-390-dark" src="https://github.com/user-attachments/assets/bd2d3bf1-f3b6-4670-a0e5-3355cf58628e" /> |
| **768×1024 (tablet)** | <img width="360" alt="f3-768-light" src="https://github.com/user-attachments/assets/6ca819a8-371c-4813-ba65-5cb02f6902d9" /> | <img width="360" alt="f3-768-dark" src="https://github.com/user-attachments/assets/a514bb57-9e1e-4e5a-8e37-151dc08aa9b0" /> |
| **1024×768 (laptop)** | <img width="360" alt="f3-1024-light" src="https://github.com/user-attachments/assets/6cc4e4f3-7c25-4a68-ada1-da7133ac981b" /> | <img width="360" alt="f3-1024-dark" src="https://github.com/user-attachments/assets/5782affe-dff6-46e1-a0c2-6b2c8c235c83" /> |
| **1440×900 (desktop)** | <img width="360" alt="f3-1440-light" src="https://github.com/user-attachments/assets/837c9fce-4315-4d08-8e1d-67ba25cd355a" /> | <img width="360" alt="f3-1440-dark" src="https://github.com/user-attachments/assets/067ad0dd-24db-4ee3-ba9d-5dbcdda4b88e" /> |
| **1920×1080 (wide)** | <img width="360" alt="f3-1920-light" src="https://github.com/user-attachments/assets/2206224f-13d2-4ec6-bd14-b7fa041f6d6e" /> | <img width="360" alt="f3-1920-dark" src="https://github.com/user-attachments/assets/777ebffe-908e-4a2b-b68d-dc0f29e68b75" /> |

This IS a motion change. **Stills cannot show motion** — the orchestrator must run a live motion pass (default + OS reduce-motion toggled mid-session). The standard 10-shot set (5 viewports × 2 themes) is still required to confirm zero static-appearance regression.

**Behaviors to verify live (the load-bearing motion deltas):**

1. **Live PRM toggle (the headline fix).** With the map open, toggle OS reduce-motion mid-session (System Settings → Accessibility → Display → Reduce motion). Then change scope (pick a different state) or drill into a cluster. The MapLibre camera flight must land **instantly (duration 0)** without a page reload. Pre-change it kept full 600/800ms flights until reload. Toggle back off → flights animate again.
2. **No spurious recenter on toggle.** Toggling reduce-motion while a scope is active must **not** by itself re-fire the scope reframe (no camera jump on the toggle alone) — only the next real scope change reads the new duration. This is the #848/#736 class the ref-not-dep design guards.
3. **Scope-clip continuous collapse.** Open then close the scope control (top-left identity card). The card-height collapse should be **continuous** — no discrete ~8px jump at the start/end of the 400ms tween (the gap-comp margin now tweens on the same clock).
4. **Chrome micro-motion unchanged.** Filters badge pop on mount (snappy back-out), theme-toggle sun/moon cross-fade (160ms), legend chevron rotate (200ms) — all visually identical to main (token substitution only).
5. **Sheet settle unchanged** (mobile): drag the species sheet between detents — the 240ms height settle reads exactly as before.
6. **Reduced-motion stagger** (desktop detail rail, reduce-motion ON): the three identity lines (name/sci/family) must land **on the same frame**, not in an 80ms cascade — the stagger guard's `transition: none` kills the surviving transition-delays that duration-zeroing alone leaves.

- [ ] Every new/renamed `className` — N/A, no className changes (token/comment/hook edits only); `scripts/check-orphan-classnames.sh` → PASS.
- [x] Multi-viewport design QA: ≥10 `user-attachments` URLs — 10 captured (5 viewports × 2 themes), embedded above.

## Design QA

**ui-design:ui-designer (opus) — OVERALL PASS** (head `48af44c`). Per-viewport: 390×844 PASS · 768×1024 PASS · 1024×768 PASS · 1440×900 PASS · 1920×1080 PASS. Four-corner anchor contract intact (identity TL · controls TR · legend BL · attribution BR), both themes coherent, no static-appearance regression — consistent with a motion-only PR intending zero static change.

## Test plan

- [x] `npx tsc -b frontend` — clean
- [x] `npm test --workspace @bird-watch/frontend -- --run` — 1512 passed (88 files); the `MapCanvas controllable camera (#736)` suite (106 tests) pins every reduced-motion flight-duration path through the new `prefersReducedMotionRef`.
- [x] New unit tests: `use-prefers-reduced-motion.test.ts` rewritten — the old "does NOT register a change listener" assertion + the forbid-reactive header are replaced with change-event-update + unmount-removal cases (mirrors `use-coarse-pointer.test.ts`). Confirmed red before implementation, green after.
- [x] `npm run build --workspace @bird-watch/frontend` — clean
- [x] `npx knip` — exit 0, no findings
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] CI lint forbidden-token guard — clean (no raw `--accent/--bg-*/--text-*` token names introduced)
- [ ] **e2e: deferred to orchestrator.** The dev plane (5173 Vite / 8787 read-api / 5440+5433 DB) was occupied by sibling worktrees (F1/F2/F4 share styles.css); `playwright.config.ts` hardcodes `baseURL: localhost:5173` with `reuseExistingServer` and no env override, so running e2e here would test another worktree's bundle, not this branch. Orchestrator runs the relevant motion specs (`scope-disclosure`, `family-legend*`, `sheet-snap`, `species-detail`, `state-scope`, `map-cell-popover`) against the PR head SHA during W.3 live verification.

## Plan reference

Part of the design-review remediation program (Epic F #1060, Wave 4 / F3). Motion verification is behavioral — see the Screenshots section for the exact transitions/easings to drive live.

Closes #1063. Part of #1060 (Wave 4 / F3).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


