### PR TITLE
test(eleatic): zero-coupling guard hardening + README (E9, #1152)

### DIFF
--- a/packages/eleatic/README.md
+++ b/packages/eleatic/README.md
@@ -1,0 +1,154 @@
+# `eleatic`
+
+A domain-agnostic, local eval-results explorer: cross-run comparison, per-row
+diff, judgment drill-down, faceted filter/sort, metric trends, and human
+adjudication — over a generic three-table SQLite store, with no knowledge of any
+particular eval domain.
+
+It has two halves: a tiny TypeScript write/read library (`openStore` +
+`makeReader`) that any eval runner records into, and a framework-free browser
+explorer served by the `eleatic serve` bin. The first consumer is bird-maps'
+photo-judge eval (`tools/photo-curation`), but the package depends on nothing in
+this monorepo — that one-way boundary (`tools/photo-curation` → `eleatic`, never
+the reverse) is enforced by `src/no-coupling.test.ts` and is what lets the
+package `git mv` to its own repo later. See **Abstraction-readiness checklist**.
+
+Runtime dependencies: `better-sqlite3`, `express`, `commander`. No
+`@bird-watch/*` dependency in any group (guard-enforced).
+
+## Usage
+
+Record an eval run from any runner, then explore it:
+
+```ts
+import { openStore } from '@bird-watch/eleatic';
+
+const store = openStore('eval.sqlite'); // ':memory:' default in tests
+
+// 1. Write the run header before any row (eval_row FKs eval_run).
+store.recordRun({ id: runId, label, baseline, config, startedAt });
+
+// 2. One row per evaluated item — output/expected/scores/metadata are JSON-or-NULL.
+for (const item of items) {
+  store.recordRow({ runId, rowKey, label, imageUrl, contentHash, output, expected, scores, metadata });
+}
+
+// 3. Patch the run's aggregates once they're computed (the runner computes them late).
+store.finalizeRun(runId, { rowCount, metrics });
+store.close();
+```
+
+```sh
+# Boot the explorer over a store (defaults: --port 8788).
+npx eleatic serve --db eval.sqlite --port 8788
+# Optional: --config <path> to an eleatic config JSON (metric registry, gates).
+```
+
+Human adjudication (`store.recordAdjudication({ rowKey, verdict, … })`) upserts a
+verdict keyed on the item; the explorer round-trips it through the UI.
+
+## Build / test
+
+```sh
+npm run build --workspace @bird-watch/eleatic   # tsc → dist/, then copies ui/ → dist/ui/
+npm run test  --workspace @bird-watch/eleatic   # vitest (incl. the zero-coupling guard)
+```
+
+`tsc` only emits from `rootDir: src`; the `build` script appends a portable
+`cpSync('ui','dist/ui')` so `eleatic serve` can serve the explorer's static
+assets from the published package (`build-output.test.ts` asserts the copy ran).
+
+## Abstraction-readiness checklist
+
+`eleatic` is built to leave the monorepo whole. When the extraction is triggered
+(a Julian-initiated `git mv packages/eleatic → its own repo`), this is the
+cold-start brief — **not executed now**:
+
+1. **Inline the tsconfig base.** `tsconfig.json` is the only sanctioned
+   file-system coupling: it `extends "../../tsconfig.base.json"`. Replace that
+   line with the resolved `compilerOptions` inline:
+
+   ```jsonc
+   {
+     "compilerOptions": {
+       "target": "ES2022",
+       "module": "ES2022",
+       "moduleResolution": "Bundler",
+       "esModuleInterop": true,
+       "skipLibCheck": true,
+       "strict": true,
+       "noUncheckedIndexedAccess": true,
+       "exactOptionalPropertyTypes": true,
+       "noImplicitOverride": true,
+       "declaration": true,
+       "declarationMap": true,
+       "sourceMap": true,
+       "resolveJsonModule": true,
+       "lib": ["ES2022"],
+       "rootDir": "src",
+       "outDir": "dist"
+     },
+     "include": ["src/**/*.ts"],
+     "exclude": ["src/**/*.test.ts"]
+   }
+   ```
+
+   (`rootDir`/`outDir` already live in the local `compilerOptions`; the rest are
+   the inherited base, copied verbatim.)
+2. **Rename the package.** `@bird-watch/eleatic` → the published name; drop
+   `"private": true` and set a real `version`.
+3. **Repoint the consumer.** `tools/photo-curation/package.json` depends on
+   `"@bird-watch/eleatic": "*"` (workspace glob). Change it to the
+   versioned/published dep (`"eleatic": "^x.y.z"` under its new name), and update
+   the imports in `tools/photo-curation/src/eval/eleatic-adapter.ts`.
+4. **Drop the monorepo knip entry.** Remove the `'packages/eleatic'` block from
+   the root `knip.ts` (the `ui/*.js` runtime-resolved-specifier ignores travel
+   into the new repo's own knip config).
+5. **The guard travels with the package.** `src/no-coupling.test.ts` is
+   self-contained (pure `node:fs`, scans `{src,ui}` + `package.json`) — it ships
+   unchanged and keeps the one-way boundary honest in the new repo too.
+
+## End-to-end verification
+
+A run-once recipe that exercises the whole eleatic surface against a real
+photo-judge eval. Needs a prod `DATABASE_URL` (read-only suffices), a
+`GEMINI_API_KEY`, and a thumbnail cache — run by a maintainer, not in CI. Env
+var names match `tools/photo-curation/scripts/run-eval-local.ts` and
+`analyze-experiment.ts`; reconcile against those scripts if a knob moves.
+
+```sh
+# 1. Build the package and assert the explorer's static assets were copied.
+npm ci
+npm run build -w @bird-watch/eleatic
+test -f packages/eleatic/dist/ui/index.html   # build copied ui/ → dist/ui/
+
+# 2. Run a photo-judge eval that writes the eleatic store (eval.sqlite).
+#    REVIEW_DB  — the local review.sqlite (dataset source: photo_current/photo_score)
+#    THUMB_DIR  — the local thumbnail cache the judge reads images from
+#    DATABASE_URL — prod, read-only (the frozen Opus baseline)
+#    GEMINI_API_KEY — the judge under test
+#    EVAL_DB    — the eleatic store this run writes (the analyzer reads it back)
+#    --first N  — optional smoke cap (e.g. --first 5) for a fast pass
+REVIEW_DB=tools/photo-curation/review.sqlite \
+THUMB_DIR=tools/photo-curation/thumbs \
+EVAL_DB=tools/photo-curation/eval.sqlite \
+DATABASE_URL=postgres://… \
+GEMINI_API_KEY=… \
+npm run eval -w @bird-watch/photo-curation -- --first 5
+#    → prints `eval run <run-id> (<n> rows) written to tools/photo-curation/eval.sqlite`
+
+# 3. Open the explorer over that store and walk every surface.
+npx eleatic serve --db tools/photo-curation/eval.sqlite --port 8788
+#    In the browser at http://localhost:8788 verify, with zero console errors:
+#      • the hub lists the run(s) with their metrics
+#      • a cross-run diff (pick two runs, inspect the per-row diff)
+#      • a facet gallery (filter/sort by a facet, e.g. keep-disagreements)
+#      • a per-row judgment drill-down (output vs expected, criteria, tokens/cost)
+#      • a human-adjudication round-trip (record a verdict, reload, confirm it persisted)
+
+# 4. Re-derive the dataset-level diagnostics from the same eleatic store.
+#    EVAL_DB points the analyzer at the store step 2 wrote (defaults ./eval.sqlite);
+#    the run-id is the first positional, `--band lo:hi` optional (default 40:70).
+EVAL_DB=tools/photo-curation/eval.sqlite \
+npm run analyze -w @bird-watch/photo-curation -- <run-id>
+```

--- a/packages/eleatic/src/no-coupling.test.ts
+++ b/packages/eleatic/src/no-coupling.test.ts
@@ -5,14 +5,18 @@ import { fileURLToPath } from 'node:url';
 
 /**
  * Zero-coupling guard: eleatic must contain NO `@bird-watch/*` import and no
- * `../../`-escaping relative import anywhere under {src,ui}. That one-way
+ * `../../`-escaping relative import anywhere under {src,ui}, and its
+ * package.json must declare NO `@bird-watch/*` dependency. That one-way
  * boundary (tools/photo-curation -> eleatic, never the reverse, and no monorepo
  * imports) is what lets the package `git mv` cleanly to its own repo later.
  *
- * Minimal by design — E9 owns the full CI step + abstraction-readiness checklist.
- * The single `extends "../../tsconfig.base.json"` line is the only sanctioned
- * file-system coupling and lives in tsconfig.json (a JSON config, not scanned
- * here); E9 tracks inlining it on extraction.
+ * E9 (#1152) extends the original E1 guard to also assert the package.json
+ * dependency surface (manifest coupling, not just source-level imports) and
+ * pins the recursive scan to `readdirSync` (the `recursive` option needs
+ * Node >= 18.17/20 — satisfied by the repo `engines.node` >= 20). The single
+ * `extends "../../tsconfig.base.json"` line is the only sanctioned file-system
+ * coupling and lives in tsconfig.json (a JSON config, not scanned here); the
+ * README's abstraction-readiness checklist tracks inlining it on extraction.
  */
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -56,6 +60,31 @@ describe('zero-coupling guard', () => {
 
   it('no source file uses a ../../-escaping relative import', () => {
     const offenders = files.filter((f) => ESCAPING_RELATIVE.test(readFileSync(f, 'utf8')));
+    expect(offenders).toEqual([]);
+  });
+
+  it('package.json declares no @bird-watch/* dependency in any dep group', () => {
+    // Manifest-level coupling is invisible to the source scan above: a
+    // `@bird-watch/*` entry in dependencies/devDependencies/peer/optional would
+    // tie the package to the monorepo even with zero import statements. Scan
+    // every dependency group so the package stays publishable standalone.
+    const pkg = JSON.parse(readFileSync(join(PKG_ROOT, 'package.json'), 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    const DEP_GROUPS = [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ];
+    const offenders = DEP_GROUPS.flatMap((group) => {
+      const deps = pkg[group];
+      if (deps === null || typeof deps !== 'object') return [];
+      return Object.keys(deps as Record<string, unknown>)
+        .filter((name) => name.startsWith('@bird-watch/'))
+        .map((name) => `${group}.${name}`);
+    });
     expect(offenders).toEqual([]);
   });
 });

--- a/tools/photo-curation/scripts/run-eval-local.test.ts
+++ b/tools/photo-curation/scripts/run-eval-local.test.ts
@@ -1,17 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import type Database from 'better-sqlite3';
 import { makeReader, openStore, type EleaticStore } from '../src/eval/eleatic-adapter.js';
-import { openDb } from '../src/db.js';
 import { instrumentedJudge, type JudgmentSink } from '../src/judges/instrumented.js';
 import { runEvalLocal, type RunEvalDeps } from './run-eval-local.js';
 import type { EvalRow } from '../src/eval/build-dataset.js';
 import type { ImageInput, SpeciesContext, JudgeOutput, VisionJudge } from '@bird-watch/photo-quality';
 
-let db: Database.Database | undefined;
 let eleatic: EleaticStore | undefined;
 afterEach(() => {
-  db?.close();
-  db = undefined;
   eleatic?.close();
   eleatic = undefined;
 });
@@ -65,7 +60,7 @@ function fakeJudge(sink: JudgmentSink, decide: (code: string) => { keep: boolean
 }
 
 /** Deps with a fake readImage (no fs) and a judge factory closing over `decide`. */
-function makeDeps(decide: (code: string) => { keep: boolean; quality: number }): Omit<RunEvalDeps, 'db' | 'rows' | 'eleatic'> {
+function makeDeps(decide: (code: string) => { keep: boolean; quality: number }): Omit<RunEvalDeps, 'rows' | 'eleatic'> {
   return {
     runId: 'run-test-1',
     model: 'gemini-2.5-flash',
@@ -81,7 +76,6 @@ function makeDeps(decide: (code: string) => { keep: boolean; quality: number }):
 
 describe('runEvalLocal', () => {
   it('writes one eleatic eval row per row + one run header with FRACTION-form aggregates', async () => {
-    db = openDb(':memory:');
     eleatic = openStore(':memory:');
     // 5 rows. Baseline keeps the first 4, replaces the 5th. The judge AGREES on
     // 4 of 5 (it flips only the last). Per the #1094 unit contract, agreement
@@ -101,7 +95,7 @@ describe('runEvalLocal', () => {
         ? { keep: false, quality: 80 } // DISAGREES (baseline keeps, judge replaces) → falseReplace
         : { keep: true, quality: 80 }; // agrees (both keep), exact score
 
-    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
 
     const reader = makeReader(eleatic.db);
     expect(reader.getRows('run-test-1')).toHaveLength(5);
@@ -123,7 +117,6 @@ describe('runEvalLocal', () => {
   });
 
   it('writes the eleatic store: run metrics as FRACTIONS + per-row disagreement', async () => {
-    db = openDb(':memory:');
     eleatic = openStore(':memory:');
     const rows: EvalRow[] = [
       evalRow({ speciesCode: 'sp1', expectedKeep: true, expectedQuality: 80 }),
@@ -141,7 +134,7 @@ describe('runEvalLocal', () => {
         ? { keep: false, quality: 20 } // agrees (both replace)
         : { keep: true, quality: 80 }; // agrees (both keep)
 
-    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
 
     // The eleatic store holds the rows + run header. Read it back via the reader.
     const reader = makeReader(eleatic.db);
@@ -165,12 +158,11 @@ describe('runEvalLocal', () => {
   });
 
   it('joins each row with the Opus baseline + the judge output + cost/tokens', async () => {
-    db = openDb(':memory:');
     eleatic = openStore(':memory:');
     const rows: EvalRow[] = [evalRow({ speciesCode: 'amerob', expectedKeep: true, expectedQuality: 85 })];
     const decide = () => ({ keep: false, quality: 60 });
 
-    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
 
     const r = makeReader(eleatic.db).getRow('run-test-1', 'amerob');
     expect(r).toBeDefined();
@@ -192,7 +184,6 @@ describe('runEvalLocal', () => {
   });
 
   it('computes falseKeep (judge keeps what baseline replaces) and total cost', async () => {
-    db = openDb(':memory:');
     eleatic = openStore(':memory:');
     const rows: EvalRow[] = [
       evalRow({ speciesCode: 'a', expectedKeep: false, expectedQuality: 20 }),
@@ -201,7 +192,7 @@ describe('runEvalLocal', () => {
     // Judge keeps BOTH → 2 falseKeep, 0 agreement.
     const decide = () => ({ keep: true, quality: 90 });
 
-    await runEvalLocal({ db, eleatic, rows, ...makeDeps(decide) });
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
 
     const reader = makeReader(eleatic.db);
     const run = reader.getRun('run-test-1')!;
@@ -215,7 +206,6 @@ describe('runEvalLocal', () => {
   });
 
   it('runs rows SERIALLY (never concurrently)', async () => {
-    db = openDb(':memory:');
     eleatic = openStore(':memory:');
     const rows: EvalRow[] = [
       evalRow({ speciesCode: 's1', expectedKeep: true, expectedQuality: 80 }),
@@ -239,7 +229,7 @@ describe('runEvalLocal', () => {
       };
     };
 
-    await runEvalLocal({ db, eleatic, rows, ...deps, makeJudge: slowJudge });
+    await runEvalLocal({ eleatic, rows, ...deps, makeJudge: slowJudge });
 
     // Serial execution never has more than one judgment in flight at a time.
     expect(maxInFlight).toBe(1);

--- a/tools/photo-curation/scripts/run-eval-local.ts
+++ b/tools/photo-curation/scripts/run-eval-local.ts
@@ -38,7 +38,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { readFileSync } from 'node:fs';
-import type Database from 'better-sqlite3';
 import type { ImageInput, VisionJudge } from '@bird-watch/photo-quality';
 import { createPool, closePool, getPhotoScores } from '@bird-watch/db-client';
 import { openDb } from '../src/db.js';
@@ -59,15 +58,14 @@ import { judgePromptForRubricVersion, resolveEvalModel } from '../eval/rubric-pr
 /** The injected collaborators `runEvalLocal` needs — all fakeable in tests. */
 export interface RunEvalDeps {
   /**
-   * The open review store — used only to BUILD the dataset (`buildEvalRows`
-   * reads `photo_current`/`photo_score`). The runner no longer writes eval
-   * results here; the eval store is `eleatic` below (E8, #1151).
-   */
-  db: Database.Database;
-  /**
    * The open eleatic store the run writes each eval row + the run header to —
    * the SOLE eval store (E7/E8, #1150/#1151). Written via the eleatic-adapter.
    * `:memory:` in tests.
+   *
+   * NOTE: the review-store handle (`db`) is no longer a dep — `runEvalLocal`
+   * never touched it after the eval write moved entirely to eleatic (E8, #1151).
+   * `main` still opens the review store locally to BUILD the dataset
+   * (`buildEvalRows`), but that handle is not handed to `runEvalLocal`.
    */
   eleatic: EleaticStore;
   /** The dataset rows (built from the pinned baseline, hash-verified). */
@@ -295,7 +293,6 @@ async function main(argv: string[]): Promise<void> {
     // The judge is built ONCE around the run's sink (a single shared Pacer — see
     // gemini.ts; one per row would reset the GEMINI_PACE_MS gate, #1015 review).
     await runEvalLocal({
-      db,
       eleatic,
       rows,
       runId,


### PR DESCRIPTION
## Diagrams

The zero-coupling guard now asserts the package's coupling surface at three levels (E9 adds the third); the README documents the extraction path that triple-assertion protects.

```mermaid
flowchart TD
    subgraph guard["packages/eleatic/src/no-coupling.test.ts (CI test gate)"]
        A["scan src/ + ui/ files"] --> B["no @bird-watch/* import"]
        A --> C["no ../../-escaping relative import"]
        D["read package.json"] --> E["no @bird-watch/* in any dep group<br/>(NEW — E9)"]
    end
    guard --> F["one-way boundary holds:<br/>tools/photo-curation → eleatic, never reverse"]
    F --> G["README: git mv packages/eleatic → own repo<br/>(abstraction-readiness checklist + E2E recipe)"]
```

## Summary

- **Why:** E9 is the final eleatic child — it locks the one-way dependency invariant so the package can `git mv` to its own repo cleanly, and ships the cold-start brief + run-once verification recipe a future extraction needs.
- **Guard hardened (TDD):** the E1 source-import guard now also asserts `packages/eleatic/package.json` declares no `@bird-watch/*` in `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` — manifest coupling was invisible to the source scan. Proven by a red-phase injection (a temp `@bird-watch/db-client` devDep was caught with the exact offender name, then reverted). Stays the committed, in-CI `test`-gate guard; no new workflow.
- **README created:** `packages/eleatic/README.md` (the package had none) — what eleatic is, a minimal `openStore`/`recordRun`/`recordRow`/`finalizeRun` + `eleatic serve` usage block, an **Abstraction-readiness checklist** (inline the `tsconfig.base.json` extends, rename the package, repoint photo-curation's dep, drop the monorepo knip entry, guard travels with the package), and an **End-to-end verification** run-once recipe with the real env var names from `run-eval-local.ts` / `analyze-experiment.ts` (`REVIEW_DB`, `THUMB_DIR`, `DATABASE_URL`, `GEMINI_API_KEY`, `EVAL_DB`, `--first N`); step 4's `npm run analyze` carries the `EVAL_DB=` prefix so a verbatim paste does not hit the store-env guard.
- **Vestigial field removed:** `RunEvalDeps.db` in `tools/photo-curation/scripts/run-eval-local.ts` — `runEvalLocal` never read it after the eval write moved fully to the eleatic store (E8); dropped the field, the `main` call-site arg, and the five test opens/spreads. `main` still opens the review store locally for `buildEvalRows`.

## Screenshots

N/A — packages/ guard test + docs.

## Test plan

- [x] `npm run build && npm test` — green (`npm test --workspaces` exit 0; eleatic 18/18 files 172 tests, photo-curation 26/26 files 363 tests)
- [x] New unit tests added — the 4th zero-coupling assertion (package.json dep scan); red-phase proven
- [x] No Playwright e2e (no user-visible behavior changed)
- [x] `npm run build` — clean production build
- [x] `npm run lint` — green; `npx knip --no-progress` — exit 0

## Plan reference

Closes #1152. Part of epic #1153 (eleatic), Wave 5 (final child E9). Plan lives in the issue per the repo convention (plans-in-issues).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
