### PR TITLE
feat(photo-curation): write the judge "why" (rationale/fieldMarks/flags) into eleatic output_json

### DIFF
--- a/tools/photo-curation/scripts/run-eval-local.test.ts
+++ b/tools/photo-curation/scripts/run-eval-local.test.ts
@@ -169,7 +169,14 @@ describe('runEvalLocal', () => {
     expect(r!.rowKey).toBe('amerob');
     // expected_json carries the Opus baseline; output_json the Gemini decision.
     const expected = r!.expected as { keep: boolean; qualityScore: number };
-    const output = r!.output as { keep: boolean; qualityScore: number; criteria?: Record<string, number> };
+    const output = r!.output as {
+      keep: boolean;
+      qualityScore: number;
+      criteria?: Record<string, number>;
+      rationale?: string;
+      fieldMarks?: string[];
+      flags?: string[];
+    };
     expect(expected.keep).toBe(true);
     expect(expected.qualityScore).toBe(85);
     expect(output.keep).toBe(false);
@@ -181,6 +188,26 @@ describe('runEvalLocal', () => {
     expect(r!.scores!.cost).toBeGreaterThan(0);
     // criteria persisted (parsed, not double-encoded).
     expect(output.criteria).toMatchObject({ framing: 8 });
+  });
+
+  it('threads the judge "why" — rationale/fieldMarks/flags — from JudgmentRecord.output into output_json', async () => {
+    // The runner half-fix guard (T2): the adapter unit test proves the SEAM, but
+    // only a real run proves the RUNNER builds the EvalResultRecord from the full
+    // JudgeOutput. If the runner threads only keep/qualityScore/criteria, the
+    // read-back row.output lacks rationale even with a correct adapter.
+    eleatic = openStore(':memory:');
+    const rows: EvalRow[] = [evalRow({ speciesCode: 'amerob', expectedKeep: true, expectedQuality: 85 })];
+    const decide = () => ({ keep: true, quality: 80 });
+
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
+
+    const r = makeReader(eleatic.db).getRow('run-test-1', 'amerob');
+    const output = r!.output as { rationale?: string; fieldMarks?: string[]; flags?: string[] };
+    // the fakeJudge emits rationale 'r', fieldMarks ['mark'], flags [] — all must
+    // survive the runner→adapter→eleatic round-trip.
+    expect(output.rationale).toBe('r');
+    expect(output.fieldMarks).toEqual(['mark']);
+    expect(output.flags).toEqual([]);
   });
 
   it('computes falseKeep (judge keeps what baseline replaces) and total cost', async () => {

--- a/tools/photo-curation/scripts/run-eval-local.ts
+++ b/tools/photo-curation/scripts/run-eval-local.ts
@@ -181,6 +181,12 @@ export async function runEvalLocal(deps: RunEvalDeps): Promise<void> {
       geminiKeep: output.keep,
       geminiQuality: output.qualityScore,
       geminiCriteriaJson: JSON.stringify(output.criteria),
+      // The judge "why" (#1167, trace Tier 1) — the full JudgeOutput's reasoning,
+      // threaded through to output_json so the eleatic drawer can render it. The
+      // adapter omits an absent key (exactOptional) and preserves empty arrays.
+      rationale: output.rationale,
+      fieldMarks: output.fieldMarks,
+      flags: output.flags,
       opusKeep: row.expected.keep,
       opusQuality: row.expected.qualityScore,
       cost: record.estimatedCost,

--- a/tools/photo-curation/src/eval/eleatic-adapter.test.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.test.ts
@@ -22,6 +22,9 @@ function result(over: Partial<EvalResultRecord> = {}): EvalResultRecord {
     geminiKeep: true,
     geminiQuality: 80,
     geminiCriteriaJson: JSON.stringify({ framing: 8, subjectClarity: 9 }),
+    rationale: 'sharp eye, clean perch',
+    fieldMarks: ['rufous breast', 'yellow bill'],
+    flags: [],
     opusKeep: true,
     opusQuality: 85,
     cost: 0.0042,
@@ -60,7 +63,9 @@ describe('toEleaticRow', () => {
   });
 
   it('embeds output_json = {keep, qualityScore, criteria} with criteria PARSED (not double-encoded)', () => {
-    const row = toEleaticRow(result());
+    // why-fields absent so this test isolates the criteria mapping (their own
+    // round-trip is covered below).
+    const row = toEleaticRow(result({ rationale: undefined, fieldMarks: undefined, flags: undefined }));
     expect(row.output).toEqual({
       keep: true,
       qualityScore: 80,
@@ -72,9 +77,55 @@ describe('toEleaticRow', () => {
   });
 
   it('omits criteria when geminiCriteriaJson is null (null-guarded → absent, not undefined)', () => {
-    const row = toEleaticRow(result({ geminiCriteriaJson: null }));
+    const row = toEleaticRow(
+      result({ geminiCriteriaJson: null, rationale: undefined, fieldMarks: undefined, flags: undefined }),
+    );
     expect(row.output).toEqual({ keep: true, qualityScore: 80 });
     expect('criteria' in (row.output as object)).toBe(false);
+  });
+
+  it('copies the judge "why" — rationale/fieldMarks/flags — into output_json when present', () => {
+    const row = toEleaticRow(
+      result({
+        rationale: 'sharp eye, clean perch',
+        fieldMarks: ['rufous breast', 'yellow bill'],
+        flags: ['watermark'],
+      }),
+    );
+    const output = row.output as {
+      rationale?: string;
+      fieldMarks?: string[];
+      flags?: string[];
+    };
+    expect(output.rationale).toBe('sharp eye, clean perch');
+    expect(output.fieldMarks).toEqual(['rufous breast', 'yellow bill']);
+    expect(output.flags).toEqual(['watermark']);
+  });
+
+  it('carries an EMPTY fieldMarks/flags array through (empty ≠ absent — the judge ran but named none)', () => {
+    const row = toEleaticRow(result({ fieldMarks: [], flags: [] }));
+    const output = row.output as { fieldMarks?: string[]; flags?: string[] };
+    expect(output.fieldMarks).toEqual([]);
+    expect(output.flags).toEqual([]);
+    // present-but-empty: the keys exist (the judge produced them), the arrays are empty.
+    expect('fieldMarks' in output).toBe(true);
+    expect('flags' in output).toBe(true);
+  });
+
+  it('omits each why-field when the source output lacked it (exactOptional — absent key, not undefined)', () => {
+    const row = toEleaticRow(
+      result({ rationale: undefined, fieldMarks: undefined, flags: undefined }),
+    );
+    const output = row.output as object;
+    expect('rationale' in output).toBe(false);
+    expect('fieldMarks' in output).toBe(false);
+    expect('flags' in output).toBe(false);
+    // the unrelated keep/qualityScore/criteria mapping is untouched.
+    expect(row.output).toEqual({
+      keep: true,
+      qualityScore: 80,
+      criteria: { framing: 8, subjectClarity: 9 },
+    });
   });
 
   it('embeds expected_json = {keep, qualityScore} from the opus baseline (no opus criteria source → absent)', () => {

--- a/tools/photo-curation/src/eval/eleatic-adapter.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.ts
@@ -52,6 +52,14 @@ export interface EvalRunRecord {
  * `promptTokens` / `completionTokens` are `undefined` for an unpriced or
  * usage-less judgment; `geminiCriteriaJson` is `null` when the candidate carried
  * no per-axis sub-scores.
+ *
+ * The judge "why" (#1167, trace Tier 1) — `rationale` / `fieldMarks` / `flags`,
+ * the candidate `JudgeOutput`'s reasoning — rides through to `output_json` so the
+ * eleatic drawer can render it. All three are OPTIONAL: a deterministic-gate
+ * pre-reject (no judge ran) carries none, and the runner omits a field entirely
+ * when the source output lacked it (exactOptionalPropertyTypes — never
+ * `undefined` on the key). An EMPTY `fieldMarks`/`flags` array (the judge ran but
+ * named none) is distinct from ABSENT and is preserved.
  */
 export interface EvalResultRecord {
   runId: string;
@@ -62,6 +70,9 @@ export interface EvalResultRecord {
   geminiKeep: boolean;
   geminiQuality: number;
   geminiCriteriaJson: string | null;
+  rationale?: string;
+  fieldMarks?: string[];
+  flags?: string[];
   opusKeep: boolean;
   opusQuality: number;
   cost: number | undefined;
@@ -92,11 +103,19 @@ export type Disagreement = 'agree' | 'falseKeep' | 'falseReplace';
  * the PARSED per-axis sub-scores object (the source `geminiCriteriaJson` is an
  * already-serialized string — it is `JSON.parse`d here, never double-encoded),
  * omitted entirely when the source was null.
+ *
+ * The judge "why" (#1167) — `rationale` / `fieldMarks` / `flags` — rides along so
+ * the eleatic drawer's Output panel can show the candidate's reasoning. Each is
+ * omitted entirely when its source field was absent (exactOptional); an EMPTY
+ * `fieldMarks`/`flags` array is preserved (present-but-empty ≠ absent).
  */
 interface OutputBlob {
   keep: boolean;
   qualityScore: number;
   criteria?: CriteriaScores;
+  rationale?: string;
+  fieldMarks?: string[];
+  flags?: string[];
 }
 
 /** The Opus baseline decision blob embedded as `expected_json`. */
@@ -136,7 +155,9 @@ function parseCriteria(json: string | null): CriteriaScores | undefined {
  * Map one photo-judge judgment onto an eleatic `EvalRowRecord`.
  *   - row_key = speciesCode, label = comName, image_url = sourceUrl (omitted
  *     when empty), content_hash = contentHash (omitted when empty).
- *   - output_json = {keep, qualityScore, criteria?} with criteria PARSED.
+ *   - output_json = {keep, qualityScore, criteria?, rationale?, fieldMarks?,
+ *     flags?} — criteria PARSED, the judge "why" (#1167) copied through when the
+ *     source carried it (absent key when it did not; empty arrays preserved).
  *   - expected_json = {keep, qualityScore} (the baseline carries no criteria).
  *   - scores_json = {outputQuality, expectedQuality} (numeric facet axes).
  *   - metadata_json = {disagreement} (the categorical facet axis).
@@ -145,6 +166,13 @@ export function toEleaticRow(r: EvalResultRecord): EvalRowRecord {
   const output: OutputBlob = { keep: r.geminiKeep, qualityScore: r.geminiQuality };
   const criteria = parseCriteria(r.geminiCriteriaJson);
   if (criteria !== undefined) output.criteria = criteria;
+  // The judge "why" (#1167) — copied through ONLY when present, so the key is
+  // ABSENT (not `undefined`) for a deterministic-gate pre-reject or any output
+  // that lacked it (exactOptionalPropertyTypes). An EMPTY array is present-but-
+  // empty (the judge ran, named none) and is preserved verbatim.
+  if (r.rationale !== undefined) output.rationale = r.rationale;
+  if (r.fieldMarks !== undefined) output.fieldMarks = r.fieldMarks;
+  if (r.flags !== undefined) output.flags = r.flags;
 
   const expected: ExpectedBlob = { keep: r.opusKeep, qualityScore: r.opusQuality };
 


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    JO["JudgeOutput<br/>keep · qualityScore · criteria<br/><b>rationale · fieldMarks · flags</b>"]
    subgraph runner["run-eval-local.ts (SERIAL loop)"]
        RR["runRow → output: JudgeOutput"]
        ERR["EvalResultRecord<br/>+ rationale? · fieldMarks? · flags?"]
    end
    subgraph adapter["eleatic-adapter.ts (the one seam)"]
        TER["toEleaticRow → OutputBlob<br/>copy why-fields when present<br/>(absent → key omitted; [] preserved)"]
    end
    ELE[("eleatic eval.sqlite<br/>output_json")]
    DRAWER["eleatic drawer · Output panel<br/>now shows the judge's WHY"]

    JO --> RR --> ERR --> TER --> ELE --> DRAWER

    style ERR fill:#fde68a,stroke:#b45309
    style TER fill:#bbf7d0,stroke:#15803d
```

Before this PR, `EvalResultRecord` threaded only `keep`/`qualityScore`/`criteria` — the judge's reasoning was dropped at the runner (the yellow node), so `output_json` never carried it and the drawer had nothing to render. The fix is the full additive path: runner populates → adapter copies → store persists.

## Summary

- **Why:** Tier 1 of trace exploration (#1167) — the eval runner already held the full `JudgeOutput` per row (`rationale`/`fieldMarks`/`flags`), but the runner→eleatic mapping reduced it to `{keep, qualityScore, criteria}`, so the eleatic drawer's Output panel could not show *why* a photo was kept or replaced. The loss point was the runner, not the adapter: an adapter-only edit is a no-op because the `EvalResultRecord` the runner builds never carried the why-fields.
- **What:** Additive 3-file change in `tools/photo-curation/` — (a) add optional `rationale?`/`fieldMarks?`/`flags?` to `EvalResultRecord`, (b) populate them in `run-eval-local.ts` from the in-scope `JudgeOutput`, (c) extend `OutputBlob` + `toEleaticRow` to copy each into `output_json` **only when present** (absent → key omitted under `exactOptionalPropertyTypes`; an empty `fieldMarks`/`flags` array — judge ran, named none — is preserved, distinct from absent).
- **Posture:** The SERIAL loop and the nothing-else-changes posture are untouched; no input framing (model/rubricVersion/sourceUrl) is added — that stays T3 trace territory. eleatic renders `output_json` automatically (`EvalRowRecord.output` is opaque `unknown`), so no eleatic change is needed and the zero-coupling guard is untouched.

## Screenshots

N/A — not UI (CLI/tooling only; no `frontend/**` files touched).

## Test plan

- [x] `npm run typecheck && npm run test` — green (full `npm test`: db-client, eleatic, geo, photo-quality, admin-api, ingestor, read-api, photo-curation 367, frontend 1536 — all pass; no separate `typecheck` script exists, type-safety is enforced by the `tsc` build below)
- [x] New unit / integration tests added — `eleatic-adapter.test.ts`: why-fields map through `output_json`; absent source → key omitted (`expect('rationale' in output).toBe(false)`); empty arrays preserved. `run-eval-local.test.ts`: read-back `row.output` carries `rationale` (the runner half-fix guard the adapter unit test cannot catch).
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible UI
- [x] `npm run build` — clean production build (all workspaces)
- [ ] (UI only) Playwright MCP smoke — N/A, not UI

Also green: `npx knip --no-progress` (clean).

## Plan reference

Part of trace-exploration epic #1169 (Wave 1, T2 — no deps, parallel with T1). Closes #1167.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
