### PR TITLE
test(eleatic): guard the trace renderers against photo-judge domain literals

### DIFF
--- a/packages/eleatic/src/no-coupling.test.ts
+++ b/packages/eleatic/src/no-coupling.test.ts
@@ -88,3 +88,52 @@ describe('zero-coupling guard', () => {
     expect(offenders).toEqual([]);
   });
 });
+
+/**
+ * Domain-agnosticism guard for the trace renderers (T7 / epic #1193 §8).
+ *
+ * eleatic renders a GENERIC span tree from an opaque `trace` blob. A span's
+ * `name` ('judge', a scorer name, …) flowing through trace_json is DATA — fine
+ * and expected. The coupling risk is a RENDERER hardcoding that vocabulary,
+ * e.g. `if (span.name === 'judge')` or an `iconByKind` that keys off a scorer
+ * name. A quoted-string scan of the trace UI source catches exactly that: a
+ * hardcoded photo-judge literal lands in source as a quoted token, while the
+ * same word arriving as runtime data does not.
+ *
+ * Why a QUOTED-string scan and why 'eval'/'task' are DELIBERATELY EXCLUDED:
+ * 'eval' and 'task' collide with the package's own identifiers and prose —
+ * EvalSpan/EvalRowRecord/evalGate, the synthesized legacy-root `kind: 'eval'`
+ * (trace-tree.js), and "eleatic invents no eval domain" comments (trace.js:3,
+ * trace-view.js). A `\beval\b`/`\btask\b` scan would false-positive and fail
+ * this guard the moment it landed. The quoted scorer/judge terms below are
+ * high-signal and collision-free against the package's own vocabulary.
+ *
+ * If this block ever fails: DO NOT weaken the regex to make it pass. A match
+ * means a renderer hardcoded a photo-judge literal — a real coupling bug to
+ * fix (rename to a generic token, or read the value as data), not to silence.
+ */
+const TRACE_UI_FILES = [
+  'trace.js',
+  'trace-tree.js',
+  'trace-view.js',
+  'trace-view-page.js',
+  'trace-format.js',
+];
+
+// Quoted-string form, high-signal + collision-free. 'eval'/'task' are EXCLUDED
+// (see block comment) — they collide with EvalSpan/evalGate and the legacy-root
+// `kind: 'eval'` and would false-positive. Verified to BITE: temporarily
+// injecting `if (span.name === 'judge')` into a renderer turns this assertion
+// red (then reverted — never committed).
+const PHOTO_JUDGE_LITERAL =
+  /['"`](judge|scorer|species|rubric|keep_agreement|score_mae|keep_confusion|criteria_mae|falseKeep|falseReplace)/;
+
+describe('trace renderer stays domain-agnostic', () => {
+  it.each(TRACE_UI_FILES)('ui/%s hardcodes no photo-judge quoted literal', (name) => {
+    const src = readFileSync(join(PKG_ROOT, 'ui', name), 'utf8');
+    const match = PHOTO_JUDGE_LITERAL.exec(src);
+    // On failure, surface the offending file + matched token so the coupling
+    // bug is locatable (escalate it; do not loosen the scan to pass).
+    expect(match, `ui/${name} contains a forbidden photo-judge literal: ${match?.[0]}`).toBeNull();
+  });
+});


### PR DESCRIPTION
## Diagrams

N/A — test-only addition (one new `describe` block in an existing guard test; no runtime/data-flow change to diagram).

## Summary

- **Why:** eleatic renders a *generic* span tree from an opaque trace blob and must stay domain-agnostic so the package can extract cleanly (one-way dep: photo-curation → eleatic). A span `name` like `'judge'` or a scorer name flowing through `trace_json` is DATA and fine — the coupling risk is a renderer *hardcoding* that vocabulary (e.g. `if (span.name === 'judge')` or an `iconByKind` keying off a scorer name). T7 locks that invariant with the cheapest possible enforcement.
- **What:** Extends `packages/eleatic/src/no-coupling.test.ts` with a `describe('trace renderer stays domain-agnostic')` block that scans the source of `ui/trace.js`, `trace-tree.js`, `trace-view.js`, `trace-view-page.js`, `trace-format.js` for quoted photo-judge literals: `/['"\`](judge|scorer|species|rubric|keep_agreement|score_mae|keep_confusion|criteria_mae|falseKeep|falseReplace)/`. The quoted-string form catches a hardcoded literal in source while ignoring the same word arriving as runtime data.
- **`eval`/`task` deliberately excluded:** they collide with the package's own identifiers (`EvalSpan`/`EvalRowRecord`/`evalGate`), the synthesized legacy-root `kind: 'eval'` (trace-tree.js:118), and "invents no eval domain" prose (trace.js:3, trace-view.js) — a `\beval\b` scan would false-positive and fail the guard on day one. The existing four guard blocks (sanity scan, `@bird-watch/*` import ban, `../../`-escaping import ban, package.json deps ban) are UNCHANGED.

## Screenshots

N/A — not UI (test-only).

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — green (22 files, 292 tests). New block: 5 cases (one per scanned file), all pass against the shipped generic renderers (0 matches).
- [x] Existing four guard `it` blocks unchanged and still pass.
- [x] **Guard BITES, verified:** temporarily injected `if (span.name === 'judge')` into `ui/trace-view.js` → the `ui/trace-view.js` case turned red with a locatable message (`contains a forbidden photo-judge literal: 'judge`); reverted (not committed). Working tree confirmed clean except the test file.
- [x] `npm run build` (root) — clean.
- [x] `npm run build -w @bird-watch/eleatic` — clean.
- [x] `npm run lint` — exit 0, no errors/warnings.
- [x] `npx knip --no-progress` — exit 0 (the single pre-existing `docs/plans/...` configuration hint is unrelated and non-failing).

## Plan reference

Part of epic #1193 (T7). Closes #1192.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)