### PR TITLE
test(frontend): clear vi.doMock registry in clarity.test.ts to fix shuffle-order flake (#1105)

### DIFF
--- a/frontend/src/clarity.test.ts
+++ b/frontend/src/clarity.test.ts
@@ -104,22 +104,24 @@ describe('safeClarity guarded wrapper', () => {
 
   it('safeClarity.event forwards to Clarity.event when window.clarity is a function', async () => {
     (window as unknown as { clarity: () => void }).clarity = vi.fn();
-    const eventSpy = vi.fn();
-    vi.doMock('@microsoft/clarity', () => ({
-      default: { init: vi.fn(), event: eventSpy, setTag: vi.fn() },
-    }));
     const { safeClarity } = await import('./clarity.js');
+    // Assert against the SAME hoisted-mock spy `clarity.ts` consumes, resolved via the
+    // mocked specifier after import — not a fresh per-test `vi.doMock`. A per-test
+    // `vi.doMock` here leaked across the unordered describe blocks under
+    // `--sequence.shuffle`: `vi.resetModules()` clears the module cache but not doMock
+    // factory registrations, so a leaked factory shadowed a later test's import and the
+    // captured spy saw 0 calls (#1105).
+    const eventSpy = (await import('@microsoft/clarity')).default.event as unknown as ReturnType<typeof vi.fn>;
     safeClarity.event('panel_opened');
     expect(eventSpy).toHaveBeenCalledWith('panel_opened');
   });
 
   it('safeClarity.setTag forwards to Clarity.setTag when window.clarity is a function', async () => {
     (window as unknown as { clarity: () => void }).clarity = vi.fn();
-    const setTagSpy = vi.fn();
-    vi.doMock('@microsoft/clarity', () => ({
-      default: { init: vi.fn(), event: vi.fn(), setTag: setTagSpy },
-    }));
     const { safeClarity } = await import('./clarity.js');
+    // See the event test above (#1105): assert against the hoisted-mock spy, no per-test
+    // `vi.doMock` (which leaked under shuffle and was the real flake source).
+    const setTagSpy = (await import('@microsoft/clarity')).default.setTag as unknown as ReturnType<typeof vi.fn>;
     safeClarity.setTag('view', 'feed');
     expect(setTagSpy).toHaveBeenCalledWith('view', 'feed');
   });


### PR DESCRIPTION
## Diagrams

N/A — test-only isolation fix (clear a leaked vi.doMock); not diagrammable.

## Summary

- **Why:** `clarity.test.ts` flaked under `--sequence.shuffle` (deterministic at seed 3 / seed 9; ~4–7% under random shuffle). The real cause is a leaked `vi.doMock('@microsoft/clarity', …)`: the two per-test `vi.doMock` calls in the `safeClarity guarded wrapper` block were never cleared. `vi.resetModules()` only drops the module *cache*, not doMock factory registrations — so under shuffle a leaked factory shadowed a *later* test's `await import('./clarity.js')`, and the captured spy saw 0 calls. The issue title's `vi.stubEnv`/`resetModules` env-bleed attribution is **wrong** (verified — `vi.unstubAllEnvs()` is correct and was left untouched).
- **What:** Dropped the two per-test `vi.doMock` blocks entirely and assert the `event`/`setTag` forwarding against the hoisted-mock spy resolved via the same `@microsoft/clarity` specifier `clarity.ts` consumes (the pattern the file's existing `currentInitSpy()` already uses for the prod-init test). This removes the leak *source* rather than papering over it. Note: `vi.doUnmock` and the `using`-disposable were both tried and rejected — they remove the mock entirely, so the next import resolves the *real* module and the first describe block's assertions throw `"not a spy"`.

## Screenshots

N/A — not UI (test-only).

## Test plan

- [x] `npx tsc -b` (frontend typecheck) — green, 0 errors
- [x] `npx vitest run src/clarity.test.ts` — 7 passed
- [x] Shuffle reproduce → fix evidence:
  - **Before fix (post-#1111 baseline):** 30× shuffle loop → 2 failed; deterministic FAIL at the captured seed `1781367645174` with `safeClarity.setTag forwards to Clarity.setTag` → `AssertionError: expected "vi.fn()" to be called with arguments: [ 'view', 'feed' ] / Number of calls: 0`.
  - **After fix:** `--sequence.seed=3` PASS (7/7), `--sequence.seed=9` PASS (7/7), previously-failing `--sequence.seed=1781367645174` PASS (7/7), plain run PASS (7/7), and a **60× `--sequence.shuffle` loop → 60 passed / 0 failed**.
- [x] No production code changed (only `frontend/src/clarity.test.ts`) — no new e2e needed.
- [ ] (UI only) Playwright MCP smoke — N/A, not UI.

## Plan reference

Out of plan — flakiness remediation from `docs/analyses/2026-06-13-spec-flakiness-assessment.md`. Closes #1105.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
