### PR TITLE
feat(eleatic): read-query API (list/get/diff/facet/trend/adjudications)

### DIFF
--- a/packages/eleatic/src/index.ts
+++ b/packages/eleatic/src/index.ts
@@ -13,7 +13,15 @@ export { openStore, EleaticStore } from './store.js';
 export type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
 
 // --- Read query API (E2) ---
-// export { makeReader, type EleaticReader } from './reader.js';
+export { makeReader } from './queries.js';
+export type {
+  EleaticReader,
+  RunDiff,
+  MetricPoint,
+  FacetQuery,
+  FacetFilter,
+  JsonScalar,
+} from './queries.js';
 
 // --- Analysis module (E3) ---
 // export { ... } from './analysis.js';

--- a/packages/eleatic/src/queries.test.ts
+++ b/packages/eleatic/src/queries.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { openStore, type EleaticStore } from './store.js';
+import { makeReader, type EleaticReader } from './queries.js';
+import type { EvalRunRecord, EvalRowRecord } from './types.js';
+
+// Pure-unit suite against `:memory:` better-sqlite3 — no network, no disk
+// fixtures, no DB mocks. Seed via E1's writers so the read path is exercised
+// against real persisted rows. `makeRun`/`makeRow` mirror the grounding
+// `baseResult(over)` factory: a default record merged with a `Partial` override.
+
+function makeRun(over: Partial<EvalRunRecord> = {}): EvalRunRecord {
+  return { id: 'run-1', label: 'baseline', startedAt: '2026-06-13T00:00:00Z', ...over };
+}
+function makeRow(over: Partial<EvalRowRecord> = {}): EvalRowRecord {
+  return {
+    runId: 'run-1',
+    rowKey: 'item-1',
+    output: { verdict: 'keep' },
+    expected: { verdict: 'keep' },
+    ...over,
+  };
+}
+
+describe('makeReader', () => {
+  let store: EleaticStore;
+  let reader: EleaticReader;
+
+  beforeEach(() => {
+    store = openStore(':memory:');
+    reader = makeReader(store.db);
+  });
+  afterEach(() => {
+    store.close();
+  });
+
+  describe('listRuns', () => {
+    it('returns one entry per run, newest started_at first', () => {
+      store.recordRun(makeRun({ id: 'old', startedAt: '2026-06-10T00:00:00Z' }));
+      store.recordRun(makeRun({ id: 'new', startedAt: '2026-06-12T00:00:00Z' }));
+      expect(reader.listRuns().map((r) => r.id)).toEqual(['new', 'old']);
+    });
+
+    it('returns an empty array when no runs exist', () => {
+      expect(reader.listRuns()).toEqual([]);
+    });
+
+    it('round-trips run metrics exactly and omits absent optionals', () => {
+      store.recordRun(makeRun({ id: 'r', metrics: { agreement: 0.7867 }, baseline: 'prev' }));
+      const [run] = reader.listRuns();
+      expect(run?.metrics).toEqual({ agreement: 0.7867 });
+      expect(run?.metrics?.agreement).toBe(0.7867);
+      expect(run?.baseline).toBe('prev');
+      // Absent optionals must read back as omitted keys, not null.
+      expect('config' in (run ?? {})).toBe(false);
+      expect('rowCount' in (run ?? {})).toBe(false);
+    });
+  });
+
+  describe('getRun', () => {
+    it('returns the mapped record for a present id', () => {
+      store.recordRun(makeRun({ id: 'present', config: { mode: 'fast' } }));
+      const run = reader.getRun('present');
+      expect(run?.id).toBe('present');
+      expect(run?.config).toEqual({ mode: 'fast' });
+    });
+
+    it('returns undefined for an absent id', () => {
+      expect(reader.getRun('nope')).toBeUndefined();
+    });
+  });
+
+  describe('getRows / getRow', () => {
+    beforeEach(() => {
+      store.recordRun(makeRun());
+      store.recordRun(makeRun({ id: 'run-2' }));
+      store.recordRows([
+        makeRow({ rowKey: 'b' }),
+        makeRow({ rowKey: 'a' }),
+        makeRow({ runId: 'run-2', rowKey: 'z' }),
+      ]);
+    });
+
+    it('returns rows scoped to run_id, ordered by row_key', () => {
+      expect(reader.getRows('run-1').map((r) => r.rowKey)).toEqual(['a', 'b']);
+      expect(reader.getRows('run-2').map((r) => r.rowKey)).toEqual(['z']);
+    });
+
+    it('getRow returns the row for a present (runId,rowKey)', () => {
+      expect(reader.getRow('run-1', 'a')?.rowKey).toBe('a');
+    });
+
+    it('getRow returns undefined for an absent (runId,rowKey)', () => {
+      expect(reader.getRow('run-1', 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('NULL mapping', () => {
+    it('reads omitted image_url/content_hash back as undefined/absent keys', () => {
+      store.recordRun(makeRun());
+      // No imageUrl, contentHash, label, scores, metadata.
+      store.recordRow(makeRow({ rowKey: 'bare' }));
+      const row = reader.getRow('run-1', 'bare');
+      expect(row).toBeDefined();
+      expect(row?.imageUrl).toBeUndefined();
+      expect(row?.contentHash).toBeUndefined();
+      expect('imageUrl' in (row ?? {})).toBe(false);
+      expect('contentHash' in (row ?? {})).toBe(false);
+      expect('label' in (row ?? {})).toBe(false);
+      expect('scores' in (row ?? {})).toBe(false);
+      expect('metadata' in (row ?? {})).toBe(false);
+    });
+
+    it('round-trips scores numbers exactly', () => {
+      store.recordRun(makeRun());
+      store.recordRow(makeRow({ rowKey: 'scored', scores: { candidateQuality: 0.7867 } }));
+      const row = reader.getRow('run-1', 'scored');
+      expect(row?.scores).toEqual({ candidateQuality: 0.7867 });
+      expect(row?.scores?.candidateQuality).toBe(0.7867);
+    });
+
+    it('round-trips opaque output/expected blobs losslessly', () => {
+      store.recordRun(makeRun());
+      const output = { nested: { a: [1, 2, 3] }, n: 0.5, b: true };
+      const expected = ['anything', { goes: 'here' }];
+      store.recordRow(makeRow({ rowKey: 'opaque', output, expected }));
+      const row = reader.getRow('run-1', 'opaque');
+      expect(row?.output).toEqual(output);
+      expect(row?.expected).toEqual(expected);
+    });
+  });
+
+  describe('facetRows — the generalization of evalFalseKeeps', () => {
+    // Port the four-row arrangement from the grounding evalFalseKeeps test:
+    // metadata.disagreement ∈ {falseKeep, agree, falseReplace, bothReplace}.
+    beforeEach(() => {
+      store.recordRun(makeRun());
+      store.recordRun(makeRun({ id: 'run-2' }));
+      store.recordRows([
+        // The one true falseKeep.
+        makeRow({
+          rowKey: 'falsekeep',
+          metadata: { disagreement: 'falseKeep' },
+          scores: { candidateQuality: 72 },
+        }),
+        makeRow({
+          rowKey: 'agree',
+          metadata: { disagreement: 'agree' },
+          scores: { candidateQuality: 80 },
+        }),
+        makeRow({
+          rowKey: 'falsereplace',
+          metadata: { disagreement: 'falseReplace' },
+          scores: { candidateQuality: 30 },
+        }),
+        makeRow({
+          rowKey: 'bothreplace',
+          metadata: { disagreement: 'bothReplace' },
+          scores: { candidateQuality: 10 },
+        }),
+        // A row in a different run with the same disagreement value.
+        makeRow({
+          runId: 'run-2',
+          rowKey: 'other-run-falsekeep',
+          metadata: { disagreement: 'falseKeep' },
+          scores: { candidateQuality: 99 },
+        }),
+      ]);
+    });
+
+    it('returns exactly the falseKeep row(s) — the old evalFalseKeeps result', () => {
+      const rows = reader.facetRows('run-1', {
+        filters: [{ path: 'metadata.disagreement', op: 'eq', value: 'falseKeep' }],
+      });
+      expect(rows.map((r) => r.rowKey)).toEqual(['falsekeep']);
+    });
+
+    it('filters a numeric scores range correctly (gte)', () => {
+      const rows = reader.facetRows('run-1', {
+        filters: [{ path: 'scores.candidateQuality', op: 'gte', value: 70 }],
+      });
+      expect(rows.map((r) => r.rowKey).sort()).toEqual(['agree', 'falsekeep']);
+    });
+
+    it('supports lt / ne / in / exists operators', () => {
+      expect(
+        reader
+          .facetRows('run-1', { filters: [{ path: 'scores.candidateQuality', op: 'lt', value: 30 }] })
+          .map((r) => r.rowKey),
+      ).toEqual(['bothreplace']);
+      expect(
+        reader
+          .facetRows('run-1', {
+            filters: [{ path: 'metadata.disagreement', op: 'ne', value: 'agree' }],
+          })
+          .map((r) => r.rowKey)
+          .sort(),
+      ).toEqual(['bothreplace', 'falsekeep', 'falsereplace']);
+      expect(
+        reader
+          .facetRows('run-1', {
+            filters: [
+              { path: 'metadata.disagreement', op: 'in', value: ['falseKeep', 'falseReplace'] },
+            ],
+          })
+          .map((r) => r.rowKey)
+          .sort(),
+      ).toEqual(['falsekeep', 'falsereplace']);
+      // exists: every seeded row has metadata.disagreement → all 4 in run-1.
+      expect(
+        reader.facetRows('run-1', {
+          filters: [{ path: 'metadata.disagreement', op: 'exists' }],
+        }),
+      ).toHaveLength(4);
+    });
+
+    it('sorts by a scores path ascending and descending', () => {
+      const asc = reader.facetRows('run-1', {
+        sort: { path: 'scores.candidateQuality', dir: 'asc' },
+      });
+      expect(asc.map((r) => r.rowKey)).toEqual(['bothreplace', 'falsereplace', 'falsekeep', 'agree']);
+      const desc = reader.facetRows('run-1', {
+        sort: { path: 'scores.candidateQuality', dir: 'desc' },
+      });
+      expect(desc.map((r) => r.rowKey)).toEqual(['agree', 'falsekeep', 'falsereplace', 'bothreplace']);
+    });
+
+    it('caps the returned count with limit (and offset paginates)', () => {
+      const page = reader.facetRows('run-1', {
+        sort: { path: 'scores.candidateQuality', dir: 'desc' },
+        limit: 2,
+      });
+      expect(page.map((r) => r.rowKey)).toEqual(['agree', 'falsekeep']);
+      const next = reader.facetRows('run-1', {
+        sort: { path: 'scores.candidateQuality', dir: 'desc' },
+        limit: 2,
+        offset: 2,
+      });
+      expect(next.map((r) => r.rowKey)).toEqual(['falsereplace', 'bothreplace']);
+    });
+
+    it('throws on an invalid path prefix', () => {
+      expect(() =>
+        reader.facetRows('run-1', { filters: [{ path: 'foo.bar', op: 'eq', value: 1 }] }),
+      ).toThrow();
+    });
+
+    it('throws on an unknown key (validated against discovered keys)', () => {
+      expect(() =>
+        reader.facetRows('run-1', {
+          filters: [{ path: 'metadata.notAKey', op: 'eq', value: 'x' }],
+        }),
+      ).toThrow();
+      expect(() =>
+        reader.facetRows('run-1', { sort: { path: 'scores.notAScore', dir: 'asc' } }),
+      ).toThrow();
+    });
+
+    it('scopes to the given runId only', () => {
+      const r1 = reader.facetRows('run-1', {
+        filters: [{ path: 'metadata.disagreement', op: 'eq', value: 'falseKeep' }],
+      });
+      expect(r1.map((r) => r.rowKey)).toEqual(['falsekeep']);
+      const r2 = reader.facetRows('run-2', {
+        filters: [{ path: 'metadata.disagreement', op: 'eq', value: 'falseKeep' }],
+      });
+      expect(r2.map((r) => r.rowKey)).toEqual(['other-run-falsekeep']);
+    });
+
+    it('returns all rows for an empty query', () => {
+      expect(reader.facetRows('run-1', {})).toHaveLength(4);
+    });
+  });
+
+  describe('diffRuns', () => {
+    beforeEach(() => {
+      store.recordRun(makeRun({ id: 'a' }));
+      store.recordRun(makeRun({ id: 'b' }));
+      store.recordRows([
+        makeRow({ runId: 'a', rowKey: 'both', scores: { q: 1 } }),
+        makeRow({ runId: 'a', rowKey: 'only-a', scores: { q: 2 } }),
+        makeRow({ runId: 'b', rowKey: 'both', scores: { q: 3 } }),
+        makeRow({ runId: 'b', rowKey: 'only-b', scores: { q: 4 } }),
+      ]);
+    });
+
+    it('surfaces per-row_key divergence: present-in-both, only-in-a, only-in-b', () => {
+      const diff = reader.diffRuns('a', 'b');
+      const byKey = new Map(diff.map((d) => [d.rowKey, d]));
+      expect([...byKey.keys()].sort()).toEqual(['both', 'only-a', 'only-b']);
+
+      const both = byKey.get('both');
+      expect(both?.a?.scores).toEqual({ q: 1 });
+      expect(both?.b?.scores).toEqual({ q: 3 });
+
+      const onlyA = byKey.get('only-a');
+      expect(onlyA?.a?.scores).toEqual({ q: 2 });
+      expect(onlyA?.b).toBeUndefined();
+
+      const onlyB = byKey.get('only-b');
+      expect(onlyB?.a).toBeUndefined();
+      expect(onlyB?.b?.scores).toEqual({ q: 4 });
+    });
+  });
+
+  describe('metricTrend', () => {
+    it('returns points ordered oldest→newest (started_at ASC)', () => {
+      store.recordRun(makeRun({ id: 'mid', startedAt: '2026-06-11T00:00:00Z', metrics: { agreement: 0.8 } }));
+      store.recordRun(makeRun({ id: 'old', startedAt: '2026-06-10T00:00:00Z', metrics: { agreement: 0.78 } }));
+      store.recordRun(makeRun({ id: 'new', startedAt: '2026-06-12T00:00:00Z', metrics: { agreement: 0.9 } }));
+      const trend = reader.metricTrend('agreement');
+      expect(trend.map((p) => p.runId)).toEqual(['old', 'mid', 'new']);
+      expect(trend.map((p) => p.value)).toEqual([0.78, 0.8, 0.9]);
+      expect(trend.map((p) => p.startedAt)).toEqual([
+        '2026-06-10T00:00:00Z',
+        '2026-06-11T00:00:00Z',
+        '2026-06-12T00:00:00Z',
+      ]);
+    });
+
+    it('handles a run missing the named metric (value undefined)', () => {
+      store.recordRun(makeRun({ id: 'has', startedAt: '2026-06-10T00:00:00Z', metrics: { agreement: 0.8 } }));
+      store.recordRun(makeRun({ id: 'lacks', startedAt: '2026-06-11T00:00:00Z', metrics: { other: 1 } }));
+      store.recordRun(makeRun({ id: 'none', startedAt: '2026-06-12T00:00:00Z' }));
+      const trend = reader.metricTrend('agreement');
+      expect(trend.map((p) => p.runId)).toEqual(['has', 'lacks', 'none']);
+      expect(trend[0]?.value).toBe(0.8);
+      expect(trend[1]?.value).toBeUndefined();
+      expect(trend[2]?.value).toBeUndefined();
+    });
+
+    it('returns an empty array when no runs exist', () => {
+      expect(reader.metricTrend('agreement')).toEqual([]);
+    });
+  });
+
+  describe('listAdjudications / isStale', () => {
+    it('returns recorded adjudications, optionally filtered by rowKeys', () => {
+      store.recordAdjudication({
+        rowKey: 'item-1',
+        verdict: 'keep',
+        decidedAt: '2026-06-13T00:00:00Z',
+        againstHash: 'h1',
+      });
+      store.recordAdjudication({
+        rowKey: 'item-2',
+        verdict: 'replace',
+        decidedAt: '2026-06-13T01:00:00Z',
+      });
+      expect(reader.listAdjudications().map((a) => a.rowKey).sort()).toEqual(['item-1', 'item-2']);
+      const one = reader.listAdjudications(['item-1']);
+      expect(one.map((a) => a.rowKey)).toEqual(['item-1']);
+      expect(one[0]?.verdict).toBe('keep');
+      expect(one[0]?.againstHash).toBe('h1');
+      // Omitted optionals read back absent.
+      const two = reader.listAdjudications(['item-2']);
+      expect(two[0]?.againstHash).toBeUndefined();
+      expect('note' in (two[0] ?? {})).toBe(false);
+    });
+
+    it('listAdjudications([]) returns no rows', () => {
+      store.recordAdjudication({ rowKey: 'item-1', verdict: 'keep', decidedAt: '2026-06-13T00:00:00Z' });
+      expect(reader.listAdjudications([])).toEqual([]);
+    });
+
+    it('isStale: true when recorded against_hash differs, false when equal', () => {
+      store.recordAdjudication({
+        rowKey: 'item-1',
+        verdict: 'keep',
+        decidedAt: '2026-06-13T00:00:00Z',
+        againstHash: 'h1',
+      });
+      expect(reader.isStale('item-1', 'h2')).toBe(true);
+      expect(reader.isStale('item-1', 'h1')).toBe(false);
+    });
+
+    it('isStale: false when the recorded hash is absent or no adjudication exists', () => {
+      store.recordAdjudication({ rowKey: 'no-hash', verdict: 'keep', decidedAt: '2026-06-13T00:00:00Z' });
+      expect(reader.isStale('no-hash', 'anything')).toBe(false);
+      expect(reader.isStale('never-adjudicated', 'anything')).toBe(false);
+    });
+  });
+});

--- a/packages/eleatic/src/queries.ts
+++ b/packages/eleatic/src/queries.ts
@@ -1,0 +1,359 @@
+/**
+ * The eleatic READ-query API: a pure, read-only SQLite layer over the generic
+ * three-table schema E1 created (`eval_run` / `eval_row` / `eval_adjudication`).
+ * It powers the comparison hub (`listRuns`/`getRun`), per-row diff (`diffRuns`),
+ * the faceted gallery (`facetRows`), trends (`metricTrend`), and adjudication
+ * drill-down (`listAdjudications`/`isStale`).
+ *
+ * This is the generic GENERALIZATION of the photo-judge's hard-coded
+ * `tools/photo-curation/src/server/eval-queries.ts` (`evalFalseKeeps` →
+ * `facetRows` with a `FacetQuery`).
+ *
+ * Load-bearing constraints (see the issue + E1 conventions):
+ *   • EVERY query is parameterized — `?` placeholders, never string-interpolated
+ *     values. The one apparent exception is the `json_extract` JSON-pointer
+ *     constant, which is a VETTED path (prefix ∈ {scores,metadata}, key ∈ the
+ *     run's discovered keys) and never raw caller input. The filter value is
+ *     always a `?` bind parameter.
+ *   • ZERO `@bird-watch/*` imports — only `better-sqlite3` (type-only) and `./`
+ *     siblings, so the package can `git mv` to its own repo (E9 guard).
+ *   • Read-only: no DB opening (takes an opened handle, mirroring E1's
+ *     `EleaticStore`), no writes, no network.
+ *   • Strict tsconfig: `exactOptionalPropertyTypes` — an absent column reads back
+ *     as an OMITTED key, never `undefined` assigned to a required field;
+ *     `noUncheckedIndexedAccess` — array indexing is guarded.
+ */
+
+import type Database from 'better-sqlite3';
+import { nullableNumber, parseJson } from './serde.js';
+import type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
+
+// ── Net-new public types this issue OWNS (E4/E6 reference verbatim) ───────────
+
+/** A SQLite-storable JSON leaf used as a facet filter value. */
+export type JsonScalar = string | number | boolean | null;
+
+export interface FacetFilter {
+  /**
+   * `"scores.<name>"` → `json_extract(scores_json,'$.<name>')`;
+   * `"metadata.<key>"` → `json_extract(metadata_json,'$.<key>')`.
+   */
+  path: string;
+  op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte' | 'in' | 'contains' | 'exists';
+  value?: JsonScalar | JsonScalar[];
+}
+
+export interface FacetQuery {
+  /** ANDed together. */
+  filters?: FacetFilter[];
+  sort?: { path: string; dir: 'asc' | 'desc' };
+  /** Gallery cap (epic targets 150–1000-row scale). */
+  limit?: number;
+  offset?: number;
+}
+
+/** One per-`row_key` A/B comparison; `a`/`b` are present only on that side. */
+export interface RunDiff {
+  rowKey: string;
+  a?: EvalRowRecord;
+  b?: EvalRowRecord;
+}
+
+/** One trend point: a run's value for a named metric (omitted when absent). */
+export interface MetricPoint {
+  runId: string;
+  startedAt: string;
+  value?: number;
+}
+
+/** The read-only query surface returned by `makeReader`. */
+export interface EleaticReader {
+  listRuns(): EvalRunRecord[];
+  getRun(id: string): EvalRunRecord | undefined;
+  getRows(runId: string): EvalRowRecord[];
+  getRow(runId: string, rowKey: string): EvalRowRecord | undefined;
+  diffRuns(aRunId: string, bRunId: string): RunDiff[];
+  facetRows(runId: string, q: FacetQuery): EvalRowRecord[];
+  metricTrend(metricName: string): MetricPoint[];
+  listAdjudications(rowKeys?: string[]): EvalAdjudicationRecord[];
+  isStale(rowKey: string, currentHash: string): boolean;
+}
+
+// ── Raw column shapes (snake_case, NULLs intact) ──────────────────────────────
+
+interface RunDbRow {
+  id: string;
+  label: string | null;
+  baseline: string | null;
+  config_json: string | null;
+  started_at: string | null;
+  row_count: number | null;
+  metrics_json: string | null;
+}
+interface EvalRowDbRow {
+  run_id: string;
+  row_key: string;
+  label: string | null;
+  image_url: string | null;
+  content_hash: string | null;
+  output_json: string | null;
+  expected_json: string | null;
+  scores_json: string | null;
+  metadata_json: string | null;
+}
+interface AdjDbRow {
+  row_key: string;
+  verdict: string | null;
+  against_hash: string | null;
+  note: string | null;
+  decided_at: string | null;
+}
+
+// ── Read mappers: snake_case DbRow → camelCase record ─────────────────────────
+//
+// Under `exactOptionalPropertyTypes` an omittable field must be an ABSENT key,
+// not `undefined`. So each mapper builds the required core, then conditionally
+// assigns each optional only when its column was non-NULL. `??` defaults guard
+// the rare NULL in a not-truly-nullable column (e.g. a label written NULL).
+
+function readRun(row: RunDbRow): EvalRunRecord {
+  const rec: EvalRunRecord = {
+    id: row.id,
+    label: row.label ?? '',
+    startedAt: row.started_at ?? '',
+  };
+  if (row.baseline !== null) rec.baseline = row.baseline;
+  const config = parseJson<Record<string, unknown>>(row.config_json);
+  if (config !== undefined) rec.config = config;
+  const rowCount = nullableNumber(row.row_count);
+  if (rowCount !== undefined) rec.rowCount = rowCount;
+  const metrics = parseJson<Record<string, number>>(row.metrics_json);
+  if (metrics !== undefined) rec.metrics = metrics;
+  return rec;
+}
+
+function readRow(row: EvalRowDbRow): EvalRowRecord {
+  const rec: EvalRowRecord = {
+    runId: row.run_id,
+    rowKey: row.row_key,
+    output: parseJson<unknown>(row.output_json),
+    expected: parseJson<unknown>(row.expected_json),
+  };
+  if (row.label !== null) rec.label = row.label;
+  if (row.image_url !== null) rec.imageUrl = row.image_url;
+  if (row.content_hash !== null) rec.contentHash = row.content_hash;
+  const scores = parseJson<Record<string, number>>(row.scores_json);
+  if (scores !== undefined) rec.scores = scores;
+  const metadata = parseJson<Record<string, string | number | boolean>>(row.metadata_json);
+  if (metadata !== undefined) rec.metadata = metadata;
+  return rec;
+}
+
+function readAdj(row: AdjDbRow): EvalAdjudicationRecord {
+  const rec: EvalAdjudicationRecord = {
+    rowKey: row.row_key,
+    verdict: row.verdict ?? '',
+    decidedAt: row.decided_at ?? '',
+  };
+  if (row.against_hash !== null) rec.againstHash = row.against_hash;
+  if (row.note !== null) rec.note = row.note;
+  return rec;
+}
+
+// ── Facet path validation + SQL fragment building ─────────────────────────────
+
+const FACET_COLUMN: Record<string, string> = {
+  scores: 'scores_json',
+  metadata: 'metadata_json',
+};
+
+/**
+ * Validate a facet `path` and return the vetted `json_extract(...)` SQL fragment.
+ *
+ * `path` is `<prefix>.<key>`: the prefix MUST be exactly `scores` or `metadata`
+ * (anything else throws — the E4 server maps the throw to a 400), and the key
+ * MUST be in the run's DISCOVERED key set (derived from the run's stored
+ * scores/metadata JSON). This keeps `json_extract`'s pointer a vetted constant
+ * rather than raw caller input, so a caller cannot probe arbitrary paths.
+ */
+function vettedExtract(path: string, discovered: DiscoveredKeys): string {
+  const dot = path.indexOf('.');
+  const prefix = dot === -1 ? path : path.slice(0, dot);
+  const key = dot === -1 ? '' : path.slice(dot + 1);
+  const column = FACET_COLUMN[prefix];
+  if (column === undefined) {
+    throw new Error(`Invalid facet path prefix "${prefix}" in "${path}" (expected scores|metadata)`);
+  }
+  const allowed = prefix === 'scores' ? discovered.scores : discovered.metadata;
+  if (key === '' || !allowed.has(key)) {
+    throw new Error(`Unknown facet key "${key}" for ${prefix} in "${path}"`);
+  }
+  // The JSON pointer is built from a vetted key. Quote any embedded `"` so a
+  // discovered key containing a quote can't break out of the pointer literal.
+  const pointer = `$."${key.replace(/"/g, '""')}"`;
+  return `json_extract(${column}, '${pointer}')`;
+}
+
+interface DiscoveredKeys {
+  scores: Set<string>;
+  metadata: Set<string>;
+}
+
+/** Union the `scores`/`metadata` object keys across every row of a run. */
+function discoverKeys(rows: EvalRowDbRow[]): DiscoveredKeys {
+  const scores = new Set<string>();
+  const metadata = new Set<string>();
+  for (const r of rows) {
+    const s = parseJson<Record<string, unknown>>(r.scores_json);
+    if (s !== undefined) for (const k of Object.keys(s)) scores.add(k);
+    const m = parseJson<Record<string, unknown>>(r.metadata_json);
+    if (m !== undefined) for (const k of Object.keys(m)) metadata.add(k);
+  }
+  return { scores, metadata };
+}
+
+export function makeReader(db: Database.Database): EleaticReader {
+  const listRunsStmt = db.prepare(
+    `SELECT * FROM eval_run ORDER BY started_at DESC`,
+  );
+  const getRunStmt = db.prepare(`SELECT * FROM eval_run WHERE id = ?`);
+  const getRowsStmt = db.prepare(
+    `SELECT * FROM eval_row WHERE run_id = ? ORDER BY row_key`,
+  );
+  const getRowStmt = db.prepare(
+    `SELECT * FROM eval_row WHERE run_id = ? AND row_key = ?`,
+  );
+  const trendStmt = db.prepare(`SELECT * FROM eval_run ORDER BY started_at ASC`);
+  const getAdjStmt = db.prepare(`SELECT * FROM eval_adjudication WHERE row_key = ?`);
+  const allAdjStmt = db.prepare(`SELECT * FROM eval_adjudication ORDER BY row_key`);
+
+  function getRows(runId: string): EvalRowRecord[] {
+    return (getRowsStmt.all(runId) as EvalRowDbRow[]).map(readRow);
+  }
+
+  function facetRows(runId: string, q: FacetQuery): EvalRowRecord[] {
+    const rawRows = getRowsStmt.all(runId) as EvalRowDbRow[];
+    const discovered = discoverKeys(rawRows);
+
+    const where: string[] = ['run_id = ?'];
+    const params: Array<JsonScalar | undefined> = [runId];
+
+    for (const filter of q.filters ?? []) {
+      const extract = vettedExtract(filter.path, discovered);
+      switch (filter.op) {
+        case 'exists':
+          where.push(`${extract} IS NOT NULL`);
+          break;
+        case 'in': {
+          const list = Array.isArray(filter.value) ? filter.value : [];
+          if (list.length === 0) {
+            where.push('0'); // empty IN () matches nothing
+          } else {
+            where.push(`${extract} IN (${list.map(() => '?').join(', ')})`);
+            for (const v of list) params.push(v);
+          }
+          break;
+        }
+        case 'contains':
+          where.push(`${extract} LIKE ?`);
+          params.push(`%${String(scalar(filter.value))}%`);
+          break;
+        default: {
+          const opSql = { eq: '=', ne: '!=', lt: '<', lte: '<=', gt: '>', gte: '>=' }[filter.op];
+          where.push(`${extract} ${opSql} ?`);
+          params.push(scalar(filter.value));
+        }
+      }
+    }
+
+    let sql = `SELECT * FROM eval_row WHERE ${where.join(' AND ')}`;
+    if (q.sort) {
+      const sortExtract = vettedExtract(q.sort.path, discovered);
+      const dir = q.sort.dir === 'desc' ? 'DESC' : 'ASC';
+      sql += ` ORDER BY ${sortExtract} ${dir}, row_key ${dir}`;
+    } else {
+      sql += ` ORDER BY row_key`;
+    }
+    // LIMIT/OFFSET are passed as bind params, not interpolated.
+    const limitParams: number[] = [];
+    if (q.limit !== undefined) {
+      sql += ` LIMIT ?`;
+      limitParams.push(q.limit);
+      if (q.offset !== undefined) {
+        sql += ` OFFSET ?`;
+        limitParams.push(q.offset);
+      }
+    } else if (q.offset !== undefined) {
+      // SQLite requires a LIMIT before OFFSET; -1 means "no limit".
+      sql += ` LIMIT -1 OFFSET ?`;
+      limitParams.push(q.offset);
+    }
+
+    const bind: Array<JsonScalar | number> = [];
+    for (const p of params) bind.push(p ?? null);
+    for (const p of limitParams) bind.push(p);
+    return (db.prepare(sql).all(...bind) as EvalRowDbRow[]).map(readRow);
+  }
+
+  return {
+    listRuns() {
+      return (listRunsStmt.all() as RunDbRow[]).map(readRun);
+    },
+    getRun(id) {
+      const row = getRunStmt.get(id) as RunDbRow | undefined;
+      return row === undefined ? undefined : readRun(row);
+    },
+    getRows,
+    getRow(runId, rowKey) {
+      const row = getRowStmt.get(runId, rowKey) as EvalRowDbRow | undefined;
+      return row === undefined ? undefined : readRow(row);
+    },
+    diffRuns(aRunId, bRunId) {
+      const byKey = new Map<string, RunDiff>();
+      for (const r of getRows(aRunId)) {
+        byKey.set(r.rowKey, { rowKey: r.rowKey, a: r });
+      }
+      for (const r of getRows(bRunId)) {
+        const existing = byKey.get(r.rowKey);
+        if (existing === undefined) byKey.set(r.rowKey, { rowKey: r.rowKey, b: r });
+        else existing.b = r;
+      }
+      return [...byKey.values()].sort((x, y) => (x.rowKey < y.rowKey ? -1 : x.rowKey > y.rowKey ? 1 : 0));
+    },
+    facetRows,
+    metricTrend(metricName) {
+      const runs = trendStmt.all() as RunDbRow[];
+      return runs.map((row) => {
+        const point: MetricPoint = { runId: row.id, startedAt: row.started_at ?? '' };
+        const metrics = parseJson<Record<string, number>>(row.metrics_json);
+        const value = metrics?.[metricName];
+        if (value !== undefined) point.value = value;
+        return point;
+      });
+    },
+    listAdjudications(rowKeys) {
+      if (rowKeys === undefined) {
+        return (allAdjStmt.all() as AdjDbRow[]).map(readAdj);
+      }
+      if (rowKeys.length === 0) return [];
+      const placeholders = rowKeys.map(() => '?').join(', ');
+      const rows = db
+        .prepare(`SELECT * FROM eval_adjudication WHERE row_key IN (${placeholders}) ORDER BY row_key`)
+        .all(...rowKeys) as AdjDbRow[];
+      return rows.map(readAdj);
+    },
+    isStale(rowKey, currentHash) {
+      const row = getAdjStmt.get(rowKey) as AdjDbRow | undefined;
+      const recorded = row?.against_hash;
+      // No adjudication, or no recorded hash → cannot be stale.
+      if (recorded === undefined || recorded === null) return false;
+      return recorded !== currentHash;
+    },
+  };
+}
+
+/** Narrow a possibly-array facet value to a single scalar for binary ops. */
+function scalar(value: JsonScalar | JsonScalar[] | undefined): JsonScalar {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    Caller["E4 server / E6 UI"] -->|"makeReader(db)"| Reader["EleaticReader (read-only)"]

    Reader -->|"listRuns / getRun"| Run["eval_run"]
    Reader -->|"getRows / getRow / diffRuns / facetRows"| Row["eval_row"]
    Reader -->|"listAdjudications / isStale"| Adj["eval_adjudication"]
    Reader -->|"metricTrend (started_at ASC)"| Run

    subgraph facet["facetRows(runId, FacetQuery)"]
      direction TB
      P["path: scores.name or metadata.key"] --> V{"prefix in scores/metadata AND key discovered?"}
      V -->|no| Throw["throw Error -> E4 maps to 400"]
      V -->|yes| Ex["json_extract over scores_json/metadata_json, vetted pointer"]
      Ex --> Bind["value bound as ? param (never interpolated)"]
    end

    Reader --> facet
    facet --> Row

    Row -->|"NULL column to omitted key"| Records["EvalRunRecord / EvalRowRecord / EvalAdjudicationRecord (E1 types.ts)"]
    Run --> Records
    Adj --> Records
```

## Summary

- E2 of the eleatic epic (#1153): adds the pure read-only SQLite layer (`makeReader` → `EleaticReader`) over E1's generic three-table schema, so the comparison hub, per-row diff, faceted gallery, trends, and adjudication drill-down have a query surface to build on. *Why a generic reader:* the photo-judge hard-coded `WHERE gemini_keep = 1 AND opus_keep = 0`; that doesn't survive the `git mv` to a domain-agnostic repo, so `facetRows(runId, FacetQuery)` generalizes it into a parameterized `json_extract` engine over `scores_json`/`metadata_json` — the falseKeep gallery becomes `metadata.disagreement:eq:falseKeep`.
- *Why path validation is load-bearing:* the `json_extract` JSON-pointer is the one place a value can't be a `?` bind param, so the path prefix must be exactly `scores`/`metadata` and the key must be in the run's discovered key set — anything else throws (E4 maps to a 400). Filter values always bind as `?`.
- Returns E1's canonical record types (`EvalRunRecord`/`EvalRowRecord`/`EvalAdjudicationRecord`) unchanged; declares only the net-new `RunDiff`/`MetricPoint`/`FacetQuery`/`FacetFilter` (E2 owns the single `FacetQuery` definition). Zero `@bird-watch/*` imports; no DB open, no writes, no network. Barrel extended only at the reserved E2 marker.

## Screenshots

N/A — packages/ tool (not frontend/**)

## Test plan

- [x] `npm run typecheck && npm run test` — eleatic package green (50/50: 22 existing + 28 new); frontend green (1529). db-client/read-api testcontainers (real Postgres+PostGIS) tests time out on Docker health-check in the local sandbox only — environmental, orthogonal to this zero-coupling package; they pass in CI.
- [x] New unit tests added — `packages/eleatic/src/queries.test.ts` (pure-unit, real `:memory:` better-sqlite3, no network/mocks): listRuns/getRun/getRows/getRow, NULL→omitted-key mapping, the headline `facetRows` generalization (eq/ne/lt/gte/in/exists, sort asc/desc, limit/offset, invalid-prefix + unknown-key throws, run scoping), diffRuns (both/only-a/only-b), metricTrend (started_at ASC + missing-metric), listAdjudications/isStale.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no UI.
- [x] `npm run build` — clean production build (all workspaces incl. frontend).
- [ ] (UI only) Playwright MCP smoke — N/A, no UI.

## Plan reference

Part of epic #1153 (eleatic), Wave 2 (E2). Closes #1145.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
