### PR TITLE
feat(eleatic): run-diff + facet gallery + drill-down drawer + adjudication UI

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -277,7 +277,26 @@ const config: KnipConfig = {
       //             deleted but its module left on disk. Re-audit 2026-07-27 —
       //             confirm ui/index.html still references both (grep
       //             `src="/hub.js"` and an `import .* '/theme.js'` in hub.js).
-      ignore: ['ui/hub.js', 'ui/theme.js'],
+      // 2026-06-13 (E6, #1149): the diff + facet pages' browser entries
+      //             ui/diff.js and ui/facets.js (loaded via diff.html/facets.html
+      //             `<script type="module" src="/diff.js">` / `/facets.js`) and
+      //             their shared collaborators ui/drawer.js + ui/adjudicate.js
+      //             (imported only BY diff.js/facets.js, which knip can't see,
+      //             so they're transitively unreachable). Same runtime-resolved-
+      //             specifier reason as hub.js/theme.js above. Their pure-unit
+      //             siblings ui/facet-grammar.js, ui/pretty.js, ui/diff-classify.js
+      //             and ui/staleness.js are deliberately NOT listed: each has a
+      //             real vitest sibling (*.test.ts) that imports it, so knip
+      //             already traces them as used (a redundant-ignore would be
+      //             flagged) — the safe.js "test-sibling makes it traced"
+      //             reasoning applies verbatim. ui/diff.html + ui/facets.html are
+      //             not JS/TS modules, so knip does not track them either.
+      //             Risk: masks a genuinely orphaned ui/ script if a page is
+      //             deleted but its module left on disk. Re-audit 2026-07-27 —
+      //             confirm diff.html references /diff.js, facets.html references
+      //             /facets.js, and both diff.js+facets.js still
+      //             `import … './drawer.js'` (drawer.js `import … './adjudicate.js'`).
+      ignore: ['ui/hub.js', 'ui/theme.js', 'ui/diff.js', 'ui/facets.js', 'ui/drawer.js', 'ui/adjudicate.js'],
     },
 
     'tools/photo-curation': {

--- a/packages/eleatic/ui/adjudicate.js
+++ b/packages/eleatic/ui/adjudicate.js
@@ -1,0 +1,129 @@
+// The human-adjudication panel inside the eleatic drawer.
+//
+// Renders a verdict <select> (vocabulary from /config.js — NOT hard-coded; the
+// package invents no domain verbs), a free-text note, and a staleness badge, then
+// POSTs to `/api/adjudications` on submit. This is the ONLY write the eleatic UI
+// performs: adjudications are run-independent, keyed on `row_key`, upsert — no
+// audit history.
+//
+// Server contract (E4, src/server/app.ts): POST accepts
+// `{ rowKey, verdict, run?, note? }`. The server captures `against_hash` itself
+// from the row's CURRENT content_hash via `run` at decision time (the UI does
+// not send a hash — sending `run` is what lets the server anchor the verdict).
+// We thread the resolved `run` (diff view → run b, facets/hub view → page run)
+// through so a submitted verdict is anchored and a later row edit flips isStale.
+//
+// Staleness: a pre-existing verdict is stale when its stored `against_hash`
+// differs from the row's current content_hash (the isStale pure unit). The drawer
+// passes both in; we render a "stale — re-decide" badge when stale.
+//
+// Optimistic update: on a 200 response we re-render the panel in place reflecting
+// the just-submitted verdict (now anchored against the current hash, so fresh).
+//
+// Plain ESM with a named export. Browser-only at runtime (touches the DOM +
+// fetch); no unit test — the logic lives in the isStale pure unit, this is glue.
+// Verified live at the epic's E2E recipe.
+
+import { esc } from './safe.js';
+import { isStale } from './staleness.js';
+import { config } from '/config.js';
+
+/**
+ * Render the adjudication panel into `container`.
+ *
+ * @param {HTMLElement} container
+ * @param {{
+ *   rowKey: string,
+ *   run: string,                       // resolved run for the POST's against_hash capture
+ *   contentHash?: string,              // the row's CURRENT content_hash
+ *   current?: { verdict?: string, note?: string, againstHash?: string } // existing verdict, if any
+ * }} opts
+ */
+export function renderAdjudication(container, opts) {
+  const { rowKey, run, contentHash, current } = opts;
+  const verdicts = Array.isArray(config.verdictVocabulary) ? config.verdictVocabulary : [];
+
+  const currentVerdict = current?.verdict ?? '';
+  const currentNote = current?.note ?? '';
+  const stale = isStale(current?.againstHash, contentHash);
+
+  const options = [
+    `<option value=""${currentVerdict === '' ? ' selected' : ''}>— choose verdict —</option>`,
+    ...verdicts.map(
+      (v) => `<option value="${esc(v)}"${v === currentVerdict ? ' selected' : ''}>${esc(v)}</option>`,
+    ),
+  ].join('');
+
+  const staleBadge = stale
+    ? '<span class="adj-stale" title="The item changed since this verdict was decided">⚠ stale — re-decide</span>'
+    : '';
+
+  const decided = current?.verdict
+    ? `<p class="adj-current">Current verdict: <strong>${esc(currentVerdict)}</strong>${staleBadge}</p>`
+    : '<p class="adj-current adj-none">No verdict yet</p>';
+
+  container.innerHTML = `
+    <div class="adjudicate">
+      <h3 class="adj-title">Adjudicate</h3>
+      ${decided}
+      <form class="adj-form" data-row-key="${esc(rowKey)}">
+        <label class="adj-field">
+          <span class="adj-label">Verdict</span>
+          <select class="adj-verdict" name="verdict" required>${options}</select>
+        </label>
+        <label class="adj-field">
+          <span class="adj-label">Note <span class="adj-optional">(optional)</span></span>
+          <textarea class="adj-note" name="note" rows="2" placeholder="Why?">${esc(currentNote)}</textarea>
+        </label>
+        <div class="adj-actions">
+          <button type="submit" class="adj-submit">Save verdict</button>
+          <span class="adj-status" role="status" aria-live="polite"></span>
+        </div>
+      </form>
+    </div>`;
+
+  const form = container.querySelector('.adj-form');
+  const status = container.querySelector('.adj-status');
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const verdict = form.querySelector('.adj-verdict').value;
+    const note = form.querySelector('.adj-note').value;
+    if (!verdict) {
+      status.textContent = 'Pick a verdict first.';
+      return;
+    }
+    status.textContent = 'Saving…';
+    // Send what we have: rowKey + verdict always, run (for against_hash capture)
+    // and note when present. Omittable keys are left off so the store coerces
+    // them to NULL at its boundary (exactOptionalPropertyTypes).
+    const payload = { rowKey, verdict };
+    if (run) payload.run = run;
+    if (note) payload.note = note;
+    try {
+      const res = await fetch('/api/adjudications', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        status.textContent = body.error ? `Failed: ${body.error}` : 'Failed to save.';
+        return;
+      }
+      // Optimistic re-render in place: the verdict is now anchored against the
+      // row's current hash, so the freshly-saved verdict is no longer stale.
+      const next = { verdict };
+      if (note) next.note = note;
+      if (contentHash) next.againstHash = contentHash;
+      renderAdjudication(container, {
+        rowKey,
+        run,
+        ...(contentHash ? { contentHash } : {}),
+        current: next,
+      });
+      container.querySelector('.adj-status').textContent = 'Saved.';
+    } catch {
+      status.textContent = 'Network error — not saved.';
+    }
+  });
+}

--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -93,3 +93,126 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .trend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
 .trend-controls label { font-size: var(--type-sm); color: var(--text-dim); }
 .trend-controls select { font: inherit; padding: 6px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+
+/* ── Header back-link (diff / facets pages) ── */
+.back-link { font-size: var(--type-sm); color: var(--text-dim); text-decoration: none; padding: 6px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); }
+.back-link:hover { background: var(--surface-2); color: var(--text); }
+
+/* ── Status colors for ✓ / ✗ marks + classifications ── */
+.diff-match, .facet-score { color: var(--status-pass); }
+.diff-miss { color: var(--status-fail); }
+.diff-absent { color: var(--text-dim); }
+
+/* ── Diff view ── */
+.diff-toolbar { display: flex; align-items: center; gap: 16px; margin: 0 0 12px; }
+.diff-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: var(--type-sm); color: var(--text-dim); cursor: pointer; }
+.badge.diff-regression { background: var(--status-fail); color: #fff; border-color: var(--status-fail); font-weight: 700; }
+.badge.diff-regression.diff-regression-zero { background: var(--surface-2); color: var(--text-dim); border-color: var(--border); font-weight: 600; }
+.diff-table { width: 100%; border-collapse: collapse; font-size: var(--type-sm); background: var(--surface); }
+.diff-table th, .diff-table td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--border); }
+.diff-table thead th { font-weight: 600; color: var(--text-dim); background: var(--surface-2); position: sticky; top: 0; }
+.diff-table tbody tr:last-child td { border-bottom: none; }
+.diff-row:hover { background: var(--surface-2); }
+.diff-rowkey code, .facet-rowkey code, .drawer-rowkey code { font-family: var(--mono-stack); font-size: var(--type-xs); }
+.diff-side { text-align: center; font-weight: 700; }
+.diff-class { display: inline-block; font-size: var(--type-xs); font-weight: 700; padding: 2px 9px; border-radius: 999px; text-transform: uppercase; letter-spacing: .03em; background: var(--surface-2); color: var(--text-dim); border: 1px solid var(--border); }
+.diff-class-regression { background: var(--status-fail); color: #fff; border-color: var(--status-fail); }
+.diff-class-improvement { background: var(--status-pass); color: #fff; border-color: var(--status-pass); }
+.diff-class-new { background: var(--accent-soft); color: var(--accent); border-color: var(--accent); }
+.diff-class-removed { background: var(--surface-2); color: var(--text-dim); }
+.diff-class-unchanged { background: transparent; }
+.diff-open { text-align: right; }
+.diff-open-btn, .facet-open-btn, .facet-more, .facet-add-btn, .adj-submit, .facet-view { font: inherit; font-size: var(--type-sm); padding: 6px 12px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
+.diff-open-btn:hover, .facet-open-btn:hover, .facet-more:hover, .facet-add-btn:hover, .facet-view:hover { background: var(--surface-2); }
+
+/* ── Facet controls ── */
+.facet-controls { margin: 0 0 14px; display: flex; flex-direction: column; gap: 10px; }
+.facet-active { display: flex; flex-wrap: wrap; gap: 8px; }
+.facet-none { font-size: var(--type-sm); color: var(--text-dim); }
+.facet-chip { display: inline-flex; align-items: center; gap: 6px; font-size: var(--type-xs); font-family: var(--mono-stack); padding: 3px 4px 3px 10px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent); }
+.facet-chip-x { font: inherit; line-height: 1; padding: 0 4px; border: none; background: transparent; color: inherit; cursor: pointer; border-radius: 50%; }
+.facet-chip-x:hover { background: rgba(0,0,0,.1); }
+.facet-add { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.facet-add-key, .facet-add-op, .facet-add-val { font: inherit; font-size: var(--type-sm); padding: 6px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+.facet-add-val { min-width: 120px; }
+
+/* ── Facet view toggle ── */
+.facet-viewbar { display: flex; justify-content: flex-end; margin: 0 0 12px; }
+.facet-view-toggle { display: inline-flex; border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; }
+.facet-view { border: none; border-radius: 0; }
+.facet-view.active { background: var(--accent); color: #fff; }
+
+/* ── Facet gallery ── */
+.facet-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 14px; }
+.facet-figure { margin: 0; border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; background: var(--surface); box-shadow: var(--card-elevation); cursor: pointer; }
+.facet-figure:hover, .facet-figure:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.facet-img { width: 100%; aspect-ratio: 4 / 3; object-fit: cover; display: block; background: var(--surface-2); }
+.facet-caption { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; }
+.facet-name { font-size: var(--type-sm); font-weight: 600; }
+.facet-score { font-size: var(--type-xs); font-family: var(--mono-stack); }
+.facet-more { display: block; margin: 16px auto 0; }
+
+/* ── Facet table ── */
+.facet-table { width: 100%; border-collapse: collapse; font-size: var(--type-sm); background: var(--surface); }
+.facet-table th, .facet-table td { padding: 9px 12px; text-align: left; border-bottom: 1px solid var(--border); white-space: nowrap; }
+.facet-table thead th { font-weight: 600; color: var(--text-dim); background: var(--surface-2); }
+.facet-table .num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--mono-stack); }
+.facet-trow:hover { background: var(--surface-2); }
+
+/* ── Drill-down drawer ── */
+.drawer-root { position: fixed; inset: 0; z-index: 10; }
+.drawer-root[hidden] { display: none; }
+.drawer-backdrop { position: absolute; inset: 0; background: rgba(8,11,16,.45); }
+.drawer-panel { position: absolute; top: 0; right: 0; height: 100%; width: min(560px, 92vw); background: var(--bg); border-left: 1px solid var(--border); box-shadow: -8px 0 24px rgba(0,0,0,.25); overflow-y: auto; padding: 20px 24px 40px; }
+.drawer-close { position: absolute; top: 12px; right: 14px; font-size: 22px; line-height: 1; width: 32px; height: 32px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); color: var(--text); cursor: pointer; }
+.drawer-close:hover { background: var(--surface-2); }
+.drawer-head { margin: 0 32px 16px 0; }
+.drawer-title { font-size: var(--type-md); font-weight: 600; margin: 0; }
+.drawer-rowkey { font-size: var(--type-xs); color: var(--text-dim); margin: 4px 0 0; }
+.drawer-img { width: 100%; max-height: 280px; object-fit: contain; border-radius: var(--radius-sm); background: var(--surface-2); margin: 0 0 16px; }
+.drawer-section { margin: 0 0 20px; }
+.drawer-h3 { font-size: var(--type-sm); font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 8px; }
+.drawer-loading, .drawer-error, .drawer-empty { font-size: var(--type-sm); color: var(--text-dim); }
+.drawer-error { color: var(--status-fail); }
+
+/* ── Score bars ── */
+.score-bars { display: flex; flex-direction: column; gap: 6px; }
+.score-row { display: grid; grid-template-columns: 120px 1fr 56px; align-items: center; gap: 8px; font-size: var(--type-sm); }
+.score-key { color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; }
+.score-track { height: 8px; background: var(--surface-2); border-radius: 999px; overflow: hidden; }
+.score-fill { display: block; height: 100%; background: var(--accent); }
+.score-val { text-align: right; font-family: var(--mono-stack); font-size: var(--type-xs); }
+
+/* ── Metadata chips ── */
+.meta-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.meta-chip { font-size: var(--type-xs); padding: 3px 8px; border-radius: 999px; background: var(--surface-2); color: var(--text); border: 1px solid var(--border); }
+.meta-key { color: var(--text-dim); margin-right: 4px; }
+
+/* ── JSON compare tree ── */
+.json-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.json-col { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px; background: var(--surface); overflow-x: auto; }
+.json-col-label { font-size: var(--type-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 6px; }
+.json-object, .json-array { list-style: none; margin: 0; padding: 0 0 0 14px; font-family: var(--mono-stack); font-size: var(--type-xs); }
+.json-item { line-height: 1.5; }
+.json-key { color: var(--accent); }
+.json-colon { color: var(--text-dim); }
+.json-str { color: var(--status-pass); }
+.json-num { color: var(--text); }
+.json-bool, .json-null { color: var(--text-dim); }
+.json-empty { font-family: var(--mono-stack); font-size: var(--type-xs); color: var(--text-dim); }
+
+/* ── Adjudication panel ── */
+.adjudicate { border-top: 1px solid var(--border); padding-top: 16px; }
+.adj-title { font-size: var(--type-sm); font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 8px; }
+.adj-current { font-size: var(--type-sm); margin: 0 0 12px; }
+.adj-current.adj-none { color: var(--text-dim); }
+.adj-stale { display: inline-block; margin-left: 8px; font-size: var(--type-xs); font-weight: 700; padding: 2px 8px; border-radius: 999px; background: var(--status-fail); color: #fff; }
+.adj-form { display: flex; flex-direction: column; gap: 10px; }
+.adj-field { display: flex; flex-direction: column; gap: 4px; }
+.adj-label { font-size: var(--type-xs); color: var(--text-dim); }
+.adj-optional { font-weight: 400; }
+.adj-verdict, .adj-note { font: inherit; font-size: var(--type-sm); padding: 6px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+.adj-note { resize: vertical; }
+.adj-actions { display: flex; align-items: center; gap: 12px; }
+.adj-submit { border-color: var(--accent); background: var(--accent); color: #fff; }
+.adj-status { font-size: var(--type-xs); color: var(--text-dim); }

--- a/packages/eleatic/ui/diff-classify.js
+++ b/packages/eleatic/ui/diff-classify.js
@@ -1,0 +1,38 @@
+// Per-row diff classifier for the eleatic run-diff view.
+//
+// Given how a row's two sides (run A, run B) relate to their `expected_json`,
+// derive a single classification the diff table and the run-level
+// regression-count badge consume:
+//
+//   regression  — matched expected in A but NOT in B   (the metric that matters)
+//   improvement — matched expected in B but NOT in A   (the reverse)
+//   new         — present in B only
+//   removed     — present in A only (or, degenerately, neither)
+//   unchanged   — present in both and the matched-state is the same on each side
+//
+// Presence dominates: a row that exists in only one run is `new`/`removed`
+// regardless of match state. Among rows present in both, the (aMatched, bMatched)
+// pair decides regression / improvement / unchanged. `diverged` (whether the two
+// outputs differ in content) is part of the input contract for the diff view's
+// display but does NOT change the classification — a row can match expected on
+// both sides yet still diverge in incidental output shape; that is `unchanged`.
+//
+// Pure: no DOM, no network. Importable by the browser (express.static) and
+// vitest in node — the safe.js / format.js precedent.
+
+/**
+ * @param {{ aMatched: boolean, bMatched: boolean, aPresent: boolean,
+ *           bPresent: boolean, diverged: boolean }} row
+ * @returns {'regression'|'improvement'|'unchanged'|'new'|'removed'}
+ */
+export function classifyRow({ aMatched, bMatched, aPresent, bPresent }) {
+  // Presence first: a one-sided row is new/removed irrespective of match state.
+  if (aPresent && !bPresent) return 'removed';
+  if (!aPresent && bPresent) return 'new';
+  if (!aPresent && !bPresent) return 'removed'; // degenerate; never in a real diff
+
+  // Both present: the expected-match transition decides the verdict.
+  if (aMatched && !bMatched) return 'regression';
+  if (!aMatched && bMatched) return 'improvement';
+  return 'unchanged';
+}

--- a/packages/eleatic/ui/diff-classify.test.ts
+++ b/packages/eleatic/ui/diff-classify.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+// diff-classify.js owns the per-row diff classification — the one piece of the
+// run-diff view with logic. diff.js maps each RunDiff into this input shape and
+// counts the `regression` results. Importable in the browser + vitest.
+import { classifyRow } from './diff-classify.js';
+
+describe('classifyRow — presence dominates', () => {
+  it('present only in B → new', () => {
+    expect(classifyRow({ aPresent: false, bPresent: true, aMatched: false, bMatched: true, diverged: false })).toBe('new');
+  });
+
+  it('present only in A → removed', () => {
+    expect(classifyRow({ aPresent: true, bPresent: false, aMatched: true, bMatched: false, diverged: false })).toBe('removed');
+  });
+
+  it('present in NEITHER → removed (degenerate; never both-absent in a real diff)', () => {
+    // A RunDiff always has at least one side, but guard the input anyway.
+    expect(classifyRow({ aPresent: false, bPresent: false, aMatched: false, bMatched: false, diverged: false }))
+      .toBe('removed');
+  });
+});
+
+describe('classifyRow — regression / improvement when both present', () => {
+  it('matched expected in A, missed in B → regression', () => {
+    expect(classifyRow({ aPresent: true, bPresent: true, aMatched: true, bMatched: false, diverged: true })).toBe('regression');
+  });
+
+  it('missed expected in A, matched in B → improvement', () => {
+    expect(classifyRow({ aPresent: true, bPresent: true, aMatched: false, bMatched: true, diverged: true })).toBe('improvement');
+  });
+
+  it('both matched expected → unchanged (even if outputs diverge in shape)', () => {
+    expect(classifyRow({ aPresent: true, bPresent: true, aMatched: true, bMatched: true, diverged: true })).toBe('unchanged');
+  });
+
+  it('both missed expected → unchanged (no regression — neither matched)', () => {
+    expect(classifyRow({ aPresent: true, bPresent: true, aMatched: false, bMatched: false, diverged: true })).toBe('unchanged');
+  });
+
+  it('both present, identical, both matched → unchanged', () => {
+    expect(classifyRow({ aPresent: true, bPresent: true, aMatched: true, bMatched: true, diverged: false })).toBe('unchanged');
+  });
+});
+
+describe('classifyRow — exhaustive truth table over both-present matched combos', () => {
+  // The 2×2 of (aMatched, bMatched) when both rows are present.
+  const cases: Array<[boolean, boolean, string]> = [
+    [true, false, 'regression'],
+    [false, true, 'improvement'],
+    [true, true, 'unchanged'],
+    [false, false, 'unchanged'],
+  ];
+  for (const [aMatched, bMatched, expected] of cases) {
+    it(`aMatched=${aMatched} bMatched=${bMatched} → ${expected}`, () => {
+      expect(classifyRow({ aPresent: true, bPresent: true, aMatched, bMatched, diverged: true })).toBe(expected);
+    });
+  }
+});

--- a/packages/eleatic/ui/diff.html
+++ b/packages/eleatic/ui/diff.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>eleatic · run diff</title>
+    <!--
+      The per-row run-diff view (E6). Framework-free, no build step — served
+      verbatim from packages/eleatic/ui/. diff.js imports /config.js (the
+      server's client-config emitter) and the sibling theme.js / safe.js modules,
+      plus the shared drawer.js / pure-unit modules. Same bootstrap + script
+      shape as the E5 hub.
+    -->
+    <link rel="stylesheet" href="/app.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <a class="back-link" href="/">← Hub</a>
+      <h1 class="app-title">eleatic<span class="app-sub">run diff</span></h1>
+      <span class="header-spacer"></span>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle light / dark theme">◐ Theme</button>
+    </header>
+
+    <main class="wrap">
+      <section class="section">
+        <div class="section-head">
+          <h2 class="section-title">Divergence</h2>
+          <span class="section-sub" id="summary">Loading…</span>
+        </div>
+        <div class="diff-toolbar">
+          <span class="badge diff-regression" id="regression-count"></span>
+          <label class="diff-toggle">
+            <input type="checkbox" id="divergent-only" /> Divergent only
+          </label>
+        </div>
+        <div class="table-scroll">
+          <table class="diff-table">
+            <thead>
+              <tr>
+                <th scope="col">Row</th>
+                <th scope="col">A</th>
+                <th scope="col">B</th>
+                <th scope="col">Class</th>
+                <th scope="col"><span class="visually-hidden">open</span></th>
+              </tr>
+            </thead>
+            <tbody id="diff-body"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="/diff.js"></script>
+  </body>
+</html>

--- a/packages/eleatic/ui/diff.js
+++ b/packages/eleatic/ui/diff.js
@@ -1,0 +1,183 @@
+// The per-row run-diff controller (E6) — framework-free vanilla ESM, no build.
+//
+// Renders `/diff?a=<a>&b=<b>`: one row per `row_key` from `GET /api/diff?a=&b=`
+// (E4, which returns E2's `RunDiff[]`). For each row it derives, via the
+// diff-classify pure unit, a classification (regression | improvement | unchanged
+// | new | removed), shows whether each side matched its expected_json, counts the
+// run-level regressions, and deep-links into the shared drawer.
+//
+// Matched-ness of a side = its OPAQUE output_json deep-equals its expected_json.
+// The blobs are never destructured — equality is a stable-key JSON compare.
+// Divergence = run A's output differs from run B's output.
+//
+// Drawer deep-link: a row opens the drawer via `&row=<b>:<row_key>` — the
+// `run:rowKey` deep-link resolved to candidate run `b` (the diff URL has `a`/`b`
+// but no single `run`; see drawer.js's run-resolution rule). EVENT DELEGATION:
+// ONE listener on #diff-body reading data-* off the target — NOT per-row binding
+// (eval.js's per-row addEventListener is the anti-pattern this view corrects; the
+// 150–1000-row scale forbids it).
+
+import { initTheme, toggleTheme } from './theme.js';
+import { esc, setImageHostAllowlist } from './safe.js';
+import { classifyRow } from './diff-classify.js';
+import { openDrawer } from './drawer.js';
+import { config } from '/config.js';
+
+// ── Boot ──
+initTheme();
+setImageHostAllowlist(config.imageHostAllowlist);
+document.getElementById('theme-toggle')?.addEventListener('click', toggleTheme);
+
+const params = new URLSearchParams(location.search);
+const a = params.get('a') ?? '';
+const b = params.get('b') ?? '';
+
+let rows = []; // [{ rowKey, classification, aPresent, bPresent, aMatched, bMatched }]
+let divergentOnly = params.get('divergent') === '1';
+
+/** Stable, key-sorted JSON serialization so {a,b} and {b,a} compare equal. */
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
+}
+
+/** Did a side's output match its expected? (both present required upstream). */
+function matched(side) {
+  if (!side) return false;
+  return stableStringify(side.output) === stableStringify(side.expected);
+}
+
+const CLASS_LABEL = {
+  regression: 'regression',
+  improvement: 'improvement',
+  unchanged: 'unchanged',
+  new: 'new',
+  removed: 'removed',
+};
+
+function deriveRows(diff) {
+  return diff.map((d) => {
+    const aPresent = d.a !== undefined;
+    const bPresent = d.b !== undefined;
+    const aMatched = matched(d.a);
+    const bMatched = matched(d.b);
+    const diverged =
+      aPresent && bPresent && stableStringify(d.a.output) !== stableStringify(d.b.output);
+    const classification = classifyRow({ aPresent, bPresent, aMatched, bMatched, diverged });
+    return { rowKey: d.rowKey, classification, aPresent, bPresent, aMatched, bMatched, diverged };
+  });
+}
+
+function check(present, isMatched) {
+  if (!present) return '<span class="diff-absent" title="absent in this run">—</span>';
+  return isMatched
+    ? '<span class="diff-match" title="matched expected">✓</span>'
+    : '<span class="diff-miss" title="did not match expected">✗</span>';
+}
+
+function render() {
+  const body = document.getElementById('diff-body');
+  const shown = divergentOnly ? rows.filter((r) => r.classification !== 'unchanged') : rows;
+
+  if (rows.length === 0) {
+    body.innerHTML = '<tr><td colspan="5" class="empty">No rows to diff for these runs.</td></tr>';
+    return;
+  }
+  if (shown.length === 0) {
+    body.innerHTML = '<tr><td colspan="5" class="empty">No divergent rows.</td></tr>';
+    return;
+  }
+
+  body.innerHTML = shown
+    .map(
+      (r) => `
+        <tr class="diff-row class-${esc(r.classification)}">
+          <td class="diff-rowkey"><code>${esc(r.rowKey)}</code></td>
+          <td class="diff-side">${check(r.aPresent, r.aMatched)}</td>
+          <td class="diff-side">${check(r.bPresent, r.bMatched)}</td>
+          <td><span class="diff-class diff-class-${esc(r.classification)}">${esc(CLASS_LABEL[r.classification] ?? r.classification)}</span></td>
+          <td class="diff-open">
+            <button type="button" class="diff-open-btn" data-row-key="${esc(r.rowKey)}" aria-label="Open detail for ${esc(r.rowKey)}">Open ›</button>
+          </td>
+        </tr>`,
+    )
+    .join('');
+}
+
+function renderSummary() {
+  const summary = document.getElementById('summary');
+  const badge = document.getElementById('regression-count');
+  const regressions = rows.filter((r) => r.classification === 'regression').length;
+  const improvements = rows.filter((r) => r.classification === 'improvement').length;
+  summary.textContent = `${rows.length} rows · ${regressions} regression${regressions === 1 ? '' : 's'} · ${improvements} improvement${improvements === 1 ? '' : 's'}`;
+  badge.textContent = `${regressions} regression${regressions === 1 ? '' : 's'}`;
+  badge.classList.toggle('diff-regression-zero', regressions === 0);
+}
+
+function syncUrl() {
+  const next = new URLSearchParams(location.search);
+  if (a) next.set('a', a);
+  if (b) next.set('b', b);
+  if (divergentOnly) next.set('divergent', '1');
+  else next.delete('divergent');
+  const qs = next.toString();
+  history.replaceState(null, '', qs ? `?${qs}` : location.pathname);
+}
+
+// ── Single delegated listener on #diff-body (NOT one per row) ──
+function bindDelegation() {
+  const body = document.getElementById('diff-body');
+  body.addEventListener('click', (ev) => {
+    const btn = ev.target.closest('.diff-open-btn');
+    if (!btn) return;
+    const rowKey = btn.getAttribute('data-row-key');
+    if (!rowKey) return;
+    // Resolve the drawer run to b (candidate side) and bake it into the deep-link.
+    const next = new URLSearchParams(location.search);
+    next.set('row', `${b}:${rowKey}`);
+    history.replaceState(null, '', `?${next.toString()}`);
+    openDrawer(`${b}:${rowKey}`, btn);
+  });
+
+  document.getElementById('divergent-only')?.addEventListener('change', (ev) => {
+    divergentOnly = ev.target.checked;
+    syncUrl();
+    render();
+  });
+}
+
+async function load() {
+  const summary = document.getElementById('summary');
+  if (!a || !b) {
+    summary.textContent = 'Provide ?a=<run>&b=<run> to compare two runs.';
+    document.getElementById('diff-body').innerHTML =
+      '<tr><td colspan="5" class="empty">No runs selected. Pick two runs on the hub.</td></tr>';
+    return;
+  }
+  let diff = [];
+  try {
+    const res = await fetch(`/api/diff?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`);
+    if (res.ok) {
+      diff = (await res.json()).diff ?? [];
+    } else {
+      const err = await res.json().catch(() => ({}));
+      summary.textContent = err.error ?? 'Could not load the diff.';
+    }
+  } catch {
+    summary.textContent = 'Network error loading the diff.';
+  }
+  rows = deriveRows(diff);
+  const cb = document.getElementById('divergent-only');
+  if (cb) cb.checked = divergentOnly;
+  renderSummary();
+  render();
+
+  // Reopen the drawer if the URL carries a row deep-link (deep-link / reload).
+  const rowParam = params.get('row');
+  if (rowParam) openDrawer(rowParam, null);
+}
+
+bindDelegation();
+load();

--- a/packages/eleatic/ui/drawer.js
+++ b/packages/eleatic/ui/drawer.js
@@ -1,0 +1,195 @@
+// The deep-linkable drill-down drawer — shared by diff.js and facets.js.
+//
+// A drawer is opened from a diff row or a facet card by a `&row=<run>:<row_key>`
+// deep-link (the colon-joined pair makes the link self-contained regardless of
+// which view opened it). On `&row=` present in the URL — on load OR after a click
+// — we fetch `GET /api/row?run=<run>&row=<row_key>` (E4) and render:
+//   • side-by-side PRETTY-PRINTED output_json / expected_json (OPAQUE blobs — the
+//     package never destructures them; rendered via the escaping prettyJson unit),
+//   • a score bar per scores_json entry,
+//   • the row's metadata,
+//   • the image via safeImg,
+//   • the adjudication panel (adjudicate.js).
+//
+// RUN RESOLUTION (the canonical API contract). The diff URL carries `a`/`b` but
+// no single `run`, and `/api/row` returns 400 on a missing run. So the OPENING
+// side resolves the run and bakes it into the `&row=<run>:<row_key>` deep-link:
+//   • from the DIFF view → run = b (the candidate / right-hand side),
+//   • from the FACETS / hub view → the page's `run`.
+// The drawer simply splits `<run>:<row_key>` off the deep-link — it never has to
+// know which view opened it.
+//
+// A11y: closing removes `&row=` from the URL and returns focus to the element
+// that opened the drawer (passed to openDrawer). Escape + the backdrop close it.
+//
+// Browser-only glue (DOM + fetch); no unit test — the logic lives in the
+// prettyJson / staleness pure units. Verified live at the epic's E2E recipe.
+
+import { esc, safeImg } from './safe.js';
+import { prettyJson } from './pretty.js';
+import { renderAdjudication } from './adjudicate.js';
+
+let lastTrigger = null;
+
+/** Split a `<run>:<row_key>` deep-link on the FIRST colon (a row_key may itself contain colons). */
+export function splitRowParam(raw) {
+  if (typeof raw !== 'string' || raw === '') return null;
+  const colon = raw.indexOf(':');
+  if (colon === -1) return null;
+  const run = raw.slice(0, colon);
+  const rowKey = raw.slice(colon + 1);
+  if (run === '' || rowKey === '') return null;
+  return { run, rowKey };
+}
+
+/** Lazily create (once) the drawer DOM scaffold and return its parts. */
+function ensureScaffold() {
+  let root = document.getElementById('drawer-root');
+  if (root) {
+    return {
+      root,
+      backdrop: root.querySelector('.drawer-backdrop'),
+      panel: root.querySelector('.drawer-panel'),
+      body: root.querySelector('.drawer-body'),
+    };
+  }
+  root = document.createElement('div');
+  root.id = 'drawer-root';
+  root.className = 'drawer-root';
+  root.hidden = true;
+  root.innerHTML = `
+    <div class="drawer-backdrop" tabindex="-1"></div>
+    <aside class="drawer-panel" role="dialog" aria-modal="true" aria-label="Row detail">
+      <button type="button" class="drawer-close" aria-label="Close detail">×</button>
+      <div class="drawer-body"></div>
+    </aside>`;
+  document.body.appendChild(root);
+  const backdrop = root.querySelector('.drawer-backdrop');
+  const panel = root.querySelector('.drawer-panel');
+  const body = root.querySelector('.drawer-body');
+  root.querySelector('.drawer-close').addEventListener('click', () => closeDrawer());
+  backdrop.addEventListener('click', () => closeDrawer());
+  document.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Escape' && !root.hidden) closeDrawer();
+  });
+  return { root, backdrop, panel, body };
+}
+
+/** A horizontal score bar (0..1 clamped) per scores_json entry. */
+function scoreBars(scores) {
+  const entries = Object.entries(scores ?? {});
+  if (entries.length === 0) return '<p class="drawer-empty">No scores</p>';
+  return entries
+    .map(([k, v]) => {
+      const num = typeof v === 'number' && Number.isFinite(v) ? v : 0;
+      const pct = Math.max(0, Math.min(1, num)) * 100;
+      return `
+        <div class="score-row">
+          <span class="score-key">${esc(k)}</span>
+          <span class="score-track"><span class="score-fill" style="width:${pct.toFixed(1)}%"></span></span>
+          <span class="score-val">${esc(num)}</span>
+        </div>`;
+    })
+    .join('');
+}
+
+/** Metadata key/value chips. */
+function metadataChips(metadata) {
+  const entries = Object.entries(metadata ?? {});
+  if (entries.length === 0) return '<p class="drawer-empty">No metadata</p>';
+  return entries
+    .map(([k, v]) => `<span class="meta-chip"><span class="meta-key">${esc(k)}</span>${esc(v)}</span>`)
+    .join('');
+}
+
+/**
+ * Open the drawer for a `<run>:<row_key>` deep-link value.
+ *
+ * @param {string} rowParam  the `&row=` value, i.e. `<run>:<row_key>`
+ * @param {HTMLElement|null} [trigger]  element to return focus to on close
+ */
+export async function openDrawer(rowParam, trigger = null) {
+  const parsed = splitRowParam(rowParam);
+  if (parsed === null) return;
+  const { run, rowKey } = parsed;
+  if (trigger) lastTrigger = trigger;
+
+  const { root, panel, body } = ensureScaffold();
+  root.hidden = false;
+  body.innerHTML = '<p class="drawer-loading">Loading…</p>';
+  panel.focus?.();
+
+  let record;
+  try {
+    const res = await fetch(`/api/row?run=${encodeURIComponent(run)}&row=${encodeURIComponent(rowKey)}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      body.innerHTML = `<p class="drawer-error">${esc(err.error ?? 'Could not load this row.')}</p>`;
+      return;
+    }
+    record = (await res.json()).row;
+  } catch {
+    body.innerHTML = '<p class="drawer-error">Network error loading this row.</p>';
+    return;
+  }
+  if (!record) {
+    body.innerHTML = '<p class="drawer-error">Row not found.</p>';
+    return;
+  }
+
+  body.innerHTML = `
+    <header class="drawer-head">
+      <h2 class="drawer-title">${esc(record.label ?? record.rowKey)}</h2>
+      <p class="drawer-rowkey"><code>${esc(record.rowKey)}</code> · run <code>${esc(run)}</code></p>
+    </header>
+    ${record.imageUrl ? `<img class="drawer-img" src="${safeImg(record.imageUrl)}" alt="${esc(record.label ?? record.rowKey)}" loading="lazy" />` : ''}
+    <section class="drawer-section">
+      <h3 class="drawer-h3">Scores</h3>
+      <div class="score-bars">${scoreBars(record.scores)}</div>
+    </section>
+    <section class="drawer-section">
+      <h3 class="drawer-h3">Metadata</h3>
+      <div class="meta-chips">${metadataChips(record.metadata)}</div>
+    </section>
+    <section class="drawer-section">
+      <h3 class="drawer-h3">Output vs expected</h3>
+      <div class="json-compare">
+        <div class="json-col"><div class="json-col-label">output</div>${prettyJson(record.output)}</div>
+        <div class="json-col"><div class="json-col-label">expected</div>${prettyJson(record.expected)}</div>
+      </div>
+    </section>
+    <section class="drawer-section" id="drawer-adjudicate"></section>`;
+
+  // Fetch the existing adjudication (if any) so the panel pre-fills + flags stale.
+  let current;
+  try {
+    const res = await fetch('/api/adjudications');
+    if (res.ok) {
+      const list = (await res.json()).adjudications ?? [];
+      current = list.find((a) => a.rowKey === record.rowKey);
+    }
+  } catch {
+    current = undefined;
+  }
+
+  renderAdjudication(document.getElementById('drawer-adjudicate'), {
+    rowKey: record.rowKey,
+    run,
+    ...(record.contentHash ? { contentHash: record.contentHash } : {}),
+    ...(current ? { current } : {}),
+  });
+}
+
+/** Close the drawer: hide it, drop `&row=` from the URL, restore focus. */
+export function closeDrawer() {
+  const root = document.getElementById('drawer-root');
+  if (root) root.hidden = true;
+  const params = new URLSearchParams(location.search);
+  if (params.has('row')) {
+    params.delete('row');
+    const qs = params.toString();
+    history.replaceState(null, '', qs ? `?${qs}` : location.pathname);
+  }
+  if (lastTrigger && typeof lastTrigger.focus === 'function') lastTrigger.focus();
+  lastTrigger = null;
+}

--- a/packages/eleatic/ui/facet-grammar.js
+++ b/packages/eleatic/ui/facet-grammar.js
@@ -1,0 +1,98 @@
+// The `f=` facet URL-grammar (de)serializer for the eleatic facet page.
+//
+// Grammar (one `f=` query param per clause):
+//   f=<axis>.<key>:<op>[:<value>]
+//   axis  ∈ {scores, metadata}   (carried as part of `path`, never split off —
+//                                 the path IS `"scores.<key>"` / `"metadata.<key>"`,
+//                                 exactly E2's FacetFilter.path)
+//   op    ∈ eq | ne | lt | lte | gt | gte | in | contains | exists  (E2 #1145)
+//   value present for every op EXCEPT `exists`; `in` is a comma list.
+//
+// Each parsed clause is an E2 `FacetFilter` — `{ path, op, value? }` — and the
+// facets controller assembles the set into an E2 `FacetQuery`
+// (`{ filters?, sort?, limit?, offset? }`). This module owns ONLY the wire
+// (de)serialization; the SERVER (src/server/app.ts#parseFacet) re-parses + the
+// query layer validates the path. Mirrors that server parser's value coercion so
+// `scores.x:gte:0.9` and `metadata.flagged:eq:true` round-trip to the same
+// scalars the server produces.
+//
+// Defensive: a malformed clause (no colon, unknown op, value-requiring op with
+// no value, empty path) is SKIPPED, never thrown — a hand-edited URL must not
+// crash the page (it just renders fewer filters).
+//
+// Plain ESM with named exports so it is importable by the browser (express.static)
+// and by vitest in node — the safe.js / format.js precedent.
+
+// The canonical FacetFilter op set (E2 #1145, queries.ts FacetFilter['op']).
+const OPS = new Set(['eq', 'ne', 'lt', 'lte', 'gt', 'gte', 'in', 'contains', 'exists']);
+
+/**
+ * Coerce a raw string facet value to a JSON scalar: `'true'`/`'false'` →
+ * boolean, a finite numeric string → number, else the string verbatim. Matches
+ * src/server/app.ts#coerceScalar so client- and server-side parses agree.
+ */
+function coerceScalar(raw) {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw !== '' && !Number.isNaN(Number(raw))) return Number(raw);
+  return raw;
+}
+
+/** Parse one `path:op[:value]` token into a FacetFilter, or null if malformed. */
+function parseFacet(token) {
+  const firstColon = token.indexOf(':');
+  if (firstColon === -1) return null;
+  const path = token.slice(0, firstColon);
+  if (path === '') return null;
+
+  const rest = token.slice(firstColon + 1);
+  const secondColon = rest.indexOf(':');
+  const op = secondColon === -1 ? rest : rest.slice(0, secondColon);
+  if (!OPS.has(op)) return null;
+
+  if (op === 'exists') return { path, op };
+  if (secondColon === -1) return null; // value-requiring op with no value
+  const valueRaw = rest.slice(secondColon + 1);
+  if (op === 'in') {
+    return { path, op, value: valueRaw.split(',').map(coerceScalar) };
+  }
+  return { path, op, value: coerceScalar(valueRaw) };
+}
+
+/**
+ * Read every `f=` clause off a URLSearchParams into an array of FacetFilters.
+ * Zero clauses → `[]`; malformed clauses are dropped (never throw).
+ */
+export function parseFacets(searchParams) {
+  const out = [];
+  for (const token of searchParams.getAll('f')) {
+    const filter = parseFacet(token);
+    if (filter !== null) out.push(filter);
+  }
+  return out;
+}
+
+/** Serialize one scalar back to its wire string (the inverse of coerceScalar). */
+function scalarToWire(value) {
+  return String(value);
+}
+
+/**
+ * Serialize FacetFilters back to a `f=…&f=…` query string (no leading `?`).
+ * The inverse of `parseFacets`: `parseFacets(new URLSearchParams(serializeFacets(c)))`
+ * round-trips. Zero clauses → `''`.
+ */
+export function serializeFacets(filters) {
+  const params = new URLSearchParams();
+  for (const f of filters) {
+    if (f.op === 'exists') {
+      params.append('f', `${f.path}:exists`);
+    } else if (f.op === 'in') {
+      const list = Array.isArray(f.value) ? f.value : [];
+      params.append('f', `${f.path}:in:${list.map(scalarToWire).join(',')}`);
+    } else {
+      params.append('f', `${f.path}:${f.op}:${scalarToWire(f.value)}`);
+    }
+  }
+  return params.toString();
+}

--- a/packages/eleatic/ui/facet-grammar.test.ts
+++ b/packages/eleatic/ui/facet-grammar.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+// facet-grammar.js is plain browser ESM (served verbatim by express.static) AND
+// importable here in node, exactly like safe.js / format.js. It owns the `f=`
+// URL grammar (de)serializer — the only piece of the facet page with logic worth
+// a unit test; the DOM controller (facets.js) is thin glue over it.
+import { parseFacets, serializeFacets } from './facet-grammar.js';
+
+// The canonical FacetFilter op set (E2 #1145, queries.ts) the grammar round-trips.
+const OPS = ['eq', 'ne', 'lt', 'lte', 'gt', 'gte', 'in', 'contains', 'exists'] as const;
+
+/** Build a URLSearchParams from raw `f=` tokens (+ optional extra params). */
+function sp(fTokens: string[], extra: Record<string, string> = {}): URLSearchParams {
+  const p = new URLSearchParams();
+  for (const [k, v] of Object.entries(extra)) p.set(k, v);
+  for (const f of fTokens) p.append('f', f);
+  return p;
+}
+
+describe('parseFacets / serializeFacets round-trip', () => {
+  it('zero clauses → empty array, and serializing [] → empty string', () => {
+    expect(parseFacets(sp([]))).toEqual([]);
+    expect(serializeFacets([])).toBe('');
+  });
+
+  it('one metadata eq clause round-trips', () => {
+    const clauses = parseFacets(sp(['metadata.disagreement:eq:falseKeep']));
+    expect(clauses).toEqual([
+      { path: 'metadata.disagreement', op: 'eq', value: 'falseKeep' },
+    ]);
+    // serialize → re-parse is identity.
+    const re = parseFacets(new URLSearchParams(serializeFacets(clauses)));
+    expect(re).toEqual(clauses);
+  });
+
+  it('one scores numeric clause coerces the value to a number', () => {
+    const clauses = parseFacets(sp(['scores.agreement:gte:0.9']));
+    expect(clauses).toEqual([{ path: 'scores.agreement', op: 'gte', value: 0.9 }]);
+    expect(typeof (clauses[0] as { value: unknown }).value).toBe('number');
+  });
+
+  it('boolean values coerce to booleans; `exists` carries no value', () => {
+    expect(parseFacets(sp(['metadata.flagged:eq:true']))).toEqual([
+      { path: 'metadata.flagged', op: 'eq', value: true },
+    ]);
+    expect(parseFacets(sp(['scores.confidence:exists']))).toEqual([
+      { path: 'scores.confidence', op: 'exists' },
+    ]);
+  });
+
+  it('`in` takes a comma list and coerces each element', () => {
+    const clauses = parseFacets(sp(['metadata.disagreement:in:falseKeep,falseReplace']));
+    expect(clauses).toEqual([
+      { path: 'metadata.disagreement', op: 'in', value: ['falseKeep', 'falseReplace'] },
+    ]);
+    const re = parseFacets(new URLSearchParams(serializeFacets(clauses)));
+    expect(re).toEqual(clauses);
+  });
+
+  it('round-trips many clauses across every canonical op and both axes', () => {
+    const clauses = OPS.map((op, i) => {
+      const axis = i % 2 === 0 ? 'scores' : 'metadata';
+      const path = `${axis}.k${i}`;
+      if (op === 'exists') return { path, op };
+      if (op === 'in') return { path, op, value: [1, 2, 3] };
+      return { path, op, value: axis === 'scores' ? i * 0.1 : `v${i}` };
+    });
+    const re = parseFacets(new URLSearchParams(serializeFacets(clauses)));
+    expect(re).toEqual(clauses);
+  });
+
+  it('preserves a value that looks empty/string, never NaN', () => {
+    // contains with a textual fragment stays a string.
+    expect(parseFacets(sp(['metadata.label:contains:owl']))).toEqual([
+      { path: 'metadata.label', op: 'contains', value: 'owl' },
+    ]);
+  });
+});
+
+describe('parseFacets skips (never throws on) malformed clauses', () => {
+  it('a token with no colon is skipped', () => {
+    expect(parseFacets(sp(['garbage']))).toEqual([]);
+  });
+
+  it('an unknown op is skipped', () => {
+    expect(parseFacets(sp(['scores.x:frobnicate:1']))).toEqual([]);
+  });
+
+  it('a value-requiring op with no value is skipped', () => {
+    expect(parseFacets(sp(['scores.x:eq']))).toEqual([]);
+  });
+
+  it('an empty path is skipped', () => {
+    expect(parseFacets(sp([':eq:1']))).toEqual([]);
+  });
+
+  it('keeps the good clauses and drops only the malformed ones', () => {
+    const clauses = parseFacets(
+      sp(['scores.agreement:gte:0.9', 'garbage', 'metadata.d:eq:falseKeep']),
+    );
+    expect(clauses).toEqual([
+      { path: 'scores.agreement', op: 'gte', value: 0.9 },
+      { path: 'metadata.d', op: 'eq', value: 'falseKeep' },
+    ]);
+  });
+
+  it('does not throw on any malformed input', () => {
+    expect(() => parseFacets(sp(['', ':', '::', 'a:b', 'x:in:', 'scores.x:eq']))).not.toThrow();
+  });
+});

--- a/packages/eleatic/ui/facets.html
+++ b/packages/eleatic/ui/facets.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>eleatic · facets</title>
+    <!--
+      The generic facet gallery/table (E6). Framework-free, no build step —
+      served verbatim from packages/eleatic/ui/. facets.js imports /config.js and
+      the sibling theme.js / safe.js modules, the facet-grammar pure unit, and the
+      shared drawer.js. Same bootstrap + script shape as the E5 hub.
+    -->
+    <link rel="stylesheet" href="/app.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <a class="back-link" href="/">← Hub</a>
+      <h1 class="app-title">eleatic<span class="app-sub">facets</span></h1>
+      <span class="header-spacer"></span>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle light / dark theme">◐ Theme</button>
+    </header>
+
+    <main class="wrap">
+      <section class="section">
+        <div class="section-head">
+          <h2 class="section-title">Facets</h2>
+          <span class="section-sub" id="facet-count">Loading…</span>
+        </div>
+        <div id="facet-controls" class="facet-controls"></div>
+        <div class="facet-viewbar">
+          <div class="facet-view-toggle" role="group" aria-label="View mode">
+            <button type="button" class="facet-view" data-view="gallery">Gallery</button>
+            <button type="button" class="facet-view" data-view="table">Table</button>
+          </div>
+        </div>
+        <div id="facet-results" class="facet-results"></div>
+      </section>
+    </main>
+
+    <script type="module" src="/facets.js"></script>
+  </body>
+</html>

--- a/packages/eleatic/ui/facets.js
+++ b/packages/eleatic/ui/facets.js
@@ -1,0 +1,297 @@
+// The generic facet gallery/table controller (E6) — framework-free vanilla ESM.
+//
+// Renders `/facets?run=<id>&f=<clause>[&f=…]&view=gallery|table`. Each `f=` clause
+// (`<axis>.<key>:<op>[:<value>]`, axis ∈ scores|metadata) is parsed by the
+// facet-grammar pure unit into an E2 `FacetFilter` `{ path, op, value? }`; the set
+// is assembled into an E2 `FacetQuery` `{ filters?, sort?, limit?, offset? }` and
+// passed to `GET /api/rows?run=&f=…` (E4 over E2's `facetRows`). The saved-URL
+// shape the epic names — the photo-judge "falseKeep gallery" — falls out as
+// `?run=…&f=metadata.disagreement:eq:falseKeep&view=gallery` with NO bespoke code.
+//
+// A facet-key discovery dropdown lets a user add a clause without hand-editing
+// the URL: keys are discovered from a sample of the run's rows (scores/metadata
+// object keys). A gallery|table view toggle switches rendering.
+//
+// SCALE GUARD: the gallery is CAPPED + lazy + paged for 150–1000 rows — a visible
+// cap with a "Show more" affordance, and every <img> is `loading="lazy"`. We never
+// render 1000 eager <img> at once.
+//
+// Drawer deep-link: a card/row opens the drawer via `&row=<run>:<row_key>` — the
+// `run:rowKey` deep-link resolved to the page's `run` (see drawer.js). EVENT
+// DELEGATION: ONE listener on #facet-results reading data-* off the target — NOT
+// per-row binding (eval.js's per-row addEventListener is the anti-pattern; the
+// 150–1000-row scale forbids it).
+
+import { initTheme, toggleTheme } from './theme.js';
+import { esc, safeImg, setImageHostAllowlist } from './safe.js';
+import { parseFacets, serializeFacets } from './facet-grammar.js';
+import { openDrawer } from './drawer.js';
+import { config } from '/config.js';
+
+// ── Boot ──
+initTheme();
+setImageHostAllowlist(config.imageHostAllowlist);
+document.getElementById('theme-toggle')?.addEventListener('click', toggleTheme);
+
+const params = new URLSearchParams(location.search);
+const run = params.get('run') ?? '';
+let view = params.get('view') === 'table' ? 'table' : 'gallery';
+let clauses = parseFacets(params); // FacetFilter[]
+
+// Gallery cap: render at most PAGE_SIZE cards, growing by PAGE_SIZE on "Show more".
+const PAGE_SIZE = 60;
+let shownCount = PAGE_SIZE;
+
+let allRows = []; // the full result set for the current facet query
+let discovered = { scores: new Set(), metadata: new Set() };
+
+// ── URL sync ──
+function syncUrl() {
+  const parts = [];
+  if (run) parts.push(`run=${encodeURIComponent(run)}`);
+  const f = serializeFacets(clauses);
+  if (f) parts.push(f);
+  parts.push(`view=${view}`);
+  const rowParam = new URLSearchParams(location.search).get('row');
+  if (rowParam) parts.push(`row=${encodeURIComponent(rowParam)}`);
+  history.replaceState(null, '', `?${parts.join('&')}`);
+}
+
+// ── Facet controls (discovery dropdown + active-clause chips) ──
+function renderControls() {
+  const host = document.getElementById('facet-controls');
+  const keyOptions = [
+    ...[...discovered.scores].sort().map((k) => `scores.${k}`),
+    ...[...discovered.metadata].sort().map((k) => `metadata.${k}`),
+  ];
+  const optionsHtml = keyOptions
+    .map((p) => `<option value="${esc(p)}">${esc(p)}</option>`)
+    .join('');
+  const ops = ['eq', 'ne', 'lt', 'lte', 'gt', 'gte', 'in', 'contains', 'exists'];
+
+  const chips = clauses
+    .map((c, i) => {
+      const val =
+        c.op === 'exists'
+          ? ''
+          : `: ${esc(Array.isArray(c.value) ? c.value.join(',') : c.value)}`;
+      return `<span class="facet-chip">${esc(c.path)} ${esc(c.op)}${val}
+        <button type="button" class="facet-chip-x" data-remove="${i}" aria-label="Remove filter">×</button></span>`;
+    })
+    .join('');
+
+  host.innerHTML = `
+    <div class="facet-active">${chips || '<span class="facet-none">No filters — all rows</span>'}</div>
+    <form class="facet-add" id="facet-add">
+      <select class="facet-add-key" name="key" aria-label="Facet key">${optionsHtml || '<option value="">no keys</option>'}</select>
+      <select class="facet-add-op" name="op" aria-label="Facet op">${ops.map((o) => `<option value="${o}">${o}</option>`).join('')}</select>
+      <input class="facet-add-val" name="value" placeholder="value" aria-label="Facet value" />
+      <button type="submit" class="facet-add-btn">Add filter</button>
+    </form>`;
+}
+
+// ── Result rendering ──
+function galleryCard(row) {
+  const score = row.scores ? Object.entries(row.scores)[0] : undefined;
+  const scoreLabel = score ? `${esc(score[0])} ${esc(score[1])}` : '';
+  return `
+    <figure class="facet-figure" data-row-key="${esc(row.rowKey)}" tabindex="0" role="button"
+            aria-label="Open detail for ${esc(row.label ?? row.rowKey)}">
+      <img class="facet-img" src="${safeImg(row.imageUrl)}" alt="${esc(row.label ?? row.rowKey)}" loading="lazy" />
+      <figcaption class="facet-caption">
+        <span class="facet-name">${esc(row.label ?? row.rowKey)}</span>
+        ${scoreLabel ? `<span class="facet-score">${scoreLabel}</span>` : ''}
+      </figcaption>
+    </figure>`;
+}
+
+function renderGallery() {
+  const host = document.getElementById('facet-results');
+  if (allRows.length === 0) {
+    host.innerHTML = '<p class="empty">No rows match these filters.</p>';
+    return;
+  }
+  const page = allRows.slice(0, shownCount);
+  const cards = page.map(galleryCard).join('');
+  const more =
+    allRows.length > shownCount
+      ? `<button type="button" class="facet-more" id="facet-more">Show more (${allRows.length - shownCount} of ${allRows.length} hidden)</button>`
+      : '';
+  host.innerHTML = `<div class="facet-grid">${cards}</div>${more}`;
+}
+
+function renderTable() {
+  const host = document.getElementById('facet-results');
+  if (allRows.length === 0) {
+    host.innerHTML = '<p class="empty">No rows match these filters.</p>';
+    return;
+  }
+  // Columns = the discovered scores + metadata keys.
+  const scoreKeys = [...discovered.scores].sort();
+  const metaKeys = [...discovered.metadata].sort();
+  const head = `
+    <th scope="col">Row</th>
+    ${scoreKeys.map((k) => `<th class="num" scope="col">${esc(k)}</th>`).join('')}
+    ${metaKeys.map((k) => `<th scope="col">${esc(k)}</th>`).join('')}
+    <th scope="col"><span class="visually-hidden">open</span></th>`;
+  const body = allRows
+    .map(
+      (row) => `
+        <tr class="facet-trow" data-row-key="${esc(row.rowKey)}">
+          <td class="facet-rowkey"><code>${esc(row.label ?? row.rowKey)}</code></td>
+          ${scoreKeys.map((k) => `<td class="num">${esc(row.scores?.[k] ?? '—')}</td>`).join('')}
+          ${metaKeys.map((k) => `<td>${esc(row.metadata?.[k] ?? '—')}</td>`).join('')}
+          <td><button type="button" class="facet-open-btn" data-row-key="${esc(row.rowKey)}" aria-label="Open detail for ${esc(row.rowKey)}">Open ›</button></td>
+        </tr>`,
+    )
+    .join('');
+  host.innerHTML = `<div class="table-scroll"><table class="facet-table"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table></div>`;
+}
+
+function renderResults() {
+  document.getElementById('facet-count').textContent =
+    `${allRows.length} row${allRows.length === 1 ? '' : 's'}`;
+  // Reflect the active view on the toggle buttons.
+  for (const btn of document.querySelectorAll('.facet-view')) {
+    btn.classList.toggle('active', btn.getAttribute('data-view') === view);
+    btn.setAttribute('aria-pressed', String(btn.getAttribute('data-view') === view));
+  }
+  if (view === 'table') renderTable();
+  else renderGallery();
+}
+
+/** Discover scores/metadata keys from the loaded rows (for the dropdown + table cols). */
+function discoverKeys(rowList) {
+  const scores = new Set();
+  const metadata = new Set();
+  for (const r of rowList) {
+    for (const k of Object.keys(r.scores ?? {})) scores.add(k);
+    for (const k of Object.keys(r.metadata ?? {})) metadata.add(k);
+  }
+  return { scores, metadata };
+}
+
+// ── Load ──
+async function load() {
+  const count = document.getElementById('facet-count');
+  if (!run) {
+    count.textContent = 'Provide ?run=<id> to explore a run.';
+    document.getElementById('facet-results').innerHTML =
+      '<p class="empty">No run selected. Pick a run on the hub.</p>';
+    return;
+  }
+  // Build the FacetQuery from the parsed clauses → the `f=` query string E4 parses.
+  const f = serializeFacets(clauses);
+  const url = f ? `/api/rows?run=${encodeURIComponent(run)}&${f}` : `/api/rows?run=${encodeURIComponent(run)}`;
+  try {
+    const res = await fetch(url);
+    if (res.ok) {
+      allRows = (await res.json()).rows ?? [];
+    } else {
+      const err = await res.json().catch(() => ({}));
+      count.textContent = err.error ?? 'Could not load rows.';
+      allRows = [];
+    }
+  } catch {
+    count.textContent = 'Network error loading rows.';
+    allRows = [];
+  }
+  // Discover keys from the (possibly filtered) result; on a filtered first load
+  // also union the unfiltered run's keys so the dropdown still offers them.
+  discovered = discoverKeys(allRows);
+  if (clauses.length > 0 || allRows.length === 0) {
+    try {
+      const all = await fetch(`/api/rows?run=${encodeURIComponent(run)}`);
+      if (all.ok) {
+        const merged = discoverKeys((await all.json()).rows ?? []);
+        for (const k of merged.scores) discovered.scores.add(k);
+        for (const k of merged.metadata) discovered.metadata.add(k);
+      }
+    } catch {
+      /* keep the filtered-result keys */
+    }
+  }
+  shownCount = PAGE_SIZE;
+  renderControls();
+  renderResults();
+
+  const rowParam = params.get('row');
+  if (rowParam) openDrawer(rowParam, null);
+}
+
+// ── Single delegated listener on #facet-results (NOT one per row) ──
+function openRow(rowKey, trigger) {
+  const next = new URLSearchParams(location.search);
+  next.set('row', `${run}:${rowKey}`);
+  history.replaceState(null, '', `?${next.toString()}`);
+  openDrawer(`${run}:${rowKey}`, trigger);
+}
+
+function bindDelegation() {
+  const results = document.getElementById('facet-results');
+  results.addEventListener('click', (ev) => {
+    if (ev.target.closest('#facet-more')) {
+      shownCount += PAGE_SIZE;
+      renderGallery();
+      return;
+    }
+    const trigger = ev.target.closest('[data-row-key]');
+    if (!trigger) return;
+    const rowKey = trigger.getAttribute('data-row-key');
+    if (rowKey) openRow(rowKey, trigger);
+  });
+  // Keyboard: Enter/Space on a focused gallery figure opens it.
+  results.addEventListener('keydown', (ev) => {
+    if (ev.key !== 'Enter' && ev.key !== ' ') return;
+    const fig = ev.target.closest('.facet-figure');
+    if (!fig) return;
+    ev.preventDefault();
+    const rowKey = fig.getAttribute('data-row-key');
+    if (rowKey) openRow(rowKey, fig);
+  });
+
+  // View toggle (buttons are static in the HTML shell).
+  for (const btn of document.querySelectorAll('.facet-view')) {
+    btn.addEventListener('click', () => {
+      view = btn.getAttribute('data-view') === 'table' ? 'table' : 'gallery';
+      shownCount = PAGE_SIZE;
+      syncUrl();
+      renderResults();
+    });
+  }
+
+  // Facet controls: add a clause / remove a chip (delegated on the controls host).
+  const controls = document.getElementById('facet-controls');
+  controls.addEventListener('click', (ev) => {
+    const rm = ev.target.closest('.facet-chip-x');
+    if (!rm) return;
+    const idx = Number(rm.getAttribute('data-remove'));
+    if (Number.isInteger(idx)) {
+      clauses = clauses.filter((_, i) => i !== idx);
+      syncUrl();
+      load();
+    }
+  });
+  controls.addEventListener('submit', (ev) => {
+    if (!ev.target.closest('#facet-add')) return;
+    ev.preventDefault();
+    const form = ev.target;
+    const path = form.querySelector('.facet-add-key').value;
+    const op = form.querySelector('.facet-add-op').value;
+    const rawVal = form.querySelector('.facet-add-val').value;
+    if (!path) return;
+    // Round-trip the new clause through the grammar unit so coercion matches.
+    const token = op === 'exists' ? `${path}:exists` : `${path}:${op}:${rawVal}`;
+    const sp = new URLSearchParams();
+    sp.append('f', token);
+    const parsed = parseFacets(sp);
+    if (parsed.length === 1) {
+      clauses = [...clauses, parsed[0]];
+      syncUrl();
+      load();
+    }
+  });
+}
+
+bindDelegation();
+load();

--- a/packages/eleatic/ui/pretty.js
+++ b/packages/eleatic/ui/pretty.js
@@ -1,0 +1,51 @@
+// Recursive JSON pretty-printer for the eleatic drawer.
+//
+// The drawer shows `output_json` and `expected_json` side by side. These are
+// OPAQUE blobs written by whatever eval harness filled the store — eleatic never
+// destructures or trusts them, and the server exposes a write route, so an
+// attacker-controlled blob like `{ name: '"><img src=x onerror=alert(1)>' }` is
+// a real XSS the moment it reaches `innerHTML`. This renderer walks the value and
+// pushes EVERY object key and string value through safe.js#esc, so the dangerous
+// payload renders as inert text. Numbers / booleans / null are emitted as their
+// literal token (no user-controlled characters), but still wrapped in escaped
+// markup-free spans.
+//
+// Output is a nested <div>/<span> tree (styled by app.css's `.json-*` classes),
+// not raw text, so the drawer can present the two blobs as readable trees.
+//
+// Plain ESM with a named export — importable by the browser (express.static) and
+// vitest in node, the safe.js / format.js precedent.
+
+import { esc } from './safe.js';
+
+/** Render a scalar leaf (string | number | boolean | null) as an escaped span. */
+function leaf(value) {
+  if (value === null) return '<span class="json-null">null</span>';
+  if (typeof value === 'number') return `<span class="json-num">${esc(value)}</span>`;
+  if (typeof value === 'boolean') return `<span class="json-bool">${esc(value)}</span>`;
+  // String (and any other primitive coerced via esc's String()) — quote + escape.
+  return `<span class="json-str">&quot;${esc(value)}&quot;</span>`;
+}
+
+/** Recursively render an arbitrary JSON value into an escaped HTML tree. */
+export function prettyJson(value) {
+  if (value === null || typeof value !== 'object') return leaf(value);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '<span class="json-empty">[]</span>';
+    const items = value
+      .map((v) => `<li class="json-item">${prettyJson(v)}</li>`)
+      .join('');
+    return `<ul class="json-array">${items}</ul>`;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length === 0) return '<span class="json-empty">{}</span>';
+  const rows = entries
+    .map(
+      ([k, v]) =>
+        `<li class="json-item"><span class="json-key">${esc(k)}</span><span class="json-colon">: </span>${prettyJson(v)}</li>`,
+    )
+    .join('');
+  return `<ul class="json-object">${rows}</ul>`;
+}

--- a/packages/eleatic/ui/pretty.test.ts
+++ b/packages/eleatic/ui/pretty.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+// pretty.js renders an OPAQUE eval blob (output_json / expected_json — eleatic
+// never destructures them) to an HTML string for the drawer. Every key and
+// string value passes through safe.js#esc, so an injected payload inside a blob
+// renders inert. Importable by the browser (express.static) and vitest in node.
+import { prettyJson } from './pretty.js';
+
+describe('prettyJson — XSS escaping (same threat model as safe.test.ts)', () => {
+  it('neutralizes an injected <img onerror> payload in a string VALUE', () => {
+    const out = prettyJson({ name: '"><img src=x onerror=alert(1)>' });
+    expect(out).toContain('&lt;');
+    expect(out).toContain('&gt;');
+    expect(out).toContain('&quot;');
+    // The raw payload must not survive as live markup.
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('onerror=alert(1)>');
+  });
+
+  it('neutralizes an injected payload in a KEY name', () => {
+    const out = prettyJson({ '"><script>x</script>': 1 });
+    expect(out).toContain('&lt;');
+    expect(out).not.toContain('<script>');
+  });
+
+  it('escapes a payload nested deep inside arrays/objects', () => {
+    const out = prettyJson({ a: [{ b: ['<x>'] }] });
+    expect(out).toContain('&lt;x&gt;');
+    expect(out).not.toContain('<x>');
+  });
+});
+
+describe('prettyJson — value rendering', () => {
+  it('renders null, numbers, and booleans verbatim (and not as escaped text fragments)', () => {
+    expect(prettyJson(null)).toContain('null');
+    expect(prettyJson(42)).toContain('42');
+    expect(prettyJson(true)).toContain('true');
+    expect(prettyJson(false)).toContain('false');
+  });
+
+  it('renders nested objects and arrays without throwing', () => {
+    const blob = {
+      verdict: 'keep',
+      scores: { agreement: 0.91, mae: 0.04 },
+      tags: ['a', 'b', 'c'],
+      nested: { deep: { deeper: [1, 2, { x: null }] } },
+    };
+    expect(() => prettyJson(blob)).not.toThrow();
+    const out = prettyJson(blob);
+    expect(out).toContain('keep');
+    expect(out).toContain('agreement');
+    expect(out).toContain('0.91');
+  });
+
+  it('renders an empty object and an empty array', () => {
+    expect(() => prettyJson({})).not.toThrow();
+    expect(() => prettyJson([])).not.toThrow();
+  });
+
+  it('returns a string for every input type', () => {
+    for (const v of [null, 1, 'x', true, {}, [], { a: 1 }, [1, 2]]) {
+      expect(typeof prettyJson(v)).toBe('string');
+    }
+  });
+});

--- a/packages/eleatic/ui/staleness.js
+++ b/packages/eleatic/ui/staleness.js
@@ -1,0 +1,26 @@
+// Adjudication staleness comparator for the eleatic drawer.
+//
+// A stored adjudication carries the `against_hash` — the row's content_hash AT
+// THE TIME the verdict was decided. The verdict is STALE when the row's CURRENT
+// content_hash differs: the underlying item changed since a human decided, so
+// the decision may no longer apply. adjudicate.js surfaces a "stale — re-decide"
+// badge when this returns true.
+//
+// Mirrors the server's contract (src/queries.ts#isStale): an adjudication with
+// no recorded against_hash is NEVER stale (it was never anchored to a hash), and
+// an absent current hash gives nothing to compare against. Both are treated the
+// same as a missing value, so empty string / null / undefined all count as
+// "absent" → not stale.
+//
+// Pure: no DOM, no network. Importable by the browser (express.static) and
+// vitest in node — the safe.js / format.js precedent.
+
+/**
+ * @param {string | null | undefined} againstHash  hash the verdict was decided against
+ * @param {string | null | undefined} currentHash  the row's current content_hash
+ * @returns {boolean} true only when both are present and differ
+ */
+export function isStale(againstHash, currentHash) {
+  if (!againstHash || !currentHash) return false;
+  return againstHash !== currentHash;
+}

--- a/packages/eleatic/ui/staleness.test.ts
+++ b/packages/eleatic/ui/staleness.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+// staleness.js owns the adjudication staleness comparator — the one piece of the
+// adjudication panel with logic. adjudicate.js renders a "stale — re-decide"
+// badge when this returns true. Mirrors the server's isStale contract
+// (queries.ts): a verdict with no recorded against_hash is never stale.
+import { isStale } from './staleness.js';
+
+describe('isStale', () => {
+  it('both present and differ → true', () => {
+    expect(isStale('h1', 'h2')).toBe(true);
+  });
+
+  it('both present and equal → false', () => {
+    expect(isStale('h1', 'h1')).toBe(false);
+  });
+
+  it('no against_hash (undefined) → false — an unanchored verdict is never stale', () => {
+    expect(isStale(undefined, 'h1')).toBe(false);
+  });
+
+  it('no current hash (undefined) → false — nothing to compare against', () => {
+    expect(isStale('h1', undefined)).toBe(false);
+  });
+
+  it('both absent → false', () => {
+    expect(isStale(undefined, undefined)).toBe(false);
+  });
+
+  it('empty-string hashes are treated as absent → false', () => {
+    expect(isStale('', 'h1')).toBe(false);
+    expect(isStale('h1', '')).toBe(false);
+    expect(isStale('', '')).toBe(false);
+  });
+
+  it('null hashes are treated as absent → false', () => {
+    expect(isStale(null, 'h1')).toBe(false);
+    expect(isStale('h1', null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph URLs["Deep-linkable URLs"]
        DiffURL["/diff?a=&b=&row=b:rowKey&divergent=1"]
        FacetURL["/facets?run=&f=path:op:val&view=gallery|table&row=run:rowKey"]
    end

    subgraph Pages["E6 framework-free pages (ui/)"]
        DiffJS["diff.js<br/>RunDiff[] → classifyRow()<br/>regression count + divergent-only"]
        FacetJS["facets.js<br/>f= grammar → FacetQuery<br/>gallery|table, capped/lazy/paged"]
        Drawer["drawer.js (shared)<br/>splits run:rowKey on 1st colon<br/>pretty-printed output/expected + score bars"]
        Adj["adjudicate.js<br/>verdict select + note + ⚠ stale"]
    end

    subgraph Units["Pure units (unit-tested)"]
        G["facet-grammar.js<br/>parse/serializeFacets"]
        P["pretty.js<br/>prettyJson (esc-escaped)"]
        C["diff-classify.js<br/>classifyRow"]
        S["staleness.js<br/>isStale"]
    end

    subgraph API["E4 server /api/*"]
        ADiff["GET /api/diff?a=&b="]
        ARows["GET /api/rows?run=&f=…"]
        ARow["GET /api/row?run=&row="]
        AAdj["GET/POST /api/adjudications"]
    end

    DiffURL --> DiffJS --> ADiff
    FacetURL --> FacetJS --> ARows
    DiffJS -- "&row=b:rowKey (run=b)" --> Drawer
    FacetJS -- "&row=run:rowKey (page run)" --> Drawer
    Drawer --> ARow
    Drawer --> Adj --> AAdj
    DiffJS --> C
    FacetJS --> G
    Drawer --> P
    Adj --> S
```

## Summary

- Ships the second half of eleatic's framework-free explorer (E6, final package PR for the epic): the per-row run-diff view, the generic facet gallery/table, the shared deep-linkable drill-down drawer, and the human-adjudication panel — all vanilla ESM over E4's `/api/*` routes and E5's chrome (`safe.js`/`theme.js`/`app.css`/`/config.js`), with zero `@bird-watch/*` imports so the package stays cleanly extractable.
- Why a `run:rowKey` deep-link: the diff URL carries `a`/`b` but no single `run`, and `/api/row` returns 400 on a missing `run`. The opening side resolves the run (diff → `b`, the candidate; facets/hub → the page's `run`) and bakes it into `&row=<run>:<row_key>`, so a diff-opened drawer never 400s and the drawer never needs to know which view opened it.
- The logic lives in four pure, unit-tested ESM modules (facet `f=` (de)serializer, escaping JSON pretty-printer, diff classifier, staleness comparator); the DOM controllers are thin glue. The photo-judge "falseKeep gallery" falls out of the generic facet engine as `?run=…&f=metadata.disagreement:eq:falseKeep&view=gallery` with no bespoke code.

## Screenshots

N/A — packages/ tool, framework-free ui/ (not frontend/**); orchestrator live-verifies at E2E

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — green (18 files, 171 tests; +4 files / +39 tests for the 4 new pure units)
- [x] `npm run test` (full repo) — green (88 files, 1529 tests)
- [x] `npm run lint` — green (no-op per-workspace + the `frontend/src/` token guard, which eleatic is outside of)
- [x] `npm run build` — clean (tsc + the `ui/`→`dist/ui/` copy ships all new files; full repo build clean)
- [x] `npx knip` — exit 0; the 4 browser-glue modules (`diff/facets/drawer/adjudicate.js`, loaded via `<script type=module>`/dynamic import) added to the `packages/eleatic` `ui/*` ignore with a dated comment; the 4 pure-unit modules have `.test.ts` siblings so knip traces them (not ignored)
- [x] New unit tests added: facet (de)serializer round-trip + malformed-rejection, JSON pretty-printer escaping (an injected `"><img onerror>` renders inert), diff classifier truth table (regression = matched A / missed B), staleness comparator
- [ ] Playwright e2e — N/A; eleatic's framework-free `ui/` is `packages/`-scoped and exempt from the `frontend/**` Playwright contract. Live behavior is verified at the epic's E2E recipe (E9).

## Plan reference

Closes #1149. Part of the eleatic epic #1153 (E6, Wave 3 — the final package PR; depends on E4 server + E5 chrome).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
