### PR TITLE
fix(eleatic): surface the drawer Trace panel — open by default, above Output

### DIFF
--- a/packages/eleatic/ui/drawer.js
+++ b/packages/eleatic/ui/drawer.js
@@ -8,9 +8,10 @@
 //     package never destructures them; rendered via the escaping prettyJson unit),
 //   • a score bar per scores_json entry,
 //   • the row's metadata,
-//   • a collapsible "Trace" section (after output-vs-expected) when the row
-//     carries a trace — rendered by the escaping renderTrace pure unit; absent
-//     entirely when the single-row read returned no trace,
+//   • a "Trace" section — expanded by default and placed ABOVE output-vs-expected
+//     so it lands in view without scrolling past the JSON blob; still collapsible.
+//     Present only when the row carries a trace (rendered by the escaping
+//     renderTrace pure unit; absent entirely when the single-row read had none),
 //   • the image via safeImg,
 //   • the adjudication panel (adjudicate.js).
 //
@@ -156,6 +157,13 @@ export async function openDrawer(rowParam, trigger = null) {
       <h3 class="drawer-h3">Metadata</h3>
       <div class="meta-chips">${metadataChips(record.metadata)}</div>
     </section>
+    ${record.trace !== undefined ? `
+    <section class="drawer-section">
+      <details class="trace-details" open>
+        <summary class="drawer-h3 trace-summary">Trace</summary>
+        ${renderTrace(record.trace)}
+      </details>
+    </section>` : ''}
     <section class="drawer-section">
       <h3 class="drawer-h3">Output vs expected</h3>
       <div class="json-compare">
@@ -163,13 +171,6 @@ export async function openDrawer(rowParam, trigger = null) {
         <div class="json-col"><div class="json-col-label">expected</div>${prettyJson(record.expected)}</div>
       </div>
     </section>
-    ${record.trace !== undefined ? `
-    <section class="drawer-section">
-      <details class="trace-details">
-        <summary class="drawer-h3 trace-summary">Trace</summary>
-        ${renderTrace(record.trace)}
-      </details>
-    </section>` : ''}
     <section class="drawer-section" id="drawer-adjudicate"></section>`;
 
   // Fetch the existing adjudication (if any) so the panel pre-fills + flags stale.


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph Before["Before — Trace below the fold, collapsed"]
      direction TB
      B1[Scores] --> B2[Metadata] --> B3["Output vs expected<br/>(tall JSON blob)"] --> B4["Trace ▸ collapsed<br/>(off-screen on open)"] --> B5[Adjudicate]
    end
    subgraph After["After — Trace in view, expanded"]
      direction TB
      A1[Scores] --> A2[Metadata] --> A3["Trace ▾ open<br/>span · usage line"] --> A4[Output vs expected] --> A5[Adjudicate]
    end
    Before -->|"add <code>open</code> + lift above Output"| After
```

## Summary

- **Why:** the per-judgment Trace drill-down (prompt · raw response · tokens · latency · cost) already existed, but was undiscoverable — it rendered as a *collapsed* `<details>` *below* the verbose Output-vs-expected JSON blob, so on a fresh drawer open it sat off-screen and read as an empty heading. Reported directly as "the trace panel doesn't look like it exists."
- **What:** render `<details class="trace-details" open>` and move the Trace `<section>` above Output-vs-expected → order is now **Scores → Metadata → Trace → Output → Adjudicate**. The nested `input`/`output` sub-disclosures stay collapsed, so the open panel is compact (span name + the two toggles + the usage line), not a wall of prompt text.
- **Generic:** a drawer-layout change in the `eleatic` package — applies to any consumer's traces, not photo-judge-specific. Header comment updated to match the new position.

## Screenshots

N/A — not under `frontend/**`. This is the `packages/eleatic` tool UI, exempt from the frontend Playwright / 10-capture design-QA contract per repo `CLAUDE.md`. **Live-verified via Playwright MCP** against the eleatic explorer (`eleatic serve`): on a fresh drawer deep-link the Trace section now renders expanded directly under Metadata (above Output), showing `judge · input ▸ · output ▸ · 881 prompt · 196 completion · 1486.25 ms · $0.0001665`; `browser_console_messages` returned **0 errors / 0 warnings**. Before/after stills captured locally — happy to attach on request.

- [x] N/A — no new/renamed `className`. `trace-details` / `trace-summary` already have rules in `packages/eleatic/ui/app.css`; this change adds only the `open` attribute and reorders two sections.
- [x] N/A — not UI under `frontend/**` (packages/ tool); the ≥10 `user-attachments` multi-viewport rule does not apply.

## Test plan

- [x] `npm run build -w @bird-watch/eleatic` — clean (`tsc` + `cpSync ui→dist/ui`); the built `dist/ui/drawer.js` contains the `open` attribute.
- [x] `npm run test -w @bird-watch/eleatic` — **193/193 pass** (19 files). `drawer.js` is browser-only DOM glue with no unit test *by existing convention*; the pure units it renders (`renderTrace`, `prettyJson`) are unchanged and remain covered.
- [x] `knip` — clean (no exports/files added or removed; the lone config hint is pre-existing and unrelated).
- [x] Live Playwright MCP smoke on the eleatic explorer — fresh drawer open renders Trace **expanded, above Output**; console 0/0. (Frontend `npm run dev` drive is N/A — not a `frontend/**` change.)
- [ ] New unit / e2e test — N/A: template reorder + one HTML attribute, no new logic; `drawer.js` is untested glue by convention.

## Plan reference

Out of plan — follow-up UX fix to the eleatic trace-exploration epic (**#1169**, merged; T1 #1170 / T3 #1172). Surfaced when the rendered Trace panel proved undiscoverable on a fresh drawer open. The data capture and `renderTrace` unit were already correct; this only changes drawer placement + default-open state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
