### PR TITLE
test(basemap): cover dark-label halo-width branch + fix contrast comments

### DIFF
--- a/frontend/src/components/map/basemap-label-contrast.test.ts
+++ b/frontend/src/components/map/basemap-label-contrast.test.ts
@@ -10,7 +10,7 @@ import { enforceDarkLabelContrast } from './basemap-label-contrast.js';
    AA against the dark canvas (`background-color: rgb(12,12,12)`). The 13 dark
    symbol layers that carry a `text-field` and their real light-mode text-color:
 
-     highway_name_motorway      hsl(0,0%,37%)        1.05  (transportation_name)
+     highway_name_motorway      hsl(0,0%,37%)        3.03  (transportation_name)
      water_name                 hsla(0,0%,0%,0.7)    1.07  (water_name)
      highway_name_other         rgba(80,78,78,1)     2.37  (transportation_name)
      place_other/suburb/village/town/city/city_large/state  rgb(101,101,101) 3.36
@@ -221,6 +221,88 @@ describe('enforceDarkLabelContrast — AA after fix (dark canvas)', () => {
     expect(map.setPaintProperty.mock.calls.some((c) => c[0] === 'poi_icon')).toBe(false);
     expect(map.setPaintProperty.mock.calls.some((c) => c[0] === 'water')).toBe(false);
     expect(map.setPaintProperty.mock.calls.some((c) => c[0] === 'background')).toBe(false);
+  });
+});
+
+describe('enforceDarkLabelContrast — halo-width bump on the neediest labels', () => {
+  /* The bump exists precisely for the label MOST in need of a halo — one whose
+     style ships a 0-width (or absent) halo. Every other fixture in this file
+     pre-sets text-halo-width: 1, so without these two cases the bump branch
+     (text-halo-width < 1 → 1, and the typeof !== 'number' arm) is never run. */
+
+  it('bumps a 0-width halo up to 1 on a recolored dark label', () => {
+    const layers: FakeLayer[] = [
+      { id: 'background', type: 'background', layout: {}, paint: { 'background-color': DARK_BG } },
+      {
+        id: 'place_city',
+        type: 'symbol',
+        layout: { 'text-field': ['get', 'name'] },
+        paint: {
+          'text-color': 'rgb(101, 101, 101)', // 3.36 vs dark canvas → fails AA, gets recolored
+          'text-halo-color': 'rgba(0,0,0,0.7)',
+          'text-halo-width': 0, // the case the bump exists for
+        },
+      },
+    ];
+    const map = makeMockMap(layers);
+
+    enforceDarkLabelContrast(map as never);
+
+    // Read back the value the fake map actually stored.
+    expect(map.byId['place_city'].paint['text-halo-width']).toBe(1);
+    expect(map.byId['place_city'].paint['text-halo-width'] as number).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sets halo-width to 1 when text-halo-width is absent (typeof !== number arm)', () => {
+    const layers: FakeLayer[] = [
+      { id: 'background', type: 'background', layout: {}, paint: { 'background-color': DARK_BG } },
+      {
+        id: 'place_city',
+        type: 'symbol',
+        layout: { 'text-field': ['get', 'name'] },
+        paint: {
+          'text-color': 'rgb(101, 101, 101)', // fails AA → recolored
+          'text-halo-color': 'rgba(0,0,0,0.7)',
+          // text-halo-width intentionally ABSENT → getPaintProperty returns undefined
+        },
+      },
+    ];
+    const map = makeMockMap(layers);
+
+    // Precondition: the property really is undefined before the call.
+    expect(map.byId['place_city'].paint['text-halo-width']).toBeUndefined();
+
+    enforceDarkLabelContrast(map as never);
+
+    expect(map.byId['place_city'].paint['text-halo-width']).toBe(1);
+    expect(map.byId['place_city'].paint['text-halo-width'] as number).toBeGreaterThanOrEqual(1);
+  });
+
+  it('leaves an already-wide (≥1) halo as the style set it', () => {
+    const layers: FakeLayer[] = [
+      { id: 'background', type: 'background', layout: {}, paint: { 'background-color': DARK_BG } },
+      {
+        id: 'place_city',
+        type: 'symbol',
+        layout: { 'text-field': ['get', 'name'] },
+        paint: {
+          'text-color': 'rgb(101, 101, 101)', // fails AA → recolored
+          'text-halo-color': 'rgba(0,0,0,0.7)',
+          'text-halo-width': 2, // already wider than the floor
+        },
+      },
+    ];
+    const map = makeMockMap(layers);
+
+    enforceDarkLabelContrast(map as never);
+
+    // Untouched: the bump must not clobber a wider halo down to 1.
+    expect(map.byId['place_city'].paint['text-halo-width']).toBe(2);
+    expect(
+      map.setPaintProperty.mock.calls.some(
+        (c) => c[0] === 'place_city' && c[1] === 'text-halo-width',
+      ),
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/components/map/basemap-label-contrast.ts
+++ b/frontend/src/components/map/basemap-label-contrast.ts
@@ -7,9 +7,10 @@
  * style ships LIGHT-mode label text colors (`hsl(0,0%,37%)` / `#656565` /
  * `rgba(80,78,78,1)` …), so at z14 every basemap symbol layer carrying a
  * `text-field` fails WCAG AA against the dark canvas (`background-color`
- * `rgb(12,12,12)`): motorway and water labels sit at ~1.05–1.07 contrast —
- * effectively invisible — and place labels at ~3.36, below the 4.5 AA floor.
- * The dark style's halos are dark too (`rgba(0,0,0,0.7)`), so they don't help.
+ * `rgb(12,12,12)`): the near-black `water_name` label sits at ~1.07 contrast —
+ * effectively invisible — and the `hsl()`/gray road + place labels at ~3.0–3.4,
+ * all below the 4.5 AA floor. The dark style's halos are dark too
+ * (`rgba(0,0,0,0.7)`), so they don't help.
  *
  * `enforceDarkLabelContrast(map)` recolors the FAILING label layers to an
  * AA-passing LIGHT text + DARK halo, preserving the light-style visual


### PR DESCRIPTION
## Diagrams

N/A — test + comment-only follow-up to #1130. Branch logic exercised:

```mermaid
flowchart LR
    A["recolor label<br/>(fails AA)"] --> B{"text-halo-width<br/>typeof !== number<br/>OR < 1 ?"}
    B -- "0 / absent" --> C["setPaintProperty<br/>text-halo-width = 1"]
    B -- "≥ 1" --> D["leave as the<br/>style set it"]
```

## Summary

- Polish follow-up to the one non-blocking reviewer SUGGESTION on #1130. The `text-halo-width < 1 → 1` bump — the branch that exists precisely for the label *most* in need of a halo (a 0-width or absent halo) — had no coverage: every prior fixture pre-set `text-halo-width: 1`. Adds a `0`-width case, an absent-property case (the `typeof !== 'number'` arm), and a guard that an already-wide (`2`) halo is left untouched. Assertions read the value the fake map actually stored.
- Non-tautology proof: with the `setPaintProperty(..., 'text-halo-width', 1)` line commented out, the two new bump assertions FAIL; restored, all 12 pass.
- Corrects two stale comments that cited `~1.05` contrast for `hsl(0,0%,37%)` labels — a parse artifact (hsl digits read as `rgb()`). True value is `~3.03`; only `water_name` (near-black) is genuinely `~1.07`. No contrast value the code uses and no assertion threshold changed — comments only.

## Screenshots

N/A — not UI (test + comment-only; no visible render change)

## Test plan

- [x] `npm run lint` — green
- [x] `npm run build --workspace @bird-watch/frontend` (`tsc -b` typecheck + vite build) — green
- [x] `npx vitest run basemap-label-contrast` — 12 passed (original 9 + 3 new)
- [x] Non-tautology check: new halo-width assertions FAIL with the bump line removed, PASS when restored
- [x] `npx knip` — clean
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] New unit tests added (3 cases covering the previously-uncovered halo-width bump branch)
- [ ] New Playwright e2e spec added — N/A — not UI
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Out of plan — non-blocking polish SUGGESTION from the #1130 review (cover the untested `text-halo-width` bump branch + correct two inaccurate contrast comments).

## Design QA

N/A — not UI

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)