### PR TITLE
feat(eleatic): scaffold packages/eleatic + generic schema + write store

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -256,6 +256,7 @@ const config: KnipConfig = {
     'packages/geo': {},
     'packages/shared-types': {},
     'packages/photo-quality': {},
+    'packages/eleatic': {},
 
     'tools/photo-curation': {
       // 2026-06-10: Part B (#971) wired the four Part A self-healing entries —

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,6 +667,10 @@
       "resolved": "packages/db-client",
       "link": true
     },
+    "node_modules/@bird-watch/eleatic": {
+      "resolved": "packages/eleatic",
+      "link": true
+    },
     "node_modules/@bird-watch/frontend": {
       "resolved": "frontend",
       "link": true
@@ -9963,6 +9967,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "packages/eleatic": {
+      "name": "@bird-watch/eleatic",
+      "version": "0.0.1",
+      "dependencies": {
+        "better-sqlite3": "^11.8.1"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.12",
+        "@types/node": "^24.13.2",
+        "vitest": "^4.1.8"
       }
     },
     "packages/geo": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "test": "npm run test --workspaces --if-present",
-    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/photo-quality && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api && npm run build -w @bird-watch/frontend",
+    "build": "npm run build -w @bird-watch/shared-types && npm run build -w @bird-watch/db-client && npm run build -w @bird-watch/photo-quality && npm run build -w @bird-watch/eleatic && npm run build -w @bird-watch/ingestor && npm run build -w @bird-watch/read-api && npm run build -w @bird-watch/frontend",
     "lint": "npm run lint --workspaces --if-present",
     "db:up": "docker compose up -d db",
     "db:down": "docker compose down",

--- a/packages/eleatic/package.json
+++ b/packages/eleatic/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@bird-watch/eleatic",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc && node -e \"require('fs').cpSync('ui','dist/ui',{recursive:true})\"",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.8.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^24.13.2",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/eleatic/src/build-output.test.ts
+++ b/packages/eleatic/src/build-output.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Build-output contract: `tsc` compiles src/ -> dist/ but does NOT copy ui/
+ * (it only emits from rootDir). The package `build` script therefore appends a
+ * portable `cpSync('ui','dist/ui',...)` so `eleatic serve` (E4) can serve static
+ * assets from the published package. This test asserts that copy ran.
+ *
+ * It is deliberately gated on dist/ presence: dist/ is gitignored and does not
+ * exist on a fresh checkout, so the CI `test` job (which runs before `build`)
+ * would otherwise flake. When dist/ exists (post-build, locally or in the build
+ * job), the copied marker MUST be there — proving tsc-alone did not silence the
+ * copy step. When dist/ is absent the test documents the contract and no-ops.
+ */
+
+const DIST = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+
+describe('build output', () => {
+  it('copies ui/ -> dist/ui/ during build (tsc alone would not)', () => {
+    if (!existsSync(DIST)) {
+      // Pre-build (e.g. the CI `test` job): nothing to assert yet.
+      return;
+    }
+    // ui/ currently holds only .gitkeep (real assets land in E5/E6). Either the
+    // placeholder or a future index.html proves the copy step ran.
+    const copied =
+      existsSync(join(DIST, 'ui', '.gitkeep')) || existsSync(join(DIST, 'ui', 'index.html'));
+    expect(copied).toBe(true);
+  });
+});

--- a/packages/eleatic/src/index.ts
+++ b/packages/eleatic/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public barrel for @bird-watch/eleatic.
+ *
+ * E1 (this PR) ships the write path: the store factory + class and the record
+ * types. The read/analysis/server surfaces land in later epic children and get
+ * exported here when they do — markers reserved below so the export order stays
+ * stable and a sibling implementer knows exactly where their symbol goes. Do
+ * NOT stub the unland ones; the marker is the contract.
+ */
+
+// --- Write store (E1) ---
+export { openStore, EleaticStore } from './store.js';
+export type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
+
+// --- Read query API (E2) ---
+// export { makeReader, type EleaticReader } from './reader.js';
+
+// --- Analysis module (E3) ---
+// export { ... } from './analysis.js';
+
+// --- Server factory (E4) ---
+// export { createApp } from './app.js';

--- a/packages/eleatic/src/no-coupling.test.ts
+++ b/packages/eleatic/src/no-coupling.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Zero-coupling guard: eleatic must contain NO `@bird-watch/*` import and no
+ * `../../`-escaping relative import anywhere under {src,ui}. That one-way
+ * boundary (tools/photo-curation -> eleatic, never the reverse, and no monorepo
+ * imports) is what lets the package `git mv` cleanly to its own repo later.
+ *
+ * Minimal by design — E9 owns the full CI step + abstraction-readiness checklist.
+ * The single `extends "../../tsconfig.base.json"` line is the only sanctioned
+ * file-system coupling and lives in tsconfig.json (a JSON config, not scanned
+ * here); E9 tracks inlining it on extraction.
+ */
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCAN_DIRS = ['src', 'ui'];
+const SCAN_EXT = /\.(ts|js|html)$/;
+
+function collectFiles(dir: string): string[] {
+  const out: string[] = [];
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out; // dir may not exist yet (ui/ holds only .gitkeep today)
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectFiles(full));
+    } else if (SCAN_EXT.test(name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// import / require / export-from lines that name a module specifier.
+const BIRD_WATCH = /(?:import|export|require)\b[^;\n]*['"]@bird-watch\/[^'"]+['"]/;
+const ESCAPING_RELATIVE = /(?:import|export|require)\b[^;\n]*['"]\.\.\/\.\.\/[^'"]*['"]/;
+
+describe('zero-coupling guard', () => {
+  const files = SCAN_DIRS.flatMap((d) => collectFiles(join(PKG_ROOT, d)));
+
+  it('scans at least the source files (sanity: the scan is not silently empty)', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no source file imports a @bird-watch/* package', () => {
+    const offenders = files.filter((f) => BIRD_WATCH.test(readFileSync(f, 'utf8')));
+    expect(offenders).toEqual([]);
+  });
+
+  it('no source file uses a ../../-escaping relative import', () => {
+    const offenders = files.filter((f) => ESCAPING_RELATIVE.test(readFileSync(f, 'utf8')));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/eleatic/src/schema.test.ts
+++ b/packages/eleatic/src/schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrate } from './schema.js';
+
+describe('schema', () => {
+  let db: Database.Database | undefined;
+
+  afterEach(() => {
+    db?.close();
+    db = undefined;
+  });
+
+  it('creates the three generic tables and three indexes on a fresh :memory: db', () => {
+    db = new Database(':memory:');
+    migrate(db);
+
+    const names = (
+      db.prepare(`SELECT name FROM sqlite_master WHERE type IN ('table','index') ORDER BY name`).all() as {
+        name: string;
+      }[]
+    ).map((r) => r.name);
+
+    expect(names).toContain('eval_run');
+    expect(names).toContain('eval_row');
+    expect(names).toContain('eval_adjudication');
+    expect(names).toContain('idx_eval_row_run');
+    expect(names).toContain('idx_eval_row_key');
+    expect(names).toContain('idx_eval_run_started');
+  });
+
+  it('turns foreign keys ON (the pragma that load-bears the FK cascade + rollback)', () => {
+    db = new Database(':memory:');
+    migrate(db);
+    // PRAGMA foreign_keys persists per-connection; WAL is a no-op on :memory:.
+    const fk = db.pragma('foreign_keys', { simple: true });
+    expect(fk).toBe(1);
+  });
+
+  it('migrate is idempotent (CREATE ... IF NOT EXISTS) — re-running does not throw', () => {
+    db = new Database(':memory:');
+    migrate(db);
+    expect(() => migrate(db!)).not.toThrow();
+  });
+});

--- a/packages/eleatic/src/schema.ts
+++ b/packages/eleatic/src/schema.ts
@@ -1,0 +1,67 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * The eleatic store's generic three-table schema.
+ *
+ * Deliberately DOMAIN-AGNOSTIC: no photo-judge columns, no fixed
+ * agreement/falseKeep metrics. Every domain concept lives inside the `*_json`
+ * blob columns. A consumer's "agreement >= 0.90" gate is a policy applied over a
+ * named entry in `metrics_json`, not a schema column — which is what lets the
+ * package later `git mv` to its own repo and serve any eval domain.
+ *
+ *   eval_run          — one row per eval run; `metrics_json` holds arbitrary
+ *                       {name:number} aggregates.
+ *   eval_row          — one row per item per run, keyed (run_id, row_key).
+ *                       `output_json`/`expected_json` are OPAQUE — pretty-printed
+ *                       in drill-down, never destructured by the store.
+ *   eval_adjudication — a human verdict keyed on the ITEM (row_key), independent
+ *                       of any run; upsert (no audit history).
+ */
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS eval_run (
+  id           TEXT PRIMARY KEY,
+  label        TEXT,
+  baseline     TEXT,
+  config_json  TEXT,
+  started_at   TEXT,
+  row_count    INTEGER,
+  metrics_json TEXT
+);
+CREATE TABLE IF NOT EXISTS eval_row (
+  run_id        TEXT NOT NULL REFERENCES eval_run(id) ON DELETE CASCADE,
+  row_key       TEXT NOT NULL,
+  label         TEXT,
+  image_url     TEXT,
+  content_hash  TEXT,
+  output_json   TEXT,
+  expected_json TEXT,
+  scores_json   TEXT,
+  metadata_json TEXT,
+  PRIMARY KEY (run_id, row_key)
+);
+CREATE TABLE IF NOT EXISTS eval_adjudication (
+  row_key      TEXT PRIMARY KEY,
+  verdict      TEXT,
+  against_hash TEXT,
+  note         TEXT,
+  decided_at   TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_eval_row_run     ON eval_row(run_id);
+CREATE INDEX IF NOT EXISTS idx_eval_row_key     ON eval_row(row_key);
+CREATE INDEX IF NOT EXISTS idx_eval_run_started ON eval_run(started_at DESC);
+`;
+
+/**
+ * Apply the schema and connection pragmas to an open database.
+ *
+ * `foreign_keys = ON` is load-bearing: it is what makes the eval_run -> eval_row
+ * ON DELETE CASCADE fire and what turns an orphan-run_id insert into a throwing
+ * FK violation (the store's bulk-insert rollback guard relies on that). WAL is
+ * enabled for the on-disk case so a reader can read while the runner writes; it
+ * is a no-op on `:memory:`. Idempotent via CREATE ... IF NOT EXISTS.
+ */
+export function migrate(db: Database.Database): void {
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(SCHEMA);
+}

--- a/packages/eleatic/src/serde.test.ts
+++ b/packages/eleatic/src/serde.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { toJsonOrNull, toTextOrNull, parseJson, nullableNumber } from './serde.js';
+
+// The JSON <-> column boundary helpers. better-sqlite3 rejects `undefined` as a
+// bind value, so every optional field must collapse to SQL NULL on the way in
+// and re-inflate to `undefined` (NOT `null`) on the way out — that round-trip is
+// what lets the record types satisfy `exactOptionalPropertyTypes`.
+describe('serde', () => {
+  it('toJsonOrNull maps undefined to null and serializes objects', () => {
+    expect(toJsonOrNull(undefined)).toBe(null);
+    expect(toJsonOrNull({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it('toJsonOrNull serializes a null value distinctly from an omitted one', () => {
+    // An explicit null is a real value: it serializes to the string "null".
+    // An omitted (undefined) field collapses to a SQL NULL (the JS null sentinel).
+    expect(toJsonOrNull(null)).toBe('null');
+    expect(toJsonOrNull(undefined)).toBe(null);
+  });
+
+  it('toTextOrNull maps undefined to null and passes strings through', () => {
+    expect(toTextOrNull(undefined)).toBe(null);
+    expect(toTextOrNull('hi')).toBe('hi');
+  });
+
+  it('parseJson maps null to undefined and parses JSON text', () => {
+    expect(parseJson(null)).toBe(undefined);
+    expect(parseJson<{ a: number }>('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('nullableNumber maps a DB null to undefined and passes numbers through', () => {
+    expect(nullableNumber(null)).toBe(undefined);
+    expect(nullableNumber(0)).toBe(0);
+    expect(nullableNumber(344)).toBe(344);
+  });
+});

--- a/packages/eleatic/src/serde.ts
+++ b/packages/eleatic/src/serde.ts
@@ -1,0 +1,34 @@
+/**
+ * JSON <-> SQLite-column boundary helpers.
+ *
+ * better-sqlite3 rejects a bound value of `undefined` (it only accepts
+ * number/string/bigint/Buffer/null). Under `exactOptionalPropertyTypes` an
+ * omitted optional record field is genuinely absent, so the store layer reads
+ * `record.field` as `undefined` — these helpers coerce that to SQL NULL on the
+ * way in and re-inflate NULL to `undefined` (never `null`) on the way out, so a
+ * round-tripped record matches the optional-field shape it was written with.
+ *
+ * An EXPLICIT `null` is preserved as a real value (it JSON-serializes to the
+ * string "null"); only `undefined` collapses to a column NULL. That keeps an
+ * omitted blob distinct from an empty `{}` and from an explicit null.
+ */
+
+/** Serialize a value to JSON text, or NULL when the value is omitted (`undefined`). */
+export function toJsonOrNull(v: unknown): string | null {
+  return v === undefined ? null : JSON.stringify(v);
+}
+
+/** Pass a string through, mapping an omitted (`undefined`) value to NULL. */
+export function toTextOrNull(v: string | undefined): string | null {
+  return v ?? null;
+}
+
+/** Parse JSON text back to `T`, mapping a column NULL to `undefined`. */
+export function parseJson<T>(text: string | null): T | undefined {
+  return text === null ? undefined : (JSON.parse(text) as T);
+}
+
+/** Re-inflate a nullable INTEGER column to `number | undefined` (NULL -> undefined). */
+export function nullableNumber(v: number | null): number | undefined {
+  return v === null ? undefined : v;
+}

--- a/packages/eleatic/src/store.test.ts
+++ b/packages/eleatic/src/store.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { openStore, type EleaticStore } from './store.js';
+import type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
+
+// Raw-column row shapes — asserting against the actual stored TEXT/NULL values,
+// not the re-inflated record API, is what proves the serde boundary works.
+interface RawRunRow {
+  id: string;
+  label: string;
+  baseline: string | null;
+  config_json: string | null;
+  started_at: string;
+  row_count: number | null;
+  metrics_json: string | null;
+}
+interface RawEvalRow {
+  run_id: string;
+  row_key: string;
+  label: string | null;
+  image_url: string | null;
+  content_hash: string | null;
+  output_json: string | null;
+  expected_json: string | null;
+  scores_json: string | null;
+  metadata_json: string | null;
+}
+interface RawAdjRow {
+  row_key: string;
+  verdict: string;
+  against_hash: string | null;
+  note: string | null;
+  decided_at: string;
+}
+
+function makeRun(over: Partial<EvalRunRecord> = {}): EvalRunRecord {
+  return { id: 'run-1', label: 'baseline', startedAt: '2026-06-13T00:00:00Z', ...over };
+}
+function makeRow(over: Partial<EvalRowRecord> = {}): EvalRowRecord {
+  return {
+    runId: 'run-1',
+    rowKey: 'item-1',
+    output: { verdict: 'keep' },
+    expected: { verdict: 'keep' },
+    ...over,
+  };
+}
+
+describe('EleaticStore', () => {
+  let store: EleaticStore;
+
+  beforeEach(() => {
+    store = openStore(':memory:');
+  });
+  afterEach(() => {
+    store.close();
+  });
+
+  it('recordRun round-trips JSON config/metrics and stores omitted optionals as SQL NULL', () => {
+    store.recordRun(
+      makeRun({ config: { mode: 'fast' }, metrics: { agreement: 0.91 }, baseline: 'prev' }),
+    );
+    const raw = store.db.prepare('SELECT * FROM eval_run WHERE id=?').get('run-1') as RawRunRow;
+    expect(JSON.parse(raw.config_json!)).toEqual({ mode: 'fast' });
+    expect(JSON.parse(raw.metrics_json!)).toEqual({ agreement: 0.91 });
+    expect(raw.baseline).toBe('prev');
+
+    store.recordRun(makeRun({ id: 'run-2' }));
+    const bare = store.db.prepare('SELECT * FROM eval_run WHERE id=?').get('run-2') as RawRunRow;
+    // Omitted optionals must be SQL NULL — not the string "undefined" and not "null".
+    expect(bare.baseline).toBe(null);
+    expect(bare.config_json).toBe(null);
+    expect(bare.metrics_json).toBe(null);
+    expect(bare.row_count).toBe(null);
+  });
+
+  it('recordRow round-trips opaque output/expected blobs losslessly without destructuring', () => {
+    store.recordRun(makeRun());
+    const opaqueOutput = { nested: { a: [1, 2, 3] }, n: 0.5, b: true };
+    const opaqueExpected = ['anything', { goes: 'here' }];
+    store.recordRow(makeRow({ output: opaqueOutput, expected: opaqueExpected }));
+    const raw = store.db
+      .prepare('SELECT * FROM eval_row WHERE run_id=? AND row_key=?')
+      .get('run-1', 'item-1') as RawEvalRow;
+    expect(JSON.parse(raw.output_json!)).toEqual(opaqueOutput);
+    expect(JSON.parse(raw.expected_json!)).toEqual(opaqueExpected);
+  });
+
+  it('recordRows bulk-inserts ~344 rows inside one transaction', () => {
+    store.recordRun(makeRun());
+    const rows = Array.from({ length: 344 }, (_, i) =>
+      makeRow({ rowKey: `item-${i}`, scores: { quality: i / 344 } }),
+    );
+    store.recordRows(rows);
+    const count = (
+      store.db.prepare('SELECT COUNT(*) AS c FROM eval_row WHERE run_id=?').get('run-1') as {
+        c: number;
+      }
+    ).c;
+    expect(count).toBe(344);
+  });
+
+  it('recordRows rolls ALL rows back when one mid-array row violates the FK (orphan run_id)', () => {
+    store.recordRun(makeRun());
+    const rows = [
+      makeRow({ rowKey: 'ok-1' }),
+      makeRow({ rowKey: 'ok-2' }),
+      // Orphan run_id -> FK violation mid-array (also a foreign_keys=ON guard).
+      makeRow({ runId: 'no-such-run', rowKey: 'orphan' }),
+      makeRow({ rowKey: 'ok-3' }),
+    ];
+    expect(() => store.recordRows(rows)).toThrow();
+    // The transaction wrapper must roll the whole batch back — zero rows landed.
+    const count = (store.db.prepare('SELECT COUNT(*) AS c FROM eval_row').get() as { c: number }).c;
+    expect(count).toBe(0);
+  });
+
+  it('cascades deletes from eval_run to eval_row (foreign_keys=ON regression guard)', () => {
+    store.recordRun(makeRun());
+    store.recordRows([makeRow({ rowKey: 'a' }), makeRow({ rowKey: 'b' })]);
+    store.db.prepare('DELETE FROM eval_run WHERE id=?').run('run-1');
+    const count = (store.db.prepare('SELECT COUNT(*) AS c FROM eval_row').get() as { c: number }).c;
+    expect(count).toBe(0);
+  });
+
+  it('maps omitted imageUrl/contentHash/metadata to SQL NULL on write', () => {
+    store.recordRun(makeRun());
+    store.recordRow(makeRow()); // no imageUrl, contentHash, scores, metadata, label
+    const raw = store.db
+      .prepare('SELECT * FROM eval_row WHERE run_id=? AND row_key=?')
+      .get('run-1', 'item-1') as RawEvalRow;
+    expect(raw.image_url).toBe(null);
+    expect(raw.content_hash).toBe(null);
+    expect(raw.metadata_json).toBe(null);
+    expect(raw.scores_json).toBe(null);
+    expect(raw.label).toBe(null);
+  });
+
+  it('recordAdjudication upserts on row_key (latest verdict/note/decided_at wins, one row)', () => {
+    const first: EvalAdjudicationRecord = {
+      rowKey: 'item-1',
+      verdict: 'keep',
+      note: 'looks fine',
+      decidedAt: '2026-06-13T00:00:00Z',
+    };
+    const second: EvalAdjudicationRecord = {
+      rowKey: 'item-1',
+      verdict: 'replace',
+      note: 'on review, swap it',
+      decidedAt: '2026-06-13T01:00:00Z',
+      againstHash: 'abc123',
+    };
+    store.recordAdjudication(first);
+    store.recordAdjudication(second);
+    const all = store.db.prepare('SELECT * FROM eval_adjudication').all() as RawAdjRow[];
+    expect(all).toHaveLength(1);
+    expect(all[0]!.verdict).toBe('replace');
+    expect(all[0]!.note).toBe('on review, swap it');
+    expect(all[0]!.decided_at).toBe('2026-06-13T01:00:00Z');
+    expect(all[0]!.against_hash).toBe('abc123');
+  });
+
+  it('recordAdjudication stores an omitted againstHash/note as SQL NULL', () => {
+    store.recordAdjudication({ rowKey: 'item-2', verdict: 'keep', decidedAt: '2026-06-13T00:00:00Z' });
+    const raw = store.db
+      .prepare('SELECT * FROM eval_adjudication WHERE row_key=?')
+      .get('item-2') as RawAdjRow;
+    expect(raw.against_hash).toBe(null);
+    expect(raw.note).toBe(null);
+  });
+
+  it('finalizeRun updates row_count/metrics_json on the existing run without touching rows', () => {
+    store.recordRun(makeRun());
+    store.recordRows([makeRow({ rowKey: 'a' }), makeRow({ rowKey: 'b' })]);
+    store.finalizeRun('run-1', { rowCount: 2, metrics: { agreement: 0.95 } });
+    const raw = store.db.prepare('SELECT * FROM eval_run WHERE id=?').get('run-1') as RawRunRow;
+    expect(raw.row_count).toBe(2);
+    expect(JSON.parse(raw.metrics_json!)).toEqual({ agreement: 0.95 });
+    // Rows untouched.
+    const count = (store.db.prepare('SELECT COUNT(*) AS c FROM eval_row').get() as { c: number }).c;
+    expect(count).toBe(2);
+  });
+
+  it('finalizeRun with only metrics leaves row_count NULL', () => {
+    store.recordRun(makeRun());
+    store.finalizeRun('run-1', { metrics: { agreement: 0.8 } });
+    const raw = store.db.prepare('SELECT * FROM eval_run WHERE id=?').get('run-1') as RawRunRow;
+    expect(raw.row_count).toBe(null);
+    expect(JSON.parse(raw.metrics_json!)).toEqual({ agreement: 0.8 });
+  });
+});

--- a/packages/eleatic/src/store.ts
+++ b/packages/eleatic/src/store.ts
@@ -1,0 +1,134 @@
+import Database from 'better-sqlite3';
+import { migrate } from './schema.js';
+import { toJsonOrNull, toTextOrNull } from './serde.js';
+import type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
+
+/**
+ * The eleatic write store: a thin, prepared-statement layer over the generic
+ * three-table SQLite schema. Open with `openStore(path?)` — pass `':memory:'`
+ * in tests (WAL is a no-op there).
+ *
+ * BINDING RULE (load-bearing under exactOptionalPropertyTypes): every method
+ * builds an EXPLICIT all-columns bind object — one key per @param in the SQL,
+ * every nullable value pushed through toJsonOrNull/toTextOrNull first — and
+ * passes THAT to `.run(...)`. We never `.run(record)` directly: an omitted
+ * optional record field is an ABSENT key (not `undefined`) under
+ * exactOptionalPropertyTypes, and better-sqlite3 throws
+ * `RangeError: Missing named parameter "@baseline"` when a @param has no key in
+ * the bound object. Constructing the bind object guarantees every placeholder
+ * resolves to an explicit value-or-NULL.
+ */
+export class EleaticStore {
+  /** The raw better-sqlite3 handle. Read-only escape hatch for E2's reader + tests. */
+  readonly db: Database.Database;
+
+  private readonly insertRunStmt: Database.Statement;
+  private readonly insertRowStmt: Database.Statement;
+  private readonly upsertAdjStmt: Database.Statement;
+  private readonly finalizeRunStmt: Database.Statement;
+  private readonly recordRowsTxn: (rows: EvalRowRecord[]) => void;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.insertRunStmt = db.prepare(
+      `INSERT INTO eval_run
+         (id, label, baseline, config_json, started_at, row_count, metrics_json)
+       VALUES (@id, @label, @baseline, @config_json, @started_at, @row_count, @metrics_json)`,
+    );
+    this.insertRowStmt = db.prepare(
+      `INSERT INTO eval_row
+         (run_id, row_key, label, image_url, content_hash,
+          output_json, expected_json, scores_json, metadata_json)
+       VALUES (@run_id, @row_key, @label, @image_url, @content_hash,
+          @output_json, @expected_json, @scores_json, @metadata_json)`,
+    );
+    this.upsertAdjStmt = db.prepare(
+      `INSERT INTO eval_adjudication
+         (row_key, verdict, against_hash, note, decided_at)
+       VALUES (@row_key, @verdict, @against_hash, @note, @decided_at)
+       ON CONFLICT(row_key) DO UPDATE SET
+         verdict=excluded.verdict,
+         against_hash=excluded.against_hash,
+         note=excluded.note,
+         decided_at=excluded.decided_at`,
+    );
+    this.finalizeRunStmt = db.prepare(
+      `UPDATE eval_run SET row_count=@row_count, metrics_json=@metrics_json WHERE id=@id`,
+    );
+
+    // A single transaction wraps the whole batch so a mid-array throw (e.g. an
+    // orphan run_id FK violation) rolls every row back — all-or-nothing.
+    this.recordRowsTxn = db.transaction((rows: EvalRowRecord[]) => {
+      for (const row of rows) this.recordRow(row);
+    });
+  }
+
+  /** INSERT a run. config/metrics -> JSON-or-NULL; baseline/rowCount nullable. */
+  recordRun(run: EvalRunRecord): void {
+    this.insertRunStmt.run({
+      id: run.id,
+      label: toTextOrNull(run.label),
+      baseline: toTextOrNull(run.baseline),
+      config_json: toJsonOrNull(run.config),
+      started_at: toTextOrNull(run.startedAt),
+      row_count: run.rowCount ?? null,
+      metrics_json: toJsonOrNull(run.metrics),
+    });
+  }
+
+  /** INSERT one evaluated item. output/expected/scores/metadata -> JSON-or-NULL. */
+  recordRow(row: EvalRowRecord): void {
+    this.insertRowStmt.run({
+      run_id: row.runId,
+      row_key: row.rowKey,
+      label: toTextOrNull(row.label),
+      image_url: toTextOrNull(row.imageUrl),
+      content_hash: toTextOrNull(row.contentHash),
+      output_json: toJsonOrNull(row.output),
+      expected_json: toJsonOrNull(row.expected),
+      scores_json: toJsonOrNull(row.scores),
+      metadata_json: toJsonOrNull(row.metadata),
+    });
+  }
+
+  /** Bulk-insert rows in a single transaction (150–1000-row scale); all-or-nothing. */
+  recordRows(rows: EvalRowRecord[]): void {
+    this.recordRowsTxn(rows);
+  }
+
+  /** Upsert a human verdict keyed on the item (row_key); no audit history. */
+  recordAdjudication(adj: EvalAdjudicationRecord): void {
+    this.upsertAdjStmt.run({
+      row_key: adj.rowKey,
+      verdict: toTextOrNull(adj.verdict),
+      against_hash: toTextOrNull(adj.againstHash),
+      note: toTextOrNull(adj.note),
+      decided_at: toTextOrNull(adj.decidedAt),
+    });
+  }
+
+  /** Patch a run's aggregates after all rows land (runner computes them late). */
+  finalizeRun(runId: string, patch: { rowCount?: number; metrics?: Record<string, number> }): void {
+    this.finalizeRunStmt.run({
+      id: runId,
+      row_count: patch.rowCount ?? null,
+      metrics_json: toJsonOrNull(patch.metrics),
+    });
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+/**
+ * Open (or create) an eleatic store at `path`, applying the schema + pragmas.
+ * Defaults to `':memory:'` so a forgotten path can never silently write a stray
+ * on-disk file in a test.
+ */
+export function openStore(path: string = ':memory:'): EleaticStore {
+  const db = new Database(path);
+  migrate(db);
+  return new EleaticStore(db);
+}

--- a/packages/eleatic/src/types.ts
+++ b/packages/eleatic/src/types.ts
@@ -1,0 +1,56 @@
+/**
+ * The public record interfaces for the eleatic write store.
+ *
+ * These are JSON-shaped and satisfy `exactOptionalPropertyTypes`: an omittable
+ * field is declared `field?: T` (NOT `field: T | undefined` on a required key),
+ * so a caller may legitimately leave it absent. The store coerces every absent
+ * optional to a column NULL at the boundary via the `serde` helpers.
+ *
+ * The `*_json` columns are represented here as structured objects / opaque
+ * values; serialization to TEXT happens only at the store boundary.
+ *
+ * Names are canonical and depended on by sibling children (E2 read API, E4
+ * server): EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord.
+ */
+
+/** A single eval run. Maps to the `eval_run` table. */
+export interface EvalRunRecord {
+  id: string;
+  label: string;
+  baseline?: string;
+  /** Arbitrary run configuration -> config_json. */
+  config?: Record<string, unknown>;
+  startedAt: string;
+  /** Often set later by finalizeRun once all rows have landed -> row_count. */
+  rowCount?: number;
+  /** Arbitrary {name:number} aggregates -> metrics_json. */
+  metrics?: Record<string, number>;
+}
+
+/** A single evaluated item within a run. Maps to the `eval_row` table. */
+export interface EvalRowRecord {
+  runId: string;
+  /** Stable cross-run identity; powers diff + adjudication. */
+  rowKey: string;
+  label?: string;
+  imageUrl?: string;
+  contentHash?: string;
+  /** Opaque blob -> output_json; never destructured by the store. */
+  output: unknown;
+  /** Opaque blob -> expected_json; never destructured by the store. */
+  expected: unknown;
+  /** Numeric facet axis -> scores_json. */
+  scores?: Record<string, number>;
+  /** Categorical facet axis -> metadata_json. */
+  metadata?: Record<string, string | number | boolean>;
+}
+
+/** A human verdict on an item, run-independent. Maps to the `eval_adjudication` table. */
+export interface EvalAdjudicationRecord {
+  rowKey: string;
+  verdict: string;
+  /** The content_hash this verdict was decided against; stale flag when eval_row.content_hash differs. */
+  againstHash?: string;
+  note?: string;
+  decidedAt: string;
+}

--- a/packages/eleatic/tsconfig.json
+++ b/packages/eleatic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "src", "outDir": "dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/eleatic/vitest.config.ts
+++ b/packages/eleatic/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph eleatic["@bird-watch/eleatic (this PR — E1)"]
        types["types.ts<br/>EvalRunRecord<br/>EvalRowRecord<br/>EvalAdjudicationRecord"]
        serde["serde.ts<br/>toJsonOrNull / toTextOrNull<br/>parseJson / nullableNumber"]
        schema["schema.ts<br/>migrate(db)<br/>3 tables + 3 indexes<br/>foreign_keys=ON, WAL"]
        store["store.ts<br/>openStore() / EleaticStore<br/>recordRun · recordRow · recordRows<br/>recordAdjudication · finalizeRun · close"]
        index["index.ts barrel<br/>exports store + record types<br/>markers reserved: makeReader (E2)<br/>analysis (E3) · createApp (E4)"]
        types --> store
        serde --> store
        schema --> store
        store --> index
    end
    store -->|explicit all-columns bind object| sqlite[("SQLite<br/>eval_run / eval_row / eval_adjudication")]
    guard["no-coupling.test.ts<br/>asserts zero @bird-watch/* + no ../../ escape"] -.guards.-> eleatic
```

## Summary

- **Why:** `eleatic` is a domain-agnostic eval-results explorer being extracted as a standalone package with a strict one-way dependency (`tools/photo-curation` → `eleatic`, never the reverse) and **zero `@bird-watch/*` imports**, so it can later `git mv` cleanly to its own repo. This is **Wave 1, the serial gate** of the eleatic epic (#1153) — every other child (E2–E9) builds on the package skeleton and write API created here.
- **What lands:** the `packages/eleatic` workspace skeleton, the generic three-table SQLite schema (no domain columns — concepts live in `*_json` blobs), the `serde` JSON⇄column boundary, the `EleaticStore` write API, the public barrel (markers reserved for E2/E3/E4 — not stubbed), plus a committed zero-coupling guard. Root wiring lands in the same PR: ordered `build` script, `knip.ts` workspace entry, regenerated `package-lock.json`.
- **Load-bearing detail:** every store method builds an explicit all-columns bind object via the `serde` helpers and passes that to `.run(...)` — never `.run(record)`. Under `exactOptionalPropertyTypes` an omitted optional is an absent key, and better-sqlite3 throws `RangeError: Missing named parameter` when a `@param` has no bound key. `recordRows`' rollback is exercised via an orphan-`run_id` FK violation, which doubles as the `foreign_keys=ON` guard.

## Screenshots

N/A — packages/ tool (not frontend/**). eleatic's framework-free `ui/` is exempt from the `frontend/**` Playwright contract.

- [ ] Every new/renamed `className` in this PR has a matching CSS rule — N/A — no UI in this PR
- [ ] Multi-viewport design QA: ≥10 `user-attachments` URLs — N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — 5 files / 22 tests green (store round-trips, FK cascade, `recordRows` orphan-FK rollback, exactOptional→NULL mapping, adjudication upsert, `finalizeRun`, serde units, schema, zero-coupling, build-output)
- [x] `npm run build -w @bird-watch/eleatic` — produces `packages/eleatic/dist/ui/.gitkeep`, proving the `ui/`→`dist/ui/` cpSync step runs (tsc alone does not copy `ui/`)
- [x] New unit / integration tests added — yes, full TDD per task (failing→impl→pass→commit)
- [ ] New Playwright e2e spec added — N/A — no user-visible behavior
- [x] `npm run test` — full workspace suite green (88 frontend files / 1529 tests + eleatic 22 + all other workspaces)
- [x] `npm run lint` — green (no workspace defines a `lint` script; eleatic omitting one is consistent)
- [x] `npm run build` — ordered root build clean; eleatic's `dist/ui/` survives the ordered run
- [x] `npx knip` — exit 0; `packages/eleatic` workspace entry recognized, no orphan-ignore findings
- [x] `package-lock.json` regenerated via a real `npm install` (new workspace + `better-sqlite3`/`@types/better-sqlite3` resolved); stable on re-install
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

## Plan reference

Closes #1144. Part of the eleatic epic #1153 (Wave 1 serial gate; dependencies: none). Prerequisite for E2 (read-query API), E3 (analysis), and transitively E4–E9.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)