### PR TITLE
feat(eleatic): framework-free explorer hub — runs table, gate badge, inline-SVG trends (#1148)

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -256,7 +256,29 @@ const config: KnipConfig = {
     'packages/geo': {},
     'packages/shared-types': {},
     'packages/photo-quality': {},
-    'packages/eleatic': {},
+    'packages/eleatic': {
+      // 2026-06-13 (E5, #1148): the explorer's browser ES modules under ui/.
+      //             ui/hub.js (the comparison hub entry) and ui/theme.js are
+      //             loaded at runtime via ui/index.html's
+      //             `<script type="module" src="/hub.js">` and a bare
+      //             `import '/theme.js'` specifier the BROWSER resolves at
+      //             runtime — never imported by any TS/JS module knip can
+      //             trace, so static analysis flags both as unused files.
+      //             Exactly the tools/photo-curation public/*.js precedent
+      //             below. Their siblings ui/safe.js + ui/format.js are
+      //             deliberately NOT listed here: each has a real vitest
+      //             sibling (ui/safe.test.ts, ui/format.test.ts) that imports
+      //             it, so knip already traces them as used (an ignore entry
+      //             for either would be flagged redundant) — the safe.js
+      //             "test-sibling makes it traced" reasoning from photo-curation
+      //             applies verbatim. ui/index.html + ui/app.css are not JS/TS
+      //             modules, so knip does not track them as unused-file entries.
+      //             Risk: masks a genuinely orphaned ui/ script if a page is
+      //             deleted but its module left on disk. Re-audit 2026-07-27 —
+      //             confirm ui/index.html still references both (grep
+      //             `src="/hub.js"` and an `import .* '/theme.js'` in hub.js).
+      ignore: ['ui/hub.js', 'ui/theme.js'],
+    },
 
     'tools/photo-curation': {
       // 2026-06-10: Part B (#971) wired the four Part A self-healing entries —

--- a/packages/eleatic/src/server/app.test.ts
+++ b/packages/eleatic/src/server/app.test.ts
@@ -205,11 +205,15 @@ describe('eleatic server', () => {
     ).toBe(400);
   });
 
-  it('GET / serves the placeholder landing page (200 HTML)', async () => {
+  it('GET / serves the comparison hub page (200 HTML, wires hub.js)', async () => {
+    // E5 replaced E4's placeholder ui/index.html with the real hub. The route
+    // is unchanged (express.static + the explicit GET / fallback); this asserts
+    // the served page is the hub (title + the hub.js module tag), not the stub.
     const res = await request(createApp(store, cfg)).get('/');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/html/);
-    expect(res.text).toContain('<title>eleatic</title>');
+    expect(res.text).toContain('<title>eleatic · eval explorer</title>');
+    expect(res.text).toContain('src="/hub.js"');
   });
 
   it('GET /config.js emits a parseable ESM client slice and OMITS server-only fields', async () => {

--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -1,0 +1,95 @@
+/* ── eleatic explorer — neutral, framework-free tokens (light/dark via [data-theme]) ──
+ *
+ * eleatic is a domain-agnostic eval-results explorer, NOT a bird-maps surface, so
+ * the palette is deliberately NEUTRAL — grays + a single blue accent — rather
+ * than the bird-maps amber/ember of tools/photo-curation. Status colors (PASS =
+ * green, fail = red, plus the blue accent) are picked to pass light- and
+ * dark-mode contrast; they are not bird-maps tokens.
+ */
+:root {
+  --type-xs: 11px; --type-sm: 13px; --type-base: 15px; --type-md: 17px; --type-lg: 22px; --type-hero: 32px;
+  --font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", "Inter", sans-serif;
+  --mono-stack: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --radius-lg: 12px;
+  --radius-sm: 8px;
+  /* Neutral accent + status (chosen for contrast, not bird-maps tokens). */
+  --accent: #2563eb;       /* blue 600 */
+  --status-pass: #15803d;  /* green 700 */
+  --status-fail: #b91c1c;  /* red 700 */
+}
+:root[data-theme="light"] {
+  --bg: #f7f8fa; --surface: #ffffff; --surface-2: #eef1f5; --text: #16181d; --text-dim: #5b626e;
+  --border: #d6dae1; --accent-soft: #e7eefe;
+  --card-elevation: 0 1px 3px rgba(15,23,42,.08), 0 4px 12px rgba(15,23,42,.04);
+}
+:root[data-theme="dark"] {
+  --bg: #0e1116; --surface: #161a22; --surface-2: #1f242e; --text: #e9edf3; --text-dim: #98a1b0;
+  --border: #2c3340; --accent-soft: #1b2740;
+  --card-elevation: 0 1px 3px rgba(0,0,0,.5), 0 4px 16px rgba(0,0,0,.35);
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); background: var(--bg); color: var(--text); }
+.visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
+/* ── Header ── */
+.app-header { display: flex; align-items: center; gap: 16px; padding: 16px 24px; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg); z-index: 2; }
+.app-title { font-size: var(--type-lg); font-weight: 600; margin: 0; letter-spacing: -.01em; }
+.app-title .app-sub { font-size: var(--type-sm); font-weight: 400; color: var(--text-dim); margin-left: 10px; }
+.header-spacer { margin-left: auto; }
+.theme-toggle { background: var(--surface); border: 1px solid var(--border); color: var(--text); border-radius: var(--radius-sm); padding: 6px 12px; cursor: pointer; font: inherit; }
+.theme-toggle:hover { background: var(--surface-2); }
+
+/* ── Layout ── */
+.wrap { max-width: 1180px; margin: 0 auto; padding: 24px; }
+.section { margin-bottom: 32px; }
+.section-head { display: flex; align-items: baseline; gap: 12px; margin: 0 0 12px; }
+.section-title { font-size: var(--type-md); font-weight: 600; margin: 0; }
+.section-sub { font-size: var(--type-sm); color: var(--text-dim); }
+.empty { padding: 40px; text-align: center; color: var(--text-dim); }
+.empty code { background: var(--surface-2); padding: 1px 6px; border-radius: 5px; font-family: var(--mono-stack); }
+
+/* ── Runs table ── */
+.table-scroll { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); }
+.runs-table { width: 100%; border-collapse: collapse; font-size: var(--type-sm); background: var(--surface); }
+.runs-table th, .runs-table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); white-space: nowrap; }
+.runs-table thead th { font-weight: 600; color: var(--text-dim); background: var(--surface-2); position: sticky; top: 0; }
+.runs-table tbody tr:last-child td { border-bottom: none; }
+.runs-table .num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono-stack); }
+.runs-table .col-select { text-align: center; width: 36px; }
+.run-row:hover { background: var(--surface-2); }
+.run-row.selected { box-shadow: inset 3px 0 0 var(--accent); }
+.run-label { font-weight: 600; }
+.run-label .baseline-star { color: var(--accent); margin-left: 4px; cursor: help; }
+.run-id { color: var(--text-dim); font-family: var(--mono-stack); font-size: var(--type-xs); }
+
+/* ── Gate badge ── */
+.gate-badge { display: inline-block; font-weight: 700; font-size: var(--type-xs); padding: 2px 10px; border-radius: 999px; color: #fff; text-transform: uppercase; letter-spacing: .03em; }
+.gate-badge.gate-pass { background: var(--status-pass); }
+.gate-badge.gate-fail { background: var(--status-fail); }
+.gate-badge.gate-none { background: var(--surface-2); color: var(--text-dim); border: 1px solid var(--border); font-weight: 600; }
+
+/* ── Generic badge / pill ── */
+.badge { display: inline-block; font-size: var(--type-xs); padding: 2px 8px; border-radius: 999px; background: var(--surface-2); color: var(--text-dim); border: 1px solid var(--border); }
+
+/* ── Compare bar ── */
+.compare-bar { display: flex; align-items: center; gap: 12px; margin: 14px 0 0; padding: 12px 14px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); box-shadow: var(--card-elevation); }
+.compare-hint { font-size: var(--type-sm); color: var(--text-dim); }
+.compare-btn { font: inherit; font-size: var(--type-sm); padding: 8px 16px; border-radius: var(--radius-sm); border: 1px solid var(--accent); background: var(--accent); color: #fff; cursor: pointer; text-decoration: none; }
+.compare-btn[aria-disabled="true"], .compare-btn:disabled { background: var(--surface-2); color: var(--text-dim); border-color: var(--border); cursor: not-allowed; }
+
+/* ── Trends (inline SVG) ── */
+.trends-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px; }
+.trend-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--card-elevation); padding: 14px 16px; }
+.trend-metric { font-size: var(--type-sm); font-weight: 600; margin: 0 0 8px; }
+.trend-svg { width: 100%; height: 60px; display: block; overflow: visible; }
+.trend-line { fill: none; stroke: var(--accent); stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+.trend-dot { fill: var(--accent); }
+.trend-empty { font-size: var(--type-xs); color: var(--text-dim); }
+.trend-legend { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+.trend-swatch { display: inline-flex; align-items: center; gap: 5px; font-size: var(--type-xs); color: var(--text-dim); }
+.trend-swatch i { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+
+/* ── Trend metric picker ── */
+.trend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.trend-controls label { font-size: var(--type-sm); color: var(--text-dim); }
+.trend-controls select { font: inherit; padding: 6px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); color: var(--text); }

--- a/packages/eleatic/ui/format.js
+++ b/packages/eleatic/ui/format.js
@@ -1,0 +1,119 @@
+// Pure, framework-free rendering primitives for the eleatic explorer hub.
+//
+// Three independent, fully-testable units, none touching the DOM or network:
+//   1. FORMATTERS / formatMetric — the per-metric display registry. The hub
+//      reads a {metric -> formatter-name} map from /config.js and renders each
+//      run-level metric cell with the named formatter. eleatic invents no
+//      domain: an unconfigured metric (or an unknown formatter name) falls back
+//      to `raw`, and a missing/non-numeric value renders an em dash (never NaN).
+//   2. evalGate — the configurable {metric, op, threshold} run gate. Generalizes
+//      photo-curation's hard-coded `agreement >= 0.90` PASS/fail to any metric +
+//      op. The 0–1 fraction contract is preserved by config, not by code: a
+//      gate of {agreement, gte, 0.9} compares against the stored fraction.
+//   3. mapPoints — the inline-SVG trend point mapper: a numeric series ->
+//      viewBox {x,y} coordinates for a <polyline>, with min/max y-scaling, y
+//      inversion (SVG y grows downward), and empty / single-point / flat-domain
+//      edge cases handled so the hub needs NO chart dependency.
+
+// ── 1. Metric formatter registry ──────────────────────────────────────────────
+
+const EM_DASH = '—';
+
+/**
+ * The four named formatters. Each takes a finite number and returns a string;
+ * the missing/NaN guard lives in `formatMetric`, so a formatter never sees a
+ * non-number.
+ */
+export const FORMATTERS = {
+  // 0–1 fraction -> one-decimal percent. Mirrors photo-curation's pct().
+  percent: (n) => `${(n * 100).toFixed(1)}%`,
+  // number -> two-decimal USD. Mirrors photo-curation's usd().
+  usd: (n) => `$${n.toFixed(2)}`,
+  // number -> rounded integer string.
+  integer: (n) => String(Math.round(n)),
+  // number -> stringified verbatim (the generic fallback; no domain assumption).
+  raw: (n) => String(n),
+};
+
+/**
+ * Render a single metric value with the named formatter. An unknown / undefined
+ * formatter name falls back to `raw`; a missing or non-finite value renders an
+ * em dash so a sparse run never shows `NaN`.
+ */
+export function formatMetric(value, formatterName) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return EM_DASH;
+  const fmt = FORMATTERS[formatterName] ?? FORMATTERS.raw;
+  return fmt(value);
+}
+
+// ── 2. Gate evaluator ──────────────────────────────────────────────────────────
+
+const OPS = {
+  eq: (a, b) => a === b,
+  ne: (a, b) => a !== b,
+  lt: (a, b) => a < b,
+  lte: (a, b) => a <= b,
+  gt: (a, b) => a > b,
+  gte: (a, b) => a >= b,
+};
+
+/**
+ * Evaluate a run gate. `gate` is `{ metric, op, threshold }` (from /config.js);
+ * `metrics` is the run's `metrics_json` object. Returns:
+ *   • 'PASS' / 'fail' when the gate is configured and the gated metric is present,
+ *   • undefined when no gate is configured OR the metric is absent (no badge).
+ * Comparison is over the stored value as-is (the 0–1 fraction contract is the
+ * config's responsibility, not this function's).
+ */
+export function evalGate(gate, metrics) {
+  if (gate === undefined || gate === null) return undefined;
+  const value = metrics?.[gate.metric];
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  const op = OPS[gate.op];
+  if (op === undefined) return undefined;
+  return op(value, gate.threshold) ? 'PASS' : 'fail';
+}
+
+// ── 3. Inline-SVG trend point mapper ────────────────────────────────────────────
+
+/**
+ * Map a numeric series into viewBox `{x, y}` points for an SVG `<polyline>`.
+ *
+ * `values` is index-ordered; a `null`/`undefined`/non-finite entry is a GAP —
+ * it is dropped from the output, but the surviving points keep their original
+ * index-derived x so the line never lies about horizontal position. `box` is
+ * `{ width, height, pad }` (pad insets the plot from the viewBox edges).
+ *
+ * x: spread evenly by index across `[pad, width - pad]` (a single visible point
+ *    sits at the horizontal center). y: min/max scaled and INVERTED so the max
+ *    value sits at the top (`pad`) and the min at the bottom (`height - pad`);
+ *    a flat domain (min === max, incl. the single-point case) sits every point
+ *    at the vertical center. Empty series -> `[]` (caller renders empty-state).
+ */
+export function mapPoints(values, box) {
+  const { width, height, pad } = box;
+  const n = values.length;
+  if (n === 0) return [];
+
+  // Indexed, gap-filtered points; x derives from the ORIGINAL index.
+  const indexed = [];
+  for (let i = 0; i < n; i += 1) {
+    const v = values[i];
+    if (typeof v === 'number' && Number.isFinite(v)) indexed.push({ i, v });
+  }
+  if (indexed.length === 0) return [];
+
+  const plotW = width - 2 * pad;
+  const plotH = height - 2 * pad;
+  const xSpan = n - 1; // index domain across the full original series
+  const xFor = (i) => (xSpan === 0 ? width / 2 : pad + (i / xSpan) * plotW);
+
+  const vs = indexed.map((p) => p.v);
+  const min = Math.min(...vs);
+  const max = Math.max(...vs);
+  const flat = max === min;
+  const yFor = (v) =>
+    flat ? height / 2 : pad + (1 - (v - min) / (max - min)) * plotH;
+
+  return indexed.map((p) => ({ x: xFor(p.i), y: yFor(p.v) }));
+}

--- a/packages/eleatic/ui/format.test.ts
+++ b/packages/eleatic/ui/format.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { formatMetric, FORMATTERS, evalGate, mapPoints } from './format.js';
+
+// ── Metric formatter registry ────────────────────────────────────────────────
+//
+// The hub looks up a per-metric formatter name from /config.js (e.g.
+// { agreement: 'percent', totalCost: 'usd' }) and renders the cell with it.
+// The four named formatters mirror photo-curation's inline pct()/usd() plus the
+// generic raw/integer fallbacks eleatic adds (it invents no domain — an
+// unconfigured metric renders raw).
+
+describe('formatMetric registry', () => {
+  it('percent renders a 0–1 fraction as a one-decimal percent (matches photo-curation pct)', () => {
+    expect(formatMetric(0.9067, 'percent')).toBe('90.7%');
+    expect(formatMetric(0, 'percent')).toBe('0.0%');
+    expect(formatMetric(1, 'percent')).toBe('100.0%');
+  });
+
+  it('usd renders a number as a two-decimal dollar amount (matches photo-curation usd)', () => {
+    expect(formatMetric(0.12, 'usd')).toBe('$0.12');
+    expect(formatMetric(270, 'usd')).toBe('$270.00');
+  });
+
+  it('integer renders a rounded count with no decimals', () => {
+    expect(formatMetric(5, 'integer')).toBe('5');
+    expect(formatMetric(4.6, 'integer')).toBe('5');
+    expect(formatMetric(150, 'integer')).toBe('150');
+  });
+
+  it('raw renders the number stringified, untouched', () => {
+    expect(formatMetric(0.904, 'raw')).toBe('0.904');
+    expect(formatMetric(42, 'raw')).toBe('42');
+  });
+
+  it('an unknown formatter name falls back to raw (no domain assumption)', () => {
+    expect(formatMetric(0.5, 'no-such-formatter')).toBe('0.5');
+    expect(formatMetric(0.5, undefined)).toBe('0.5');
+  });
+
+  it('a missing / non-numeric value renders an em dash, not NaN', () => {
+    expect(formatMetric(undefined, 'percent')).toBe('—');
+    expect(formatMetric(null, 'usd')).toBe('—');
+    expect(formatMetric(Number.NaN, 'integer')).toBe('—');
+  });
+
+  it('exposes the four named formatters', () => {
+    expect(Object.keys(FORMATTERS).sort()).toEqual(['integer', 'percent', 'raw', 'usd']);
+  });
+});
+
+// ── Gate evaluator ────────────────────────────────────────────────────────────
+//
+// A configurable {metric, op, threshold} predicate over a run's metrics object.
+// Generalizes photo-curation's hard-coded `agreement >= 0.90` (PASS/fail). The
+// fraction contract is preserved: gte 0.9 on a 0–1 fraction, NOT >= 90.
+
+describe('evalGate', () => {
+  const gate = { metric: 'agreement', op: 'gte', threshold: 0.9 };
+
+  it('PASS when the run meets a gte threshold (the 0.90 fraction contract)', () => {
+    expect(evalGate(gate, { agreement: 0.9067 })).toBe('PASS');
+    expect(evalGate(gate, { agreement: 0.9 })).toBe('PASS');
+  });
+
+  it('fail when the run is below a gte threshold', () => {
+    expect(evalGate(gate, { agreement: 0.7867 })).toBe('fail');
+  });
+
+  it('supports every comparison op', () => {
+    expect(evalGate({ metric: 'm', op: 'gt', threshold: 1 }, { m: 2 })).toBe('PASS');
+    expect(evalGate({ metric: 'm', op: 'gt', threshold: 1 }, { m: 1 })).toBe('fail');
+    expect(evalGate({ metric: 'm', op: 'lt', threshold: 1 }, { m: 0.5 })).toBe('PASS');
+    expect(evalGate({ metric: 'm', op: 'lte', threshold: 1 }, { m: 1 })).toBe('PASS');
+    expect(evalGate({ metric: 'm', op: 'eq', threshold: 3 }, { m: 3 })).toBe('PASS');
+    expect(evalGate({ metric: 'm', op: 'ne', threshold: 3 }, { m: 4 })).toBe('PASS');
+    expect(evalGate({ metric: 'm', op: 'ne', threshold: 3 }, { m: 3 })).toBe('fail');
+  });
+
+  it('returns undefined (no badge) when no gate is configured', () => {
+    expect(evalGate(undefined, { agreement: 0.9 })).toBeUndefined();
+  });
+
+  it('returns undefined when the gated metric is absent from the run', () => {
+    expect(evalGate(gate, { somethingElse: 1 })).toBeUndefined();
+    expect(evalGate(gate, {})).toBeUndefined();
+    expect(evalGate(gate, undefined)).toBeUndefined();
+  });
+});
+
+// ── Inline-SVG point mapper ─────────────────────────────────────────────────
+//
+// Maps a list of {x:index, y:value} data points into a viewBox coordinate
+// space for a <polyline>. Pure: no DOM. y is inverted (SVG y grows downward,
+// so the max value sits at the top = a small y). min/max scaling fits the data
+// to the box height with a configurable padding inset.
+
+describe('mapPoints', () => {
+  const box = { width: 100, height: 40, pad: 4 };
+
+  it('maps a normal series across the full plot width and inverts y', () => {
+    const pts = mapPoints([0, 0.5, 1], box);
+    // 3 points → x at pad, mid, width-pad.
+    expect(pts.map((p) => p.x)).toEqual([4, 50, 96]);
+    // y inverted: max value (1) → top (y = pad), min value (0) → bottom (height - pad).
+    expect(pts[0].y).toBe(36); // value 0 → bottom
+    expect(pts[2].y).toBe(4); // value 1 → top
+    // mid value (0.5) → vertical center.
+    expect(pts[1].y).toBeCloseTo(20, 5);
+  });
+
+  it('handles an empty series → no points (caller renders an empty-state)', () => {
+    expect(mapPoints([], box)).toEqual([]);
+  });
+
+  it('handles a single point → centered horizontally, vertically centered (flat domain)', () => {
+    const pts = mapPoints([0.42], box);
+    expect(pts).toHaveLength(1);
+    // Single x → horizontal center of the plot area.
+    expect(pts[0].x).toBe(50);
+    // A flat (min === max) domain can't scale; the point sits at the vertical center.
+    expect(pts[0].y).toBeCloseTo(20, 5);
+  });
+
+  it('handles a flat multi-point series (all equal) → all at vertical center', () => {
+    const pts = mapPoints([0.5, 0.5, 0.5], box);
+    expect(pts.map((p) => p.y)).toEqual([20, 20, 20]);
+    expect(pts.map((p) => p.x)).toEqual([4, 50, 96]);
+  });
+
+  it('skips gaps (null/undefined values are dropped, x index preserved for the rest)', () => {
+    // Points with a missing value are omitted; the surviving points keep their
+    // index-based x so the polyline does not lie about position.
+    const pts = mapPoints([0, null, 1], box);
+    expect(pts).toHaveLength(2);
+    expect(pts[0].x).toBe(4); // index 0
+    expect(pts[1].x).toBe(96); // index 2 (the gap at index 1 is preserved)
+  });
+});

--- a/packages/eleatic/ui/hub.js
+++ b/packages/eleatic/ui/hub.js
@@ -1,0 +1,293 @@
+// The eleatic comparison hub — framework-free vanilla ESM, NO build step.
+//
+// Renders the landing page served at `GET /`:
+//   1. A union-of-metrics table over `GET /api/runs`. Columns are the UNION of
+//      every run's `metrics_json` keys (generic — eleatic invents no fixed
+//      agreement/falseKeep columns). Each cell is rendered with the per-metric
+//      formatter named in /config.js (percent/usd/integer/raw). A configurable
+//      gate badge ({metric,op,threshold} from /config.js) shows PASS/fail per
+//      run; the run named by `baseline` carries a ★ marker.
+//   2. A "compare 2" affordance: a checkbox per row, exactly two selectable,
+//      enabling a "Compare →" link to `/diff?a=<id>&b=<id>` (the E4 diff route).
+//   3. Inline-SVG trends from `GET /api/trends?metric=<m>`: ONE <polyline> per
+//      run-label group (no chart dependency — the geometry comes from
+//      format.js#mapPoints). A metric picker switches the trended metric.
+//
+// State (selected metric for trends, the up-to-2 compare selection) is synced to
+// the URL query string so a view is shareable / reload-safe.
+//
+// Event handling: a SINGLE delegated listener on the table container reads
+// `data-*` off the event target (deliberately improving on photo-curation's
+// eval.js, which binds one click listener PER ROW inside its render loop). One
+// listener survives full re-renders and scales to the epic's 150–1000-row range.
+
+import { initTheme, toggleTheme } from './theme.js';
+import { esc, setImageHostAllowlist } from './safe.js';
+import { formatMetric, evalGate, mapPoints } from './format.js';
+import { config } from '/config.js';
+
+// ── Boot ──
+initTheme();
+setImageHostAllowlist(config.imageHostAllowlist);
+const themeBtn = document.getElementById('theme-toggle');
+if (themeBtn) themeBtn.addEventListener('click', toggleTheme);
+
+const params = new URLSearchParams(location.search);
+// Compare selection: up to two run ids carried in the URL (?sel=a,b).
+let selected = (params.get('sel') ?? '').split(',').filter(Boolean).slice(0, 2);
+// The metric currently trended (?trend=<metric>); resolved against the data once loaded.
+let trendMetric = params.get('trend') ?? '';
+
+let runs = [];
+
+// ── Pure helpers over the loaded runs ──
+
+/** The sorted union of every run's metrics_json keys (generic columns). */
+function unionMetricKeys(runList) {
+  const keys = new Set();
+  for (const run of runList) {
+    for (const k of Object.keys(run.metrics ?? {})) keys.add(k);
+  }
+  return [...keys].sort();
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+// A small categorical palette for the per-label trend lines (CSS var on line 0,
+// then explicit hues). Distinct enough at the 2–6 series the hub targets.
+const SERIES_COLORS = ['var(--accent)', '#d97706', '#15803d', '#9333ea', '#dc2626', '#0891b2'];
+
+// ── URL sync ──
+function syncUrl() {
+  const next = new URLSearchParams(location.search);
+  if (selected.length > 0) next.set('sel', selected.join(','));
+  else next.delete('sel');
+  if (trendMetric) next.set('trend', trendMetric);
+  else next.delete('trend');
+  const qs = next.toString();
+  history.replaceState(null, '', qs ? `?${qs}` : location.pathname);
+}
+
+// ── Runs table ──
+function renderRunsTable() {
+  const host = document.getElementById('runs');
+  const metricKeys = unionMetricKeys(runs);
+
+  if (runs.length === 0) {
+    host.innerHTML =
+      '<p class="empty">No eval runs yet — ingest a run with <code>eleatic ingest</code>.</p>';
+    return;
+  }
+
+  const head = `
+    <th class="col-select" scope="col"><span class="visually-hidden">compare</span></th>
+    <th scope="col">Run</th>
+    <th scope="col">Started</th>
+    <th class="num" scope="col">Rows</th>
+    ${metricKeys.map((k) => `<th class="num" scope="col">${esc(k)}</th>`).join('')}
+    ${config.gate ? '<th scope="col">Gate</th>' : ''}`;
+
+  const rows = runs
+    .map((run) => {
+      const isSel = selected.includes(run.id);
+      const isBaseline = run.baseline !== undefined && run.baseline === run.id;
+      const metricCells = metricKeys
+        .map(
+          (k) =>
+            `<td class="num">${esc(formatMetric(run.metrics?.[k], config.metricFormatters?.[k]))}</td>`,
+        )
+        .join('');
+      let gateCell = '';
+      if (config.gate) {
+        const verdict = evalGate(config.gate, run.metrics);
+        gateCell =
+          verdict === undefined
+            ? '<td><span class="gate-badge gate-none">n/a</span></td>'
+            : `<td><span class="gate-badge ${verdict === 'PASS' ? 'gate-pass' : 'gate-fail'}">${esc(verdict)}</span></td>`;
+      }
+      // Disable the checkbox for unselected rows once two are picked.
+      const disabled = !isSel && selected.length >= 2 ? 'disabled' : '';
+      return `
+        <tr class="run-row${isSel ? ' selected' : ''}" data-run-id="${esc(run.id)}">
+          <td class="col-select">
+            <input type="checkbox" class="run-select" data-run-id="${esc(run.id)}"
+                   ${isSel ? 'checked' : ''} ${disabled}
+                   aria-label="Select ${esc(run.label)} to compare" />
+          </td>
+          <td class="run-label">${esc(run.label)}${isBaseline ? '<span class="baseline-star" title="baseline">★</span>' : ''}<div class="run-id">${esc(run.id)}</div></td>
+          <td>${esc(run.startedAt)}</td>
+          <td class="num">${esc(formatMetric(run.rowCount, 'integer'))}</td>
+          ${metricCells}
+          ${gateCell}
+        </tr>`;
+    })
+    .join('');
+
+  host.innerHTML = `
+    <div class="table-scroll">
+      <table class="runs-table">
+        <thead><tr>${head}</tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+}
+
+// ── Compare bar ──
+function renderCompareBar() {
+  const bar = document.getElementById('compare-bar');
+  if (runs.length < 2) {
+    bar.innerHTML = '';
+    return;
+  }
+  const ready = selected.length === 2;
+  const hint = ready
+    ? `Comparing ${selected.length} runs`
+    : `Select ${2 - selected.length} more run${selected.length === 1 ? '' : 's'} to compare`;
+  const href = ready
+    ? `/diff?a=${encodeURIComponent(selected[0])}&b=${encodeURIComponent(selected[1])}`
+    : '';
+  bar.innerHTML = `
+    <span class="compare-hint">${esc(hint)}</span>
+    ${
+      ready
+        ? `<a class="compare-btn" href="${esc(href)}">Compare →</a>`
+        : '<span class="compare-btn" aria-disabled="true">Compare →</span>'
+    }`;
+}
+
+// ── Trends (inline SVG, one polyline per label group) ──
+async function renderTrends() {
+  const section = document.getElementById('trends');
+  const metricKeys = unionMetricKeys(runs);
+  if (runs.length === 0 || metricKeys.length === 0) {
+    section.innerHTML = '<p class="trend-empty">No run-level metrics to trend yet.</p>';
+    return;
+  }
+  if (!metricKeys.includes(trendMetric)) trendMetric = metricKeys[0];
+
+  // Metric picker.
+  const picker = `
+    <div class="trend-controls">
+      <label for="trend-metric">Trend metric</label>
+      <select id="trend-metric">
+        ${metricKeys.map((k) => `<option value="${esc(k)}"${k === trendMetric ? ' selected' : ''}>${esc(k)}</option>`).join('')}
+      </select>
+    </div>`;
+
+  // Fetch the trend for the active metric (all runs, oldest→newest).
+  let trend = [];
+  try {
+    const res = await fetch(`/api/trends?metric=${encodeURIComponent(trendMetric)}`);
+    if (res.ok) trend = (await res.json()).trend ?? [];
+  } catch {
+    trend = [];
+  }
+
+  // Join trend points to run labels, then group into one series per label.
+  const labelOf = new Map(runs.map((r) => [r.id, r.label]));
+  const seriesByLabel = new Map();
+  for (const point of trend) {
+    const label = labelOf.get(point.runId) ?? point.runId;
+    if (!seriesByLabel.has(label)) seriesByLabel.set(label, []);
+    // null-value points are gaps; mapPoints drops them but keeps the x slot.
+    seriesByLabel.get(label).push(point.value ?? null);
+  }
+
+  const box = { width: 240, height: 60, pad: 6 };
+  const fmt = config.metricFormatters?.[trendMetric];
+  const labels = [...seriesByLabel.keys()];
+
+  const lines = labels
+    .map((label, idx) => {
+      const color = SERIES_COLORS[idx % SERIES_COLORS.length];
+      const pts = mapPoints(seriesByLabel.get(label), box);
+      if (pts.length === 0) {
+        return `<svg class="trend-svg" viewBox="0 0 ${box.width} ${box.height}" role="img" aria-label="${esc(label)}: no data"></svg>`;
+      }
+      const polyPts = pts.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+      const dots = pts
+        .map((p) => `<circle class="trend-dot" cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="2.5" style="fill:${color}" />`)
+        .join('');
+      const last = seriesByLabel.get(label).filter((v) => typeof v === 'number').pop();
+      const lastLabel = last === undefined ? '—' : formatMetric(last, fmt);
+      return `
+        <svg class="trend-svg" viewBox="0 0 ${box.width} ${box.height}" role="img"
+             aria-label="${esc(label)} ${esc(trendMetric)} trend, latest ${esc(lastLabel)}">
+          <polyline class="trend-line" points="${polyPts}" style="stroke:${color}" />
+          ${dots}
+        </svg>`;
+    })
+    .join('');
+
+  const legend = labels
+    .map(
+      (label, idx) =>
+        `<span class="trend-swatch"><i style="background:${SERIES_COLORS[idx % SERIES_COLORS.length]}"></i>${esc(label)}</span>`,
+    )
+    .join('');
+
+  section.innerHTML = `
+    ${picker}
+    <div class="trend-card">
+      <p class="trend-metric">${esc(trendMetric)} over time</p>
+      ${lines || '<p class="trend-empty">No data for this metric.</p>'}
+      <div class="trend-legend">${legend}</div>
+    </div>`;
+
+  // Re-bind the picker (innerHTML replaced its node).
+  const sel = document.getElementById('trend-metric');
+  if (sel) {
+    sel.addEventListener('change', (e) => {
+      trendMetric = e.target.value;
+      syncUrl();
+      renderTrends();
+    });
+  }
+}
+
+// ── Single delegated table listener (NOT one per row) ──
+//
+// Bound ONCE to the persistent #runs container. It survives every re-render of
+// the table's innerHTML and reads the acted-on run id from the target's
+// data-run-id. Improves on photo-curation eval.js, which binds a click listener
+// inside its per-row render loop (re-created on every render, O(rows) listeners).
+function onRunsChange(e) {
+  const cb = e.target.closest('.run-select');
+  if (!cb) return;
+  const id = cb.getAttribute('data-run-id');
+  if (!id) return;
+  if (cb.checked) {
+    if (!selected.includes(id) && selected.length < 2) selected.push(id);
+  } else {
+    selected = selected.filter((s) => s !== id);
+  }
+  syncUrl();
+  renderRunsTable();
+  renderCompareBar();
+}
+
+function bindDelegation() {
+  const host = document.getElementById('runs');
+  // `change` fires for the checkbox inputs; one handler, read data-* off target.
+  host.addEventListener('change', onRunsChange);
+}
+
+// ── Load ──
+async function load() {
+  try {
+    const res = await fetch('/api/runs');
+    runs = res.ok ? (await res.json()).runs ?? [] : [];
+  } catch {
+    runs = [];
+  }
+  // Drop any URL-carried selection that names a run that no longer exists.
+  const known = new Set(runs.map((r) => r.id));
+  selected = selected.filter((id) => known.has(id)).slice(0, 2);
+  syncUrl();
+
+  renderRunsTable();
+  renderCompareBar();
+  await renderTrends();
+}
+
+bindDelegation();
+load();

--- a/packages/eleatic/ui/index.html
+++ b/packages/eleatic/ui/index.html
@@ -3,23 +3,42 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>eleatic</title>
+    <title>eleatic · eval explorer</title>
+    <!--
+      The comparison hub (E5). Framework-free: app.css for the neutral token
+      system, hub.js as a single ES module. hub.js imports /config.js (the
+      server's client-config emitter: formatters, gate, theme key, image-host
+      allowlist) and the sibling theme.js / safe.js / format.js modules. No
+      build step, no bundler — served verbatim from packages/eleatic/ui/.
+    -->
+    <link rel="stylesheet" href="/app.css" />
   </head>
   <body>
-    <!--
-      Placeholder landing page. The real comparison hub / diff / facets pages
-      land in E5 / E6; this page only keeps `GET /` a 200 so `eleatic serve` is
-      complete before those pages exist. It imports `/config.js` (the server's
-      client-config emitter) so the wiring is exercised end-to-end today.
-    -->
-    <main>
-      <h1>eleatic</h1>
-      <p>eval-results explorer — UI pages land in a later epic child.</p>
+    <header class="app-header">
+      <h1 class="app-title">eleatic<span class="app-sub">eval explorer</span></h1>
+      <span class="header-spacer"></span>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle light / dark theme">◐ Theme</button>
+    </header>
+
+    <main class="wrap">
+      <section class="section">
+        <div class="section-head">
+          <h2 class="section-title">Runs</h2>
+          <span class="section-sub">Select two runs to compare</span>
+        </div>
+        <div id="runs"></div>
+        <div id="compare-bar" class="compare-bar"></div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2 class="section-title">Trends</h2>
+          <span class="section-sub">One line per run label</span>
+        </div>
+        <div id="trends" class="trends-grid"></div>
+      </section>
     </main>
-    <script type="module">
-      import { config } from '/config.js';
-      // eslint-disable-next-line no-console
-      console.log('eleatic config', config);
-    </script>
+
+    <script type="module" src="/hub.js"></script>
   </body>
 </html>

--- a/packages/eleatic/ui/safe.js
+++ b/packages/eleatic/ui/safe.js
@@ -1,0 +1,78 @@
+// Shared browser-safety helpers for the eleatic explorer UI.
+//
+// The hub (hub.js) and any future page build their DOM with `innerHTML` template
+// strings that interpolate EXTERNAL, UNTRUSTED data: run labels, metric keys,
+// row keys, and image urls — all of which originate from whatever eval harness
+// wrote the SQLite store (eleatic invents no domain). The server exposes a write
+// route (POST /api/adjudications), so an unescaped payload like
+// `"><img src=x onerror=alert(1)>` is a real XSS that can drive that route.
+// These helpers neutralize that:
+//   - `esc(s)`     HTML-escapes & < > " ' so a payload renders as inert text.
+//   - `safeImg(u)` returns the URL only when it is an https URL whose host is on
+//                  the CONFIGURED allowlist; otherwise a transparent 1×1
+//                  placeholder.
+//
+// Unlike the photo-curation original (which hard-coded a bird-photo-host set),
+// the allowlist here is read from `/config.js` at runtime via
+// `setImageHostAllowlist(cfg.imageHostAllowlist)`. The eleatic default is the
+// any-https sentinel `['https://*']` (any https host allowed) — the package
+// makes no domain assumption. A deployment that wants to lock images down passes
+// an explicit host list in its `--config` file. Non-https / `javascript:` /
+// unparseable input always falls back to the placeholder, regardless of the
+// allowlist.
+//
+// Plain ESM with named exports so it is importable both by the browser (served
+// verbatim by the server's express.static) and by vitest in node.
+
+const ESCAPES = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+
+/** HTML-escape `& < > " '` so an interpolated value renders as inert text. */
+export function esc(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ESCAPES[c]);
+}
+
+// 1×1 transparent PNG — the fallback when an image URL is not a trusted https
+// URL on the allowlist. Inert: a data: URI can't run JS in <img src>.
+export const PLACEHOLDER =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+// The any-https sentinel: when this string is present in the allowlist, ANY
+// https host is accepted (the eleatic zero-config default — no domain coupling).
+const ANY_HTTPS = 'https://*';
+
+// Lowercased host allowlist, set from /config.js at page init. Until configured
+// it is empty — fail-closed: nothing matches, so every URL → placeholder.
+let allowedHosts = new Set();
+let anyHttps = false;
+
+/**
+ * Apply the image-host allowlist read from `/config.js`. Accepts the any-https
+ * sentinel `'https://*'` (any https host) and/or explicit lowercased hostnames.
+ * Hosts are compared case-insensitively.
+ */
+export function setImageHostAllowlist(hosts) {
+  const list = Array.isArray(hosts) ? hosts : [];
+  anyHttps = list.includes(ANY_HTTPS);
+  allowedHosts = new Set(
+    list.filter((h) => h !== ANY_HTTPS).map((h) => String(h).toLowerCase()),
+  );
+}
+
+/**
+ * Validate an image URL before it reaches `<img src>`. Returns `u` unchanged
+ * only when it parses, is https, and its host is allowed (the any-https sentinel
+ * or an explicit allowlist match); otherwise a transparent 1×1 data-URI
+ * placeholder.
+ */
+export function safeImg(u) {
+  let parsed;
+  try {
+    parsed = new URL(u);
+  } catch {
+    return PLACEHOLDER;
+  }
+  if (parsed.protocol !== 'https:') return PLACEHOLDER;
+  if (anyHttps) return u;
+  if (!allowedHosts.has(parsed.host.toLowerCase())) return PLACEHOLDER;
+  return u;
+}

--- a/packages/eleatic/ui/safe.test.ts
+++ b/packages/eleatic/ui/safe.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+// safe.js is plain ESM with named exports, served verbatim to the browser by the
+// eleatic server's express.static AND importable here in node. Unlike the
+// photo-curation port it reads its image-host allowlist from /config.js at
+// runtime (default: any https), so the test drives that configurator directly.
+import { esc, safeImg, setImageHostAllowlist, PLACEHOLDER } from './safe.js';
+
+describe('esc', () => {
+  it('neutralizes an injected <img onerror> payload — no raw < > "', () => {
+    const out = esc('"><img src=x onerror=alert(1)>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).not.toContain('"');
+    // The dangerous characters survive only in their escaped form.
+    expect(out).toContain('&lt;');
+    expect(out).toContain('&gt;');
+    expect(out).toContain('&quot;');
+  });
+
+  it('escapes & < > " and single quote', () => {
+    expect(esc('Tom & Jerry')).toBe('Tom &amp; Jerry');
+    expect(esc("O'Brien")).toBe('O&#39;Brien');
+  });
+
+  it('leaves benign text untouched and coerces non-strings', () => {
+    expect(esc('© Jane Photographer')).toBe('© Jane Photographer');
+    expect(esc(42)).toBe('42');
+    expect(esc(null)).toBe('null');
+  });
+});
+
+describe('safeImg — default (any-https) allowlist', () => {
+  beforeEach(() => {
+    // The config default the server emits when no allowlist is configured.
+    setImageHostAllowlist(['https://*']);
+  });
+
+  it('accepts ANY https host under the any-https sentinel (not a hard-coded host set)', () => {
+    for (const url of [
+      'https://photos.bird-maps.com/x.webp',
+      'https://example.com/photo.jpg',
+      'https://cdn.some-other-eval.io/img.png',
+    ]) {
+      expect(safeImg(url)).toBe(url);
+    }
+  });
+
+  it('rejects a javascript: URL → placeholder, even under any-https', () => {
+    expect(safeImg('javascript:alert(1)')).toBe(PLACEHOLDER);
+  });
+
+  it('rejects a non-https (http:) URL → placeholder, even under any-https', () => {
+    expect(safeImg('http://example.com/x.jpg')).toBe(PLACEHOLDER);
+  });
+
+  it('rejects an unparseable / empty / undefined value → placeholder', () => {
+    expect(safeImg('not a url')).toBe(PLACEHOLDER);
+    expect(safeImg('')).toBe(PLACEHOLDER);
+    expect(safeImg(undefined)).toBe(PLACEHOLDER);
+  });
+});
+
+describe('safeImg — explicit host allowlist (from config)', () => {
+  beforeEach(() => {
+    setImageHostAllowlist(['photos.bird-maps.com', 'upload.wikimedia.org']);
+  });
+
+  it('returns an allowlisted https host unchanged', () => {
+    const url = 'https://photos.bird-maps.com/x.webp';
+    expect(safeImg(url)).toBe(url);
+  });
+
+  it('accepts every configured host (case-insensitive)', () => {
+    expect(safeImg('https://UPLOAD.WIKIMEDIA.ORG/photo.jpg')).toBe(
+      'https://UPLOAD.WIKIMEDIA.ORG/photo.jpg',
+    );
+  });
+
+  it('rejects an https URL on a non-allowlisted host → placeholder', () => {
+    expect(safeImg('https://evil.example.com/x.jpg')).toBe(PLACEHOLDER);
+  });
+
+  it('still rejects non-https even when the host is allowlisted', () => {
+    expect(safeImg('http://photos.bird-maps.com/x.jpg')).toBe(PLACEHOLDER);
+  });
+});
+
+describe('safeImg — before any config is applied', () => {
+  beforeEach(() => {
+    // An empty allowlist (no setImageHostAllowlist call equivalent) is fail-closed:
+    // nothing matches, so every URL falls back to the placeholder.
+    setImageHostAllowlist([]);
+  });
+
+  it('an empty allowlist matches nothing → placeholder', () => {
+    expect(safeImg('https://photos.bird-maps.com/x.webp')).toBe(PLACEHOLDER);
+  });
+});

--- a/packages/eleatic/ui/theme.js
+++ b/packages/eleatic/ui/theme.js
@@ -1,0 +1,22 @@
+// Light/dark theme toggle for the eleatic explorer, via a [data-theme] attribute
+// on <html> + a localStorage-persisted preference. Ported from photo-curation's
+// theme.js with a NAMESPACED storage key — `eleatic-theme`, not
+// `photo-curate-theme` — so the two tools served from different origins (or the
+// same browser during dev) never read each other's preference.
+//
+// Browser-only (touches localStorage + document); loaded via
+// `<script type="module">`. No unit test (no DOM-free surface); the rendered
+// toggle is exercised at the orchestrator's live-verify step.
+
+const KEY = 'eleatic-theme';
+
+export function initTheme() {
+  const saved = localStorage.getItem(KEY) || 'light';
+  document.documentElement.setAttribute('data-theme', saved);
+}
+
+export function toggleTheme() {
+  const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem(KEY, next);
+}

--- a/packages/eleatic/vitest.config.ts
+++ b/packages/eleatic/vitest.config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    // src/ holds the store/queries/server/CLI suites; ui/ holds the
+    // framework-free explorer's pure-node unit suites (safe.js escaping +
+    // allowlist, the metric-formatter registry, the gate evaluator, and the
+    // inline-SVG point-mapper). ui/*.ts is excluded from tsconfig (tsc copies
+    // ui/ verbatim, never compiles it), so these run under vitest only.
+    include: ['src/**/*.test.ts', 'ui/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph Browser["Browser — framework-free ESM (no build step)"]
        HTML["ui/index.html"]
        HUB["ui/hub.js"]
        FMT["ui/format.js<br/>formatMetric · evalGate · mapPoints"]
        SAFE["ui/safe.js<br/>esc · safeImg (allowlist from /config.js)"]
        THEME["ui/theme.js<br/>key: eleatic-theme"]
    end

    subgraph Server["Express server (E4 — unchanged)"]
        CFG["GET /config.js<br/>formatters · gate · allowlist · themeKey"]
        RUNS["GET /api/runs"]
        TRENDS["GET /api/trends?metric="]
        DIFF["GET /diff?a=&b="]
    end

    HTML -->|script type=module| HUB
    HUB --> FMT
    HUB --> SAFE
    HUB --> THEME
    HUB -->|import| CFG
    HUB -->|fetch| RUNS
    HUB -->|fetch per metric| TRENDS

    RUNS --> TABLE["Union-of-metrics table<br/>+ gate badge + baseline star"]
    TRENDS --> SVG["Inline-SVG trends<br/>one polyline per run label"]
    TABLE -->|select 2 → single delegated listener| COMPARE["Compare link"]
    COMPARE --> DIFF
```

## Summary

- **Why:** E1–E4 shipped the eleatic eval-explorer's store/queries/analysis/server/CLI, but `GET /` was a placeholder. E5 adds the framework-free explorer UI chrome — the comparison hub — so a run-set is actually browsable. No React, no bundler, no build step: plain ES modules served verbatim from `packages/eleatic/ui/`.
- **What:** a union-of-metrics runs table (columns = the union of every run's `metrics_json` keys — generic, no fixed agreement/falseKeep columns), each cell rendered by the per-metric formatter from `/config.js` (`percent`/`usd`/`integer`/`raw`); a configurable `{metric,op,threshold}` gate badge (PASS/fail); a `★` baseline marker; checkbox-select exactly two runs → a `Compare →` link to `/diff?a=&b=`; and inline-SVG trends from `/api/trends` (one `<polyline>` per run-label group via `mapPoints` — no chart dependency). Selection + trend metric are URL-synced.
- **Discipline preserved:** the pure units (formatter registry, gate evaluator, SVG point-mapper, and the `esc`/`safeImg` safety helpers) are unit-tested as pure node modules. `safeImg` reads its image-host allowlist from `/config.js` (default any-https — no bird-host coupling). The hub uses a **single delegated listener** on the `#runs` container (reads `data-run-id` off the target), deliberately improving on photo-curation `eval.js`'s per-row binding. Theme key is namespaced `eleatic-theme`; tokens are neutral grays + a blue accent, not bird-maps amber. Zero `@bird-watch/*` imports (the E1 zero-coupling guard scans `ui/` and passes).

## Screenshots

N/A — `packages/` tool, framework-free `ui/` (not `frontend/**`); orchestrator live-verifies at E2E.

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — 14 files / 132 tests green (adds `ui/safe.test.ts` 12 + `ui/format.test.ts` 17)
- [x] `npm run test` (full repo) — 88 files / 1529 tests green
- [x] `npm run lint` — green
- [x] `npm run build` (full) + `npm run build -w @bird-watch/eleatic` — clean; `ui/` copies to `dist/ui/` with the real `index.html`/`hub.js`/`app.css`/`theme.js`/`safe.js`/`format.js`
- [x] `npx knip` — exit 0 (dated `ui/hub.js` + `ui/theme.js` ignore added in this PR; `safe.js`/`format.js` traced via their `.test.ts` siblings)
- [x] New unit tests added: pure formatter registry, gate evaluator, inline-SVG point-mapper, and the `esc`/configurable-allowlist `safeImg` units (no browser, no network)
- [x] (UI) No `frontend/**` change — `packages/`-scoped framework-free `ui/`, exempt from the Playwright contract; orchestrator live-verifies the rendered hub at the E5 E2E step

## Plan reference

Closes #1148. Part of epic #1153 (eleatic), Wave 3 / E5.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
