### PR TITLE
fix(read-api): --ignore-scripts in Docker build — unbreak read-api deploy (better-sqlite3 musl build)

### DIFF
--- a/services/read-api/Dockerfile
+++ b/services/read-api/Dockerfile
@@ -8,7 +8,16 @@ COPY tsconfig.base.json ./
 COPY packages ./packages
 COPY services/read-api ./services/read-api
 
-RUN npm ci --workspaces --include-workspace-root --include=dev
+# --ignore-scripts: the monorepo install pulls EVERY workspace's deps, including
+# packages/eleatic's `better-sqlite3` (the local eval store). better-sqlite3 ships
+# no musl prebuilt, so on this alpine (musl) image its install falls back to
+# `node-gyp rebuild`, which needs Python + a C toolchain the build image lacks —
+# failing the whole image build (and thus every read-api deploy since eleatic
+# landed, #1153). The read-api uses NO native modules (hono, pg, @bird-watch/* are
+# pure JS), so skipping install lifecycle scripts is safe: better-sqlite3 is
+# fetched but never compiled or loaded. The explicit `npm run build` steps below
+# are NOT install lifecycle scripts and still run.
+RUN npm ci --workspaces --include-workspace-root --include=dev --ignore-scripts
 RUN npm run build --workspace @bird-watch/shared-types
 RUN npm run build --workspace @bird-watch/db-client
 RUN npm run build --workspace @bird-watch/read-api
@@ -25,7 +34,9 @@ COPY --from=build /repo/packages/shared-types ./packages/shared-types
 COPY --from=build /repo/services/read-api/package.json ./services/read-api/
 COPY --from=build /repo/services/read-api/dist ./services/read-api/dist
 
-RUN npm ci --omit=dev --workspaces --include-workspace-root
+# --ignore-scripts: same reason as the build stage — skip the native build of the
+# unused better-sqlite3 (musl, no prebuilt) so the runtime install doesn't fail.
+RUN npm ci --omit=dev --workspaces --include-workspace-root --ignore-scripts
 
 # Drop root — alpine images ship a built-in 'node' user (uid 1000).
 USER node


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TB
    A["merge to main"] --> B["deploy-read-api: docker build<br/>node:24-ALPINE (musl)"]
    B --> C["npm ci --workspaces<br/>(whole monorepo)"]
    C --> D["installs packages/eleatic<br/>→ better-sqlite3"]
    D --> E{"musl prebuilt?"}
    E -->|"no → node-gyp rebuild"| F["needs Python+toolchain<br/>❌ build FAILS → no new image"]
    E -->|"--ignore-scripts (this PR)"| G["fetched, not compiled<br/>✅ build succeeds → image ships"]
    F -.->|"read-api stuck on old image"| H["prod 404s /api/species-in-scope<br/>→ 'Could not load the species list'"]
```

## Summary

- **Incident:** prod's species filter shows "Could not load the species list". Cause: `GET /api/species-in-scope` (shipped in #1165) returns **404** on prod — the read-api image never deployed it.
- **Why:** `deploy-read-api` has failed at "Build and push image" on **every** run since the eleatic/eval work (#1153) landed (~22:59Z 2026-06-13, *before* #1165). The read-api image is `node:24-alpine` (musl) and runs `npm ci --workspaces` over the whole monorepo, which installs `packages/eleatic`'s **`better-sqlite3`**. better-sqlite3 has no musl prebuilt → `node-gyp rebuild` → needs Python/toolchain the build image lacks → build dies. So read-api (and ingestor) deploys have been silently broken; #1165's route sat in the undeployed backlog, and the already-deployed frontend hard-depends on it.
- **Fix:** `--ignore-scripts` on both `npm ci` steps in `services/read-api/Dockerfile`. The read-api uses no native modules (hono/pg/@bird-watch/* are pure JS), so skipping install scripts is safe — better-sqlite3 is fetched but never compiled or loaded. Unblocks read-api + ingestor deploys generally.

## Screenshots

N/A — not UI (Dockerfile/CI infra change).

## Test plan

- [x] `docker build -f services/read-api/Dockerfile -t test .` from repo root — **succeeds** (was failing at the better-sqlite3 node-gyp step).
- [x] Ran the built image against the dev DB: `GET /health` → 200 and `GET /api/species-in-scope?since=14d` → **200** (the route the PROD image 404s today).
- [x] read-api uses no native modules — verified deps (hono, pg, @bird-watch/db-client, @bird-watch/shared-types) are pure JS, so `--ignore-scripts` drops nothing it needs.
- [ ] Post-merge: confirm `deploy-read-api` goes green and prod `GET https://api.bird-maps.com/api/species-in-scope` returns 200 (will verify after merge).

## Plan reference

Out of plan — prod incident hotfix (read-api deploy broken since #1153; surfaced by #1165's frontend dependency).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
