### PR TITLE
test(frontend): round sub-pixel boundingBox in mobile-bundle-e touch-target asserts (#1129)

### DIFF
--- a/frontend/e2e/mobile-bundle-e.spec.ts
+++ b/frontend/e2e/mobile-bundle-e.spec.ts
@@ -83,8 +83,8 @@ test.describe('AppHeader buttons ≥ 44×44pt', () => {
 
     const box = await app.filtersTrigger.boundingBox();
     expect(box, 'Filters button bounding box must exist').not.toBeNull();
-    expect(box!.height, 'Filters button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
-    expect(box!.width, 'Filters button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.height), 'Filters button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.width), 'Filters button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 
   test('Attribution button is ≥ 44px tall', async ({ page, apiStub }) => {
@@ -95,8 +95,8 @@ test.describe('AppHeader buttons ≥ 44×44pt', () => {
 
     const box = await app.attributionTrigger.boundingBox();
     expect(box, 'Attribution button bounding box must exist').not.toBeNull();
-    expect(box!.height, 'Attribution button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
-    expect(box!.width, 'Attribution button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.height), 'Attribution button height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.width), 'Attribution button width must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 
   // Regression guard: round-1 fix used font-size:0 which produced empty
@@ -146,8 +146,8 @@ test.describe('MOB-7 — sheet handle ≥ 44pt drag target', () => {
     const handle = page.locator('[data-testid=species-detail-sheet-handle]');
     const box = await handle.boundingBox();
     expect(box, 'sheet handle bounding box must exist').not.toBeNull();
-    expect(box!.height, 'sheet handle height must be ≥ 44px').toBeGreaterThanOrEqual(44);
-    expect(box!.width, 'sheet handle width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.height), 'sheet handle height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.width), 'sheet handle width must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 });
 
@@ -173,7 +173,7 @@ test.describe('MOB-N1 — .filters-panel-close touch target ≥ 44×44pt', () =>
     const closeBtn = page.locator('.filters-panel-close');
     const box = await closeBtn.boundingBox();
     expect(box, 'filters-panel-close bounding box must exist').not.toBeNull();
-    expect(box!.height, 'filters-panel-close height must be ≥ 44px').toBeGreaterThanOrEqual(44);
-    expect(box!.width, 'filters-panel-close width must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.height), 'filters-panel-close height must be ≥ 44px').toBeGreaterThanOrEqual(44);
+    expect(Math.round(box!.width), 'filters-panel-close width must be ≥ 44px').toBeGreaterThanOrEqual(44);
   });
 });


### PR DESCRIPTION
## Diagrams

N/A — test-only assertion-rounding fix; not diagrammable.

## Summary

- **Why:** the four `mobile-bundle-e` touch-target tests compared an un-rounded sub-pixel `boundingBox()` dimension against a strict integer 44px floor with `toBeGreaterThanOrEqual(44)`. On some CI hosts a nominally-44px element resolves to `43.999969482421875` (DPR / font-metric / box rounding), so `43.99997 < 44` failed intermittently — twice in CI, dequeuing PR #1110. The components are 44px to design intent; this is a float-comparison flake, not a real WCAG/HIG touch-target violation.
- **Fix:** wrap each measured `box!.height` / `box!.width` in `Math.round(...)` so `43.99997` rounds to `44` and passes, while a real regression (e.g. `41`) still fails. Eight asserts across four tests (Filters button, Attribution button, MOB-7 sheet handle, MOB-N1 filters-panel-close); assertion messages unchanged. Only `frontend/e2e/mobile-bundle-e.spec.ts` is touched.

## Screenshots

N/A — not UI (test-only e2e assertion change).

- [ ] Every new/renamed `className` in this PR has a matching CSS rule (N/A — no CSS / className changes)
- [ ] Multi-viewport design QA: ≥10 `user-attachments` URLs (N/A — not UI)

## Test plan

- [x] Typecheck — `tsc --noEmit` over `frontend/e2e/mobile-bundle-e.spec.ts` (with `vite/client` types) reports zero errors; `Math.round(number): number` is a trivially well-typed wrapper.
- [x] Lint — repo `npm run lint` (workspaces, `--if-present`) green.
- [x] `grep -n "Math.round" frontend/e2e/mobile-bundle-e.spec.ts` confirms all four touch-target asserts (8 lines: 86/87, 98/99, 149/150, 176/177) are wrapped; no bare `box!.height`/`box!.width` vs 44 remain.
- [x] Did NOT run the live `mobile-bundle-e` spec locally: a Vite dev server from a different worktree is already on port 5173, and Playwright's `reuseExistingServer:true` would run this spec against that stale server (out-of-sync page-object selectors), producing spurious 60s timeouts unrelated to this fix. The flake is environment-dependent and does not reproduce on this dev host.
- [x] Real cross-host verification is the required `e2e` CI check, which runs the spec against a fresh seeded server — the only environment that exercises the sub-pixel path this fix targets.
- [ ] (UI only) Playwright MCP smoke — N/A (test-only e2e assertion change).

## Plan reference

Out of plan — flakiness remediation from `docs/analyses/2026-06-13-spec-flakiness-assessment.md`. Closes #1129.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
