### PR TITLE
feat(photo-curation): capture per-judgment trace into eleatic trace_json (T3, #1168)

### DIFF
--- a/tools/photo-curation/scripts/run-eval-local.test.ts
+++ b/tools/photo-curation/scripts/run-eval-local.test.ts
@@ -56,7 +56,20 @@ function fakeJudge(sink: JudgmentSink, decide: (code: string) => { keep: boolean
     sink,
     // a fixed, priced usage so every judgment carries a known cost.
     usage: () => ({ promptTokenCount: 1000, candidatesTokenCount: 100, totalTokenCount: 1100 }),
+    // a deterministic latency clock (before/after) → latencyMs = 250 per call.
+    now: makeStepClock(1000, 250),
+    // a fixed raw envelope so the trace span's output.raw round-trips.
+    rawResponse: () => FAKE_RAW,
   });
+}
+
+/** The raw model envelope the fakeJudge reports — flows into the trace span. */
+const FAKE_RAW = { candidates: [{ content: { parts: [{ text: '{...}' }] } }], usageMetadata: { promptTokenCount: 1000 } };
+
+/** A monotonic clock that returns `start, start+step, start+2*step, …` on each call. */
+function makeStepClock(start: number, step: number): () => number {
+  let i = 0;
+  return () => start + step * i++;
 }
 
 /** Deps with a fake readImage (no fs) and a judge factory closing over `decide`. */
@@ -208,6 +221,59 @@ describe('runEvalLocal', () => {
     expect(output.rationale).toBe('r');
     expect(output.fieldMarks).toEqual(['mark']);
     expect(output.flags).toEqual([]);
+  });
+
+  it('writes the per-judgment trace span (T3) into trace_json, read back via getRow', async () => {
+    // End-to-end T3 guard: only a real run proves the RUNNER builds the span from
+    // record.input + the in-scope prompt + record.latencyMs/rawResponse/usage and
+    // threads it via toEleaticRow(result, trace) → recordRow. getRow is the ONLY
+    // eleatic read path that surfaces trace_json (T1); getRows omits it.
+    eleatic = openStore(':memory:');
+    const rows: EvalRow[] = [evalRow({ speciesCode: 'amerob', expectedKeep: true, expectedQuality: 85 })];
+    const decide = () => ({ keep: true, quality: 80 });
+
+    await runEvalLocal({ eleatic, rows, ...makeDeps(decide) });
+
+    const reader = makeReader(eleatic.db);
+    const r = reader.getRow('run-test-1', 'amerob');
+    const trace = r!.trace as {
+      spans: {
+        name: string;
+        input: { prompt: string; imageUrl?: string; species: Record<string, string>; rubricVersion: string; model: string };
+        output: { raw?: unknown; parsed: { keep: boolean; rationale: string } };
+        usage: Record<string, number>;
+      }[];
+    };
+    expect(trace.spans).toHaveLength(1);
+    const span = trace.spans[0]!;
+    expect(span.name).toBe('judge');
+    // input: prompt is runner-scope; species/model/rubricVersion from record.input;
+    // imageUrl is the PORTABLE R2 sourceUrl (the row's imageUrl), not the readPath.
+    expect(span.input.prompt).toBe('rubric prompt');
+    expect(span.input.imageUrl).toBe('https://photos.bird-maps.com/amerob.jpeg');
+    expect(span.input.species).toEqual({ comName: 'Common amerob', sciName: 'Sci amerob', family: 'Testidae' });
+    expect(span.input.rubricVersion).toBe('0.2.1');
+    expect(span.input.model).toBe('gemini-2.5-flash');
+    // output: the raw envelope + the full parsed JudgeOutput.
+    expect(span.output.raw).toEqual(FAKE_RAW);
+    expect(span.output.parsed.keep).toBe(true);
+    expect(span.output.parsed.rationale).toBe('r');
+    // usage: latency (clock delta 250) + tokens + cost.
+    expect(span.usage.latencyMs).toBe(250);
+    expect(span.usage.promptTokens).toBe(1000);
+    expect(span.usage.completionTokens).toBe(100);
+    expect(span.usage.costUsd).toBeGreaterThan(0);
+  });
+
+  it('omits trace_json from the lean list payload (getRows stays trace-free)', async () => {
+    eleatic = openStore(':memory:');
+    const rows: EvalRow[] = [evalRow({ speciesCode: 'amerob', expectedKeep: true, expectedQuality: 85 })];
+
+    await runEvalLocal({ eleatic, rows, ...makeDeps(() => ({ keep: true, quality: 80 })) });
+
+    const listed = makeReader(eleatic.db).getRows('run-test-1');
+    expect(listed).toHaveLength(1);
+    expect('trace' in listed[0]!).toBe(false);
   });
 
   it('computes falseKeep (judge keeps what baseline replaces) and total cost', async () => {

--- a/tools/photo-curation/scripts/run-eval-local.ts
+++ b/tools/photo-curation/scripts/run-eval-local.ts
@@ -50,8 +50,8 @@ import { mimeFromUrl } from '../src/sources.js';
 // The photo-judge domain records (`EvalResultRecord`) also live there now (E8,
 // #1151, after the bespoke src/eval/store.ts was retired).
 import {
-  openStore, makeReader, toEleaticRow, toEleaticRun,
-  type EleaticStore, type EvalResultRecord,
+  openStore, makeReader, toEleaticRow, toEleaticRun, buildTraceSpan,
+  type EleaticStore, type EvalResultRecord, type JudgeTraceInput,
 } from '../src/eval/eleatic-adapter.js';
 import { judgePromptForRubricVersion, resolveEvalModel } from '../eval/rubric-prompts.js';
 
@@ -193,11 +193,36 @@ export async function runEvalLocal(deps: RunEvalDeps): Promise<void> {
       promptTokens: record.promptTokens,
       completionTokens: record.completionTokens,
     };
+    // Build the per-judgment trace span (#1168, trace T3). This is the ONLY
+    // scope where all three sources meet: the species/model/rubric framing on
+    // `record.input` (a JudgmentInput), the in-scope rubric `prompt` (on neither
+    // record), and the per-call latency / raw response / parsed output / usage on
+    // `record`. `imageUrl` is the PORTABLE R2 sourceUrl (`record.input.sourceUrl`
+    // == `row.input.imageUrl`), never the local readPath. Optional sources are
+    // forwarded as-is; `buildTraceSpan` omits each absent field (exactOptional).
+    const traceInput: JudgeTraceInput = {
+      prompt,
+      comName: record.input.comName,
+      sciName: record.input.sciName,
+      family: record.input.family,
+      rubricVersion: record.input.judgedRubricVersion,
+      model: record.input.model,
+      parsed: output,
+      latencyMs: record.latencyMs,
+      ...(record.input.sourceUrl !== undefined ? { imageUrl: record.input.sourceUrl } : {}),
+      ...(record.rawResponse !== undefined ? { raw: record.rawResponse } : {}),
+      ...(record.promptTokens !== undefined ? { promptTokens: record.promptTokens } : {}),
+      ...(record.completionTokens !== undefined ? { completionTokens: record.completionTokens } : {}),
+      ...(record.estimatedCost !== undefined ? { costUsd: record.estimatedCost } : {}),
+    };
+    const trace = buildTraceSpan(traceInput);
+
     // Record the judgment to the eleatic store via the adapter — the SOLE eval
     // store (E8, #1151). Written serially, one row per `runRow`, so the SERIAL
     // loop invariant (#1094) is preserved and a mid-run crash leaves the store
-    // at exactly the rows already scored.
-    eleatic.recordRow(toEleaticRow(result));
+    // at exactly the rows already scored. The trace rides through to trace_json
+    // so the eleatic drawer's Trace panel (T1) renders the full per-call record.
+    eleatic.recordRow(toEleaticRow(result, trace));
   }
 
   const n = rows.length;

--- a/tools/photo-curation/src/eval/eleatic-adapter.test.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.test.ts
@@ -5,10 +5,12 @@ import {
   openStore,
   toEleaticRow,
   toEleaticRun,
+  buildTraceSpan,
   fromEleaticRow,
   costFromEleaticRow,
   type EvalResultRecord,
   type EvalRunRecord,
+  type JudgeTraceInput,
 } from './eleatic-adapter.js';
 
 /** A photo-judge result record with controllable keep/score/criteria fields. */
@@ -176,6 +178,108 @@ describe('toEleaticRow', () => {
   it('omits content_hash when contentHash is empty', () => {
     const row = toEleaticRow(result({ contentHash: '' }));
     expect('contentHash' in row).toBe(false);
+  });
+});
+
+/** A full trace-span input the runner assembles from record.input + prompt + record. */
+function traceInput(over: Partial<JudgeTraceInput> = {}): JudgeTraceInput {
+  return {
+    prompt: 'rubric prompt v0.2.1',
+    imageUrl: 'https://photos.bird-maps.com/amerob.jpeg',
+    comName: 'American Robin',
+    sciName: 'Turdus migratorius',
+    family: 'Turdidae',
+    rubricVersion: '0.2.1',
+    model: 'gemini-2.5-flash',
+    parsed: {
+      fieldMarks: ['rufous breast'],
+      criteria: { framing: 8, subjectClarity: 9, liveness: 10, naturalness: 9, pose: 7, background: 8, lighting: 8 },
+      flags: [],
+      keep: true,
+      qualityScore: 85,
+      rationale: 'sharp wild adult',
+    },
+    raw: { candidates: [{ content: { parts: [{ text: '{...}' }] } }], usageMetadata: { promptTokenCount: 1000 } },
+    promptTokens: 1000,
+    completionTokens: 100,
+    latencyMs: 350,
+    costUsd: 0.0042,
+    ...over,
+  };
+}
+
+describe('buildTraceSpan', () => {
+  it('builds the { spans:[{ name:"judge", input, output, usage }] } shape', () => {
+    const trace = buildTraceSpan(traceInput()) as {
+      spans: {
+        name: string;
+        input: Record<string, unknown>;
+        output: Record<string, unknown>;
+        usage: Record<string, number>;
+      }[];
+    };
+    expect(trace.spans).toHaveLength(1);
+    const span = trace.spans[0]!;
+    expect(span.name).toBe('judge');
+    expect(span.input).toEqual({
+      prompt: 'rubric prompt v0.2.1',
+      imageUrl: 'https://photos.bird-maps.com/amerob.jpeg',
+      species: { comName: 'American Robin', sciName: 'Turdus migratorius', family: 'Turdidae' },
+      rubricVersion: '0.2.1',
+      model: 'gemini-2.5-flash',
+    });
+    expect(span.output).toEqual({
+      raw: { candidates: [{ content: { parts: [{ text: '{...}' }] } }], usageMetadata: { promptTokenCount: 1000 } },
+      parsed: traceInput().parsed,
+    });
+    expect(span.usage).toEqual({
+      promptTokens: 1000,
+      completionTokens: 100,
+      latencyMs: 350,
+      costUsd: 0.0042,
+    });
+  });
+
+  it('omits absent usage fields (exactOptional — promptTokens/completionTokens/costUsd undefined → absent key)', () => {
+    const trace = buildTraceSpan(
+      traceInput({ promptTokens: undefined, completionTokens: undefined, costUsd: undefined }),
+    ) as { spans: { usage: Record<string, number> }[] };
+    const usage = trace.spans[0]!.usage;
+    // latency is ALWAYS present (every recorded judgment has a duration).
+    expect(usage).toEqual({ latencyMs: 350 });
+    expect('promptTokens' in usage).toBe(false);
+    expect('completionTokens' in usage).toBe(false);
+    expect('costUsd' in usage).toBe(false);
+  });
+
+  it('omits the raw output field when no raw response was captured (absent key, not undefined)', () => {
+    const trace = buildTraceSpan(traceInput({ raw: undefined })) as {
+      spans: { output: Record<string, unknown> }[];
+    };
+    const output = trace.spans[0]!.output;
+    expect('raw' in output).toBe(false);
+    // the parsed output is still present.
+    expect(output.parsed).toEqual(traceInput().parsed);
+  });
+
+  it('omits the imageUrl input field when the image has no portable URL', () => {
+    const trace = buildTraceSpan(traceInput({ imageUrl: undefined })) as {
+      spans: { input: Record<string, unknown> }[];
+    };
+    expect('imageUrl' in trace.spans[0]!.input).toBe(false);
+  });
+});
+
+describe('toEleaticRow — trace threading (T3, #1168)', () => {
+  it('omits row.trace when no trace is passed (T1/T2 callers unchanged)', () => {
+    const row = toEleaticRow(result());
+    expect('trace' in row).toBe(false);
+  });
+
+  it('threads a passed trace onto row.trace verbatim', () => {
+    const trace = buildTraceSpan(traceInput());
+    const row = toEleaticRow(result(), trace);
+    expect(row.trace).toEqual(trace);
   });
 });
 

--- a/tools/photo-curation/src/eval/eleatic-adapter.ts
+++ b/tools/photo-curation/src/eval/eleatic-adapter.ts
@@ -23,7 +23,7 @@
 
 import { openStore, makeReader } from '@bird-watch/eleatic';
 import type { EvalRowRecord, EvalRunRecord as EleaticRunRecord, EleaticStore } from '@bird-watch/eleatic';
-import type { CriteriaScores } from '@bird-watch/photo-quality';
+import type { CriteriaScores, JudgeOutput } from '@bird-watch/photo-quality';
 
 /**
  * One eval RUN's record — the photo-judge domain vocabulary the runner produces
@@ -78,6 +78,71 @@ export interface EvalResultRecord {
   cost: number | undefined;
   promptTokens: number | undefined;
   completionTokens: number | undefined;
+}
+
+/**
+ * The full per-judgment framing the runner assembles to build one trace span
+ * (#1168, trace T3). It is the UNION of three sources that no single existing
+ * record carries: the species/model/rubric framing (`JudgmentRecord.input`),
+ * the runner-scope rubric `prompt` (on neither record), and the per-call
+ * latency / raw response / parsed output / usage (`JudgmentRecord`). The runner
+ * is the only place all three meet, so the span is built there from this input.
+ *
+ * exactOptionalPropertyTypes: every optional source is declared `?` and OMITTED
+ * (never `undefined`) — `imageUrl` for an image with no portable URL, `raw` for
+ * an absent raw response, and each of `promptTokens`/`completionTokens`/`costUsd`
+ * for a usage-less or unpriced judgment. `latencyMs` is always present.
+ */
+export interface JudgeTraceInput {
+  /** The rubric prompt the runner handed the judge (runner-scope only). */
+  prompt: string;
+  /** The portable R2 provenance URL (the row's `imageUrl`, NOT the local readPath). */
+  imageUrl?: string;
+  comName: string;
+  sciName: string;
+  family: string;
+  /** The rubric version the judge was invoked with. */
+  rubricVersion: string;
+  /** The judge model id. */
+  model: string;
+  /** The full parsed JudgeOutput (fieldMarks/criteria/flags/keep/qualityScore/rationale). */
+  parsed: JudgeOutput;
+  /** The model's RAW reply (the Gemini envelope); absent when none was captured. */
+  raw?: unknown;
+  promptTokens?: number;
+  completionTokens?: number;
+  latencyMs: number;
+  costUsd?: number;
+}
+
+/**
+ * Build the generic eleatic trace blob for one judgment (#1168, trace T3). Shape:
+ *   { spans: [{ name:'judge', input:{prompt,imageUrl?,species,rubricVersion,model},
+ *               output:{raw?,parsed}, usage:{promptTokens?,completionTokens?,latencyMs,costUsd?} }] }
+ * — the conventional eleatic span shape (T1) the drawer's Trace panel renders.
+ * Absent optional fields are omitted entirely (exactOptionalPropertyTypes), so a
+ * usage-less / unpriced / raw-less judgment yields a lean span, never a key set
+ * to `undefined`. Returned as an OPAQUE blob (eleatic never destructures it).
+ */
+export function buildTraceSpan(t: JudgeTraceInput): unknown {
+  const input: Record<string, unknown> = {
+    prompt: t.prompt,
+    species: { comName: t.comName, sciName: t.sciName, family: t.family },
+    rubricVersion: t.rubricVersion,
+    model: t.model,
+  };
+  if (t.imageUrl !== undefined) input.imageUrl = t.imageUrl;
+
+  const output: Record<string, unknown> = { parsed: t.parsed };
+  if (t.raw !== undefined) output.raw = t.raw;
+
+  // latencyMs is always present; the token/cost fields are omitted when absent.
+  const usage: Record<string, number> = { latencyMs: t.latencyMs };
+  if (t.promptTokens !== undefined) usage.promptTokens = t.promptTokens;
+  if (t.completionTokens !== undefined) usage.completionTokens = t.completionTokens;
+  if (t.costUsd !== undefined) usage.costUsd = t.costUsd;
+
+  return { spans: [{ name: 'judge', input, output, usage }] };
 }
 
 // Re-export the eleatic LIFECYCLE surface the runner + analyzer need, so this
@@ -161,8 +226,13 @@ function parseCriteria(json: string | null): CriteriaScores | undefined {
  *   - expected_json = {keep, qualityScore} (the baseline carries no criteria).
  *   - scores_json = {outputQuality, expectedQuality} (numeric facet axes).
  *   - metadata_json = {disagreement} (the categorical facet axis).
+ *   - trace_json = the optional per-judgment trace span (#1168, trace T3) when
+ *     the caller passes one; the key is ABSENT otherwise (T1/T2 callers pass no
+ *     trace and the row carries none). The trace is OPAQUE here — built by
+ *     {@link buildTraceSpan} in the runner (the only scope with prompt + record)
+ *     and forwarded to eleatic's `recordRow` verbatim.
  */
-export function toEleaticRow(r: EvalResultRecord): EvalRowRecord {
+export function toEleaticRow(r: EvalResultRecord, trace?: unknown): EvalRowRecord {
   const output: OutputBlob = { keep: r.geminiKeep, qualityScore: r.geminiQuality };
   const criteria = parseCriteria(r.geminiCriteriaJson);
   if (criteria !== undefined) output.criteria = criteria;
@@ -198,6 +268,10 @@ export function toEleaticRow(r: EvalResultRecord): EvalRowRecord {
   // when their source is missing, so the store coerces them to a column NULL.
   if (r.sourceUrl !== '') row.imageUrl = r.sourceUrl;
   if (r.contentHash !== '') row.contentHash = r.contentHash;
+  // The per-judgment trace (#1168, trace T3) rides through to trace_json when
+  // the runner passes one — absent key otherwise (exactOptional), so the store
+  // writes a column NULL and getRow reads it back as an absent `trace`.
+  if (trace !== undefined) row.trace = trace;
   return row;
 }
 

--- a/tools/photo-curation/src/judges/gemini.test.ts
+++ b/tools/photo-curation/src/judges/gemini.test.ts
@@ -349,6 +349,40 @@ describe('GeminiVisionJudge', () => {
     expect(judge.lastUsage()).toBeUndefined();
   });
 
+  // #1168 (trace T3): the raw v1beta response envelope is captured INTERNALLY
+  // (mirroring lastUsage()) so the runner can write it into the eleatic trace
+  // span without any VisionJudge-interface change. The accessor returns the
+  // PARSED `await res.json()` value of the latest 200 response.
+  it('captures the raw response envelope, readable via lastRawResponse()', async () => {
+    const usage = { promptTokenCount: 1234, candidatesTokenCount: 56, totalTokenCount: 1290 };
+    const fetchImpl = async () => geminiOk(JSON.stringify(VALID_OUTPUT), usage);
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    expect(judge.lastRawResponse()).toBeUndefined(); // nothing judged yet
+    await judge.judge(img, ctx, 'p');
+    // The raw envelope is the full v1beta JSON — candidates + usageMetadata.
+    expect(judge.lastRawResponse()).toEqual({
+      candidates: [{ content: { parts: [{ text: JSON.stringify(VALID_OUTPUT) }] } }],
+      usageMetadata: usage,
+    });
+  });
+
+  it('lastRawResponse() reflects the LATEST response (the re-ask wins on a parse retry)', async () => {
+    let n = 0;
+    const fetchImpl = async () => {
+      n += 1;
+      // First response is non-JSON text (forces a re-ask); the second is valid.
+      return n === 1 ? geminiOk('not json') : geminiOk(JSON.stringify(VALID_OUTPUT));
+    };
+    const judge = new GeminiVisionJudge({ apiKey: 'k', clock: makeFakeClock(), fetchImpl });
+
+    await judge.judge(img, ctx, 'p');
+    // The successful re-ask's envelope is the one surfaced — not the first body.
+    expect(judge.lastRawResponse()).toEqual({
+      candidates: [{ content: { parts: [{ text: JSON.stringify(VALID_OUTPUT) }] } }],
+    });
+  });
+
   it('re-asks once on a non-JSON body then throws GeminiJudgeError', async () => {
     let n = 0;
     const fetchImpl = async () => {

--- a/tools/photo-curation/src/judges/gemini.ts
+++ b/tools/photo-curation/src/judges/gemini.ts
@@ -328,6 +328,8 @@ export class GeminiVisionJudge implements VisionJudge {
   private dailyExhaustedQuotaId: string | null = null;
   /** usageMetadata of the LATEST 200 response — overwritten (or cleared) per response (#1037). */
   private _lastUsage: GeminiUsage | undefined;
+  /** The RAW parsed envelope of the LATEST 200 response — overwritten per response (#1168). */
+  private _lastRawResponse: unknown;
 
   constructor(opts: GeminiVisionJudgeOptions) {
     if (!opts.apiKey) {
@@ -362,6 +364,10 @@ export class GeminiVisionJudge implements VisionJudge {
     // PREVIOUS row's token counts. On a parse re-ask the second response wins:
     // lastUsage() is per-output, not a per-row cost accumulator.
     this._lastUsage = extractUsage(json);
+    // Capture the RAW envelope too (#1168, trace T3) — same per-response
+    // overwrite semantics as _lastUsage, so the eleatic trace span carries the
+    // model's actual reply (candidates + usageMetadata), not a re-derived shape.
+    this._lastRawResponse = json;
     return extractText(json);
   }
 
@@ -373,6 +379,17 @@ export class GeminiVisionJudge implements VisionJudge {
    */
   lastUsage(): GeminiUsage | undefined {
     return this._lastUsage;
+  }
+
+  /**
+   * The RAW parsed v1beta envelope of the latest 200 response, or `undefined`
+   * when none has been seen (#1168, trace T3). The instrumented wrapper reads
+   * this right after a judgment resolves to surface the model's actual reply in
+   * the eleatic trace span's `output.raw` — `VisionJudge` and `JudgeOutput`
+   * stay unchanged (the accessor is on the concrete class, read by the wrapper).
+   */
+  lastRawResponse(): unknown {
+    return this._lastRawResponse;
   }
 
   /** One paced, backoff-wrapped ask → parsed JudgeOutput. */

--- a/tools/photo-curation/src/judges/instrumented.test.ts
+++ b/tools/photo-curation/src/judges/instrumented.test.ts
@@ -84,6 +84,70 @@ describe('instrumentedJudge', () => {
     expect(records).toHaveLength(0);
   });
 
+  // #1168 (trace T3): per-call latency is measured via an INJECTABLE monotonic
+  // clock (the Clock-injection precedent), so the recorded value is the
+  // deterministic clock delta around the inner judge call — not a real timer.
+  it('records latencyMs as the injected clock delta around the inner judge call', async () => {
+    const ticks = [1000, 1350]; // before, after → 350 ms elapsed.
+    let i = 0;
+    const now = () => ticks[i++]!;
+    const { records, sink } = makeSink();
+    const judge = instrumentedJudge(new FakeJudge(), {
+      model: 'gemini-2.5-flash', rubricVersion: '0.2.1', sink, now,
+    });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    expect(records[0]!.latencyMs).toBe(350);
+  });
+
+  it('defaults to a real monotonic clock — latencyMs is a finite, non-negative number', async () => {
+    const { records, sink } = makeSink();
+    const judge = instrumentedJudge(new FakeJudge(), { model: 'gemini-2.5-flash', rubricVersion: '0.2.1', sink });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    const ms = records[0]!.latencyMs;
+    expect(Number.isFinite(ms)).toBe(true);
+    expect(ms).toBeGreaterThanOrEqual(0);
+  });
+
+  // The raw model response is surfaced via the injectable accessor (mirroring
+  // the usage accessor), read AFTER the judgment resolves. No VisionJudge change.
+  it('records rawResponse from the rawResponse accessor', async () => {
+    const raw = { candidates: [{ content: { parts: [{ text: '{}' }] } }], usageMetadata: { promptTokenCount: 5 } };
+    const { records, sink } = makeSink();
+    const judge = instrumentedJudge(new FakeJudge(), {
+      model: 'gemini-2.5-flash', rubricVersion: '0.2.1', sink, rawResponse: () => raw,
+    });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    expect(records[0]!.rawResponse).toEqual(raw);
+  });
+
+  it('leaves rawResponse ABSENT (not undefined) when no accessor is provided', async () => {
+    const { records, sink } = makeSink();
+    const judge = instrumentedJudge(new FakeJudge(), { model: 'gemini-2.5-flash', rubricVersion: '0.2.1', sink });
+
+    await judge.judge(img, ctx, PROMPT);
+
+    // exactOptionalPropertyTypes: the key is omitted entirely, never `undefined`.
+    expect('rawResponse' in records[0]!).toBe(false);
+  });
+
+  it('a throwing judge emits no record even with the latency clock + raw accessor wired', async () => {
+    const { records, sink } = makeSink();
+    const judge = instrumentedJudge(new ThrowingJudge(), {
+      model: 'opus', rubricVersion: '0.2.1', sink,
+      now: () => 0,
+      rawResponse: () => ({ never: 'read' }),
+    });
+
+    await expect(judge.judge(img, ctx, PROMPT)).rejects.toThrow('inner boom');
+    expect(records).toHaveLength(0);
+  });
+
   // Token extraction (ported from traced.ts): completion_tokens includes
   // thinking tokens; total is implicit. The sink surfaces prompt/completion.
   it('emits prompt/completion tokens from the usage accessor', async () => {

--- a/tools/photo-curation/src/judges/instrumented.ts
+++ b/tools/photo-curation/src/judges/instrumented.ts
@@ -61,6 +61,13 @@ export interface JudgmentInput {
  * `completionTokens` are `undefined` when no usage was reported;
  * `estimatedCost` is `undefined` for an unpriced model OR an absent-usage
  * judgment (the unpriced warning fires only for a price-table miss).
+ *
+ * `latencyMs` (#1168, trace T3) is the wall time the inner `judge()` took,
+ * measured with an INJECTABLE monotonic clock (deterministic in tests). It is
+ * always present — every recorded judgment completed, so a duration exists.
+ * `rawResponse` is the model's raw reply (the Gemini judge's `await res.json()`
+ * envelope), surfaced via an injectable accessor; the key is ABSENT when no
+ * accessor is wired or it returned `undefined` (exactOptionalPropertyTypes).
  */
 export interface JudgmentRecord {
   input: JudgmentInput;
@@ -68,6 +75,8 @@ export interface JudgmentRecord {
   promptTokens: number | undefined;
   completionTokens: number | undefined;
   estimatedCost: number | undefined;
+  latencyMs: number;
+  rawResponse?: unknown;
 }
 
 /** The injectable record boundary — every judgment emits exactly one record. */
@@ -89,6 +98,21 @@ export interface InstrumentedJudgeOptions {
    * internal to this package so `JudgeOutput` stays SDK-free and unchanged.
    */
   usage?: () => GeminiUsage | undefined;
+  /**
+   * Optional accessor for the inner judge's latest-call RAW response (#1168,
+   * trace T3) — the Gemini judge's `await res.json()` envelope, read AFTER each
+   * judgment resolves (mirroring `usage`). Kept on the concrete judge + read
+   * here so `VisionJudge`/`JudgeOutput` stay unchanged. When absent or it
+   * returns `undefined`, the record's `rawResponse` key is omitted entirely.
+   */
+  rawResponse?: () => unknown;
+  /**
+   * Injectable monotonic clock (#1168) — read immediately before and after the
+   * inner `judge()` call; the delta is recorded as `latencyMs`. Defaults to a
+   * real monotonic clock (`performance.now`). Injected so the latency assertion
+   * is deterministic (the Clock-injection precedent in gemini.ts / pacing.ts).
+   */
+  now?: () => number;
   /**
    * One-line warning sink (#1088). Surfaces an UNPRICED model — exactly ONCE
    * per unpriced model id for the lifetime of this wrapped judge (a per-judgment
@@ -157,15 +181,28 @@ function tokensFor(usage: GeminiUsage | undefined): { promptTokens: number | und
 export function instrumentedJudge(inner: VisionJudge, opts: InstrumentedJudgeOptions): VisionJudge {
   const { model, rubricVersion, sink, usage } = opts;
   const warn = opts.warn ?? ((line: string) => console.warn(line));
+  // Default to a real monotonic clock (#1168). `performance.now()` is monotonic
+  // (immune to wall-clock adjustments) and millisecond-fractional; an injected
+  // `now` makes the latency delta deterministic in tests.
+  const now = opts.now ?? (() => performance.now());
   // Per-wrapped-judge set of unpriced model ids already warned about, so the
   // unpriced-model warning fires once per model for this judge's lifetime — not
   // once per judgment (#1088 review). Lives OUTSIDE the per-call closure.
   const warnedUnpriced = new Set<string>();
   return {
     async judge(img: ImageInput, ctx: SpeciesContext, prompt: string): Promise<JudgeOutput> {
+      // Time the inner call with the injectable clock. A judgment that THROWS
+      // never reaches the sink (no record), so latency is only ever recorded
+      // for a completed judgment — `startedAt` read here, `latencyMs` below.
+      const startedAt = now();
       const output = await inner.judge(img, ctx, prompt);
+      const latencyMs = now() - startedAt;
       const { promptTokens, completionTokens } = tokensFor(usage?.());
       const estimatedCost = costFor(model, promptTokens, completionTokens, warn, warnedUnpriced);
+      // Raw model reply (#1168), read AFTER the judgment resolves (mirrors
+      // `usage`). Spread-guarded so the key is ABSENT when no accessor is wired
+      // or it returns `undefined` (never `rawResponse: undefined`).
+      const rawResponse = opts.rawResponse?.();
       sink({
         input: {
           speciesCode: ctx.speciesCode,
@@ -183,6 +220,8 @@ export function instrumentedJudge(inner: VisionJudge, opts: InstrumentedJudgeOpt
         promptTokens,
         completionTokens,
         estimatedCost,
+        latencyMs,
+        ...(rawResponse !== undefined ? { rawResponse } : {}),
       });
       return output;
     },
@@ -229,5 +268,9 @@ export function resolveJudge(env: JudgeEnv, opts: ResolveJudgeOptions): VisionJu
     // Internal usage hand-off (#1037 decision 5): the wrapper reads the inner
     // judge's latest usageMetadata after each judgment to record token counts.
     usage: () => inner.lastUsage(),
+    // Internal raw-response hand-off (#1168, trace T3): the wrapper reads the
+    // inner judge's latest raw envelope after each judgment to record it on the
+    // trace span. Kept here (not on VisionJudge) so the seam stays unchanged.
+    rawResponse: () => inner.lastRawResponse(),
   });
 }


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Runner as run-eval-local
    participant Judge as instrumentedJudge
    participant Gemini as GeminiVisionJudge
    participant Adapter as eleatic-adapter
    participant Eleatic as eleatic store

    Runner->>Judge: judge(img, ctx, prompt)
    Note over Judge: now() before/after → latencyMs
    Judge->>Gemini: inner.judge(...)
    Gemini-->>Gemini: _lastRawResponse = await res.json()
    Gemini-->>Judge: JudgeOutput (parsed)
    Judge->>Gemini: lastRawResponse() / lastUsage()
    Judge-->>Runner: sink(JudgmentRecord{latencyMs, rawResponse, tokens, cost})
    Runner->>Adapter: buildTraceSpan(record.input + prompt + record)
    Adapter-->>Runner: { spans:[{ name:'judge', input, output, usage }] }
    Runner->>Adapter: toEleaticRow(result, trace)
    Runner->>Eleatic: recordRow({ ..., trace })
    Note over Eleatic: trace_json → drawer Trace panel (T1)
```

## Summary

- **Why:** T1 added eleatic's generic `trace_json` field + the drawer's Trace panel, but nothing wrote the per-judgment trace. T3 captures the full per-call record (latency + raw model response + prompt + parsed output + usage) and threads it into `trace_json` so the panel renders it.
- **Where the span is built:** no single existing record carries all three sources — the model/rubric/species framing (`JudgmentRecord.input`), the runner-scope rubric `prompt` (on neither record), and the per-call latency/raw/usage (`JudgmentRecord`). The runner is the only scope where they meet, so `buildTraceSpan` runs there and the trace rides through `toEleaticRow(result, trace)` → `recordRow`.
- **Seam discipline:** `latencyMs` uses an injectable monotonic clock (defaults to `performance.now`); the raw response is surfaced via a `lastRawResponse()` accessor on the concrete `GeminiVisionJudge` mirroring `lastUsage()` — **no `VisionJudge`-interface change**. eleatic is untouched (one-way dep via the adapter seam); the SERIAL loop + additive posture are intact.

## Screenshots

N/A — CLI/tooling (trace capture)

## Test plan

- [x] `npm run test` (full monorepo, `--workspaces`) — green (exit 0); photo-curation 382 + eleatic 193 verified individually
- [x] New unit tests added: instrumented (fake clock → `latencyMs` is the clock delta; fake `lastRawResponse` → `rawResponse` flows; throwing judge emits no record), gemini (`lastRawResponse()` captures the envelope, re-ask wins), adapter (`buildTraceSpan` shape + exactOptional omission + `toEleaticRow(result, trace)` threading), runner (trace span read back via `makeReader.getRow`; `getRows` stays lean)
- [x] `npm run build` — clean (`tsc` under strict tsconfig: exactOptionalPropertyTypes, noUncheckedIndexedAccess, Bundler)
- [x] `npm run lint` — clean; `npx knip` — clean (no findings on new exports)
- [x] N/A — not UI (no Playwright MCP smoke)

## Plan reference

Part of epic #1169 (trace-exploration), Wave 2 / T3. Out of `docs/plans/` — plans live in issues. Closes #1168.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)