### PR TITLE
fix(legend): seat the overflow fade flush to the card's inner border edge

### DIFF
--- a/frontend/e2e/legend-usability-e3.spec.ts
+++ b/frontend/e2e/legend-usability-e3.spec.ts
@@ -218,18 +218,38 @@ test.describe('E3 (#1055): overflow cue is visible at rest when the list overflo
       fadeHeight,
       'the overflow ::after fade must have a non-zero height at rest',
     ).toBeGreaterThan(0);
-    // Geometry pin: the fade spans (nearly) the full inner card width — NOT the
-    // old narrow inset width (list padding + classic scrollbar gutter made the
-    // <ul>-::after lopsided: 9px left / ~20px right). In headless Chromium the
-    // scrollbar is overlay/0-width, so inset-inline:1px ≈ cardWidth − 2.
-    const { fadeWidth, cardWidth } = await card.evaluate((el) => ({
-      fadeWidth: parseFloat(getComputedStyle(el, '::after').width),
-      cardWidth: el.getBoundingClientRect().width,
-    }));
+    // Geometry pin: the fade must seat FLUSH against the card's inner border
+    // edge — NOT the old narrow inset width (list padding + classic scrollbar
+    // gutter made the <ul>-::after lopsided: 9px left / ~20px right), and NOT
+    // inset 1px from the padding box (which double-counts the border and leaves
+    // a ~1px hairline gap at the rounded bottom corner). Absolute insets are
+    // measured from the card's padding box (already inside the 1px border), so
+    // inset:0 lands flush on the inner edge: fadeWidth === cardWidth − 2×border.
+    // The ≤1px tolerance is tight enough to FAIL the old inset-inline:1px (which
+    // rendered ~2.3px short of the inner width); ≤3px let that bug pass.
+    const geo = await card.evaluate((el) => {
+      const after = getComputedStyle(el, '::after');
+      const cs = getComputedStyle(el);
+      return {
+        fadeWidth: parseFloat(after.width),
+        left: parseFloat(after.left),
+        right: parseFloat(after.right),
+        cardWidth: el.getBoundingClientRect().width,
+        borderLeft: parseFloat(cs.borderLeftWidth),
+        borderRight: parseFloat(cs.borderRightWidth),
+      };
+    });
+    const innerWidth = geo.cardWidth - geo.borderLeft - geo.borderRight;
+    // (a) the fade spans the FULL inner width — flush, not 1px short:
     expect(
-      Math.abs(fadeWidth - (cardWidth - 2)),
-      `the fade must span the full inner card width (fade ${fadeWidth}px vs inner ${cardWidth - 2}px)`,
-    ).toBeLessThanOrEqual(3);
+      Math.abs(geo.fadeWidth - innerWidth),
+      `the fade must seat flush to the inner border edge (fade ${geo.fadeWidth}px vs inner ${innerWidth}px)`,
+    ).toBeLessThanOrEqual(1);
+    // (b) symmetric — equal left/right insets (no lopsided gutter, no 1px skew):
+    expect(
+      Math.abs(geo.left - geo.right),
+      `the fade insets must be symmetric (left ${geo.left}px vs right ${geo.right}px)`,
+    ).toBeLessThanOrEqual(1);
   });
 
   test('no overflow flag when the list fits', async ({ page, apiStub }) => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1564,9 +1564,14 @@ body {
   position: absolute;
   /* Full inner width, inside the 1px card border — NOT inset by the list
      padding or the scrollbar gutter. This symmetry is the whole point of the
-     fix (was 9px left / ~20px right on the old <ul>-::after). */
-  inset-inline: 1px;
-  bottom: 1px;
+     fix (was 9px left / ~20px right on the old <ul>-::after).
+     inset:0 (not 1px): absolute insets are measured from the card's padding
+     box, which is ALREADY inside the 1px border, so 0 seats the fade flush
+     against the inner border edge; a 1px inset double-counts the border and
+     leaves a ~1px hairline gap at the rounded bottom corner. The 11px inner
+     radius (`--card-radius − 1px`) matches the border's inner corner. */
+  inset-inline: 0;
+  bottom: 0;
   height: 28px;
   pointer-events: none;
   background: linear-gradient(


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    subgraph card["family-legend card (border 1px, no padding)"]
        border["1px border ring"]
        subgraph pad["padding box == inner edge (absolute-inset origin)"]
            old["OLD inset 1px: fade boxed 1px IN from padding box → ~2.3px short<br/>(double-counts the border → ~1px hairline gap at rounded corner)"]
            new["NEW inset 0: fade fills the padding box → flush to inner border edge<br/>(11px inner radius == card-radius minus 1px matches the corner)"]
        end
    end
    old -. "fixed by inset 1px → 0" .-> new
```

## Summary

- PR #1142 placed the overflow fade as a card-level `::after` with `inset-inline: 1px; bottom: 1px`. **Why that's wrong:** absolute-positioned insets resolve from the containing block's *padding box*, and `.family-legend` is `border: 1px` with no padding — so its padding box is already inside the border. The `1px` inset therefore double-counts the border, seating the fade ~1px inside the inner border edge and leaving a visible ~1px hairline gap at the rounded bottom corner (measured live: fade 253.7px vs the 256px padding box).
- **Fix:** `inset-inline: 0; bottom: 0` seats the fade flush against the inner border edge (where `inset: 0` lands). Height, gradient, `pointer-events: none`, and the 11px inner radius (`--card-radius − 1px`, which already matches the border's inner corner) are unchanged.
- **Test gap closed:** the e2e asserted fade width within **3px** of `cardWidth − 2`, so the buggy 253.7px passed. Tightened to pin the *flush* geometry: fade width == inner width (`cardWidth − 2×border`) within **1px**, plus a left/right symmetry assertion (≤1px). The new bound fails on the old `inset: 1px` and passes on `inset: 0`.

## Screenshots

**Live verification (W.3 — orchestrator, head `17cb926`).** Diagnosed + re-verified live at `?state=US-CA` (legend overflows).

**The 1px corner — 6× zoomed bottom-left (the proof):**

<img width="420" alt="corner-1155" src="https://github.com/user-attachments/assets/8ccc673a-85b8-4cb8-a707-40e0730434a3" />

**Geometry — before (#1142) → after (this PR), measured live:**
| | Before (`inset: 1px`) | After (`inset: 0`) |
|---|---|---|
| Fade `left` / `right` / `bottom` | `1px` | **`0px`** |
| Fade width vs inner card (256px) | 253.7px (−2.3px) | **255.7px** (flush, ≤1px) |
| Flush to inner border edge? | ❌ ~1px gap | ✅ flush |

The fade now seats flush against the card's inner border edge; the ~1px hairline at the rounded bottom corner is gone (zoomed proof above). The 11px inner radius (`--card-radius − 1px`) already matched the border's inner corner — only the inset was wrong.

**Edge cases / theme:** dark still fades to the dark surface; the 4 no-fade states unchanged (this PR only moves the fade 1px outward). **Console 0 errors / 0 warnings** at every light viewport (dark = known `circle-11`/`wood-pattern` #947 noise only).

**Static pass:** 10 canonical captures (5 viewports × 2 themes), legend expanded + overflowing.

| Viewport | Light | Dark |
|---|---|---|
| **390×844 (mobile)** | <img width="360" alt="fc-390-light" src="https://github.com/user-attachments/assets/fd3a871a-a469-44a2-857d-dd55e3df9481" /> | <img width="360" alt="fc-390-dark" src="https://github.com/user-attachments/assets/aa21279f-e741-48d2-8a48-916eb67fe876" /> |
| **768×1024 (tablet)** | <img width="360" alt="fc-768-light" src="https://github.com/user-attachments/assets/ae903fcb-17f9-4e36-9aca-461f170dd8c1" /> | <img width="360" alt="fc-768-dark" src="https://github.com/user-attachments/assets/54cfb66e-3a88-4010-ba96-6474c065c29d" /> |
| **1024×768 (laptop)** | <img width="360" alt="fc-1024-light" src="https://github.com/user-attachments/assets/6ff178a2-5f2b-4ec7-aede-9902f3f3c423" /> | <img width="360" alt="fc-1024-dark" src="https://github.com/user-attachments/assets/0c59e83a-a7d1-466e-81ce-9621676e02e1" /> |
| **1440×900 (desktop)** | <img width="360" alt="fc-1440-light" src="https://github.com/user-attachments/assets/b4904e48-9d77-4a4d-a72c-9a2ca0e052c6" /> | <img width="360" alt="fc-1440-dark" src="https://github.com/user-attachments/assets/1d4ad3db-ebef-42b1-aeed-24f32fba4b9c" /> |
| **1920×1080 (wide)** | <img width="360" alt="fc-1920-light" src="https://github.com/user-attachments/assets/dbae83fe-97e1-4dd2-867f-feedc2fd651f" /> | <img width="360" alt="fc-1920-dark" src="https://github.com/user-attachments/assets/d05bc130-dcca-4652-8b75-3d0c40d93010" /> |

## Test plan

- [x] `npm run lint` (root) — exit 0
- [x] `npm run build --workspace @bird-watch/frontend` (tsc -b + vite) — clean
- [x] `npx vitest run FamilyLegend` — 45 passed
- [x] `npx playwright test legend-usability-e3 --list` — 8 tests enumerate cleanly
- [x] `npx knip` — clean (one unrelated prototype config hint, non-failing)
- [x] `bash scripts/check-orphan-classnames.sh` — PASS
- [x] (UI) Playwright MCP multi-viewport smoke + console check — done; flush geometry re-measured (inset 0, width 255.7px ≈ inner 256px), 6× corner proof above, console clean

**Design QA — ui-design:ui-designer (opus) OVERALL PASS** (head `17cb926`). Corner proof: clean single rounded corner (the ~1px hairline gap is gone, no doubled edge). All 5 viewports × 2 themes PASS; only delta is the corner closing flush; dark fades to the dark surface; four-corner chrome unchanged.

## Plan reference

Out of plan — follow-up to PR #1142 (1px geometry bug on the family-legend overflow fade, spotted on review).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

