### PR TITLE
fix(legend): make the overflow fade hug the card's bottom edge

### DIFF
--- a/frontend/e2e/legend-usability-e3.spec.ts
+++ b/frontend/e2e/legend-usability-e3.spec.ts
@@ -205,16 +205,31 @@ test.describe('E3 (#1055): overflow cue is visible at rest when the list overflo
 
     const list = page.locator('.family-legend-entries');
     await expect(list).toBeVisible();
-    // The component measured an overflow and stamped the flag…
+    // The component measured an overflow and stamped the flag on the <ul>…
     await expect(list).toHaveAttribute('data-overflow', 'true');
-    // …and the ::after fade pseudo-element is painted (non-zero height) at rest.
-    const fadeHeight = await list.evaluate((el) =>
+    // …and the fade is now painted on the CARD (.family-legend::after), lifted
+    // off the <ul> via :has() so it spans the full inner width and hugs the
+    // bottom rounded corners regardless of the scrollbar gutter.
+    const card = page.locator('.family-legend');
+    const fadeHeight = await card.evaluate((el) =>
       parseFloat(getComputedStyle(el, '::after').height),
     );
     expect(
       fadeHeight,
       'the overflow ::after fade must have a non-zero height at rest',
     ).toBeGreaterThan(0);
+    // Geometry pin: the fade spans (nearly) the full inner card width — NOT the
+    // old narrow inset width (list padding + classic scrollbar gutter made the
+    // <ul>-::after lopsided: 9px left / ~20px right). In headless Chromium the
+    // scrollbar is overlay/0-width, so inset-inline:1px ≈ cardWidth − 2.
+    const { fadeWidth, cardWidth } = await card.evaluate((el) => ({
+      fadeWidth: parseFloat(getComputedStyle(el, '::after').width),
+      cardWidth: el.getBoundingClientRect().width,
+    }));
+    expect(
+      Math.abs(fadeWidth - (cardWidth - 2)),
+      `the fade must span the full inner card width (fade ${fadeWidth}px vs inner ${cardWidth - 2}px)`,
+    ).toBeLessThanOrEqual(3);
   });
 
   test('no overflow flag when the list fits', async ({ page, apiStub }) => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1535,27 +1535,38 @@ body {
   overflow-y: auto;
   border-top: 1px solid var(--color-border-subtle);
   border-radius: 0 0 var(--card-radius) var(--card-radius);
-  /* E3 (#1055): the entries list is the relative anchor for the overflow fade
-     pseudo-element below — it must clip to the rounded bottom corners. */
-  position: relative;
 }
 /* E3 (#1055): overflow cue. macOS overlay scrollbars are invisible at rest, so
    a half-hidden family list gave no signal that more rows lie below the fold.
    FamilyLegend.tsx measures scrollHeight > clientHeight and sets
    data-overflow="true" on the <ul>; this paints a bottom fade gradient that is
    visible at rest (not only while scrolling) and disappears once the user
-   scrolls to the end (the component clears the flag at the bottom). The
-   gradient is a sticky pseudo-element inside the scroll container so it tracks
-   the viewport edge of the list, not the scrolled content. pointer-events:none
-   keeps clicks falling through to the rows beneath. */
-.family-legend-entries[data-overflow='true']::after {
+   scrolls to the end (the component clears the flag at the bottom).
+   pointer-events:none keeps clicks (and scrollbar drags) falling through to the
+   rows beneath.
+
+   Geometry fix: the fade lives on the CARD (.family-legend), not the scrolling
+   <ul>, so it spans the full inner width and hugs the bottom rounded corners
+   regardless of the list's 8px side padding or the scrollbar gutter. As a
+   <ul>-`::after` it was boxed by the list's content area — inset 9px on the
+   left but ~20px on the right once a classic scrollbar reserved its gutter
+   (lopsided), with its own rounded corners floating inside the card instead of
+   aligning to the card's bottom edge. JS still stamps data-overflow on the
+   <ul>; :has() lifts it to the card (the repo already uses :has() on the legend
+   — e.g. .family-legend-toggle:has(+ .family-legend-entries)). The card is
+   position:fixed (a containing block), so position:absolute anchors the strip
+   to it; absolute keeps it out of flow (no layout shift, as the old
+   margin-top:-28px sticky trick also ensured). The <ul> is the card's bottom
+   element (capped max-height), so the card's bottom edge IS the list's visible
+   bottom — the strip correctly fades the last visible rows. */
+.family-legend:has(.family-legend-entries[data-overflow='true'])::after {
   content: '';
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  /* Pull the strip up over the last rows without consuming layout height. */
-  margin-top: -28px;
-  display: block;
+  position: absolute;
+  /* Full inner width, inside the 1px card border — NOT inset by the list
+     padding or the scrollbar gutter. This symmetry is the whole point of the
+     fix (was 9px left / ~20px right on the old <ul>-::after). */
+  inset-inline: 1px;
+  bottom: 1px;
   height: 28px;
   pointer-events: none;
   background: linear-gradient(
@@ -1563,7 +1574,9 @@ body {
     transparent,
     var(--color-bg-surface)
   );
-  border-radius: 0 0 var(--card-radius) var(--card-radius);
+  /* Match the card's INNER bottom radius (outer 12px − 1px border = 11px) so
+     the strip's corners align with the card's, not float inside it. */
+  border-radius: 0 0 calc(var(--card-radius) - 1px) calc(var(--card-radius) - 1px);
 }
 /* E3 (#1055): expanded-but-empty muted row. Keeps aria-expanded truthful (the
    header still reports expanded) while telling the user why the card is empty,


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph before["Before — fade on the scrolling ul"]
        cardA[".family-legend (card, 1px border, 12px radius)"]
        ulA[".family-legend-entries (8px padding + scrollbar gutter)"]
        fadeA["::after fade — inset 9px left / ~20px right, own corners floating inside"]
        cardA --> ulA --> fadeA
    end
    subgraph after["After — fade on the card via has()"]
        cardB[".family-legend (position:fixed = containing block)"]
        ulB[".family-legend-entries — data-overflow stamped by JS (unchanged)"]
        fadeB["::after fade — position:absolute, inset-inline:1px, bottom:1px, 11px inner radius"]
        cardB --> ulB
        cardB -. ":has(.entries[data-overflow=true])" .-> fadeB
    end
```

## Summary

- The E3 (#1055) scroll-fade cue was a `::after` on the scrolling `<ul>`, so it was boxed by the list's content area — inset 9px on the left but ~20px on the right once a classic scrollbar reserved its gutter (lopsided), with its own rounded corners floating ~1px above the card's bottom border. The offset double-radius read as a botched inner-shadow notch and the side gutters/corners stayed un-faded. Measured live: card 258px wide, fade only 228.7px.
- Moved the fade to the **card** (`.family-legend::after`) and toggled it with the same `data-overflow` flag lifted via `:has()`. Absolutely positioned `inset-inline: 1px` / `bottom: 1px` with an 11px inner radius, so it spans the full inner width and hugs the bottom rounded corners regardless of the scrollbar. Out-of-flow, so no layout shift (preserving the old `margin-top:-28px` no-shift property).
- JS overflow measurement in `FamilyLegend.tsx` is **unchanged** — `data-overflow` still stamps on the `<ul>`; the four no-fade edge cases (not overflowing, scrolled-to-bottom, expanded-empty, force-collapsed) all remain correct because the selector only matches a present `.family-legend-entries[data-overflow='true']`.

## Screenshots

**Live verification (W.3 — orchestrator, head `411c975`).** Diagnosed and fixed live on the running app at `?state=US-CA` (legend overflows at every viewport here).

**Geometry — before → after (measured live):**
| | Before (`<ul>::after`) | After (`.family-legend::after`) |
|---|---|---|
| Fade width vs card (258px) | **228.7px** | **253.7px** (≈ full inner width) |
| Left inset from card edge | 9px | **~2px** |
| Right inset from card edge | **~20px** (scrollbar gutter) | **~2px** |
| Symmetric? | ❌ lopsided | ✅ symmetric |
| Corners | own radius floating inside | inner-radius 11px, hugs the card's rounded bottom |

**Behaviour verified live:**
- The fade now **spans the full inner width and hugs the bottom corners** — no more lopsided floating strip / inner-shadow notch.
- **Theme-aware:** fades to `var(--color-bg-surface)` — confirmed in dark mode it fades to the *dark* surface (no white glow), not a hardcoded white.
- **Edge cases all correct:** scrolled-to-bottom → `data-overflow="false"` → `:has()` no longer matches → fade `content: none` (verified by toggling scroll live); not-overflowing / expanded-empty / force-collapsed → no fade.
- **Console 0 errors / 0 warnings** at every light viewport; dark shows only the known `circle-11`/`wood-pattern` #947 dark-basemap noise.

**Static pass:** 10 captures (5 viewports × 2 themes), legend expanded + overflowing (the fade is visible at the bottom of each). Four-corner chrome unchanged — this PR only moves one pseudo-element.

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="lf-390-light" src="https://github.com/user-attachments/assets/7e9a54c7-5910-4152-9a9e-1de4fb1d1e22" /> | <img width="360" alt="lf-390-dark" src="https://github.com/user-attachments/assets/2eb77f96-a225-4269-bbc4-cf8d455a81dc" /> |
| **768×1024 (tablet)** | <img width="360" alt="lf-768-light" src="https://github.com/user-attachments/assets/fec69605-eadd-4c4b-aa5b-3a8db011dad5" /> | <img width="360" alt="lf-768-dark" src="https://github.com/user-attachments/assets/e9d66e74-f83a-483d-b75a-8f13c0d695a5" /> |
| **1024×768 (laptop)** | <img width="360" alt="lf-1024-light" src="https://github.com/user-attachments/assets/e19cd182-39c2-4ed1-9429-a27ae48db6f8" /> | <img width="360" alt="lf-1024-dark" src="https://github.com/user-attachments/assets/3c3e5f9d-028e-45c6-ae94-44335c6ae213" /> |
| **1440×900 (desktop)** | <img width="360" alt="lf-1440-light" src="https://github.com/user-attachments/assets/746223e2-3b0d-4d79-93cf-fb44ccc56c5e" /> | <img width="360" alt="lf-1440-dark" src="https://github.com/user-attachments/assets/087dd68e-9ea4-4a0c-8766-9f72294b932e" /> |
| **1920×1080 (wide)** | <img width="360" alt="lf-1920-light" src="https://github.com/user-attachments/assets/5691d491-88cb-47f3-8014-622d561844a4" /> | <img width="360" alt="lf-1920-dark" src="https://github.com/user-attachments/assets/c75a195c-5d88-4470-aced-ec85ee42a094" /> |

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`)
      — N/A — no className added/renamed (CSS selector + e2e only).
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs — 10 captured (5 viewports × 2 themes), embedded above.

## Test plan

- [x] `npm run lint` — green (exit 0)
- [x] `npm run build --workspace @bird-watch/frontend` — clean `tsc -b` + vite build
- [x] `npx vitest run FamilyLegend` — 45/45 green (JS untouched)
- [x] `npx playwright test legend-usability-e3 --list` — enumerates 8 tests cleanly
- [x] `npx knip` — clean (exit 0)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] E2E assertion strengthened to pin the geometry fix: reads `.family-legend::after` height and asserts the fade width ≈ inner card width (`cardWidth − 2`, within 3px), not the old narrow inset width.
- [x] (UI only) Playwright MCP smoke — done; geometry re-measured live (253.7px full-width symmetric, was 228.7px/9px/20px), edge cases + dark-surface fade verified.

## Design QA

**ui-design:ui-designer (opus) — OVERALL PASS** (head `411c975`). All 5 viewports × 2 themes PASS. The fade now spans the full inner card width and meets both rounded bottom corners symmetrically — the lopsided-inset / floating-rounded-rectangle notch is gone; dark mode fades to the dark surface (no white glow); the rest of the legend + four-corner chrome unchanged.

## Plan reference

Out of plan — geometry bugfix for the E3 (#1055) overflow fade cue diagnosed live on `main`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

