### PR TITLE
refactor(photo-curation): refit eval runner + analyzer onto @bird-watch/eleatic (E7, #1150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,12 +62,17 @@ terraform.tfstate.backup
 prototype/
 
 # Local photo-curation tool workspace (photo-quality epic, Slice 4).
-# review.sqlite holds scored reports + staged decisions; thumb-cache/ holds
-# downloaded candidate thumbnails. Operator-local and regenerable — never
+# review.sqlite holds scored reports + staged decisions; eval.sqlite is the
+# eleatic eval store the photo-judge runner mirrors to (E7, #1150); thumb-cache/
+# holds downloaded candidate thumbnails. Operator-local and regenerable — never
 # commit. dist/ is the tsc build output.
 tools/photo-curation/review.sqlite
 tools/photo-curation/review.sqlite-journal
 tools/photo-curation/review.sqlite-wal
 tools/photo-curation/review.sqlite-shm
+tools/photo-curation/eval.sqlite
+tools/photo-curation/eval.sqlite-journal
+tools/photo-curation/eval.sqlite-wal
+tools/photo-curation/eval.sqlite-shm
 tools/photo-curation/thumb-cache/
 tools/photo-curation/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10349,6 +10349,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@bird-watch/db-client": "*",
+        "@bird-watch/eleatic": "*",
         "@bird-watch/ingestor": "*",
         "@bird-watch/photo-quality": "*",
         "@bird-watch/shared-types": "*",

--- a/tools/photo-curation/package.json
+++ b/tools/photo-curation/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@bird-watch/db-client": "*",
+    "@bird-watch/eleatic": "*",
     "@bird-watch/ingestor": "*",
     "@bird-watch/photo-quality": "*",
     "@bird-watch/shared-types": "*",

--- a/tools/photo-curation/scripts/analyze-experiment.test.ts
+++ b/tools/photo-curation/scripts/analyze-experiment.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { afterEach } from 'vitest';
-import type Database from 'better-sqlite3';
-import { openDb } from '../src/db.js';
-import { insertEvalResult } from '../src/eval/store.js';
+import type { insertEvalResult } from '../src/eval/store.js';
+import { openStore, toEleaticRow, toEleaticRun, type EleaticStore } from '../src/eval/eleatic-adapter.js';
 import {
   keepAgreement,
   confusionCounts,
@@ -16,8 +15,8 @@ import {
   projectRows,
   projectCostRows,
   summarizeCost,
-  makeSqliteReader,
-  makeSqliteCostReader,
+  makeEleaticReader,
+  makeEleaticCostReader,
   main,
   type AnalysisRow,
   type CostRow,
@@ -336,39 +335,64 @@ describe('main (injected reader, no network)', () => {
   });
 });
 
-describe('sqlite readers (#1094 — local store repoint)', () => {
-  let db: Database.Database | undefined;
+describe('eleatic readers (#1150 — eleatic store repoint)', () => {
+  let store: EleaticStore | undefined;
   afterEach(() => {
-    db?.close();
-    db = undefined;
+    store?.close();
+    store = undefined;
   });
 
-  /** Seed one eval_result row for a run. */
-  function seed(d: Database.Database, runId: string, over: Partial<Parameters<typeof insertEvalResult>[1]>): void {
-    insertEvalResult(d, {
-      runId,
-      speciesCode: over.speciesCode ?? 'amerob',
-      comName: 'American Robin',
-      contentHash: 'h',
-      sourceUrl: 'u',
-      geminiKeep: over.geminiKeep ?? true,
-      geminiQuality: over.geminiQuality ?? 80,
-      geminiCriteriaJson: null,
-      opusKeep: over.opusKeep ?? true,
-      opusQuality: over.opusQuality ?? 85,
-      cost: over.cost,
-      promptTokens: over.promptTokens,
-      completionTokens: over.completionTokens,
-    });
+  /** Seed one eleatic eval_run header + one eval_row via the adapter. */
+  function seedRun(s: EleaticStore, runId: string): void {
+    s.recordRun(
+      toEleaticRun({
+        id: runId,
+        model: 'gemini-2.5-flash',
+        baselineModel: 'claude-opus-4-8',
+        baselineRubric: '0.2.1',
+        sampleSize: 0,
+        startedAt: `2026-06-12T00:00:0${runId.slice(-1)}.000Z`,
+        agreement: 0,
+        falseKeep: 0,
+        falseReplace: 0,
+        scoreMae: 0,
+        totalCost: 0,
+      }),
+    );
+  }
+  function seedRow(
+    s: EleaticStore,
+    runId: string,
+    over: Partial<Parameters<typeof insertEvalResult>[1]>,
+  ): void {
+    s.recordRow(
+      toEleaticRow({
+        runId,
+        speciesCode: over.speciesCode ?? 'amerob',
+        comName: 'American Robin',
+        contentHash: 'h',
+        sourceUrl: 'u',
+        geminiKeep: over.geminiKeep ?? true,
+        geminiQuality: over.geminiQuality ?? 80,
+        geminiCriteriaJson: null,
+        opusKeep: over.opusKeep ?? true,
+        opusQuality: over.opusQuality ?? 85,
+        cost: over.cost,
+        promptTokens: over.promptTokens,
+        completionTokens: over.completionTokens,
+      }),
+    );
   }
 
-  it('makeSqliteReader yields AnalysisRow[] from eval_result for the run', async () => {
-    db = openDb(':memory:');
-    seed(db, 'run-1', { speciesCode: 'a', geminiKeep: true, geminiQuality: 90, opusKeep: true, opusQuality: 85 });
-    seed(db, 'run-1', { speciesCode: 'b', geminiKeep: false, geminiQuality: 20, opusKeep: false, opusQuality: 15 });
-    seed(db, 'run-2', { speciesCode: 'c', geminiKeep: true, geminiQuality: 99, opusKeep: false, opusQuality: 10 });
+  it('makeEleaticReader yields AnalysisRow[] from eval_row (via fromEleaticRow) for the run', async () => {
+    store = openStore(':memory:');
+    seedRun(store, 'run-1');
+    seedRun(store, 'run-2');
+    seedRow(store, 'run-1', { speciesCode: 'a', geminiKeep: true, geminiQuality: 90, opusKeep: true, opusQuality: 85 });
+    seedRow(store, 'run-1', { speciesCode: 'b', geminiKeep: false, geminiQuality: 20, opusKeep: false, opusQuality: 15 });
+    seedRow(store, 'run-2', { speciesCode: 'c', geminiKeep: true, geminiQuality: 99, opusKeep: false, opusQuality: 10 });
 
-    const reader = makeSqliteReader(db);
+    const reader = makeEleaticReader(store.db);
     const rows = await reader('run-1');
     expect(rows).toHaveLength(2); // only run-1's rows
     expect(rows).toEqual(
@@ -379,13 +403,32 @@ describe('sqlite readers (#1094 — local store repoint)', () => {
     );
   });
 
-  it('makeSqliteCostReader yields CostRow[]; priced rows carry cost, unpriced → undefined', async () => {
-    db = openDb(':memory:');
-    seed(db, 'run-1', { speciesCode: 'a', cost: 0.42, promptTokens: 1000, completionTokens: 100 });
-    seed(db, 'run-1', { speciesCode: 'b', cost: undefined, promptTokens: 800, completionTokens: 50 }); // unpriced
-    seed(db, 'run-2', { speciesCode: 'c', cost: 9.99, promptTokens: 1, completionTokens: 1 });
+  it('eleatic-backed rows feed analyze() to the existing fixture numbers', async () => {
+    store = openStore(':memory:');
+    seedRun(store, 'run-1');
+    // The exact analyze+formatReport fixture (keepAgreement 0.5, falseKeep 1, falseReplace 1).
+    seedRow(store, 'run-1', { speciesCode: 'a', geminiKeep: true, geminiQuality: 90, opusKeep: true, opusQuality: 85 });
+    seedRow(store, 'run-1', { speciesCode: 'b', geminiKeep: false, geminiQuality: 20, opusKeep: false, opusQuality: 15 });
+    seedRow(store, 'run-1', { speciesCode: 'c', geminiKeep: true, geminiQuality: 60, opusKeep: false, opusQuality: 40 }); // falseKeep
+    seedRow(store, 'run-1', { speciesCode: 'd', geminiKeep: false, geminiQuality: 30, opusKeep: true, opusQuality: 70 }); // falseReplace
 
-    const costReader = makeSqliteCostReader(db);
+    const reader = makeEleaticReader(store.db);
+    const rows = await reader('run-1');
+    const a = analyze(rows, { bandLo: 40, bandHi: 70 });
+    expect(a.n).toBe(4);
+    expect(a.keepAgreement).toBeCloseTo(0.5);
+    expect(a.confusion).toEqual({ falseKeep: 1, falseReplace: 1 });
+  });
+
+  it('makeEleaticCostReader yields CostRow[]; priced rows carry cost, unpriced → undefined', async () => {
+    store = openStore(':memory:');
+    seedRun(store, 'run-1');
+    seedRun(store, 'run-2');
+    seedRow(store, 'run-1', { speciesCode: 'a', cost: 0.42, promptTokens: 1000, completionTokens: 100 });
+    seedRow(store, 'run-1', { speciesCode: 'b', cost: undefined, promptTokens: 800, completionTokens: 50 }); // unpriced
+    seedRow(store, 'run-2', { speciesCode: 'c', cost: 9.99, promptTokens: 1, completionTokens: 1 });
+
+    const costReader = makeEleaticCostReader(store.db);
     const rows = await costReader('run-1');
     expect(rows).toHaveLength(2);
     const costs = rows.map((r) => r.estimatedCost);
@@ -394,9 +437,9 @@ describe('sqlite readers (#1094 — local store repoint)', () => {
     expect(costs).toContain(undefined);
   });
 
-  it('makeSqliteReader returns [] for an unknown run id', async () => {
-    db = openDb(':memory:');
-    const reader = makeSqliteReader(db);
+  it('makeEleaticReader returns [] for an unknown run id', async () => {
+    store = openStore(':memory:');
+    const reader = makeEleaticReader(store.db);
     expect(await reader('nope')).toEqual([]);
   });
 });

--- a/tools/photo-curation/scripts/analyze-experiment.ts
+++ b/tools/photo-curation/scripts/analyze-experiment.ts
@@ -32,8 +32,13 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type Database from 'better-sqlite3';
-import { openDb } from '../src/db.js';
-import { readEvalResults } from '../src/eval/store.js';
+// All eleatic access goes through the adapter — the single domain seam (#1150).
+import {
+  openStore,
+  makeReader,
+  fromEleaticRow,
+  costFromEleaticRow,
+} from '../src/eval/eleatic-adapter.js';
 
 /**
  * One experiment row reduced to the four values the diagnostics need:
@@ -391,34 +396,31 @@ export function projectCostRows(raw: RawMetricsRow[]): CostRow[] {
 export type CostReader = (experiment: string) => Promise<CostRow[]>;
 
 /**
- * Build the local-store reader (#1094): reads the run's `eval_result` rows from
- * SQLite and projects them onto `AnalysisRow` (the candidate `gemini_*` decision
- * vs. the Opus `opus_*` baseline). Replaces the old `bt sql` shell-out — the
- * store is local, so there is no network and no `bt` CLI dependency. A FACTORY
- * over the open db so the CLI wires `openDb(REVIEW_DB)` while tests inject an
- * in-memory db. Returns a plain `ExperimentReader` function (`experiment` = run id).
+ * Build the eleatic-store reader (#1150): reads the run's `eval_row` rows from
+ * the eleatic SQLite via the package `makeReader`, projecting each
+ * `EvalRowRecord` onto `AnalysisRow` through the adapter's `fromEleaticRow` (the
+ * candidate decision vs. the Opus baseline). Replaces the #1094 review-store
+ * read — the eleatic store is local, so there is no network. A FACTORY over the
+ * open db so the CLI wires `openStore(EVAL_DB).db` while tests inject an
+ * in-memory store. Returns a plain `ExperimentReader` function (`experiment` =
+ * run id).
  */
-export function makeSqliteReader(db: Database.Database): ExperimentReader {
-  return async (runId) =>
-    readEvalResults(db, runId).map((r) => ({
-      outputKeep: r.geminiKeep,
-      outputScore: r.geminiQuality,
-      expectedKeep: r.opusKeep,
-      expectedScore: r.opusQuality,
-    }));
+export function makeEleaticReader(db: Database.Database): ExperimentReader {
+  const reader = makeReader(db);
+  return async (runId) => reader.getRows(runId).map(fromEleaticRow);
 }
 
 /**
- * Build the local-store cost reader (#1094): reads the run's `eval_result.cost`
- * back and projects each row onto `CostRow` — a priced judgment carries a number,
- * an unpriced one carries `undefined` (stored NULL). Replaces the old `bt sql`
- * metrics read; same FACTORY-over-db shape as {@link makeSqliteReader} so the
- * cost block + `eval_run.total_cost` have a local source. `summarizeCost` then
- * prints the total/mean/unpriced lines.
+ * Build the eleatic-store cost reader (#1150): reads the run's `eval_row` back
+ * via the package `makeReader` and projects each row's `cost` numeric axis onto
+ * `CostRow` through the adapter's `costFromEleaticRow` — a priced judgment carries
+ * a number, an unpriced one carries `undefined` (the axis is absent). Same
+ * FACTORY-over-db shape as {@link makeEleaticReader} so the cost block has a
+ * local source; `summarizeCost` prints the total/mean/unpriced lines.
  */
-export function makeSqliteCostReader(db: Database.Database): CostReader {
-  return async (runId) =>
-    readEvalResults(db, runId).map((r) => ({ estimatedCost: r.cost }));
+export function makeEleaticCostReader(db: Database.Database): CostReader {
+  const reader = makeReader(db);
+  return async (runId) => reader.getRows(runId).map(costFromEleaticRow);
 }
 
 /** Parse `--band lo:hi` (default 40:70) from argv; everything else is the exp name. */
@@ -467,21 +469,18 @@ export async function main(
 }
 
 // Run only when invoked directly (tsx scripts/analyze-experiment.ts …), never on import.
-// REVIEW_DB is the local review store the runner wrote eval_result/eval_run to.
+// EVAL_DB is the local eleatic store the runner mirrored eval_run/eval_row to
+// (#1150; defaults to ./eval.sqlite, the same default run-eval-local writes to).
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const reviewDb = process.env.REVIEW_DB;
-  if (!reviewDb) {
-    console.error('REVIEW_DB is required (the local review.sqlite the run wrote to)');
-    process.exit(2);
-  }
-  const db = openDb(reviewDb);
-  main(process.argv.slice(2), makeSqliteReader(db), makeSqliteCostReader(db))
+  const evalDb = process.env.EVAL_DB ?? './eval.sqlite';
+  const store = openStore(evalDb);
+  main(process.argv.slice(2), makeEleaticReader(store.db), makeEleaticCostReader(store.db))
     .then((code) => {
-      db.close();
+      store.close();
       process.exit(code);
     })
     .catch((err: unknown) => {
-      db.close();
+      store.close();
       console.error(err instanceof Error ? err.message : String(err));
       process.exit(1);
     });

--- a/tools/photo-curation/scripts/run-eval-local.test.ts
+++ b/tools/photo-curation/scripts/run-eval-local.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import type Database from 'better-sqlite3';
+import { makeReader, openStore, type EleaticStore } from '../src/eval/eleatic-adapter.js';
 import { openDb } from '../src/db.js';
 import { readEvalRun, readEvalResults } from '../src/eval/store.js';
 import { instrumentedJudge, type JudgmentSink } from '../src/judges/instrumented.js';
@@ -8,9 +9,12 @@ import type { EvalRow } from '../src/eval/build-dataset.js';
 import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
 
 let db: Database.Database | undefined;
+let eleatic: EleaticStore | undefined;
 afterEach(() => {
   db?.close();
   db = undefined;
+  eleatic?.close();
+  eleatic = undefined;
 });
 
 /** Build one eval row with a controllable Opus baseline + species fields. */
@@ -62,7 +66,7 @@ function fakeJudge(sink: JudgmentSink, decide: (code: string) => { keep: boolean
 }
 
 /** Deps with a fake readImage (no fs) and a judge factory closing over `decide`. */
-function makeDeps(decide: (code: string) => { keep: boolean; quality: number }): Omit<RunEvalDeps, 'db' | 'rows'> {
+function makeDeps(decide: (code: string) => { keep: boolean; quality: number }): Omit<RunEvalDeps, 'db' | 'rows' | 'eleatic'> {
   return {
     runId: 'run-test-1',
     model: 'gemini-2.5-flash',
@@ -79,6 +83,7 @@ function makeDeps(decide: (code: string) => { keep: boolean; quality: number }):
 describe('runEvalLocal', () => {
   it('writes one eval_result per row + one eval_run with FRACTION-form aggregates', async () => {
     db = openDb(':memory:');
+    eleatic = openStore(':memory:');
     // 5 rows. Baseline keeps the first 4, replaces the 5th. The judge AGREES on
     // 4 of 5 (it flips only the last). Per the #1094 unit contract, agreement
     // must be stored as the 0–1 fraction 0.8, NOT 80.
@@ -97,7 +102,7 @@ describe('runEvalLocal', () => {
         ? { keep: false, quality: 80 } // DISAGREES (baseline keeps, judge replaces) → falseReplace
         : { keep: true, quality: 80 }; // agrees (both keep), exact score
 
-    await runEvalLocal({ db, rows, ...makeDeps(decide) });
+    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
 
     const results = readEvalResults(db, 'run-test-1');
     expect(results).toHaveLength(5);
@@ -118,12 +123,59 @@ describe('runEvalLocal', () => {
     expect(run!.sampleSize).toBe(5);
   });
 
+  it('ALSO writes the eleatic store (additive): run metrics as FRACTIONS + per-row disagreement', async () => {
+    db = openDb(':memory:');
+    eleatic = openStore(':memory:');
+    const rows: EvalRow[] = [
+      evalRow({ speciesCode: 'sp1', expectedKeep: true, expectedQuality: 80 }),
+      evalRow({ speciesCode: 'sp2', expectedKeep: true, expectedQuality: 80 }),
+      evalRow({ speciesCode: 'sp3', expectedKeep: true, expectedQuality: 80 }),
+      evalRow({ speciesCode: 'sp4', expectedKeep: false, expectedQuality: 20 }),
+      evalRow({ speciesCode: 'sp5', expectedKeep: false, expectedQuality: 20 }),
+    ];
+    // sp1–sp3 agree (keep). sp4: baseline replace, judge KEEPS → falseKeep.
+    // sp5: baseline replace, judge replaces → agree. 4/5 keep-agreement → 0.8.
+    const decide = (code: string) =>
+      code === 'sp4'
+        ? { keep: true, quality: 90 } // DISAGREES → falseKeep
+        : code === 'sp5'
+        ? { keep: false, quality: 20 } // agrees (both replace)
+        : { keep: true, quality: 80 }; // agrees (both keep)
+
+    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
+
+    // BOTH stores written: the old review store still holds the rows…
+    expect(readEvalResults(db, 'run-test-1')).toHaveLength(5);
+    expect(readEvalRun(db, 'run-test-1')).toBeDefined();
+
+    // …and the eleatic store mirrors them. Read it back via the package reader.
+    const reader = makeReader(eleatic.db);
+    const eleaticRun = reader.getRun('run-test-1');
+    expect(eleaticRun).toBeDefined();
+    expect(eleaticRun!.label).toBe('gemini-2.5-flash');
+    expect(eleaticRun!.baseline).toBe('claude-opus-4-8');
+    // metrics stored as 0–1 FRACTIONS — 4/5 → 0.8, NOT 80.
+    expect(eleaticRun!.metrics!.agreement).toBe(0.8);
+    expect(eleaticRun!.metrics!.agreement).not.toBe(80);
+    expect(eleaticRun!.metrics!.falseKeep).toBe(1);
+    expect(eleaticRun!.config!.sampleSize).toBe(5);
+
+    const eleaticRows = reader.getRows('run-test-1');
+    expect(eleaticRows).toHaveLength(5);
+    // per-row categorical facet axis: the sp4 row is a falseKeep.
+    const sp4 = reader.getRow('run-test-1', 'sp4');
+    expect(sp4!.metadata!.disagreement).toBe('falseKeep');
+    const sp1 = reader.getRow('run-test-1', 'sp1');
+    expect(sp1!.metadata!.disagreement).toBe('agree');
+  });
+
   it('joins each result with the Opus baseline + the judge output + cost/tokens', async () => {
     db = openDb(':memory:');
+    eleatic = openStore(':memory:');
     const rows: EvalRow[] = [evalRow({ speciesCode: 'amerob', expectedKeep: true, expectedQuality: 85 })];
     const decide = () => ({ keep: false, quality: 60 });
 
-    await runEvalLocal({ db, rows, ...makeDeps(decide) });
+    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
 
     const [r] = readEvalResults(db, 'run-test-1');
     expect(r!.speciesCode).toBe('amerob');
@@ -143,6 +195,7 @@ describe('runEvalLocal', () => {
 
   it('computes falseKeep (judge keeps what baseline replaces) and total_cost', async () => {
     db = openDb(':memory:');
+    eleatic = openStore(':memory:');
     const rows: EvalRow[] = [
       evalRow({ speciesCode: 'a', expectedKeep: false, expectedQuality: 20 }),
       evalRow({ speciesCode: 'b', expectedKeep: false, expectedQuality: 20 }),
@@ -150,7 +203,7 @@ describe('runEvalLocal', () => {
     // Judge keeps BOTH → 2 falseKeep, 0 agreement.
     const decide = () => ({ keep: true, quality: 90 });
 
-    await runEvalLocal({ db, rows, ...makeDeps(decide) });
+    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
 
     const run = readEvalRun(db, 'run-test-1')!;
     expect(run.agreement).toBe(0);
@@ -165,6 +218,7 @@ describe('runEvalLocal', () => {
 
   it('runs rows SERIALLY (never concurrently)', async () => {
     db = openDb(':memory:');
+    eleatic = openStore(':memory:');
     const rows: EvalRow[] = [
       evalRow({ speciesCode: 's1', expectedKeep: true, expectedQuality: 80 }),
       evalRow({ speciesCode: 's2', expectedKeep: true, expectedQuality: 80 }),
@@ -187,7 +241,7 @@ describe('runEvalLocal', () => {
       };
     };
 
-    await runEvalLocal({ db, rows, ...deps, makeJudge: slowJudge });
+    await runEvalLocal({ db, eleatic, rows, ...deps, makeJudge: slowJudge });
 
     // Serial execution never has more than one judgment in flight at a time.
     expect(maxInFlight).toBe(1);

--- a/tools/photo-curation/scripts/run-eval-local.ts
+++ b/tools/photo-curation/scripts/run-eval-local.ts
@@ -41,12 +41,20 @@ import { keepAgreement, scoreMAE, keepConfusion } from '../src/eval/scorers.js';
 import { runRow } from '../src/eval/run-row.js';
 import { mimeFromUrl } from '../src/sources.js';
 import { insertEvalResult, insertEvalRun, type EvalResultRecord } from '../src/eval/store.js';
+// All eleatic access goes through the adapter — the single domain seam (#1150).
+import { openStore, toEleaticRow, toEleaticRun, type EleaticStore } from '../src/eval/eleatic-adapter.js';
 import { judgePromptForRubricVersion, resolveEvalModel } from '../eval/rubric-prompts.js';
 
 /** The injected collaborators `runEvalLocal` needs — all fakeable in tests. */
 export interface RunEvalDeps {
   /** The open review store the run writes `eval_result` + `eval_run` to. */
   db: Database.Database;
+  /**
+   * The open eleatic store the run ADDITIVELY mirrors each row + the run header
+   * to (E7, #1150). Written alongside `db` via the eleatic-adapter; the old
+   * review writes are unchanged. `:memory:` in tests.
+   */
+  eleatic: EleaticStore;
   /** The dataset rows (built from the pinned baseline, hash-verified). */
   rows: EvalRow[];
   /** The run id (e.g. `<model>-<unix>`) — the `eval_run.id` / `eval_result.run_id`. */
@@ -86,7 +94,30 @@ export interface RunEvalDeps {
  * summed, and total cost summed over the priced judgments.
  */
 export async function runEvalLocal(deps: RunEvalDeps): Promise<void> {
-  const { db, rows, runId, model, baselineModel, baselineRubric, sampleSize, startedAt, prompt } = deps;
+  const { db, eleatic, rows, runId, model, baselineModel, baselineRubric, sampleSize, startedAt, prompt } = deps;
+
+  // Write the eleatic run HEADER before any child row (E7, #1150). eval_row has
+  // a `run_id REFERENCES eval_run(id)` FK with `foreign_keys = ON`, so a row
+  // inserted before its run would throw. The header carries identity + config +
+  // startedAt now; `finalizeRun` patches the aggregate metrics after the loop
+  // (the runner computes them late, exactly the finalize seam's purpose).
+  eleatic.recordRun(
+    toEleaticRun({
+      id: runId,
+      model,
+      baselineModel,
+      baselineRubric,
+      sampleSize,
+      startedAt,
+      // Placeholder aggregates — overwritten by finalizeRun below. Stored as the
+      // same 0–1 fraction units the runner uses (#1094); these are never read.
+      agreement: 0,
+      falseKeep: 0,
+      falseReplace: 0,
+      scoreMae: 0,
+      totalCost: 0,
+    }),
+  );
 
   // The sink appends each judgment's record; the loop reads the one emitted by
   // the row it just ran (the judge emits exactly once per resolved judgment, so
@@ -142,11 +173,17 @@ export async function runEvalLocal(deps: RunEvalDeps): Promise<void> {
       promptTokens: record.promptTokens,
       completionTokens: record.completionTokens,
     };
+    // ADDITIVE dual-write (#1150): the old review.sqlite write is unchanged…
     insertEvalResult(db, result);
+    // …and the SAME record is mirrored to the eleatic store via the adapter.
+    // Written serially in lockstep with the review write (no batching) so the
+    // SERIAL loop invariant (#1094) is preserved and a mid-run crash leaves the
+    // two stores at the same row.
+    eleatic.recordRow(toEleaticRow(result));
   }
 
   const n = rows.length;
-  insertEvalRun(db, {
+  const run = {
     id: runId,
     model,
     baselineModel,
@@ -159,7 +196,15 @@ export async function runEvalLocal(deps: RunEvalDeps): Promise<void> {
     falseReplace,
     scoreMae: n === 0 ? 0 : maeSum / n,
     totalCost,
-  });
+  };
+  insertEvalRun(db, run);
+  // Patch the eleatic run header's aggregates now they are computed. finalizeRun
+  // writes row_count + metrics_json; the metrics are the SAME 0–1 fractions the
+  // review store holds (toEleaticRun maps them through unchanged, #1094).
+  // `toEleaticRun` always sets `metrics`, but the field is optional on the
+  // record type; `?? {}` keeps exactOptionalPropertyTypes happy without ever
+  // hitting the fallback in practice.
+  eleatic.finalizeRun(runId, { rowCount: n, metrics: toEleaticRun(run).metrics ?? {} });
 }
 
 /** Fail loud on a missing required env var — never run the eval half-configured. */
@@ -194,16 +239,20 @@ async function main(argv: string[]): Promise<void> {
   const THUMB_DIR = requireEnv('THUMB_DIR');
   // PROD baseline connection (#1073). A READ-ONLY connection string suffices.
   const DATABASE_URL = requireEnv('DATABASE_URL');
+  // The eleatic store the run is ADDITIVELY mirrored to (E7, #1150). Defaults to
+  // ./eval.sqlite alongside REVIEW_DB; the analyzer reads it back.
+  const EVAL_DB = process.env.EVAL_DB ?? './eval.sqlite';
   const EVAL_SAMPLE = Number(process.env.EVAL_SAMPLE ?? 150);
   const EVAL_MODEL = resolveEvalModel(process.env);
   const BASELINE_PIN = resolveBaselinePin(process.env);
 
   const db = openDb(REVIEW_DB);
+  const eleatic = openStore(EVAL_DB);
 
-  // Close on BOTH the success and error paths (#1108). `db` is opened inside
-  // main (unlike the sibling analyze-experiment.ts, which opens it at the entry
-  // block and closes in both .then/.catch), so a try/finally here is the clean
-  // mirror of that close-on-both contract.
+  // Close BOTH stores on BOTH the success and error paths (#1108). `db` +
+  // `eleatic` are opened inside main (unlike the sibling analyze-experiment.ts,
+  // which opens at the entry block and closes in both .then/.catch), so a
+  // try/finally here is the clean mirror of that close-on-both contract.
   try {
     // Eager build (#1037/#1073): reads the pinned baseline from PROD and hash-
     // verifies each local image against it. Hard-fails on a mixed/unknown rubric
@@ -234,6 +283,7 @@ async function main(argv: string[]): Promise<void> {
     // gemini.ts; one per row would reset the GEMINI_PACE_MS gate, #1015 review).
     await runEvalLocal({
       db,
+      eleatic,
       rows,
       runId,
       model: EVAL_MODEL,
@@ -251,7 +301,7 @@ async function main(argv: string[]): Promise<void> {
       agreement: number; false_keep: number; false_replace: number; score_mae: number; total_cost: number;
     };
 
-    console.log(`eval run ${runId} (${rows.length} rows) written to ${REVIEW_DB}`);
+    console.log(`eval run ${runId} (${rows.length} rows) written to ${REVIEW_DB} + ${EVAL_DB}`);
     console.log(`  agreement     ${(run.agreement * 100).toFixed(2)}%  (stored as fraction ${run.agreement})`);
     console.log(`  falseKeep     ${run.false_keep}   falseReplace ${run.false_replace}`);
     console.log(`  score MAE     ${run.score_mae.toFixed(4)} (fraction)`);
@@ -259,6 +309,7 @@ async function main(argv: string[]): Promise<void> {
     console.log(`  analyze with: npm run analyze -w @bird-watch/photo-curation ${runId}`);
   } finally {
     db.close();
+    eleatic.close();
   }
 }
 

--- a/tools/photo-curation/src/eval/eleatic-adapter.test.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import type { EvalResultRecord, EvalRunRecord } from './store.js';
+import {
+  PHOTO_JUDGE_GATE,
+  makeReader,
+  openStore,
+  toEleaticRow,
+  toEleaticRun,
+  fromEleaticRow,
+  costFromEleaticRow,
+} from './eleatic-adapter.js';
+
+/** A photo-judge result record with controllable keep/score/criteria fields. */
+function result(over: Partial<EvalResultRecord> = {}): EvalResultRecord {
+  return {
+    runId: 'run-1',
+    speciesCode: 'amerob',
+    comName: 'American Robin',
+    contentHash: 'hash-amerob',
+    sourceUrl: 'https://photos.bird-maps.com/amerob.jpeg',
+    geminiKeep: true,
+    geminiQuality: 80,
+    geminiCriteriaJson: JSON.stringify({ framing: 8, subjectClarity: 9 }),
+    opusKeep: true,
+    opusQuality: 85,
+    cost: 0.0042,
+    promptTokens: 1000,
+    completionTokens: 100,
+    ...over,
+  };
+}
+
+/** A photo-judge run record. */
+function run(over: Partial<EvalRunRecord> = {}): EvalRunRecord {
+  return {
+    id: 'run-1',
+    model: 'gemini-2.5-flash',
+    baselineModel: 'claude-opus-4-8',
+    baselineRubric: '0.2.1',
+    sampleSize: 150,
+    startedAt: '2026-06-12T00:00:00.000Z',
+    agreement: 0.8,
+    falseKeep: 5,
+    falseReplace: 27,
+    scoreMae: 0.92,
+    totalCost: 12.34,
+    ...over,
+  };
+}
+
+describe('toEleaticRow', () => {
+  it('maps identity, label, image_url, content_hash from the photo-judge record', () => {
+    const row = toEleaticRow(result());
+    expect(row.runId).toBe('run-1');
+    expect(row.rowKey).toBe('amerob');
+    expect(row.label).toBe('American Robin');
+    expect(row.imageUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
+    expect(row.contentHash).toBe('hash-amerob');
+  });
+
+  it('embeds output_json = {keep, qualityScore, criteria} with criteria PARSED (not double-encoded)', () => {
+    const row = toEleaticRow(result());
+    expect(row.output).toEqual({
+      keep: true,
+      qualityScore: 80,
+      // the criteria string was JSON.parsed into a clean object, NOT left as a string.
+      criteria: { framing: 8, subjectClarity: 9 },
+    });
+    // load-bearing: the criteria value is an object, never the raw JSON string.
+    expect(typeof (row.output as { criteria: unknown }).criteria).toBe('object');
+  });
+
+  it('omits criteria when geminiCriteriaJson is null (null-guarded → absent, not undefined)', () => {
+    const row = toEleaticRow(result({ geminiCriteriaJson: null }));
+    expect(row.output).toEqual({ keep: true, qualityScore: 80 });
+    expect('criteria' in (row.output as object)).toBe(false);
+  });
+
+  it('embeds expected_json = {keep, qualityScore} from the opus baseline (no opus criteria source → absent)', () => {
+    const row = toEleaticRow(result({ opusKeep: false, opusQuality: 30 }));
+    expect(row.expected).toEqual({ keep: false, qualityScore: 30 });
+    expect('criteria' in (row.expected as object)).toBe(false);
+  });
+
+  it('puts numeric axes in scores_json = {outputQuality, expectedQuality, cost} when priced', () => {
+    const row = toEleaticRow(result({ geminiQuality: 70, opusQuality: 90, cost: 0.0042 }));
+    expect(row.scores).toEqual({ outputQuality: 70, expectedQuality: 90, cost: 0.0042 });
+  });
+
+  it('omits the cost axis when the judgment is unpriced (cost undefined → absent key)', () => {
+    const row = toEleaticRow(result({ geminiQuality: 70, opusQuality: 90, cost: undefined }));
+    expect(row.scores).toEqual({ outputQuality: 70, expectedQuality: 90 });
+    expect('cost' in row.scores!).toBe(false);
+  });
+
+  describe('disagreement matrix (metadata.disagreement) — all 4 cells', () => {
+    it('agree when both keep', () => {
+      expect(toEleaticRow(result({ geminiKeep: true, opusKeep: true })).metadata).toEqual({
+        disagreement: 'agree',
+      });
+    });
+    it('agree when both replace', () => {
+      expect(toEleaticRow(result({ geminiKeep: false, opusKeep: false })).metadata).toEqual({
+        disagreement: 'agree',
+      });
+    });
+    it('falseKeep when gemini keep ∧ ¬opus keep', () => {
+      expect(toEleaticRow(result({ geminiKeep: true, opusKeep: false })).metadata).toEqual({
+        disagreement: 'falseKeep',
+      });
+    });
+    it('falseReplace when ¬gemini keep ∧ opus keep', () => {
+      expect(toEleaticRow(result({ geminiKeep: false, opusKeep: true })).metadata).toEqual({
+        disagreement: 'falseReplace',
+      });
+    });
+  });
+
+  it('omits image_url when sourceUrl is empty (exactOptional — absent key, not undefined)', () => {
+    const row = toEleaticRow(result({ sourceUrl: '' }));
+    expect('imageUrl' in row).toBe(false);
+  });
+
+  it('omits content_hash when contentHash is empty', () => {
+    const row = toEleaticRow(result({ contentHash: '' }));
+    expect('contentHash' in row).toBe(false);
+  });
+});
+
+describe('toEleaticRun', () => {
+  it('maps id, label=model, baseline=baselineModel, startedAt, sampleSize→config', () => {
+    const r = toEleaticRun(run());
+    expect(r.id).toBe('run-1');
+    expect(r.label).toBe('gemini-2.5-flash');
+    expect(r.baseline).toBe('claude-opus-4-8');
+    expect(r.startedAt).toBe('2026-06-12T00:00:00.000Z');
+    expect(r.config).toEqual({
+      baselineModel: 'claude-opus-4-8',
+      baselineRubric: '0.2.1',
+      sampleSize: 150,
+    });
+  });
+
+  it('stores metrics as the SAME 0–1 fractions (0.8 must NOT become 80)', () => {
+    const r = toEleaticRun(run({ agreement: 0.8, scoreMae: 0.92 }));
+    expect(r.metrics).toEqual({
+      agreement: 0.8,
+      falseKeep: 5,
+      falseReplace: 27,
+      scoreMae: 0.92,
+      totalCost: 12.34,
+    });
+    // explicit fraction guard — agreement is the fraction, not a percent.
+    expect(r.metrics!.agreement).toBe(0.8);
+    expect(r.metrics!.agreement).not.toBe(80);
+    expect(r.metrics!.scoreMae).toBe(0.92);
+    expect(r.metrics!.scoreMae).not.toBe(92);
+  });
+});
+
+describe('PHOTO_JUDGE_GATE', () => {
+  it('is agreement >= 0.90', () => {
+    expect(PHOTO_JUDGE_GATE).toEqual({ metric: 'agreement', op: 'gte', threshold: 0.9 });
+  });
+});
+
+describe('fromEleaticRow', () => {
+  it('round-trips a stored row back to an AnalysisRow', () => {
+    const store = openStore(':memory:');
+    store.recordRun(toEleaticRun(run()));
+    store.recordRow(
+      toEleaticRow(
+        result({ geminiKeep: true, geminiQuality: 77, opusKeep: false, opusQuality: 33 }),
+      ),
+    );
+    const reader = makeReader(store.db);
+    const [stored] = reader.getRows('run-1');
+    expect(stored).toBeDefined();
+
+    const analysis = fromEleaticRow(stored!);
+    expect(analysis).toEqual({
+      outputKeep: true,
+      outputScore: 77,
+      expectedKeep: false,
+      expectedScore: 33,
+    });
+    store.close();
+  });
+});
+
+describe('costFromEleaticRow', () => {
+  it('round-trips a priced row back to {estimatedCost: number}', () => {
+    const store = openStore(':memory:');
+    store.recordRun(toEleaticRun(run()));
+    store.recordRow(toEleaticRow(result({ cost: 0.0042 })));
+    const reader = makeReader(store.db);
+    const [stored] = reader.getRows('run-1');
+    expect(costFromEleaticRow(stored!)).toEqual({ estimatedCost: 0.0042 });
+    store.close();
+  });
+
+  it('round-trips an unpriced row (no cost axis) back to {estimatedCost: undefined}', () => {
+    const store = openStore(':memory:');
+    store.recordRun(toEleaticRun(run()));
+    store.recordRow(toEleaticRow(result({ cost: undefined })));
+    const reader = makeReader(store.db);
+    const [stored] = reader.getRows('run-1');
+    expect(costFromEleaticRow(stored!)).toEqual({ estimatedCost: undefined });
+    store.close();
+  });
+});

--- a/tools/photo-curation/src/eval/eleatic-adapter.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.ts
@@ -1,0 +1,192 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// The SINGLE domain seam between photo-curation's photo-judge eval and the
+// generic @bird-watch/eleatic store (E7, #1150).
+//
+// This is the ONLY file in tools/photo-curation that imports @bird-watch/eleatic.
+// It maps the photo-judge's `EvalResultRecord` / `EvalRunRecord` (src/eval/store.ts)
+// onto eleatic's generic three-table records, and reads them back for the
+// analyzer. Keeping the import here means eleatic stays zero-`@bird-watch`-coupled
+// and the runner/analyzer only ever speak the photo-judge vocabulary.
+//
+// UNIT CONTRACT (#1094, load-bearing for the #1095 gate): `agreement` and
+// `scoreMae` are stored as the SAME 0–1 FRACTIONS the runner computes — 0.8 must
+// NOT become 80. PHOTO_JUDGE_GATE reads `agreement` as a fraction (>= 0.90).
+//
+// exactOptionalPropertyTypes: every omittable eleatic field (imageUrl,
+// contentHash, output.criteria) is left ABSENT when its source is missing —
+// never assigned `undefined` on a required key.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { openStore, makeReader } from '@bird-watch/eleatic';
+import type { EvalRowRecord, EvalRunRecord as EleaticRunRecord, EleaticStore } from '@bird-watch/eleatic';
+import type { CriteriaScores } from '@bird-watch/photo-quality';
+import type { EvalResultRecord, EvalRunRecord } from './store.js';
+
+// Re-export the eleatic LIFECYCLE surface the runner + analyzer need, so this
+// adapter stays the SINGLE file in tools/photo-curation that imports
+// `@bird-watch/eleatic` (#1150). The scripts open/read the store through here,
+// never reaching into the package directly — the one-seam rule keeps the
+// photo-judge↔eleatic coupling auditable in one place.
+export { openStore, makeReader };
+export type { EleaticStore };
+
+/**
+ * The eleatic gate for the photo-judge eval: keep-agreement at or above 0.90,
+ * read as a 0–1 fraction (NOT a percent). Mirrors the #1095 `>= 0.90` gate; the
+ * E4 server / E6 UI read this metric/op/threshold directly off the stored run.
+ */
+export const PHOTO_JUDGE_GATE = { metric: 'agreement', op: 'gte', threshold: 0.9 } as const;
+
+/** The disagreement cell a row falls into, used as a categorical facet axis. */
+export type Disagreement = 'agree' | 'falseKeep' | 'falseReplace';
+
+/**
+ * The candidate (Gemini) decision blob embedded as `output_json`. `criteria` is
+ * the PARSED per-axis sub-scores object (the source `geminiCriteriaJson` is an
+ * already-serialized string — it is `JSON.parse`d here, never double-encoded),
+ * omitted entirely when the source was null.
+ */
+interface OutputBlob {
+  keep: boolean;
+  qualityScore: number;
+  criteria?: CriteriaScores;
+}
+
+/** The Opus baseline decision blob embedded as `expected_json`. */
+interface ExpectedBlob {
+  keep: boolean;
+  qualityScore: number;
+  criteria?: CriteriaScores;
+}
+
+/**
+ * The four values the analyzer's dataset-level diagnostics need, projected back
+ * out of an eleatic row. Structurally identical to the analyzer's own
+ * `AnalysisRow` (scripts/analyze-experiment.ts) — kept here so the adapter (a
+ * `src/**` build target) does not import from `scripts/**` (outside rootDir).
+ */
+export interface AnalysisRow {
+  outputKeep: boolean;
+  outputScore: number;
+  expectedKeep: boolean;
+  expectedScore: number;
+}
+
+/** Classify a row into its keep-disagreement cell (gemini vs. opus). */
+function disagreementOf(geminiKeep: boolean, opusKeep: boolean): Disagreement {
+  if (geminiKeep && !opusKeep) return 'falseKeep';
+  if (!geminiKeep && opusKeep) return 'falseReplace';
+  return 'agree';
+}
+
+/** Parse the (already-serialized) criteria JSON, null-guarded → `undefined`. */
+function parseCriteria(json: string | null): CriteriaScores | undefined {
+  if (json === null) return undefined;
+  return JSON.parse(json) as CriteriaScores;
+}
+
+/**
+ * Map one photo-judge judgment onto an eleatic `EvalRowRecord`.
+ *   - row_key = speciesCode, label = comName, image_url = sourceUrl (omitted
+ *     when empty), content_hash = contentHash (omitted when empty).
+ *   - output_json = {keep, qualityScore, criteria?} with criteria PARSED.
+ *   - expected_json = {keep, qualityScore} (the baseline carries no criteria).
+ *   - scores_json = {outputQuality, expectedQuality} (numeric facet axes).
+ *   - metadata_json = {disagreement} (the categorical facet axis).
+ */
+export function toEleaticRow(r: EvalResultRecord): EvalRowRecord {
+  const output: OutputBlob = { keep: r.geminiKeep, qualityScore: r.geminiQuality };
+  const criteria = parseCriteria(r.geminiCriteriaJson);
+  if (criteria !== undefined) output.criteria = criteria;
+
+  const expected: ExpectedBlob = { keep: r.opusKeep, qualityScore: r.opusQuality };
+
+  // Numeric facet axes. `cost` is an axis too (the analyzer's #1088 cost block
+  // reads it back) — present for a priced judgment, ABSENT for an unpriced one
+  // (cost `undefined` → omitted key, mirroring the review store's NULL).
+  const scores: Record<string, number> = {
+    outputQuality: r.geminiQuality,
+    expectedQuality: r.opusQuality,
+  };
+  if (r.cost !== undefined) scores.cost = r.cost;
+
+  const row: EvalRowRecord = {
+    runId: r.runId,
+    rowKey: r.speciesCode,
+    label: r.comName,
+    output,
+    expected,
+    scores,
+    metadata: { disagreement: disagreementOf(r.geminiKeep, r.opusKeep) },
+  };
+  // exactOptionalPropertyTypes: leave the optional keys ABSENT (not `undefined`)
+  // when their source is missing, so the store coerces them to a column NULL.
+  if (r.sourceUrl !== '') row.imageUrl = r.sourceUrl;
+  if (r.contentHash !== '') row.contentHash = r.contentHash;
+  return row;
+}
+
+/**
+ * Map the photo-judge run aggregate onto an eleatic `EvalRunRecord`.
+ *   - label = model, baseline = baselineModel.
+ *   - config = {baselineModel, baselineRubric, sampleSize}.
+ *   - metrics = {agreement, falseKeep, falseReplace, scoreMae, totalCost} — the
+ *     SAME 0–1 fractions the runner computed (agreement/scoreMae are NOT scaled
+ *     to percents; #1094 unit contract).
+ */
+export function toEleaticRun(run: EvalRunRecord): EleaticRunRecord {
+  return {
+    id: run.id,
+    label: run.model,
+    baseline: run.baselineModel,
+    startedAt: run.startedAt,
+    config: {
+      baselineModel: run.baselineModel,
+      baselineRubric: run.baselineRubric,
+      sampleSize: run.sampleSize,
+    },
+    metrics: {
+      agreement: run.agreement,
+      falseKeep: run.falseKeep,
+      falseReplace: run.falseReplace,
+      scoreMae: run.scoreMae,
+      totalCost: run.totalCost,
+    },
+  };
+}
+
+/**
+ * Project a stored eleatic row back to the analyzer's `AnalysisRow`. Reads the
+ * candidate/baseline keep + qualityScore from the row's `output_json` /
+ * `expected_json` blobs (written by {@link toEleaticRow}).
+ */
+export function fromEleaticRow(row: EvalRowRecord): AnalysisRow {
+  const output = row.output as OutputBlob;
+  const expected = row.expected as ExpectedBlob;
+  return {
+    outputKeep: output.keep,
+    outputScore: output.qualityScore,
+    expectedKeep: expected.keep,
+    expectedScore: expected.qualityScore,
+  };
+}
+
+/**
+ * One judgment's cost, structurally identical to the analyzer's `CostRow`
+ * (scripts/analyze-experiment.ts). `estimatedCost` is the priced USD figure or
+ * `undefined` for an unpriced judgment — kept here so the adapter (a `src/**`
+ * build target) does not import from `scripts/**`.
+ */
+export interface CostRow {
+  estimatedCost: number | undefined;
+}
+
+/**
+ * Project a stored eleatic row back to the analyzer's `CostRow` (#1088). Reads
+ * the `cost` numeric axis from `scores_json` (written by {@link toEleaticRow}):
+ * present → priced, absent → unpriced (`undefined`), mirroring the review
+ * store's priced/NULL distinction.
+ */
+export function costFromEleaticRow(row: EvalRowRecord): CostRow {
+  return { estimatedCost: row.scores?.cost };
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph runner["run-eval-local.ts (WRITE)"]
        loop["serial loop\n(one judgment at a time, #1094)"]
    end
    subgraph adapter["src/eval/eleatic-adapter.ts\n(SINGLE @bird-watch/eleatic seam)"]
        toRow["toEleaticRow"]
        toRun["toEleaticRun"]
        fromRow["fromEleaticRow / costFromEleaticRow"]
    end
    subgraph review["review.sqlite (UNCHANGED — E8 retires)"]
        er["eval_result + eval_run"]
    end
    subgraph eleatic["eval.sqlite (@bird-watch/eleatic, NEW)"]
        erow["eval_row + eval_run"]
    end
    subgraph analyzer["analyze-experiment.ts (READ)"]
        an["analyze() + pure helpers (UNCHANGED)"]
    end

    loop -->|insertEvalResult / insertEvalRun| er
    loop -->|toEleaticRow → recordRow| toRow --> erow
    loop -->|recordRun before loop, finalizeRun after| toRun --> erow
    erow -->|makeReader.getRows| fromRow --> an
```

## Summary

- E7 of the eleatic epic (#1153): the photo-judge eval runner + analyzer now read/write the generic `@bird-watch/eleatic` store, ADDITIVELY — the old `review.sqlite` writes are untouched (E8 retires them after this lands). The *why*: consolidate the bespoke `#1094` eval store onto the reusable eleatic three-table schema without disturbing the live `/eval` viewer.
- A single domain seam (`src/eval/eleatic-adapter.ts`) is the only photo-curation file that imports the package, so eleatic stays zero-`@bird-watch`-coupled. It maps the photo-judge records onto eleatic's generic ones: criteria parsed-not-double-encoded, metrics kept as the same 0–1 fractions (`#1094` unit contract — `0.8` does not become `80`), `disagreement` as a categorical facet axis, `cost` as a numeric axis.
- The SERIAL loop invariant (`#1094`, no concurrency) is preserved; the eleatic run header is written before child rows (the `eval_row.run_id` FK requires it) and `finalizeRun` patches the aggregates after the loop.

## Screenshots

N/A — CLI/tooling (tools/photo-curation script + adapter)

## Test plan

- [x] `npm run typecheck && npm run test` — green (full repo: db-client 21, eleatic 18, geo 1, photo-quality 8, admin-api 10, ingestor 25, read-api 5, photo-curation 28, frontend 88 files; all pass). photo-curation: 385 tests pass.
- [x] New unit / integration tests added: pure `eleatic-adapter.test.ts` (mapping, 4-cell disagreement matrix, exactOptional-absent-key, fraction-not-percent, `fromEleaticRow`/`costFromEleaticRow` round-trips); extended `run-eval-local.test.ts` (BOTH stores written, serial `maxInFlight===1` intact, eleatic metrics read back as fractions + per-row `metadata.disagreement`); extended `analyze-experiment.test.ts` (eleatic-backed reader → AnalysisRow → existing fixture numbers).
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior.
- [x] `npm run build` — clean production build (all workspaces incl. frontend vite build).
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` changes.

Also verified: `npm run lint` green, `npx knip` exit 0 (no new surface — adapter is ordinary `src/**`, traced via its `.test.ts` sibling), `package-lock.json` regenerated via real `npm install`, scripts type-check clean under `exactOptionalPropertyTypes`.

## Plan reference

Part of epic #1153 (eleatic), E7 / Wave 4. Closes #1150. Out of `docs/plans/` — plans live in issues.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)