### PR TITLE
feat(eleatic): EvalSpan/EvalTrace doc types + pure backward-compat trace-tree builder

### DIFF
--- a/packages/eleatic/src/index.ts
+++ b/packages/eleatic/src/index.ts
@@ -11,6 +11,9 @@
 // --- Write store (E1) ---
 export { openStore, EleaticStore } from './store.js';
 export type { EvalRunRecord, EvalRowRecord, EvalAdjudicationRecord } from './types.js';
+// Doc types for the conventional tree layered over the opaque trace blob (the
+// trace-tree epic). Additive — EvalRowRecord.trace stays `trace?: unknown`.
+export type { EvalSpan, EvalTrace } from './types.js';
 
 // --- Read query API (E2) ---
 export { makeReader } from './queries.js';

--- a/packages/eleatic/src/types.ts
+++ b/packages/eleatic/src/types.ts
@@ -53,6 +53,57 @@ export interface EvalRowRecord {
   trace?: unknown;
 }
 
+/**
+ * The conventional TREE layout layered over the opaque `trace_json` blob.
+ *
+ * DOCUMENTATION types only: they describe the shape `buildTraceTree`
+ * (ui/trace-tree.js) reconstructs a tree from, and the shape the photo-curation
+ * producer emits. They DO NOT retype `EvalRowRecord.trace`, which STAYS
+ * `trace?: unknown` so legacy + non-conforming blobs still round-trip unchanged.
+ * A producer MAY locally type its trace value as `EvalTrace`; the store and the
+ * read path remain blob-opaque.
+ *
+ * A span is keyed by `id` and points at its parent by `parentId` (null = a
+ * root). `kind` is free-form and producer-owned — eleatic STYLES by it but never
+ * branches on its semantics. `metrics` is the canonical camelCase metrics object
+ * new producers emit; a legacy span instead carries `usage` (latencyMs, …),
+ * which `buildTraceTree` normalizes to a node's `metrics` at its single mapping
+ * point (latencyMs→durationMs the only rename) — renderers read the node's
+ * normalized metrics, never `span.usage`.
+ */
+export interface EvalSpan {
+  /** Stable within the trace; the tree key. */
+  id: string;
+  /** null = a root; else the id of a sibling span. */
+  parentId: string | null;
+  /** Node label (icon · name in the tree pane). */
+  name: string;
+  /** Free-form, producer-owned: "eval" | "task" | "llm" | "scorer" | … */
+  kind?: string;
+  /** Pretty-printed in the right pane (opaque). */
+  input?: unknown;
+  /** Pretty-printed in the right pane (opaque). */
+  output?: unknown;
+  /** Canonical metrics object (camelCase). New producers emit this. */
+  metrics?: {
+    startMs?: number;
+    durationMs?: number;
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+    costUsd?: number;
+  };
+  /** A scorer leaf carries its score here. */
+  scores?: Record<string, number>;
+  /** Free-form, producer-owned. */
+  status?: string;
+}
+
+/** The `{ spans }` envelope — the SAME `spans` key as today's flat trace. */
+export interface EvalTrace {
+  spans: EvalSpan[];
+}
+
 /** A human verdict on an item, run-independent. Maps to the `eval_adjudication` table. */
 export interface EvalAdjudicationRecord {
   rowKey: string;

--- a/packages/eleatic/ui/trace-tree.js
+++ b/packages/eleatic/ui/trace-tree.js
@@ -1,0 +1,226 @@
+// PURE render-time tree builder for the eleatic trace explorer.
+//
+// A row's `trace` blob (trace_json) is OPAQUE — eleatic invents no eval domain
+// and never branches on a span's semantics. Conventionally it is a flat
+// `{ spans: [...] }` envelope. buildTraceTree reconstructs a TraceNode tree from
+// that flat array, tolerating three shapes:
+//   1. NON-CONFORMING (no spans array, scalar, bare array) → { ok:false, roots:[] }
+//      so the caller falls back to the lossless renderTrace(trace) preview. The
+//      conformance gate is the SAME test ui/trace.js uses.
+//   2. LEGACY id-less flat (today's producer: one `{name,input,output,usage}`
+//      span, no ids) → every span is wrapped under ONE synthesized
+//      `{ id:'legacy:root', name:'trace', kind:'eval' }` root, with synthesized
+//      `legacy:<index>` child ids, so even legacy data shows a tree (Decision 3).
+//      Synthesized ids are render-time only.
+//   3. KEYED (≥1 span carries a string `id`) → spans are linked by `parentId`:
+//      an ORPHAN (missing/null/unknown parentId) is PROMOTED to a root (never
+//      dropped); a DUPLICATE id keeps the first and demotes the later span to a
+//      root; a self-cycle / back-edge is re-rooted. A seen-set guarantees the
+//      walk always TERMINATES — it never hangs on a cycle.
+//
+// This is the SINGLE place legacy `usage` is normalized to a canonical `metrics`
+// object on the node (latencyMs→durationMs the only rename; prompt/completion
+// tokens + costUsd identical). Renderers read `node.metrics` and never touch
+// `span.usage`. A node carrying a canonical `span.metrics` uses it verbatim.
+//
+// TraceNode = {
+//   id: string,             // stable id; 'legacy:<i>' for id-less spans
+//   span: object,           // the ORIGINAL opaque span (renderer reads name/kind/input/output/scores)
+//   metrics: object|undefined,  // NORMALIZED metrics (span.metrics, else mapped span.usage, else undefined)
+//   depth: number,          // 0 at roots, +1 per level
+//   children: TraceNode[],
+// }
+//
+// Plain ESM, named export — importable by the browser (express.static) and by
+// vitest in node (the trace.js / pretty.js / format.js precedent). PURE: no DOM,
+// no fetch, never throws.
+
+/** True iff `t` is the conforming `{ spans: [...] }` envelope (the trace.js gate). */
+function isConforming(t) {
+  return t !== null && typeof t === 'object' && Array.isArray(t.spans);
+}
+
+/**
+ * Normalize a span's metrics for the node. Prefer the canonical camelCase
+ * `span.metrics`; else map a legacy `span.usage` (latencyMs→durationMs the only
+ * rename, the rest identical); else undefined. Never throws.
+ */
+function normalizeMetrics(span) {
+  if (span === null || typeof span !== 'object') return undefined;
+  if (span.metrics !== null && typeof span.metrics === 'object') {
+    return span.metrics;
+  }
+  const usage = span.usage;
+  if (usage === null || typeof usage !== 'object') return undefined;
+  const out = {};
+  if ('latencyMs' in usage) out.durationMs = usage.latencyMs;
+  if ('promptTokens' in usage) out.promptTokens = usage.promptTokens;
+  if ('completionTokens' in usage) out.completionTokens = usage.completionTokens;
+  if ('totalTokens' in usage) out.totalTokens = usage.totalTokens;
+  if ('costUsd' in usage) out.costUsd = usage.costUsd;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Make a fresh TraceNode wrapping the original span (depth filled in the linking
+ * pass). `ord` is the span's index in the original spans[] array — the stable
+ * tiebreaker that preserves array order regardless of which collection a root
+ * lands in (orphan vs duplicate-demoted vs cycle-broken). It is render-internal
+ * and not part of the TraceNode contract renderers read.
+ */
+function makeNode(id, span, ord) {
+  return { id, span, metrics: normalizeMetrics(span), depth: 0, children: [], ord };
+}
+
+/** A finite numeric startMs, else undefined. */
+function startMs(node) {
+  const m = node.metrics;
+  const v = m && typeof m === 'object' ? m.startMs : undefined;
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * STABLE sibling order: preserve original spans[] array order, sorting by
+ * metrics.startMs ONLY when BOTH siblings carry a finite numeric startMs. The
+ * `ord` (original array index) is the deterministic tiebreaker — it keeps array
+ * order even for roots gathered from different collections, where insertion
+ * order alone would not. Mutates `nodes` in place.
+ */
+function orderSiblings(nodes) {
+  nodes.sort((a, b) => {
+    const sa = startMs(a);
+    const sb = startMs(b);
+    if (sa !== undefined && sb !== undefined && sa !== sb) return sa - sb;
+    return a.ord - b.ord; // not both timed (or equal) → original array order
+  });
+}
+
+/**
+ * Build the trace tree.
+ * @returns {{ ok: boolean, roots: object[] }} PURE; never throws. ok=false ⇒
+ *   caller renders renderTrace(trace) fallback.
+ */
+export function buildTraceTree(trace) {
+  if (!isConforming(trace)) return { ok: false, roots: [] };
+  const spans = trace.spans;
+
+  // Conforming but empty → a valid (empty) tree, NOT a synthesized legacy root.
+  if (spans.length === 0) return { ok: true, roots: [] };
+
+  // LEGACY id-less branch: NO span carries a string `id`. Wrap all spans under
+  // one synthesized root so even legacy data shows a tree (Decision 3).
+  const hasAnyId = spans.some(
+    (s) => s !== null && typeof s === 'object' && typeof s.id === 'string',
+  );
+  if (!hasAnyId) {
+    // The legacy branch returns directly (no link/cycle pass), so build clean
+    // TraceNodes without the internal `ord` tiebreaker the keyed branch needs.
+    const rootSpan = { id: 'legacy:root', name: 'trace', kind: 'eval' };
+    const root = {
+      id: 'legacy:root',
+      span: rootSpan,
+      metrics: undefined, // the synthesized root carries no metrics of its own
+      depth: 0,
+      children: spans.map((span, i) => ({
+        id: `legacy:${i}`,
+        span,
+        metrics: normalizeMetrics(span),
+        depth: 1,
+        children: [],
+      })),
+    };
+    return { ok: true, roots: [root] };
+  }
+
+  // KEYED branch. Index by id (first wins); collect roots (orphans + duplicates
+  // + cycle-breaks) and parent→child links.
+  const byId = new Map();
+  /** @type {object[]} nodes in encounter order whose parent must be resolved. */
+  const nodes = [];
+  /** @type {object[]} nodes promoted to roots (no resolvable parent). */
+  const explicitRoots = [];
+
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i];
+    const rawId = span !== null && typeof span === 'object' ? span.id : undefined;
+    const id = typeof rawId === 'string' ? rawId : `legacy:${i}`;
+    const node = makeNode(id, span, i);
+    if (typeof rawId === 'string' && byId.has(rawId)) {
+      // DUPLICATE id: first wins; this later span is demoted to a root and keeps
+      // its (now non-indexable) id but is never attachable as a parent target.
+      explicitRoots.push(node);
+      continue;
+    }
+    byId.set(id, node);
+    nodes.push(node);
+  }
+
+  // Link pass: attach each indexed node to its resolvable parent; else root it.
+  const linkedRoots = [];
+  for (const node of nodes) {
+    const span = node.span;
+    const parentId =
+      span !== null && typeof span === 'object' ? span.parentId : undefined;
+    const parent =
+      typeof parentId === 'string' && parentId !== node.id ? byId.get(parentId) : undefined;
+    if (parent === undefined) {
+      // ORPHAN (missing/null/unknown parentId) OR self-cycle (parentId===id) →
+      // promoted to a root, never dropped.
+      linkedRoots.push(node);
+    } else {
+      parent.children.push(node);
+    }
+  }
+
+  // Cycle break: a back-edge cycle (a→b→a) leaves every node with a resolvable
+  // parent, so NONE landed in linkedRoots — yet a tree needs ≥1 root. Detect any
+  // node not reachable from a current root and re-root it. The seen-set is keyed
+  // on the NODE OBJECT (not its id string — a demoted-duplicate root reuses a
+  // live node's id), and guarantees termination regardless of cycle length.
+  const roots = [...explicitRoots, ...linkedRoots];
+  const reachable = new Set();
+  const markReachable = (start) => {
+    const stack = [start];
+    while (stack.length > 0) {
+      const n = stack.pop();
+      if (reachable.has(n)) continue; // seen-set on node identity: terminates on any cycle
+      reachable.add(n);
+      for (const c of n.children) stack.push(c);
+    }
+  };
+  for (const r of roots) markReachable(r);
+  // Any indexed node still unreachable belongs to a pure cycle with no external
+  // root. Re-root them in encounter order; marking each as we go keeps the rest
+  // of the cycle linked beneath the first re-rooted member.
+  for (const node of nodes) {
+    if (!reachable.has(node)) {
+      // Sever this node from any parent that links it, so it doesn't appear
+      // twice (as a re-rooted root AND as a child inside the cycle).
+      for (const other of nodes) {
+        const idx = other.children.indexOf(node);
+        if (idx !== -1) other.children.splice(idx, 1);
+      }
+      roots.push(node);
+      markReachable(node);
+    }
+  }
+
+  // Assign depth + stable sibling order in one traversal, then drop the internal
+  // `ord` so the returned node matches the TraceNode contract exactly
+  // ({ id, span, metrics, depth, children }). The seen-set is belt-and-suspenders:
+  // the structure is already acyclic here, but it guarantees termination even if
+  // a future change reintroduced a back-edge.
+  const visited = new Set();
+  const assign = (node, depth) => {
+    if (visited.has(node)) return; // node-identity seen-set (ids may collide)
+    visited.add(node);
+    node.depth = depth;
+    orderSiblings(node.children);
+    for (const c of node.children) assign(c, depth + 1);
+    delete node.ord;
+  };
+  orderSiblings(roots);
+  for (const r of roots) assign(r, 0);
+
+  return { ok: true, roots };
+}

--- a/packages/eleatic/ui/trace-tree.test.ts
+++ b/packages/eleatic/ui/trace-tree.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect } from 'vitest';
+// buildTraceTree (ui/trace-tree.js) reconstructs a TraceNode tree from the flat,
+// OPAQUE `{ spans: [...] }` trace blob (trace_json — eleatic invents no eval
+// domain and never branches on a span's semantics). It is PURE and never throws:
+//   - the SAME conformance gate as trace.js (object && Array.isArray(trace.spans))
+//     guards the build; a non-conforming blob returns { ok:false, roots:[] } so
+//     the caller can fall back to the lossless renderTrace(trace) preview.
+//   - today's LEGACY id-less flat shape (one `{name,input,output,usage}` span, no
+//     ids) is wrapped under one synthesized `legacy:root` so even legacy data
+//     shows a tree (Decision 3); synthesized ids are render-time only.
+//   - a KEYED shape (≥1 string id) links by parentId, promoting orphans to roots
+//     (never dropping), demoting duplicate ids to roots (first wins), and re-
+//     rooting cycles/back-edges (a seen-set guarantees termination).
+//   - the SINGLE legacy `usage`→`metrics` normalization point lives here: a node's
+//     `metrics` is span.metrics if present, else span.usage mapped (latencyMs→
+//     durationMs the only rename), else undefined. Renderers read node.metrics.
+// Importable by the browser (express.static) and by vitest in node.
+import { buildTraceTree } from './trace-tree.js';
+
+describe('buildTraceTree — conformance gate', () => {
+  it('returns { ok:false, roots:[] } for null', () => {
+    expect(buildTraceTree(null)).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:false, roots:[] } for a number', () => {
+    expect(buildTraceTree(42)).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:false, roots:[] } for a string', () => {
+    expect(buildTraceTree('x')).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:false, roots:[] } for a bare array', () => {
+    expect(buildTraceTree([1, 2, 3])).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:false, roots:[] } when spans is not an array', () => {
+    expect(buildTraceTree({ spans: 'not-an-array' })).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:false, roots:[] } when there is no spans key', () => {
+    expect(buildTraceTree({ no: 'spans' })).toEqual({ ok: false, roots: [] });
+  });
+
+  it('returns { ok:true, roots:[] } for a conforming-but-empty spans array', () => {
+    expect(buildTraceTree({ spans: [] })).toEqual({ ok: true, roots: [] });
+  });
+});
+
+describe('buildTraceTree — legacy id-less flat shape (Decision 3)', () => {
+  it('wraps a single id-less span under one synthesized legacy:root', () => {
+    const { ok, roots } = buildTraceTree({ spans: [{ name: 'judge' }] });
+    expect(ok).toBe(true);
+    expect(roots).toHaveLength(1);
+    const root = roots[0];
+    expect(root.id).toBe('legacy:root');
+    expect(root.depth).toBe(0);
+    expect(root.span).toEqual({ id: 'legacy:root', name: 'trace', kind: 'eval' });
+    expect(root.children).toHaveLength(1);
+    const child = root.children[0];
+    expect(child.id).toBe('legacy:0');
+    expect(child.depth).toBe(1);
+    // The child wraps the ORIGINAL opaque span object (not a copy of a synth root).
+    expect(child.span).toEqual({ name: 'judge' });
+  });
+
+  it('places every id-less span under the synthesized root in array order', () => {
+    const { ok, roots } = buildTraceTree({
+      spans: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+    });
+    expect(ok).toBe(true);
+    expect(roots).toHaveLength(1);
+    const root = roots[0];
+    expect(root.children.map((c) => c.span.name)).toEqual(['a', 'b', 'c']);
+    expect(root.children.map((c) => c.id)).toEqual(['legacy:0', 'legacy:1', 'legacy:2']);
+    expect(root.children.every((c) => c.depth === 1)).toBe(true);
+  });
+
+  it('normalizes a legacy usage object to node.metrics (latencyMs→durationMs)', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        {
+          name: 'judge',
+          usage: { latencyMs: 250, promptTokens: 12, completionTokens: 34, costUsd: 0.01 },
+        },
+      ],
+    });
+    const child = roots[0].children[0];
+    expect(child.metrics).toEqual({
+      durationMs: 250,
+      promptTokens: 12,
+      completionTokens: 34,
+      costUsd: 0.01,
+    });
+  });
+
+  it('leaves node.metrics undefined for a legacy span with no usage', () => {
+    const { roots } = buildTraceTree({ spans: [{ name: 'plain' }] });
+    expect(roots[0].children[0].metrics).toBeUndefined();
+    // The synthesized root carries no metrics either.
+    expect(roots[0].metrics).toBeUndefined();
+  });
+});
+
+describe('buildTraceTree — keyed build', () => {
+  it('builds eval→task→(judge, scorers) with correct depths and child order', () => {
+    const { ok, roots } = buildTraceTree({
+      spans: [
+        { id: 'eval', parentId: null, name: 'eval', kind: 'eval' },
+        { id: 'task', parentId: 'eval', name: 'task', kind: 'task' },
+        { id: 'judge', parentId: 'task', name: 'judge', kind: 'llm' },
+        { id: 'scorer:keep', parentId: 'task', name: 'keep', kind: 'scorer' },
+        { id: 'scorer:mae', parentId: 'task', name: 'mae', kind: 'scorer' },
+      ],
+    });
+    expect(ok).toBe(true);
+    expect(roots).toHaveLength(1);
+    const evalNode = roots[0];
+    expect(evalNode.id).toBe('eval');
+    expect(evalNode.depth).toBe(0);
+    expect(evalNode.children).toHaveLength(1);
+    const taskNode = evalNode.children[0];
+    expect(taskNode.id).toBe('task');
+    expect(taskNode.depth).toBe(1);
+    // judge before scorers — original spans[] order preserved.
+    expect(taskNode.children.map((c) => c.id)).toEqual(['judge', 'scorer:keep', 'scorer:mae']);
+    expect(taskNode.children.every((c) => c.depth === 2)).toBe(true);
+  });
+
+  it('carries the ORIGINAL span object on each keyed node', () => {
+    const span = { id: 'eval', parentId: null, name: 'eval', kind: 'eval' };
+    const { roots } = buildTraceTree({ spans: [span] });
+    expect(roots[0].span).toBe(span);
+  });
+
+  it('reads node.metrics from a canonical span.metrics when present', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        {
+          id: 'judge',
+          parentId: null,
+          name: 'judge',
+          metrics: { startMs: 5, durationMs: 99, promptTokens: 1, totalTokens: 3 },
+        },
+      ],
+    });
+    expect(roots[0].metrics).toEqual({ startMs: 5, durationMs: 99, promptTokens: 1, totalTokens: 3 });
+  });
+
+  it('prefers span.metrics over span.usage when both exist', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        {
+          id: 'judge',
+          parentId: null,
+          name: 'judge',
+          metrics: { durationMs: 11 },
+          usage: { latencyMs: 999 },
+        },
+      ],
+    });
+    expect(roots[0].metrics).toEqual({ durationMs: 11 });
+  });
+});
+
+describe('buildTraceTree — orphan tolerance', () => {
+  it('promotes a span whose parentId is an unknown id to a root', () => {
+    const { ok, roots } = buildTraceTree({
+      spans: [
+        { id: 'root', parentId: null, name: 'root' },
+        { id: 'orphan', parentId: 'ghost', name: 'orphan' },
+      ],
+    });
+    expect(ok).toBe(true);
+    expect(roots.map((r) => r.id)).toEqual(['root', 'orphan']);
+    expect(roots.every((r) => r.depth === 0)).toBe(true);
+    // The orphan is never dropped.
+    expect(roots).toHaveLength(2);
+  });
+
+  it('treats a missing parentId (undefined) as a root', () => {
+    const { roots } = buildTraceTree({ spans: [{ id: 'lonely', name: 'lonely' }] });
+    expect(roots.map((r) => r.id)).toEqual(['lonely']);
+    expect(roots[0].depth).toBe(0);
+  });
+});
+
+describe('buildTraceTree — duplicate ids', () => {
+  it('keeps the first span for a duplicate id and demotes the later one to a root', () => {
+    const { ok, roots } = buildTraceTree({
+      spans: [
+        { id: 'eval', parentId: null, name: 'first' },
+        { id: 'child', parentId: 'eval', name: 'child' },
+        { id: 'eval', parentId: null, name: 'second' },
+      ],
+    });
+    expect(ok).toBe(true);
+    // The first 'eval' wins the id; the duplicate is demoted to its own root.
+    expect(roots).toHaveLength(2);
+    const firstEval = roots[0];
+    expect(firstEval.span.name).toBe('first');
+    expect(firstEval.children.map((c) => c.span.name)).toEqual(['child']);
+    const demoted = roots[1];
+    expect(demoted.span.name).toBe('second');
+    expect(demoted.depth).toBe(0);
+    expect(demoted.children).toEqual([]);
+  });
+});
+
+describe('buildTraceTree — cycle safety (always terminates)', () => {
+  it('re-roots a self-cycle (parentId === id) and terminates', () => {
+    const { ok, roots } = buildTraceTree({
+      spans: [{ id: 'a', parentId: 'a', name: 'a' }],
+    });
+    expect(ok).toBe(true);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('a');
+    expect(roots[0].depth).toBe(0);
+  });
+
+  it('re-roots a two-node back-edge cycle and terminates', () => {
+    // a parents b, b parents a — a classic 2-cycle. Exactly one becomes a root;
+    // the other links under it. The key invariant: the call RETURNS (no hang).
+    const result = buildTraceTree({
+      spans: [
+        { id: 'a', parentId: 'b', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    // Every span appears exactly once across the whole tree (none dropped, none
+    // duplicated by the cycle break).
+    const seen: string[] = [];
+    const walk = (n: { id: string; children: { id: string; children: unknown[] }[] }) => {
+      seen.push(n.id);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      n.children.forEach((c: any) => walk(c));
+    };
+    result.roots.forEach((r) => walk(r));
+    expect(seen.sort()).toEqual(['a', 'b']);
+  });
+
+  it('terminates on a longer cycle (a→b→c→a)', () => {
+    const result = buildTraceTree({
+      spans: [
+        { id: 'a', parentId: 'c', name: 'a' },
+        { id: 'b', parentId: 'a', name: 'b' },
+        { id: 'c', parentId: 'b', name: 'c' },
+      ],
+    });
+    expect(result.ok).toBe(true);
+    const seen: string[] = [];
+    const walk = (n: { id: string; children: { id: string; children: unknown[] }[] }) => {
+      seen.push(n.id);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      n.children.forEach((c: any) => walk(c));
+    };
+    result.roots.forEach((r) => walk(r));
+    expect(seen.sort()).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('buildTraceTree — sibling ordering', () => {
+  it('preserves spans[] array order for two untimed siblings', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        { id: 'root', parentId: null, name: 'root' },
+        { id: 'second', parentId: 'root', name: 'second' },
+        { id: 'first', parentId: 'root', name: 'first' },
+      ],
+    });
+    expect(roots[0].children.map((c) => c.id)).toEqual(['second', 'first']);
+  });
+
+  it('sorts two timed siblings by metrics.startMs', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        { id: 'root', parentId: null, name: 'root' },
+        { id: 'late', parentId: 'root', name: 'late', metrics: { startMs: 200 } },
+        { id: 'early', parentId: 'root', name: 'early', metrics: { startMs: 100 } },
+      ],
+    });
+    expect(roots[0].children.map((c) => c.id)).toEqual(['early', 'late']);
+  });
+
+  it('preserves array order when one sibling lacks a finite startMs', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        { id: 'root', parentId: null, name: 'root' },
+        { id: 'timed', parentId: 'root', name: 'timed', metrics: { startMs: 100 } },
+        { id: 'untimed', parentId: 'root', name: 'untimed' },
+      ],
+    });
+    // startMs sort only applies when BOTH siblings carry a finite startMs.
+    expect(roots[0].children.map((c) => c.id)).toEqual(['timed', 'untimed']);
+  });
+
+  it('preserves array order when a startMs is non-finite (NaN / Infinity)', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        { id: 'root', parentId: null, name: 'root' },
+        { id: 'b', parentId: 'root', name: 'b', metrics: { startMs: Number.NaN } },
+        { id: 'a', parentId: 'root', name: 'a', metrics: { startMs: 50 } },
+      ],
+    });
+    expect(roots[0].children.map((c) => c.id)).toEqual(['b', 'a']);
+  });
+
+  it('also sorts timed roots by startMs', () => {
+    const { roots } = buildTraceTree({
+      spans: [
+        { id: 'late', parentId: null, name: 'late', metrics: { startMs: 9 } },
+        { id: 'early', parentId: null, name: 'early', metrics: { startMs: 1 } },
+      ],
+    });
+    expect(roots.map((r) => r.id)).toEqual(['early', 'late']);
+  });
+});
+
+describe('buildTraceTree — totality (never throws)', () => {
+  it('returns an object for every input over the trace.test.ts matrix', () => {
+    for (const v of [
+      null,
+      undefined,
+      1,
+      'x',
+      true,
+      {},
+      [],
+      [1, 2, 3],
+      { spans: 'not-an-array' },
+      { no: 'spans' },
+      { spans: [] },
+      { spans: [{ name: 'a' }] },
+      { spans: [{ id: 'a', parentId: 'a' }] },
+      { spans: [null, 42, 'str', { name: 'ok' }] },
+    ]) {
+      const out = buildTraceTree(v);
+      expect(out).toHaveProperty('ok');
+      expect(out).toHaveProperty('roots');
+      expect(Array.isArray(out.roots)).toBe(true);
+    }
+  });
+
+  it('tolerates non-object spans inside a conforming envelope without throwing', () => {
+    // A legacy-shaped envelope (no ids) containing junk entries: still wrapped
+    // under one synthesized root, junk entries carried opaquely.
+    const { ok, roots } = buildTraceTree({ spans: [null, 'str', 7, { name: 'ok' }] });
+    expect(ok).toBe(true);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('legacy:root');
+    expect(roots[0].children).toHaveLength(4);
+    expect(roots[0].children.map((c) => c.id)).toEqual([
+      'legacy:0',
+      'legacy:1',
+      'legacy:2',
+      'legacy:3',
+    ]);
+  });
+});


### PR DESCRIPTION
## Diagrams

`buildTraceTree(trace)` — the pure, never-throws render-time tree builder. One conformance gate, then three load-bearing shape branches, then a single normalize + depth pass:

```mermaid
flowchart TD
    A["buildTraceTree(trace)"] --> B{"object && Array.isArray(trace.spans)?<br/>(same gate as trace.js)"}
    B -- no --> X["{ ok:false, roots:[] }<br/>caller falls back to renderTrace(trace)"]
    B -- yes --> C{"spans.length === 0?"}
    C -- yes --> E0["{ ok:true, roots:[] }"]
    C -- no --> D{"any span has a string id?"}
    D -- "no (legacy id-less)" --> L["wrap ALL spans under one synthesized<br/>{ id:'legacy:root', name:'trace', kind:'eval' }<br/>children get 'legacy:&lt;i&gt;' ids, depth 1"]
    D -- "yes (keyed)" --> K["index by id (first wins);<br/>link by parentId;<br/>orphan → root (never dropped);<br/>dup id → demote later to root;<br/>self-cycle / back-edge → re-root<br/>(node-identity seen-set ⇒ terminates)"]
    L --> N["normalize metrics per node:<br/>span.metrics ?? map(span.usage) ?? undefined<br/>(latencyMs→durationMs the only rename)"]
    K --> N
    N --> O["assign depth (root 0, child +1) +<br/>stable sibling order<br/>(array order; startMs sort only when BOTH finite)"]
    O --> R["{ ok:true, roots: TraceNode[] }"]
```

## Summary

- **Why a render-time builder, not a stored tree:** `trace_json` stays one OPAQUE blob eleatic never destructures (`EvalRowRecord.trace` remains `trace?: unknown`); the tree is reconstructed only when a renderer needs it. This is the single anti-drift point Wave-2 children (T2 producer, T3/T4 panes) all import.
- **Why it must tolerate everything:** `buildTraceTree` is PURE and never throws across today's legacy id-less flat trace (wrapped under one synthesized `legacy:root` so even legacy data shows a tree — Decision 3), a keyed `parentId` tree (orphan-tolerant, duplicate-id-safe, cycle-safe via a node-identity seen-set), and any non-conforming blob (`ok:false` → caller uses the lossless `renderTrace` fallback).
- **Why the normalization lives here:** this is the SINGLE place legacy `usage` is mapped to a node's canonical `metrics` (`latencyMs`→`durationMs` the only rename); T3/T4 renderers read `node.metrics` and never touch `span.usage`. `EvalSpan`/`EvalTrace` are documentation types only and do NOT retype `EvalRowRecord.trace`, so legacy + non-conforming blobs still round-trip.

## Screenshots

N/A — packages/ tool (eleatic ui/ is not frontend/**).

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — green (20 files, 221 tests, incl. the existing `no-coupling.test.ts`; new `trace-tree.test.ts` adds 28 cases)
- [x] New unit tests added — `ui/trace-tree.test.ts` covers the conformance gate (non-object / missing-spans / scalar / array → `ok:false`), legacy id-less → single synthesized root + `legacy:` ids + `usage`→`metrics` mapping, keyed `eval→task→judge+scorers` depths & child order, orphan promotion, duplicate-id demotion, self-cycle / back-edge re-rooting + termination, stable sibling order, `startMs` sort only when both finite, and a never-throws totality sweep
- [x] `npm run build -w @bird-watch/eleatic` — clean (tsc)
- [x] `npx knip --no-progress` — green (only the pre-existing unrelated `map-v1-prototype` hint; `trace-tree.js` is auto-traced by its `.test.ts` sibling, so NO knip ignore entry)
- [x] `npm run lint` — green
- [ ] (UI only) Playwright MCP smoke — N/A, no `frontend/**` change

## Plan reference

Part of epic #1193 (T1).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
