### PR TITLE
refactor(db-client): group migration tests into src/migrations/

### DIFF
--- a/packages/db-client/src/migrations/down-chain.test.ts
+++ b/packages/db-client/src/migrations/down-chain.test.ts
@@ -23,7 +23,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/ptiliogonatidae-dedupe-migration.test.ts
+++ b/packages/db-client/src/migrations/ptiliogonatidae-dedupe-migration.test.ts
@@ -38,7 +38,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/species-descriptions-inat-source-migration.test.ts
+++ b/packages/db-client/src/migrations/species-descriptions-inat-source-migration.test.ts
@@ -20,7 +20,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/species-descriptions-migration.test.ts
+++ b/packages/db-client/src/migrations/species-descriptions-migration.test.ts
@@ -15,7 +15,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/species-meta-x00013-migration.test.ts
+++ b/packages/db-client/src/migrations/species-meta-x00013-migration.test.ts
@@ -32,7 +32,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/species-photo-scores-migration.test.ts
+++ b/packages/db-client/src/migrations/species-photo-scores-migration.test.ts
@@ -18,7 +18,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/species-photos-migration.test.ts
+++ b/packages/db-client/src/migrations/species-photos-migration.test.ts
@@ -28,7 +28,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;

--- a/packages/db-client/src/migrations/state-boundaries-migration.test.ts
+++ b/packages/db-client/src/migrations/state-boundaries-migration.test.ts
@@ -25,7 +25,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import pg from 'pg';
 // Side-effect import: registers pool-wide type parsers before any query.
-import './pool.js';
+import '../pool.js';
 
 let container: StartedPostgreSqlContainer;
 let pool: pg.Pool;


### PR DESCRIPTION
## Diagrams

```
Before (src/ flat, 32 entries interleaved):
packages/db-client/src/
├── observations.ts
├── observations.test.ts
├── observations-aggregated-perf.test.ts
├── migrations-down-chain.test.ts          ← schema-evolution concern
├── ptiliogonatidae-dedupe-migration.test.ts ← schema-evolution concern
├── species-descriptions-migration.test.ts  ← schema-evolution concern
├── species-descriptions-inat-source-migration.test.ts ← …
├── species-meta-x00013-migration.test.ts   ← …
├── species-photo-scores-migration.test.ts  ← …
├── species-photos-migration.test.ts        ← …
├── state-boundaries-migration.test.ts      ← …
├── pool.ts
├── test-helpers.ts
└── … (more table-access modules)

After (src/ root 24 entries, migrations grouped):
packages/db-client/src/
├── observations.ts
├── observations.test.ts
├── observations-aggregated-perf.test.ts
├── pool.ts
├── test-helpers.ts                         ← stays (deep-import contract)
├── … (table-access modules only)
└── migrations/
    ├── down-chain.test.ts                  ← was migrations-down-chain.test.ts
    ├── ptiliogonatidae-dedupe-migration.test.ts
    ├── species-descriptions-migration.test.ts
    ├── species-descriptions-inat-source-migration.test.ts
    ├── species-meta-x00013-migration.test.ts
    ├── species-photo-scores-migration.test.ts
    ├── species-photos-migration.test.ts
    └── state-boundaries-migration.test.ts
```

## Summary

- Migration tests are a distinct concern from table-access modules — they exercise schema-evolution SQL (Up/Down migrations) against isolated testcontainers instances and have no source sibling to co-locate with. Grouping them under `src/migrations/` makes the flat `src/` list easier to scan.
- Pure file-move: no logic changes. The single relative import in each file (`./pool.js`) was updated to `../pool.js`. `test-helpers.ts` intentionally stays at `src/` root because `dist/test-helpers.js` is a deep-import contract consumed by service-level test files.
- `migrations-down-chain.test.ts` is renamed to `migrations/down-chain.test.ts` — drops the now-redundant `migrations-` prefix since the subdirectory supplies the context.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run build -w @bird-watch/db-client` — clean (tsc emits no errors)
- [x] `npx tsc -p packages/db-client/tsconfig.test.json --noEmit` — zero errors in `src/migrations/`; pre-existing errors in unmoved files (family-silhouettes-contrast.test.ts, observation-grid-agg.test.ts, photo-scores.test.ts, pool-error-handler.test.ts) are unchanged from main
- [x] Grep-confirmed no moved file retains `from './pool` (all now `'../pool.js'`)
- [ ] `npm test -w @bird-watch/db-client` — NOT run locally (requires Docker/testcontainers); CI will exercise the full integration suite
- [ ] New unit / integration tests added (if behavior changed) — N/A, pure refactor
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, not UI

## Plan reference

Out of plan — folder-structure reorganization (Tier B; db-client migration tests → src/migrations/).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)