### PR TITLE
feat(frontend): add @/ → src path alias for reorg-stable imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,46 +5,46 @@ import type { LngLatBounds } from 'maplibre-gl';
 // `CONUS_BOUNDS` (nested `[[w,s],[e,n]]`) for the camera below; this flat geo
 // one seeds the initial `/api/observations` bbox so it lands on the warmed key.
 import { CONUS_BOUNDS as GEO_CONUS_BOUNDS } from '@bird-watch/geo';
-import { analytics } from './analytics.js';
-import { ApiClient, ApiError } from './api/client.js';
-import { useUrlState, DEFAULTS } from './state/url-state.js';
-import type { Scope } from './state/url-state.js';
-import type { ScopeResolution } from './state/scope-types.js';
-import { useBirdData } from './data/use-bird-data.js';
-import { useSilhouettes } from './data/use-silhouettes.js';
-import { useSpeciesDictionary } from './data/use-species-dictionary.js';
-import { useSpeciesInScope, type SpeciesScopeFilters } from './data/use-species-in-scope.js';
-import { useStates } from './data/use-states.js';
+import { analytics } from '@/analytics.js';
+import { ApiClient, ApiError } from '@/api/client.js';
+import { useUrlState, DEFAULTS } from '@/state/url-state.js';
+import type { Scope } from '@/state/url-state.js';
+import type { ScopeResolution } from '@/state/scope-types.js';
+import { useBirdData } from '@/data/use-bird-data.js';
+import { useSilhouettes } from '@/data/use-silhouettes.js';
+import { useSpeciesDictionary } from '@/data/use-species-dictionary.js';
+import { useSpeciesInScope, type SpeciesScopeFilters } from '@/data/use-species-in-scope.js';
+import { useStates } from '@/data/use-states.js';
 import {
   familyCountsFromBuckets,
   totalCountFromBuckets,
-} from './data/bucket-aggregates.js';
-import { useStatePolygon } from './data/state-polygons.js';
-import { useSpeciesDetail } from './data/use-species-detail.js';
+} from '@/data/bucket-aggregates.js';
+import { useStatePolygon } from '@/data/state-polygons.js';
+import { useSpeciesDetail } from '@/data/use-species-detail.js';
 // ARTBOARD_PAD lives in the map's mask util but mask.ts imports only `geojson`
 // *types* (erased at build), so this does NOT pull the lazy maplibre chunk into
 // the entry bundle — App owns the scope→clampPad derivation (#760/#762).
-import { ARTBOARD_PAD } from './components/map/mask.js';
-import { FiltersBar } from './components/FiltersBar.js';
-import type { FamilyOption, SpeciesOption } from './components/FiltersBar.js';
-import { FamilyLegend } from './components/FamilyLegend.js';
-import { MapSurface } from './components/MapSurface.js';
-import { ScopeChooser } from './components/ScopeChooser.js';
-import { SpeciesDetailRail } from './components/SpeciesDetailRail.js';
-import { SpeciesDetailSheet } from './components/SpeciesDetailSheet.js';
-import type { SnapState } from './components/SpeciesDetailSheet.js';
-import { AppHeader } from './components/AppHeader.js';
-import { useIsCompact } from './lib/use-is-compact.js';
-import { useBreakpoint } from './hooks/use-breakpoint.js';
-import { AttributionModal } from './components/AttributionModal.js';
-import { resolveFamilyName } from './derived.js';
-import { filterObservationsByBounds, filterBucketsByBounds } from './lib/viewport-filter.js';
-import { regionLabelFor } from './config/region.js';
-import { prefetchMapCanvas } from './prefetch.js';
-import { SurfaceTitleSync } from './components/SurfaceTitleSync.js';
-import { StatusBlock } from './components/ds/StatusBlock.js';
-import { SheetHeader } from './components/ds/SheetHeader.js';
-import { craftLede } from './lede.js';
+import { ARTBOARD_PAD } from '@/components/map/mask.js';
+import { FiltersBar } from '@/components/FiltersBar.js';
+import type { FamilyOption, SpeciesOption } from '@/components/FiltersBar.js';
+import { FamilyLegend } from '@/components/FamilyLegend.js';
+import { MapSurface } from '@/components/MapSurface.js';
+import { ScopeChooser } from '@/components/ScopeChooser.js';
+import { SpeciesDetailRail } from '@/components/SpeciesDetailRail.js';
+import { SpeciesDetailSheet } from '@/components/SpeciesDetailSheet.js';
+import type { SnapState } from '@/components/SpeciesDetailSheet.js';
+import { AppHeader } from '@/components/AppHeader.js';
+import { useIsCompact } from '@/lib/use-is-compact.js';
+import { useBreakpoint } from '@/hooks/use-breakpoint.js';
+import { AttributionModal } from '@/components/AttributionModal.js';
+import { resolveFamilyName } from '@/derived.js';
+import { filterObservationsByBounds, filterBucketsByBounds } from '@/lib/viewport-filter.js';
+import { regionLabelFor } from '@/config/region.js';
+import { prefetchMapCanvas } from '@/prefetch.js';
+import { SurfaceTitleSync } from '@/components/SurfaceTitleSync.js';
+import { StatusBlock } from '@/components/ds/StatusBlock.js';
+import { SheetHeader } from '@/components/ds/SheetHeader.js';
+import { craftLede } from '@/lede.js';
 
 const apiClient = new ApiClient({ baseUrl: import.meta.env.VITE_API_BASE_URL ?? '' });
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,8 @@
     "outDir": "dist",
     "noEmit": true,
     "allowImportingTsExtensions": true,
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "node_modules", "dist"]

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -9,7 +9,8 @@
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "useDefineForClassFields": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": { "@/*": ["./src/*"] }
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
       // is robust against future hoist drift (e.g. when a peer-dep'd
       // sibling package gets installed at root).
       'maplibre-gl': path.resolve(__dirname, 'node_modules/maplibre-gl'),
+      // `@/…` → `frontend/src/…`. Lets a moved module keep stable import
+      // specifiers so future folder reorgs churn the moved file, not every
+      // importer of it. Mirrored in tsconfig.json + tsconfig.test.json paths.
+      '@': path.resolve(__dirname, 'src'),
     },
   },
   server: {


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A["import '@/components/FiltersBar.js'"] --> R{"@/* resolver"}
    R -->|vite.config.ts resolve.alias| V["app bundle + Vitest"]
    R -->|tsconfig.json paths| T["app typecheck (tsc -b)"]
    R -->|tsconfig.test.json paths| U["unit-test typecheck"]
    V --> S["frontend/src/components/FiltersBar.tsx"]
    T --> S
    U --> S
```

## Summary

- **Why:** the upcoming `components/map` and `e2e` reorganizations move files between directories. With relative imports, every move rewrites the import in the moved file **and** in every importer. A stable `@/` specifier means a move churns only the moved file's own imports — turning each future reorg from an N-file edit into a localized one.
- Declares `@/* → frontend/src/*` in the three resolvers that govern frontend resolution (Vite/Vitest, app `tsc`, test `tsc`) and adopts it in `App.tsx` (the root composition, loaded by the build + 4 test suites) as the first consumer and proof it resolves end-to-end.
- `baseUrl` intentionally omitted — it is deprecated toward TS 7.0; modern `moduleResolution: "Bundler"` resolves `paths` relative to the tsconfig.

## Screenshots

N/A — not UI. This is a build-config + import-path refactor: the only `frontend/src` change is rewriting `App.tsx`'s 34 import specifiers from `./x` to `@/x` (identical module resolution). Zero rendered-output change — verified by the full 1536-test unit suite passing on the new resolution.

## Test plan

- [x] `tsc -b` (frontend typecheck) — green, `@/` resolves
- [x] `vite build` (Vite 8 / rolldown) — clean production build, `@/` resolves in the bundler
- [x] `npm test --workspace @bird-watch/frontend` — **1536 passed (89 files)**
- [x] `npx knip` — clean (no unresolved imports introduced)
- [x] No new tests: behavior is unchanged (import-specifier + config only)
- [ ] e2e — covered by CI (no e2e-touching change; App behavior byte-identical)

## Plan reference

Out of plan — folder-structure reorganization initiative (foundation PR). This is the first of a sequenced set of small PRs; the `@/` alias must land before the `components/map` (by-kind split) and `e2e` (by-surface grouping) reorgs so those moves don't churn every importer. Approach decided with Julian after a 15-agent research+audit pass (Tier A + Tier B scope, alias-first).