### PR TITLE
fix(frontend): name the active species filter in the aggregated-mode lede (closes #1175)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2515,6 +2515,10 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // #1175: restoreAllMocks does NOT reset a plain vi.fn(), so a per-test dict
+    // seed here would otherwise persist into later describe blocks that don't
+    // re-seed it. Restore the empty default so no seed bleeds across suites.
+    mockGetSpeciesDictionary.mockResolvedValue([]);
   });
 
   it('Default (T4): "{N} sightings" — no region, no window', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -52,6 +52,7 @@ const {
   mockGetObservations,
   mockGetSilhouettes,
   mockGetStates,
+  mockGetSpeciesDictionary,
   mockUrlState,
   mapSurfaceRef,
   mockPrefetchMapCanvas,
@@ -60,6 +61,10 @@ const {
   mockGetHotspots: vi.fn(),
   mockGetObservations: vi.fn(),
   mockGetSilhouettes: vi.fn(),
+  // #1175: controllable species dictionary so the lede suite can SEED it and
+  // assert the aggregated-mode species qualifier resolves from the dictionary
+  // (a cold dictionary would silently assert the fallback, not the fix).
+  mockGetSpeciesDictionary: vi.fn(),
   // O9 (#781): spy on the scope-gated MapCanvas chunk prefetch. App must call
   // it on a scoped landing + each scope-pick, and NEVER on the unscoped
   // chooser landing (the #740/C6 fetch-light landing guarantee).
@@ -115,6 +120,11 @@ const {
     scopeControl: 0,
   },
 }));
+
+// Global default for the species dictionary: empty (the prior class-field
+// default). vi.restoreAllMocks() does NOT reset a plain vi.fn(), so this persists
+// across suites; only tests that explicitly seed it (the #1175 lede case) differ.
+mockGetSpeciesDictionary.mockResolvedValue([]);
 
 // Stub url-state before App imports it. #738: App now imports the exported
 // DEFAULTS to compute `noFiltersActive` (`since === DEFAULTS.since`), so the
@@ -268,11 +278,10 @@ vi.mock('./api/client.js', async () => {
       getSpecies = vi.fn().mockResolvedValue({
         speciesCode: 'vermfly', comName: 'Vermilion Flycatcher', sciName: 'Pyrocephalus rubinus',
       });
-      // #859: App mounts useSpeciesDictionary → client.getSpeciesDictionary.
-      // Stub it (resolves an empty dictionary) so the hook doesn't throw; the
-      // dictionary only affects low-zoom popover NAME resolution, which these
-      // scope/legend/lede tests don't assert on.
-      getSpeciesDictionary = vi.fn().mockResolvedValue([]);
+      // #859/#1175: App mounts useSpeciesDictionary → client.getSpeciesDictionary.
+      // Routed through the hoisted mock (default []) so the lede suite can seed it
+      // to assert the aggregated-mode species qualifier (#1175).
+      getSpeciesDictionary = mockGetSpeciesDictionary;
       // #species: App mounts useSpeciesInScope → client.getSpeciesInScope to
       // source the FiltersBar combobox. Stub it (empty represented set) so the
       // hook doesn't throw; these scope/legend/lede tests don't assert on the
@@ -2500,6 +2509,7 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     mockGetHotspots.mockResolvedValue([]);
     mockGetSilhouettes.mockResolvedValue([]);
     mockGetStates.mockResolvedValue(STATES);
+    mockGetSpeciesDictionary.mockResolvedValue([]); // #1175: seeded per-test below
     mockUrlState.set.mockClear();
   });
 
@@ -2614,6 +2624,41 @@ describe('#828: lede dedupe — count-only copy, no region, no time-window', () 
     expect(lede).not.toHaveTextContent(/seen across/i);
     expect(lede).not.toHaveTextContent(/Arizona/i);
     expect(lede).not.toHaveTextContent(/in the last/i);
+  });
+
+  // #1175: in AGGREGATED mode there are no per-observation rows, so the species
+  // name cannot come from `observations[0].comName`. With an active species
+  // filter the lede must still name it, resolved from the SEEDED dictionary.
+  // (The dictionary is seeded here precisely so this asserts the FIX path — a
+  // cold dictionary would fall through and silently assert the bare-count path.)
+  it('Aggregated mode + active species filter (T2, #1175): names the filtered species from the dictionary', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: 'norcar', familyCode: null,
+      view: 'map', scope: { kind: 'us' },
+    };
+    mockGetSpeciesDictionary.mockResolvedValue([
+      { code: 'norcar', comName: 'Northern Cardinal', familyCode: 'cardinalidae' },
+    ]);
+    mockGetObservations.mockResolvedValue({
+      mode: 'aggregated',
+      buckets: [
+        {
+          lat: 38.0, lng: -97.0, count: 1823, speciesCount: 1,
+          families: [{
+            code: 'cardinalidae', count: 1823, speciesCount: 1,
+            species: [{ code: 'norcar', count: 1823 }],
+          }],
+        },
+      ],
+      meta: { freshestObservationAt: new Date().toISOString() },
+    });
+    render(<App />);
+    const lede = await screen.findByTestId('map-lede');
+    await waitFor(() =>
+      expect(lede).toHaveTextContent('1,823 sightings of Northern Cardinal'),
+    );
+    // The fix names the active FILTER, not a distinct-species COUNT (#1047).
+    expect(lede).not.toHaveTextContent(/species/i);
   });
 
   it('Single species (T2): "{N} sightings of {commonName}" — no region, no window', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,7 @@ import { prefetchMapCanvas } from './prefetch.js';
 import { SurfaceTitleSync } from './components/SurfaceTitleSync.js';
 import { StatusBlock } from './components/ds/StatusBlock.js';
 import { SheetHeader } from './components/ds/SheetHeader.js';
-import { formatCount } from './lib/format-count.js';
+import { craftLede } from './lede.js';
 
 const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? '' });
 
@@ -107,16 +107,6 @@ export const INITIAL_ZOOM_SEED = 3;
  * component-local `SCOPE_MOVE_SETTLE_MS` is evaluated.
  */
 const AGGREGATED_SEED_ZOOM = 3;
-
-/**
- * #872: count-free lede placeholder shown while a refetch is in flight. On a
- * state→state transition use-bird-data keeps the prior scope's nonzero
- * `observations` mounted until the new fetch resolves, so the lede must show
- * this neutral "updating" copy rather than the stale count. Count-free by
- * design — no number can be trusted mid-refetch. The cold-load case (count 0)
- * still returns null upstream so the row stays hidden until the first paint.
- */
-const LEDE_LOADING_PLACEHOLDER = 'Updating…';
 
 /**
  * O2 (#770): Default-expanded breakpoint for FamilyLegend, moved here from
@@ -1171,51 +1161,28 @@ export function App() {
   // was removed along with the freshness line — the lede no longer consumes a
   // freshness state and the card no longer renders a recency label.
   const ledeText = useMemo<string | null>(() => {
-    if (region === null) return null;
+    // #859: aggregated mode carries no per-observation rows, so the count comes
+    // from the EXACT bucket totals (not `observations.length`, empty at low zoom)
+    // and `speciesCount` is 0 there. Per-observation mode keeps both row-derived.
     const speciesCount = new Set(observations.map(o => o.speciesCode).filter(Boolean)).size;
-    // #859: aggregated mode no longer fabricates synthetic observations, so the
-    // sightings count comes from the EXACT bucket totals (sum of bucket.count),
-    // not `observations.length` (which is empty at low zoom). Per-observation
-    // mode keeps `observations.length`.
     const observationCount =
       mode === 'aggregated' ? totalCountFromBuckets(buckets) : observations.length;
-    // Cold-load guard (#716/#720): suppress Template 1 while the first fetch is
-    // in flight. Same discipline as the former context-strip lede's `loading` guard.
-    if (observationsLoading && observationCount === 0 && speciesCount === 0) return null;
-    // #872: state→state stale-count guard. use-bird-data keeps the PRIOR scope's
-    // `observations` mounted while the new fetch is in flight (it clears only on
-    // resolve), so during a state→state transition `observationCount` is NONZERO
-    // and the cold-load guard above (which only fires at count === 0) misses it —
-    // leaking the previous state's number until the new data lands. Branch on
-    // `observationsLoading` alone so any in-flight refetch shows a count-free
-    // placeholder rather than the stale number. (The cold-load case still
-    // returns null above so the row stays hidden until the first data arrives.)
-    if (observationsLoading) return LEDE_LOADING_PLACEHOLDER;
-    // #828: the lede is count-only. The region moved into the wordmark headline
-    // (no longer repeated in the sentence) and the time-window dropped entirely
-    // (it's discoverable via Filters). No period clause, no `${region}` — see the
-    // 5-template table in the issue and docs/design/01-spec/voice-and-content.md.
-    if (observationCount === 0 && speciesCount === 0) {
-      return noFiltersActive
-        ? 'No recent sightings'
-        : 'No matches for these filters';
-    }
-    // #852/#859: in aggregated (low-zoom / whole-state) mode there are no
-    // per-observation rows to count distinct species from — the buckets carry an
-    // EXACT total sightings count but only a capped per-family species sample.
-    // #1047 (locked product call): the lede metric follows SCOPE, not aggregation
-    // mode. An exact species count does not exist in aggregated mode (the wire
-    // intentionally omits the distinct-species set), so ALL non-zero lede
-    // templates unify on the sightings count. "N species" copy is removed from
-    // both the aggregated and the per-observation paths.
-    const speciesCommonName =
-      speciesCount === 1 ? (observations[0]?.comName ?? null) : null;
-    if (speciesCommonName) {
-      return `${formatCount(observationCount)} sightings of ${speciesCommonName}`;
-    } else if (familyName) {
-      return `${formatCount(observationCount)} sightings of ${familyName}`;
-    }
-    return `${formatCount(observationCount)} sightings`;
+    // #1175: name the ACTIVE species filter from the dictionary (mode-independent),
+    // so the qualifier survives aggregated mode where `observations[0]` is absent.
+    // The per-obs coincidental single-species name stays the fallback.
+    return craftLede({
+      region,
+      observationCount,
+      speciesCount,
+      observationsLoading,
+      noFiltersActive,
+      activeSpeciesName: state.speciesCode
+        ? (dictionary.get(state.speciesCode)?.comName ?? null)
+        : null,
+      singleObservedSpeciesName:
+        speciesCount === 1 ? (observations[0]?.comName ?? null) : null,
+      familyName: familyName ?? null,
+    });
   }, [
     region,
     observations,
@@ -1224,6 +1191,8 @@ export function App() {
     observationsLoading,
     noFiltersActive,
     familyName,
+    dictionary,
+    state.speciesCode,
   ]);
 
   // O1 (#776) — App-root polite aria-live result-settle narration (R9).

--- a/frontend/src/lede.test.ts
+++ b/frontend/src/lede.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { craftLede, LEDE_LOADING_PLACEHOLDER, type LedeInput } from './lede.js';
+
+// Minimal valid base — a settled, scoped, no-filter, multi-species view.
+const base: LedeInput = {
+  region: 'Arizona',
+  observationCount: 100,
+  speciesCount: 12,
+  observationsLoading: false,
+  noFiltersActive: true,
+  activeSpeciesName: null,
+  singleObservedSpeciesName: null,
+  familyName: null,
+};
+
+describe('craftLede', () => {
+  it('returns null when unscoped (region === null)', () => {
+    expect(craftLede({ ...base, region: null })).toBeNull();
+  });
+
+  it('returns null on cold load (loading + zero count + zero species)', () => {
+    expect(craftLede({
+      ...base, observationsLoading: true, observationCount: 0, speciesCount: 0,
+    })).toBeNull();
+  });
+
+  it('returns the loading placeholder during an in-flight refetch with a stale count', () => {
+    // #872: a state->state refetch keeps the prior count nonzero while loading.
+    expect(craftLede({
+      ...base, observationsLoading: true, observationCount: 50, speciesCount: 3,
+    })).toBe(LEDE_LOADING_PLACEHOLDER);
+  });
+
+  it('reads "No recent sightings" for an empty unfiltered result', () => {
+    expect(craftLede({
+      ...base, observationCount: 0, speciesCount: 0, noFiltersActive: true,
+    })).toBe('No recent sightings');
+  });
+
+  it('reads "No matches for these filters" for an empty filtered result', () => {
+    expect(craftLede({
+      ...base, observationCount: 0, speciesCount: 0, noFiltersActive: false,
+    })).toBe('No matches for these filters');
+  });
+
+  // THE BUG (#1175): aggregated mode has NO per-observation rows, so
+  // `speciesCount` is 0 and `singleObservedSpeciesName` is null — but an active
+  // species filter must still be named, resolved from the dictionary.
+  it('names the active species filter in aggregated mode (speciesCount 0, no per-obs rows)', () => {
+    expect(craftLede({
+      ...base,
+      observationCount: 1823,
+      speciesCount: 0,
+      noFiltersActive: false,
+      activeSpeciesName: 'Northern Cardinal',
+      singleObservedSpeciesName: null,
+    })).toBe('1,823 sightings of Northern Cardinal');
+  });
+
+  it('keeps naming a coincidental single species in per-observation mode (no active filter)', () => {
+    expect(craftLede({
+      ...base,
+      observationCount: 43,
+      speciesCount: 1,
+      noFiltersActive: true,
+      activeSpeciesName: null,
+      singleObservedSpeciesName: 'Verdin',
+    })).toBe('43 sightings of Verdin');
+  });
+
+  it('prefers the active filter name over the coincidental per-obs name', () => {
+    expect(craftLede({
+      ...base,
+      observationCount: 43,
+      speciesCount: 1,
+      noFiltersActive: false,
+      activeSpeciesName: 'Northern Cardinal',
+      singleObservedSpeciesName: 'Verdin',
+    })).toBe('43 sightings of Northern Cardinal');
+  });
+
+  it('names the family for a family-only filter', () => {
+    expect(craftLede({
+      ...base,
+      observationCount: 300,
+      speciesCount: 0,
+      noFiltersActive: false,
+      familyName: 'Tyrant Flycatchers',
+    })).toBe('300 sightings of Tyrant Flycatchers');
+  });
+
+  it('falls back to the bare count for a multi-species unfiltered view', () => {
+    expect(craftLede({ ...base, observationCount: 6901, speciesCount: 200 }))
+      .toBe('6,901 sightings');
+  });
+
+  it('degrades to the bare count when the dictionary is cold (active filter, no resolved name)', () => {
+    // Aggregated + active species but the dictionary has not resolved the name
+    // yet → activeSpeciesName null → bare count, never a crash or "of null".
+    expect(craftLede({
+      ...base,
+      observationCount: 1823,
+      speciesCount: 0,
+      noFiltersActive: false,
+      activeSpeciesName: null,
+      singleObservedSpeciesName: null,
+    })).toBe('1,823 sightings');
+  });
+});

--- a/frontend/src/lede.ts
+++ b/frontend/src/lede.ts
@@ -1,0 +1,78 @@
+import { formatCount } from './lib/format-count.js';
+
+// Placeholder shown while an observations refetch is in flight but a stale count
+// is still mounted (#872 state->state guard). Lived inline in App.tsx before the
+// lede computation was extracted here for unit testability.
+export const LEDE_LOADING_PLACEHOLDER = 'Updating…';
+
+export interface LedeInput {
+  /** Active scope's region label; null ⟺ unscoped (the chooser landing). */
+  region: string | null;
+  /** EXACT total sightings: bucket totals in aggregated mode, row count in per-obs. */
+  observationCount: number;
+  /**
+   * Distinct species in the PER-OBSERVATION rows. Always 0 in aggregated mode
+   * (#859 carries no per-obs rows there) — used only by the guards and the
+   * coincidental-single-species fallback, NOT to name the active filter.
+   */
+  speciesCount: number;
+  observationsLoading: boolean;
+  noFiltersActive: boolean;
+  /**
+   * #1175: the name of the ACTIVE species filter (`state.speciesCode` resolved
+   * via the species dictionary), or null when no species filter is set / the
+   * dictionary has not resolved it yet. This is mode-INDEPENDENT — it is what
+   * lets the qualifier survive aggregated (low-zoom) mode, where `observations`
+   * is empty and the per-obs fallback below resolves to null. Naming the active
+   * FILTER is distinct from a distinct-species COUNT, so it does not reintroduce
+   * the #1047 "N species" metric that aggregated mode intentionally omits.
+   */
+  activeSpeciesName: string | null;
+  /**
+   * `observations[0].comName` when `speciesCount === 1` — the coincidental
+   * "only one species happens to be in view" case (per-observation mode only).
+   * Preserved as a fallback so a single-species viewport with NO explicit filter
+   * still names the species, exactly as before.
+   */
+  singleObservedSpeciesName: string | null;
+  /** Resolved colloquial family name for an active family-only filter, else null. */
+  familyName: string | null;
+}
+
+/**
+ * The AppHeader identity-card count lede (#800/#779/#828). Pure so it is unit-
+ * testable (#1175) and reused verbatim by the O1 (#776) aria-live narration, so
+ * the screen-reader announcement and the visible lede never diverge.
+ *
+ * Returns null to render NOTHING (unscoped, or the cold-load guard). The
+ * `LEDE_LOADING_PLACEHOLDER` covers an in-flight refetch that still has a stale
+ * count mounted (#872). The non-zero templates unify on the sightings count
+ * (#1047: no distinct-species count in aggregated mode); the species/family
+ * qualifier names the active FILTER, not a count.
+ */
+export function craftLede(i: LedeInput): string | null {
+  if (i.region === null) return null;
+  // Cold-load guard (#716/#720): suppress the lede entirely while the FIRST
+  // fetch is in flight (nothing to count yet).
+  if (i.observationsLoading && i.observationCount === 0 && i.speciesCount === 0) {
+    return null;
+  }
+  // #872 state->state guard: any in-flight refetch shows a count-free placeholder
+  // rather than the previous scope's stale number.
+  if (i.observationsLoading) return LEDE_LOADING_PLACEHOLDER;
+
+  if (i.observationCount === 0 && i.speciesCount === 0) {
+    return i.noFiltersActive ? 'No recent sightings' : 'No matches for these filters';
+  }
+
+  // Active species FILTER wins (works in both modes); the coincidental single
+  // species in per-obs rows is the fallback.
+  const speciesCommonName = i.activeSpeciesName ?? i.singleObservedSpeciesName;
+  if (speciesCommonName) {
+    return `${formatCount(i.observationCount)} sightings of ${speciesCommonName}`;
+  }
+  if (i.familyName) {
+    return `${formatCount(i.observationCount)} sightings of ${i.familyName}`;
+  }
+  return `${formatCount(i.observationCount)} sightings`;
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    subgraph Before
      A["active species filter<br/>(state.speciesCode set)"] --> B["speciesCount = distinct(observations)"]
      B --> C{"speciesCount === 1?"}
      C -->|"per-obs zoom"| D["observations[0].comName ✅"]
      C -->|"aggregated zoom<br/>(observations EMPTY, #859)"| E["null → qualifier DROPPED<br/>'1,823 sightings'"]
    end
    subgraph After["After (#1175)"]
      F["active species filter"] --> G["dictionary.get(speciesCode)?.comName<br/>(mode-independent)"]
      G --> H["'1,823 sightings of Northern Cardinal' ✅<br/>(both modes)"]
      I["coincidental single species<br/>in view, no filter"] -.->|"fallback, per-obs only"| H
    end
```

## Summary

- **Why:** at country / low-zoom (aggregated) the count lede dropped the active species-filter qualifier — `1,823 sightings` instead of `1,823 sightings of Northern Cardinal` (per-observation/state zoom showed it). Found during #1164/#1165.
- **Root cause:** the species name came from `observations[0].comName` gated on a per-observation distinct count; `observations` is empty in aggregated mode (#859), so the name resolved to null and the qualifier vanished.
- **Fix:** resolve the active filter's name from the species **dictionary** (mode-independent), keyed on `state.speciesCode`. Naming the active FILTER ≠ a distinct-species COUNT, so it does not reintroduce the #1047 "N species" metric aggregated mode omits. The per-obs coincidental single-species fallback is preserved; the O1 (#776) aria-live narration gains the qualifier in lockstep (it reuses `ledeText`).
- **Design:** extracted the lede computation into a pure `craftLede` helper (`frontend/src/lede.ts`) so the logic is unit-testable — the fix path (active species resolved) is asserted SEPARATELY from the cold-dictionary degrade, directly resolving the issue-gate review's "green-but-meaningless test" caveat.

## Screenshots

N/A (live capture) — and a transparency note. The visible change is the lede gaining `… of {species}` at aggregated zoom. It could not be driven on the local stack: the dev-seed uses fake species codes (`devseed-…`) that 400 (`invalid species`) on the `/api/observations` species commit (the same #1165 seed artifact), so the species branch never reaches the lede locally. The bug itself was confirmed live on bird-maps.com (old code: `1,823 sightings` with `?species=norcar` at whole-US). The fixed output is asserted exactly by the new App integration test (seeded dictionary, aggregated buckets, active filter → `1,823 sightings of Northern Cardinal`).

- [x] No new/renamed `className` — `N/A — no CSS/className changes`
- [x] Multi-viewport design QA — `N/A` per above (text-only lede change; species branch not locally drivable — seed artifact)

## Test plan

- [x] `tsc` (frontend) — green
- [x] New unit tests: `lede.test.ts` (11 — all 5 templates incl. **aggregated + active species** and **cold-dictionary degrade**, precedence, family, zero/loading guards)
- [x] New integration test: `App.test.tsx` aggregated-mode + **seeded dictionary** + active species → `1,823 sightings of Northern Cardinal` (dictionary mock made controllable). Full App suite 88, frontend 1548 green.
- [x] `npm run build` (all workspaces) — clean · `npx knip` — clean
- [x] e2e compatibility verified by reading: `zip-scope.spec.ts:128` already allows `( of .+)?`; `scope-disclosure.spec.ts:88` runs with no species filter so its `^\d+ sightings$` holds. No e2e edits required.

## Plan reference

Out of plan — follow-up discovered during #1164/#1165. Closes #1175.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
