### PR TITLE
feat(eleatic): ARIA tree keyboard nav + trace-detail polish

### DIFF
--- a/packages/eleatic/ui/app.css
+++ b/packages/eleatic/ui/app.css
@@ -227,6 +227,12 @@ body { margin: 0; font-family: var(--font-stack); font-size: var(--type-base); b
 .trace-node-row { display: flex; align-items: center; gap: 6px; padding: 4px 10px 4px calc(8px + var(--depth) * 16px); border-radius: var(--radius-sm); cursor: pointer; }
 .trace-node-row:hover { background: var(--surface-2); }
 .trace-node[aria-selected="true"] > .trace-node-row { background: var(--accent-soft); box-shadow: inset 3px 0 0 var(--accent); }
+/* Keyboard focus ring: the roving-tabindex treeitem (.trace-node <li>) is the
+   single tab stop, so make keyboard focus visible (mouse focus stays quiet via
+   :focus-visible). The outline sits on the row so it tracks the visible band. */
+.trace-node:focus { outline: none; }
+.trace-node:focus-visible { outline: none; }
+.trace-node:focus-visible > .trace-node-row { outline: 2px solid var(--accent); outline-offset: -2px; }
 .trace-twisty { flex: none; width: 16px; padding: 0; border: 0; background: none; color: var(--text-dim); font: inherit; line-height: 1; cursor: pointer; }
 .trace-node-icon { flex: none; color: var(--text-dim); font-size: var(--type-xs); }
 .trace-node-name { font-family: var(--mono-stack); font-size: var(--type-sm); color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/packages/eleatic/ui/trace-view-page.js
+++ b/packages/eleatic/ui/trace-view-page.js
@@ -61,6 +61,19 @@ let roots = [];
 let selectedId = '';
 const collapsed = new Set();
 
+/**
+ * Escape a span id for safe use inside an attribute selector. Span ids come from
+ * the OPAQUE, attacker-influenceable trace blob, so they may contain quotes /
+ * brackets that would break (or inject into) a `[data-span-id="…"]` selector.
+ * CSS.escape is the standard primitive; the typeof guard keeps the module
+ * importable in a non-browser context (it is browser-only glue, but stays safe).
+ */
+function cssEscape(value) {
+  return typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape(String(value))
+    : String(value).replace(/["\\\]]/g, '\\$&');
+}
+
 /** A flat id→TraceNode index over the whole forest, for selection + detail render. */
 function indexNodes(rootList) {
   const index = new Map();
@@ -115,21 +128,48 @@ function syncSpanParam() {
   history.replaceState(null, '', `?${next.toString()}`);
 }
 
-/** Select a node: update the panes, the URL, and (on mobile) flip to the detail view. */
+/**
+ * Select a node: update the panes, the URL, and (on mobile) flip to the detail
+ * view. The tree re-render replaces the DOM, so if a node currently holds
+ * keyboard focus (Enter/Space select), restore focus to the now-selected row so
+ * arrow-nav can continue. A mouse click doesn't focus the row, so focus is only
+ * restored when the page already had keyboard focus inside the tree.
+ */
 function selectSpan(id) {
   if (!nodeIndex.has(id)) return; // ignore a click on a stale / unknown id
+  const hadTreeFocus = !!document.activeElement?.closest?.('[data-span-id]');
   selectedId = id;
   renderTreePane(); // re-render so aria-selected + roving tabindex track the selection
   renderDetailPane();
   syncSpanParam();
   if (main) main.setAttribute('data-mobile-view', 'detail');
+  if (hadTreeFocus) {
+    // The re-rendered selected row already carries tabindex=0 (renderNode); just
+    // move DOM focus onto it so keyboard traversal resumes from the selection.
+    treeHost.querySelector(`[data-span-id="${cssEscape(id)}"]`)?.focus();
+  }
 }
 
-/** Toggle a branch's collapsed state and re-render the tree. */
+/**
+ * Toggle a branch's collapsed state and re-render the tree. A keyboard toggle
+ * (←/→) destroys + re-creates the DOM, so restore focus + the roving tab stop to
+ * the toggled row afterwards (renderNode only puts tabindex=0 on the SELECTED
+ * row, which may differ from the focused one). A mouse toggle leaves focus where
+ * it was, so only re-focus when the toggled row currently holds keyboard focus.
+ */
 function toggleSpan(id) {
+  const hadFocus =
+    document.activeElement?.closest?.('[data-span-id]')?.getAttribute('data-span-id') === id;
   if (collapsed.has(id)) collapsed.delete(id);
   else collapsed.add(id);
   renderTreePane();
+  if (hadFocus) {
+    const row = treeHost.querySelector(`[data-span-id="${cssEscape(id)}"]`);
+    if (row) {
+      row.setAttribute('tabindex', '0');
+      row.focus();
+    }
+  }
 }
 
 /** Render the lossless fallback for a non-conforming trace (single column). */
@@ -172,6 +212,14 @@ async function load() {
   const built = buildTraceTree(record.trace);
   if (!built.ok) {
     // Non-conforming / legacy-scalar trace → the lossless flat preview.
+    renderFallback(record.trace);
+    return;
+  }
+  if (built.roots.length === 0) {
+    // A CONFORMING but EMPTY trace ({ spans: [] }) builds ok:true with no roots.
+    // Rendering the two panes would leave both blank — contradicting the page's
+    // "never a blank pane" intent (T6 fold #2). Route it through the same
+    // lossless fallback, which shows renderTrace's empty-trace note.
     renderFallback(record.trace);
     return;
   }

--- a/packages/eleatic/ui/trace-view.js
+++ b/packages/eleatic/ui/trace-view.js
@@ -16,12 +16,15 @@
 //
 // Plain ESM, named exports — importable by the browser (express.static) and by
 // vitest in node (the trace.js / pretty.js / format.js precedent). The render
-// functions are PURE (no DOM, no fetch, never throw); wireTree is the single
-// glue that binds the host element (the only DOM-touching export).
+// functions + the keyboard model (flattenVisible / keyToAction) are PURE (no
+// DOM, no fetch, never throw); wireTree is the single glue that binds the host
+// element (the only DOM-touching export) and implements the full WAI-ARIA tree
+// keyboard model (arrow nav with roving tabindex, expand/collapse, Home/End,
+// Enter/Space select) via ONE delegated keydown listener over the visible rows.
 
 import { esc } from './safe.js';
 import { prettyJson } from './pretty.js';
-import { formatDuration, formatTokens, formatCost, sumTokens } from './format.js';
+import { formatDuration, formatTokens, formatCost } from './format.js';
 import { scoreBars, metricRow } from './trace-format.js';
 
 // Generic, domain-neutral glyphs keyed purely off a node's STRUCTURE. A node
@@ -136,12 +139,14 @@ export function renderTree(roots, selectedId, collapsed) {
  * bottom (mirrors the Braintrust span panel):
  *   • a <header> with the node's structural glyph + name + a mobile back button
  *     (`[data-mobile-back]`, the single-column collapse's "← Spans" affordance),
- *   • a Metrics <dl> reading node.metrics: Start · Duration · Total tokens ·
- *     Prompt tokens · Completion tokens · Est. cost — each via metricRow, OMITTED
- *     when its source is absent (the omit-when-absent §4 discipline). "Total
- *     tokens" reuses the SAME sumTokens(prompt, completion) the tree meta line
- *     uses — the arithmetic lives in ONE place — and is omitted when neither is
- *     finite,
+ *   • a Metrics <dl> reading node.metrics: Duration · Total tokens · Prompt
+ *     tokens · Completion tokens · Est. cost — each via metricRow, OMITTED when
+ *     its source is absent (the omit-when-absent §4 discipline). All three token
+ *     rows render through formatTokens, so the detail pane reads identically to
+ *     the tree meta line (thousands-separated + " tok"); "Total tokens" passes
+ *     prompt + completion and is omitted when neither is finite. There is no
+ *     "Start" row: startMs is a timestamp (no producer field, no timeline
+ *     feature) and was wrongly run through the DURATION formatter (T6 fold #1),
  *   • a Scores block ONLY when node.span.scores exists, wrapped in the caller's
  *     `.score-bars` flex container around the shared scoreBars (matching the
  *     drawer, where `.score-bars` wraps the call rather than scoreBars emitting
@@ -157,12 +162,18 @@ export function renderSpanDetail(node) {
   const span = node.span !== null && typeof node.span === 'object' ? node.span : {};
   const metrics = node.metrics !== null && typeof node.metrics === 'object' ? node.metrics : {};
 
-  // Compute the combined token count ONCE (the same sum the tree meta line uses).
-  const total = sumTokens(metrics.promptTokens, metrics.completionTokens);
+  // Token rows ALL route through formatTokens so the detail pane reads
+  // identically to the tree meta line — thousands-separated + " tok" suffix
+  // (e.g. "1,884 tok"), never a bare integer. "Total tokens" passes BOTH
+  // prompt + completion (the same sum the tree meta line computes); the
+  // single-arg calls render each component alone. formatTokens returns '' when
+  // its source is absent, so metricRow omits the row (the omit-when-absent §4
+  // discipline). No "Start" row: metrics.startMs is a timestamp, not a
+  // duration, has no producer field, and there is no timeline feature yet —
+  // formatting it through the DURATION formatter was wrong (T6 fold #1).
   const rows =
-    metricRow('Start', formatDuration(metrics.startMs)) +
     metricRow('Duration', formatDuration(metrics.durationMs)) +
-    metricRow('Total tokens', total === undefined ? '' : total) +
+    metricRow('Total tokens', formatTokens(metrics.promptTokens, metrics.completionTokens)) +
     metricRow('Prompt tokens', formatTokens(metrics.promptTokens, undefined)) +
     metricRow('Completion tokens', formatTokens(undefined, metrics.completionTokens)) +
     metricRow('Est. cost', formatCost(metrics.costUsd));
@@ -197,13 +208,162 @@ export function renderSpanDetail(node) {
 }
 
 /**
+ * Flatten the forest into the ordered list of VISIBLE treeitems — a pre-order
+ * walk that recurses into a node's children ONLY when the node is NOT collapsed.
+ * The result is the exact set of rows the user can move focus between with the
+ * arrow keys (a collapsed subtree's descendants are excluded), and is the pure
+ * core the wireTree keydown handler's DOM walk mirrors. Each descriptor carries
+ * only the structural facts keyToAction needs. PURE; never throws.
+ *
+ * @returns {{ id: string, hasChildren: boolean, expanded: boolean, depth: number, parentId: string|null }[]}
+ */
+export function flattenVisible(roots, collapsed) {
+  const out = [];
+  const walk = (node, parentId) => {
+    const hasChildren = node.children.length > 0;
+    const expanded = hasChildren && !collapsed.has(node.id);
+    out.push({ id: node.id, hasChildren, expanded, depth: node.depth, parentId });
+    if (expanded) {
+      for (const c of node.children) walk(c, node.id);
+    }
+  };
+  for (const r of roots) walk(r, null);
+  return out;
+}
+
+// The set of keys the tree's keydown handler consumes (preventing the default
+// page scroll / caret motion). Any other key falls through (type:'none', no
+// preventDefault) so the page's normal handling is untouched.
+const TREE_KEYS = new Set([
+  'ArrowDown',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowLeft',
+  'Home',
+  'End',
+  'Enter',
+  ' ',
+]);
+
+/**
+ * The PURE WAI-ARIA tree key model: given a `key`, the currently-focused id,
+ * and the ordered `visible` list (from flattenVisible), return the action the
+ * delegated keydown handler should apply:
+ *   { type: 'focus'|'select'|'toggle'|'none', id?: string, preventDefault: boolean }
+ *
+ *   • ↓ / ↑  — focus the next / previous visible item (CLAMP at the ends, no
+ *              wrap). A focused id absent from the list defaults ↓→first, ↑→last
+ *              so navigation never gets stuck on stale focus.
+ *   • →      — a COLLAPSED branch expands (toggle); an EXPANDED branch focuses
+ *              its first child; a leaf is a no-op (still prevents scroll).
+ *   • ←      — an EXPANDED branch collapses (toggle); otherwise focus moves to
+ *              the parent (a root with no parent is a no-op).
+ *   • Enter / Space — select the focused item (Space prevents page scroll; we
+ *              prevent default for both for a consistent roving experience).
+ *   • Home / End — focus the first / last visible item.
+ *
+ * No DOM, no callbacks — wireTree owns applying the action. PURE; never throws.
+ */
+export function keyToAction(key, focusedId, visible) {
+  if (!TREE_KEYS.has(key) || visible.length === 0) {
+    return { type: 'none', preventDefault: false };
+  }
+  const i = visible.findIndex((v) => v.id === focusedId);
+  const focused = i === -1 ? undefined : visible[i];
+  const last = visible.length - 1;
+
+  switch (key) {
+    case 'ArrowDown': {
+      const next = i === -1 ? visible[0] : visible[Math.min(i + 1, last)];
+      return { type: 'focus', id: next.id, preventDefault: true };
+    }
+    case 'ArrowUp': {
+      const prev = i === -1 ? visible[last] : visible[Math.max(i - 1, 0)];
+      return { type: 'focus', id: prev.id, preventDefault: true };
+    }
+    case 'ArrowRight': {
+      if (focused === undefined) return { type: 'none', preventDefault: true };
+      if (focused.hasChildren && !focused.expanded) {
+        return { type: 'toggle', id: focused.id, preventDefault: true };
+      }
+      if (focused.hasChildren && focused.expanded) {
+        // The first child is the very next visible row (pre-order guarantees it).
+        const child = visible[i + 1];
+        if (child) return { type: 'focus', id: child.id, preventDefault: true };
+      }
+      return { type: 'none', preventDefault: true }; // a leaf: nothing to expand
+    }
+    case 'ArrowLeft': {
+      if (focused === undefined) return { type: 'none', preventDefault: true };
+      if (focused.hasChildren && focused.expanded) {
+        return { type: 'toggle', id: focused.id, preventDefault: true };
+      }
+      if (focused.parentId !== null && focused.parentId !== undefined) {
+        return { type: 'focus', id: focused.parentId, preventDefault: true };
+      }
+      return { type: 'none', preventDefault: true }; // a root: no parent
+    }
+    case 'Home':
+      return { type: 'focus', id: visible[0].id, preventDefault: true };
+    case 'End':
+      return { type: 'focus', id: visible[last].id, preventDefault: true };
+    case 'Enter':
+    case ' ': {
+      if (focused === undefined) return { type: 'none', preventDefault: true };
+      return { type: 'select', id: focused.id, preventDefault: true };
+    }
+    default:
+      return { type: 'none', preventDefault: false };
+  }
+}
+
+/**
+ * Read the VISIBLE treeitems straight from the rendered DOM, in document order.
+ * Because renderNode only nests a branch's children when it is expanded, the
+ * collapsed subtrees are simply absent from the DOM — so the live treeitems ARE
+ * the visible list. Each descriptor mirrors flattenVisible's shape (id +
+ * hasChildren + expanded + parentId) so keyToAction is fed identically whether
+ * driven by the pure unit test or the browser. parentId is the data-span-id of
+ * the nearest ANCESTOR treeitem (null at a root).
+ */
+function visibleFromDom(host) {
+  const items = Array.from(host.querySelectorAll('[role="treeitem"]'));
+  const byEl = new Map(items.map((el) => [el, el.getAttribute('data-span-id')]));
+  return items.map((el) => {
+    const expandedAttr = el.getAttribute('aria-expanded');
+    // A parent treeitem is the nearest ancestor row; null at a root. `closest`
+    // from the element itself returns itself, so search from the parent node.
+    let parentId = null;
+    const parentEl =
+      typeof el.parentElement?.closest === 'function'
+        ? el.parentElement.closest('[role="treeitem"]')
+        : null;
+    if (parentEl && byEl.has(parentEl)) parentId = byEl.get(parentEl);
+    return {
+      el,
+      id: el.getAttribute('data-span-id'),
+      hasChildren: expandedAttr !== null, // aria-expanded only exists on a branch
+      expanded: expandedAttr === 'true',
+      parentId,
+    };
+  });
+}
+
+/**
  * Bind the tree's interaction with ONE delegated click + ONE delegated keydown
  * listener on `host` (the facets.js anti-per-row-binding pattern — never one
  * listener per node). A click on a twisty (`[data-toggle]`) calls onToggle(id);
- * any other click inside a node row (`[data-span-id]`) calls onSelect(id). Enter
- * or Space on a focused node selects it (preventing the default scroll). The
- * collapsed Set is owned by the caller (the page glue, T4) — wireTree only routes
- * events to the two callbacks.
+ * any other click inside a node row (`[data-span-id]`) calls onSelect(id).
+ *
+ * The keydown listener implements the full WAI-ARIA tree keyboard model
+ * (keyToAction) over the VISIBLE treeitems (read live from the DOM):
+ *   ↓/↑ move focus (roving tabindex — the focused row gets tabindex=0, the rest
+ *   -1, and .focus() lands on the new row); → expands-or-descends; ← collapses-
+ *   or-ascends; Enter/Space select; Home/End jump to the first/last visible row.
+ * Selection (onSelect) and toggling (onToggle) re-render via the caller's
+ * callbacks; after a re-render renderNode re-establishes the roving tabindex
+ * from selectedId. The collapsed Set is owned by the caller (the page glue) —
+ * wireTree only routes events to the two callbacks + manages transient focus.
  */
 export function wireTree(host, { onSelect, onToggle }) {
   host.addEventListener('click', (ev) => {
@@ -220,11 +380,37 @@ export function wireTree(host, { onSelect, onToggle }) {
   });
 
   host.addEventListener('keydown', (ev) => {
-    if (ev.key !== 'Enter' && ev.key !== ' ') return;
-    const row = ev.target.closest('[data-span-id]');
-    if (!row) return;
-    ev.preventDefault();
-    const id = row.getAttribute('data-span-id');
-    if (id !== null) onSelect(id);
+    if (!TREE_KEYS.has(ev.key)) return; // leave every other key to the page
+
+    // Select (Enter/Space) is DOM-light: it routes the focused row's id to
+    // onSelect without needing the full visible list. Arrow / Home / End nav
+    // reads the live visible treeitems and moves roving focus.
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      const row = ev.target.closest('[data-span-id]');
+      if (!row) return;
+      ev.preventDefault();
+      const id = row.getAttribute('data-span-id');
+      if (id !== null) onSelect(id);
+      return;
+    }
+
+    const visible = visibleFromDom(host);
+    if (visible.length === 0) return;
+    const focusedRow = ev.target.closest('[role="treeitem"]');
+    const focusedId = focusedRow ? focusedRow.getAttribute('data-span-id') : null;
+    const action = keyToAction(ev.key, focusedId, visible);
+    if (action.preventDefault) ev.preventDefault();
+
+    if (action.type === 'focus') {
+      const target = visible.find((v) => v.id === action.id);
+      if (!target) return;
+      // Roving tabindex: the focused row is the single tab stop (0), the rest -1.
+      for (const v of visible) v.el.setAttribute('tabindex', v === target ? '0' : '-1');
+      target.el.focus();
+    } else if (action.type === 'toggle') {
+      onToggle(action.id);
+    } else if (action.type === 'select') {
+      onSelect(action.id);
+    }
   });
 }

--- a/packages/eleatic/ui/trace-view.test.ts
+++ b/packages/eleatic/ui/trace-view.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { renderTree, renderNode, iconByKind, wireTree, renderSpanDetail } from './trace-view.js';
+import {
+  renderTree,
+  renderNode,
+  iconByKind,
+  wireTree,
+  renderSpanDetail,
+  flattenVisible,
+  keyToAction,
+} from './trace-view.js';
 import { buildTraceTree } from './trace-tree.js';
 
 // trace-view.js is the LEFT pane of the eleatic trace explorer: a PURE recursive
@@ -234,21 +242,30 @@ describe('renderSpanDetail — the RIGHT pane (Metrics · Scores · Input · Out
         metrics: { startMs: 5, durationMs: 1500, promptTokens: 1000, completionTokens: 884, costUsd: 0.0123 },
       }),
     );
-    expect(out).toContain('Start');
+    // No "Start" row — startMs is a timestamp, NOT a duration, and there is no
+    // producer field nor timeline feature yet (T6 fold #1: the row was dropped
+    // rather than mis-formatted through the DURATION formatter).
+    expect(out).not.toContain('Start');
     expect(out).toContain('Duration');
     expect(out).toContain('1.50s');
     expect(out).toContain('Prompt tokens');
     expect(out).toContain('Completion tokens');
     expect(out).toContain('Est. cost');
     expect(out).toContain('$0.0123');
-    // Total tokens = prompt + completion (1884), computed ONCE via sumTokens.
+    // Total tokens = prompt + completion, formatted with a thousands separator +
+    // " tok" suffix (T6 fold #3) so the detail row MATCHES the tree meta line
+    // (1,884 tok) instead of a bare 1884. The arithmetic is still sumTokens.
     expect(out).toContain('Total tokens');
-    expect(out).toContain('1884');
+    expect(out).toContain('1,884 tok');
+    expect(out).not.toMatch(/>1884</); // never the bare, unseparated number
+    // Prompt / Completion rows are also thousands-separated + suffixed for
+    // consistency across the three token rows.
+    expect(out).toContain('1,000 tok');
+    expect(out).toContain('884 tok');
   });
 
   it('omits ALL metric rows when the node has no metrics (a usage-less scorer span)', () => {
     const out = renderSpanDetail(node({ id: 's', span: { name: 'keep_agreement', scores: { keep_agreement: 1 } } }));
-    expect(out).not.toContain('Start');
     expect(out).not.toContain('Duration');
     expect(out).not.toContain('Total tokens');
     expect(out).not.toContain('Prompt tokens');
@@ -313,7 +330,7 @@ describe('renderSpanDetail — the RIGHT pane (Metrics · Scores · Input · Out
     expect(out).toContain('judge');
     expect(out).toContain('250ms'); // durationMs normalized from latencyMs
     expect(out).toContain('Total tokens');
-    expect(out).toContain('46'); // 12 + 34
+    expect(out).toContain('46 tok'); // 12 + 34, thousands-sep + " tok" suffix
     expect(out).toContain('$0.01');
   });
 });
@@ -400,12 +417,285 @@ describe('wireTree — delegation', () => {
     expect(ev.defaultPrevented).toBe(true);
   });
 
-  it('ignores keydown that is not Enter/Space', () => {
+  it('ignores keydown that is not a handled key', () => {
     const host = fakeHost();
     const selected = [];
     wireTree(host, { onSelect: (id) => selected.push(id), onToggle() {} });
     const row = { getAttribute: () => 'eval' };
     host.listeners.keydown[0](fakeEvent('[data-span-id]', row, { key: 'a' }));
     expect(selected).toEqual([]);
+  });
+});
+
+// ── flattenVisible: the ordered list of VISIBLE treeitems ──
+//
+// PURE pre-order flatten over the TraceNode forest, recursing into a node's
+// children ONLY when it is not collapsed. The result drives both the arrow-key
+// next-focus computation and (in the browser) the DOM walk. Each descriptor
+// carries exactly the structural facts keyToAction needs: id, hasChildren,
+// expanded, depth, parentId.
+describe('flattenVisible — ordered visible treeitems (collapsed subtrees skipped)', () => {
+  const tree = buildTraceTree({
+    spans: [
+      { id: 'eval', parentId: null, name: 'eval' },
+      { id: 'task', parentId: 'eval', name: 'task' },
+      { id: 'judge', parentId: 'task', name: 'judge' },
+      { id: 's1', parentId: 'task', name: 's1' },
+    ],
+  }).roots;
+
+  it('pre-orders the whole forest when nothing is collapsed', () => {
+    const vis = flattenVisible(tree, new Set());
+    expect(vis.map((v) => v.id)).toEqual(['eval', 'task', 'judge', 's1']);
+    expect(vis.map((v) => v.depth)).toEqual([0, 1, 2, 2]);
+    expect(vis.find((v) => v.id === 'eval')).toMatchObject({
+      hasChildren: true,
+      expanded: true,
+      parentId: null,
+    });
+    expect(vis.find((v) => v.id === 'judge')).toMatchObject({
+      hasChildren: false,
+      parentId: 'task',
+    });
+  });
+
+  it('skips the children of a collapsed node (but keeps the node itself)', () => {
+    const vis = flattenVisible(tree, new Set(['task']));
+    // task is visible (and collapsed), but its children judge/s1 are hidden.
+    expect(vis.map((v) => v.id)).toEqual(['eval', 'task']);
+    expect(vis.find((v) => v.id === 'task')).toMatchObject({
+      hasChildren: true,
+      expanded: false,
+    });
+  });
+
+  it('reports parentId so keyToAction can navigate ← to a parent', () => {
+    const vis = flattenVisible(tree, new Set());
+    expect(vis.find((v) => v.id === 's1').parentId).toBe('task');
+    expect(vis.find((v) => v.id === 'eval').parentId).toBe(null);
+  });
+});
+
+// ── keyToAction: the PURE key → action mapping (the WAI-ARIA tree model) ──
+//
+// Given a key, the currently-focused id, and the ordered visible list,
+// keyToAction returns { type, id, preventDefault } where type is one of
+// 'focus' | 'select' | 'toggle' | 'none'. wireTree's single delegated keydown
+// listener reads the visible list from the DOM and APPLIES the returned action
+// (roving tabindex + .focus(), onSelect, or onToggle). No DOM here — pure.
+describe('keyToAction — WAI-ARIA tree key model (pure)', () => {
+  // eval(branch,expanded) > task(branch,expanded) > [judge(leaf), s1(leaf)]
+  const visible = [
+    { id: 'eval', hasChildren: true, expanded: true, depth: 0, parentId: null },
+    { id: 'task', hasChildren: true, expanded: true, depth: 1, parentId: 'eval' },
+    { id: 'judge', hasChildren: false, expanded: false, depth: 2, parentId: 'task' },
+    { id: 's1', hasChildren: false, expanded: false, depth: 2, parentId: 'task' },
+  ];
+
+  it('ArrowDown moves focus to the next visible item', () => {
+    expect(keyToAction('ArrowDown', 'eval', visible)).toMatchObject({ type: 'focus', id: 'task', preventDefault: true });
+    expect(keyToAction('ArrowDown', 'judge', visible)).toMatchObject({ type: 'focus', id: 's1' });
+  });
+
+  it('ArrowDown clamps at the last item (no wrap)', () => {
+    expect(keyToAction('ArrowDown', 's1', visible)).toMatchObject({ type: 'focus', id: 's1' });
+  });
+
+  it('ArrowUp moves focus to the previous visible item', () => {
+    expect(keyToAction('ArrowUp', 's1', visible)).toMatchObject({ type: 'focus', id: 'judge', preventDefault: true });
+  });
+
+  it('ArrowUp clamps at the first item (no wrap)', () => {
+    expect(keyToAction('ArrowUp', 'eval', visible)).toMatchObject({ type: 'focus', id: 'eval' });
+  });
+
+  it('ArrowRight on a COLLAPSED branch expands it (toggle)', () => {
+    const collapsedTask = [
+      { id: 'eval', hasChildren: true, expanded: true, depth: 0, parentId: null },
+      { id: 'task', hasChildren: true, expanded: false, depth: 1, parentId: 'eval' },
+    ];
+    expect(keyToAction('ArrowRight', 'task', collapsedTask)).toMatchObject({ type: 'toggle', id: 'task', preventDefault: true });
+  });
+
+  it('ArrowRight on an EXPANDED branch moves to its first child', () => {
+    expect(keyToAction('ArrowRight', 'eval', visible)).toMatchObject({ type: 'focus', id: 'task' });
+  });
+
+  it('ArrowRight on a LEAF is a no-op (but still prevents scroll)', () => {
+    expect(keyToAction('ArrowRight', 'judge', visible)).toMatchObject({ type: 'none', preventDefault: true });
+  });
+
+  it('ArrowLeft on an EXPANDED branch collapses it (toggle)', () => {
+    expect(keyToAction('ArrowLeft', 'task', visible)).toMatchObject({ type: 'toggle', id: 'task', preventDefault: true });
+  });
+
+  it('ArrowLeft on a LEAF moves focus to its parent', () => {
+    expect(keyToAction('ArrowLeft', 'judge', visible)).toMatchObject({ type: 'focus', id: 'task' });
+  });
+
+  it('ArrowLeft on a COLLAPSED branch moves to its parent (no parent at a root → none)', () => {
+    const collapsedTask = [
+      { id: 'eval', hasChildren: true, expanded: true, depth: 0, parentId: null },
+      { id: 'task', hasChildren: true, expanded: false, depth: 1, parentId: 'eval' },
+    ];
+    // collapsed branch with a parent → move to the parent.
+    expect(keyToAction('ArrowLeft', 'task', collapsedTask)).toMatchObject({ type: 'focus', id: 'eval' });
+    // a collapsed root has no parent → no-op.
+    const rootCollapsed = [{ id: 'r', hasChildren: true, expanded: false, depth: 0, parentId: null }];
+    expect(keyToAction('ArrowLeft', 'r', rootCollapsed)).toMatchObject({ type: 'none' });
+  });
+
+  it('Enter selects the focused item', () => {
+    expect(keyToAction('Enter', 'judge', visible)).toMatchObject({ type: 'select', id: 'judge', preventDefault: true });
+  });
+
+  it('Space selects the focused item and prevents default (no page scroll)', () => {
+    expect(keyToAction(' ', 'judge', visible)).toMatchObject({ type: 'select', id: 'judge', preventDefault: true });
+  });
+
+  it('Home focuses the first visible item, End the last', () => {
+    expect(keyToAction('Home', 's1', visible)).toMatchObject({ type: 'focus', id: 'eval', preventDefault: true });
+    expect(keyToAction('End', 'eval', visible)).toMatchObject({ type: 'focus', id: 's1', preventDefault: true });
+  });
+
+  it('an unhandled key yields a no-op that does not prevent default', () => {
+    expect(keyToAction('a', 'eval', visible)).toMatchObject({ type: 'none', preventDefault: false });
+  });
+
+  it('a focused id absent from the visible list defaults arrows to the ends', () => {
+    // Stale focus (e.g. a just-collapsed child) → ArrowDown lands on the first
+    // item, ArrowUp on the last, so navigation never gets stuck.
+    expect(keyToAction('ArrowDown', 'gone', visible)).toMatchObject({ type: 'focus', id: 'eval' });
+    expect(keyToAction('ArrowUp', 'gone', visible)).toMatchObject({ type: 'focus', id: 's1' });
+  });
+
+  it('empty visible list → no-op for every key', () => {
+    expect(keyToAction('ArrowDown', 'x', [])).toMatchObject({ type: 'none' });
+    expect(keyToAction('Enter', 'x', [])).toMatchObject({ type: 'none' });
+  });
+});
+
+// ── wireTree keyboard nav: the single delegated keydown drives focus/roving ──
+//
+// A richer fake host exposes querySelectorAll over the rendered treeitems (each
+// a fake element with the attributes + a focus() spy + a tabindex setter) so the
+// DOM wiring (roving tabindex + .focus() on arrow nav) is exercised without
+// jsdom. The fake mirrors only the surface wireTree's keydown handler touches.
+function fakeTreeItem(attrs) {
+  let tabindex = attrs['tabindex'] ?? '-1';
+  const el = {
+    _focused: 0,
+    getAttribute: (a) => (a === 'tabindex' ? tabindex : attrs[a] ?? null),
+    setAttribute: (a, v) => {
+      if (a === 'tabindex') tabindex = String(v);
+      else attrs[a] = v;
+    },
+    focus() {
+      this._focused += 1;
+    },
+  };
+  return el;
+}
+
+/**
+ * A fake tree host whose querySelectorAll('[role="treeitem"]') returns the
+ * given fake items in document order, and whose keydown listener can be invoked
+ * with a fake event whose target is one of those items.
+ */
+function fakeTreeHost(items) {
+  const listeners = {};
+  return {
+    items,
+    listeners,
+    addEventListener(type, fn) {
+      (listeners[type] ??= []).push(fn);
+    },
+    querySelectorAll(sel) {
+      return sel === '[role="treeitem"]' ? items : [];
+    },
+  };
+}
+/** A keydown event whose target IS the given fake treeitem (target.closest returns it). */
+function keydownEvent(key, targetItem) {
+  return {
+    key,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    target: {
+      closest(sel) {
+        return sel === '[data-span-id]' || sel === '[role="treeitem"]' ? targetItem : null;
+      },
+    },
+  };
+}
+
+describe('wireTree — keyboard navigation drives roving tabindex + focus', () => {
+  function setup() {
+    const evalItem = fakeTreeItem({ 'data-span-id': 'eval', 'aria-expanded': 'true', tabindex: '0' });
+    const taskItem = fakeTreeItem({ 'data-span-id': 'task', 'aria-expanded': 'true', tabindex: '-1' });
+    const judgeItem = fakeTreeItem({ 'data-span-id': 'judge', tabindex: '-1' }); // leaf: no aria-expanded
+    const host = fakeTreeHost([evalItem, taskItem, judgeItem]);
+    const selected = [];
+    const toggled = [];
+    wireTree(host, { onSelect: (id) => selected.push(id), onToggle: (id) => toggled.push(id) });
+    return { host, evalItem, taskItem, judgeItem, selected, toggled };
+  }
+
+  it('ArrowDown focuses the next item and sets roving tabindex (0 on it, -1 elsewhere)', () => {
+    const { host, evalItem, taskItem, judgeItem } = setup();
+    const ev = keydownEvent('ArrowDown', evalItem);
+    host.listeners.keydown[0](ev);
+    expect(taskItem._focused).toBe(1); // moved focus to the next visible item
+    expect(taskItem.getAttribute('tabindex')).toBe('0'); // roving: focused → 0
+    expect(evalItem.getAttribute('tabindex')).toBe('-1'); // others → -1
+    expect(judgeItem.getAttribute('tabindex')).toBe('-1');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('ArrowUp clamps at the first item', () => {
+    const { host, evalItem } = setup();
+    const ev = keydownEvent('ArrowUp', evalItem);
+    host.listeners.keydown[0](ev);
+    expect(evalItem._focused).toBe(1); // stays on the first, re-focused
+  });
+
+  it('Enter on a focused item fires onSelect (no focus move)', () => {
+    const { host, taskItem, selected } = setup();
+    const ev = keydownEvent('Enter', taskItem);
+    host.listeners.keydown[0](ev);
+    expect(selected).toEqual(['task']);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it('ArrowRight on an expanded branch focuses its first child', () => {
+    const { host, evalItem, taskItem } = setup();
+    const ev = keydownEvent('ArrowRight', evalItem);
+    host.listeners.keydown[0](ev);
+    expect(taskItem._focused).toBe(1);
+  });
+
+  it('ArrowLeft on an expanded branch toggles (collapse) via onToggle', () => {
+    const { host, taskItem, toggled } = setup();
+    const ev = keydownEvent('ArrowLeft', taskItem);
+    host.listeners.keydown[0](ev);
+    expect(toggled).toEqual(['task']);
+  });
+
+  it('Home focuses the first, End the last', () => {
+    const { host, evalItem, judgeItem } = setup();
+    host.listeners.keydown[0](keydownEvent('End', evalItem));
+    expect(judgeItem._focused).toBe(1);
+    host.listeners.keydown[0](keydownEvent('Home', judgeItem));
+    expect(evalItem._focused).toBe(1);
+  });
+
+  it('an unhandled key does not prevent default and moves no focus', () => {
+    const { host, evalItem, taskItem } = setup();
+    const ev = keydownEvent('a', evalItem);
+    host.listeners.keydown[0](ev);
+    expect(ev.defaultPrevented).toBe(false);
+    expect(taskItem._focused).toBe(0);
   });
 });


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    K["keydown on tree host<br/>(ONE delegated listener)"] --> G{key in<br/>TREE_KEYS?}
    G -->|no| P[leave to the page]
    G -->|Enter / Space| S["onSelect(focusedId)<br/>preventDefault"]
    G -->|Arrow / Home / End| V["visibleFromDom(host)<br/>→ keyToAction(key, focusedId, visible)"]
    V --> A{action.type}
    A -->|focus| R["roving tabindex:<br/>target=0, rest=-1<br/>target.el.focus()"]
    A -->|toggle| T["onToggle(id)<br/>(← collapse / → expand)"]
    A -->|select| S
    A -->|none| N["no focus move<br/>(preventDefault per key)"]
    T --> RR[page re-renders tree<br/>+ restores focus to toggled row]
    S --> RR2[page re-renders tree<br/>+ restores focus to selected row]
```

## Summary

- **T6 of epic #1193** — makes the `/trace` span tree fully keyboard-operable per the WAI-ARIA tree pattern, so the explorer is usable without a mouse. `wireTree`'s single delegated `keydown` listener now drives focus over the *visible* treeitems (collapsed subtrees excluded): ↓/↑ move with a roving tabindex (focused row `tabindex=0`, rest `-1`, `.focus()` lands on the new row, clamp at the ends); → expands a collapsed branch or descends to the first child; ← collapses an expanded branch or ascends to the parent; Enter/Space select (Space `preventDefault`s the page scroll); Home/End jump to the first/last visible row. The model is two PURE unit-tested helpers (`flattenVisible`, `keyToAction`); the DOM wiring reads the live treeitems so the pure model and the browser are fed identically. The mouse click path is unchanged.
- **Folds the 3 trace-detail SUGGESTIONs from the T4 review** — (1) drops the `renderSpanDetail` "Start" row (`startMs` is a timestamp, not a duration — no producer field, no timeline feature, and it was mis-formatted through the DURATION formatter; timestamps are YAGNI-deferred per epic §6); (2) an empty conforming trace (`{spans:[]}`, which builds `ok:true`/`roots:[]`) now routes through the lossless `renderTrace` fallback (the "No spans" empty state) instead of two blank panes; (3) the detail "Total tokens" + Prompt/Completion rows now render through `formatTokens` (thousands separator + `tok` suffix) so they read identically to the tree meta line (`1,884 tok`) instead of a bare number.
- **Part C** — a visible `:focus-visible` ring on the focusable treeitem (reuses `--accent`) so keyboard focus is apparent. Renderers stay generic — no photo-judge literal added (the T7 no-coupling guard stays green).

## Screenshots

N/A — packages/ tool (not frontend/**); orchestrator live-verifies the keyboard nav via Playwright.

## Test plan

- [x] `npm run test -w @bird-watch/eleatic` — green (313 passed, +26 new: `flattenVisible`, `keyToAction`, wireTree keyboard nav, updated `renderSpanDetail` token/Start assertions)
- [x] New unit tests added — pure `flattenVisible` ordering + collapsed-skip, full `keyToAction` key→action mapping (↓/↑ clamp, →/← expand-collapse-vs-move, Enter/Space select, Home/End), and a fake-DOM wireTree suite proving roving tabindex + `.focus()`
- [x] `npm run build` (root) + `npm run build -w @bird-watch/eleatic` (tsc) — clean
- [x] `npm run lint` — exit 0; `npx knip --no-progress` — exit 0; `src/no-coupling.test.ts` (T7 domain guard) — green
- [ ] (UI only) Playwright MCP smoke — N/A here (packages/ tool); orchestrator drives the live /trace keyboard verification

## Plan reference

Part of epic #1193 (T6). Folds the 3 trace-detail SUGGESTIONs from the T4 review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)