### PR TITLE
feat(eleatic): add per-run "Explore rows →" link from the hub to its facet gallery

### DIFF
--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -61,6 +61,8 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .run-label { font-weight: 600; }
 .run-label .baseline-star { color: var(--accent); margin-left: 4px; cursor: help; }
 .run-id { color: var(--text-dim); font-family: var(--mono-stack); font-size: var(--type-xs); }
+.explore-link { display: inline-block; margin-top: 4px; font-weight: 400; font-size: var(--type-xs); color: var(--accent); text-decoration: none; }
+.explore-link:hover { text-decoration: underline; }
 
 /* ── Gate badge ── */
 .gate-badge { display: inline-block; font-weight: 700; font-size: var(--type-xs); padding: 2px 10px; border-radius: 999px; color: #fff; text-transform: uppercase; letter-spacing: .03em; }

--- a/packages/eleatic/ui/hub.js
+++ b/packages/eleatic/ui/hub.js
@@ -6,7 +6,9 @@
 //      agreement/falseKeep columns). Each cell is rendered with the per-metric
 //      formatter named in /config.js (percent/usd/integer/raw). A configurable
 //      gate badge ({metric,op,threshold} from /config.js) shows PASS/fail per
-//      run; the run named by `baseline` carries a ★ marker.
+//      run; the run named by `baseline` carries a ★ marker. Each row also carries
+//      an "Explore rows →" link to `/facets?run=<id>` — the single-run path into
+//      the row gallery + drilldown drawer (compare needs two runs; explore one).
 //   2. A "compare 2" affordance: a checkbox per row, exactly two selectable,
 //      enabling a "Compare →" link to `/diff?a=<id>&b=<id>` (the E4 diff route).
 //   3. Inline-SVG trends from `GET /api/trends?metric=<m>`: ONE <polyline> per
@@ -113,7 +115,7 @@ function renderRunsTable() {
                    ${isSel ? 'checked' : ''} ${disabled}
                    aria-label="Select ${esc(run.label)} to compare" />
           </td>
-          <td class="run-label">${esc(run.label)}${isBaseline ? '<span class="baseline-star" title="baseline">★</span>' : ''}<div class="run-id">${esc(run.id)}</div></td>
+          <td class="run-label">${esc(run.label)}${isBaseline ? '<span class="baseline-star" title="baseline">★</span>' : ''}<div class="run-id">${esc(run.id)}</div><a class="explore-link" href="/facets?run=${encodeURIComponent(run.id)}" aria-label="Explore rows of ${esc(run.label)}">Explore rows →</a></td>
           <td>${esc(run.startedAt)}</td>
           <td class="num">${esc(formatMetric(run.rowCount, 'integer'))}</td>
           ${metricCells}


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    subgraph Before["Before — no UI path to a single run's rows"]
      H1["Hub /"] -->|"select 2 runs → Compare →"| D1["/diff"]
      H1 -.->|"NO link"| F1["/facets?run=X<br/>(URL-only)"]
      D1 --> DR1[drawer + Trace]
      F1 --> DR1
    end
    subgraph After["After — Explore rows → completes the path"]
      H2["Hub /"] -->|"Explore rows → (per run)"| F2["/facets?run=X"]
      H2 -->|"select 2 → Compare →"| D2["/diff"]
      F2 --> C2[click card] --> DR2[drawer + Trace]
      D2 --> DR2
    end
```

## Summary

- **Why:** the hub's only navigation affordance was **"Compare →"**, which requires **two** selected runs (→ `/diff`). The per-run facet gallery (`/facets?run=<id>`) — the only click-path into the row drilldown drawer + **Trace** panel — was reachable **solely by typing the URL**. So with a single run there was *no way to reach any row detail from the UI at all*. (Reported: "I don't see a way to get to the facets route from the ui.")
- **What:** add an **"Explore rows →"** link in each run row's **Run** column (left side — always visible without horizontal-scrolling past the wide metrics table) → `/facets?run=<id>`, mirroring the existing "Compare →" pattern. **Compare needs two runs; explore needs one.** New `.explore-link` style reuses the design tokens (`--accent`, `--type-xs`).
- **Result:** completes the click path **hub → Explore rows → → gallery → card → drawer → Trace** — no URL-typing required.

## Screenshots

N/A — not under `frontend/**`. This is the `packages/eleatic` tool UI, exempt from the frontend Playwright / 10-capture design-QA contract per repo `CLAUDE.md`. **Live-verified via Playwright MCP** — drove the full path end to end on the running explorer: hub → clicked **"Explore rows →"** (href `/facets?run=gemini-2.5-flash-lite-1781400884`) → gallery (12 cards) → clicked a card → drawer opened with the **Trace** panel expanded (`883 prompt · 178 completion · 1595.29 ms · $0.0001595`). `browser_console_messages` returned **0 errors / 0 warnings** across the whole flow.

- [x] N/A — `explore-link` has a matching CSS rule in `packages/eleatic/ui/app.css` (added in this PR); no other new classes.
- [x] N/A — not UI under `frontend/**` (packages/ tool); the ≥10 `user-attachments` multi-viewport rule does not apply.

## Test plan

- [x] `npm run build -w @bird-watch/eleatic` — clean (`tsc` + `cpSync ui→dist/ui`); built `dist/ui/hub.js` carries `explore-link` and `dist/ui/app.css` carries `.explore-link`.
- [x] `npm run test -w @bird-watch/eleatic` — **193/193 pass** (19 files). `hub.js` is browser-only DOM glue with no unit test *by existing convention* (matches `drawer.js`); the change is one anchor + a CSS rule, no new logic.
- [x] `knip` — clean (no new findings).
- [x] Live Playwright MCP smoke — full path hub → Explore → facets → card → drawer → Trace works by clicking; console 0/0. (Frontend `npm run dev` drive is N/A — not a `frontend/**` change.)
- [ ] New unit / e2e test — N/A: one `<a>` element + one CSS rule, no logic.

## Plan reference

Out of plan — follow-up to the eleatic trace-exploration work (epic #1169 / drawer discoverability #1174). Surfaced when the merged trace panel proved reachable only by hand-typing `/facets?run=…`; this adds the missing UI navigation into the per-run gallery.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
