### PR TITLE
refactor(frontend): artboard float colors + label isolation onto descriptor; delete SYMBOL_NAME_PATTERN

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -74,14 +74,21 @@ function makeFakeMap() {
   // moveLayer guard).
   let styleHasMaskLayer = true;
   const baseStyleLayers = () => {
-    const layers: Array<{ id: string; type: string; source?: string; filter?: unknown }> = [
+    const TEXT_LAYOUT = { 'text-field': ['get', 'name'] };
+    const layers: Array<{
+      id: string;
+      type: string;
+      source?: string;
+      filter?: unknown;
+      layout?: Record<string, unknown>;
+    }> = [
       { id: 'background', type: 'background' },
       { id: 'water', type: 'fill' },
-      { id: 'place_country', type: 'symbol', source: 'openmaptiles', filter: ['==', 'class', 'country'] },
-      { id: 'place_city', type: 'symbol', source: 'openmaptiles' },
-      { id: 'poi_z14', type: 'symbol', source: 'openmaptiles' },
-      { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles' }, // _name label
-      { id: 'transit_route_ref', type: 'symbol', source: 'openmaptiles' }, // symbol, no token
+      { id: 'place_country', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT }, filter: ['==', 'class', 'country'] },
+      { id: 'place_city', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
+      { id: 'poi_z14', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
+      { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } }, // text label
+      { id: 'transit_route_ref', type: 'symbol', source: 'openmaptiles' }, // symbol, NO text-field → not isolated
     ];
     if (styleHasMaskLayer) layers.push({ id: 'state-mask-fill', type: 'fill' });
     // Stray basemap line/fill layers painted ABOVE the mask (sink targets).

--- a/frontend/src/components/map/geometry/artboard-layers.test.ts
+++ b/frontend/src/components/map/geometry/artboard-layers.test.ts
@@ -15,6 +15,124 @@ import {
   ARTBOARD_LINE_SOURCE_ID,
   isIsolatableSymbolLayer,
 } from './artboard-layers.js';
+import {
+  THEME_REGISTRY,
+  type BasemapDescriptor,
+} from './basemap-style.js';
+
+const POSITRON_DESCRIPTOR: BasemapDescriptor = THEME_REGISTRY.positron;
+const DARK_DESCRIPTOR: BasemapDescriptor = THEME_REGISTRY.dark;
+
+/**
+ * A short text-field-bearing `layout` so a fixture symbol layer reads as a
+ * label under `isLabelLayer` (which checks `layout['text-field'] != null`).
+ */
+const TEXT_LAYOUT = { 'text-field': ['get', 'name'] } as const;
+
+/**
+ * The OLD `SYMBOL_NAME_PATTERN` regex, snapshotted here as the equivalence
+ * oracle. The production code DELETED this regex in favor of `isLabelLayer`
+ * (text-field introspection); this snapshot lets the fixture-backed test below
+ * assert the isolated SET is byte-identical between the regex and `isLabelLayer`
+ * over the REAL positron + dark layer lists.
+ */
+const OLD_SYMBOL_NAME_PATTERN =
+  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country|shield|airport)([-_]|$)|[-_]name([-_]|$)/i;
+
+function oldRegexIsolates(layer: {
+  id: string;
+  type: string;
+  source?: string;
+}): boolean {
+  if (layer.type !== 'symbol') return false;
+  if (layer.source === 'observations') return false;
+  return OLD_SYMBOL_NAME_PATTERN.test(layer.id);
+}
+
+/**
+ * Fixture-backed REAL layer lists, trimmed to the fields the detectors read
+ * (`id`, `type`, `source`, and `layout['text-field']` presence). Captured from
+ * the live OpenFreeMap styles fetched in the C-epic pre-flight:
+ *   - https://tiles.openfreemap.org/styles/positron — 55 layers, 19 symbol
+ *   - https://tiles.openfreemap.org/styles/dark     — 47 layers, 15 symbol
+ * Every symbol layer that carries a `text-field` gets a truthy `layout`; the two
+ * icon-only `road_oneway*` arrows in the dark style get NO `layout` (they have
+ * no `text-field`). These two facts are the whole equivalence claim: the shields
+ * and airport the old regex matched all carry a `text-field`, and the arrows it
+ * excluded carry none.
+ */
+type FixtureLayer = {
+  id: string;
+  type: string;
+  source?: string;
+  layout?: Record<string, unknown>;
+};
+const L = (
+  id: string,
+  type: string,
+  opts: { source?: string; text?: boolean } = {},
+): FixtureLayer => {
+  const o: FixtureLayer = { id, type };
+  if (opts.source != null) o.source = opts.source;
+  if (opts.text) o.layout = { ...TEXT_LAYOUT };
+  return o;
+};
+const OMT = 'openmaptiles';
+const POSITRON_REAL_LAYERS: FixtureLayer[] = [
+  L('background', 'background'),
+  L('park', 'fill', { source: OMT }),
+  L('water', 'fill', { source: OMT }),
+  L('landcover_glacier', 'fill', { source: OMT }),
+  L('waterway', 'line', { source: OMT }),
+  L('building', 'fill', { source: OMT }),
+  L('highway_motorway_inner', 'line', { source: OMT }),
+  L('boundary_2', 'line', { source: OMT }),
+  // 19 symbol layers — every one carries a text-field in the live style.
+  L('waterway_line_label', 'symbol', { source: OMT, text: true }),
+  L('water_name_point_label', 'symbol', { source: OMT, text: true }),
+  L('water_name_line_label', 'symbol', { source: OMT, text: true }),
+  L('highway-name-path', 'symbol', { source: OMT, text: true }),
+  L('highway-name-minor', 'symbol', { source: OMT, text: true }),
+  L('highway-name-major', 'symbol', { source: OMT, text: true }),
+  L('highway-shield-non-us', 'symbol', { source: OMT, text: true }),
+  L('highway-shield-us-interstate', 'symbol', { source: OMT, text: true }),
+  L('road_shield_us', 'symbol', { source: OMT, text: true }),
+  L('airport', 'symbol', { source: OMT, text: true }),
+  L('label_other', 'symbol', { source: OMT, text: true }),
+  L('label_village', 'symbol', { source: OMT, text: true }),
+  L('label_town', 'symbol', { source: OMT, text: true }),
+  L('label_state', 'symbol', { source: OMT, text: true }),
+  L('label_city', 'symbol', { source: OMT, text: true }),
+  L('label_city_capital', 'symbol', { source: OMT, text: true }),
+  L('label_country_3', 'symbol', { source: OMT, text: true }),
+  L('label_country_2', 'symbol', { source: OMT, text: true }),
+  L('label_country_1', 'symbol', { source: OMT, text: true }),
+];
+const DARK_REAL_LAYERS: FixtureLayer[] = [
+  L('background', 'background'),
+  L('water', 'fill', { source: OMT }),
+  L('landcover_glacier', 'fill', { source: OMT }),
+  L('waterway', 'line', { source: OMT }),
+  L('building', 'fill', { source: OMT }),
+  L('highway_motorway_inner', 'line', { source: OMT }),
+  L('boundary_country_z5-', 'line', { source: OMT }),
+  // 15 symbol layers — 13 carry a text-field; the two road_oneway* arrows do NOT.
+  L('water_name', 'symbol', { source: OMT, text: true }),
+  L('road_oneway', 'symbol', { source: OMT }), // icon-only arrow — NO text-field
+  L('road_oneway_opposite', 'symbol', { source: OMT }), // icon-only arrow — NO text-field
+  L('highway_name_other', 'symbol', { source: OMT, text: true }),
+  L('highway_name_motorway', 'symbol', { source: OMT, text: true }),
+  L('place_other', 'symbol', { source: OMT, text: true }),
+  L('place_suburb', 'symbol', { source: OMT, text: true }),
+  L('place_village', 'symbol', { source: OMT, text: true }),
+  L('place_town', 'symbol', { source: OMT, text: true }),
+  L('place_city', 'symbol', { source: OMT, text: true }),
+  L('place_city_large', 'symbol', { source: OMT, text: true }),
+  L('place_state', 'symbol', { source: OMT, text: true }),
+  L('place_country_other', 'symbol', { source: OMT, text: true }),
+  L('place_country_minor', 'symbol', { source: OMT, text: true }),
+  L('place_country_major', 'symbol', { source: OMT, text: true }),
+];
 
 /* ── Fixtures ────────────────────────────────────────────────────────────────
    A minimal 1-part MultiPolygon standing in for a state's render-only geometry
@@ -45,16 +163,17 @@ function makeStyleLayers() {
     { id: 'background', type: 'background' },
     { id: 'water', type: 'fill' },
     { id: 'water_outline', type: 'line' },
-    { id: 'place_country', type: 'symbol', source: 'openmaptiles', filter: ['==', 'class', 'country'] },
-    { id: 'place_city', type: 'symbol', source: 'openmaptiles' },
-    { id: 'poi_z14', type: 'symbol', source: 'openmaptiles' },
+    { id: 'place_country', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT }, filter: ['==', 'class', 'country'] },
+    { id: 'place_city', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
+    { id: 'poi_z14', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
     // The `<thing>_name` label convention (was bleeding CA/MX freeway names).
-    { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles' },
-    { id: 'water_name', type: 'symbol', source: 'openmaptiles' },
-    // A symbol layer that must NOT match the heuristic (no place/label/_name token).
+    { id: 'highway_name_motorway', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
+    { id: 'water_name', type: 'symbol', source: 'openmaptiles', layout: { ...TEXT_LAYOUT } },
+    // A symbol layer that must NOT isolate (no text-field — e.g. an icon-only ref).
     { id: 'transit_route_ref', type: 'symbol', source: 'openmaptiles' },
-    // An app-owned observation symbol layer — must NEVER be isolated.
-    { id: 'unclustered-point', type: 'symbol', source: 'observations' },
+    // An app-owned observation symbol layer — must NEVER be isolated (even though
+    // it paints a text-field, the source guard excludes it).
+    { id: 'unclustered-point', type: 'symbol', source: 'observations', layout: { ...TEXT_LAYOUT } },
     // The mask fill (the z-order anchor).
     { id: MASK_LAYER_ID, type: 'fill' },
     // Stray basemap fill/line layers painted ABOVE the mask — must be sunk.
@@ -163,61 +282,98 @@ describe('bufferIsolationPolygon', () => {
   });
 });
 
-describe('isIsolatableSymbolLayer (type + name heuristic, fails OPEN)', () => {
-  it('matches symbol layers whose id contains a place/label token', () => {
-    expect(isIsolatableSymbolLayer({ id: 'place_city', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'place_country', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'poi_z14', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'settlement-major', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'state_label', type: 'symbol' })).toBe(true);
+describe('isIsolatableSymbolLayer (delegates to isLabelLayer — text-field introspection)', () => {
+  it('matches any text-bearing basemap symbol layer (regardless of its id)', () => {
+    // The detector no longer reads the id at all — a `symbol` with a `text-field`
+    // is a label. (These ids happen to also have carried a regex token, but the
+    // truth now is the text-field, not the name.)
+    expect(isIsolatableSymbolLayer({ id: 'place_city', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'label_country_1', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway_name_motorway', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'water_name', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-name-major', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    // A symbol whose id carries NO recognizable token still isolates if it paints
+    // text — the introspection is strictly more robust than the id heuristic.
+    expect(isIsolatableSymbolLayer({ id: 'some_future_label', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
   });
 
-  it('matches the openmaptiles <thing>_name text-label layers (the freeway/water-name bleed fix)', () => {
-    expect(isIsolatableSymbolLayer({ id: 'highway_name_motorway', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'highway_name_other', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'water_name', type: 'symbol' })).toBe(true);
+  it('matches the shield/airport label layers (they carry a text-field — route number / airport name)', () => {
+    // The old regex matched these by the `shield`/`airport` token; under
+    // isLabelLayer they match because they DO paint a text-field. The
+    // fixture-backed equivalence test below proves this on the real layer list.
+    expect(isIsolatableSymbolLayer({ id: 'road_shield_us', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-shield-us-interstate', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'highway-shield-non-us', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
+    expect(isIsolatableSymbolLayer({ id: 'airport', type: 'symbol', layout: TEXT_LAYOUT })).toBe(true);
   });
 
-  it('matches the LIGHT (positron) basemap label/road/shield/airport layers (hyphenated + new tokens)', () => {
-    // positron uses `label_*` instead of `place_*`.
-    expect(isIsolatableSymbolLayer({ id: 'label_other', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'label_city', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'label_country_1', type: 'symbol' })).toBe(true);
-    // HYPHENATED road-name labels — the `_name`-only pattern silently missed
-    // these, so VA-side freeway names bled onto the gray once the mask dropped
-    // below the labels. `[-_]name([-_]|$)` now catches them.
-    expect(isIsolatableSymbolLayer({ id: 'highway-name-major', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'highway-name-minor', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'highway-name-path', type: 'symbol' })).toBe(true);
-    // Shields + airport labels (own symbol layers, no place/label/name token).
-    expect(isIsolatableSymbolLayer({ id: 'road_shield_us', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'highway-shield-us-interstate', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'highway-shield-non-us', type: 'symbol' })).toBe(true);
-    expect(isIsolatableSymbolLayer({ id: 'airport', type: 'symbol' })).toBe(true);
-  });
-
-  it('does NOT match symbol layers with no place/label/name/shield/airport token (fails open: rendered exterior, not blanked)', () => {
-    expect(isIsolatableSymbolLayer({ id: 'transit_route_ref', type: 'symbol' })).toBe(false);
-    // road_oneway is an icon-only arrow layer, not a text label — left untouched
-    // (no label-bearing token; a bare `road`/`highway` token is deliberately not
-    // used so this LineString arrow set is never within-dropped).
+  it('does NOT match a symbol layer with NO text-field (road_oneway — icon-only arrow, still excluded)', () => {
+    // road_oneway / road_oneway_opposite are icon-only arrow layers with no
+    // text-field — both the old regex and isLabelLayer exclude them, so the
+    // in-state arrow set is never within-dropped.
     expect(isIsolatableSymbolLayer({ id: 'road_oneway', type: 'symbol' })).toBe(false);
+    expect(isIsolatableSymbolLayer({ id: 'road_oneway_opposite', type: 'symbol' })).toBe(false);
+    // A text-token-bearing id with NO text-field also does not isolate (truth is
+    // the text-field, not the id).
+    expect(isIsolatableSymbolLayer({ id: 'transit_route_ref', type: 'symbol' })).toBe(false);
   });
 
-  it('NEVER matches the app observation/cluster symbol layers (source: observations)', () => {
-    // Guard over the name heuristic: even though the id contains no basemap
-    // token, the source check is the belt — the bird layers are never isolated.
+  it('NEVER matches the app observation/cluster symbol layers even with a text-field (source: observations)', () => {
+    // The bird data is never isolated — isLabelLayer excludes source:observations.
     expect(
-      isIsolatableSymbolLayer({ id: 'unclustered-point', type: 'symbol', source: 'observations' }),
+      isIsolatableSymbolLayer({ id: 'unclustered-point', type: 'symbol', source: 'observations', layout: TEXT_LAYOUT }),
     ).toBe(false);
     expect(
-      isIsolatableSymbolLayer({ id: 'cluster-count', type: 'symbol', source: 'observations' }),
+      isIsolatableSymbolLayer({ id: 'cluster-count', type: 'symbol', source: 'observations', layout: TEXT_LAYOUT }),
     ).toBe(false);
   });
 
-  it('does NOT match non-symbol layers even when the id contains a token', () => {
-    expect(isIsolatableSymbolLayer({ id: 'place_fill', type: 'fill' })).toBe(false);
+  it('does NOT match non-symbol layers even when they carry a layout', () => {
+    expect(isIsolatableSymbolLayer({ id: 'place_fill', type: 'fill', layout: TEXT_LAYOUT })).toBe(false);
     expect(isIsolatableSymbolLayer({ id: 'boundary_country', type: 'line' })).toBe(false);
+  });
+});
+
+describe('isLabelLayer equivalence vs SYMBOL_NAME_PATTERN (fixture-backed, REAL layer lists)', () => {
+  const isolatedSet = (
+    layers: FixtureLayer[],
+    predicate: (l: FixtureLayer) => boolean,
+  ): string[] => layers.filter(predicate).map((l) => l.id).sort();
+
+  it('positron: the isolated SET is byte-identical between the old regex and isLabelLayer', () => {
+    const regexSet = isolatedSet(POSITRON_REAL_LAYERS, oldRegexIsolates);
+    const labelSet = isolatedSet(POSITRON_REAL_LAYERS, isIsolatableSymbolLayer);
+    expect(labelSet).toEqual(regexSet);
+    // Sanity: the set is the full 19-symbol-layer label set (all carry text-field).
+    expect(labelSet).toHaveLength(19);
+    // The shields + airport are IN the set (the equivalence guard the issue names).
+    expect(labelSet).toEqual(
+      expect.arrayContaining([
+        'road_shield_us',
+        'highway-shield-us-interstate',
+        'highway-shield-non-us',
+        'airport',
+      ]),
+    );
+  });
+
+  it('dark: the isolated SET is byte-identical between the old regex and isLabelLayer', () => {
+    const regexSet = isolatedSet(DARK_REAL_LAYERS, oldRegexIsolates);
+    const labelSet = isolatedSet(DARK_REAL_LAYERS, isIsolatableSymbolLayer);
+    expect(labelSet).toEqual(regexSet);
+    // 13 of the 15 symbol layers isolate; the two road_oneway* arrows do NOT.
+    expect(labelSet).toHaveLength(13);
+    expect(labelSet).not.toContain('road_oneway');
+    expect(labelSet).not.toContain('road_oneway_opposite');
+  });
+
+  it('road_oneway / road_oneway_opposite are excluded by BOTH detectors (icon-only, no text-field)', () => {
+    for (const id of ['road_oneway', 'road_oneway_opposite']) {
+      const layer = DARK_REAL_LAYERS.find((l) => l.id === id);
+      expect(layer).toBeDefined();
+      expect(oldRegexIsolates(layer!)).toBe(false);
+      expect(isIsolatableSymbolLayer(layer!)).toBe(false);
+    }
   });
 });
 
@@ -422,7 +578,7 @@ describe('sinkStrayLayersBelowMask', () => {
 describe('addFloatLayers / removeFloatLayers', () => {
   it('adds the halo (line + line-blur) and crisp outline (line) above the mask, with stable app-owned ids', () => {
     const map = makeMockMap();
-    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     const added = map.addLayer.mock.calls.map((c) => c[0] as { id: string; type: string; paint?: Record<string, unknown> });
     const halo = added.find((l) => l.id === ARTBOARD_HALO_ID);
     const outline = added.find((l) => l.id === ARTBOARD_OUTLINE_ID);
@@ -438,7 +594,7 @@ describe('addFloatLayers / removeFloatLayers', () => {
 
   it('anchors the float adds on the first layer ABOVE the mask (so they paint above the gray, not below it)', () => {
     const map = makeMockMap();
-    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     // addLayer(spec, beforeId) inserts BELOW beforeId. The anchor is the first
     // non-float layer above state-mask-fill (here: boundary_country) → the
     // floats land just above the mask fill, NOT below it.
@@ -450,21 +606,40 @@ describe('addFloatLayers / removeFloatLayers', () => {
     expect(haloCall?.[1]).not.toBe(MASK_LAYER_ID);
   });
 
-  it('theme param drives the halo paint (light drop-shadow vs dark glow differ)', () => {
+  const paintColor = (
+    m: ReturnType<typeof makeMockMap>,
+    layerId: string,
+  ): unknown =>
+    (m.addLayer.mock.calls.find((c) => (c[0] as { id: string }).id === layerId)?.[0] as {
+      paint: Record<string, unknown>;
+    }).paint['line-color'];
+
+  it('descriptor.floatColors drive the outline + halo paint (positron vs dark differ)', () => {
     const lightMap = makeMockMap();
-    addFloatLayers(lightMap as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(lightMap as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     const darkMap = makeMockMap();
-    addFloatLayers(darkMap as never, AZ_POLYGON, MASK_LAYER_ID, 'dark');
-    const haloColor = (m: ReturnType<typeof makeMockMap>) =>
-      (m.addLayer.mock.calls.find((c) => (c[0] as { id: string }).id === ARTBOARD_HALO_ID)?.[0] as {
-        paint: Record<string, unknown>;
-      }).paint['line-color'];
-    expect(haloColor(lightMap)).not.toEqual(haloColor(darkMap));
+    addFloatLayers(darkMap as never, AZ_POLYGON, MASK_LAYER_ID, DARK_DESCRIPTOR);
+    expect(paintColor(lightMap, ARTBOARD_HALO_ID)).not.toEqual(paintColor(darkMap, ARTBOARD_HALO_ID));
+    expect(paintColor(lightMap, ARTBOARD_OUTLINE_ID)).not.toEqual(paintColor(darkMap, ARTBOARD_OUTLINE_ID));
+  });
+
+  it('reproduces TODAY\'s exact float hexes — positron outline #1a1d24 / halo #3a3f4a (byte-identical refactor)', () => {
+    const map = makeMockMap();
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
+    expect(paintColor(map, ARTBOARD_OUTLINE_ID)).toBe('#1a1d24');
+    expect(paintColor(map, ARTBOARD_HALO_ID)).toBe('#3a3f4a');
+  });
+
+  it('reproduces TODAY\'s exact float hexes — dark outline #e8edf4 / halo #7fd0ff (byte-identical refactor)', () => {
+    const map = makeMockMap();
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, DARK_DESCRIPTOR);
+    expect(paintColor(map, ARTBOARD_OUTLINE_ID)).toBe('#e8edf4');
+    expect(paintColor(map, ARTBOARD_HALO_ID)).toBe('#7fd0ff');
   });
 
   it('adds ONE explicit named source shared by both layers (no per-layer inline source → no orphan on setStyle)', () => {
     const map = makeMockMap();
-    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     expect(map.addSource).toHaveBeenCalledWith(
       ARTBOARD_LINE_SOURCE_ID,
       expect.objectContaining({ type: 'geojson' }),
@@ -478,7 +653,7 @@ describe('addFloatLayers / removeFloatLayers', () => {
   it('is idempotent — guarded removal of an already-present layer before re-add', () => {
     const map = makeMockMap();
     // Float layers already present in the style (post theme-swap re-apply).
-    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(map as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     // getLayer returns the existing halo/outline → addFloatLayers removes first.
     expect(map.removeLayer).toHaveBeenCalledWith(ARTBOARD_HALO_ID);
     expect(map.removeLayer).toHaveBeenCalledWith(ARTBOARD_OUTLINE_ID);
@@ -493,7 +668,7 @@ describe('addFloatLayers / removeFloatLayers', () => {
 
     // A map where the floats + source ARE present: remove both layers + source.
     const present = makeMockMap();
-    addFloatLayers(present as never, AZ_POLYGON, MASK_LAYER_ID, 'light');
+    addFloatLayers(present as never, AZ_POLYGON, MASK_LAYER_ID, POSITRON_DESCRIPTOR);
     present.removeLayer.mockClear();
     present.removeSource.mockClear();
     removeFloatLayers(present as never);
@@ -506,7 +681,7 @@ describe('addFloatLayers / removeFloatLayers', () => {
 describe('applyArtboardFidelity (mask-move + float/sink composite — item 3b)', () => {
   it('moves the mask below the first label, sinks stray layers, then adds the float layers above the mask', () => {
     const map = makeMockMap();
-    applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
+    applyArtboardFidelity(map as never, AZ_POLYGON, DARK_DESCRIPTOR);
     // Step 1: the mask moved below the first basemap label layer (place_country).
     expect(map.moveLayer).toHaveBeenCalledWith(MASK_LAYER_ID, 'place_country');
     // moveLayer (mask-move + sink) and addLayer (float) both fire.
@@ -525,7 +700,7 @@ describe('applyArtboardFidelity (mask-move + float/sink composite — item 3b)',
 
   it('runs the mask-move BEFORE the float/sink (interior labels end up above the mask)', () => {
     const map = makeMockMap();
-    applyArtboardFidelity(map as never, AZ_POLYGON, 'dark');
+    applyArtboardFidelity(map as never, AZ_POLYGON, DARK_DESCRIPTOR);
     // After the composite, every basemap label layer paints ABOVE the lowered
     // mask — the interior-label un-clip invariant.
     const after = map.layers.map((l) => l.id);

--- a/frontend/src/components/map/geometry/artboard-layers.ts
+++ b/frontend/src/components/map/geometry/artboard-layers.ts
@@ -1,5 +1,9 @@
 import { buffer } from '@turf/buffer';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
+import {
+  isLabelLayer,
+  type BasemapDescriptor,
+} from '@/components/map/geometry/basemap-style.js';
 
 /**
  * State-artboard FIDELITY layer manipulation (#760/#763 — SUB2).
@@ -59,30 +63,33 @@ export const ARTBOARD_OUTLINE_ID = 'state-artboard-outline';
 export const ARTBOARD_LINE_SOURCE_ID = 'state-artboard-line';
 
 /**
- * Float-layer paint tokens.
+ * Float-layer paint GEOMETRY tokens.
+ *
+ * The float OUTLINE + HALO COLORS no longer live here — they are carried per
+ * basemap on `descriptor.floatColors` (tuned against that style's land) and
+ * threaded in from the swap site, so the helper never branches on a `theme`
+ * string. Only the geometry (widths / blur / opacity) is style-invariant and
+ * stays local.
  *
  * The crisp outline is the WCAG 1.4.11 load-bearing boundary: the mask fill
  * alone is ≈1.05:1 (dark `#06090e`) / ≈1.26:1 (light `#d8d8d8`) against the
  * adjacent in-state land, which fails the 3:1 non-text-contrast target. The
- * outline therefore carries an explicit ≥3:1 target against BOTH (i) the mask
- * fill and (ii) the adjacent land, in both themes:
+ * descriptor outline therefore carries an explicit ≥3:1 target against BOTH
+ * (i) the mask fill and (ii) the adjacent land of EVERY registered style.
+ * Recomputed with the WCAG relative-luminance formula (recorded in the PR body):
  *
- *   LIGHT outline `#1a1d24` (near-black):
- *     vs mask fill `#d8d8d8` (L≈0.690) → contrast ≈ 12.3:1  ✓
- *     vs positron land (`#f8f4f0`, L≈0.940) → contrast ≈ 16.3:1  ✓
- *   DARK outline `#e8edf4` (near-white):
- *     vs mask fill `#06090e` (L≈0.0027) → contrast ≈ 16.4:1  ✓
- *     vs positron-dark land (`#0e1116`, L≈0.0055) → contrast ≈ 15.6:1  ✓
+ *   LIGHT outline `#1a1d24` (near-black), `positron`.floatColors.outline:
+ *     vs positron land (`#f4f1ea`, db-client LIGHT_BASE) → ≈ 14.95:1  ✓
+ *     vs bright/liberty land (`#f8f4f0`)                 → ≈ 15.41:1  ✓
+ *   DARK outline `#e8edf4` (near-white), `dark`.floatColors.outline:
+ *     vs dark land (`#0E1116`, db-client DARK_BASE)      → ≈ 16.08:1  ✓
+ *     vs fiord land (`#45516E`, the real risk)           → ≈  6.72:1  ✓
  *
- * (Ratios computed with the WCAG relative-luminance formula; recorded in the
- * PR body.) The halo is a soft drop-shadow in light / a soft glow in dark — it
- * reinforces the "float" but is NOT the load-bearing boundary, so its contrast
- * is not asserted.
+ * (`#f8f4f0` is the bright/liberty land — NOT positron, whose land is `#f4f1ea`;
+ * the prior comment mislabeled it.) The halo is a soft drop-shadow in light / a
+ * soft glow in dark — it reinforces the "float" but is NOT the load-bearing
+ * boundary, so its contrast is not asserted.
  */
-const OUTLINE_LIGHT = '#1a1d24';
-const OUTLINE_DARK = '#e8edf4';
-const HALO_LIGHT = '#3a3f4a'; // soft dark drop-shadow on the light gray field
-const HALO_DARK = '#7fd0ff'; // soft cyan glow on the near-black dark field
 const OUTLINE_WIDTH = 1.5;
 const HALO_WIDTH = 6;
 const HALO_BLUR = 4;
@@ -96,7 +103,14 @@ const HALO_OPACITY = 0.55;
  */
 export interface ArtboardMap {
   getStyle: () =>
-    | { layers?: Array<{ id: string; type: string; source?: string }> }
+    | {
+        layers?: Array<{
+          id: string;
+          type: string;
+          source?: string;
+          layout?: Record<string, unknown>;
+        }>;
+      }
     | undefined;
   getFilter: (layerId: string) => unknown;
   setFilter: (layerId: string, filter: unknown) => void;
@@ -122,65 +136,38 @@ export interface ArtboardMap {
 type SavedFilters = Record<string, unknown>;
 
 /**
- * The basemap symbol-layer name heuristic. Matched against the layer id with a
- * conservative place/label token pattern. The two basemaps use DIFFERENT layer
- * id conventions, so we match by TYPE + NAME, never by a hardcoded id list:
- *   - DARK (`.../styles/dark`): underscore ids — `place_city`, `place_country*`,
- *     `water_name`, `highway_name_motorway`, `highway_name_other`.
- *   - LIGHT (`.../styles/positron`): a mix of `label_*` (`label_other`,
- *     `label_city`, `label_country_1`…) AND HYPHENATED road labels
- *     (`highway-name-major`, `highway-name-minor`, `highway-name-path`),
- *     shields (`road_shield_us`, `highway-shield-us-interstate`,
- *     `highway-shield-non-us`), and `airport`.
+ * True iff the layer is a basemap text-LABEL `symbol` layer that should be
+ * within-isolated. Delegates to C1's runtime {@link isLabelLayer} detector: a
+ * `symbol` layer that paints a `text-field` and is not one of our own
+ * observation layers (`source: 'observations'`, so the bird data is never
+ * isolated even if a future basemap names a layer collisionally).
  *
- * Tokens:
- *   - place/label tokens: `place|settlement|poi|label|town|city|village|state|
- *     country` (catches both `place_city` AND `label_city`).
- *   - `name` with EITHER an underscore OR a hyphen separator
- *     (`[-_]name([-_]|$)`) — catches the dark `water_name`/`highway_name_*` AND
- *     the light `highway-name-*`. The earlier `_name(_|$)`-only form silently
- *     missed the light basemap's hyphenated road labels, so VA-side freeway
- *     names bled onto the gray once the mask dropped below the labels (#762/#763
- *     interior-label-clipping fix). The separator class is what now catches them.
- *   - `shield` / `airport` — the light basemap renders road shields and the
- *     airport label as their own symbol layers with no place/label/name token;
- *     both are decorations tied to a road/place and must isolate with the rest.
+ * This replaced the drift-prone `SYMBOL_NAME_PATTERN` id regex. The swap is
+ * proven byte-identical against the REAL positron + dark layer lists by a
+ * fixture-backed test in `artboard-layers.test.ts`: the isolated SET is
+ * unchanged. The shields/airport layers the old regex deliberately matched all
+ * carry a `text-field` (route number / airport name), so `isLabelLayer`
+ * matches them too; `road_oneway`/`road_oneway_opposite` are icon-only arrows
+ * with NO `text-field`, so both detectors exclude them.
  *
- * **`road_oneway` is still EXCLUDED** (the original calibration constraint): it
- * is an icon-only arrow layer with no place/label/`name`/`shield`/`airport`
- * token, so it does NOT match — a bare `road`/`highway` token (deliberately not
- * used) would have wrongly within-isolated that LineString arrow set, dropping
- * in-state arrows along with foreign ones. We require a label-bearing token.
- *
- * **Fails OPEN by design:** a new/unmatched symbol layer in a future basemap
+ * **Fails OPEN by design:** a label-less symbol layer in a future basemap
  * release simply renders exterior (detectable in QA) rather than throwing or
  * blanking the whole map. We never blanket-isolate every symbol layer.
- */
-const SYMBOL_NAME_PATTERN =
-  /(^|[-_])(place|settlement|poi|label|town|city|village|state|country|shield|airport)([-_]|$)|[-_]name([-_]|$)/i;
-
-/**
- * True iff the layer is a basemap text-LABEL `symbol` layer that should be
- * within-isolated. Matches by the name heuristic but EXCLUDES the app's own
- * observation/cluster symbol layers (`source: 'observations'`) so the bird data
- * is never isolated even if a future basemap names a layer collisionally — a
- * belt over the name heuristic's fail-open default.
  */
 export function isIsolatableSymbolLayer(layer: {
   id: string;
   type: string;
   source?: string;
+  layout?: Record<string, unknown>;
 }): boolean {
-  if (layer.type !== 'symbol') return false;
-  if (layer.source === 'observations') return false; // never isolate bird layers
-  return SYMBOL_NAME_PATTERN.test(layer.id);
+  return isLabelLayer(layer);
 }
 
 /**
  * True iff the layer is a basemap text-LABEL `symbol` layer that the mask FILL
  * should be moved BELOW (the "isolate mode" of the v3 mockup). Reuses the same
- * type+name heuristic as `isIsolatableSymbolLayer` so the mask anchors on the
- * SAME class of layer the `within` isolation operates on — but additionally
+ * `isLabelLayer` delegation as `isIsolatableSymbolLayer` so the mask anchors on
+ * the SAME class of layer the `within` isolation operates on — but additionally
  * EXCLUDES the app-owned float layers (`state-artboard-*`). Those are `line`
  * layers (so the symbol check already drops them), but the exclusion is an
  * explicit belt in case a future float layer is ever a symbol.
@@ -193,6 +180,7 @@ function isFirstLabelAnchorLayer(layer: {
   id: string;
   type: string;
   source?: string;
+  layout?: Record<string, unknown>;
 }): boolean {
   if (layer.id === ARTBOARD_HALO_ID || layer.id === ARTBOARD_OUTLINE_ID) {
     return false;
@@ -402,8 +390,9 @@ export function sinkStrayLayersBelowMask(map: ArtboardMap, maskLayerId: string):
 
 /**
  * Add the halo (blurred `line`) + crisp outline (`line`) float layers ABOVE the
- * mask, theme-aware. Both trace the state polygon's exterior. Idempotent:
- * removes any existing instance (post theme-swap re-apply) before re-adding.
+ * mask, colored from the descriptor. Both trace the state polygon's exterior.
+ * Idempotent: removes any existing instance (post theme-swap re-apply) before
+ * re-adding.
  *
  * The float layers source the EXACT state polygon (not the buffered isolation
  * polygon) — they draw the visible artboard edge, which must match the gray
@@ -421,14 +410,16 @@ export function addFloatLayers(
   map: ArtboardMap,
   maskPolygon: MultiPolygon,
   maskLayerId: string,
-  theme: 'light' | 'dark',
+  descriptor: BasemapDescriptor,
 ): void {
   // Idempotent guard: a theme-swap re-apply runs against the NEW style where a
   // prior instance may linger; remove before re-add so ids stay unique.
   removeFloatLayers(map);
 
-  const outlineColor = theme === 'dark' ? OUTLINE_DARK : OUTLINE_LIGHT;
-  const haloColor = theme === 'dark' ? HALO_DARK : HALO_LIGHT;
+  // Float colors come from the descriptor (tuned against this style's land),
+  // NOT a hardcoded light/dark pair — see basemap-style.ts `floatColors`.
+  const outlineColor = descriptor.floatColors.outline;
+  const haloColor = descriptor.floatColors.halo;
 
   // Anchor: the first layer ABOVE the mask. addLayer(spec, anchor) inserts the
   // spec just below `anchor` → just above the mask. Skip our own float ids so a
@@ -538,9 +529,9 @@ export function removeFloatLayers(map: ArtboardMap): void {
 export function applyArtboardFidelity(
   map: ArtboardMap,
   maskPolygon: MultiPolygon,
-  theme: 'light' | 'dark',
+  descriptor: BasemapDescriptor,
 ): void {
   moveMaskBelowFirstLabel(map, MASK_LAYER_ID);
   sinkStrayLayersBelowMask(map, MASK_LAYER_ID);
-  addFloatLayers(map, maskPolygon, MASK_LAYER_ID, theme);
+  addFloatLayers(map, maskPolygon, MASK_LAYER_ID, descriptor);
 }

--- a/frontend/src/components/map/hooks/use-state-artboard.test.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.test.ts
@@ -45,13 +45,23 @@ import type {
  * `e2e/scope/state-artboard.spec.ts` is the live transform-clone-timing backstop.
  */
 
-// Minimal isolatable basemap symbol layer (matches SYMBOL_NAME_PATTERN: 'label'
-// token) + the #762 mask fill (the z-order anchor) + a stray basemap line layer
-// painted ABOVE the mask (so the sink has something to move) + a cluster layer
-// (the float anchor that sits above the mask). Order is array-paint order.
-type StyleLayer = { id: string; type: string; source?: string };
+// Minimal isolatable basemap symbol layer (a `symbol` that paints a `text-field`,
+// so `isLabelLayer` isolates it) + the #762 mask fill (the z-order anchor) + a
+// stray basemap line layer painted ABOVE the mask (so the sink has something to
+// move) + a cluster layer (the float anchor that sits above the mask). Order is
+// array-paint order.
+type StyleLayer = {
+  id: string;
+  type: string;
+  source?: string;
+  layout?: Record<string, unknown>;
+};
 
-const ISOLATABLE_LAYER: StyleLayer = { id: 'label_city', type: 'symbol' };
+const ISOLATABLE_LAYER: StyleLayer = {
+  id: 'label_city',
+  type: 'symbol',
+  layout: { 'text-field': ['get', 'name'] },
+};
 const MASK_LAYER: StyleLayer = { id: MASK_LAYER_ID, type: 'fill' };
 const STRAY_LINE: StyleLayer = { id: 'boundary_country', type: 'line' };
 const CLUSTER_LAYER: StyleLayer = { id: 'clusters', type: 'circle', source: 'observations' };
@@ -422,8 +432,8 @@ describe('useStateArtboard — ordering invariants (P2 backfill, #884 · U13)', 
    But `useStateArtboard`'s label-isolation capture (`applyLabelIsolation` in the
    `style.load` handler / mask-change effect) records each isolatable symbol
    layer's RAW filter into `savedFiltersRef` — and the road-shield layers ARE
-   isolatable (the `shield` token in SYMBOL_NAME_PATTERN), so what is captured is
-   the RAW, un-sanitized `["<=", ["get","ref_length"], 6]`. The capture runs
+   isolatable (they paint a `text-field`, so `isLabelLayer` matches them), so what
+   is captured is the RAW, un-sanitized `["<=", ["get","ref_length"], 6]`. The capture runs
    BEFORE the sanitizer effect in MapCanvas, so the saved filter is never the
    guarded shape.
 
@@ -445,14 +455,15 @@ const SHIELD_GUARDED_FILTER = [
 
 /**
  * A minimal stateful fake map for the restore-path test: a single isolatable
- * road-shield symbol layer (matches SYMBOL_NAME_PATTERN via the `shield` token)
- * pre-seeded with the RAW null-prone filter, plus the mask fill + a cluster
- * layer so the float/sink half can run without throwing. Backs `getFilter`/
- * `setFilter` with a real store so the round-trip's net filter is observable.
+ * road-shield symbol layer (it paints a `text-field` — the route number — so
+ * `isLabelLayer` matches it) pre-seeded with the RAW null-prone filter, plus the
+ * mask fill + a cluster layer so the float/sink half can run without throwing.
+ * Backs `getFilter`/`setFilter` with a real store so the round-trip's net filter
+ * is observable.
  */
 function makeShieldFakeMap() {
   const layers: StyleLayer[] = [
-    { id: 'road_shield_us', type: 'symbol' },
+    { id: 'road_shield_us', type: 'symbol', layout: { 'text-field': ['get', 'ref'] } },
     MASK_LAYER,
     CLUSTER_LAYER,
   ];

--- a/frontend/src/components/map/hooks/use-state-artboard.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.ts
@@ -315,8 +315,9 @@ export function useStateArtboard(
   }, [mapReady, maskPolygon]);
 
   // (3b) Float layers + stray-sink — runs from a `maskPolygon`-watching,
-  // `mapReady`-gated effect (also keyed on `maskTheme` so the float re-tints on
-  // a theme swap). It fires AFTER react-map-gl's reconcile has (re-)added
+  // `mapReady`-gated effect (also keyed on `activeThemeId` so the float re-tints
+  // on a theme swap — including a same-kind swap, which `maskTheme` alone could
+  // not reach). It fires AFTER react-map-gl's reconcile has (re-)added
   // `state-mask-fill`, and `addFloatLayers` is idempotent (removes any prior
   // instance before re-adding), so re-running it on a theme change re-tints
   // cleanly without thrashing the LABEL filters (which are owned by the (3a)
@@ -339,13 +340,17 @@ export function useStateArtboard(
       return;
     }
     try {
-      applyArtboardFidelity(map, maskPolygon, maskTheme);
+      // The float outline/halo colors come from the active descriptor's
+      // `floatColors` (tuned against this style's land) — NOT a light/dark
+      // branch. Behavior-preserving for positron/dark (their `floatColors` carry
+      // today's exact hexes).
+      applyArtboardFidelity(map, maskPolygon, resolver(activeThemeId));
     } catch {
       /* defensive — layer/style churn after a swap */
     }
     // `styleEpoch` re-runs this AFTER a theme `setStyle`+`style.load` so the
     // floats `setStyle` dropped are re-added once `state-mask-fill` is back.
-  }, [mapReady, maskPolygon, maskTheme, styleEpoch]);
+  }, [mapReady, maskPolygon, activeThemeId, resolver, styleEpoch]);
 
   // (3b-teardown) Restore label filters + remove float layers when the mask
   // unmounts (scope → us/chooser) OR the component unmounts. Keyed ONLY on


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph C1["C1 #1212 — basemap-style.ts (merged)"]
      DESC["BasemapDescriptor<br/>floatColors {outline, halo}"]
      ISLABEL["isLabelLayer(layer)<br/>symbol + text-field + source≠observations"]
    end
    subgraph C15["C1.5 #1213 — use-state-artboard.ts (merged)"]
      RESOLVE["resolver(activeThemeId)<br/>→ descriptor"]
    end
    subgraph C3["C3 #1215 — artboard-layers.ts (this PR)"]
      FLOAT["addFloatLayers / applyArtboardFidelity<br/>(map, maskPolygon, descriptor)"]
      ISO["isIsolatableSymbolLayer(layer)<br/>= isLabelLayer(layer)"]
    end
    RESOLVE -->|descriptor| FLOAT
    DESC -->|floatColors| FLOAT
    ISLABEL -->|delegates| ISO
    FLOAT -->|outline #1a1d24/halo #3a3f4a · positron| PAINT["line-color paint<br/>(byte-identical)"]
    FLOAT -->|outline #e8edf4/halo #7fd0ff · dark| PAINT
    ISO -.->|"SYMBOL_NAME_PATTERN DELETED"| X["(regex gone)"]
```

## Summary

- **Why:** The artboard float outline/halo colors (`OUTLINE_*`/`HALO_*`) and a drift-prone label-id regex (`SYMBOL_NAME_PATTERN`) both hardcoded facts about two specific basemaps. C1 (#1212) introduced the `BasemapDescriptor` (carrying per-style `floatColors`) and a runtime `isLabelLayer` detector; C1.5 (#1213) threads the descriptor at the swap site. This PR moves both concerns onto that descriptor so the helpers never branch on a `'light'|'dark'` string.
- **Float colors:** `addFloatLayers`/`applyArtboardFidelity` now take a `BasemapDescriptor` and read `descriptor.floatColors.{outline,halo}`. The color consts are deleted; the geometry consts (`OUTLINE_WIDTH`/`HALO_WIDTH`/`HALO_BLUR`/`HALO_OPACITY`) stay local. The 3b float effect resolves the descriptor from the active theme id and re-keys on it (so a future same-kind swap re-tints, which `maskTheme` alone could not reach).
- **Label isolation:** `isIsolatableSymbolLayer` delegates to `isLabelLayer` (symbol + `text-field` + `source !== 'observations'`); `SYMBOL_NAME_PATTERN` is **deleted**. The `ArtboardMap` layer shape gains `layout?` so the detector can read `text-field`.
- **Documentation-integrity:** the file-header WCAG-1.4.11 proof no longer mislabels `#f8f4f0` (the bright/liberty land) as "positron land" (positron is `#f4f1ea`, db-client `LIGHT_BASE`); per-land outline ratios recorded below.

**Behavior-preserving (no visual delta).** Recomputed WCAG outline ratios (relative-luminance formula), all clearing the 3:1 non-text target:

| Outline | vs land | ratio |
|---|---|---|
| LIGHT `#1a1d24` | positron `#f4f1ea` | **14.95:1** ✓ |
| LIGHT `#1a1d24` | bright/liberty `#f8f4f0` | **15.41:1** ✓ |
| DARK `#e8edf4` | dark `#0E1116` | **16.08:1** ✓ |
| DARK `#e8edf4` | fiord `#45516E` (the real risk) | **6.72:1** ✓ |

**Shield/airport equivalence (the deletion guard).** I loaded the real positron + dark style JSON and enumerated every symbol layer the old regex matched. The isolated SET is **byte-identical** between `SYMBOL_NAME_PATTERN` and `isLabelLayer` on both styles:
- **positron** (55 layers, 19 symbol): regex 19 = isLabelLayer 19, identical. All 4 shield/airport layers (`road_shield_us`, `highway-shield-us-interstate`, `highway-shield-non-us`, `airport`) carry a `text-field` (route number / airport name) → still isolated.
- **dark** (47 layers, 15 symbol): regex 13 = isLabelLayer 13, identical. The only 2 non-isolated symbols are `road_oneway` / `road_oneway_opposite` — icon-only arrows with NO `text-field`, excluded by **both** detectors (so in-state arrows are never within-dropped). `road_oneway` excluded as before. ✓

This equivalence is locked into a fixture-backed unit test over the real layer lists (`artboard-layers.test.ts`).

## Screenshots

N/A — behavior-preserving refactor, no visual delta; positron/dark reproduce the current float colors (`#1a1d24`/`#3a3f4a`, `#e8edf4`/`#7fd0ff`) and `isLabelLayer` selects the same label-layer set `SYMBOL_NAME_PATTERN` did. Covered by existing artboard/label e2e (`frontend/e2e/scope/state-artboard.spec.ts`) + unit tests.

- [x] N/A — not a visible-UI change (no `className` added/renamed)
- [x] N/A — not UI (no visual delta)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (91 files / 1581 tests)
- [x] New unit tests added: descriptor-driven float colors + byte-identical hexes (positron/dark), `isIsolatableSymbolLayer` via `text-field` introspection, fixture-backed regex↔`isLabelLayer` equivalence over the real positron + dark layer lists, `road_oneway*` excluded by both
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `bash scripts/ci/check-orphan-classnames.sh` — PASS
- [x] `npx knip` — exit 0
- [x] `npx tsc -b frontend` — exit 0
- [x] N/A — Playwright MCP smoke: behavior-preserving refactor, no visual delta (existing `state-artboard.spec.ts` covers the artboard/label paths)

## Plan reference

Closes #1215. Part of #1221 — child C3. Depends on C1 (#1212) + C1.5 (#1213), both merged to main.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)