### PR TITLE
feat(api,frontend): scope the species filter combobox to represented species (closes #1164)

### DIFF
--- a/frontend/e2e/deep-link.spec.ts
+++ b/frontend/e2e/deep-link.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, VERMFLY_OBS } from './fixtures.js';
+import { test, expect, VERMFLY_OBS, SPECIES_DICT_FIXTURE } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 // `exact: true` mandatory on every getByLabel filter locator — see
@@ -33,13 +33,13 @@ test.describe('deep-link restore', () => {
   });
 
   test('species param shows common name in input', async ({ page, apiStub }) => {
-    // /api/observations returns aggregated buckets at low zoom (#627) — the
-    // default cold-start fetch (CONUS bbox + zoom=3) hits aggregated mode,
-    // which carries no per-observation rows at all (#859 moved species
-    // aggregation server-side and removed the synthetic-observation expansion
-    // the frontend used to fabricate). Stub a real observation so the
-    // speciesIndex contains "Vermilion Flycatcher" → "vermfly".
+    // #species: the FiltersBar combobox is sourced from /api/species-in-scope
+    // (the represented-species set). Stub it so the deep-linked `?species=vermfly`
+    // resolves "Vermilion Flycatcher" in the field deterministically (the active
+    // species is also unioned in from the dictionary as a fallback, but stubbing
+    // the scope source keeps this hermetic). stubObservations feeds the map.
     await apiStub.stubObservations(VERMFLY_OBS);
+    await apiStub.stubSpeciesInScope(SPECIES_DICT_FIXTURE);
     const app = new AppPage(page);
     await app.goto('species=vermfly');
     await app.waitForAppReady();

--- a/frontend/e2e/filters-card-sheet-boundary.spec.ts
+++ b/frontend/e2e/filters-card-sheet-boundary.spec.ts
@@ -39,6 +39,7 @@ test.describe('F2 #1062 — filters card↔sheet boundary at ≤480', () => {
     // Hermetic stubs — mirror filters.spec.ts so the typeahead/datalist never
     // touch the seeded DB.
     await apiStub.stubObservations(VERMFLY_OBS);
+    await apiStub.stubSpeciesInScope(SPECIES_DICT_FIXTURE);
     await apiStub.stubSpeciesDictionary(SPECIES_DICT_FIXTURE);
     app = new AppPage(page);
     await app.goto();

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -13,10 +13,13 @@ test.describe('filter flows', () => {
     // per-observation payload to resolve "Vermilion Flycatcher" → "vermfly";
     // stub before navigation.
     await apiStub.stubObservations(VERMFLY_OBS);
-    // D2 (#1050): the FiltersBar species index is now dictionary-backed (bare
-    // GET /api/species). Stub it so the datalist + typeahead stay hermetic —
-    // without it these specs would silently hit the live seeded DB. The one
-    // fixture row resolves "Vermilion Flycatcher" → "vermfly".
+    // #species: the FiltersBar species combobox is now sourced from
+    // GET /api/species-in-scope (the represented-species set), NOT the bare
+    // /api/species dictionary. Stub it so the datalist + typeahead stay
+    // hermetic — the fixture rows resolve "Vermilion Flycatcher" → "vermfly".
+    // The dictionary stub stays for the popover/deep-link name resolution that
+    // still reads it.
+    await apiStub.stubSpeciesInScope(SPECIES_DICT_FIXTURE);
     await apiStub.stubSpeciesDictionary(SPECIES_DICT_FIXTURE);
     app = new AppPage(page);
     await app.goto();

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -12,7 +12,7 @@ import type {
  * (`GET /api/states`) — adding it here makes `stubApiFailure('states', …)` /
  * `stubApiAbort('states')` typecheck for the #741 fetch-error case.
  */
-export type StubbableEndpoint = 'hotspots' | 'observations' | 'species' | 'silhouettes' | 'states';
+export type StubbableEndpoint = 'hotspots' | 'observations' | 'species' | 'species-in-scope' | 'silhouettes' | 'states';
 
 /**
  * Canonical Vermilion Flycatcher SpeciesMeta fixture (NO photoUrl) — exercises
@@ -175,6 +175,16 @@ export interface ApiStub {
    */
   stubSpeciesDictionary(entries?: SpeciesDictEntry[]): Promise<void>;
   /**
+   * #species — stubs `GET /api/species-in-scope` (the represented-species
+   * combobox source) to return `200` with the provided rows (default
+   * `SPECIES_DICT_FIXTURE`, same `{code,comName,familyCode}` shape). Matched by a
+   * URL PREDICATE (pathname ending in `/api/species-in-scope`) so it never
+   * collides with the bare `/api/species` dictionary stub or the
+   * `/api/species/{code}` detail route. Every spec exercising the species
+   * typeahead must register this — the datalist is sourced from this endpoint.
+   */
+  stubSpeciesInScope(entries?: SpeciesDictEntry[]): Promise<void>;
+  /**
    * #847 — state-aware, bbox-intersecting `/api/observations` stub. Models the
    * server's `stateCode AND bbox` clip (packages/db-client/src/observations.ts:
    * 184): it parses `state` and `bbox=[w,s,e,n]` off the request URL and returns
@@ -273,6 +283,21 @@ export const test = base.extend<{ apiStub: ApiStub }>({
         // dev-server. A `**/api/species**` glob would wrongly capture both.
         await page.route(
           (url) => url.pathname.endsWith('/api/species'),
+          async route => {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(entries),
+            });
+          },
+        );
+      },
+      async stubSpeciesInScope(entries = SPECIES_DICT_FIXTURE) {
+        // URL PREDICATE: match ONLY `/api/species-in-scope`. This does NOT end
+        // with `/api/species`, so the dictionary stub's predicate never captures
+        // it (and vice-versa); both can be registered side-by-side.
+        await page.route(
+          (url) => url.pathname.endsWith('/api/species-in-scope'),
           async route => {
             await route.fulfill({
               status: 200,

--- a/frontend/e2e/species-detail.spec.ts
+++ b/frontend/e2e/species-detail.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, VERMFLY, VERMFLY_OBS, VERMFLY_WITH_PHOTO } from './fixtures.js';
+import { test, expect, VERMFLY, VERMFLY_OBS, VERMFLY_WITH_PHOTO, SPECIES_DICT_FIXTURE } from './fixtures.js';
 import { AppPage } from './pages/app-page.js';
 
 /**
@@ -53,6 +53,9 @@ test.describe('species detail surface (#151)', () => {
     // pairs, so it needs a real-species observation stubbed in to resolve
     // "Vermilion Flycatcher" → "vermfly".
     await apiStub.stubObservations(VERMFLY_OBS);
+    // #species: the combobox datalist is sourced from /api/species-in-scope —
+    // stub it so the typeahead is hermetic and "Vermilion Flycatcher" is offered.
+    await apiStub.stubSpeciesInScope(SPECIES_DICT_FIXTURE);
     const app = new AppPage(page);
     await app.goto('scope=us');
     await app.waitForAppReady();

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -273,6 +273,11 @@ vi.mock('./api/client.js', async () => {
       // dictionary only affects low-zoom popover NAME resolution, which these
       // scope/legend/lede tests don't assert on.
       getSpeciesDictionary = vi.fn().mockResolvedValue([]);
+      // #species: App mounts useSpeciesInScope → client.getSpeciesInScope to
+      // source the FiltersBar combobox. Stub it (empty represented set) so the
+      // hook doesn't throw; these scope/legend/lede tests don't assert on the
+      // species combobox contents.
+      getSpeciesInScope = vi.fn().mockResolvedValue([]);
     },
   };
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import type { ScopeResolution } from './state/scope-types.js';
 import { useBirdData } from './data/use-bird-data.js';
 import { useSilhouettes } from './data/use-silhouettes.js';
 import { useSpeciesDictionary } from './data/use-species-dictionary.js';
+import { useSpeciesInScope, type SpeciesScopeFilters } from './data/use-species-in-scope.js';
 import { useStates } from './data/use-states.js';
 import {
   familyCountsFromBuckets,
@@ -908,22 +909,49 @@ export function App() {
   // correctly: defer the no-match verdict while loading (a verdict against a
   // not-yet-populated index would be a false hint), and surface a fetch-error
   // outcome on error — both honoring the "never silent" contract.
-  const {
-    dictionary,
-    loading: dictionaryLoading,
-    error: dictionaryError,
-  } = useSpeciesDictionary(apiClient);
+  // The dictionary still resolves bucket/popover/deep-link species CODES → names
+  // (threaded to MapSurface below). It is NO LONGER the Species combobox source:
+  // its loading/error are unused here now (the combobox sources from
+  // useSpeciesInScope instead — see below).
+  const { dictionary } = useSpeciesDictionary(apiClient);
 
-  // Dictionary-backed Species filter index: `{ code, comName }` per entry,
-  // common-name-sorted to match the prior observation-derived ordering. Memoized
-  // on the dictionary identity (stable once resolved, per the hook's tab cache).
+  // Species combobox source filters: the SAME non-species filters the map fetch
+  // uses, MINUS speciesCode/bbox/zoom. Species is omitted so the combobox keeps
+  // offering every sibling while one is active (no self-narrowing); bbox/zoom are
+  // omitted so the list is the whole scope's species at any zoom. `stateCode` is
+  // sent ONLY for a state scope (whole-US sends none → national species set).
+  const speciesScopeFilters = useMemo<SpeciesScopeFilters>(() => {
+    const f: SpeciesScopeFilters = { since: state.since };
+    if (state.notable) f.notable = true;
+    if (state.familyCode) f.familyCode = state.familyCode;
+    if (scopeStateCode) f.stateCode = scopeStateCode;
+    return f;
+  }, [state.since, state.notable, state.familyCode, scopeStateCode]);
+
+  // The represented-species index backing the FiltersBar combobox (#species —
+  // "only show species that are represented"). Gated on `scopeActive`: while
+  // unscoped the combobox is not in use, so no fetch fires.
+  const {
+    speciesIndex: scopedSpeciesIndex,
+    loading: speciesIndexLoading,
+    error: speciesIndexError,
+  } = useSpeciesInScope(apiClient, speciesScopeFilters, scopeActive);
+
+  // Keep an actively-filtered species selectable even if it has zero current
+  // sightings in scope (e.g. a `?species=` deep link to a bird not observed in
+  // the last 14d): the scoped list would omit it, leaving the field blank and
+  // the user unable to read/clear what they filtered to. Union it in, resolving
+  // its name from the dictionary, so the field always shows the active species.
   const speciesIndex = useMemo<SpeciesOption[]>(() => {
-    const opts: SpeciesOption[] = [];
-    for (const [code, { comName, familyCode }] of dictionary) {
-      opts.push({ code, comName, familyCode });
-    }
-    return opts.sort((a, b) => a.comName.localeCompare(b.comName));
-  }, [dictionary]);
+    if (!state.speciesCode) return scopedSpeciesIndex;
+    if (scopedSpeciesIndex.some(s => s.code === state.speciesCode)) return scopedSpeciesIndex;
+    const meta = dictionary.get(state.speciesCode);
+    if (!meta) return scopedSpeciesIndex;
+    return [
+      ...scopedSpeciesIndex,
+      { code: state.speciesCode, comName: meta.comName, familyCode: meta.familyCode },
+    ].sort((a, b) => a.comName.localeCompare(b.comName));
+  }, [scopedSpeciesIndex, state.speciesCode, dictionary]);
 
   // Active species meta for the detail view (issue #327 task-11). The
   // hook fires only when state.view === 'detail' AND state.detail is set
@@ -1394,8 +1422,8 @@ export function App() {
               familyCode={state.familyCode}
               families={families}
               speciesIndex={speciesIndex}
-              speciesIndexLoading={dictionaryLoading}
-              speciesIndexError={dictionaryError !== null}
+              speciesIndexLoading={speciesIndexLoading}
+              speciesIndexError={speciesIndexError !== null}
               onChange={set}
             />
           </div>

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -293,6 +293,42 @@ describe('ApiClient', () => {
     expect(rows[0]).toEqual({ code: 'norcar', comName: 'Northern Cardinal', familyCode: 'cardinalidae' });
   });
 
+  it('fetches represented species from GET /api/species-in-scope with the non-species filters only', async () => {
+    const rows = JSON.stringify([
+      { code: 'norcar', comName: 'Northern Cardinal', familyCode: 'cardinalidae' },
+    ]);
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(rows, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    const out = await client.getSpeciesInScope({
+      since: '14d', notable: true, familyCode: 'cardinalidae', stateCode: 'US-AZ',
+      // speciesCode/bbox/zoom MUST be ignored even if a caller passes them.
+      speciesCode: 'norcar', bbox: [-112, 31, -110, 33], zoom: 3,
+    });
+    const call = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]!;
+    const url = call[0];
+    expect(url).toContain('/api/species-in-scope');
+    expect(url).toContain('since=14d');
+    expect(url).toContain('notable=true');
+    expect(url).toContain('family=cardinalidae');
+    expect(url).toContain('state=US-AZ');
+    // The combobox source must be species/bbox/zoom-INDEPENDENT.
+    expect(url).not.toContain('species=');
+    expect(url).not.toContain('bbox=');
+    expect(url).not.toContain('zoom=');
+    expect(out).toEqual([{ code: 'norcar', comName: 'Northern Cardinal', familyCode: 'cardinalidae' }]);
+  });
+
+  it('omits absent filters from the /api/species-in-scope query', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('[]', { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getSpeciesInScope({ since: '14d' });
+    const url = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]![0];
+    expect(url).toContain('since=14d');
+    expect(url).not.toContain('notable=');
+    expect(url).not.toContain('family=');
+    expect(url).not.toContain('state=');
+  });
+
   it('throws on non-2xx response', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
     const client = new ApiClient({ baseUrl: '' });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -169,6 +169,25 @@ export class ApiClient {
     return this.get<SpeciesDictEntry[]>('/api/species');
   }
 
+  // The distinct species REPRESENTED in the current scope — the source for the
+  // FiltersBar Species combobox (replaces the full ~17.8k global dictionary as
+  // the candidate list). Sends ONLY the non-species, non-viewport filters:
+  // `species`/`bbox`/`zoom` are deliberately NOT forwarded even if present on
+  // the filter object, so the combobox keeps offering every sibling species
+  // while one is active (no self-narrowing) and stays the same complete list at
+  // any zoom. Same `{code,comName,familyCode}` shape as the dictionary; plain
+  // idempotent GET (CDN/browser-cached — no in-flight dedup needed).
+  getSpeciesInScope(
+    f: Pick<ObservationFilters, 'since' | 'notable' | 'familyCode' | 'stateCode'> = {},
+  ): Promise<SpeciesDictEntry[]> {
+    const url = new URL('/api/species-in-scope', 'http://x');
+    if (f.since) url.searchParams.set('since', f.since);
+    if (f.notable === true) url.searchParams.set('notable', 'true');
+    if (f.familyCode) url.searchParams.set('family', f.familyCode);
+    if (f.stateCode) url.searchParams.set('state', f.stateCode);
+    return this.get<SpeciesDictEntry[]>(url.pathname + url.search);
+  }
+
   getSilhouettes(): Promise<FamilySilhouette[]> {
     return this.get<FamilySilhouette[]>('/api/silhouettes');
   }

--- a/frontend/src/data/use-species-in-scope.test.tsx
+++ b/frontend/src/data/use-species-in-scope.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSpeciesInScope } from './use-species-in-scope.js';
+import { ApiClient } from '../api/client.js';
+
+function makeClient(getSpeciesInScope: unknown): ApiClient {
+  return Object.assign(new ApiClient(), { getSpeciesInScope });
+}
+
+const ROWS = [
+  { code: 'annhum', comName: "Anna's Hummingbird", familyCode: 'trochilidae' },
+  { code: 'vermfly', comName: 'Vermilion Flycatcher', familyCode: 'tyrannidae' },
+];
+
+describe('useSpeciesInScope', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the represented species and exposes them as SpeciesOption[]', async () => {
+    const getSpeciesInScope = vi.fn().mockResolvedValue(ROWS);
+    const client = makeClient(getSpeciesInScope);
+
+    const { result } = renderHook(() =>
+      useSpeciesInScope(client, { since: '14d' }, true),
+    );
+    expect(result.current.loading).toBe(true);
+    expect(result.current.speciesIndex).toEqual([]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.speciesIndex).toEqual([
+      { code: 'annhum', comName: "Anna's Hummingbird", familyCode: 'trochilidae' },
+      { code: 'vermfly', comName: 'Vermilion Flycatcher', familyCode: 'tyrannidae' },
+    ]);
+    expect(getSpeciesInScope).toHaveBeenCalledWith({ since: '14d' });
+  });
+
+  it('does NOT fetch (and reports not-loading) while disabled (unscoped landing)', async () => {
+    const getSpeciesInScope = vi.fn().mockResolvedValue(ROWS);
+    const client = makeClient(getSpeciesInScope);
+    const { result } = renderHook(() =>
+      useSpeciesInScope(client, { since: '14d' }, false),
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.speciesIndex).toEqual([]);
+    expect(getSpeciesInScope).not.toHaveBeenCalled();
+  });
+
+  it('refetches when a scalar filter value changes (family)', async () => {
+    const getSpeciesInScope = vi
+      .fn()
+      .mockResolvedValueOnce(ROWS)
+      .mockResolvedValueOnce([ROWS[1]]); // family-narrowed to tyrannidae
+    const client = makeClient(getSpeciesInScope);
+
+    const { result, rerender } = renderHook(
+      ({ family }: { family?: string }) =>
+        useSpeciesInScope(
+          client,
+          family ? { since: '14d', familyCode: family } : { since: '14d' },
+          true,
+        ),
+      { initialProps: {} as { family?: string } },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.speciesIndex).toHaveLength(2);
+
+    rerender({ family: 'tyrannidae' });
+    await waitFor(() => expect(result.current.speciesIndex).toHaveLength(1));
+    expect(result.current.speciesIndex[0]!.code).toBe('vermfly');
+    expect(getSpeciesInScope).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT refetch when given a fresh identical filter object (scalar-keyed)', async () => {
+    const getSpeciesInScope = vi.fn().mockResolvedValue(ROWS);
+    const client = makeClient(getSpeciesInScope);
+    const { result, rerender } = renderHook(() =>
+      // New object literal every render — same VALUES.
+      useSpeciesInScope(client, { since: '14d', notable: false }, true),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    rerender();
+    rerender();
+    expect(getSpeciesInScope).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a fetch error without throwing', async () => {
+    const getSpeciesInScope = vi.fn().mockRejectedValue(new Error('scope 503'));
+    const client = makeClient(getSpeciesInScope);
+    const { result } = renderHook(() =>
+      useSpeciesInScope(client, { since: '14d' }, true),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error?.message).toBe('scope 503');
+    expect(result.current.speciesIndex).toEqual([]);
+  });
+});

--- a/frontend/src/data/use-species-in-scope.ts
+++ b/frontend/src/data/use-species-in-scope.ts
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import type { ApiClient } from '../api/client.js';
+import type { ObservationFilters, SpeciesDictEntry } from '@bird-watch/shared-types';
+import type { SpeciesOption } from '../components/FiltersBar.js';
+
+/**
+ * Represented-species hook — the source for the FiltersBar Species combobox.
+ *
+ * Loads `GET /api/species-in-scope` for the active scope's non-species filters
+ * (since / notable / family / state) and exposes the result as the
+ * `SpeciesOption[]` the combobox `<datalist>` renders. This REPLACES the #1050
+ * dictionary-backed index (the full ~17.8k global taxonomy) with the species
+ * actually represented on the map for the current scope+filters — so the user
+ * only sees birds they can find, and picking a family narrows the list to that
+ * family's represented species server-side.
+ *
+ * Why a dedicated endpoint (not derived from the loaded observations/buckets):
+ *  - The endpoint is species-filter-INDEPENDENT, so the list does NOT collapse
+ *    to a single entry once a species is selected (the self-narrowing trap the
+ *    #1050 family-options fix avoids by sourcing from the stable catalogue).
+ *  - It is bbox/zoom-INDEPENDENT, so the list is complete at any zoom — the
+ *    low-zoom aggregated buckets carry only each family's top species, which
+ *    would otherwise hide rarer ones at the country view.
+ *
+ * Keyed on the scalar filter values (NOT object identity): a new identical
+ * filter object each render must NOT refetch. Gated on `enabled` — while the
+ * scope is `unscoped` (the chooser landing) the combobox is not in use, so the
+ * hook fires no request and reports `loading: false` (mirrors `useBirdData`).
+ *
+ * Tolerate-not-loaded: `speciesIndex` is ALWAYS an array (empty until resolved),
+ * never undefined. `error` is surfaced (FiltersBar renders the never-silent
+ * "could not load the species list" alert) but never thrown.
+ */
+
+export type SpeciesScopeFilters = Pick<
+  ObservationFilters,
+  'since' | 'notable' | 'familyCode' | 'stateCode'
+>;
+
+export interface SpeciesInScopeState {
+  speciesIndex: SpeciesOption[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useSpeciesInScope(
+  client: ApiClient,
+  filters: SpeciesScopeFilters,
+  enabled: boolean = true,
+): SpeciesInScopeState {
+  const [speciesIndex, setSpeciesIndex] = useState<SpeciesOption[]>([]);
+  const [loading, setLoading] = useState<boolean>(enabled);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Scalar keys so the effect re-runs on VALUE change, not object identity.
+  const sinceKey = filters.since ?? '';
+  const notableKey = filters.notable === true;
+  const familyKey = filters.familyCode ?? '';
+  const stateKey = filters.stateCode ?? '';
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      setSpeciesIndex([]);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    client
+      .getSpeciesInScope(filters)
+      .then((rows: SpeciesDictEntry[]) => {
+        if (cancelled) return;
+        // The server already orders by comName; preserve that order.
+        setSpeciesIndex(
+          rows.map(r => ({ code: r.code, comName: r.comName, familyCode: r.familyCode })),
+        );
+      })
+      .catch(err => {
+        if (!cancelled) setError(err as Error);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `filters` is intentionally read at fetch time but excluded from the dep
+    // list — the scalar keys above are the real triggers (a fresh identical
+    // object each render must not refetch). Mirrors useBirdData's effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, enabled, sinceKey, notableKey, familyKey, stateKey]);
+
+  return { speciesIndex, loading, error };
+}

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -12,6 +12,7 @@ export {
 export {
   getSpeciesMeta,
   getSpeciesDictionary,
+  getSpeciesInScope,
   getSpeciesWithPhotos,
   upsertSpeciesMeta,
   findMissingSpeciesMeta,

--- a/packages/db-client/src/species.test.ts
+++ b/packages/db-client/src/species.test.ts
@@ -3,6 +3,7 @@ import { startTestDb, type TestDb } from './test-helpers.js';
 import {
   getSpeciesMeta,
   getSpeciesDictionary,
+  getSpeciesInScope,
   upsertSpeciesMeta,
   findMissingSpeciesMeta,
   insertSpeciesPhoto,
@@ -76,6 +77,101 @@ describe('getSpeciesDictionary (#859)', () => {
     // beforeEach truncates species_meta — no seed here.
     const dict = await getSpeciesDictionary(db.pool);
     expect(dict).toEqual([]);
+  });
+});
+
+describe('getSpeciesInScope — represented-species combobox source', () => {
+  // species_meta universe: three taxa across two families, plus one taxon
+  // (sagspa1) that has a meta row but NEVER any observation — it must NEVER
+  // appear, proving the result is "represented" (has ≥1 observation), not the
+  // full dictionary.
+  beforeEach(async () => {
+    await db.pool.query('TRUNCATE observations');
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+      { speciesCode: 'blkpho', comName: 'Black Phoebe',
+        sciName: 'Sayornis nigricans', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30600 },
+      { speciesCode: 'sagspa1', comName: 'Sagebrush Sparrow',
+        sciName: 'Artemisiospiza nevadensis', familyCode: 'passerellidae',
+        familyName: 'New World Sparrows', taxonOrder: 40000 },
+    ]);
+    // AZ observations: vermfly (×2 — dedup guard), annhum (notable), blkpho.
+    // One FL-only observation of annhum exercises the state clip below.
+    await upsertObservations(db.pool, [
+      { subId: 'I1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: '2026-04-15T08:00:00Z',
+        locId: 'L1', locName: 'AZ', howMany: 1, isNotable: false },
+      { subId: 'I2', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.30, lng: -110.99, obsDt: '2026-04-16T08:00:00Z',
+        locId: 'L2', locName: 'AZ', howMany: 1, isNotable: false },
+      { subId: 'I3', speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        lat: 32.30, lng: -110.99, obsDt: '2026-04-10T08:00:00Z',
+        locId: 'L3', locName: 'AZ', howMany: 1, isNotable: true },
+      { subId: 'I4', speciesCode: 'blkpho', comName: 'Black Phoebe',
+        lat: 33.45, lng: -112.07, obsDt: '2026-04-12T08:00:00Z',
+        locId: 'L4', locName: 'AZ', howMany: 1, isNotable: false },
+      { subId: 'I5-FL', speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        lat: 27.8, lng: -81.7, obsDt: '2026-04-12T08:00:00Z',
+        locId: 'L-FL', locName: 'FL', howMany: 1, isNotable: false },
+    ]);
+  });
+
+  it('returns ONLY species with ≥1 observation, deduped, comName-sorted, in {code,comName,familyCode} shape', async () => {
+    const rows = await getSpeciesInScope(db.pool, {});
+    // sagspa1 has a meta row but no observation → excluded. The rest appear
+    // ONCE each (vermfly has two obs), sorted by comName:
+    //   Anna's Hummingbird, Black Phoebe, Vermilion Flycatcher.
+    expect(rows.map(r => r.code)).toEqual(['annhum', 'blkpho', 'vermfly']);
+    const anna = rows.find(r => r.code === 'annhum')!;
+    expect(anna.comName).toBe("Anna's Hummingbird");
+    expect(anna.familyCode).toBe('trochilidae');
+    // EXACTLY the three wire fields — no sci_name / taxon_order leak.
+    expect(Object.keys(anna).sort()).toEqual(['code', 'comName', 'familyCode']);
+  });
+
+  it('honors the family filter (only that family\'s represented species)', async () => {
+    const rows = await getSpeciesInScope(db.pool, { familyCode: 'tyrannidae' });
+    // vermfly + blkpho are tyrannidae; annhum (trochilidae) is excluded.
+    expect(rows.map(r => r.code)).toEqual(['blkpho', 'vermfly']);
+  });
+
+  it('honors the notable filter (only species with a notable observation)', async () => {
+    const rows = await getSpeciesInScope(db.pool, { notable: true });
+    // Only annhum has a notable observation (I3).
+    expect(rows.map(r => r.code)).toEqual(['annhum']);
+  });
+
+  it('honors the since window (species whose observation falls inside it)', async () => {
+    // Make vermfly recent and annhum/blkpho old, then ask for 14d.
+    await db.pool.query(`UPDATE observations SET obs_dt = now() - interval '3 days' WHERE species_code = 'vermfly'`);
+    await db.pool.query(`UPDATE observations SET obs_dt = now() - interval '30 days' WHERE species_code IN ('annhum','blkpho')`);
+    const rows = await getSpeciesInScope(db.pool, { since: '14d' });
+    expect(rows.map(r => r.code)).toEqual(['vermfly']);
+  });
+
+  it('clips to the state polygon (US-AZ excludes a FL-only species; US-FL includes it) — ST_Intersects guard', async () => {
+    // Remove the AZ annhum row so annhum is FL-ONLY; vermfly + blkpho stay AZ.
+    await db.pool.query(`DELETE FROM observations WHERE sub_id = 'I3'`);
+
+    const az = await getSpeciesInScope(db.pool, { stateCode: 'US-AZ' });
+    // Non-empty (inverted-predicate guard) and annhum (FL-only) excluded.
+    expect(az.length).toBeGreaterThan(0);
+    expect(az.map(r => r.code).sort()).toEqual(['blkpho', 'vermfly']);
+
+    const fl = await getSpeciesInScope(db.pool, { stateCode: 'US-FL' });
+    expect(fl.map(r => r.code)).toEqual(['annhum']);
+  });
+
+  it('returns [] when no observations match (empty represented set is not an error)', async () => {
+    await db.pool.query('TRUNCATE observations');
+    const rows = await getSpeciesInScope(db.pool, {});
+    expect(rows).toEqual([]);
   });
 });
 

--- a/packages/db-client/src/species.ts
+++ b/packages/db-client/src/species.ts
@@ -1,5 +1,7 @@
 import type { Pool } from './pool.js';
-import type { SpeciesMeta, SpeciesDictEntry, SpeciesWithPhoto } from '@bird-watch/shared-types';
+import type {
+  SpeciesMeta, SpeciesDictEntry, SpeciesWithPhoto, ObservationFilters,
+} from '@bird-watch/shared-types';
 
 /**
  * One row of `species_photos`. Mirrors the column shape verbatim — used by
@@ -257,6 +259,99 @@ export async function getSpeciesDictionary(
     `SELECT species_code AS code, com_name, family_code
        FROM species_meta
       ORDER BY species_code`
+  );
+  return rows.map(r => ({
+    code: r.code,
+    comName: r.com_name,
+    familyCode: r.family_code,
+  }));
+}
+
+/**
+ * Distinct species REPRESENTED in the current scope — every species with at
+ * least one observation matching the non-species filters (since / notable /
+ * family / state). This is the dictionary-shaped source for the FiltersBar
+ * Species combobox: it offers ONLY birds the user can actually find on the map
+ * for the active scope+filters, replacing the full ~17.8k global taxonomy the
+ * #1050 `/api/species` dictionary index surfaced (the "so many species it's hard
+ * to find things" problem).
+ *
+ * Deliberately species-filter-INDEPENDENT (there is NO `speciesCode` predicate):
+ * the combobox must keep offering every sibling species while one is selected,
+ * so a user can switch species without first clearing. This sidesteps the same
+ * self-narrowing trap the #1050 family-options fix avoids by sourcing the family
+ * `<select>` from the stable silhouettes catalogue rather than the active fetch.
+ * It is ALSO bbox/zoom-INDEPENDENT: the list is the whole scope's species at any
+ * zoom (the product decision behind this endpoint — completeness over
+ * viewport-coupling), which collapses the CDN cache-key space to a handful of
+ * `(scope, since, notable, family)` combinations.
+ *
+ * EXISTS semi-join (not `DISTINCT` over a JOIN that would multiply rows before
+ * dedupe). The planner picks a bounded, index-backed plan: for the national
+ * (no-bbox) case it scans the 14d window via `obs_dt_idx`, hash-aggregates to
+ * the ~hundreds of distinct `species_code`s, then joins `species_meta`
+ * (verified with EXPLAIN); a state/family-narrowed case can instead probe
+ * `obs_species_idx` per candidate. Family is filtered on the outer
+ * `species_meta` row; the time / notable / state predicates live inside the
+ * EXISTS against `observations o` and mirror `getObservations` byte-for-byte
+ * (same state-clip idiom: `&&` GiST prune + `ST_Intersects(polygon, point)`).
+ * Selecting FROM `species_meta` guarantees a real `com_name` — an observation
+ * with no meta parent is impossible by the #484 ingest invariant, and could
+ * not render a name anyway.
+ *
+ * Cost note: the whole-US case is a national 14d scan with no bbox to prune —
+ * the same input volume the precompute grid keeps off the aggregated render
+ * path. It is strictly LIGHTER than `getObservationsAggregated` (no PostGIS
+ * gridding/per-bucket aggregation — just one scan → small hash-agg → small
+ * join) and has no hidden-blowup CTE like #862, so it needs no precompute of
+ * its own. The cold scan is kept off the user-facing path by the long
+ * `species-scope` SWR window (cache-headers.ts): the represented SET is
+ * near-static, so the origin recomputes at most once per key per hour and
+ * always in the background.
+ */
+export async function getSpeciesInScope(
+  pool: Pool,
+  f: Pick<ObservationFilters, 'since' | 'notable' | 'familyCode' | 'stateCode'>
+): Promise<SpeciesDictEntry[]> {
+  const conditions: string[] = [];
+  // The EXISTS subquery's predicates; the correlation predicate is always first.
+  const inner: string[] = ['o.species_code = sm.species_code'];
+  const params: unknown[] = [];
+
+  if (f.familyCode) {
+    conditions.push(`sm.family_code = $${params.length + 1}`);
+    params.push(f.familyCode);
+  }
+  if (f.since) {
+    const days = parseInt(f.since.replace('d', ''), 10);
+    inner.push(`o.obs_dt >= now() - ($${params.length + 1}::int * interval '1 day')`);
+    params.push(days);
+  }
+  if (f.notable === true) {
+    inner.push('o.is_notable = true');
+  }
+  if (f.stateCode) {
+    // Mirror getObservations' #733 state clip: `&&` GiST prune to the state's
+    // bbox, then exact `ST_Intersects(polygon, point)` (inclusive — a border
+    // point resolves into a state instead of vanishing). One param, two predicates.
+    const si = params.length + 1;
+    inner.push(`o.geom && (SELECT geom FROM state_boundaries WHERE state_code = $${si})`);
+    inner.push(`ST_Intersects((SELECT geom FROM state_boundaries WHERE state_code = $${si}), o.geom)`);
+    params.push(f.stateCode);
+  }
+
+  conditions.push(`EXISTS (SELECT 1 FROM observations o WHERE ${inner.join(' AND ')})`);
+
+  const { rows } = await pool.query<{
+    code: string;
+    com_name: string;
+    family_code: string;
+  }>(
+    `SELECT sm.species_code AS code, sm.com_name, sm.family_code
+       FROM species_meta sm
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY sm.com_name`,
+    params
   );
   return rows.map(r => ({
     code: r.code,

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1328,6 +1328,75 @@ describe('GET /api/species/:code/phenology', () => {
   });
 });
 
+describe('GET /api/species-in-scope', () => {
+  beforeAll(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'sis-verm', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'sis-anna', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+      // Meta-only — no observation seeded → must NEVER appear in the response.
+      { speciesCode: 'sis-ghost', comName: 'Ghost Bird',
+        sciName: 'Nullus avis', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 99999 },
+    ]);
+    await db.pool.query("DELETE FROM observations WHERE sub_id LIKE 'SIS-%'");
+    await upsertObservations(db.pool, [
+      { subId: 'SIS-1', speciesCode: 'sis-verm', comName: 'Vermilion Flycatcher',
+        lat: 31.72, lng: -110.88, obsDt: new Date(Date.now() - 3 * 86400_000).toISOString(),
+        locId: 'L1', locName: 'AZ', howMany: 1, isNotable: false },
+      { subId: 'SIS-2', speciesCode: 'sis-anna', comName: "Anna's Hummingbird",
+        lat: 32.30, lng: -110.99, obsDt: new Date(Date.now() - 4 * 86400_000).toISOString(),
+        locId: 'L2', locName: 'AZ', howMany: 1, isNotable: true },
+    ]);
+  });
+
+  type SisRow = { code: string; comName: string; familyCode: string };
+
+  it('returns represented species as {code,comName,familyCode}[], comName-sorted, excluding unobserved meta rows', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species-in-scope?since=14d');
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as SisRow[];
+    const codes = rows.map(r => r.code);
+    // sis-ghost (meta-only) excluded; the two observed appear comName-sorted
+    // (Anna's Hummingbird before Vermilion Flycatcher).
+    expect(codes).toContain('sis-verm');
+    expect(codes).toContain('sis-anna');
+    expect(codes).not.toContain('sis-ghost');
+    const annaIdx = codes.indexOf('sis-anna');
+    const vermIdx = codes.indexOf('sis-verm');
+    expect(annaIdx).toBeLessThan(vermIdx);
+    const anna = rows.find(r => r.code === 'sis-anna')!;
+    expect(Object.keys(anna).sort()).toEqual(['code', 'comName', 'familyCode']);
+  });
+
+  it('honors the ?family= filter', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species-in-scope?since=14d&family=trochilidae');
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as SisRow[];
+    const codes = rows.map(r => r.code);
+    expect(codes).toContain('sis-anna');
+    expect(codes).not.toContain('sis-verm');
+  });
+
+  it('rejects an invalid ?state= with 400 (shared allowlist validation)', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species-in-scope?state=US-ZZ');
+    expect(res.status).toBe(400);
+  });
+
+  it('sets the species-scope Cache-Control tier', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species-in-scope?since=14d');
+    expect(res.headers.get('cache-control'))
+      .toBe('public, s-maxage=3600, stale-while-revalidate=86400');
+  });
+});
+
 describe('gzip compression middleware', () => {
   beforeAll(async () => {
     // The compress middleware's default threshold is 1024 bytes — responses

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1341,6 +1341,11 @@ describe('GET /api/species-in-scope', () => {
       { speciesCode: 'sis-ghost', comName: 'Ghost Bird',
         sciName: 'Nullus avis', familyCode: 'tyrannidae',
         familyName: 'Tyrant Flycatchers', taxonOrder: 99999 },
+      // Has ONLY an observation older than 14d → appears in an all-history scan
+      // but NOT in the default 14d window (proves the no-since default below).
+      { speciesCode: 'sis-old', comName: 'Stale Crow',
+        sciName: 'Corvus vetus', familyCode: 'corvidae',
+        familyName: 'Crows, Jays, and Magpies', taxonOrder: 50000 },
     ]);
     await db.pool.query("DELETE FROM observations WHERE sub_id LIKE 'SIS-%'");
     await upsertObservations(db.pool, [
@@ -1350,10 +1355,24 @@ describe('GET /api/species-in-scope', () => {
       { subId: 'SIS-2', speciesCode: 'sis-anna', comName: "Anna's Hummingbird",
         lat: 32.30, lng: -110.99, obsDt: new Date(Date.now() - 4 * 86400_000).toISOString(),
         locId: 'L2', locName: 'AZ', howMany: 1, isNotable: true },
+      { subId: 'SIS-OLD', speciesCode: 'sis-old', comName: 'Stale Crow',
+        lat: 32.30, lng: -110.99, obsDt: new Date(Date.now() - 30 * 86400_000).toISOString(),
+        locId: 'L3', locName: 'AZ', howMany: 1, isNotable: false },
     ]);
   });
 
   type SisRow = { code: string; comName: string; familyCode: string };
+
+  it('defaults the window to 14d when ?since= is absent (excludes a >14d-old observation)', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/species-in-scope');
+    expect(res.status).toBe(200);
+    const codes = ((await res.json()) as SisRow[]).map(r => r.code);
+    // Recent species present; the all-history-only species is excluded by the
+    // 14d default (an unbounded scan would have included sis-old).
+    expect(codes).toContain('sis-verm');
+    expect(codes).not.toContain('sis-old');
+  });
 
   it('returns represented species as {code,comName,familyCode}[], comName-sorted, excluding unobserved meta rows', async () => {
     const app = createApp({ pool: db.pool });

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -443,7 +443,14 @@ export function createApp(deps: AppDeps): Hono {
     }
 
     const filters: Parameters<typeof getSpeciesInScope>[1] = {};
-    if (sinceResult.value !== undefined) filters.since = sinceResult.value;
+    // Default the window to 14d when `?since=` is absent. Unlike /api/observations
+    // (where an absent since means an all-history query bounded by bbox/state),
+    // this endpoint's cost is a national distinct-species scan with no bbox to
+    // prune — an unbounded all-history scan from a direct no-since hit would
+    // defeat the bounded-scan intent the species-scope cache tier documents. The
+    // frontend always sends since=14d; this hardens the direct-hit path
+    // (julianken-bot #1165 review).
+    filters.since = sinceResult.value ?? '14d';
     if (notableResult.value === true) filters.notable = true;
     if (familyResult.value !== undefined) filters.familyCode = familyResult.value;
     if (stateResult.value !== undefined) filters.stateCode = stateResult.value;

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -5,7 +5,7 @@ import type { Pool } from '@bird-watch/db-client';
 import {
   getHotspots, getObservations, getObservationsAggregated,
   getFreshestObservationAt,
-  getSpeciesMeta, getSpeciesDictionary, getSpeciesWithPhotos, getSilhouettes,
+  getSpeciesMeta, getSpeciesDictionary, getSpeciesInScope, getSpeciesWithPhotos, getSilhouettes,
   getSpeciesPhenology,
   listStatesWithBbox,
   // #878 — precomputed per-scope aggregation grid.
@@ -405,6 +405,51 @@ export function createApp(deps: AppDeps): Hono {
   app.get('/api/species/with-photos', async c => {
     const rows = await getSpeciesWithPhotos(deps.pool);
     c.header('Cache-Control', cacheControlFor('species'));
+    return c.json(rows);
+  });
+
+  // The distinct species REPRESENTED in the current scope (#species-combobox):
+  // every species with ≥1 observation matching the active since/notable/family
+  // filters and the optional `?state=` clip. Backs the FiltersBar Species
+  // combobox so it offers ONLY birds the user can actually find on the map for
+  // this scope — not the full ~17.8k global /api/species dictionary. It takes
+  // NO `?species=` (so the combobox keeps offering siblings while one is active)
+  // and NO `?bbox=`/`?zoom=` (the list is the whole scope's species at any
+  // zoom). Same allowlist validation as /api/observations for the four params it
+  // does honor. Registered BEFORE `/api/species/:code` for the same explicit-
+  // precedence reason as /api/species above — `species-in-scope` is a distinct
+  // single segment and cannot be shadowed by `:code`, but declaring it first
+  // keeps precedence order-independent of any future router change.
+  app.get('/api/species-in-scope', async c => {
+    const sinceResult = parseSince(c.req.query('since'));
+    if (!sinceResult.ok) {
+      console.log(JSON.stringify(sinceResult.log));
+      return c.json({ error: sinceResult.error }, 400);
+    }
+    const notableResult = parseNotable(c.req.query('notable'));
+    if (!notableResult.ok) {
+      console.log(JSON.stringify(notableResult.log));
+      return c.json({ error: notableResult.error }, 400);
+    }
+    const familyResult = parseFamily(c.req.query('family'));
+    if (!familyResult.ok) {
+      console.log(JSON.stringify(familyResult.log));
+      return c.json({ error: familyResult.error }, 400);
+    }
+    const stateResult = parseState(c.req.query('state'));
+    if (!stateResult.ok) {
+      console.log(JSON.stringify(stateResult.log));
+      return c.json({ error: stateResult.error }, 400);
+    }
+
+    const filters: Parameters<typeof getSpeciesInScope>[1] = {};
+    if (sinceResult.value !== undefined) filters.since = sinceResult.value;
+    if (notableResult.value === true) filters.notable = true;
+    if (familyResult.value !== undefined) filters.familyCode = familyResult.value;
+    if (stateResult.value !== undefined) filters.stateCode = stateResult.value;
+
+    const rows = await getSpeciesInScope(deps.pool, filters);
+    c.header('Cache-Control', cacheControlFor('species-scope'));
     return c.json(rows);
   });
 

--- a/services/read-api/src/cache-headers.ts
+++ b/services/read-api/src/cache-headers.ts
@@ -1,4 +1,4 @@
-export type Endpoint = 'observations' | 'hotspots' | 'species' | 'species-dict' | 'silhouettes' | 'phenology' | 'states';
+export type Endpoint = 'observations' | 'hotspots' | 'species' | 'species-dict' | 'species-scope' | 'silhouettes' | 'phenology' | 'states';
 
 // Cache-Control TTL table for public read endpoints.
 //
@@ -56,6 +56,28 @@ const TABLE: Record<Endpoint, string> = {
   // than the per-code 'species' tier's browser `max-age` — the dictionary is
   // one shared body, so edge caching is where the win is.
   'species-dict': 'public, s-maxage=86400, stale-while-revalidate=172800',
+  // GET /api/species-in-scope — the distinct species REPRESENTED in a scope
+  // (state|US) for the active since/notable/family filters, backing the
+  // FiltersBar Species combobox. It is bbox/zoom/species-INDEPENDENT, so the
+  // key space is just a few (scope, since, notable, family) combos.
+  //
+  // The whole-US, no-family cold query is a national 14d EXISTS+distinct over
+  // `observations` (no bbox to prune) — the same input volume the precompute
+  // grid exists to keep off the request path for the aggregated render. It is
+  // index-backed (obs_dt_idx + obs_species_idx) and strictly lighter than
+  // getObservationsAggregated (no PostGIS gridding — a single scan → small
+  // distinct-species hash-agg → join to species_meta), but it is still a
+  // national scan. The mitigation is the LONG SWR below: unlike the
+  // observations COUNT (which rolls every ~30min ingest), the represented
+  // SET of species is near-static (a species enters/leaves the 14d window
+  // only rarely), so 1h freshness + a 24h stale-while-revalidate window means
+  // a cold origin compute happens at most once per key per hour AND is served
+  // from the background (SWR) — a user never waits on it after the first-ever
+  // request for a key. Staleness cost: a newly-observed species can be absent
+  // from the combobox for up to ~1h (it is still reachable on the map / in
+  // popovers meanwhile) — an accepted trade for keeping the scan off the
+  // user-facing path.
+  'species-scope': 'public, s-maxage=3600, stale-while-revalidate=86400',
   // Family silhouette payload drifts between deploys (curation, Phylopic
   // seed expansion). `s-maxage=3600` keeps a 1h CDN window — short enough
   // that curation pushes reach users quickly without scripts/purge-...sh,


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before["Before (#1050)"]
      direction TB
      D1["GET /api/species<br/>17,849-species GLOBAL taxonomy"] --> SI1["speciesIndex"]
      SI1 --> DL1["&lt;datalist&gt;<br/>17,849 options<br/>(ignores Family filter)"]
    end
    subgraph After["After (#1164)"]
      direction TB
      F["since / notable / family / state<br/><b>no</b> species, <b>no</b> bbox/zoom"] --> H["useSpeciesInScope<br/>(gated on scopeActive)"]
      H --> EP["GET /api/species-in-scope"]
      EP --> Q["getSpeciesInScope()<br/>EXISTS semi-join over observations<br/>obs_dt_idx + obs_species_idx"]
      Q --> SI2["speciesIndex = represented species<br/>(+ active deep-link species unioned in)"]
      SI2 --> DL2["&lt;datalist&gt;<br/>scoped + family-narrowed"]
    end
    Before -.->|"#1164"| After
```

Why species-/bbox-independent is load-bearing:

```mermaid
flowchart TB
    A["user picks a species"] --> B{"is the source<br/>species-filtered?"}
    B -->|"yes (naive)"| C["fetch collapses to that 1 species<br/>→ datalist shrinks to 1<br/>(the #1050 self-narrowing trap)"]
    B -->|"no (this PR)"| D["siblings stay listed<br/>→ switch species without clearing"]
```

## Summary

- **Why:** the species autocomplete offered the entire ~17,849-species global eBird taxonomy (confirmed live: the `<datalist>` held 17,849 `<option>`s), most with zero US sightings — "so many species it's hard to find things" — and ignored the active Family filter. `#1050` introduced this when it re-pointed the index at `GET /api/species` to fix a real low-zoom-empty bug (the observation-derived index went empty in aggregated mode, `#859`).
- **What:** a new scope-keyed source — `getSpeciesInScope()` (db-client) → `GET /api/species-in-scope` (read-api) → `useSpeciesInScope` (frontend) — lists only species **represented** in the current scope, narrowed by the active Family filter. It is **species- and bbox/zoom-independent** by design: that dissolves the self-narrowing trap (diagram 2) and keeps the list complete at any zoom (the aggregated buckets carry only each family's top species).
- **Verified live** (local stack, my branch): whole-US offers **54** represented species (dev seed) vs 17,849; selecting **Tyrant Flycatchers** narrows the datalist to its **3** represented species; console clean; commit sets `?species=` + the field shows the name.

### Notes on the issue-gate review (#1164)
- *Finding 1 (precedent for catalogue-sourcing) was a false positive* — it was raised against the stale primary checkout (`0dec722`, ~230 commits behind); on current `main` the Family `<select>` **does** source from the stable silhouettes catalogue (`App.tsx` `families` memo). The PR-review bot is briefed to check out the PR head SHA.
- *Finding 2 (national cold-compute) addressed:* the `species-scope` cache tier is `s-maxage=3600, stale-while-revalidate=86400` so the national 14d scan is background-only (the represented *set* is near-static, unlike per-ingest counts); the query is index-backed and strictly lighter than the already-guarded aggregated grid (no PostGIS gridding, no hidden-blowup CTE like `#862`). Plan verified with EXPLAIN.
- *Finding 3:* `since` and `notable` narrowing are covered by db-client tests (not only family).

## Screenshots

N/A — functional change, **no visual diff**. The change swaps the `<datalist>`'s *contents* (54 scoped vs 17,849 global; 3 under a family filter), not its appearance; the filters panel renders pixel-identical to `main`, and the native `<datalist>` popup is browser-chrome that screenshot tools don't capture. Evidence in lieu of stills (local stack, this branch):

- whole-US: `datalist#species-options` → **54** options (real US birds, comName-sorted) vs 17,849 on `main`
- Family = `tyrannidae`: datalist → **3** (`Black Phoebe, Eastern Kingbird, Vermilion Flycatcher`); URL `?family=tyrannidae`
- `browser_console_messages` (chrome-devtools) → **0 errors, 0 warnings**
- species commit → `?species=` set, field shows the common name

- [x] No new/renamed `className` in this PR — `N/A — no CSS/className changes`
- [x] Multi-viewport design QA — `N/A — not UI` (no visual diff; see above)

## Test plan

- [x] `tsc` (frontend) + per-workspace `vitest run` — green
- [x] New unit / integration tests: db-client `getSpeciesInScope` (6 — ST_Intersects state clip, since + notable + family narrowing, dedupe, excludes unobserved), read-api route (4), frontend client (2) + new `useSpeciesInScope` hook (5). Full suites: frontend 1536, read-api 92, db-client species 37.
- [x] e2e: existing species specs (`filters`, `species-detail`, `deep-link`, `filters-card-sheet-boundary`) repointed at `/api/species-in-scope` via new `stubSpeciesInScope` fixture
- [x] `npm run build` (all workspaces) — clean · `npx knip` — clean
- [x] UI smoke — drove this branch on a local stack (read-api :8788 + Vite :5174 against the shared dev DB) via **chrome-devtools MCP** (Playwright MCP browser was locked by a concurrent session); console clean; verified the scoped + family-narrowed datalist and the commit path at desktop. Reviewers: `gh pr checkout`, `npm run dev`, open Filters, focus Species — suggestions are the scoped set.

## Plan reference

Out of plan — direct maintainer request. Closes #1164.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
