### PR TITLE
feat(eleatic): generic analysis module (ported pure diagnostics)

### DIFF
--- a/packages/eleatic/src/analysis.test.ts
+++ b/packages/eleatic/src/analysis.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from 'vitest';
+import {
+  labelAgreement,
+  confusionCounts,
+  scoreMAE,
+  auc,
+  calibratedThreshold,
+  ambiguityBand,
+  hybridRouting,
+  analyze,
+  projectForAnalysis,
+  aggregateScores,
+  type AnalysisRow,
+} from './analysis.js';
+
+/**
+ * A hand-built fixture set with KNOWN answers, ported verbatim (with the
+ * keep→label / falseKeep→falsePositive / falseReplace→falseNegative renames)
+ * from tools/photo-curation/scripts/analyze-experiment.test.ts. The pure
+ * dataset-level helpers (AUC, calibrated-threshold sweep, ambiguity band,
+ * hybrid routing) are verified against these by-hand calculations — no SQLite,
+ * no store, no network.
+ *
+ * Convention per row: `[outputLabel, outputScore, expectedLabel, expectedScore]`.
+ * outputScore is the candidate's numeric score (the ranking signal);
+ * expectedScore is the baseline's numeric score (the band axis).
+ */
+function row(outputLabel: boolean, outputScore: number, expectedLabel: boolean, expectedScore: number): AnalysisRow {
+  return { outputLabel, outputScore, expectedLabel, expectedScore };
+}
+
+describe('labelAgreement', () => {
+  it('is the fraction of rows where outputLabel === expectedLabel', () => {
+    const rows = [
+      row(true, 80, true, 85),   // agree
+      row(false, 20, false, 15), // agree
+      row(true, 60, false, 40),  // disagree (falsePositive)
+      row(false, 30, true, 70),  // disagree (falseNegative)
+    ];
+    expect(labelAgreement(rows)).toBeCloseTo(0.5);
+  });
+
+  it('is 1 for a perfectly-agreeing set and 0 for a fully-disagreeing set', () => {
+    expect(labelAgreement([row(true, 80, true, 80), row(false, 10, false, 10)])).toBe(1);
+    expect(labelAgreement([row(true, 80, false, 10), row(false, 10, true, 80)])).toBe(0);
+  });
+
+  it('is 0 for an empty set', () => {
+    expect(labelAgreement([])).toBe(0);
+  });
+});
+
+describe('confusionCounts', () => {
+  it('counts falsePositive (output true, expected false) and falseNegative', () => {
+    const rows = [
+      row(true, 80, true, 85),
+      row(true, 60, false, 40),  // falsePositive
+      row(true, 55, false, 30),  // falsePositive
+      row(false, 30, true, 70),  // falseNegative
+    ];
+    expect(confusionCounts(rows)).toEqual({ falsePositive: 2, falseNegative: 1 });
+  });
+});
+
+describe('scoreMAE', () => {
+  it('is the mean absolute difference of the scores', () => {
+    const rows = [
+      row(true, 80, true, 70),   // |80-70| = 10
+      row(false, 20, false, 50), // |20-50| = 30
+    ];
+    // mean(10, 30) = 20
+    expect(scoreMAE(rows)).toBeCloseTo(20);
+  });
+
+  it('is 0 for an empty set', () => {
+    expect(scoreMAE([])).toBe(0);
+  });
+});
+
+describe('auc', () => {
+  // AUC = P(a random label-positive outranks a random label-negative) by the
+  // output score. Use expectedLabel as the positive label, outputScore as rank.
+  it('is 1.0 when the output score perfectly separates the label classes', () => {
+    const rows = [
+      row(true, 90, true, 0),   // positive (expected true), high score
+      row(true, 80, true, 0),   // positive, high score
+      row(false, 40, false, 0), // negative, low score
+      row(false, 30, false, 0), // negative, low score
+    ];
+    expect(auc(rows)).toBeCloseTo(1);
+  });
+
+  it('is 0.5 for ties between every positive/negative pair', () => {
+    const rows = [
+      row(true, 50, true, 0),
+      row(true, 50, true, 0),
+      row(false, 50, false, 0),
+      row(false, 50, false, 0),
+    ];
+    expect(auc(rows)).toBeCloseTo(0.5);
+  });
+
+  it('is 0.75 for a known mixed ordering', () => {
+    // positives scored {90, 50}, negatives scored {60, 40}.
+    // Pairs (pos,neg): (90,60)=1, (90,40)=1, (50,60)=0, (50,40)=1 → 3/4 = 0.75.
+    const rows = [
+      row(true, 90, true, 0),
+      row(true, 50, true, 0),
+      row(false, 60, false, 0),
+      row(false, 40, false, 0),
+    ];
+    expect(auc(rows)).toBeCloseTo(0.75);
+  });
+
+  it('returns null when a class is empty (AUC undefined)', () => {
+    expect(auc([row(true, 90, true, 0), row(true, 50, true, 0)])).toBeNull();
+  });
+});
+
+describe('calibratedThreshold', () => {
+  // Sweep a score threshold t: predict label iff outputScore >= t, then measure
+  // boolean agreement against expectedLabel. Report the best agreement + winning t.
+  it('finds the threshold maximizing boolean agreement against the expected label', () => {
+    // Baseline keeps the two high-output-score rows, replaces the two low ones.
+    const rows = [
+      row(true, 90, true, 0),
+      row(true, 70, true, 0),
+      row(false, 40, false, 0),
+      row(false, 20, false, 0),
+    ];
+    const { bestAgreement, threshold } = calibratedThreshold(rows);
+    expect(bestAgreement).toBeCloseTo(1); // a clean split exists
+    // A threshold in (40, 70] perfectly separates; the sweep picks one such t.
+    expect(threshold).toBeGreaterThan(40);
+    expect(threshold).toBeLessThanOrEqual(70);
+  });
+
+  it('caps below 1 when no threshold can separate the classes', () => {
+    // Interleaved: positive at 30, negative at 80 — no monotone score split works.
+    const rows = [
+      row(true, 30, true, 0),
+      row(false, 80, false, 0),
+      row(true, 80, true, 0),
+      row(false, 30, false, 0),
+    ];
+    const { bestAgreement } = calibratedThreshold(rows);
+    expect(bestAgreement).toBeLessThan(1);
+    expect(bestAgreement).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('is { bestAgreement: 0, threshold: 0 } for an empty set', () => {
+    expect(calibratedThreshold([])).toEqual({ bestAgreement: 0, threshold: 0 });
+  });
+});
+
+describe('ambiguityBand', () => {
+  // Count disagreements whose expected score sits inside [lo, hi].
+  it('counts only DISAGREEMENTS whose expected score is inside the band', () => {
+    const rows = [
+      row(true, 60, false, 55),  // disagree, expected 55 IN [50,70]
+      row(false, 40, true, 65),  // disagree, expected 65 IN band
+      row(true, 90, false, 80),  // disagree, expected 80 OUT of band
+      row(true, 70, true, 60),   // AGREE, expected 60 in band — not counted
+    ];
+    const res = ambiguityBand(rows, 50, 70);
+    expect(res.inBandDisagreements).toBe(2);
+    expect(res.totalDisagreements).toBe(3);
+  });
+});
+
+describe('hybridRouting', () => {
+  // Route any row whose output score lands in the mid-band [lo, hi] to the
+  // baseline (auto-correct). Outside the band, keep the candidate's decision.
+  it('routes mid-band rows to the baseline, leaving the rest on the candidate', () => {
+    const rows = [
+      row(true, 55, false, 30),  // in band → routed → auto-correct (was falsePositive)
+      row(false, 60, true, 70),  // in band → routed → auto-correct (was falseNegative)
+      row(true, 90, true, 85),   // out of band, candidate agrees
+      row(true, 95, false, 20),  // out of band, candidate WRONG (residual falseKeep)
+      row(false, 10, false, 15), // out of band, candidate agrees
+    ];
+    const res = hybridRouting(rows, 50, 70);
+    expect(res.routed).toBe(2);
+    expect(res.routedFraction).toBeCloseTo(2 / 5);
+    // After routing: the 2 routed become correct; out-of-band keep the
+    // candidate's call. Agreement = (2 routed-correct + agrees) / total.
+    // out-of-band: row3 agree, row4 disagree, row5 agree → 2 correct of 3.
+    // total correct = 2 + 2 = 4 of 5.
+    expect(res.autoSetAgreement).toBeCloseTo(4 / 5);
+    // residual falseKeep: out-of-band rows where output keeps but expected replaces.
+    expect(res.residualFalseKeep).toBe(1); // row4 (score 95, output true, expected false)
+  });
+
+  it('is all-zero for an empty set', () => {
+    expect(hybridRouting([], 50, 70)).toEqual({
+      routed: 0,
+      routedFraction: 0,
+      autoSetAgreement: 0,
+      residualFalseKeep: 0,
+    });
+  });
+});
+
+describe('analyze', () => {
+  const rows = [
+    row(true, 90, true, 85),
+    row(false, 20, false, 15),
+    row(true, 60, false, 40),  // falsePositive
+    row(false, 30, true, 70),  // falseNegative
+  ];
+
+  it('aggregates every diagnostic from the rows', () => {
+    const a = analyze(rows, { bandLo: 40, bandHi: 70 });
+    expect(a.n).toBe(4);
+    expect(a.labelAgreement).toBeCloseTo(0.5);
+    expect(a.confusion).toEqual({ falsePositive: 1, falseNegative: 1 });
+    expect(typeof a.scoreMAE).toBe('number');
+    expect(a.auc).not.toBeNull();
+    expect(a.calibrated.bestAgreement).toBeGreaterThanOrEqual(a.labelAgreement);
+    expect(a.band.lo).toBe(40);
+    expect(a.band.hi).toBe(70);
+    expect(a.hybrid.routedFraction).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('projectForAnalysis', () => {
+  // Generic eleatic rows carry opaque output_json / expected_json / scores_json.
+  // The consumer-supplied selector pulls the four AnalysisRow axes out (or null).
+  interface FixtureRow {
+    output: { label?: unknown; score?: unknown } | null;
+    expected: { label?: unknown; score?: unknown } | null;
+  }
+  const toNumber = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+  const select = (r: FixtureRow): AnalysisRow | null => {
+    const outputLabel = r.output?.label;
+    const expectedLabel = r.expected?.label;
+    const outputScore = toNumber(r.output?.score);
+    const expectedScore = toNumber(r.expected?.score);
+    if (
+      typeof outputLabel === 'boolean' &&
+      typeof expectedLabel === 'boolean' &&
+      outputScore !== undefined &&
+      expectedScore !== undefined
+    ) {
+      return { outputLabel, outputScore, expectedLabel, expectedScore };
+    }
+    return null;
+  };
+
+  it('keeps only rows the selector fully resolves; drops incomplete rows', () => {
+    const raw: FixtureRow[] = [
+      { output: { label: true, score: 80 }, expected: { label: false, score: 40 } }, // ok
+      { output: { label: true, score: 80 }, expected: null },                          // no expected side
+      { output: { label: true }, expected: { label: false, score: 40 } },              // missing output score
+      { output: { label: 'yes', score: 80 }, expected: { label: false, score: 40 } },  // label not boolean
+    ];
+    const rows = projectForAnalysis(raw, select);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ outputLabel: true, outputScore: 80, expectedLabel: false, expectedScore: 40 });
+  });
+
+  it('returns [] when every row maps to null', () => {
+    const raw: FixtureRow[] = [{ output: null, expected: null }];
+    expect(projectForAnalysis(raw, select)).toEqual([]);
+  });
+});
+
+describe('aggregateScores', () => {
+  it('emits exactly the scores_json scorer names, each averaged across the rows', () => {
+    // Two scorers carried on each row's scores_json; the result is keyed by those
+    // exact names — no eleatic-invented run-level metric names (e.g. "agreement").
+    const rows = [
+      { sharpness: 0.8, exposure: 0.4 },
+      { sharpness: 0.6, exposure: 0.6 },
+      { sharpness: 0.7, exposure: 0.5 },
+    ];
+    const agg = aggregateScores(rows);
+    expect(Object.keys(agg).sort()).toEqual(['exposure', 'sharpness']);
+    expect(agg.sharpness).toBeCloseTo((0.8 + 0.6 + 0.7) / 3);
+    expect(agg.exposure).toBeCloseTo((0.4 + 0.6 + 0.5) / 3);
+    expect(agg).not.toHaveProperty('agreement');
+    expect(agg).not.toHaveProperty('labelAgreement');
+  });
+
+  it('averages only over the rows that carry a given scorer', () => {
+    const rows = [{ a: 10 }, { a: 20, b: 100 }];
+    const agg = aggregateScores(rows);
+    expect(agg.a).toBeCloseTo((10 + 20) / 2);
+    expect(agg.b).toBeCloseTo(100); // present on one row only
+  });
+
+  it('is an empty map for no rows', () => {
+    expect(aggregateScores([])).toEqual({});
+  });
+});
+
+describe('consumer-derived run-level metrics (analyze path, not aggregateScores)', () => {
+  // A consumer is free to derive labelAgreement / scoreMAE / auc from `analyze`
+  // and merge them under whatever metric names its gate expects — eleatic does
+  // not invent those names; analyze just exposes the values.
+  const rows = [
+    row(true, 90, true, 85),
+    row(false, 20, false, 15),
+    row(true, 60, false, 40),
+    row(false, 30, true, 70),
+  ];
+
+  it('analyze exposes labelAgreement and scoreMAE; auc is present-or-null per the rule', () => {
+    const a = analyze(rows, { bandLo: 40, bandHi: 70 });
+    expect(a.labelAgreement).toBeCloseTo(0.5);
+    expect(typeof a.scoreMAE).toBe('number');
+    // auc is non-null here (both classes present); null only when a class is empty.
+    expect(a.auc).not.toBeNull();
+    const positivesOnly = [row(true, 90, true, 85), row(true, 60, true, 40)];
+    expect(analyze(positivesOnly, { bandLo: 40, bandHi: 70 }).auc).toBeNull();
+  });
+});

--- a/packages/eleatic/src/analysis.ts
+++ b/packages/eleatic/src/analysis.ts
@@ -1,0 +1,289 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Generic, domain-free dataset-level diagnostics for a completed eval run.
+//
+// Ported VERBATIM IN MATH from tools/photo-curation/scripts/analyze-experiment.ts
+// (#1067), but rewritten over a domain-free row shape: the photo-judge "keep"
+// decision becomes a generic boolean `label`, and the confusion-matrix axes are
+// renamed to the domain-free `falsePositive` / `falseNegative`. The threshold-free
+// read (AUC) and the calibrated-threshold sweep need every row at once, so they
+// live here as committed, repeatable PURE functions rather than per-row scorers.
+//
+// This module is PURE: no SQLite, no better-sqlite3, no store import, no I/O, no
+// network, and ZERO `@bird-watch/*` imports (the one-way dependency contract that
+// lets the package `git mv` to its own repo later). The store→analysis projection
+// lives in `projectForAnalysis`, fed by a consumer-supplied selector — eleatic
+// never hard-codes where in output_json / expected_json / scores_json each axis
+// lives. The consumer (e.g. the photo-curation adapter) owns that mapping.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One eval row reduced to the four values the diagnostics need, in domain-free
+ * terms. `label` is the boolean class (the photo-judge "keep" decision maps here);
+ * `score` is the numeric ranking / sweep / band axis (the photo-judge qualityScore).
+ *   - outputLabel   — the candidate model's boolean class decision.
+ *   - outputScore   — the candidate's numeric score: the RANKING signal for AUC,
+ *                     the sweep axis for the calibrated threshold, the routing axis.
+ *   - expectedLabel — the baseline (proxy ground-truth) boolean class.
+ *   - expectedScore — the baseline's numeric score: the AMBIGUITY-BAND axis.
+ */
+export interface AnalysisRow {
+  outputLabel: boolean;
+  outputScore: number;
+  expectedLabel: boolean;
+  expectedScore: number;
+}
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────────
+
+/** Fraction of rows where the candidate and baseline label decisions match. Empty → 0. */
+export function labelAgreement(rows: AnalysisRow[]): number {
+  if (rows.length === 0) return 0;
+  const agree = rows.filter((r) => r.outputLabel === r.expectedLabel).length;
+  return agree / rows.length;
+}
+
+/**
+ * Confusion-matrix counts in domain-free terms:
+ *   falsePositive = output is `true`, expected is `false` (the photo-judge
+ *                   "falseKeep" — the dangerous direction).
+ *   falseNegative = output is `false`, expected is `true` (the photo-judge
+ *                   "falseReplace" — the cheap direction).
+ */
+export function confusionCounts(rows: AnalysisRow[]): { falsePositive: number; falseNegative: number } {
+  let falsePositive = 0;
+  let falseNegative = 0;
+  for (const r of rows) {
+    if (r.outputLabel && !r.expectedLabel) falsePositive++;
+    else if (!r.outputLabel && r.expectedLabel) falseNegative++;
+  }
+  return { falsePositive, falseNegative };
+}
+
+/** Mean absolute error of the candidate vs. baseline score. Empty → 0. */
+export function scoreMAE(rows: AnalysisRow[]): number {
+  if (rows.length === 0) return 0;
+  const sum = rows.reduce((acc, r) => acc + Math.abs(r.outputScore - r.expectedScore), 0);
+  return sum / rows.length;
+}
+
+/**
+ * AUC of the candidate `outputScore` as a ranker of the baseline `label`:
+ * P(a random expected-true row outranks a random expected-false row), ties
+ * counting as 0.5. Computed by the exhaustive pairwise (Mann–Whitney) definition
+ * — O(n²), fine at ≤~1000 rows and exactly matching the by-hand fixture.
+ * Returns `null` when either class is empty (AUC undefined).
+ */
+export function auc(rows: AnalysisRow[]): number | null {
+  const pos = rows.filter((r) => r.expectedLabel).map((r) => r.outputScore);
+  const neg = rows.filter((r) => !r.expectedLabel).map((r) => r.outputScore);
+  if (pos.length === 0 || neg.length === 0) return null;
+  let acc = 0;
+  for (const p of pos) {
+    for (const n of neg) {
+      if (p > n) acc += 1;
+      else if (p === n) acc += 0.5;
+    }
+  }
+  return acc / (pos.length * neg.length);
+}
+
+/**
+ * Calibrated-threshold ceiling: sweep a score threshold `t` and predict
+ * label iff `outputScore >= t`, then measure boolean agreement against the
+ * baseline label. Returns the best agreement reachable and the winning `t`.
+ *
+ * Candidate thresholds are the distinct scores plus one just above the max (so
+ * "label nothing" is reachable). The best achievable agreement is the ceiling a
+ * recalibrated score-only gate could hit — when it sits well below 1.0 the
+ * disagreement is genuine model divergence, not boundary noise. Empty →
+ * `{ bestAgreement: 0, threshold: 0 }`.
+ */
+export function calibratedThreshold(rows: AnalysisRow[]): { bestAgreement: number; threshold: number } {
+  if (rows.length === 0) return { bestAgreement: 0, threshold: 0 };
+  const scores = rows.map((r) => r.outputScore);
+  const max = Math.max(...scores);
+  // Candidate cut points: each observed score (predict label at >= score) plus a
+  // sentinel above the max (predict label for nothing).
+  const candidates = Array.from(new Set([...scores, max + 1])).sort((a, b) => a - b);
+  let best = { bestAgreement: -1, threshold: candidates[0]! };
+  for (const t of candidates) {
+    let agree = 0;
+    for (const r of rows) {
+      const predictedLabel = r.outputScore >= t;
+      if (predictedLabel === r.expectedLabel) agree++;
+    }
+    const agreement = agree / rows.length;
+    if (agreement > best.bestAgreement) best = { bestAgreement: agreement, threshold: t };
+  }
+  return best;
+}
+
+/**
+ * Ambiguity-band breakdown: of all label-disagreements, how many sit inside the
+ * baseline-score band `[lo, hi]` (inclusive). A disagreement near the baseline's
+ * own midpoint is a genuine close call (the kind a hybrid would route); a
+ * disagreement at the extremes is a real model miss.
+ */
+export function ambiguityBand(
+  rows: AnalysisRow[],
+  lo: number,
+  hi: number,
+): { inBandDisagreements: number; totalDisagreements: number } {
+  let inBand = 0;
+  let total = 0;
+  for (const r of rows) {
+    if (r.outputLabel === r.expectedLabel) continue;
+    total++;
+    if (r.expectedScore >= lo && r.expectedScore <= hi) inBand++;
+  }
+  return { inBandDisagreements: inBand, totalDisagreements: total };
+}
+
+/**
+ * Hybrid-routing preview: route any row whose CANDIDATE score lands in the
+ * mid-band `[lo, hi]` to the baseline (which, being the proxy ground truth,
+ * decides correctly); outside the band, keep the candidate's own decision.
+ * Reports:
+ *   - routed / routedFraction — baseline-call budget the hybrid would spend.
+ *   - autoSetAgreement        — label-agreement after routing (routed rows are
+ *                               auto-correct; out-of-band rows keep the candidate).
+ *   - residualFalseKeep       — falseKeeps the hybrid still ships (a dangerous
+ *                               candidate-true call whose score fell OUTSIDE the
+ *                               band, so it was never re-judged). NOTE: this is a
+ *                               routing-RESIDUAL count, distinct from the
+ *                               `confusionCounts` axis — so it keeps the ported
+ *                               `residualFalseKeep` name (only the confusion-matrix
+ *                               fields rename to falsePositive / falseNegative).
+ * Empty → all zeros.
+ */
+export function hybridRouting(
+  rows: AnalysisRow[],
+  lo: number,
+  hi: number,
+): { routed: number; routedFraction: number; autoSetAgreement: number; residualFalseKeep: number } {
+  if (rows.length === 0) return { routed: 0, routedFraction: 0, autoSetAgreement: 0, residualFalseKeep: 0 };
+  let routed = 0;
+  let correct = 0;
+  let residualFalseKeep = 0;
+  for (const r of rows) {
+    const inBand = r.outputScore >= lo && r.outputScore <= hi;
+    if (inBand) {
+      // Routed to the baseline → decided correctly by construction (it is the label).
+      routed++;
+      correct++;
+    } else {
+      // Keep the candidate's decision.
+      if (r.outputLabel === r.expectedLabel) correct++;
+      else if (r.outputLabel && !r.expectedLabel) residualFalseKeep++;
+    }
+  }
+  return {
+    routed,
+    routedFraction: routed / rows.length,
+    autoSetAgreement: correct / rows.length,
+    residualFalseKeep,
+  };
+}
+
+// ── Composed analysis ────────────────────────────────────────────────────────
+
+/** Tunable band edges for the ambiguity + hybrid-routing analysis. */
+export interface AnalysisOptions {
+  /** Lower edge of the ambiguity / routing band (inclusive). */
+  bandLo: number;
+  /** Upper edge of the ambiguity / routing band (inclusive). */
+  bandHi: number;
+}
+
+/** The full dataset-level diagnostic, aggregated from the eval rows. */
+export interface Analysis {
+  n: number;
+  labelAgreement: number;
+  confusion: { falsePositive: number; falseNegative: number };
+  scoreMAE: number;
+  auc: number | null;
+  calibrated: { bestAgreement: number; threshold: number };
+  band: { lo: number; hi: number; inBandDisagreements: number; totalDisagreements: number };
+  hybrid: { routed: number; routedFraction: number; autoSetAgreement: number; residualFalseKeep: number };
+}
+
+/** Compose every pure helper into one Analysis over the rows. */
+export function analyze(rows: AnalysisRow[], opts: AnalysisOptions): Analysis {
+  const band = ambiguityBand(rows, opts.bandLo, opts.bandHi);
+  return {
+    n: rows.length,
+    labelAgreement: labelAgreement(rows),
+    confusion: confusionCounts(rows),
+    scoreMAE: scoreMAE(rows),
+    auc: auc(rows),
+    calibrated: calibratedThreshold(rows),
+    band: { lo: opts.bandLo, hi: opts.bandHi, ...band },
+    hybrid: hybridRouting(rows, opts.bandLo, opts.bandHi),
+  };
+}
+
+// ── Generic projection + per-scorer aggregation ──────────────────────────────
+
+/**
+ * Consumer-supplied reduction of one generic eleatic row to the four AnalysisRow
+ * values, or `null` to drop the row. The selector — not eleatic — owns where in
+ * output_json / expected_json / scores_json each of the four axes lives, so the
+ * package never hard-codes a domain mapping. Generic over the row type `T` so it
+ * matches whatever row shape a consumer reads (E1's write-side record, an E2
+ * read-side row, or a raw projection) without coupling eleatic to any one of them.
+ */
+export type AnalysisSelector<T> = (row: T) => AnalysisRow | null;
+
+/**
+ * Project a run's generic rows onto `AnalysisRow[]` via a consumer selector,
+ * dropping any row the selector maps to `null` (its "incomplete row" signal —
+ * a missing boolean label or non-finite score on either side). Pure and tolerant
+ * of incomplete rows: a `null` row is dropped, never thrown. Mirrors the
+ * photo-judge `projectRows`' "keep only complete rows" discipline, but with the
+ * extraction pushed into the consumer.
+ */
+export function projectForAnalysis<T>(rows: T[], select: AnalysisSelector<T>): AnalysisRow[] {
+  const out: AnalysisRow[] = [];
+  for (const r of rows) {
+    const projected = select(r);
+    if (projected !== null) out.push(projected);
+  }
+  return out;
+}
+
+/**
+ * Reduce a run's per-row `scores_json` blobs into a `{name: number}` map of
+ * per-scorer means: each key is EXACTLY a scorer name that appears in the rows'
+ * scores_json, and each value is the mean of that scorer across the rows that
+ * carry it (a scorer present on only some rows is averaged over only those rows).
+ *
+ * This is deliberately the per-scorer aggregate, NOT the run-level gate metrics:
+ * the run-level metric names the hub gate reads out of eval_run.metrics_json
+ * (e.g. "agreement") are the CONSUMER's responsibility — the consumer chooses
+ * those names and persists them via the write store's finalizeRun. eleatic
+ * invents no run-level metric names here. A consumer is free to ALSO derive
+ * labelAgreement / scoreMAE / auc (skip auc when it is null) from `analyze` and
+ * merge them under whatever metric names its gate expects.
+ *
+ * Takes the scores blobs directly (one `Record<string, number>` per row) rather
+ * than `AnalysisRow[]`, because `AnalysisRow` carries none of the named-scorer
+ * data this averages — the four-axis projection deliberately discards scorer
+ * names, so per-scorer means must read the scores blobs.
+ */
+export function aggregateScores(rows: Array<Record<string, number>>): Record<string, number> {
+  const sums: Record<string, number> = {};
+  const counts: Record<string, number> = {};
+  for (const scores of rows) {
+    for (const [name, value] of Object.entries(scores)) {
+      if (!Number.isFinite(value)) continue;
+      sums[name] = (sums[name] ?? 0) + value;
+      counts[name] = (counts[name] ?? 0) + 1;
+    }
+  }
+  const means: Record<string, number> = {};
+  for (const [name, sum] of Object.entries(sums)) {
+    const count = counts[name]!; // present by construction: a name in `sums` was counted.
+    means[name] = sum / count;
+  }
+  return means;
+}

--- a/packages/eleatic/src/index.ts
+++ b/packages/eleatic/src/index.ts
@@ -16,7 +16,19 @@ export type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './typ
 // export { makeReader, type EleaticReader } from './reader.js';
 
 // --- Analysis module (E3) ---
-// export { ... } from './analysis.js';
+export {
+  labelAgreement,
+  confusionCounts,
+  scoreMAE,
+  auc,
+  calibratedThreshold,
+  ambiguityBand,
+  hybridRouting,
+  analyze,
+  projectForAnalysis,
+  aggregateScores,
+} from './analysis.js';
+export type { AnalysisRow, AnalysisOptions, Analysis, AnalysisSelector } from './analysis.js';
 
 // --- Server factory (E4) ---
 // export { createApp } from './app.js';


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph consumer["consumer (e.g. photo-curation adapter)"]
        rows["generic eleatic rows<br/>(output_json / expected_json / scores_json)"]
        sel["AnalysisSelector&lt;T&gt;<br/>(row) =&gt; AnalysisRow | null"]
    end
    subgraph eleatic["@bird-watch/eleatic · src/analysis.ts (PURE)"]
        proj["projectForAnalysis(rows, select)<br/>drops null rows"]
        ar["AnalysisRow[]<br/>{outputLabel, outputScore,<br/>expectedLabel, expectedScore}"]
        an["analyze(rows, opts) -&gt; Analysis"]
        helpers["labelAgreement · confusionCounts<br/>{falsePositive, falseNegative}<br/>scoreMAE · auc · calibratedThreshold<br/>ambiguityBand · hybridRouting"]
        agg["aggregateScores(scoresBlobs)<br/>per-scorer means, exact scores_json names"]
    end
    rows --> proj
    sel --> proj
    proj --> ar
    ar --> an
    an --> helpers
    rows -.scores_json.-> agg
```

## Summary

- Ports the pure dataset-level diagnostics from `tools/photo-curation/scripts/analyze-experiment.ts` into `packages/eleatic/src/analysis.ts`, made generic over a domain-free `AnalysisRow{outputLabel, outputScore, expectedLabel, expectedScore}` — *why*: eleatic is being extracted as a domain-agnostic eval explorer, so the photo-judge "keep" decision becomes a generic boolean `label` and the confusion-matrix axes rename to `falsePositive`/`falseNegative`. The math is verbatim; `hybridRouting` keeps its `residualFalseKeep` field (a routing-residual count, not the confusion axis).
- Adds two generic functions replacing the photo-judge store/CLI surface: `projectForAnalysis(rows, select)` pushes all four-axis extraction into a consumer-supplied `(row) => AnalysisRow | null` selector (eleatic hard-codes neither where each axis lives nor any one row shape), and `aggregateScores(rows)` emits per-scorer means keyed by exactly the `scores_json` scorer names — it invents no run-level metric names ("agreement" etc. are the consumer's responsibility, derived from `analyze` and persisted via the write store's `finalizeRun`).
- Module is PURE: no SQLite, no store import, no I/O, no network, zero `@bird-watch/*` imports (the one-way dependency contract). The photo-judge cost / `formatReport` / sqlite-reader / CLI surfaces are deliberately NOT ported. Barrel re-exports the analysis surface at the reserved E3 marker only (E2/E4 markers untouched to avoid conflict with the sibling Wave-2 PR).

## Screenshots

N/A — packages/ tool (not frontend/**)

## Test plan

- [x] `npm run typecheck && npm run test` — green (`npm run lint` and full `npm run test` from repo root; package suite 45 tests pass — 22 baseline + 23 new)
- [x] New unit / integration tests added — `packages/eleatic/src/analysis.test.ts`, pure unit tests reusing the photo-curation fixture's expected numbers verbatim with the field renames (no `:memory:` db, no network)
- [x] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no UI
- [x] `npm run build` — clean production build
- [x] (UI only) Playwright MCP smoke — N/A, no UI

## Plan reference

Part of the eleatic epic #1153 (E3, Wave 2). Closes #1146.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
