### PR TITLE
fix(frontend): stop CellHoverPreview flipping render mode on cell mouse-leave

### DIFF
--- a/frontend/src/components/map/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.test.tsx
@@ -1153,6 +1153,42 @@ describe('AdaptiveGridMarker — cell popover (Phase 1, #558)', () => {
     expect(tooltip.style.left).toBe('316px');
     expect(tooltip.style.top).toBe('412px');
   });
+
+  it('pointer:fine: tooltip stays cursor-anchored through the leave dwell, then unmounts — no mode-flip', async () => {
+    // Regression: on mouseleave the preview stays mounted for the spec §4.5
+    // 250ms dwell. It must NOT lose its cursor-anchored render (position:fixed,
+    // portaled) during that window. Eagerly clearing cursorPos on leave flipped
+    // it to the CSS-anchored fallback (position:'') for the whole 250ms — the
+    // visible "tooltip jumps to a different state, then disappears" glitch.
+    vi.useFakeTimers();
+    const { AdaptiveGridMarker } = await import('./AdaptiveGridMarker.js');
+    render(
+      <AdaptiveGridMarker
+        shape={SHAPE_1x1}
+        tiles={[rendered('hummingbirds', 5, 'M0 0L24 24Z', '#888', '#888', [
+          { comName: "Anna's Hummingbird", count: 5, speciesCode: 'annhum' },
+        ])]}
+        totalCount={5}
+        uniqueFamilies={1}
+        ariaLabel="Cluster: 5 observations."
+        isCoarsePointer={false}
+        onClick={noop}
+      />
+    );
+    const cell = screen.getByTestId('adaptive-grid-marker-cell-rendered');
+    fireEvent.mouseEnter(cell);
+    fireEvent.mouseMove(cell, { clientX: 300, clientY: 400 });
+    expect(screen.getByRole('tooltip').style.position).toBe('fixed');
+
+    // Pointer leaves: preview lingers for the dwell, still cursor-anchored.
+    fireEvent.mouseLeave(cell);
+    expect(screen.getByRole('tooltip').style.position).toBe('fixed');
+
+    // After the dwell it unmounts cleanly — no intermediate flipped render.
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    vi.useRealTimers();
+  });
 });
 
 // --- Phase 2 (#559): coarse-pointer cluster list popover ---------------------

--- a/frontend/src/components/map/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/AdaptiveGridMarker.tsx
@@ -290,7 +290,14 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
   }
 
   function onCellMouseLeave(i: number) {
-    setCursorPos(null);
+    // Do NOT reset cursorPos here. The preview stays mounted for the 250ms
+    // dwell below; clearing cursorPos now would flip <CellHoverPreview> from its
+    // cursor-anchored render (position:fixed, portaled to body) to the
+    // CSS-anchored fallback (position:absolute, inline) for that whole window —
+    // a visible "tooltip jumps to a different spot, then disappears" glitch.
+    // The preview either follows the cursor or unmounts; never an in-between.
+    // Positioning is reset on keyboard focus (onCellFocus) instead, which is the
+    // only path that legitimately needs the CSS-anchored render.
     // Spec §4.5: 250ms delay; skipped when click-promoted to popover.
     mouseLeaveTimers.current[i] = window.setTimeout(() => {
       setActiveCell((prev) => (prev?.index === i && prev.mode === 'preview' ? null : prev));
@@ -298,6 +305,10 @@ export function AdaptiveGridMarker(props: AdaptiveGridMarkerProps) {
   }
 
   function onCellFocus(i: number) {
+    // Keyboard/programmatic focus carries no pointer coordinate. Reset cursorPos
+    // so the preview renders CSS-anchored near the focused cell rather than
+    // following a stale mouse coordinate left over from an earlier hover.
+    setCursorPos(null);
     setActiveCell((prev) => (prev?.mode === 'popover' ? prev : { index: i, mode: 'preview' }));
   }
 


### PR DESCRIPTION
## Diagrams

The bug is a two-phase teardown of the cursor-following hover tooltip. `CellHoverPreview` picks its render mode from `cursorPos`; clearing it before unmount flips a still-mounted tooltip into a different render mode.

**Before — `onCellMouseLeave` clears `cursorPos` immediately, preview unmounts 250ms later:**

```mermaid
sequenceDiagram
    participant U as User
    participant M as AdaptiveGridMarker
    participant T as CellHoverPreview
    Note over T: hovering — cursorPos set ⇒ position:fixed, portaled to body (follows cursor)
    U->>M: mouse-leave cell
    M->>M: setCursorPos(null)  (immediate)
    M-->>T: re-render, still mounted, cursorPos=null
    Note over T: BUG — flips to position:absolute, inline ⇒ snaps to the marker
    Note over M,T: 250ms dwell — tooltip sits in the wrong place
    M->>M: setActiveCell(null)  (timer fires)
    M-->>T: unmount ⇒ disappears
```

**After — `cursorPos` is kept through the dwell; the preview either follows the cursor or unmounts, never an in-between:**

```mermaid
sequenceDiagram
    participant U as User
    participant M as AdaptiveGridMarker
    participant T as CellHoverPreview
    Note over T: hovering — cursorPos set ⇒ position:fixed, portaled (follows cursor)
    U->>M: mouse-leave cell
    Note over M: cursorPos left untouched
    Note over M,T: 250ms dwell — tooltip holds its cursor-anchored position
    M->>M: setActiveCell(null)  (timer fires)
    M-->>T: unmount ⇒ disappears cleanly (no mode-flip)
    Note over M: keyboard focus path now resets cursorPos in onCellFocus
```

## Summary

- **Why:** Un-hovering a species silhouette made the hover tooltip visibly jump to a different spot and linger for 250ms before disappearing, instead of just going away.
- **Root cause:** `onCellMouseLeave` reset `cursorPos` immediately while the preview stayed mounted for the spec §4.5 250ms dwell. `CellHoverPreview` renders bimodally on `cursorPos` (set ⇒ `position:fixed`, portaled to `<body>`; null ⇒ CSS-anchored `position:absolute`, inline), so clearing it eagerly flipped the still-mounted tooltip's render mode mid-life.
- **Fix:** Keep `cursorPos` through the dwell so the preview either follows the cursor or unmounts — never an intermediate render. Move the reset to `onCellFocus`, the only path that legitimately needs the CSS-anchored render (keyboard focus carries no pointer coordinate, so it must not follow a stale hover coord).

## Screenshots

N/A — behavioral fix with no visual delta. The tooltip renders identically while shown; the only change is that on un-hover it no longer flips render mode. The behavior is captured by a deterministic RED→GREEN regression test (asserts `position` stays `'fixed'` across `mouse-leave` until the 250ms timer unmounts the preview).

- [x] N/A — no new/renamed `className` in this PR (handler-logic change only)
- [x] N/A — not UI in the screenshot sense (no visual delta; behavioral teardown fix)

## Test plan

- [x] Typecheck (`tsc -b`) clean + full frontend `vitest run` green (1537 tests, incl. the new regression test)
- [x] New unit test added — RED→GREEN: `AdaptiveGridMarker` "tooltip stays cursor-anchored through the leave dwell, then unmounts — no mode-flip" (confirmed it fails on the old code: `''` vs `'fixed'`, passes after the fix)
- [x] N/A — Playwright e2e spec: behavior is a transient hover teardown deterministically covered by the unit test; an e2e would need the full map stack to reproduce a sub-second transient with no static delta
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] N/A — UI-only Playwright MCP smoke: no visual delta to capture; verified via the unit test above (agreed verification bar for this behavioral fix)

## Plan reference

Out of plan — ad-hoc bugfix: `CellHoverPreview` teardown mode-flip reported directly. No tracking issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
