### PR TITLE
refactor(frontend): convert remaining map/ imports to the @/ alias

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -30,11 +30,11 @@ import {
   CLUSTER_RADIUS,
   FALLBACK_SILHOUETTE_ID,
 } from './geometry/observation-layers.js';
-import { mergeLeafBuckets } from '../../data/bucket-aggregates.js';
-import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
+import { mergeLeafBuckets } from '@/data/bucket-aggregates.js';
+import type { SpeciesDictionary } from '@/data/use-species-dictionary.js';
 import { ObservationPopover } from './layers/ObservationPopover.js';
 import { ClusterListPopover } from './layers/ClusterListPopover.js';
-import { StatusBlock } from '../ds/StatusBlock.js';
+import { StatusBlock } from '@/components/ds/StatusBlock.js';
 // Marker render-tree dispatch extracted to two presentational layers
 // (epic #884 · U11 / #896). MapCanvas keeps every handler + derived state and
 // threads them as props; the layers hold no map ref and render only.
@@ -70,7 +70,7 @@ import {
 // in the adaptive-grid reconciler effect below assembles `inputs` (owning both
 // `map.project` calls), calls this with an injected `unproject`, then commits.
 import { reconcileToGroups } from './geometry/reconcile-viewport.js';
-import { resolveFamilyName } from '../../derived.js';
+import { resolveFamilyName } from '@/derived.js';
 // Pure observation derives extracted to obs-derive.ts (epic #884 · U8, #892).
 // The fresh-closure `obsLookupRef` latch below stays in the component (it's
 // the indirection, not the memo).
@@ -93,8 +93,8 @@ import type {
 // module before the U1 extraction. Re-export it so any importer of
 // `./MapCanvas.js` (none today — zero importers repo-wide) keeps resolving.
 export type { MapCanvasProps } from './MapCanvas.types.js';
-import { useCoarsePointer } from '../../lib/use-coarse-pointer.js';
-import { usePrefersReducedMotion } from '../../lib/use-prefers-reduced-motion.js';
+import { useCoarsePointer } from '@/lib/use-coarse-pointer.js';
+import { usePrefersReducedMotion } from '@/lib/use-prefers-reduced-motion.js';
 
 /**
  * Adaptive-grid reconciler memoization (epic #539 spec §5.3).

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -11,7 +11,7 @@
 // build — see mask.ts for the same idiom.
 import type { MultiPolygon } from 'geojson';
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
-import type { SpeciesDictionary } from '../../data/use-species-dictionary.js';
+import type { SpeciesDictionary } from '@/data/use-species-dictionary.js';
 import type { AdaptiveTile, ResolvedGrid } from './geometry/adaptive-grid.js';
 
 /**

--- a/frontend/src/components/map/geometry/adaptive-grid.ts
+++ b/frontend/src/components/map/geometry/adaptive-grid.ts
@@ -23,7 +23,7 @@
  *     ascending familyCode tie-break, null-familyCode dropout.
  */
 
-import { resolveFamilyName } from '../../../derived.js';
+import { resolveFamilyName } from '@/derived.js';
 
 export type PositiveInt = number & { readonly __brand: 'PositiveInt' };
 

--- a/frontend/src/components/map/geometry/deconflict.ts
+++ b/frontend/src/components/map/geometry/deconflict.ts
@@ -1,7 +1,7 @@
 import type { AdaptiveTile, ResolvedGrid } from './adaptive-grid.js';
 import { markerDimensions, MIN_MARKER_PX } from '@/components/map/layers/AdaptiveGridMarker.js';
 import { pillDimensions } from '@/components/ds/ClusterPill.js';
-import { countNoun, formatCount } from '../../../lib/format-count.js';
+import { countNoun, formatCount } from '@/lib/format-count.js';
 
 /**
  * Pure post-clustering deconflict layer (issue #554). Resolves visible

--- a/frontend/src/components/map/geometry/obs-derive.ts
+++ b/frontend/src/components/map/geometry/obs-derive.ts
@@ -2,7 +2,7 @@ import type { Observation } from '@bird-watch/shared-types';
 import type { SilhouettesById } from './adaptive-grid.js';
 import type { HitTargetMarker } from '@/components/map/layers/MapMarkerHitLayer.js';
 import { CLUSTER_MAX_ZOOM } from './observation-layers.js';
-import { resolveFamilyName } from '../../../derived.js';
+import { resolveFamilyName } from '@/derived.js';
 
 /**
  * Pure observation derives extracted from MapCanvas.tsx (epic #884 · U8).

--- a/frontend/src/components/map/geometry/observation-layers.test.ts
+++ b/frontend/src/components/map/geometry/observation-layers.test.ts
@@ -12,7 +12,7 @@ import {
   CLUSTER_RADIUS,
   FALLBACK_SILHOUETTE_ID,
 } from './observation-layers.js';
-import { FAMILY_COLOR_FALLBACK } from '../../../data/family-color.js';
+import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
 
 function makeObs(partial: Partial<Observation> = {}): Observation {
   return {
@@ -286,7 +286,7 @@ describe('layer specs', () => {
       // layer config bound. Snapshot the import path; if either side
       // forks the constant, the import resolves to a module that doesn't
       // re-export it.
-      const config = await import('../../../config/cluster.js');
+      const config = await import('@/config/cluster.js');
       expect(config.CLUSTER_TIER_BOUNDARIES).toEqual({ sand: 100, ember: 750 });
     });
   });

--- a/frontend/src/components/map/geometry/observation-layers.ts
+++ b/frontend/src/components/map/geometry/observation-layers.ts
@@ -1,7 +1,7 @@
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import type { LayerProps } from 'react-map-gl/maplibre';
-import { FAMILY_COLOR_FALLBACK } from '../../../data/family-color.js';
-import { CLUSTER_TIER_BOUNDARIES } from '../../../config/cluster.js';
+import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
+import { CLUSTER_TIER_BOUNDARIES } from '@/config/cluster.js';
 
 // Epic #539 cutover: `inStack` plumbing is retired. The auto-spider
 // subsystem that produced it has been deleted along with its filter

--- a/frontend/src/components/map/hooks/use-scope-camera.ts
+++ b/frontend/src/components/map/hooks/use-scope-camera.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
-import { ZIP_FLYTO_ZOOM } from '../../../state/scope-types.js';
+import { ZIP_FLYTO_ZOOM } from '@/state/scope-types.js';
 import {
   CONUS_BOUNDS,
   FIT_BOUNDS_PADDING,

--- a/frontend/src/components/map/layers/AdaptiveGridMarker.test.tsx
+++ b/frontend/src/components/map/layers/AdaptiveGridMarker.test.tsx
@@ -4,7 +4,7 @@ import { AdaptiveGridMarker } from './AdaptiveGridMarker.js';
 import { markerDimensions, MIN_MARKER_PX } from './AdaptiveGridMarker.js';
 import type { AdaptiveTile, ResolvedGrid, PositiveInt, SpeciesAggregate } from '@/components/map/geometry/adaptive-grid.js';
 import { toPositiveInt } from '@/components/map/geometry/adaptive-grid.js';
-import { setMatchMedia } from '../../../test-setup.js';
+import { setMatchMedia } from '@/test-setup.js';
 
 // Helpers --------------------------------------------------------------------
 

--- a/frontend/src/components/map/layers/AdaptiveGridMarker.tsx
+++ b/frontend/src/components/map/layers/AdaptiveGridMarker.tsx
@@ -2,13 +2,13 @@ import { useState, useId, useRef, useEffect } from 'react';
 import type { MouseEvent as ReactMouseEvent, CSSProperties, KeyboardEvent } from 'react';
 import type { AdaptiveTile, ResolvedGrid } from '@/components/map/geometry/adaptive-grid.js';
 import { visibleCapacity } from '@/components/map/geometry/adaptive-grid.js';
-import { prettyFamily } from '../../../derived.js';
+import { prettyFamily } from '@/derived.js';
 import { FALLBACK_SILHOUETTE_PATH } from '@/components/map/geometry/silhouette-fallback.js';
-import { useMediaQuery } from '../../../hooks/use-media-query.js';
-import { useTheme } from '../../../hooks/use-theme.js';
+import { useMediaQuery } from '@/hooks/use-media-query.js';
+import { useTheme } from '@/hooks/use-theme.js';
 import { CellHoverPreview } from './CellHoverPreview.js';
 import { CellPopover } from './CellPopover.js';
-import { countNoun, formatCount } from '../../../lib/format-count.js';
+import { countNoun, formatCount } from '@/lib/format-count.js';
 import { ClusterListPopover } from './ClusterListPopover.js';
 
 /**

--- a/frontend/src/components/map/layers/CellHoverPreview.tsx
+++ b/frontend/src/components/map/layers/CellHoverPreview.tsx
@@ -1,8 +1,8 @@
 import type { CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import type { SpeciesAggregate } from '@/components/map/geometry/adaptive-grid.js';
-import { prettyFamily } from '../../../derived.js';
-import { formatCount } from '../../../lib/format-count.js';
+import { prettyFamily } from '@/derived.js';
+import { formatCount } from '@/lib/format-count.js';
 
 /**
  * `<CellHoverPreview>` — compact hover preview for an adaptive-grid cell

--- a/frontend/src/components/map/layers/CellPopover.tsx
+++ b/frontend/src/components/map/layers/CellPopover.tsx
@@ -2,8 +2,8 @@ import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { SpeciesAggregate } from '@/components/map/geometry/adaptive-grid.js';
-import { prettyFamily } from '../../../derived.js';
-import { formatCount } from '../../../lib/format-count.js';
+import { prettyFamily } from '@/derived.js';
+import { formatCount } from '@/lib/format-count.js';
 
 /**
  * `<CellPopover>` — full popover for one family within an adaptive-grid cell

--- a/frontend/src/components/map/layers/ClusterListPopover.tsx
+++ b/frontend/src/components/map/layers/ClusterListPopover.tsx
@@ -2,8 +2,8 @@ import { useEffect, useId, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { FamilyAggregate, SpeciesAggregate } from '@/components/map/geometry/adaptive-grid.js';
-import { prettyFamily } from '../../../derived.js';
-import { formatCount } from '../../../lib/format-count.js';
+import { prettyFamily } from '@/derived.js';
+import { formatCount } from '@/lib/format-count.js';
 
 /**
  * `<ClusterListPopover>` — mobile / coarse-pointer sheet-style popover for

--- a/frontend/src/components/map/layers/MapMarkerHitLayer.tsx
+++ b/frontend/src/components/map/layers/MapMarkerHitLayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
-import { prettyFamily } from '../../../derived.js';
+import { prettyFamily } from '@/derived.js';
 
 /**
  * Per-marker hit-target overlay rendered above the map canvas.

--- a/frontend/src/components/map/layers/ObservationPopover.tsx
+++ b/frontend/src/components/map/layers/ObservationPopover.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import type { Observation } from '@bird-watch/shared-types';
-import { formatCount } from '../../../lib/format-count.js';
+import { formatCount } from '@/lib/format-count.js';
 import { POPOVER_VIEWPORT_INSET_PX } from './CellPopover.js';
 
 export interface ObservationPopoverProps {


### PR DESCRIPTION
## Diagrams

N/A — import-specifier refactor (no control/data flow change).

## Summary

- **Why:** the by-kind map split (#1185) aliased 32 imports to `@/` but left **21** (across `map/layers/ hooks/ geometry/`) as deepened `../../../X` relative paths reaching `src/` root — the exact fragility the `@/` alias exists to prevent (a future move re-breaks all 21). This was the carried-over SUGGESTION on #1185.
- Converts them uniformly: `../../../X` → `@/X`. Zero behavior change — identical module resolution.
- The one 2-level `../../ds/ds-primitives.css` reference is left as-is: it's an `import.meta.dirname` filesystem read in a test, not a module import (the `@/` alias doesn't apply to `import.meta.dirname`-relative reads).

## Screenshots

N/A — not UI. Pure import-specifier refactor; the full 1549-test unit suite passes on identical module resolution.

## Test plan

- [x] `tsc -b && vite build` (frontend) — green; `@/` resolves to the converted paths
- [x] `npm test --workspace @bird-watch/frontend` — **1549/1549 pass (90 files)**
- [x] `git status` clean; diff is 15 files / 28 insertions / 28 deletions (map/ subfolder files + the 2 MapCanvas root files)

## Plan reference

Out of plan — folder-structure reorganization follow-up (the alias-consistency SUGGESTION the bot raised on #1185, the map by-kind split).