### PR TITLE
feat(frontend): active-theme-id state + id-driven basemap-swap effect (replaces the [data-theme] trigger)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -11,7 +11,8 @@ import {
 import type { MapLayerMouseEvent, MapRef } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { AggregatedBucket, Observation } from '@bird-watch/shared-types';
-import { BASEMAP_LIGHT, BASEMAP_DARK } from './geometry/basemap-style.js';
+import { resolveDescriptor } from './geometry/basemap-style.js';
+import { useActiveThemeId } from './theme-state.js';
 import { INITIAL_VIEW, MIN_ZOOM } from './geometry/camera-config.js';
 import {
   buildMaskFeature,
@@ -518,22 +519,36 @@ export function MapCanvas({
   // invariant that the observer only ever calls `map.resize()`).
   useMapResize(mapRef, mapWrapperRef, mapReady);
 
+  // Active basemap-theme id state (C1.5 · #1213) — the reactive source of truth
+  // for the basemap swap. Seeded from the persisted `[data-theme]` attribute (the
+  // back-compat bridge, until C7's `applyTheme` owns the write path). For C1.5 the
+  // only reachable production ids are `positron`/`dark`, so the observable
+  // behavior is unchanged; this is the plumbing that lets the swap depend on the
+  // id (not the lossy `[data-theme]` attribute) so C2–C4/C8 can reach all 5 themes.
+  const { themeId: activeThemeId } = useActiveThemeId();
+
   // State-artboard machinery consolidated into ONE hook (`use-state-artboard.ts`,
   // epic #884 · U13 / #898; the #760/#762/#763/#765/#849/#850 blank-map class).
-  // `useStateArtboard` owns the four mask/label-isolation effects, the
-  // `[data-theme]` MutationObserver (basemap `setStyle` + mask-fill re-tint), and
-  // the `renderWorldCopies` reassertion — moved as ONE indivisible unit with ALL
-  // their cross-effect state (`maskTheme`, `savedFiltersRef`, `maskPolygonRef`,
-  // `styleEpoch`, and the MutationObserver-private `prevThemeRef` same-value
-  // guard). The hook's JSDoc carries the full rationale (the load-bearing 3a/3b
-  // reconcile-sequencing split deferred via the `styleEpoch` re-fire, the
-  // once-registered `style.load` fresh-closure ref-mirror, the camera↔
-  // `renderWorldCopies` transform-clone race, and the no-op `data-theme` write
-  // guard). `maskTheme` is the reactive mask-fill theme consumed by the
-  // `<Layer>` `paint` prop below; `mapRef` + the `<MapView>`/`<Source>`/`<Layer>`
-  // JSX stay here. Behaviour-preserving: the effect bodies, deps, and
-  // exhaustive-deps disables are 1:1 with the pre-extraction code.
-  const { maskTheme } = useStateArtboard(mapRef, mapReady, maskPolygon);
+  // `useStateArtboard` owns the four mask/label-isolation effects, the id-driven
+  // basemap swap (C1.5 · #1213: an effect keyed on `activeThemeId` →
+  // `swapBasemap`, with a `[data-theme]` MutationObserver kept only as a belt for
+  // external/devtools attribute writes), and the `renderWorldCopies` reassertion —
+  // moved as ONE indivisible unit with ALL their cross-effect state (`maskTheme`,
+  // `savedFiltersRef`, `maskPolygonRef`, `styleEpoch`, and the swap-private
+  // `prevThemeIdRef` id-keyed same-value guard). The hook's JSDoc carries the full
+  // rationale (the load-bearing 3a/3b reconcile-sequencing split deferred via the
+  // `styleEpoch` re-fire, the once-registered `style.load` fresh-closure
+  // ref-mirror, the camera↔`renderWorldCopies` transform-clone race, and the
+  // no-op-id swap guard). `maskTheme` is the reactive mask-fill theme consumed by
+  // the `<Layer>` `paint` prop below; `mapRef` + the `<MapView>`/`<Source>`/
+  // `<Layer>` JSX stay here. Behaviour-preserving: only positron/dark are reachable,
+  // so the toggle still flips light↔dark and swaps the basemap exactly as today.
+  const { maskTheme } = useStateArtboard(
+    mapRef,
+    mapReady,
+    maskPolygon,
+    activeThemeId,
+  );
 
   // Unmount cleanup for the `window.__birdMap` test hook (#291). The hook is
   // assigned in `handleLoad` (which fires once per mount); without an unmount
@@ -1053,11 +1068,9 @@ export function MapCanvas({
   // clear the card and re-arm the watchdog so a still-dead CDN re-surfaces it.
   const handleBasemapRetry = useCallback(() => {
     const map = mapRef.current?.getMap();
-    const style =
-      typeof document !== 'undefined' &&
-      document.documentElement.getAttribute('data-theme') === 'dark'
-        ? BASEMAP_DARK
-        : BASEMAP_LIGHT;
+    // C1.5 (#1213): resolve the CURRENT basemap URL from the active theme id (the
+    // reactive source of truth), not the lossy `[data-theme]` attribute ternary.
+    const style = resolveDescriptor(activeThemeId).url;
     basemapHealthyRef.current = false;
     basemapErrorCountRef.current = 0;
     setBasemapFailed(false);
@@ -1065,7 +1078,7 @@ export function MapCanvas({
     // re-surfaces the card after the window (no silent dead-end).
     map?.setStyle(style);
     setWatchdogEpoch((n) => n + 1);
-  }, []);
+  }, [activeThemeId]);
 
   /* Sprite registration (issue #246).
      Run after the map fires `load` (mapReady) and whenever `silhouettes`
@@ -1937,12 +1950,11 @@ export function MapCanvas({
         // invariant survives #761's always-mounted lifecycle without a remount.
         renderWorldCopies={maskPolygon == null}
         style={{ width: '100%', height: '100%' }}
-        mapStyle={
-          typeof document !== 'undefined' &&
-          document.documentElement.getAttribute('data-theme') === 'dark'
-            ? BASEMAP_DARK
-            : BASEMAP_LIGHT
-        }
+        // C1.5 (#1213): the initial basemap URL resolves from the active theme id
+        // (`resolveDescriptor(activeThemeId).url`), NOT the lossy `[data-theme]`
+        // attribute ternary. The id-driven swap effect in `useStateArtboard` owns
+        // every subsequent swap.
+        mapStyle={resolveDescriptor(activeThemeId).url}
         onLoad={handleLoad}
         // #854: swallow benign transient map errors (AbortErrors from tile
         // fetches cancelled mid-camera-move; OpenFreeMap CDN hiccups keyed on

--- a/frontend/src/components/map/hooks/use-state-artboard.test.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.test.ts
@@ -8,6 +8,10 @@ import {
   ARTBOARD_HALO_ID,
   ARTBOARD_OUTLINE_ID,
 } from '@/components/map/geometry/artboard-layers.js';
+import type {
+  BasemapDescriptor,
+  ThemeId,
+} from '@/components/map/geometry/basemap-style.js';
 
 /**
  * P2 ordering-invariant backfill for the consolidated state-artboard hook
@@ -529,5 +533,119 @@ describe('useStateArtboard — restore-path re-sanitization (#1124 · S1)', () =
     // null-prone comparison that re-introduces the z14 warning.
     expect(fake.filters['road_shield_us']).toEqual(SHIELD_GUARDED_FILTER);
     expect(fake.filters['road_shield_us']).not.toEqual(SHIELD_RAW_FILTER);
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────────────
+   C1.5 (#1213) — id-driven basemap swap: the END-TO-END regression guard for
+   the lossy-trigger trap.
+
+   The swap effect now depends on the active `ThemeId`, not the `[data-theme]`
+   attribute. The trap: the attribute is 'light'|'dark' only, so a kind-keyed
+   trigger can never swap BETWEEN two same-kind themes — leaving 3 of the 5
+   themes unreachable. C1's `ThemeId` union is still only the cross-kind pair
+   `positron`/`dark`, so we exercise the same-kind path through the hook's
+   INJECTED `resolver`: register two synthetic same-kind descriptors and assert
+   an id change between them re-runs the effect and calls `setStyle(newUrl)`
+   through the REAL wiring (effect → `swapBasemap`), not just the pure helper.
+   ────────────────────────────────────────────────────────────────────────── */
+
+const SYN_DARK_A: BasemapDescriptor = {
+  id: 'dark',
+  url: 'syn://dark-A',
+  kind: 'dark',
+  landColor: '#000000',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#fff', halo: '#fff' },
+};
+const SYN_DARK_B: BasemapDescriptor = {
+  id: 'dark',
+  url: 'syn://dark-B',
+  kind: 'dark',
+  landColor: '#000000',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#fff', halo: '#fff' },
+};
+
+describe('useStateArtboard — id-driven basemap swap (C1.5 · #1213)', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+  });
+
+  it('SAME-KIND id change re-runs the swap effect and calls setStyle(newUrl) through the real wiring (the lossy-trigger trap)', () => {
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    // Injected resolver over two SAME-KIND synthetic descriptors keyed by id.
+    const synRegistry: Record<string, BasemapDescriptor> = {
+      darkA: SYN_DARK_A,
+      darkB: SYN_DARK_B,
+    };
+    const resolver = (id: ThemeId): BasemapDescriptor =>
+      synRegistry[id as string] ?? SYN_DARK_A;
+
+    const { rerender } = renderHook(
+      ({ id }: { id: ThemeId }) =>
+        useStateArtboard(ref, true, null, id, resolver),
+      { initialProps: { id: 'darkA' as ThemeId } },
+    );
+
+    // Initial mount swapped to darkA's url.
+    expect(fake.map.setStyle).toHaveBeenCalledWith('syn://dark-A');
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+    // Change the id to a DIFFERENT SAME-KIND theme. SYN_DARK_A.kind === darkB.kind
+    // ('dark'), so a kind-keyed trigger would NOT fire — the trap. The id-driven
+    // effect re-runs and swaps to darkB's url.
+    rerender({ id: 'darkB' as ThemeId });
+
+    expect(SYN_DARK_A.kind).toBe(SYN_DARK_B.kind); // proves same-kind
+    expect(SYN_DARK_A.url).not.toBe(SYN_DARK_B.url); // but different urls
+    expect(fake.map.setStyle).toHaveBeenCalledTimes(1);
+    expect(fake.map.setStyle).toHaveBeenCalledWith('syn://dark-B');
+  });
+
+  it('de-dups on the id: re-rendering with an UNCHANGED id does NOT re-fire setStyle', () => {
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    const { rerender } = renderHook(
+      ({ id }: { id: ThemeId }) => useStateArtboard(ref, true, null, id),
+      { initialProps: { id: 'positron' as ThemeId } },
+    );
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+    // Same id again: the effect's deps include the id, but the id-keyed de-dup
+    // guard (prevThemeIdRef) short-circuits the swap.
+    rerender({ id: 'positron' as ThemeId });
+    expect(fake.map.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('back-compat bridge: a legacy setAttribute(data-theme, dark) resolves to the dark id and swaps (keeps basemap-dark-flip.spec.ts green)', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    // Default resolver (resolveDescriptor) + default activeThemeId (attr-bridged
+    // 'positron'): the belt MutationObserver routes the attribute through the same
+    // id-driven path. This is exactly how the existing e2e drives the theme.
+    renderHook(() => useStateArtboard(ref, true, null));
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    // The belt observer mapped 'dark' → the `dark` id and swapped to the real
+    // dark tile URL through swapBasemap.
+    await waitFor(() =>
+      expect(fake.map.setStyle).toHaveBeenCalledWith(
+        'https://tiles.openfreemap.org/styles/dark',
+      ),
+    );
   });
 });

--- a/frontend/src/components/map/hooks/use-state-artboard.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.ts
@@ -1,7 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 import type { MultiPolygon } from 'geojson';
-import { BASEMAP_LIGHT, BASEMAP_DARK } from '@/components/map/geometry/basemap-style.js';
+import {
+  resolveDescriptor,
+  type BasemapDescriptor,
+  type ThemeId,
+} from '@/components/map/geometry/basemap-style.js';
+import {
+  swapBasemap,
+  attrToThemeId,
+} from '@/components/map/theme-state.js';
 import {
   applyLabelIsolation,
   restoreLabelIsolation,
@@ -25,8 +33,10 @@ import { sanitizeNullNumericFilters } from '@/components/map/geometry/basemap-nu
  *       (3a-ii) label isolation re-apply on MASK CHANGE,
  *       (3b)    float layers + stray-sink (post-reconcile, `styleEpoch`-keyed),
  *       (3b-teardown) restore filters + remove floats on mask unmount,
- *   - the `[data-theme]` MutationObserver that swaps the basemap (`setStyle`)
- *     and re-tints the mask fill (`setMaskTheme`).
+ *   - the id-driven basemap swap (C1.5 · #1213): an effect keyed on the active
+ *     `ThemeId` (re-resolve descriptor → `swapBasemap` → `setStyle` + mask
+ *     re-tint), plus a `[data-theme]` MutationObserver kept ONLY as a belt for
+ *     external/devtools attribute writes (routed through the same id path).
  *
  * It is the SOLE owner of ALL state the moved effects own:
  *   - `maskTheme`        — reactive mask-fill theme (the ONLY value the parent
@@ -37,11 +47,12 @@ import { sanitizeNullNumericFilters } from '@/components/map/geometry/basemap-nu
  *   - `styleEpoch`       — bumps once per `style.load`; re-fires the float effect
  *                          AFTER react-map-gl re-adds `state-mask-fill` (the
  *                          3a/3b reconcile-sequencing split, #763), and
- *   - `prevThemeRef`     — the MutationObserver's PRIVATE same-value de-dup guard
- *                          (a no-op `data-theme` write must NOT re-fire
+ *   - `prevThemeIdRef`   — the swap's PRIVATE same-value de-dup guard, now keyed
+ *                          on the **id** (a no-op swap to the current id, e.g.
+ *                          from a no-op `data-theme` write, must NOT re-fire
  *                          `setStyle`).
  *
- * `styleEpoch` and `prevThemeRef` are fully PRIVATE (no parent/JSX consumer);
+ * `styleEpoch` and `prevThemeIdRef` are fully PRIVATE (no parent/JSX consumer);
  * only `maskTheme` is returned. The `mapRef` + the `<Map>`/`<Source>`/`<Layer>`
  * JSX stay in `MapCanvas`; only the state + effects move here.
  *
@@ -69,7 +80,7 @@ import { sanitizeNullNumericFilters } from '@/components/map/geometry/basemap-nu
  * world-copies, style-swap, and event methods the artboard effects call
  * directly:
  *   - `getRenderWorldCopies` / `setRenderWorldCopies` — the #762/#765 reassert,
- *   - `setStyle` — the `[data-theme]` basemap swap,
+ *   - `setStyle` — the id-driven basemap swap (C1.5 · #1213),
  *   - `on` / `off` — `style.load` (theme-swap re-isolation) + `moveend`
  *     (world-copies reassert win against the in-flight transform-clone replay).
  *
@@ -97,20 +108,46 @@ export interface StateArtboardMapRef {
 
 /**
  * Consolidated state-artboard hook (#884 · U13 / #898). Wires ALL artboard
- * machinery — the four mask/label-isolation effects, the `[data-theme]`
- * MutationObserver (basemap + mask-fill swap), and the `renderWorldCopies`
- * reassertion — to the live `mapRef`, owning every piece of cross-effect state.
+ * machinery — the four mask/label-isolation effects, the id-driven basemap swap
+ * (C1.5 · #1213, replacing the old `[data-theme]`-keyed trigger), and the
+ * `renderWorldCopies` reassertion — to the live `mapRef`, owning every piece of
+ * cross-effect state.
+ *
+ * Basemap swap (C1.5 · #1213): the swap is now keyed on the active `ThemeId`,
+ * NOT the `[data-theme]` attribute. The attribute is lossy (`'light'`|`'dark'`
+ * only) — it cannot trigger a swap BETWEEN two same-kind themes, which would
+ * leave 3 of the 5 themes unreachable. The primary trigger is the `activeThemeId`
+ * prop: on change the descriptor is re-resolved (`resolver(activeThemeId)`) and
+ * the pure `swapBasemap(map, descriptor, setMaskTheme)` performs the swap, with
+ * the same-value de-dup now keyed on the **id** (`prevThemeIdRef`). The
+ * `[data-theme]` MutationObserver is RETAINED only as a belt for external/devtools
+ * attribute writes (notably the existing `basemap-dark-flip.spec.ts`, which drives
+ * via `setAttribute('data-theme', …)`): it maps the attribute → a kind-consistent
+ * id (`attrToThemeId`) and routes that through the SAME id-keyed swap path, so it
+ * can never double-fire `setStyle` for an id already swapped.
  *
  * @param mapRef       ref to the react-map-gl `MapRef` (`getMap()` → maplibre)
  * @param mapReady     gate: only touch the map once the `load` event fired
  * @param maskPolygon  the current state-scope mask polygon, or undefined/null
+ * @param activeThemeId  the active basemap `ThemeId` (source of truth for the
+ *                       swap). Defaults to the attribute-bridged id so callers
+ *                       that have not threaded it yet keep today's behavior.
+ * @param resolver     id → descriptor lookup. Defaults to `resolveDescriptor`;
+ *                     tests override it with synthetic same-kind descriptors to
+ *                     exercise the same-kind swap path (the injection seam).
  * @returns `{ maskTheme }` — the reactive mask-fill theme the `<Layer>` paint
- *          prop reads. `styleEpoch` + `prevThemeRef` stay private to the hook.
+ *          prop reads. `styleEpoch` + `prevThemeIdRef` stay private to the hook.
  */
 export function useStateArtboard(
   mapRef: RefObject<StateArtboardMapRef | null>,
   mapReady: boolean,
   maskPolygon: MultiPolygon | null | undefined,
+  activeThemeId: ThemeId = attrToThemeId(
+    typeof document !== 'undefined'
+      ? document.documentElement.getAttribute('data-theme')
+      : null,
+  ),
+  resolver: (id: ThemeId) => BasemapDescriptor = resolveDescriptor,
 ): { maskTheme: 'light' | 'dark' } {
   /**
    * Reactive theme for the state-artboard mask fill (#760/#762). Seeded from the
@@ -343,31 +380,60 @@ export function useStateArtboard(
     };
   }, [mapReady, maskPolygon]);
 
-  // [data-theme] observer — swap basemap when user toggles theme.
-  // Registered after mapReady so the map instance is guaranteed to exist.
-  // Cleaned up on unmount to prevent leaks. The observer is the single
-  // source of truth for basemap-vs-theme coupling — no prop drilling.
-  // Dark URL aliasing (G8): BASEMAP_DARK may resolve to the same
-  // visual tiles as light during the rollout window; the swap mechanism
-  // is correct regardless. See docs/design/01-spec/open-questions.md.
+  // ── id-driven basemap swap (C1.5 · #1213) ──────────────────────────────────
   //
-  // Same-value guard: MutationRecord fires on every attribute write,
-  // including writes that set the SAME value the attribute already had
-  // (e.g. setAttribute('data-theme', 'light') when it's already 'light').
-  // Without the prevTheme ref, a no-op write would trigger setStyle and
-  // a redundant tile re-fetch.
-  const prevThemeRef = useRef<'light' | 'dark' | null>(null);
+  // `prevThemeIdRef` is the same-value de-dup guard, now keyed on the **id**
+  // (replacing the old `prevThemeRef` light/dark kind ref). A swap to an id the
+  // map already shows is a no-op — this is what prevents a no-op `data-theme`
+  // write (or a re-render with an unchanged id) from re-firing `setStyle` and a
+  // redundant tile re-fetch. Because BOTH the id-driven effect and the belt
+  // observer route through `performSwap`, the de-dup covers both: the observer
+  // can never double-fire `setStyle` for an id the effect already swapped.
+  const prevThemeIdRef = useRef<ThemeId | null>(null);
+  // Mirror the live resolver in a ref so the once-registered observer below reads
+  // the current resolver without re-subscribing (fresh-closure pattern, #849).
+  const resolverRef = useRef(resolver);
+  resolverRef.current = resolver;
+
+  // The single swap entry point. De-dups on the id, resolves the descriptor via
+  // the live resolver, then runs the pure `swapBasemap` (setStyle + mask re-tint).
+  const performSwap = useRef((id: ThemeId) => {
+    if (id === prevThemeIdRef.current) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    prevThemeIdRef.current = id;
+    // #760/#762: `swapBasemap` re-tints the state-artboard mask fill in lockstep
+    // with the basemap swap. The mask <Layer> reads `maskTheme`; react-map-gl
+    // diffs `paint` so this re-tints the gray with no remount.
+    swapBasemap(map, resolverRef.current(id), setMaskTheme);
+  });
+
+  // Primary trigger: re-resolve + swap whenever the active id changes — INCLUDING
+  // between two same-kind themes (the whole point; the `[data-theme]` attribute
+  // is structurally incapable of this). Gated on `mapReady` so the map exists.
+  useEffect(() => {
+    if (!mapReady) return;
+    performSwap.current(activeThemeId);
+  }, [mapReady, activeThemeId]);
+
+  // Belt: `[data-theme]` MutationObserver, RETAINED only for external/devtools
+  // attribute writes (the existing `basemap-dark-flip.spec.ts` drives the theme
+  // by `setAttribute('data-theme', …)`). It maps the attribute → a kind-consistent
+  // id (`attrToThemeId`: `'dark'`→`dark`, else `positron`) and routes that through
+  // the SAME id-keyed `performSwap`, so it can never double-fire `setStyle` for an
+  // id the primary effect already swapped (the id de-dup covers both paths).
+  // Registered after mapReady so the map instance is guaranteed to exist; cleaned
+  // up on unmount to prevent leaks.
   useEffect(() => {
     if (!mapReady) return;
     const map = mapRef.current?.getMap();
     if (!map) return;
 
-    // Seed the prev ref with the current attribute value so the first
-    // observed mutation only fires setStyle when the value genuinely flips.
-    prevThemeRef.current =
-      document.documentElement.getAttribute('data-theme') === 'dark'
-        ? 'dark'
-        : 'light';
+    // Seed the de-dup ref with the current attribute's id so the first observed
+    // mutation only swaps when the id genuinely changes.
+    prevThemeIdRef.current = attrToThemeId(
+      document.documentElement.getAttribute('data-theme'),
+    );
 
     const observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
@@ -375,18 +441,11 @@ export function useStateArtboard(
           mutation.type === 'attributes' &&
           mutation.attributeName === 'data-theme'
         ) {
-          const next: 'light' | 'dark' =
-            document.documentElement.getAttribute('data-theme') === 'dark'
-              ? 'dark'
-              : 'light';
-          if (next === prevThemeRef.current) return;
-          prevThemeRef.current = next;
-          const style = next === 'dark' ? BASEMAP_DARK : BASEMAP_LIGHT;
-          map.setStyle(style);
-          // #760/#762: re-paint the state-artboard mask fill in lockstep with
-          // the basemap swap. The mask <Layer> reads `maskTheme`; react-map-gl
-          // diffs `paint` so this re-tints the gray with no remount.
-          setMaskTheme(next);
+          performSwap.current(
+            attrToThemeId(
+              document.documentElement.getAttribute('data-theme'),
+            ),
+          );
         }
       }
     });

--- a/frontend/src/components/map/theme-state.test.ts
+++ b/frontend/src/components/map/theme-state.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  attrToThemeId,
+  readActiveThemeIdFromDom,
+  swapBasemap,
+  useActiveThemeId,
+} from './theme-state.js';
+import type { BasemapDescriptor, ThemeId } from './geometry/basemap-style.js';
+import { THEME_REGISTRY } from './geometry/basemap-style.js';
+
+/**
+ * C1.5 (#1213) — active-theme-id state + id-driven basemap-swap seam.
+ *
+ * The whole point of this child is a regression guard proving **the id/url —
+ * not the kind — drives the basemap swap**. C1's `ThemeId` union is only the
+ * cross-kind pair `positron`/`dark`, so the trap is unreachable through
+ * `resolveDescriptor` alone. The pure `swapBasemap(map, descriptor)` helper +
+ * synthetic same-kind `BasemapDescriptor` objects are the injection seam that
+ * makes it reachable (see issue §"The injection seam").
+ */
+
+// A minimal maplibre-map spy: only the `setStyle` swap surface `swapBasemap`
+// touches. The mask-theme setter is injected separately so the pure helper can
+// run with no React.
+function makeMapSpy() {
+  return {
+    setStyle: vi.fn<(style: string) => void>(),
+  };
+}
+
+// Two SYNTHETIC descriptors that share `kind: 'dark'` but differ in `url`/`id`.
+// They need NO registry entry (BasemapDescriptor is a plain interface), so the
+// same-kind trap is exercised without widening `ThemeId` or touching knip.ts.
+const SYN_DARK_A: BasemapDescriptor = {
+  id: 'dark',
+  url: 'syn://A',
+  kind: 'dark',
+  landColor: '#000000',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#fff', halo: '#fff' },
+};
+const SYN_DARK_B: BasemapDescriptor = {
+  id: 'dark',
+  url: 'syn://B',
+  kind: 'dark',
+  landColor: '#000000',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#fff', halo: '#fff' },
+};
+
+describe('theme-state — attrToThemeId / readActiveThemeIdFromDom (back-compat bridge)', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('maps the [data-theme] attribute to a kind-consistent ThemeId', () => {
+    expect(attrToThemeId('dark')).toBe('dark');
+    expect(attrToThemeId('light')).toBe('positron');
+    expect(attrToThemeId(null)).toBe('positron');
+    // Any non-'dark' value resolves to positron (light kind) — the legacy
+    // `=== 'dark'` semantics preserved.
+    expect(attrToThemeId('whatever')).toBe('positron');
+  });
+
+  it('reads the active id from the live [data-theme] attribute', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    expect(readActiveThemeIdFromDom()).toBe('dark');
+    document.documentElement.setAttribute('data-theme', 'light');
+    expect(readActiveThemeIdFromDom()).toBe('positron');
+    document.documentElement.removeAttribute('data-theme');
+    expect(readActiveThemeIdFromDom()).toBe('positron');
+  });
+});
+
+describe('theme-state — swapBasemap (pure, injection-seam #1)', () => {
+  it('issues map.setStyle(descriptor.url) and routes the kind to setMaskTheme', () => {
+    const map = makeMapSpy();
+    const setMaskTheme = vi.fn();
+
+    swapBasemap(map, THEME_REGISTRY.dark, setMaskTheme);
+
+    expect(map.setStyle).toHaveBeenCalledTimes(1);
+    expect(map.setStyle).toHaveBeenCalledWith(THEME_REGISTRY.dark.url);
+    expect(setMaskTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('does NOT call resolveDescriptor — it consumes the descriptor argument', () => {
+    // swapBasemap takes the resolved descriptor; the URL comes straight off the
+    // argument. We prove this by passing a synthetic descriptor whose url is NOT
+    // in any registry entry and asserting setStyle gets exactly that url.
+    const map = makeMapSpy();
+    swapBasemap(map, SYN_DARK_A, vi.fn());
+    expect(map.setStyle).toHaveBeenCalledWith('syn://A');
+  });
+
+  // ── Same-kind regression guard (the lossy-trigger trap) ──────────────────
+  it('SAME-KIND regression guard: two descriptors with the SAME kind but different url each issue a fresh setStyle (url/id, not kind, drives the swap)', () => {
+    const map = makeMapSpy();
+    const setMaskTheme = vi.fn();
+
+    // Both descriptors are kind 'dark'. A kind-keyed mechanism would treat the
+    // second swap as a no-op (kind unchanged) and SKIP setStyle('syn://B') — the
+    // exact bug that left 3 of 5 themes unreachable. swapBasemap is url-driven,
+    // so each call re-issues setStyle with its own descriptor.url.
+    swapBasemap(map, SYN_DARK_A, setMaskTheme);
+    swapBasemap(map, SYN_DARK_B, setMaskTheme);
+
+    expect(SYN_DARK_A.kind).toBe(SYN_DARK_B.kind); // proves they are same-kind
+    expect(SYN_DARK_A.url).not.toBe(SYN_DARK_B.url); // but different urls
+    expect(map.setStyle).toHaveBeenCalledTimes(2);
+    expect(map.setStyle).toHaveBeenNthCalledWith(1, 'syn://A');
+    // The crux: the SECOND call issued setStyle with the SECOND url. A kind-keyed
+    // implementation would fail here (it would skip the second swap).
+    expect(map.setStyle).toHaveBeenNthCalledWith(2, 'syn://B');
+  });
+});
+
+describe('theme-state — useActiveThemeId (state + injectable resolver, seam #2)', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('seeds the active id + descriptor from the current [data-theme] attribute', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useActiveThemeId());
+    expect(result.current.themeId).toBe('dark');
+    expect(result.current.descriptor).toBe(THEME_REGISTRY.dark);
+  });
+
+  it('defaults to positron when no attribute is set', () => {
+    const { result } = renderHook(() => useActiveThemeId());
+    expect(result.current.themeId).toBe('positron');
+    expect(result.current.descriptor).toBe(THEME_REGISTRY.positron);
+  });
+
+  it('re-resolves the descriptor when the id is set', () => {
+    const { result } = renderHook(() => useActiveThemeId());
+    expect(result.current.themeId).toBe('positron');
+
+    act(() => {
+      result.current.setThemeId('dark');
+    });
+
+    expect(result.current.themeId).toBe('dark');
+    expect(result.current.descriptor).toBe(THEME_REGISTRY.dark);
+  });
+
+  it('accepts an injectable resolver so tests can register synthetic same-kind ids (seam #2)', () => {
+    // Register a resolver over two SAME-KIND synthetic descriptors keyed by id.
+    // (We reuse the production `dark` id plus a second synthetic id cast in, since
+    // the resolver signature is `(id: ThemeId) => BasemapDescriptor` and the seam
+    // is exactly that the resolver — not a closed registry lookup — supplies the
+    // descriptor.)
+    const synRegistry: Record<string, BasemapDescriptor> = {
+      darkA: SYN_DARK_A,
+      darkB: SYN_DARK_B,
+    };
+    const resolver = (id: ThemeId): BasemapDescriptor =>
+      synRegistry[id as string] ?? THEME_REGISTRY.positron;
+
+    const { result } = renderHook(() => useActiveThemeId(resolver));
+
+    act(() => {
+      result.current.setThemeId('darkA' as ThemeId);
+    });
+    expect(result.current.descriptor).toBe(SYN_DARK_A);
+    expect(result.current.descriptor.url).toBe('syn://A');
+
+    // Switch between two SAME-KIND synthetic ids: the descriptor (and url) MUST
+    // change even though kind does not — the injectable-resolver seam makes the
+    // same-kind transition reachable end-to-end.
+    act(() => {
+      result.current.setThemeId('darkB' as ThemeId);
+    });
+    expect(result.current.descriptor).toBe(SYN_DARK_B);
+    expect(result.current.descriptor.url).toBe('syn://B');
+    expect(SYN_DARK_A.kind).toBe(SYN_DARK_B.kind);
+  });
+});

--- a/frontend/src/components/map/theme-state.ts
+++ b/frontend/src/components/map/theme-state.ts
@@ -1,0 +1,127 @@
+import { useState, useMemo, useCallback } from 'react';
+import {
+  resolveDescriptor,
+  type BasemapDescriptor,
+  type BasemapKind,
+  type ThemeId,
+} from '@/components/map/geometry/basemap-style.js';
+
+/**
+ * Active-theme-id state + id-driven basemap-swap seam (C1.5 · #1213).
+ *
+ * The basemap swap used to be keyed on the `[data-theme]` attribute, which only
+ * ever holds `'light'`|`'dark'` — a LOSSY trigger. With the 5-theme model there
+ * are two dark-kind themes (`dark`, `fiord`) and three light-kind
+ * (`positron`/`bright`/`liberty`); switching WITHIN a kind never changes the
+ * attribute, so a kind-keyed observer can never reach 3 of the 5 themes.
+ *
+ * This module makes the active `ThemeId` the reactive source of truth and the
+ * swap effect depend on the **id**, re-resolving the descriptor whenever the id
+ * changes — including between two same-kind themes. C1's `ThemeId` union is
+ * still only `positron`/`dark` (two DIFFERENT kinds), so the same-kind path is
+ * unreachable through `resolveDescriptor` alone; the two seams below make it
+ * testable WITHOUT widening `ThemeId`:
+ *
+ *   1. `swapBasemap(map, descriptor, setMaskTheme)` — the pure unit that performs
+ *      ONE swap. It takes the resolved `BasemapDescriptor` as an ARGUMENT and
+ *      never calls `resolveDescriptor`, so a same-kind regression test can call
+ *      it directly with two synthetic descriptors that share `kind` but differ in
+ *      `url`/`id`. Asserting it issues a fresh `setStyle` for the second url
+ *      proves the URL — not the kind — drives the swap.
+ *   2. `useActiveThemeId(resolver?)` — an injectable `resolver` (default
+ *      `resolveDescriptor`) lets tests register synthetic same-kind ids and assert
+ *      an id change between them re-resolves the descriptor.
+ *
+ * Until C7's `applyTheme`/`resolveInitialTheme` owns the persisted write path,
+ * the active id is seeded from the current `[data-theme]` attribute via the
+ * back-compat bridge below (`'dark'`→`dark` id, else `positron`). That bridge is
+ * what keeps the existing `basemap-dark-flip.spec.ts` green — it drives the theme
+ * by `setAttribute('data-theme', …)`, which still resolves to a kind-consistent
+ * id and swaps the basemap exactly as today. Behavior-preserving: no visible
+ * change.
+ *
+ * Spec: docs/design/01-spec/architecture.md §"Light / dark mode". Epic #1221.
+ */
+
+/**
+ * Back-compat bridge: map a `[data-theme]` attribute value to a kind-consistent
+ * `ThemeId`. Preserves the legacy `=== 'dark'` semantics — `'dark'` → the
+ * `dark`-kind id, every other value (including `null`) → the `positron`-kind id.
+ * This is the one-line bridge the existing attribute-driven e2e relies on.
+ */
+export function attrToThemeId(attr: string | null): ThemeId {
+  return attr === 'dark' ? 'dark' : 'positron';
+}
+
+/**
+ * Read the active `ThemeId` from the live `<html data-theme>` attribute. SSR-safe
+ * (returns the `positron` default when `document` is unavailable).
+ */
+export function readActiveThemeIdFromDom(): ThemeId {
+  if (typeof document === 'undefined') return 'positron';
+  return attrToThemeId(document.documentElement.getAttribute('data-theme'));
+}
+
+/**
+ * The minimal maplibre-map surface a basemap swap touches: just `setStyle`.
+ */
+export interface SwappableMap {
+  setStyle: (style: string) => void;
+}
+
+/**
+ * Pure, id-driven basemap swap (injection seam #1). Performs exactly ONE swap
+ * from a RESOLVED descriptor:
+ *
+ *   - `map.setStyle(descriptor.url)` — re-points the basemap at the descriptor's
+ *     URL (the url, NOT the kind, drives this), and
+ *   - `setMaskTheme(descriptor.kind)` — re-tints the state-artboard mask fill in
+ *     lockstep (consumed by the `<Layer>` `paint` prop in `MapCanvas`).
+ *
+ * It receives the descriptor as an ARGUMENT and never calls `resolveDescriptor`,
+ * so the same-kind regression guard can drive it directly with two synthetic
+ * descriptors that share `kind` but differ in `url`. Same-value de-dup is the
+ * CALLER's concern (keyed on the id), so this helper always performs the swap.
+ */
+export function swapBasemap(
+  map: SwappableMap,
+  descriptor: BasemapDescriptor,
+  setMaskTheme: (kind: BasemapKind) => void,
+): void {
+  map.setStyle(descriptor.url);
+  setMaskTheme(descriptor.kind);
+}
+
+/**
+ * The shape `useActiveThemeId` returns: the active id, its resolved descriptor,
+ * and the setter that drives an id change (re-resolving the descriptor).
+ */
+export interface ActiveThemeIdState {
+  themeId: ThemeId;
+  descriptor: BasemapDescriptor;
+  setThemeId: (id: ThemeId) => void;
+}
+
+/**
+ * Active-theme-id state primitive (injection seam #2). Seeds the active id from
+ * the current `[data-theme]` attribute (via {@link readActiveThemeIdFromDom})
+ * and exposes `setThemeId` to drive an id change. The descriptor is re-resolved
+ * from the id on every change — INCLUDING between two same-kind themes.
+ *
+ * @param resolver maps an id → descriptor. Defaults to the production
+ *   `resolveDescriptor` (a closed `THEME_REGISTRY` lookup). Tests override it
+ *   with a map of synthetic same-kind descriptors so the same-kind transition is
+ *   reachable without widening `ThemeId` or touching `knip.ts`.
+ */
+export function useActiveThemeId(
+  resolver: (id: ThemeId) => BasemapDescriptor = resolveDescriptor,
+): ActiveThemeIdState {
+  const [themeId, setThemeId] = useState<ThemeId>(() =>
+    readActiveThemeIdFromDom(),
+  );
+  const descriptor = useMemo(() => resolver(themeId), [resolver, themeId]);
+  const setThemeIdStable = useCallback((id: ThemeId) => {
+    setThemeId(id);
+  }, []);
+  return { themeId, descriptor, setThemeId: setThemeIdStable };
+}


### PR DESCRIPTION
## Diagrams

The swap trigger moves from the lossy `[data-theme]` attribute to the active `ThemeId`. The attribute observer is retained only as a belt that maps `attr → id` and routes through the SAME id-keyed path.

```mermaid
flowchart TD
    subgraph Source of truth
      A[useActiveThemeId<br/>activeThemeId: ThemeId] -->|prop| E
    end
    E[id-driven swap effect<br/>deps: activeThemeId] -->|resolver id| D[resolveDescriptor / injected resolver]
    D -->|BasemapDescriptor| S[swapBasemap map, descriptor, setMaskTheme<br/>PURE — never calls resolveDescriptor]
    S --> ST[map.setStyle descriptor.url]
    S --> MT[setMaskTheme descriptor.kind]
    O["[data-theme] MutationObserver<br/>(BELT only — devtools/e2e writes)"] -->|attrToThemeId: 'dark'→dark, else positron| P[performSwap id]
    E -->|performSwap id| P
    P -->|de-dup on prevThemeIdRef id| S
    classDef seam fill:#e8f0ff,stroke:#36c;
    class S,D seam;
```

```mermaid
sequenceDiagram
    participant Test as same-kind regression guard
    participant Swap as swapBasemap (pure)
    participant Map as map.setStyle

    Note over Test,Map: descA / descB share kind 'dark' but differ in url
    Test->>Swap: swapBasemap(map, descA{url: syn://A}, setMaskTheme)
    Swap->>Map: setStyle('syn://A')
    Test->>Swap: swapBasemap(map, descB{url: syn://B}, setMaskTheme)
    Swap->>Map: setStyle('syn://B')
    Note over Test,Map: a kind-keyed impl would SKIP the 2nd swap — guard catches it
```

## Summary

- **Why:** the basemap swap was keyed on `[data-theme]` ('light'|'dark' only) — a structurally lossy trigger that cannot swap BETWEEN two same-kind themes, leaving 3 of the eventual 5 themes unreachable. This child makes the active `ThemeId` the reactive source of truth and rewrites the swap to depend on the **id**, re-resolving the descriptor whenever the id changes (including same-kind transitions).
- **Behavior-preserving:** C1's `ThemeId` union is still only `positron`/`dark`, so the observable behavior (toggle flips light↔dark and swaps the basemap) is unchanged. This is the plumbing, not the user-facing change. No visible delta.
- **The injection seam (the bot's earlier blocking finding):** a pure `swapBasemap(map, descriptor, setMaskTheme)` takes a resolved `BasemapDescriptor` argument and never calls `resolveDescriptor`, so the same-kind regression guard drives it directly with two synthetic same-kind descriptors (same `kind`, different `url`) — proving the url/id, not the kind, drives the swap. `useActiveThemeId(resolver = resolveDescriptor)` accepts an injectable resolver so tests register synthetic same-kind ids without widening `ThemeId` or touching `knip.ts`. The `[data-theme]` observer is kept ONLY as a belt (maps attr→id via `attrToThemeId`, routes through the same id-keyed de-dup), keeping `basemap-dark-flip.spec.ts` green; the two `MapCanvas.tsx` initial-URL ternaries are replaced with `resolveDescriptor(activeThemeId).url`.

## Screenshots

N/A — behavior-preserving runtime change, no visual delta; positron/dark look identical and only the swap TRIGGER changes. Covered by `basemap-dark-flip.spec.ts` (drives the theme via `setAttribute('data-theme', …)`; the back-compat attribute→id bridge keeps it green).

- [x] Every new/renamed `className` in this PR has a matching CSS rule (`N/A — no JSX/className changes; runtime/logic-only change`)
- [x] Multi-viewport design QA (`N/A — not UI`; behavior-preserving, no visual delta)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (91 files, **1577 tests passed**), including the new `theme-state.test.ts` and the `use-state-artboard.test.ts` id-driven suite, plus the unchanged MapCanvas-mounted `[data-theme] MutationObserver swaps basemap` + O8 dedup suites (back-compat verified end-to-end through the real component).
- [x] New unit / integration tests added: `theme-state.test.ts` (pure `swapBasemap` same-kind guard + injectable-resolver seam); `use-state-artboard.test.ts` (same-kind id change re-runs the effect → `setStyle(newUrl)` through the real wiring; id de-dup; legacy `setAttribute('data-theme','dark')` → dark id → swap).
- [x] `tsc --noEmit` clean; `npm run build --workspace @bird-watch/frontend` — clean production build (exit 0).
- [x] `bash scripts/ci/check-orphan-classnames.sh` — PASS; `npx knip` — exit 0.
- [x] No new Playwright e2e spec needed — behavior-preserving; existing theme specs cover it.

## Plan reference

Part of #1221 (epic). Implements child **C1.5 — #1213**. Depends on C1 (#1212, merged). C2/C3/C4 consume the threaded descriptor; C7 builds the persisted-id `applyTheme` write path on top of this state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)