### PR TITLE
feat(eleatic): per-trace rollup line + pure rollupTrace

### DIFF
--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -215,6 +215,11 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .trace-raw { margin-top: 10px; }
 
 /* ── Trace tree pane (left pane of the trace explorer) ── */
+/* Per-trace rollup (tree-root label): a compact spans · tokens · cost · latency
+   header above the span tree. Reuses the trace-usage mono/dim convention. */
+.trace-rollup { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin: 0 0 10px; padding: 0 10px 10px; border-bottom: 1px solid var(--border); font-family: var(--mono-stack); font-size: var(--type-xs); color: var(--text-dim); }
+.trace-rollup-part { color: var(--text); }
+.trace-rollup-sep { color: var(--border); }
 .trace-tree, .trace-tree ul[role="group"] { list-style: none; margin: 0; padding: 0; }
 /* The .trace-node <li> carries the inline `--depth` custom property; its indent
    is applied on .trace-node-row below via calc(... var(--depth) ...) — depth is

--- a/packages/eleatic/ui/trace-view-page.js
+++ b/packages/eleatic/ui/trace-view-page.js
@@ -11,7 +11,8 @@
 //        • ok === false → render renderTrace(record.trace), the lossless flat
 //          fallback (a non-conforming / legacy-scalar trace still renders),
 //        • else → render renderTree(roots, selectedId, collapsed) into the LEFT
-//          pane and renderSpanDetail(selectedNode) into the RIGHT pane.
+//          pane and renderSpanDetail(selectedNode) into the RIGHT pane, plus the
+//          per-trace rollup (rollupTrace) as a tree-root label above the tree.
 //   4. selectedId = the &span= param when it resolves to a real node, else
 //      roots[0].id — an unknown / stale span falls back to the root, never a
 //      blank pane.
@@ -30,10 +31,11 @@
 // packages/eleatic knip ignore (T4).
 
 import { initTheme, toggleTheme } from './theme.js';
-import { setImageHostAllowlist } from './safe.js';
+import { esc, setImageHostAllowlist } from './safe.js';
 import { buildTraceTree } from './trace-tree.js';
 import { renderTree, renderSpanDetail, wireTree } from './trace-view.js';
-import { renderTrace } from './trace.js';
+import { renderTrace, rollupTrace } from './trace.js';
+import { formatTokens, formatCost, formatDuration } from './format.js';
 import { config } from '/config.js';
 
 // ── Boot ──
@@ -46,6 +48,7 @@ const run = params.get('run') ?? '';
 const rowKey = params.get('row') ?? '';
 
 const main = document.querySelector('.trace-explorer');
+const rollupHost = document.getElementById('trace-rollup');
 const treeHost = document.getElementById('trace-tree');
 const detailHost = document.getElementById('trace-detail');
 const fallbackHost = document.getElementById('trace-fallback');
@@ -68,6 +71,30 @@ function indexNodes(rootList) {
     for (const c of n.children) stack.push(c);
   }
   return index;
+}
+
+/**
+ * Render the per-trace ROLLUP line — the tree-root label above the span tree:
+ * `{spanCount} spans · {totalTokens} · {costUsd} · {latencyMs}`. The rollup is a
+ * pure structural reduction (rollupTrace) over the raw trace; each segment is
+ * OMITTED when its field is absent (a usage-less trace shows only the span
+ * count). Tokens / cost / latency reuse the same format.js formatters the tree
+ * meta line uses. Every dynamic value routes through esc() — the trace blob is
+ * attacker-influenceable (the trace.test.ts / pretty.test.ts threat model).
+ */
+function renderRollup(trace) {
+  const r = rollupTrace(trace);
+  const spanWord = r.spanCount === 1 ? 'span' : 'spans';
+  const segments = [
+    `${r.spanCount} ${spanWord}`,
+    formatTokens(r.totalTokens, undefined), // single combined count → '{n} tok'
+    formatCost(r.costUsd),
+    formatDuration(r.latencyMs),
+  ].filter((s) => s !== '');
+  rollupHost.innerHTML = segments
+    .map((s) => `<span class="trace-rollup-part">${esc(s)}</span>`)
+    .join('<span class="trace-rollup-sep">·</span>');
+  rollupHost.hidden = false;
 }
 
 /** Re-render the LEFT tree pane from the current roots / selection / collapsed set. */
@@ -107,6 +134,7 @@ function toggleSpan(id) {
 
 /** Render the lossless fallback for a non-conforming trace (single column). */
 function renderFallback(trace) {
+  rollupHost.hidden = true; // no tree-root label when there is no tree
   treeHost.hidden = true;
   detailHost.hidden = true;
   fallbackHost.hidden = false;
@@ -150,6 +178,10 @@ async function load() {
 
   roots = built.roots;
   nodeIndex = indexNodes(roots);
+
+  // The tree-root label: total spans / tokens / cost / latency over the whole
+  // trace, summed from the raw blob (no tree-builder dependency).
+  renderRollup(record.trace);
 
   // Default selection = the &span= param when it resolves to a real node, else
   // the first root (an unknown / stale span never leaves the detail pane blank).

--- a/packages/eleatic/ui/trace.html
+++ b/packages/eleatic/ui/trace.html
@@ -31,7 +31,13 @@
       fallback (renderTrace) is rendered into #trace-fallback instead.
     -->
     <main class="trace-explorer" data-mobile-view="tree">
-      <div class="trace-tree-pane" id="trace-tree" role="presentation"></div>
+      <div class="trace-tree-pane" role="presentation">
+        <!-- Per-trace rollup (tree-root label): spans · tokens · cost · latency,
+             rendered by trace-view-page.js from rollupTrace(record.trace). Sits
+             above the span tree as a header; hidden until the page fills it. -->
+        <div class="trace-rollup" id="trace-rollup" hidden></div>
+        <div id="trace-tree" role="presentation"></div>
+      </div>
       <div class="trace-detail-pane" id="trace-detail" role="presentation"></div>
       <div class="trace-fallback" id="trace-fallback" hidden></div>
     </main>

--- a/packages/eleatic/ui/trace.js
+++ b/packages/eleatic/ui/trace.js
@@ -16,7 +16,12 @@
 // injected `"><img onerror>` renders as inert text — the same threat model and
 // proof as pretty.test.ts / safe.test.ts.
 //
-// Plain ESM with a named export — importable by the browser (express.static) and
+// This module also exports `rollupTrace` (the per-trace structural reduction the
+// /trace page's tree-root label sums from): total spans + summed tokens / cost /
+// latency over every span, domain-agnostic and with no dependency on the tree
+// builder. See its own doc-comment below.
+//
+// Plain ESM with named exports — importable by the browser (express.static) and
 // by vitest in node (the pretty.js / format.js precedent). PURE: no DOM, no fetch.
 
 import { esc } from './safe.js';
@@ -79,4 +84,70 @@ export function renderTrace(trace) {
   }
   if (spans.length === 0) return '<p class="drawer-empty">No spans</p>';
   return `<div class="trace-spans">${spans.map(renderSpan).join('')}</div>`;
+}
+
+/**
+ * Reduce an OPAQUE trace blob to a per-trace rollup — the totals the tree-root
+ * label shows above the span tree. PURE, domain-agnostic, never throws.
+ *
+ * Self-contained over the raw trace's generic span keys (NO dependency on the
+ * tree builder): for each span it reads `metrics` ELSE the legacy `usage` object
+ * (a span carrying both prefers `metrics`, so a normalized span is never
+ * double-counted against its own legacy mirror) and sums every finite numeric
+ * field via the SAME guard `renderUsage` uses. Latency comes from
+ * `metrics.durationMs` OR `usage.latencyMs`.
+ *
+ * Each field is OMITTED from the result when NO span carried it — so a usage-less
+ * trace rolls up to `{ spanCount }` alone (never `costUsd: 0`). `totalTokens` is
+ * the sum of prompt + completion across spans (the same arithmetic the detail
+ * pane's "Total tokens" row uses), emitted only when at least one is present.
+ *
+ * The flat sum over `trace.spans` is correct for the pinned producer convention
+ * (tokens/cost live ONLY on the judge leaf; eval/task/scorer spans carry none),
+ * so it does not double-count. A non-conforming blob → `{ spanCount: 0 }`.
+ *
+ * @returns {{ spanCount: number, promptTokens?: number, completionTokens?: number, totalTokens?: number, costUsd?: number, latencyMs?: number }}
+ */
+export function rollupTrace(trace) {
+  const spans =
+    trace !== null && typeof trace === 'object' && Array.isArray(trace.spans)
+      ? trace.spans
+      : undefined;
+  if (spans === undefined) return { spanCount: 0 };
+
+  const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+  // A running accumulator: value stays undefined until the first finite addend,
+  // so a field never appears in the result unless some span actually carried it.
+  const add = (acc, v) => (v === undefined ? acc : (acc ?? 0) + v);
+
+  let promptTokens;
+  let completionTokens;
+  let costUsd;
+  let latencyMs;
+
+  for (const span of spans) {
+    const obj = span !== null && typeof span === 'object' ? span : {};
+    // Prefer the canonical `metrics`; fall back to the legacy `usage` mirror.
+    const m = obj.metrics !== null && typeof obj.metrics === 'object' ? obj.metrics : undefined;
+    const u = obj.usage !== null && typeof obj.usage === 'object' ? obj.usage : undefined;
+    const src = m ?? u ?? {};
+
+    promptTokens = add(promptTokens, num(src.promptTokens));
+    completionTokens = add(completionTokens, num(src.completionTokens));
+    costUsd = add(costUsd, num(src.costUsd));
+    // Latency: durationMs (canonical) OR latencyMs (legacy) on the chosen source.
+    latencyMs = add(latencyMs, num(src.durationMs ?? src.latencyMs));
+  }
+
+  const result = { spanCount: spans.length };
+  if (promptTokens !== undefined) result.promptTokens = promptTokens;
+  if (completionTokens !== undefined) result.completionTokens = completionTokens;
+  // totalTokens = prompt + completion, emitted when EITHER is present (the same
+  // sum the detail pane shows — never the absent-when-zero trap).
+  if (promptTokens !== undefined || completionTokens !== undefined) {
+    result.totalTokens = (promptTokens ?? 0) + (completionTokens ?? 0);
+  }
+  if (costUsd !== undefined) result.costUsd = costUsd;
+  if (latencyMs !== undefined) result.latencyMs = latencyMs;
+  return result;
 }

--- a/packages/eleatic/ui/trace.test.ts
+++ b/packages/eleatic/ui/trace.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from 'vitest';
 // usage line); anything else falls back to pretty-printing the whole blob. Every
 // key / string value flows through pretty.js → safe.js#esc, so an injected
 // payload renders inert. Importable by the browser (express.static) and vitest.
-import { renderTrace } from './trace.js';
+import { renderTrace, rollupTrace } from './trace.js';
 
 describe('renderTrace — span rendering', () => {
   it('renders one labeled block per span with the span name', () => {
@@ -122,5 +122,153 @@ describe('renderTrace — XSS escaping (same threat model as pretty.test.ts)', (
     const out = renderTrace({ evil: '"><img src=x onerror=alert(1)>' });
     expect(out).toContain('&lt;');
     expect(out).not.toContain('<img');
+  });
+});
+
+describe('rollupTrace — per-trace structural reduction', () => {
+  it('sums usage/metrics across all spans and counts them', () => {
+    // An eval→task→judge+scorers tree: tokens/cost live ONLY on the judge leaf
+    // (the pinned producer convention) — so the flat sum equals the judge leaf.
+    const r = rollupTrace({
+      spans: [
+        { id: 'eval', name: 'eval' },
+        { id: 'task', name: 'task' },
+        {
+          id: 'judge',
+          name: 'judge',
+          metrics: { promptTokens: 1200, completionTokens: 684, costUsd: 0.0009, durationMs: 1720 },
+        },
+        { id: 'scorer:a', name: 'a', scores: { a: 1 } },
+        { id: 'scorer:b', name: 'b', scores: { b: 0 } },
+      ],
+    });
+    expect(r.spanCount).toBe(5);
+    expect(r.promptTokens).toBe(1200);
+    expect(r.completionTokens).toBe(684);
+    expect(r.totalTokens).toBe(1884);
+    expect(r.costUsd).toBeCloseTo(0.0009, 10);
+    expect(r.latencyMs).toBe(1720);
+  });
+
+  it('sums the same field across MULTIPLE bearing spans (no double-count guard relies on producer, but math is additive)', () => {
+    const r = rollupTrace({
+      spans: [
+        { id: 'a', metrics: { promptTokens: 10, completionTokens: 5, costUsd: 0.001, durationMs: 100 } },
+        { id: 'b', metrics: { promptTokens: 20, completionTokens: 7, costUsd: 0.002, durationMs: 250 } },
+      ],
+    });
+    expect(r.spanCount).toBe(2);
+    expect(r.promptTokens).toBe(30);
+    expect(r.completionTokens).toBe(12);
+    expect(r.totalTokens).toBe(42);
+    expect(r.costUsd).toBeCloseTo(0.003, 10);
+    expect(r.latencyMs).toBe(350);
+  });
+
+  it('omits a field that NO span carried (no costUsd:0 when no span had cost)', () => {
+    const r = rollupTrace({
+      spans: [{ id: 'judge', metrics: { promptTokens: 50, completionTokens: 10 } }],
+    });
+    expect(r.spanCount).toBe(1);
+    expect(r.promptTokens).toBe(50);
+    expect(r.completionTokens).toBe(10);
+    expect(r.totalTokens).toBe(60);
+    expect('costUsd' in r).toBe(false);
+    expect('latencyMs' in r).toBe(false);
+  });
+
+  it('sets totalTokens from a lone prompt or completion (either present)', () => {
+    const promptOnly = rollupTrace({ spans: [{ id: 'j', metrics: { promptTokens: 99 } }] });
+    expect(promptOnly.promptTokens).toBe(99);
+    expect('completionTokens' in promptOnly).toBe(false);
+    expect(promptOnly.totalTokens).toBe(99);
+
+    const completionOnly = rollupTrace({ spans: [{ id: 'j', metrics: { completionTokens: 7 } }] });
+    expect('promptTokens' in completionOnly).toBe(false);
+    expect(completionOnly.completionTokens).toBe(7);
+    expect(completionOnly.totalTokens).toBe(7);
+  });
+
+  it('sums LEGACY usage (latencyMs) and new metrics (durationMs) both', () => {
+    // A legacy flat single-span trace (today's producer) still rolls up.
+    const legacy = rollupTrace({
+      spans: [
+        { name: 'judge', usage: { promptTokens: 12, completionTokens: 34, latencyMs: 250, costUsd: 0.0123 } },
+      ],
+    });
+    expect(legacy.spanCount).toBe(1);
+    expect(legacy.promptTokens).toBe(12);
+    expect(legacy.completionTokens).toBe(34);
+    expect(legacy.totalTokens).toBe(46);
+    expect(legacy.latencyMs).toBe(250);
+    expect(legacy.costUsd).toBeCloseTo(0.0123, 10);
+  });
+
+  it('reads latencyMs from durationMs OR usage.latencyMs across mixed spans', () => {
+    const r = rollupTrace({
+      spans: [
+        { id: 'a', metrics: { durationMs: 100 } },
+        { id: 'b', usage: { latencyMs: 50 } },
+      ],
+    });
+    expect(r.spanCount).toBe(2);
+    expect(r.latencyMs).toBe(150);
+  });
+
+  it('prefers metrics over usage on a span carrying both (no double-add)', () => {
+    const r = rollupTrace({
+      spans: [
+        {
+          id: 'j',
+          metrics: { promptTokens: 100, completionTokens: 20, durationMs: 300, costUsd: 0.01 },
+          usage: { promptTokens: 999, completionTokens: 999, latencyMs: 999, costUsd: 9.99 },
+        },
+      ],
+    });
+    expect(r.promptTokens).toBe(100);
+    expect(r.completionTokens).toBe(20);
+    expect(r.totalTokens).toBe(120);
+    expect(r.latencyMs).toBe(300);
+    expect(r.costUsd).toBeCloseTo(0.01, 10);
+  });
+
+  it('ignores non-finite values (NaN/Infinity) — the renderUsage num-guard', () => {
+    const r = rollupTrace({
+      spans: [
+        { id: 'a', metrics: { promptTokens: Number.NaN, completionTokens: Infinity, costUsd: 0.5, durationMs: 100 } },
+      ],
+    });
+    expect('promptTokens' in r).toBe(false);
+    expect('completionTokens' in r).toBe(false);
+    // totalTokens omitted when neither prompt nor completion is finite anywhere.
+    expect('totalTokens' in r).toBe(false);
+    expect(r.costUsd).toBe(0.5);
+    expect(r.latencyMs).toBe(100);
+  });
+
+  it('a usage-less trace rolls up to { spanCount } only (no numeric line)', () => {
+    const r = rollupTrace({ spans: [{ id: 'a', name: 'a' }, { id: 'b', name: 'b' }] });
+    expect(r).toEqual({ spanCount: 2 });
+  });
+
+  it('an empty spans array → { spanCount: 0 }', () => {
+    expect(rollupTrace({ spans: [] })).toEqual({ spanCount: 0 });
+  });
+
+  it('a non-conforming blob → { spanCount: 0 }, never throws', () => {
+    expect(rollupTrace({ anything: 'goes' })).toEqual({ spanCount: 0 });
+    expect(rollupTrace({ spans: 'not-an-array' })).toEqual({ spanCount: 0 });
+    expect(rollupTrace('a string')).toEqual({ spanCount: 0 });
+    expect(rollupTrace([1, 2, 3])).toEqual({ spanCount: 0 });
+    expect(rollupTrace(42)).toEqual({ spanCount: 0 });
+  });
+
+  it('never throws on any garbage input and always returns a spanCount', () => {
+    for (const v of [null, undefined, 1, 'x', true, {}, [], { spans: [null, 1, 'x', {}] }]) {
+      const r = rollupTrace(v);
+      expect(typeof r.spanCount).toBe('number');
+    }
+    // A spans array of garbage entries: each is a span (counted), none carries usage.
+    expect(rollupTrace({ spans: [null, 1, 'x', {}] })).toEqual({ spanCount: 4 });
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    T["trace.spans[]<br/>(opaque blob)"] --> R["rollupTrace(trace)<br/>(PURE, no tree dep)"]
    R -->|"per span: metrics ELSE legacy usage<br/>finite-number guard (renderUsage)"| S["sum promptTokens + completionTokens<br/>sum costUsd · sum durationMs or latencyMs<br/>omit any field no span carried"]
    S --> O["{ spanCount, promptTokens?,<br/>completionTokens?, totalTokens?,<br/>costUsd?, latencyMs? }"]
    O --> P["trace-view-page.js renderRollup()<br/>format.js: formatTokens/Cost/Duration + esc()"]
    P --> H["#trace-rollup header above the tree<br/>'4 spans · 1,884 tok · $0.0009 · 1.72s'"]
```

## Summary

- **Why:** the `/trace` explorer renders a per-span detail pane but had no per-trace summary — a viewer had to eyeball the judge leaf to learn the whole call's token/cost/latency footprint. The rollup line gives that at a glance, as a tree-root label above the span tree.
- `rollupTrace(trace)` is a new PURE, domain-agnostic export in `ui/trace.js`: it sums the raw `trace.spans` array directly (NO `buildTraceTree` dependency, so no double-count — the pinned producer convention keeps tokens/cost on the judge leaf only), reading each span's `metrics` ELSE the legacy `usage` mirror via the same finite-number guard `renderUsage` uses. A field is OMITTED when no span carried it (a usage-less trace → `{ spanCount }` alone, never `costUsd:0`); non-conforming blob → `{ spanCount: 0 }`; never throws.
- The page renders the rollup into a new `#trace-rollup` header, reusing `format.js`'s `formatTokens`/`formatCost`/`formatDuration` and `esc()`; each segment is dropped when its rollup field is absent. `trace.js` keeps its `trace.test.ts` sibling, so knip still traces it (no ignore change).

## Screenshots

N/A — packages/ tool (not frontend/**); orchestrator live-verifies

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — green (287 tests, incl. 13 new `rollupTrace` cases + the unchanged `no-coupling` domain-agnostic guard)
- [x] New unit tests added: `rollupTrace` sums across spans; omits absent fields; legacy `usage` and new `metrics` both summed; `latencyMs` from `durationMs` OR `usage.latencyMs`; prefers `metrics` over `usage` on a span carrying both; ignores non-finite; non-conforming → `{spanCount:0}`; never throws on garbage
- [x] `npm run build` (root, then `-w @bird-watch/eleatic`) — clean
- [x] `npm run lint` — green
- [x] `npx knip --no-progress` — exit 0 (no new ignore needed; `trace.js` is test-sibling-traced)
- [x] (UI only) N/A — packages/ tool, no frontend/** change; orchestrator live-verifies the `/trace` page

## Plan reference

Part of epic #1193 (T5). Implements issue #1190.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
