### PR TITLE
feat(frontend): BasemapDescriptor type + registry + resolver + isLabelLayer + LAND_COLORS

### DIFF
--- a/frontend/src/components/map/geometry/basemap-style.test.ts
+++ b/frontend/src/components/map/geometry/basemap-style.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { BASEMAP_LIGHT, BASEMAP_DARK, basemapStyle } from './basemap-style.js';
+import {
+  BASEMAP_LIGHT,
+  BASEMAP_DARK,
+  basemapStyle,
+  basemapStyleLight,
+  basemapStyleDark,
+  THEME_REGISTRY,
+  LAND_COLORS,
+  resolveDescriptor,
+  isLabelLayer,
+} from './basemap-style.js';
+import type { ThemeId } from './basemap-style.js';
 
 describe('basemap-style', () => {
   it('exports BASEMAP_LIGHT pointing at OpenFreeMap positron', () => {
@@ -17,5 +28,104 @@ describe('basemap-style', () => {
 
   it('keeps `basemapStyle` as a back-compat alias of BASEMAP_LIGHT', () => {
     expect(basemapStyle).toBe(BASEMAP_LIGHT);
+  });
+
+  it('keeps `basemapStyleLight`/`basemapStyleDark` as back-compat aliases', () => {
+    expect(basemapStyleLight).toBe(BASEMAP_LIGHT);
+    expect(basemapStyleDark).toBe(BASEMAP_DARK);
+  });
+
+  describe('THEME_REGISTRY', () => {
+    it('contains both positron and dark descriptors with all required fields', () => {
+      const positron = THEME_REGISTRY.positron;
+      const dark = THEME_REGISTRY.dark;
+
+      expect(positron.id).toBe('positron');
+      expect(positron.url).toBe('https://tiles.openfreemap.org/styles/positron');
+      expect(positron.kind).toBe('light');
+      expect(positron.landColor).toBe('#f4f1ea');
+      expect(positron.markerHaloColor).toBe('#ffffff');
+      expect(positron.floatColors).toEqual({ outline: '#1a1d24', halo: '#3a3f4a' });
+
+      expect(dark.id).toBe('dark');
+      expect(dark.url).toBe('https://tiles.openfreemap.org/styles/dark');
+      expect(dark.kind).toBe('dark');
+      expect(dark.landColor).toBe('#0E1116');
+      expect(dark.markerHaloColor).toBe('#ffffff');
+      expect(dark.floatColors).toEqual({ outline: '#e8edf4', halo: '#7fd0ff' });
+    });
+
+    it('gives the dark descriptor darkLabelTextColors and the light one none', () => {
+      expect(THEME_REGISTRY.dark.darkLabelTextColors).toEqual({
+        road: '#d8d8d8',
+        place: '#c4c4c4',
+        water: '#9db4d8',
+      });
+      expect(THEME_REGISTRY.positron.darkLabelTextColors).toBeUndefined();
+    });
+
+    it('keeps registry urls byte-identical to the back-compat aliases', () => {
+      expect(BASEMAP_LIGHT).toBe(THEME_REGISTRY.positron.url);
+      expect(BASEMAP_DARK).toBe(THEME_REGISTRY.dark.url);
+    });
+
+    it('keeps each descriptor landColor in sync with LAND_COLORS', () => {
+      (['positron', 'dark'] as ThemeId[]).forEach((id) => {
+        expect(THEME_REGISTRY[id].landColor).toBe(LAND_COLORS[id].land);
+      });
+    });
+  });
+
+  describe('LAND_COLORS', () => {
+    it('declares all 5 lands with the canonical hexes and kinds', () => {
+      expect(Object.keys(LAND_COLORS).sort()).toEqual(
+        ['bright', 'dark', 'fiord', 'liberty', 'positron'].sort(),
+      );
+      expect(LAND_COLORS.positron).toEqual({ land: '#f4f1ea', kind: 'light' });
+      expect(LAND_COLORS.bright).toEqual({ land: '#f8f4f0', kind: 'light' });
+      expect(LAND_COLORS.liberty).toEqual({ land: '#f8f4f0', kind: 'light' });
+      expect(LAND_COLORS.dark).toEqual({ land: '#0E1116', kind: 'dark' });
+      expect(LAND_COLORS.fiord).toEqual({ land: '#45516E', kind: 'dark' });
+    });
+
+    it('uses #f4f1ea (NOT #f8f4f0) for positron land', () => {
+      expect(LAND_COLORS.positron.land).toBe('#f4f1ea');
+      expect(LAND_COLORS.positron.land).not.toBe('#f8f4f0');
+    });
+  });
+
+  describe('resolveDescriptor', () => {
+    it('returns the matching descriptor object for each registered id', () => {
+      expect(resolveDescriptor('positron')).toBe(THEME_REGISTRY.positron);
+      expect(resolveDescriptor('dark')).toBe(THEME_REGISTRY.dark);
+    });
+  });
+
+  describe('isLabelLayer', () => {
+    it('returns true for a symbol layer with a text-field and non-observations source', () => {
+      expect(isLabelLayer({ type: 'symbol', layout: { 'text-field': '{name}' } })).toBe(true);
+    });
+
+    it('returns false for a symbol/text-field layer whose source is observations', () => {
+      expect(
+        isLabelLayer({
+          type: 'symbol',
+          source: 'observations',
+          layout: { 'text-field': '{name}' },
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false for a symbol layer with no text-field', () => {
+      expect(isLabelLayer({ type: 'symbol', layout: {} })).toBe(false);
+    });
+
+    it('returns false for a non-symbol line layer', () => {
+      expect(isLabelLayer({ type: 'line' })).toBe(false);
+    });
+
+    it('returns false for a background layer', () => {
+      expect(isLabelLayer({ type: 'background' })).toBe(false);
+    });
   });
 });

--- a/frontend/src/components/map/geometry/basemap-style.ts
+++ b/frontend/src/components/map/geometry/basemap-style.ts
@@ -1,11 +1,29 @@
 /**
- * Basemap styles for the map surface.
+ * Basemap descriptors for the map surface.
  *
- * Two named exports — BASEMAP_LIGHT and BASEMAP_DARK — drive the basemap
- * swap when `[data-theme]` changes on <html>. The MutationObserver wired
- * up in Phase 1 of the adaptive-grid contrast epic (#575, MapCanvas.tsx)
- * reads the current attribute on every mutation and calls map.setStyle()
- * with the matching URL.
+ * A `BasemapDescriptor` carries every fact a rendering subsystem needs about a
+ * single OpenFreeMap style: its URL, its canvas polarity (`kind`, which drives
+ * `[data-theme]`), its dominant land hex, and the float/marker/label colors the
+ * helpers tune against that land. `THEME_REGISTRY` maps each theme id to its
+ * descriptor; `resolveDescriptor(id)` looks one up. This replaces the old model
+ * where subsystems hardcoded facts about two specific styles.
+ *
+ * `LAND_COLORS` is the single source of truth for the land hex + kind of ALL
+ * five OpenFreeMap styles (positron, bright, liberty, dark, fiord). It is
+ * declared in full here — ahead of the descriptors for bright/liberty/fiord,
+ * which land in a later child — so the contrast audit and the descriptor table
+ * read one authority instead of duplicating literals. `THEME_REGISTRY`
+ * descriptors derive their `landColor` from this table.
+ *
+ * Only `positron` and `dark` are registered as descriptors right now, seeded
+ * with the exact values already live so the rendered output is byte-identical:
+ * no visible change. The other three descriptors are added in a follow-up.
+ *
+ * Two named exports — BASEMAP_LIGHT and BASEMAP_DARK — remain as thin aliases
+ * of the registered urls. They drive the basemap swap when `[data-theme]`
+ * changes on <html>. The MutationObserver wired up in Phase 1 of the
+ * adaptive-grid contrast epic (#575, MapCanvas.tsx) reads the current attribute
+ * on every mutation and calls map.setStyle() with the matching URL.
  *
  * Gate closure:
  * - G7 (family palette × basemap contrast): closed by Phase 1 PR #577.
@@ -23,10 +41,94 @@
  * Spec: docs/design/01-spec/architecture.md §"Light / dark mode"
  * Gates: docs/design/01-spec/open-questions.md G7 (closed), G8 (closed)
  */
-export const BASEMAP_LIGHT: string = 'https://tiles.openfreemap.org/styles/positron';
+
+/** Registered basemap theme ids. Widened to all 5 styles in a follow-up. */
+export type ThemeId = 'positron' | 'dark';
+
+/** Canvas polarity of a basemap — drives the `[data-theme]` attribute. */
+export type BasemapKind = 'light' | 'dark';
+
+export interface BasemapDescriptor {
+  /** Stable id for labels/tests. NEVER branched on in rendering code. */
+  id: ThemeId;
+  /** OpenFreeMap style URL. */
+  url: string;
+  /** Canvas polarity — DRIVES [data-theme]. */
+  kind: BasemapKind;
+  /** Dominant land hex — palette + float-contrast reference. */
+  landColor: string;
+  /** Silhouette icon-halo-color. */
+  markerHaloColor: string;
+  /** Float-surface outline + halo colors tuned against this land. */
+  floatColors: { outline: string; halo: string };
+  /** Per-label-class text colors. Required for `kind: 'dark'` basemaps. */
+  darkLabelTextColors?: { road: string; place: string; water: string };
+}
+
+/**
+ * Canonical land hex + kind per theme. The single audit/descriptor source of
+ * truth for ALL five OpenFreeMap styles — the contrast audit and the
+ * descriptor table both read this, rather than duplicating literals.
+ */
+export const LAND_COLORS = {
+  positron: { land: '#f4f1ea', kind: 'light' }, // db-client LIGHT_BASE / tokens --color-bg-page
+  bright: { land: '#f8f4f0', kind: 'light' },
+  liberty: { land: '#f8f4f0', kind: 'light' },
+  dark: { land: '#0E1116', kind: 'dark' }, // db-client DARK_BASE
+  fiord: { land: '#45516E', kind: 'dark' },
+} as const;
+
+/**
+ * Theme id → descriptor. Seeded with `positron`/`dark` only, using the exact
+ * values already live so output is byte-identical. The other three descriptors
+ * arrive in a follow-up (their LAND colors already live in `LAND_COLORS`).
+ */
+export const THEME_REGISTRY: Record<ThemeId, BasemapDescriptor> = {
+  positron: {
+    id: 'positron',
+    url: 'https://tiles.openfreemap.org/styles/positron',
+    kind: 'light',
+    landColor: LAND_COLORS.positron.land, // '#f4f1ea'
+    markerHaloColor: '#ffffff', // observation-layers.ts icon-halo-color
+    floatColors: { outline: '#1a1d24', halo: '#3a3f4a' }, // OUTLINE_LIGHT / HALO_LIGHT
+  },
+  dark: {
+    id: 'dark',
+    url: 'https://tiles.openfreemap.org/styles/dark',
+    kind: 'dark',
+    landColor: LAND_COLORS.dark.land, // '#0E1116'
+    markerHaloColor: '#ffffff',
+    floatColors: { outline: '#e8edf4', halo: '#7fd0ff' }, // OUTLINE_DARK / HALO_DARK
+    darkLabelTextColors: { road: '#d8d8d8', place: '#c4c4c4', water: '#9db4d8' }, // ROAD/PLACE/WATER_TEXT
+  },
+};
+
+/** Look up the descriptor for a registered theme id. */
+export function resolveDescriptor(id: ThemeId): BasemapDescriptor {
+  return THEME_REGISTRY[id];
+}
+
+/**
+ * Runtime label-layer detector. Replaces drift-prone id heuristics: a label is
+ * a `symbol` layer that paints a `text-field` and is not one of our own
+ * observation layers. Accepts the minimal structural shape the helpers use.
+ */
+export function isLabelLayer(layer: {
+  type?: string;
+  source?: string;
+  layout?: Record<string, unknown>;
+}): boolean {
+  return (
+    layer.type === 'symbol' &&
+    layer.layout?.['text-field'] != null &&
+    layer.source !== 'observations'
+  );
+}
+
+export const BASEMAP_LIGHT: string = THEME_REGISTRY.positron.url;
 
 /** Real dark tile URL — G8 closed 2026-05-16 (Phase 4, PR #582, issue #573). */
-export const BASEMAP_DARK: string = 'https://tiles.openfreemap.org/styles/dark';
+export const BASEMAP_DARK: string = THEME_REGISTRY.dark.url;
 
 /** @deprecated Use BASEMAP_LIGHT — alias preserved for back-compat. */
 export const basemapStyle = BASEMAP_LIGHT;


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    LC["LAND_COLORS (frozen)<br/>5 lands + kinds<br/>positron · bright · liberty · dark · fiord"]
    REG["THEME_REGISTRY<br/>(positron, dark only)"]
    LC -- "landColor derives from" --> REG
    REG --> RD["resolveDescriptor(id)<br/>→ BasemapDescriptor"]
    REG -- ".positron.url" --> BL["BASEMAP_LIGHT (alias)"]
    REG -- ".dark.url" --> BD["BASEMAP_DARK (alias)"]
    BL --> CALLERS["existing callers:<br/>MapCanvas · use-state-artboard"]
    BD --> CALLERS
    IL["isLabelLayer(layer)<br/>type==symbol && text-field && source!=observations"]
    classDef new fill:#1a1d24,color:#e8edf4,stroke:#7fd0ff;
    class LC,REG,RD,IL new;
```

## Summary

- **Why:** the map subsystems each hardcode facts about two specific OpenFreeMap styles, and the upcoming theme-decoupling epic (#1221) needs one authority for those facts before C5 (contrast audit) and C6 (descriptor widening) can proceed without a mutual-dependency cycle. This child lays that pure, fully unit-tested foundation.
- **What lands:** the `BasemapDescriptor`/`BasemapKind`/`ThemeId` types, a frozen `LAND_COLORS` table declaring all 5 lands + kinds up front (the single source of truth that breaks the C5↔C6 cycle), `THEME_REGISTRY` seeded with **only** `positron`+`dark` descriptors using the exact live hex values, `resolveDescriptor`, and the runtime `isLabelLayer` detector (`symbol` + `text-field` + `source !== 'observations'`, replacing drift-prone id heuristics).
- **Behavior-preserving:** `BASEMAP_LIGHT`/`BASEMAP_DARK` and the deprecated `basemapStyle*` exports are kept as thin aliases of the registered urls, so every current caller (MapCanvas, use-state-artboard, the test harnesses) type-checks and renders identically. No visible change. `knip.ts` deliberately untouched — alias + rule removal land together in C6.

## Screenshots

N/A — not UI. (Pure type/logic module — no React, no DOM, no maplibre import; no visible change.)

## Test plan

- [x] `npm run typecheck && npm run test` — green (`tsc -b` clean via `npm run build`; full frontend suite **1565 passed / 90 files**)
- [x] New unit tests added — extended `basemap-style.test.ts`: registry shape, `darkLabelTextColors` presence asymmetry, `LAND_COLORS` 5-entry invariants (positron `#f4f1ea` not `#f8f4f0`), `resolveDescriptor`, descriptor↔LAND_COLORS sync, back-compat alias equality, and the table-driven `isLabelLayer` cases (incl. the `source === 'observations'` exclusion)
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A, no user-visible behavior changed (e2e unchanged)
- [x] `npm run build` — clean production build (`✓ built in 499ms`)
- [x] (UI only) Playwright MCP smoke — N/A, not UI

Additional gates run locally from the worktree: `npm run lint` exit 0, Sky-Atlas forbidden-token guard PASS, `scripts/ci/check-orphan-classnames.sh` PASS, `npx knip` clean (exit 0).

## Plan reference

Out of plan — epic #1221 child C1, filed as bot-approved issue #1212 (plans-in-issues convention). Closes #1212.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)