### PR TITLE
test(frontend): await idle-handler registration in MapCanvas.test.tsx to fix describe-shuffle flake (#1134)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -440,6 +440,20 @@ async function fireAllIdleHandlers() {
   }
 }
 
+// #1134: `deferMapLoad`/`deferredOnLoad` are module-scope flags. The load-gating
+// tests (#736, #1049) set `deferMapLoad = true` to hold MockMap's `onLoad` so they
+// can assert the pre-`load` state. A describe block whose `beforeEach` forgot to
+// reset these would inherit a stale `deferMapLoad = true` under describe-shuffle:
+// MockMap then never fires `onLoad`, `mapReady` never flips, no `idle` listener
+// registers, and `await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'))`
+// times out. This top-level afterEach guarantees the defaults are restored after
+// every test in the file regardless of describe order, so no future block can
+// re-introduce the leak even if its beforeEach omits the reset.
+afterEach(() => {
+  deferMapLoad = false;
+  deferredOnLoad = null;
+});
+
 describe('MapCanvas', () => {
   beforeEach(() => {
     capturedSourceProps = {};
@@ -1767,6 +1781,8 @@ describe('#860 — lone clustered bucket opens its real species (coarse pointer)
     registeredHandlers = {};
     bareHandlers = {};
     bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
     fakeMap = makeFakeMap();
     document.documentElement.removeAttribute('data-theme');
 
@@ -2197,6 +2213,8 @@ describe('onSelectSpecies popover wire', () => {
     registeredHandlers = {};
     bareHandlers = {};
     bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
     fakeMap = makeFakeMap();
     document.documentElement.removeAttribute('data-theme');
 
@@ -2362,6 +2380,8 @@ describe('ObservationPopover anchoring — displaced silhouette regression (#718
     registeredHandlers = {};
     bareHandlers = {};
     bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
     fakeMap = makeFakeMap();
     document.documentElement.removeAttribute('data-theme');
     __resetAdaptiveGridCacheForTesting();


### PR DESCRIPTION
## Diagrams

N/A — test-only timing/isolation fix; not diagrammable.

## Summary

- **Why:** `MapCanvas.test.tsx` flaked ~20–25% of the time under describe-shuffle (#1134). The load-gating tests (#736/#1049) set the module-scope flag `deferMapLoad = true` so MockMap holds its `onLoad` callback and the pre-`load` state can be asserted. Three describe blocks — `#860 lone clustered bucket`, `onSelectSpecies popover wire`, and `#718 displaced silhouette` — had `beforeEach` hooks that reset every other capture map but **omitted** the `deferMapLoad`/`deferredOnLoad` reset that four sibling blocks already carry. Under shuffle, when a load-gating test ran before one of these blocks, the stale `deferMapLoad = true` leaked in: MockMap never fired `onLoad`, `mapReady` never flipped, no `idle` listener registered, and the `await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'))` guard timed out at its default 1000 ms window — `expected undefined to be type of 'function'`.
- **Fix:** Restore `deferMapLoad = false; deferredOnLoad = null;` in the three offending `beforeEach` blocks (matching the existing convention), and add a top-level module-scope `afterEach` that resets both flags after every test, so no future block can re-introduce the same leak even if its `beforeEach` omits the reset. Test-only — no production change to `MapCanvas.tsx`, shuffle stays on, no retries added.

## Screenshots

N/A — not UI (test-only).

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — not UI` (no className changes; test-only)
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

- [x] `npm run typecheck` — green (`npx tsc -b` exit 0)
- [x] New unit / integration tests added (if behavior changed) — N/A; this fixes an existing test's isolation, no behavior changed
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A; test-only
- [ ] `npm run build` — not re-run (no production source touched; typecheck green)
- [x] (UI only) Playwright MCP smoke — N/A; test-only, no UI change

**Reproduce (FAIL, before fix):** file-only-shuffle batch over the 4-file group `MapSurface + MapCanvas + DisplacedSilhouetteLayer + GroupMarkerLayer`, 20 runs → **4/20 failed (20%)**, every failure the identical `bareHandlers['idle']` assertion on exactly the four tests from the ticket (`#718 displaced silhouette`, `#860 clustered bucket`, and both `onSelectSpecies popover wire` cases). Example failing seed `1781370731544`.

**Verify (PASS, after fix):**
- File-shuffle batch (`--sequence.shuffle`, same 4 files), **30 runs → 0/30 failed**.
- All five diagnosis failing seeds (`1781370280958`, `1781370288490`, `1781370294284`, `1781370315367`, `1781370320242`) → **pass**.
- Solo MapCanvas-only failing seed `1781370515379` (`--sequence.shuffle.tests`) → **pass**.
- `MapCanvas.test.tsx` alone with within-file shuffle (`--sequence.shuffle.tests`), **20 runs → 0/20 failed**.
- `MapCanvas.test.tsx` default order → **95/95 pass** (confirms the load-gating tests #736/#1049 that intentionally set `deferMapLoad = true` still pass with the new `afterEach`).
- `npx tsc -b` clean; `eslint` on the changed file clean.

## Plan reference

Out of plan — flakiness follow-up from docs/analyses/2026-06-13-spec-flakiness-assessment.md. Closes #1134.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
