### PR TITLE
refactor(frontend): marker icon-halo-color onto descriptor.markerHaloColor (reactive memo deps)

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -525,7 +525,8 @@ export function MapCanvas({
   // only reachable production ids are `positron`/`dark`, so the observable
   // behavior is unchanged; this is the plumbing that lets the swap depend on the
   // id (not the lossy `[data-theme]` attribute) so C2–C4/C8 can reach all 5 themes.
-  const { themeId: activeThemeId } = useActiveThemeId();
+  const { themeId: activeThemeId, descriptor: activeDescriptor } =
+    useActiveThemeId();
 
   // State-artboard machinery consolidated into ONE hook (`use-state-artboard.ts`,
   // epic #884 · U13 / #898; the #760/#762/#763/#765/#849/#850 blank-map class).
@@ -710,7 +711,15 @@ export function MapCanvas({
   const clusterCountLayer = useMemo(() => buildClusterCountLayerSpec(), []);
   const clustersHitLayer = useMemo(() => buildClustersHitLayerSpec(), []);
   const notableRingLayer = useMemo(() => buildNotableRingLayerSpec(), []);
-  const unclusteredLayer = useMemo(() => buildUnclusteredPointLayerSpec(), []);
+  // #1216: the marker halo color now comes from the active descriptor, so the
+  // spec must be recomputed when the descriptor changes (a live theme swap).
+  // react-map-gl `<Layer>` specs are built once at mount and only re-diff on a
+  // NEW spec object — without `activeDescriptor` in the deps the halo would
+  // freeze at the mount-time descriptor and never update on swap.
+  const unclusteredLayer = useMemo(
+    () => buildUnclusteredPointLayerSpec(activeDescriptor),
+    [activeDescriptor],
+  );
 
   // Observation lookup by subId for click handler. Pure derive extracted to
   // obs-derive.ts (#892); prototype-free record built there.

--- a/frontend/src/components/map/geometry/observation-layers.test.ts
+++ b/frontend/src/components/map/geometry/observation-layers.test.ts
@@ -12,6 +12,7 @@ import {
   CLUSTER_RADIUS,
   FALLBACK_SILHOUETTE_ID,
 } from './observation-layers.js';
+import { resolveDescriptor, type BasemapDescriptor } from './basemap-style.js';
 import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
 
 function makeObs(partial: Partial<Observation> = {}): Observation {
@@ -205,7 +206,12 @@ describe('layer specs', () => {
     // Each feature renders its family's silhouette via icon-image, tinted by
     // the per-feature color property (sourced from the silhouettes join in
     // observationsToGeoJson).
-    const spec = buildUnclusteredPointLayerSpec();
+    //
+    // #1216: the marker halo is now a per-style descriptor fact — the spec
+    // takes the active BasemapDescriptor. positron carries
+    // markerHaloColor '#ffffff', so this assertion is byte-identical to the
+    // pre-refactor hardcode.
+    const spec = buildUnclusteredPointLayerSpec(resolveDescriptor('positron'));
     expect(spec.id).toBe('unclustered-point');
     expect(spec.type).toBe('symbol');
     // Epic #539 cutover: inStack filter removed alongside auto-spider.
@@ -224,6 +230,8 @@ describe('layer specs', () => {
     // SDF tint sourced from the per-feature color property — this is what
     // makes the silhouettes share the family color from the legend.
     expect(paint['icon-color']).toEqual(['get', 'color']);
+    // #1216: halo width is unchanged; only the color is threaded.
+    expect(paint['icon-halo-width']).toBe(1.5);
     // _FALLBACK silhouette renders at 50% opacity so missing-Phylopic
     // families read as "we don't have a shape for this" instead of
     // visually equal to the rest. The first branch (issue #554 scope
@@ -236,6 +244,44 @@ describe('layer specs', () => {
       ['==', ['get', 'silhouetteId'], FALLBACK_SILHOUETTE_ID], 0.5,
       1.0,
     ]);
+  });
+
+  describe('icon-halo-color comes from descriptor.markerHaloColor (#1216)', () => {
+    // The halo color is a per-style design fact threaded through the active
+    // BasemapDescriptor — NOT a hardcoded literal. positron/dark both declare
+    // markerHaloColor '#ffffff', so the production paint stays byte-identical.
+    it('positron descriptor → #ffffff (byte-identical to the pre-refactor hardcode)', () => {
+      const paint = buildUnclusteredPointLayerSpec(resolveDescriptor('positron'))
+        .paint as Record<string, unknown>;
+      expect(paint['icon-halo-color']).toBe('#ffffff');
+    });
+
+    it('dark descriptor → #ffffff (byte-identical)', () => {
+      const paint = buildUnclusteredPointLayerSpec(resolveDescriptor('dark'))
+        .paint as Record<string, unknown>;
+      expect(paint['icon-halo-color']).toBe('#ffffff');
+    });
+
+    it('a synthetic descriptor with a non-#ffffff halo paints that color (proves wiring, not a hardcode)', () => {
+      // The injection seam: a same-shape BasemapDescriptor carrying a
+      // different markerHaloColor must flow straight into the paint. This is
+      // the unit-level proof that a live theme swap to a non-white-halo theme
+      // re-renders the halo (the live-swap guarantee itself lives in C8's
+      // e2e, where such a theme first becomes reachable).
+      const synthetic: BasemapDescriptor = {
+        id: 'positron',
+        url: 'https://example.invalid/style',
+        kind: 'light',
+        landColor: '#abcdef',
+        markerHaloColor: '#123456',
+        floatColors: { outline: '#000000', halo: '#ffffff' },
+      };
+      const paint = buildUnclusteredPointLayerSpec(synthetic).paint as Record<
+        string,
+        unknown
+      >;
+      expect(paint['icon-halo-color']).toBe('#123456');
+    });
   });
 
   it('notable-ring layer is a circle layer filtered to notable observations', () => {

--- a/frontend/src/components/map/geometry/observation-layers.ts
+++ b/frontend/src/components/map/geometry/observation-layers.ts
@@ -1,5 +1,6 @@
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import type { LayerProps } from 'react-map-gl/maplibre';
+import type { BasemapDescriptor } from './basemap-style.js';
 import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
 import { CLUSTER_TIER_BOUNDARIES } from '@/config/cluster.js';
 
@@ -330,8 +331,13 @@ export function buildClustersHitLayerSpec(): LayerProps {
  * Sprites must be registered via map.addImage(...) BEFORE this layer is
  * added to the map. MapCanvas orchestrates the addImage Promise.all and
  * then mounts this layer — see the `handleLoad` flow in MapCanvas.tsx.
+ *
+ * The active `BasemapDescriptor` (#1216) carries the per-style marker halo
+ * color. MapCanvas threads the reactive descriptor into the `useMemo` deps so
+ * a live theme swap recomputes this spec and react-map-gl diffs the new
+ * `icon-halo-color` paint onto the layer.
  */
-export function buildUnclusteredPointLayerSpec(): LayerProps {
+export function buildUnclusteredPointLayerSpec(descriptor: BasemapDescriptor): LayerProps {
   return {
     id: 'unclustered-point',
     type: 'symbol',
@@ -359,15 +365,18 @@ export function buildUnclusteredPointLayerSpec(): LayerProps {
       // SDF tint: each feature's color property paints its own silhouette.
       // This is what gives the map the same family-color signal as the legend.
       'icon-color': ['get', 'color'],
-      // White halo around each silhouette for contrast against the
-      // light OpenFreeMap positron basemap. Without it, families whose
-      // seed color is naturally low-saturation (accipitridae #222222,
-      // cathartidae #444444, corvidae #222244, strigidae #5A4A2A,
-      // troglodytidae #7A5028, plus _FALLBACK #555 at half opacity)
-      // read as faint smudges. The halo is the same trick maplibre
-      // text-symbol labels use to stand out against varied backgrounds —
-      // see basemap-style.ts text layers for the precedent.
-      'icon-halo-color': '#ffffff',
+      // Halo around each silhouette for contrast against the basemap land.
+      // The color is a per-style design fact carried on the active
+      // `BasemapDescriptor` (#1216) — for positron AND dark it is '#ffffff',
+      // so the paint stays byte-identical to the pre-refactor hardcode.
+      // Without the halo, families whose seed color is naturally
+      // low-saturation (accipitridae #222222, cathartidae #444444,
+      // corvidae #222244, strigidae #5A4A2A, troglodytidae #7A5028, plus
+      // _FALLBACK #555 at half opacity) read as faint smudges. The halo is
+      // the same trick maplibre text-symbol labels use to stand out against
+      // varied backgrounds — see basemap-style.ts text layers for the
+      // precedent.
+      'icon-halo-color': descriptor.markerHaloColor,
       'icon-halo-width': 1.5,
       // Fade _FALLBACK markers so missing-Phylopic families read as
       // distinct from the rest. The condition uses the literal sentinel


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    Swap["theme swap → setThemeId(id)"] --> Hook["useActiveThemeId()"]
    Hook -->|"reactive descriptor"| Memo["useMemo(() => buildUnclusteredPointLayerSpec(descriptor), [descriptor])"]
    Memo -->|"NEW spec object"| RMG["react-map-gl &lt;Layer&gt; paint diff"]
    RMG --> Paint["icon-halo-color = descriptor.markerHaloColor"]
```

Before this change the `unclusteredLayer` memo had an EMPTY dep array and the halo was the literal `'#ffffff'`. react-map-gl `<Layer>` specs are built once at mount and only re-diff on a NEW spec object — they are NOT rebuilt on `style.load` or the theme swap. So the halo could only ever update if the memo produced a new spec. Threading the reactive `descriptor` into the deps is what makes a future non-white-halo theme actually re-render.

## Summary

- The silhouette marker halo (`icon-halo-color`) was hardcoded `'#ffffff'` in `buildUnclusteredPointLayerSpec` — a per-style design fact that belongs on the `BasemapDescriptor`. The spec now takes the active descriptor and reads `descriptor.markerHaloColor`.
- `MapCanvas.tsx` memoizes the spec on the reactive `[activeDescriptor]` from C1.5's `useActiveThemeId()` (was `[]`). Without this, the halo would freeze at the mount-time descriptor and never update on a live swap — the latent bug C8's e2e asserts against.
- **Behavior-preserving / no visual delta**: `positron` and `dark` descriptors both declare `markerHaloColor: '#ffffff'`, so the production paint is byte-identical. The notable-ring amber stays kind-coupled (CSS token), carved out per epic #1221; C5 owns the all-lands amber assertion.

## Screenshots

N/A — behavior-preserving refactor, no visual delta; halo value unchanged via descriptor (positron/dark both carry `markerHaloColor: '#ffffff'`, so the rendered halo is byte-identical to before).

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className changes`
- [x] Multi-viewport design QA — `N/A — not UI` (behavior-preserving; no visual change)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (91 files / 1580 tests)
- [x] New unit tests added: positron→`#ffffff`, dark→`#ffffff` (byte-identical), and a synthetic descriptor with `markerHaloColor: '#123456'` → paint `'#123456'` (proves wiring, not a hardcode). TDD: synthetic test went red first, then green after the impl.
- [x] No new Playwright e2e — no user-visible behavior change (the non-white-halo live-swap guarantee lives in C8's e2e, where such a theme first becomes reachable)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `npx tsc -b frontend` — exit 0; `npx knip` — exit 0; `bash scripts/ci/check-orphan-classnames.sh` — PASS; `npm run lint` — exit 0
- [x] (UI only) Playwright MCP smoke — `N/A — behavior-preserving refactor, no visual delta`

## Plan reference

Closes #1216. Part of #1221 (child C4). Depends on C1 (#1212) and C1.5 (#1213), both merged to `main`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)