### PR TITLE
feat(eleatic): generic per-row trace (trace_json) + drawer Trace panel (closes #1166)

### DIFF
--- a/packages/eleatic/src/queries.test.ts
+++ b/packages/eleatic/src/queries.test.ts
@@ -129,6 +129,45 @@ describe('makeReader', () => {
     });
   });
 
+  describe('trace (single-row read path only)', () => {
+    const trace = {
+      spans: [
+        { name: 'judge', input: { prompt: 'x' }, output: { keep: true }, usage: { promptTokens: 10 } },
+      ],
+    };
+
+    beforeEach(() => {
+      store.recordRun(makeRun());
+      store.recordRow(makeRow({ rowKey: 'traced', trace }));
+      store.recordRow(makeRow({ rowKey: 'untraced' })); // no trace
+    });
+
+    it('getRow round-trips the opaque trace blob losslessly', () => {
+      expect(reader.getRow('run-1', 'traced')?.trace).toEqual(trace);
+    });
+
+    it('getRow reads an omitted trace back as an absent key (NULL → undefined)', () => {
+      const row = reader.getRow('run-1', 'untraced');
+      expect(row?.trace).toBeUndefined();
+      expect('trace' in (row ?? {})).toBe(false);
+    });
+
+    it('getRows NEVER carries trace — list payloads stay lean', () => {
+      const rows = reader.getRows('run-1');
+      const traced = rows.find((r) => r.rowKey === 'traced');
+      expect(traced).toBeDefined();
+      expect(traced?.trace).toBeUndefined();
+      expect('trace' in (traced ?? {})).toBe(false);
+    });
+
+    it('facetRows NEVER carries trace — list payloads stay lean', () => {
+      const rows = reader.facetRows('run-1', {});
+      const traced = rows.find((r) => r.rowKey === 'traced');
+      expect(traced).toBeDefined();
+      expect('trace' in (traced ?? {})).toBe(false);
+    });
+  });
+
   describe('facetRows — the generalization of evalFalseKeeps', () => {
     // Port the four-row arrangement from the grounding evalFalseKeeps test:
     // metadata.disagreement ∈ {falseKeep, agree, falseReplace, bothReplace}.

--- a/packages/eleatic/src/queries.ts
+++ b/packages/eleatic/src/queries.ts
@@ -70,7 +70,9 @@ export interface MetricPoint {
 export interface EleaticReader {
   listRuns(): EvalRunRecord[];
   getRun(id: string): EvalRunRecord | undefined;
+  /** Lean list payload — never includes the per-row `trace` blob. */
   getRows(runId: string): EvalRowRecord[];
+  /** The drill-down read — the ONLY surface that returns the optional `trace`. */
   getRow(runId: string, rowKey: string): EvalRowRecord | undefined;
   diffRuns(aRunId: string, bRunId: string): RunDiff[];
   facetRows(runId: string, q: FacetQuery): EvalRowRecord[];
@@ -100,6 +102,7 @@ interface EvalRowDbRow {
   expected_json: string | null;
   scores_json: string | null;
   metadata_json: string | null;
+  trace_json: string | null;
 }
 interface AdjDbRow {
   row_key: string;
@@ -132,6 +135,12 @@ function readRun(row: RunDbRow): EvalRunRecord {
   return rec;
 }
 
+// The SHARED row mapper behind every list/diff path (`getRows`/`facetRows`/
+// `diffRuns`). It deliberately OMITS `trace`: a trace blob can be large, and the
+// gallery/diff payloads carry one record per row at 150–1000-row scale — keeping
+// the heavy blob out of the list responses is the leanness invariant. The single
+// `trace` consumer (`getRow`, the drawer drill-down) layers it back on via
+// `readRowWithTrace` below.
 function readRow(row: EvalRowDbRow): EvalRowRecord {
   const rec: EvalRowRecord = {
     runId: row.run_id,
@@ -146,6 +155,16 @@ function readRow(row: EvalRowDbRow): EvalRowRecord {
   if (scores !== undefined) rec.scores = scores;
   const metadata = parseJson<Record<string, string | number | boolean>>(row.metadata_json);
   if (metadata !== undefined) rec.metadata = metadata;
+  return rec;
+}
+
+// The single-row mapper: `readRow` plus the optional `trace` blob. Only `getRow`
+// uses this, so the trace never bloats the list/diff payloads above. NULL → an
+// ABSENT `trace` key (exactOptionalPropertyTypes), never `undefined` assigned.
+function readRowWithTrace(row: EvalRowDbRow): EvalRowRecord {
+  const rec = readRow(row);
+  const trace = parseJson<unknown>(row.trace_json);
+  if (trace !== undefined) rec.trace = trace;
   return rec;
 }
 
@@ -306,7 +325,9 @@ export function makeReader(db: Database.Database): EleaticReader {
     getRows,
     getRow(runId, rowKey) {
       const row = getRowStmt.get(runId, rowKey) as EvalRowDbRow | undefined;
-      return row === undefined ? undefined : readRow(row);
+      // The ONLY path that surfaces `trace` — the drawer drill-down. List/diff
+      // paths use the lean `readRow` so the heavy blob never rides the gallery.
+      return row === undefined ? undefined : readRowWithTrace(row);
     },
     diffRuns(aRunId, bRunId) {
       const byKey = new Map<string, RunDiff>();

--- a/packages/eleatic/src/schema.test.ts
+++ b/packages/eleatic/src/schema.test.ts
@@ -41,4 +41,16 @@ describe('schema', () => {
     migrate(db);
     expect(() => migrate(db!)).not.toThrow();
   });
+
+  it('eval_row carries the nullable trace_json column (generic per-row trace)', () => {
+    db = new Database(':memory:');
+    migrate(db);
+    const cols = (
+      db.prepare(`PRAGMA table_info(eval_row)`).all() as { name: string; notnull: number }[]
+    );
+    const trace = cols.find((c) => c.name === 'trace_json');
+    expect(trace).toBeDefined();
+    // Additive + nullable: existing rows read NULL, no backfill needed.
+    expect(trace?.notnull).toBe(0);
+  });
 });

--- a/packages/eleatic/src/schema.ts
+++ b/packages/eleatic/src/schema.ts
@@ -12,8 +12,11 @@ import type Database from 'better-sqlite3';
  *   eval_run          — one row per eval run; `metrics_json` holds arbitrary
  *                       {name:number} aggregates.
  *   eval_row          — one row per item per run, keyed (run_id, row_key).
- *                       `output_json`/`expected_json` are OPAQUE — pretty-printed
- *                       in drill-down, never destructured by the store.
+ *                       `output_json`/`expected_json`/`trace_json` are OPAQUE —
+ *                       pretty-printed in drill-down, never destructured by the
+ *                       store. `trace_json` holds an optional generic LLM trace
+ *                       (spans of name/input/output/usage) returned ONLY by the
+ *                       single-row read path, never the list payloads.
  *   eval_adjudication — a human verdict keyed on the ITEM (row_key), independent
  *                       of any run; upsert (no audit history).
  */
@@ -37,6 +40,7 @@ CREATE TABLE IF NOT EXISTS eval_row (
   expected_json TEXT,
   scores_json   TEXT,
   metadata_json TEXT,
+  trace_json    TEXT,
   PRIMARY KEY (run_id, row_key)
 );
 CREATE TABLE IF NOT EXISTS eval_adjudication (

--- a/packages/eleatic/src/server/app.test.ts
+++ b/packages/eleatic/src/server/app.test.ts
@@ -48,6 +48,11 @@ function seedStore(): EleaticStore {
       expected: { keep: false },
       scores: { quality: 55 },
       metadata: { disagreement: 'falseKeep' },
+      trace: {
+        spans: [
+          { name: 'judge', input: { prompt: 'p' }, output: { keep: true }, usage: { promptTokens: 12 } },
+        ],
+      },
     },
   ]);
   store.recordRows([
@@ -113,6 +118,9 @@ describe('eleatic server', () => {
     const res = await request(createApp(store, cfg)).get('/api/rows?run=run-a');
     expect(res.status).toBe(200);
     expect(res.body.rows.map((r: { rowKey: string }) => r.rowKey)).toEqual(['item-1', 'item-2']);
+    // The list payload stays lean: trace is never carried, even for a traced row.
+    const traced = res.body.rows.find((r: { rowKey: string }) => r.rowKey === 'item-2');
+    expect(traced.trace).toBeUndefined();
   });
 
   it('GET /api/rows with f= filters (generalized falseKeep gallery)', async () => {
@@ -147,6 +155,20 @@ describe('eleatic server', () => {
     expect((await request(app).get('/api/row?row=item-1')).status).toBe(400);
     expect((await request(app).get('/api/row?run=run-a&row=ghost')).status).toBe(404);
     expect((await request(app).get('/api/row?run=nope&row=item-1')).status).toBe(404);
+  });
+
+  it('GET /api/row returns the per-row trace verbatim (drill-down only)', async () => {
+    const app = createApp(store, cfg);
+    const traced = await request(app).get('/api/row?run=run-a&row=item-2');
+    expect(traced.status).toBe(200);
+    expect(traced.body.row.trace).toEqual({
+      spans: [
+        { name: 'judge', input: { prompt: 'p' }, output: { keep: true }, usage: { promptTokens: 12 } },
+      ],
+    });
+    // A row with no trace omits the key entirely.
+    const untraced = await request(app).get('/api/row?run=run-a&row=item-1');
+    expect(untraced.body.row.trace).toBeUndefined();
   });
 
   it('GET /api/trends returns trend points; 400 when metric omitted', async () => {

--- a/packages/eleatic/src/store.test.ts
+++ b/packages/eleatic/src/store.test.ts
@@ -23,6 +23,7 @@ interface RawEvalRow {
   expected_json: string | null;
   scores_json: string | null;
   metadata_json: string | null;
+  trace_json: string | null;
 }
 interface RawAdjRow {
   row_key: string;
@@ -83,6 +84,29 @@ describe('EleaticStore', () => {
       .get('run-1', 'item-1') as RawEvalRow;
     expect(JSON.parse(raw.output_json!)).toEqual(opaqueOutput);
     expect(JSON.parse(raw.expected_json!)).toEqual(opaqueExpected);
+  });
+
+  it('recordRow round-trips an opaque trace blob losslessly without destructuring', () => {
+    store.recordRun(makeRun());
+    const trace = {
+      spans: [
+        { name: 'judge', input: { prompt: 'x' }, output: { keep: true }, usage: { promptTokens: 10 } },
+      ],
+    };
+    store.recordRow(makeRow({ rowKey: 'traced', trace }));
+    const raw = store.db
+      .prepare('SELECT * FROM eval_row WHERE run_id=? AND row_key=?')
+      .get('run-1', 'traced') as RawEvalRow;
+    expect(JSON.parse(raw.trace_json!)).toEqual(trace);
+  });
+
+  it('maps an omitted trace to SQL NULL on write', () => {
+    store.recordRun(makeRun());
+    store.recordRow(makeRow()); // no trace
+    const raw = store.db
+      .prepare('SELECT * FROM eval_row WHERE run_id=? AND row_key=?')
+      .get('run-1', 'item-1') as RawEvalRow;
+    expect(raw.trace_json).toBe(null);
   });
 
   it('recordRows bulk-inserts ~344 rows inside one transaction', () => {

--- a/packages/eleatic/src/store.ts
+++ b/packages/eleatic/src/store.ts
@@ -39,9 +39,9 @@ export class EleaticStore {
     this.insertRowStmt = db.prepare(
       `INSERT INTO eval_row
          (run_id, row_key, label, image_url, content_hash,
-          output_json, expected_json, scores_json, metadata_json)
+          output_json, expected_json, scores_json, metadata_json, trace_json)
        VALUES (@run_id, @row_key, @label, @image_url, @content_hash,
-          @output_json, @expected_json, @scores_json, @metadata_json)`,
+          @output_json, @expected_json, @scores_json, @metadata_json, @trace_json)`,
     );
     this.upsertAdjStmt = db.prepare(
       `INSERT INTO eval_adjudication
@@ -77,7 +77,7 @@ export class EleaticStore {
     });
   }
 
-  /** INSERT one evaluated item. output/expected/scores/metadata -> JSON-or-NULL. */
+  /** INSERT one evaluated item. output/expected/scores/metadata/trace -> JSON-or-NULL. */
   recordRow(row: EvalRowRecord): void {
     this.insertRowStmt.run({
       run_id: row.runId,
@@ -89,6 +89,7 @@ export class EleaticStore {
       expected_json: toJsonOrNull(row.expected),
       scores_json: toJsonOrNull(row.scores),
       metadata_json: toJsonOrNull(row.metadata),
+      trace_json: toJsonOrNull(row.trace),
     });
   }
 

--- a/packages/eleatic/src/types.ts
+++ b/packages/eleatic/src/types.ts
@@ -43,6 +43,14 @@ export interface EvalRowRecord {
   scores?: Record<string, number>;
   /** Categorical facet axis -> metadata_json. */
   metadata?: Record<string, string | number | boolean>;
+  /**
+   * Optional, OPAQUE generic LLM trace -> trace_json; never destructured by the
+   * store. Conventionally `{ spans: [{ name, input, output, usage }] }`, but any
+   * JSON value round-trips (a non-conforming blob is pretty-printed whole in the
+   * drawer). Surfaced ONLY by the single-row read path (`getRow`) — list
+   * payloads stay lean and omit it.
+   */
+  trace?: unknown;
 }
 
 /** A human verdict on an item, run-independent. Maps to the `eval_adjudication` table. */

--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -201,6 +201,17 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .json-bool, .json-null { color: var(--text-dim); }
 .json-empty { font-family: var(--mono-stack); font-size: var(--type-xs); color: var(--text-dim); }
 
+/* ── Trace section ── */
+.trace-details > summary.trace-summary { cursor: pointer; margin: 0; }
+.trace-spans { display: flex; flex-direction: column; gap: 10px; margin-top: 10px; }
+.trace-span { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px; background: var(--surface); }
+.trace-span-name { font-family: var(--mono-stack); font-size: var(--type-xs); font-weight: 600; color: var(--accent); margin: 0 0 6px; }
+.trace-io { margin: 0 0 4px; }
+.trace-io-label { cursor: pointer; font-size: var(--type-xs); color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; }
+.trace-usage { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 6px; font-family: var(--mono-stack); font-size: var(--type-xs); color: var(--text-dim); }
+.trace-usage-sep { color: var(--border); }
+.trace-raw { margin-top: 10px; }
+
 /* ── Adjudication panel ── */
 .adjudicate { border-top: 1px solid var(--border); padding-top: 16px; }
 .adj-title { font-size: var(--type-sm); font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: .04em; margin: 0 0 8px; }

--- a/packages/eleatic/ui/drawer.js
+++ b/packages/eleatic/ui/drawer.js
@@ -8,6 +8,9 @@
 //     package never destructures them; rendered via the escaping prettyJson unit),
 //   • a score bar per scores_json entry,
 //   • the row's metadata,
+//   • a collapsible "Trace" section (after output-vs-expected) when the row
+//     carries a trace — rendered by the escaping renderTrace pure unit; absent
+//     entirely when the single-row read returned no trace,
 //   • the image via safeImg,
 //   • the adjudication panel (adjudicate.js).
 //
@@ -23,10 +26,12 @@
 // that opened the drawer (passed to openDrawer). Escape + the backdrop close it.
 //
 // Browser-only glue (DOM + fetch); no unit test — the logic lives in the
-// prettyJson / staleness pure units. Verified live at the epic's E2E recipe.
+// prettyJson / renderTrace / staleness pure units. Verified live at the epic's
+// E2E recipe.
 
 import { esc, safeImg } from './safe.js';
 import { prettyJson } from './pretty.js';
+import { renderTrace } from './trace.js';
 import { renderAdjudication } from './adjudicate.js';
 
 let lastTrigger = null;
@@ -158,6 +163,13 @@ export async function openDrawer(rowParam, trigger = null) {
         <div class="json-col"><div class="json-col-label">expected</div>${prettyJson(record.expected)}</div>
       </div>
     </section>
+    ${record.trace !== undefined ? `
+    <section class="drawer-section">
+      <details class="trace-details">
+        <summary class="drawer-h3 trace-summary">Trace</summary>
+        ${renderTrace(record.trace)}
+      </details>
+    </section>` : ''}
     <section class="drawer-section" id="drawer-adjudicate"></section>`;
 
   // Fetch the existing adjudication (if any) so the panel pre-fills + flags stale.

--- a/packages/eleatic/ui/trace.js
+++ b/packages/eleatic/ui/trace.js
@@ -1,0 +1,82 @@
+// Generic per-row TRACE renderer for the eleatic drawer.
+//
+// A row may carry an OPAQUE `trace` blob (trace_json — eleatic invents no eval
+// domain and never destructures it on the store/read side). When it conforms to
+// the conventional `{ spans: [{ name, input, output, usage }] }` shape, we render
+// one LABELED BLOCK per span: the span name, a collapsible (<details>) pretty-
+// print of its input and output, and a compact usage line
+// (promptTokens·completionTokens·latencyMs·$costUsd) that OMITS any absent field.
+// Anything that doesn't conform — no `spans` array, a scalar, an array — falls
+// back to pretty-printing the WHOLE blob, so a non-standard trace still renders
+// losslessly rather than vanishing.
+//
+// SECURITY: the blob is attacker-influenceable (the server exposes a write path
+// and the harness that filled the store is untrusted). Every dynamic value goes
+// through prettyJson (which escapes via safe.js#esc) or esc directly, so an
+// injected `"><img onerror>` renders as inert text — the same threat model and
+// proof as pretty.test.ts / safe.test.ts.
+//
+// Plain ESM with a named export — importable by the browser (express.static) and
+// by vitest in node (the pretty.js / format.js precedent). PURE: no DOM, no fetch.
+
+import { esc } from './safe.js';
+import { prettyJson } from './pretty.js';
+
+/** A collapsible labeled pretty-print of one sub-value (input / output). */
+function collapsible(label, value) {
+  return `<details class="trace-io"><summary class="trace-io-label">${esc(label)}</summary>${prettyJson(value)}</details>`;
+}
+
+/**
+ * Render a usage line from a span's `usage` object. Each field is independent and
+ * OMITTED when absent / non-finite; cost is dollar-formatted, the rest are bare
+ * integers. Returns '' when nothing renders (so the caller drops the line).
+ */
+function renderUsage(usage) {
+  if (usage === null || typeof usage !== 'object') return '';
+  const parts = [];
+  const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+
+  const prompt = num(usage.promptTokens);
+  if (prompt !== undefined) parts.push(`<span class="trace-usage-part">${esc(prompt)} prompt</span>`);
+  const completion = num(usage.completionTokens);
+  if (completion !== undefined) parts.push(`<span class="trace-usage-part">${esc(completion)} completion</span>`);
+  const latency = num(usage.latencyMs);
+  if (latency !== undefined) parts.push(`<span class="trace-usage-part">${esc(latency)} ms</span>`);
+  const cost = num(usage.costUsd);
+  if (cost !== undefined) parts.push(`<span class="trace-usage-part">$${esc(cost)}</span>`);
+
+  if (parts.length === 0) return '';
+  return `<div class="trace-usage">${parts.join('<span class="trace-usage-sep">·</span>')}</div>`;
+}
+
+/** Render a single span block: name + collapsible input/output + usage line. */
+function renderSpan(span, index) {
+  const obj = span !== null && typeof span === 'object' ? span : {};
+  const rawName = typeof obj.name === 'string' && obj.name !== '' ? obj.name : `span ${index}`;
+  const io = [];
+  if ('input' in obj) io.push(collapsible('input', obj.input));
+  if ('output' in obj) io.push(collapsible('output', obj.output));
+  const usage = renderUsage(obj.usage);
+  return `<div class="trace-span"><div class="trace-span-name">${esc(rawName)}</div>${io.join('')}${usage}</div>`;
+}
+
+/**
+ * Render an OPAQUE trace blob to an HTML string.
+ *
+ * Conforming shape: `{ spans: [{ name?, input?, output?, usage? }] }` → one
+ * labeled block per span. Anything else (no spans array, scalar, array) → the
+ * whole blob pretty-printed. Always returns a string and never throws.
+ */
+export function renderTrace(trace) {
+  const spans =
+    trace !== null && typeof trace === 'object' && Array.isArray(trace.spans)
+      ? trace.spans
+      : undefined;
+  if (spans === undefined) {
+    // Non-conforming → pretty-print the whole blob (lossless fallback).
+    return `<div class="trace-raw">${prettyJson(trace ?? null)}</div>`;
+  }
+  if (spans.length === 0) return '<p class="drawer-empty">No spans</p>';
+  return `<div class="trace-spans">${spans.map(renderSpan).join('')}</div>`;
+}

--- a/packages/eleatic/ui/trace.test.ts
+++ b/packages/eleatic/ui/trace.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+// trace.js renders an OPAQUE per-row trace blob (trace_json — eleatic never
+// destructures the eval domain) to an HTML string for the drawer's Trace
+// section. A conforming `{ spans: [...] }` shape renders one labeled block per
+// span (name + collapsible input/output via the escaping prettyJson unit + a
+// usage line); anything else falls back to pretty-printing the whole blob. Every
+// key / string value flows through pretty.js → safe.js#esc, so an injected
+// payload renders inert. Importable by the browser (express.static) and vitest.
+import { renderTrace } from './trace.js';
+
+describe('renderTrace — span rendering', () => {
+  it('renders one labeled block per span with the span name', () => {
+    const out = renderTrace({
+      spans: [{ name: 'retrieve' }, { name: 'judge' }],
+    });
+    expect(out).toContain('retrieve');
+    expect(out).toContain('judge');
+    // Two span blocks.
+    expect(out.match(/class="trace-span"/g)?.length).toBe(2);
+  });
+
+  it('pretty-prints a span input and output inside collapsible blocks', () => {
+    const out = renderTrace({
+      spans: [{ name: 'judge', input: { prompt: 'hello' }, output: { keep: true } }],
+    });
+    // Collapsible <details>/<summary> per the issue.
+    expect(out).toContain('<details');
+    expect(out).toContain('<summary');
+    expect(out).toContain('input');
+    expect(out).toContain('output');
+    // prettyJson tree markup proves the blob was rendered, not stringified raw.
+    expect(out).toContain('json-key');
+    expect(out).toContain('prompt');
+    expect(out).toContain('hello');
+  });
+
+  it('renders a usage line with the present metrics only, omitting absent ones', () => {
+    const out = renderTrace({
+      spans: [
+        {
+          name: 'judge',
+          usage: { promptTokens: 12, completionTokens: 34, latencyMs: 250, costUsd: 0.0123 },
+        },
+      ],
+    });
+    expect(out).toContain('12');
+    expect(out).toContain('34');
+    expect(out).toContain('250');
+    // costUsd is dollar-formatted.
+    expect(out).toContain('$0.0123');
+  });
+
+  it('omits absent usage fields (only completionTokens present)', () => {
+    const out = renderTrace({
+      spans: [{ name: 'judge', usage: { completionTokens: 7 } }],
+    });
+    expect(out).toContain('7');
+    // No prompt-token / latency / cost tokens leak in when absent.
+    expect(out).not.toContain('promptTokens');
+    expect(out).not.toContain('latencyMs');
+    expect(out).not.toContain('$');
+  });
+
+  it('omits the usage line entirely when a span has no usage', () => {
+    const out = renderTrace({ spans: [{ name: 'plain' }] });
+    expect(out).toContain('plain');
+    expect(out).not.toContain('trace-usage');
+  });
+
+  it('falls back to a span index label when a span has no name', () => {
+    const out = renderTrace({ spans: [{ input: { a: 1 } }] });
+    // Some non-empty label still renders (e.g. "span 0") — never an empty block.
+    expect(out).toContain('trace-span');
+    expect(out).toContain('span');
+  });
+});
+
+describe('renderTrace — non-conforming blob fallback', () => {
+  it('pretty-prints a blob with no spans array as a whole', () => {
+    const out = renderTrace({ anything: 'goes', n: 1 });
+    expect(out).toContain('anything');
+    expect(out).toContain('goes');
+    // Rendered via prettyJson (tree markup), not as a span list.
+    expect(out).toContain('json-key');
+    expect(out).not.toContain('trace-span');
+  });
+
+  it('pretty-prints a non-object trace (string / number / array) as a whole', () => {
+    expect(renderTrace('just a string')).toContain('just a string');
+    expect(renderTrace([1, 2, 3])).toContain('json-array');
+    expect(renderTrace(42)).toContain('42');
+  });
+
+  it('treats spans that is not an array as a non-conforming blob', () => {
+    const out = renderTrace({ spans: 'not-an-array' });
+    expect(out).not.toContain('trace-span');
+    expect(out).toContain('not-an-array');
+  });
+
+  it('returns a string for every input type (never throws)', () => {
+    for (const v of [null, undefined, 1, 'x', true, {}, [], { spans: [] }, { spans: [{ name: 'a' }] }]) {
+      expect(typeof renderTrace(v)).toBe('string');
+    }
+  });
+});
+
+describe('renderTrace — XSS escaping (same threat model as pretty.test.ts)', () => {
+  it('neutralizes an injected payload in a span name', () => {
+    const out = renderTrace({ spans: [{ name: '"><img src=x onerror=alert(1)>' }] });
+    expect(out).toContain('&lt;');
+    expect(out).not.toContain('<img');
+    expect(out).not.toContain('onerror=alert(1)>');
+  });
+
+  it('neutralizes an injected payload inside a span input blob', () => {
+    const out = renderTrace({ spans: [{ name: 'x', input: { p: '<script>x</script>' } }] });
+    expect(out).toContain('&lt;');
+    expect(out).not.toContain('<script>');
+  });
+
+  it('neutralizes an injected payload in the non-conforming fallback', () => {
+    const out = renderTrace({ evil: '"><img src=x onerror=alert(1)>' });
+    expect(out).toContain('&lt;');
+    expect(out).not.toContain('<img');
+  });
+});


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Harness[Eval harness] -->|"recordRow({ trace })"| Store[EleaticStore]
    Store -->|"toJsonOrNull → trace_json TEXT"| DB[(eval_row)]
    DB -->|getRow only| RowWithTrace[readRowWithTrace]
    DB -.->|"getRows / facetRows / diffRuns (lean)"| RowLean[readRow]
    RowWithTrace -->|"/api/row verbatim"| Drawer[drawer.js]
    Drawer -->|renderTrace| Panel["Trace section: span blocks + usage line"]
    RowLean -.->|no trace| List[gallery / diff list]
```

## Summary

- Adds a generic, opaque per-row `trace_json` so any eval domain can attach an LLM trace, surfaced as a collapsible drawer panel — *why*: trace-exploration (epic #1169) needs per-row spans without baking a domain shape into the package.
- The trace rides the single-row read path (`getRow` → `/api/row`) ONLY; `getRows`/`facetRows`/`diffRuns` stay lean via the shared `readRow` mapper, so the 150–1000-row gallery/diff payloads never carry the heavy blob.
- New pure `ui/trace.js#renderTrace` reuses `pretty.js` (escaping via `safe.js#esc`); zero `@bird-watch/*` imports keep the package's git-mv boundary intact, and a `trace.test.ts` sibling keeps knip tracing it with no `knip.ts` change.

## Screenshots

N/A — not UI. This PR touches only `packages/eleatic/**` (the Express-served explorer UI), not the React app under `frontend/**`; the multi-viewport screenshot policy targets `frontend/**`.

## Test plan

- [x] `npm run test` (full, all workspaces) — green (1536+ tests; eleatic 193/193, up from 172)
- [x] New unit / integration tests added: schema column, store write + NULL, `getRow` round-trip + `getRows`/`facetRows` leanness, `/api/row` trace verbatim, `renderTrace` (spans / usage-omit / non-conforming fallback / XSS)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A; eleatic UI is covered by pure-unit tests per the package's drawer convention
- [x] `npm run build` — clean production build (eleatic tsc strict: exactOptionalPropertyTypes, noUncheckedIndexedAccess, Bundler)
- [x] `npm run lint` — green · `npx knip` — green
- [ ] (UI only) Playwright MCP smoke — N/A — not `frontend/**`

## Plan reference

Part of epic #1169 (trace-exploration), task T1 (Wave 1). Closes #1166.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)