### PR TITLE
feat(eleatic): express server (read API + adjudication write) + `eleatic serve` CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9973,11 +9973,19 @@
       "name": "@bird-watch/eleatic",
       "version": "0.0.1",
       "dependencies": {
-        "better-sqlite3": "^11.8.1"
+        "better-sqlite3": "^11.8.1",
+        "commander": "^13.1.0",
+        "express": "^5.2.1"
+      },
+      "bin": {
+        "eleatic": "dist/cli.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
+        "@types/express": "^5.0.6",
         "@types/node": "^24.13.2",
+        "@types/supertest": "^6.0.3",
+        "supertest": "^7.2.2",
         "vitest": "^4.1.8"
       }
     },

--- a/packages/eleatic/package.json
+++ b/packages/eleatic/package.json
@@ -5,16 +5,24 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "eleatic": "dist/cli.js"
+  },
   "scripts": {
     "build": "tsc && node -e \"require('fs').cpSync('ui','dist/ui',{recursive:true})\"",
     "test": "vitest run"
   },
   "dependencies": {
-    "better-sqlite3": "^11.8.1"
+    "better-sqlite3": "^11.8.1",
+    "commander": "^13.1.0",
+    "express": "^5.2.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
+    "@types/express": "^5.0.6",
     "@types/node": "^24.13.2",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.2.2",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/eleatic/src/__fixtures__/config.sample.json
+++ b/packages/eleatic/src/__fixtures__/config.sample.json
@@ -1,0 +1,5 @@
+{
+  "verdictVocabulary": ["keep", "replace", "uncertain"],
+  "gate": { "metric": "agreement", "op": "gte", "threshold": 0.9 },
+  "metricFormatters": { "agreement": "percent" }
+}

--- a/packages/eleatic/src/cli.test.ts
+++ b/packages/eleatic/src/cli.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { buildProgram } from './cli.js';
+
+/**
+ * Pure-unit CLI tests: build the commander program with an injected fake
+ * `startServer`, parse argv, and inspect the parsed options + the args handed to
+ * startServer. We NEVER bind a real port — the fake captures the call instead of
+ * `app.listen`-ing.
+ */
+describe('eleatic CLI', () => {
+  it('registers a `serve` command with required --db and --port defaulting to 8788', () => {
+    const program = buildProgram(() => ({ close: () => {} }));
+    const serve = program.commands.find((c) => c.name() === 'serve');
+    expect(serve).toBeDefined();
+    expect(program.name()).toBe('eleatic');
+
+    const opts = serve!.options;
+    const db = opts.find((o) => o.long === '--db');
+    const port = opts.find((o) => o.long === '--port');
+    const config = opts.find((o) => o.long === '--config');
+    // commander: `mandatory` = the option itself must be present (requiredOption);
+    // `required` = the option's *value* is required (`<value>` vs `[value]`).
+    expect(db?.mandatory).toBe(true); // --db is a requiredOption
+    expect(port?.defaultValue).toBe('8788');
+    expect(config).toBeDefined();
+    expect(config?.mandatory).toBe(false); // --config is optional
+  });
+
+  it('passes parsed --db/--port through to startServer (port coerced to Number)', () => {
+    let captured: { dbPath: string; port: number; configPath?: string } | undefined;
+    const program = buildProgram((o) => {
+      captured = o;
+      return { close: () => {} };
+    });
+    program.parse(['node', 'eleatic', 'serve', '--db', '/tmp/eval.sqlite', '--port', '9001']);
+    expect(captured).toEqual({ dbPath: '/tmp/eval.sqlite', port: 9001 });
+  });
+
+  it('omits configPath entirely when --config is absent (exactOptionalPropertyTypes)', () => {
+    let captured: { dbPath: string; port: number; configPath?: string } | undefined;
+    const program = buildProgram((o) => { captured = o; return { close: () => {} }; });
+    program.parse(['node', 'eleatic', 'serve', '--db', '/tmp/eval.sqlite']);
+    expect(captured).toBeDefined();
+    expect('configPath' in captured!).toBe(false); // key absent, not undefined
+    expect(captured!.port).toBe(8788); // default
+  });
+
+  it('sets configPath only when --config is passed', () => {
+    let captured: { dbPath: string; port: number; configPath?: string } | undefined;
+    const program = buildProgram((o) => { captured = o; return { close: () => {} }; });
+    program.parse(['node', 'eleatic', 'serve', '--db', '/tmp/eval.sqlite', '--config', '/tmp/cfg.json']);
+    expect(captured!.configPath).toBe('/tmp/cfg.json');
+  });
+});

--- a/packages/eleatic/src/cli.ts
+++ b/packages/eleatic/src/cli.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * The `eleatic` bin — a commander CLI with one `serve` subcommand that boots the
+ * eval-results explorer. Modelled on `tools/photo-curation/src/cli.ts`.
+ *
+ * `buildProgram(startServerFn)` constructs the program with an INJECTABLE server
+ * starter, so cli.test.ts can parse argv and inspect the parsed options (and the
+ * args handed to startServer) without binding a real port. The module only
+ * actually parses `process.argv` + uses the real `startServer` when run as a
+ * script (the `import.meta.url`/`process.argv[1]` guard at the bottom).
+ */
+
+import { Command } from 'commander';
+import { startServer, type ServeOptions } from './server/serve.js';
+
+/** The starter signature buildProgram injects (real or fake). */
+export type StartServerFn = (opts: ServeOptions) => { close: () => void };
+
+export function buildProgram(start: StartServerFn): Command {
+  const program = new Command();
+  program.name('eleatic').description('Domain-agnostic eval-results explorer');
+
+  program
+    .command('serve')
+    .description('Start the eleatic eval-results explorer')
+    .requiredOption('--db <path>', 'eval store path (eval.sqlite)')
+    .option('--port <port>', 'port to bind', '8788')
+    .option('--config <path>', 'optional eleatic config JSON')
+    .action((opts: { db: string; port: string; config?: string }) => {
+      // Only set the optional configPath key when --config was passed
+      // (exactOptionalPropertyTypes: an omitted optional is an ABSENT key).
+      start({
+        dbPath: opts.db,
+        port: Number(opts.port),
+        ...(opts.config !== undefined ? { configPath: opts.config } : {}),
+      });
+    });
+
+  return program;
+}
+
+// Run as a script (`eleatic ...` / `node dist/cli.js ...`), not on import. The
+// guard keeps `import { buildProgram } from './cli.js'` (the test) side-effect
+// free — importing must not parse argv or start a server.
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (invokedAsScript) {
+  buildProgram(startServer).parseAsync(process.argv);
+}

--- a/packages/eleatic/src/config.test.ts
+++ b/packages/eleatic/src/config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig, clientConfigSlice, type EleaticConfig } from './config.js';
+
+describe('resolveConfig', () => {
+  it('returns a zero-config default when no path is given', () => {
+    const cfg = resolveConfig();
+    // Defaults: a non-empty verdict vocabulary, an any-https image allowlist, a
+    // namespaced theme key, no gate, no named metrics, no formatters.
+    expect(cfg.verdictVocabulary.length).toBeGreaterThan(0);
+    expect(cfg.imageHostAllowlist).toEqual(['https://*']);
+    expect(cfg.themeKey).toBe('eleatic-theme');
+    expect(cfg.gate).toBeUndefined();
+    expect(cfg.metricFormatters).toEqual({});
+  });
+
+  it('reads + merges a config JSON file over the defaults', () => {
+    const cfg = resolveConfig(
+      new URL('./__fixtures__/config.sample.json', import.meta.url).pathname,
+    );
+    expect(cfg.verdictVocabulary).toEqual(['keep', 'replace', 'uncertain']);
+    expect(cfg.gate).toEqual({ metric: 'agreement', op: 'gte', threshold: 0.9 });
+    expect(cfg.metricFormatters.agreement).toBe('percent');
+    // A field absent from the file falls back to the default.
+    expect(cfg.themeKey).toBe('eleatic-theme');
+  });
+});
+
+describe('clientConfigSlice', () => {
+  const full: EleaticConfig = {
+    verdictVocabulary: ['keep', 'replace'],
+    imageHostAllowlist: ['https://*'],
+    themeKey: 'eleatic-theme',
+    metricFormatters: { agreement: 'percent' },
+    gate: { metric: 'agreement', op: 'gte', threshold: 0.9 },
+    // a server-only field that must NOT leak to the browser
+    dbPath: '/secret/eval.sqlite',
+  };
+
+  it('projects only client-safe fields', () => {
+    const slice = clientConfigSlice(full);
+    expect(slice).toEqual({
+      verdictVocabulary: ['keep', 'replace'],
+      imageHostAllowlist: ['https://*'],
+      themeKey: 'eleatic-theme',
+      metricFormatters: { agreement: 'percent' },
+      gate: { metric: 'agreement', op: 'gte', threshold: 0.9 },
+    });
+  });
+
+  it('omits server-only fields entirely (no dbPath key)', () => {
+    const slice = clientConfigSlice(full);
+    expect('dbPath' in slice).toBe(false);
+  });
+
+  it('omits an absent gate rather than emitting undefined', () => {
+    const noGate = resolveConfig();
+    const slice = clientConfigSlice(noGate);
+    expect('gate' in slice).toBe(false);
+  });
+});

--- a/packages/eleatic/src/config.ts
+++ b/packages/eleatic/src/config.ts
@@ -1,0 +1,105 @@
+/**
+ * eleatic configuration — resolved server config and the client-safe slice.
+ *
+ * All configurability is OPTIONAL: `resolveConfig()` with no path returns a
+ * zero-config default that works out of the box (the "zero-config works" resolved
+ * default from the plan). A `--config <path>` JSON file shallow-overrides those
+ * defaults. The package invents no domain mapping: the verdict vocabulary, named
+ * metrics, gate, and image-host allowlist all come from config (or the generic
+ * defaults), never from a hard-coded bird/photo assumption.
+ *
+ * `clientConfigSlice(cfg)` projects ONLY the browser-safe subset that the UI's
+ * `/config.js` import needs. Server-only fields (e.g. the on-disk db path) never
+ * appear in the emitted module. Under `exactOptionalPropertyTypes` every omittable
+ * field is declared `?:` and is set on the projected object only when present, so
+ * an absent key is genuinely absent (never `undefined`) in the emitted JSON.
+ */
+
+import { readFileSync } from 'node:fs';
+
+/** A declarative pass/fail gate over one run-level metric. */
+export interface EleaticGate {
+  metric: string;
+  op: 'eq' | 'ne' | 'lt' | 'lte' | 'gt' | 'gte';
+  threshold: number;
+}
+
+/** The client-visible config slice the UI imports via `/config.js`. */
+export interface ClientConfig {
+  /** Allowed verdict strings for the adjudication dropdown. */
+  verdictVocabulary: string[];
+  /** Image-host allowlist for the gallery (default: any https). */
+  imageHostAllowlist: string[];
+  /** Namespaced localStorage key for the UI theme. */
+  themeKey: string;
+  /** Per-metric display formatter hints, e.g. `{ agreement: 'percent' }`. */
+  metricFormatters: Record<string, string>;
+  /** Declarative run gate, if configured. */
+  gate?: EleaticGate;
+}
+
+/**
+ * The fully-resolved server config. Extends the client slice with server-only
+ * fields that must NOT leak to the browser (e.g. the db path, carried for
+ * provenance / logging). Server-only keys are added here and explicitly NOT
+ * copied by `clientConfigSlice`.
+ */
+export interface EleaticConfig extends ClientConfig {
+  /** Server-only: the resolved store path (never emitted to the client). */
+  dbPath?: string;
+}
+
+const DEFAULT_VERDICTS = ['keep', 'replace', 'uncertain'];
+
+/** The zero-config baseline applied before any `--config` file overrides. */
+function defaults(): EleaticConfig {
+  return {
+    verdictVocabulary: [...DEFAULT_VERDICTS],
+    imageHostAllowlist: ['https://*'],
+    themeKey: 'eleatic-theme',
+    metricFormatters: {},
+  };
+}
+
+/** Shape of the optional on-disk config JSON (every field optional). */
+interface ConfigFile {
+  verdictVocabulary?: string[];
+  imageHostAllowlist?: string[];
+  themeKey?: string;
+  metricFormatters?: Record<string, string>;
+  gate?: EleaticGate;
+}
+
+/**
+ * Resolve the eleatic config. With no `path`, returns the zero-config default.
+ * With a `path`, shallow-merges the JSON file over the defaults; only the keys
+ * present in the file override, the rest fall back. Optional keys are assigned
+ * only when present (exactOptionalPropertyTypes).
+ */
+export function resolveConfig(path?: string): EleaticConfig {
+  const cfg = defaults();
+  if (path === undefined) return cfg;
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as ConfigFile;
+  if (parsed.verdictVocabulary !== undefined) cfg.verdictVocabulary = parsed.verdictVocabulary;
+  if (parsed.imageHostAllowlist !== undefined) cfg.imageHostAllowlist = parsed.imageHostAllowlist;
+  if (parsed.themeKey !== undefined) cfg.themeKey = parsed.themeKey;
+  if (parsed.metricFormatters !== undefined) cfg.metricFormatters = parsed.metricFormatters;
+  if (parsed.gate !== undefined) cfg.gate = parsed.gate;
+  return cfg;
+}
+
+/**
+ * Project the client-safe subset for the `/config.js` emitter. Server-only
+ * fields (dbPath) are intentionally dropped. An absent `gate` is omitted (the
+ * key never appears) rather than serialized as `undefined`.
+ */
+export function clientConfigSlice(cfg: EleaticConfig): ClientConfig {
+  const slice: ClientConfig = {
+    verdictVocabulary: cfg.verdictVocabulary,
+    imageHostAllowlist: cfg.imageHostAllowlist,
+    themeKey: cfg.themeKey,
+    metricFormatters: cfg.metricFormatters,
+  };
+  if (cfg.gate !== undefined) slice.gate = cfg.gate;
+  return slice;
+}

--- a/packages/eleatic/src/index.ts
+++ b/packages/eleatic/src/index.ts
@@ -39,4 +39,8 @@ export {
 export type { AnalysisRow, AnalysisOptions, Analysis, AnalysisSelector } from './analysis.js';
 
 // --- Server factory (E4) ---
-// export { createApp } from './app.js';
+export { createApp } from './server/app.js';
+export { startServer } from './server/serve.js';
+export type { ServeOptions } from './server/serve.js';
+export { resolveConfig, clientConfigSlice } from './config.js';
+export type { EleaticConfig, ClientConfig, EleaticGate } from './config.js';

--- a/packages/eleatic/src/server/app.test.ts
+++ b/packages/eleatic/src/server/app.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from './app.js';
+import { openStore, type EleaticStore } from '../store.js';
+import type { EleaticConfig } from '../config.js';
+
+// A minimal, generic config: a default verdict vocabulary, one named metric
+// formatter, and a declarative gate. No domain (bird/photo) assumptions.
+const cfg: EleaticConfig = {
+  verdictVocabulary: ['keep', 'replace', 'uncertain'],
+  imageHostAllowlist: ['https://*'],
+  themeKey: 'eleatic-theme',
+  metricFormatters: { agreement: 'percent' },
+  gate: { metric: 'agreement', op: 'gte', threshold: 0.9 },
+  dbPath: '/secret/eval.sqlite', // server-only — must never reach /config.js
+};
+
+/**
+ * Seed an in-memory store via E1's WRITE path only (no hand-written DDL — that
+ * would couple the test to schema internals E1 owns). Two runs so diff/trends
+ * have something to compare; rows carry scores + metadata so facet filtering and
+ * key-discovery validation are exercised.
+ */
+function seedStore(): EleaticStore {
+  const store = openStore(':memory:');
+  store.recordRun({ id: 'run-a', label: 'baseline', startedAt: '2026-06-01T00:00:00Z' });
+  store.recordRun({
+    id: 'run-b',
+    label: 'candidate',
+    baseline: 'run-a',
+    startedAt: '2026-06-02T00:00:00Z',
+  });
+  store.recordRows([
+    {
+      runId: 'run-a',
+      rowKey: 'item-1',
+      contentHash: 'h1-a',
+      output: { keep: true },
+      expected: { keep: true },
+      scores: { quality: 80 },
+      metadata: { disagreement: 'agree' },
+    },
+    {
+      runId: 'run-a',
+      rowKey: 'item-2',
+      contentHash: 'h2-a',
+      output: { keep: true },
+      expected: { keep: false },
+      scores: { quality: 55 },
+      metadata: { disagreement: 'falseKeep' },
+    },
+  ]);
+  store.recordRows([
+    {
+      runId: 'run-b',
+      rowKey: 'item-1',
+      contentHash: 'h1-b',
+      output: { keep: false },
+      expected: { keep: true },
+      scores: { quality: 40 },
+      metadata: { disagreement: 'falseReplace' },
+    },
+    {
+      runId: 'run-b',
+      rowKey: 'item-2',
+      contentHash: 'h2-b',
+      output: { keep: true },
+      expected: { keep: false },
+      scores: { quality: 60 },
+      metadata: { disagreement: 'falseKeep' },
+    },
+  ]);
+  store.finalizeRun('run-a', { rowCount: 2, metrics: { agreement: 0.5 } });
+  store.finalizeRun('run-b', { rowCount: 2, metrics: { agreement: 0.75 } });
+  return store;
+}
+
+describe('eleatic server', () => {
+  let store: EleaticStore;
+  beforeEach(() => { store = seedStore(); });
+  afterEach(() => store.close());
+
+  it('GET /api/runs lists runs newest-first', async () => {
+    const res = await request(createApp(store, cfg)).get('/api/runs');
+    expect(res.status).toBe(200);
+    expect(res.body.runs.map((r: { id: string }) => r.id)).toEqual(['run-b', 'run-a']);
+  });
+
+  it('GET /api/runs/:id returns a run; 404 for unknown', async () => {
+    const app = createApp(store, cfg);
+    const ok = await request(app).get('/api/runs/run-a');
+    expect(ok.status).toBe(200);
+    expect(ok.body.run.id).toBe('run-a');
+    expect((await request(app).get('/api/runs/bogus')).status).toBe(404);
+  });
+
+  it('GET /api/diff compares two runs; 400 on missing param, 404 on unknown', async () => {
+    const app = createApp(store, cfg);
+    const ok = await request(app).get('/api/diff?a=run-a&b=run-b');
+    expect(ok.status).toBe(200);
+    expect(ok.body.diff.length).toBe(2); // item-1 + item-2, each present on both sides
+    const byKey = Object.fromEntries(ok.body.diff.map((d: { rowKey: string }) => [d.rowKey, d]));
+    expect(byKey['item-1'].a.rowKey).toBe('item-1');
+    expect(byKey['item-1'].b.rowKey).toBe('item-1');
+
+    expect((await request(app).get('/api/diff?a=run-a')).status).toBe(400);
+    expect((await request(app).get('/api/diff?b=run-b')).status).toBe(400);
+    expect((await request(app).get('/api/diff?a=run-a&b=nope')).status).toBe(404);
+    expect((await request(app).get('/api/diff?a=nope&b=run-b')).status).toBe(404);
+  });
+
+  it('GET /api/rows returns all rows for a run', async () => {
+    const res = await request(createApp(store, cfg)).get('/api/rows?run=run-a');
+    expect(res.status).toBe(200);
+    expect(res.body.rows.map((r: { rowKey: string }) => r.rowKey)).toEqual(['item-1', 'item-2']);
+  });
+
+  it('GET /api/rows with f= filters (generalized falseKeep gallery)', async () => {
+    const res = await request(createApp(store, cfg))
+      .get('/api/rows?run=run-b&f=metadata.disagreement:eq:falseKeep');
+    expect(res.status).toBe(200);
+    expect(res.body.rows.map((r: { rowKey: string }) => r.rowKey)).toEqual(['item-2']);
+  });
+
+  it('GET /api/rows validation: 400 missing run, 400 malformed/unknown facet path, 404 unknown run', async () => {
+    const app = createApp(store, cfg);
+    expect((await request(app).get('/api/rows')).status).toBe(400); // missing run
+    expect((await request(app).get('/api/rows?run=nope')).status).toBe(404); // unknown run
+    // malformed f= (no colons)
+    expect((await request(app).get('/api/rows?run=run-a&f=garbage')).status).toBe(400);
+    // path not among discovered keys for this run
+    expect(
+      (await request(app).get('/api/rows?run=run-a&f=metadata.nonexistent:eq:x')).status,
+    ).toBe(400);
+    // bad prefix (neither scores nor metadata)
+    expect(
+      (await request(app).get('/api/rows?run=run-a&f=other.x:eq:y')).status,
+    ).toBe(400);
+  });
+
+  it('GET /api/row returns one row; 400 on missing param, 404 on unknown row', async () => {
+    const app = createApp(store, cfg);
+    const ok = await request(app).get('/api/row?run=run-a&row=item-1');
+    expect(ok.status).toBe(200);
+    expect(ok.body.row.rowKey).toBe('item-1');
+    expect((await request(app).get('/api/row?run=run-a')).status).toBe(400);
+    expect((await request(app).get('/api/row?row=item-1')).status).toBe(400);
+    expect((await request(app).get('/api/row?run=run-a&row=ghost')).status).toBe(404);
+    expect((await request(app).get('/api/row?run=nope&row=item-1')).status).toBe(404);
+  });
+
+  it('GET /api/trends returns trend points; 400 when metric omitted', async () => {
+    const app = createApp(store, cfg);
+    const ok = await request(app).get('/api/trends?metric=agreement');
+    expect(ok.status).toBe(200);
+    // newest-first is for listRuns; metricTrend is chronological (asc) by E2.
+    expect(ok.body.trend.map((p: { runId: string; value: number }) => [p.runId, p.value]))
+      .toEqual([['run-a', 0.5], ['run-b', 0.75]]);
+    expect((await request(app).get('/api/trends')).status).toBe(400);
+  });
+
+  it('GET /api/adjudications flags isStale when against_hash diverges from current content_hash', async () => {
+    // Record one verdict against the CURRENT hash (fresh) and one against a stale hash.
+    store.recordAdjudication({ rowKey: 'item-1', verdict: 'keep', againstHash: 'h1-a', decidedAt: '2026-06-03T00:00:00Z' });
+    store.recordAdjudication({ rowKey: 'item-2', verdict: 'replace', againstHash: 'OLD-HASH', decidedAt: '2026-06-03T00:00:00Z' });
+    const res = await request(createApp(store, cfg)).get('/api/adjudications?run=run-a');
+    expect(res.status).toBe(200);
+    const byKey = Object.fromEntries(
+      res.body.adjudications.map((a: { rowKey: string }) => [a.rowKey, a]),
+    );
+    expect(byKey['item-1'].isStale).toBe(false); // matches current content_hash
+    expect(byKey['item-2'].isStale).toBe(true); // OLD-HASH !== h2-a
+  });
+
+  it('POST /api/adjudications round-trips (upsert on row_key) + captures against_hash', async () => {
+    const app = createApp(store, cfg);
+    const post = await request(app)
+      .post('/api/adjudications')
+      .send({ rowKey: 'item-1', verdict: 'keep', run: 'run-a', note: 'looks good' });
+    expect(post.status).toBe(200);
+
+    const list = await request(app).get('/api/adjudications?run=run-a');
+    const item1 = list.body.adjudications.find((a: { rowKey: string }) => a.rowKey === 'item-1');
+    expect(item1.verdict).toBe('keep');
+    expect(item1.note).toBe('looks good');
+    // against_hash captured from the row's current content_hash at decision time.
+    expect(item1.againstHash).toBe('h1-a');
+    expect(item1.isStale).toBe(false);
+
+    // Upsert: a second POST for the same row_key replaces, not duplicates.
+    await request(app).post('/api/adjudications').send({ rowKey: 'item-1', verdict: 'replace', run: 'run-a' });
+    const list2 = await request(app).get('/api/adjudications?run=run-a');
+    const dupes = list2.body.adjudications.filter((a: { rowKey: string }) => a.rowKey === 'item-1');
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0].verdict).toBe('replace');
+  });
+
+  it('POST /api/adjudications rejects out-of-vocabulary verdict (400) and missing rowKey (400)', async () => {
+    const app = createApp(store, cfg);
+    expect(
+      (await request(app).post('/api/adjudications').send({ rowKey: 'item-1', verdict: 'frobnicate' })).status,
+    ).toBe(400);
+    expect(
+      (await request(app).post('/api/adjudications').send({ verdict: 'keep' })).status,
+    ).toBe(400);
+  });
+
+  it('GET / serves the placeholder landing page (200 HTML)', async () => {
+    const res = await request(createApp(store, cfg)).get('/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.text).toContain('<title>eleatic</title>');
+  });
+
+  it('GET /config.js emits a parseable ESM client slice and OMITS server-only fields', async () => {
+    const res = await request(createApp(store, cfg)).get('/config.js');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/javascript/);
+    // body is `export const config = {...};` — extract + parse the object literal.
+    const match = /export const config = (\{[\s\S]*\});\s*$/.exec(res.text);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]) as Record<string, unknown>;
+    expect(parsed.verdictVocabulary).toEqual(['keep', 'replace', 'uncertain']);
+    expect(parsed.gate).toEqual({ metric: 'agreement', op: 'gte', threshold: 0.9 });
+    expect(parsed.metricFormatters).toEqual({ agreement: 'percent' });
+    expect(parsed.imageHostAllowlist).toEqual(['https://*']);
+    expect('dbPath' in parsed).toBe(false); // server-only field must not leak
+  });
+});

--- a/packages/eleatic/src/server/app.ts
+++ b/packages/eleatic/src/server/app.ts
@@ -1,0 +1,236 @@
+/**
+ * The eleatic Express app factory.
+ *
+ * `createApp(store, cfg)` builds the read API (+ the single adjudication write)
+ * over E2's `EleaticReader` and E1's write store. It writes NO SQL itself — every
+ * read delegates to the reader, the one write delegates to `store.recordAdjudication`.
+ *
+ * Why it takes the `EleaticStore` (not a raw `Database.Database`): `startServer`
+ * opens the store via E1's `openStore`, and the store is the natural unit a test
+ * seeds (`createApp(openStore(':memory:'), cfg)`). The reader needs the raw handle
+ * (`store.db` — E1's documented read-only escape hatch for E2), and the lone write
+ * goes through the store's prepared `recordAdjudication`. Zero `@bird-watch/*`
+ * imports (the package's git-mv boundary); all imports are `./`/`../` siblings.
+ *
+ * HTTP-status contract (E4 owns this; E6's drawer relies on it):
+ *   • a MISSING / empty required query param → 400
+ *   • a well-formed but UNKNOWN run id / row → 404
+ * This deliberately diverges from the photo-curation grounding (index.ts:182-187),
+ * which returns 400 for an unknown run; eleatic uses 404 for a well-formed unknown id.
+ */
+
+import express, { type Express, type Request, type Response } from 'express';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { makeReader, type FacetFilter, type FacetQuery, type JsonScalar } from '../queries.js';
+import { clientConfigSlice, type EleaticConfig } from '../config.js';
+import type { EleaticStore } from '../store.js';
+
+// ── Facet `f=` deserialization ────────────────────────────────────────────────
+//
+// `f=metadata.disagreement:eq:falseKeep` → a single FacetFilter. The query layer
+// (E2) owns path VALIDATION (prefix ∈ {scores,metadata}, key ∈ the run's
+// discovered keys) and throws on a bad path; this only parses the wire format. A
+// structurally malformed `f=` (missing op, unknown op) throws here → mapped to 400.
+
+const FACET_OPS = new Set<FacetFilter['op']>([
+  'eq', 'ne', 'lt', 'lte', 'gt', 'gte', 'in', 'contains', 'exists',
+]);
+
+/** Coerce a string facet value to a JSON scalar: numeric → number, bool → boolean. */
+function coerceScalar(raw: string): JsonScalar {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw !== '' && !Number.isNaN(Number(raw))) return Number(raw);
+  return raw;
+}
+
+/**
+ * Parse one `path:op:value` (or `path:exists`) facet token into a FacetFilter.
+ * Throws on a structurally malformed token (the route maps the throw to 400).
+ * `in` takes a comma-separated value list; `exists` takes no value.
+ */
+export function parseFacet(token: string): FacetFilter {
+  const firstColon = token.indexOf(':');
+  if (firstColon === -1) throw new Error(`malformed facet (expected path:op[:value]): "${token}"`);
+  const path = token.slice(0, firstColon);
+  const rest = token.slice(firstColon + 1);
+  const secondColon = rest.indexOf(':');
+  const opRaw = secondColon === -1 ? rest : rest.slice(0, secondColon);
+  const op = opRaw as FacetFilter['op'];
+  if (!FACET_OPS.has(op)) throw new Error(`unknown facet op "${opRaw}" in "${token}"`);
+  if (path === '') throw new Error(`empty facet path in "${token}"`);
+
+  if (op === 'exists') return { path, op };
+  if (secondColon === -1) throw new Error(`facet op "${op}" requires a value in "${token}"`);
+  const valueRaw = rest.slice(secondColon + 1);
+  if (op === 'in') {
+    return { path, op, value: valueRaw.split(',').map(coerceScalar) };
+  }
+  return { path, op, value: coerceScalar(valueRaw) };
+}
+
+/** Narrow an Express-5 query/param value (`string | string[] | undefined`) to a non-empty string. */
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v !== '' ? v : undefined;
+}
+
+export function createApp(store: EleaticStore, cfg: EleaticConfig): Express {
+  const reader = makeReader(store.db);
+  const verdicts = new Set(cfg.verdictVocabulary);
+  const app = express();
+  app.use(express.json());
+
+  // ── Static UI + bare page routes ──
+  // The committed UI lives at the package-root `ui/` (E1 ALSO copies it to
+  // `dist/ui/` at build via `cpSync('ui','dist/ui')`, but the source `ui/` is
+  // never deleted). `app.{ts,js}` lives in `<root>/{src,dist}/server/`, so a
+  // `../../ui` hop reaches the package-root `ui/` in BOTH layouts — the built
+  // run (`dist/server/app.js → ../../ui`) and the source/vitest run
+  // (`src/server/app.ts → ../../ui`). This keeps the supertest route contracts
+  // (run against source) and `eleatic serve` (run against dist) on one path.
+  // Use sendFile's `{ root }` form (relative filename) — a bare absolute path
+  // trips `send`'s NotFoundError on some paths (see photo-curation index.ts:33-37).
+  const uiDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'ui');
+  app.use(express.static(uiDir));
+
+  // The `/config.js` ESM the UI imports — only the client-safe slice (server-only
+  // fields like dbPath are dropped by clientConfigSlice).
+  app.get('/config.js', (_req: Request, res: Response) => {
+    res
+      .type('application/javascript')
+      .send(`export const config = ${JSON.stringify(clientConfigSlice(cfg))};`);
+  });
+
+  // Bare HTML page routes (pages land in E5/E6; routes wired here so `serve` is
+  // complete). `index.html` is also served by express.static; the explicit route
+  // keeps `GET /` 200 even before a real index page exists (a placeholder ships
+  // in this PR's ui/index.html).
+  app.get('/', (_req: Request, res: Response) => res.sendFile('index.html', { root: uiDir }));
+  app.get('/diff', (_req: Request, res: Response) => res.sendFile('diff.html', { root: uiDir }));
+  app.get('/facets', (_req: Request, res: Response) => res.sendFile('facets.html', { root: uiDir }));
+
+  // ── Read API ──
+  app.get('/api/runs', (_req: Request, res: Response) => {
+    res.json({ runs: reader.listRuns() });
+  });
+
+  app.get('/api/runs/:id', (req: Request, res: Response) => {
+    const id = asString(req.params.id);
+    if (id === undefined) return res.status(400).json({ error: 'run id required' });
+    const run = reader.getRun(id);
+    if (run === undefined) return res.status(404).json({ error: `unknown run: ${id}` });
+    return res.json({ run });
+  });
+
+  app.get('/api/diff', (req: Request, res: Response) => {
+    const a = asString(req.query.a);
+    const b = asString(req.query.b);
+    if (a === undefined || b === undefined) {
+      return res.status(400).json({ error: 'both `a` and `b` run ids are required' });
+    }
+    if (reader.getRun(a) === undefined) return res.status(404).json({ error: `unknown run: ${a}` });
+    if (reader.getRun(b) === undefined) return res.status(404).json({ error: `unknown run: ${b}` });
+    return res.json({ diff: reader.diffRuns(a, b) });
+  });
+
+  app.get('/api/rows', (req: Request, res: Response) => {
+    const run = asString(req.query.run);
+    if (run === undefined) return res.status(400).json({ error: 'run required' });
+    if (reader.getRun(run) === undefined) return res.status(404).json({ error: `unknown run: ${run}` });
+
+    // No facets / sort: the cheap single-arg path.
+    const fParams = ([] as string[]).concat(
+      typeof req.query.f === 'string' ? [req.query.f] : Array.isArray(req.query.f) ? (req.query.f as string[]) : [],
+    );
+    const sortRaw = asString(req.query.sort);
+    if (fParams.length === 0 && sortRaw === undefined) {
+      return res.json({ rows: reader.getRows(run) });
+    }
+
+    // Build a FacetQuery. parseFacet (wire malformed) and the reader's path
+    // validation (unknown key / bad prefix) both surface as a 400.
+    try {
+      const filters: FacetFilter[] = fParams.map(parseFacet);
+      const query: FacetQuery = filters.length > 0 ? { filters } : {};
+      if (sortRaw !== undefined) {
+        const colon = sortRaw.lastIndexOf(':');
+        const path = colon === -1 ? sortRaw : sortRaw.slice(0, colon);
+        const dir = colon === -1 ? 'asc' : sortRaw.slice(colon + 1);
+        if (dir !== 'asc' && dir !== 'desc') throw new Error(`bad sort dir: ${dir}`);
+        query.sort = { path, dir };
+      }
+      return res.json({ rows: reader.facetRows(run, query) });
+    } catch (err) {
+      return res.status(400).json({ error: err instanceof Error ? err.message : 'bad facet' });
+    }
+  });
+
+  app.get('/api/row', (req: Request, res: Response) => {
+    const run = asString(req.query.run);
+    const row = asString(req.query.row);
+    if (run === undefined || row === undefined) {
+      return res.status(400).json({ error: 'both `run` and `row` are required' });
+    }
+    const record = reader.getRow(run, row);
+    if (record === undefined) return res.status(404).json({ error: `unknown row: ${row} in ${run}` });
+    return res.json({ row: record });
+  });
+
+  app.get('/api/trends', (req: Request, res: Response) => {
+    const metric = asString(req.query.metric);
+    if (metric === undefined) return res.status(400).json({ error: 'metric required' });
+    return res.json({ trend: reader.metricTrend(metric) });
+  });
+
+  // List adjudications + an `isStale` flag per row (the verdict's against_hash vs
+  // the row's CURRENT content_hash). Staleness needs a run to resolve a row's
+  // current hash; `?run=` is optional — without it, isStale is reported false
+  // (no current hash to compare against).
+  app.get('/api/adjudications', (req: Request, res: Response) => {
+    const run = asString(req.query.run);
+    const adjudications = reader.listAdjudications().map((adj) => {
+      let isStale = false;
+      if (run !== undefined) {
+        const row = reader.getRow(run, adj.rowKey);
+        if (row?.contentHash !== undefined) isStale = reader.isStale(adj.rowKey, row.contentHash);
+      }
+      return { ...adj, isStale };
+    });
+    return res.json({ adjudications });
+  });
+
+  // The ONLY write. Captures against_hash from the row's current content_hash at
+  // decision time when a `run` (and a matching row) is supplied. Verdict must be
+  // in cfg's vocabulary; rowKey is required.
+  app.post('/api/adjudications', (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as {
+      rowKey?: unknown; verdict?: unknown; run?: unknown; note?: unknown;
+    };
+    const rowKey = asString(body.rowKey);
+    const verdict = asString(body.verdict);
+    if (rowKey === undefined) return res.status(400).json({ error: 'rowKey required' });
+    if (verdict === undefined || !verdicts.has(verdict)) {
+      return res.status(400).json({ error: `verdict must be one of: ${cfg.verdictVocabulary.join(', ')}` });
+    }
+    const run = asString(body.run);
+    const note = asString(body.note);
+    // Capture the row's current content_hash as the against_hash, so a later edit
+    // to the row flips isStale. Omit (no run / no row / no hash) when unresolvable.
+    let againstHash: string | undefined;
+    if (run !== undefined) {
+      const row = reader.getRow(run, rowKey);
+      if (row?.contentHash !== undefined) againstHash = row.contentHash;
+    }
+    store.recordAdjudication({
+      rowKey,
+      verdict,
+      decidedAt: new Date().toISOString(),
+      ...(againstHash !== undefined ? { againstHash } : {}),
+      ...(note !== undefined ? { note } : {}),
+    });
+    return res.json({ ok: true });
+  });
+
+  return app;
+}

--- a/packages/eleatic/src/server/facet-parse.test.ts
+++ b/packages/eleatic/src/server/facet-parse.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { parseFacet } from './app.js';
+
+describe('parseFacet', () => {
+  it('parses path:op:value into a FacetFilter', () => {
+    expect(parseFacet('metadata.disagreement:eq:falseKeep')).toEqual({
+      path: 'metadata.disagreement',
+      op: 'eq',
+      value: 'falseKeep',
+    });
+  });
+
+  it('coerces numeric + boolean values', () => {
+    expect(parseFacet('scores.quality:gte:70')).toEqual({ path: 'scores.quality', op: 'gte', value: 70 });
+    expect(parseFacet('metadata.flagged:eq:true')).toEqual({ path: 'metadata.flagged', op: 'eq', value: true });
+    expect(parseFacet('metadata.flagged:eq:false')).toEqual({ path: 'metadata.flagged', op: 'eq', value: false });
+  });
+
+  it('parses the no-value `exists` op', () => {
+    expect(parseFacet('scores.quality:exists')).toEqual({ path: 'scores.quality', op: 'exists' });
+  });
+
+  it('parses `in` into a coerced scalar list', () => {
+    expect(parseFacet('metadata.disagreement:in:falseKeep,falseReplace')).toEqual({
+      path: 'metadata.disagreement',
+      op: 'in',
+      value: ['falseKeep', 'falseReplace'],
+    });
+  });
+
+  it('keeps a colon inside the value (only the first two colons are delimiters)', () => {
+    expect(parseFacet('metadata.url:eq:https://x')).toEqual({
+      path: 'metadata.url',
+      op: 'eq',
+      value: 'https://x',
+    });
+  });
+
+  it('throws on a structurally malformed token', () => {
+    expect(() => parseFacet('garbage')).toThrow();          // no colon at all
+    expect(() => parseFacet('path:bogusop:v')).toThrow();    // unknown op
+    expect(() => parseFacet(':eq:v')).toThrow();             // empty path
+    expect(() => parseFacet('path:eq')).toThrow();           // op needs a value
+  });
+});

--- a/packages/eleatic/src/server/serve.test.ts
+++ b/packages/eleatic/src/server/serve.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { startServer } from './serve.js';
+
+/**
+ * serve.ts is thin glue: open the store (E1) -> resolve config -> build the app
+ * (createApp) -> listen -> return { close }. The route behaviour is covered
+ * exhaustively by app.test.ts's supertest contracts; here we only prove the glue
+ * boots and tears down cleanly. We bind the OS-assigned ephemeral port (0) on
+ * loopback — no fixed port (no collision with a running dev server), no network —
+ * and close immediately. `:memory:` keeps it off disk.
+ */
+describe('startServer', () => {
+  it('opens an in-memory store, listens, and returns a working close()', () => {
+    const handle = startServer({ dbPath: ':memory:', port: 0 });
+    expect(typeof handle.close).toBe('function');
+    // close() releases the listener + db without throwing.
+    expect(() => handle.close()).not.toThrow();
+  });
+
+  it('boots with the zero-config default when configPath is omitted', () => {
+    // configPath omitted entirely (exactOptionalPropertyTypes) — resolveConfig()
+    // returns the default and startServer does not throw.
+    const handle = startServer({ dbPath: ':memory:', port: 0 });
+    expect(() => handle.close()).not.toThrow();
+  });
+});

--- a/packages/eleatic/src/server/serve.ts
+++ b/packages/eleatic/src/server/serve.ts
@@ -1,0 +1,33 @@
+/**
+ * `startServer` — boot the eleatic explorer. Opens `eval.sqlite` via E1's
+ * `openStore`, resolves the config (zero-config default when `--config` omitted),
+ * builds the app via `createApp`, listens, and returns `{ close }` that shuts
+ * down both the HTTP server and the db. Modelled on
+ * `tools/photo-curation/src/server/serve.ts`.
+ */
+
+import { openStore } from '../store.js';
+import { resolveConfig } from '../config.js';
+import { createApp } from './app.js';
+
+export interface ServeOptions {
+  dbPath: string;
+  port: number;
+  /** Optional eleatic config JSON; omitted -> zero-config default. */
+  configPath?: string;
+}
+
+export function startServer(opts: ServeOptions): { close: () => void } {
+  const store = openStore(opts.dbPath); // opens eval.sqlite (WAL, IF NOT EXISTS — E1)
+  const cfg = resolveConfig(opts.configPath); // zero-config default when omitted
+  const app = createApp(store, cfg);
+  const server = app.listen(opts.port, () => {
+    console.log(`eleatic on http://localhost:${opts.port}  (db: ${opts.dbPath})`);
+  });
+  return {
+    close: () => {
+      server.close();
+      store.close();
+    },
+  };
+}

--- a/packages/eleatic/ui/index.html
+++ b/packages/eleatic/ui/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>eleatic</title>
+  </head>
+  <body>
+    <!--
+      Placeholder landing page. The real comparison hub / diff / facets pages
+      land in E5 / E6; this page only keeps `GET /` a 200 so `eleatic serve` is
+      complete before those pages exist. It imports `/config.js` (the server's
+      client-config emitter) so the wiring is exercised end-to-end today.
+    -->
+    <main>
+      <h1>eleatic</h1>
+      <p>eval-results explorer — UI pages land in a later epic child.</p>
+    </main>
+    <script type="module">
+      import { config } from '/config.js';
+      // eslint-disable-next-line no-console
+      console.log('eleatic config', config);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
  CLI["eleatic serve --db --port (--config)"] --> SS["startServer"]
  SS -->|openStore E1| Store[("EvalStore eval.sqlite")]
  SS -->|resolveConfig| Cfg["EleaticConfig (zero-config default)"]
  SS -->|createApp store cfg| App["Express app"]

  App -->|"GET /config.js"| Slice["clientConfigSlice (server-only dbPath dropped)"]
  App -->|"GET / and /diff and /facets"| UI["express.static dist/ui plus placeholder index.html"]

  subgraph ReadAPI["api routes — all via E2 EleaticReader, no SQL here"]
    R1["GET /api/runs and /runs/:id"]
    R2["GET /api/diff a b"]
    R3["GET /api/rows run f sort — facetRows or getRows"]
    R4["GET /api/row run row"]
    R5["GET /api/trends metric"]
    R6["GET /api/adjudications plus isStale"]
  end
  App --> ReadAPI
  ReadAPI -->|"makeReader store.db"| Reader["EleaticReader E2"]
  Reader --> Store

  App -->|"POST /api/adjudications — the ONLY write"| W["store.recordAdjudication captures against_hash from row current content_hash"]
  W --> Store
```

## Summary

- Adds E4 of the eleatic epic (#1153): the Express server (read API + the single adjudication write) and the `eleatic serve` CLI, layered over E1's write store and E2's `EleaticReader` — `createApp` writes no SQL itself. **Zero `@bird-watch/*` imports** (the package's git-mv boundary; the E1 zero-coupling guard passes).
- Canonical contract honored exactly: barrel export is **`createApp`** (fills the E1-reserved marker; no `createEvalRouter`); routes use E2's real `FacetQuery {filters,sort,limit,offset}` (single-arg `getRows`, `facetRows(runId, q)`); HTTP-status split is **400 for a missing/empty param, 404 for a well-formed-but-unknown run id / row** (a deliberate divergence from the photo-curation grounding's 400-for-unknown-run). `/config.js` emits only the client-safe slice (server-only `dbPath` dropped); image-host allowlist defaults to any-https (no hard-coded host).
- `npx knip` is **green with no `knip.ts` delta** — the `package.json` `bin` + the `cli.test.ts` sibling make knip trace `src/cli.ts` as an entry, exactly the photo-curation precedent; a redundant ignore would have reded the queue (the #1094 rule). Closes #1147.

## Screenshots

N/A — packages/ tool (not frontend/**). eleatic's framework-free `ui/` is exempt from the `frontend/**` Playwright contract; this PR ships only a placeholder `ui/index.html` (real pages land in E5/E6).

- [x] N/A — not UI (no file under `frontend/**`)

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — 12 files / 103 tests green (was 73 on E2's head; +30 across config, app, facet-parse, serve, cli)
- [x] `npm test` (full monorepo) — all workspaces green (1529 tests), real Postgres testcontainers included
- [x] `npm run build` — clean (strict tsconfig: `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `moduleResolution: Bundler`); `dist/cli.js` shebang preserved, `ui/` copied to `dist/ui/`
- [x] `npx knip --no-progress` — exit 0, no eleatic finding (no `knip.ts` change)
- [x] `package-lock.json` regenerated + consistent (express ^5.2.1, commander ^13.1.0, supertest/@types pinned to the photo-curation lockfile entries)
- [x] End-to-end smoke: built `node dist/cli.js serve --db <tmp> --port 8799` → `GET /` 200, `/config.js` emits the slice with no `dbPath`, `/api/runs` → `{"runs":[]}`, unknown run → 404
- [x] New unit / integration tests added (supertest route contracts against `createApp(openStore(':memory:'), cfg)`; pure-unit config emitter, `f=` parser, CLI option parsing — no network, no port bound in unit tests)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, packages/ tool, no `frontend/**`

## Plan reference

Part of eleatic epic #1153, Wave 3 (E4). Depends on E2 (#1145, read-query API) and E3 (#1146, analysis) — both merged. Soft order within Wave 3: E4 → E5 → E6 (E5/E6 build the `ui/` pages this server's static + page routes serve). Plans live in the epic + child issues, not in `docs/plans/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
