### PR TITLE
feat(frontend): register all 5 theme descriptors (positron, bright, liberty, dark, fiord)

### DIFF
--- a/frontend/src/components/map/geometry/basemap-label-contrast.test.ts
+++ b/frontend/src/components/map/geometry/basemap-label-contrast.test.ts
@@ -382,22 +382,14 @@ describe('enforceDarkLabelContrast — per-layer MEASURED gate (mid-luminance la
      land (fiord, `#45516E`) a label that already passes AA against that land
      must be left alone, and only a label that fails IS recolored. This proves
      the per-layer `contrastFromRgb(current, landRgb) >= AA` measurement path,
-     not just the near-black `dark` happy path. We synthesize a fiord-like
-     mid-luminance dark descriptor (NOT registered live — C6 owns that) so the
-     measurement runs against `#45516E`. */
-  const FIORD_LIKE: BasemapDescriptor = {
-    id: 'dark', // id is never branched on; only kind/landColor/darkLabelTextColors matter
-    url: 'https://example.test/fiord',
-    kind: 'dark',
-    landColor: '#45516E',
-    markerHaloColor: '#ffffff',
-    floatColors: { outline: '#e8edf4', halo: '#7fd0ff' },
-    // An AA-passing-vs-#45516E palette so a recolored label is itself ≥ AA.
-    darkLabelTextColors: { road: '#f2f2f2', place: '#e6e6e6', water: '#b8cae6' },
-  };
+     not just the near-black `dark` happy path. C6 registered the REAL fiord
+     descriptor (navy land `#45516E`, AA-passing dark-label palette), so the
+     measured-gate test now runs against `resolveDescriptor('fiord')` instead of
+     a synthetic proxy — the gate exercises the production descriptor. */
+  const FIORD_LIKE: BasemapDescriptor = resolveDescriptor('fiord');
 
   it('does NOT touch a label whose current color already passes AA vs the land', () => {
-    // `#e6e6e6` is ~5.7:1 vs `#45516E` — already passes, so it is skipped.
+    // `#e6e6e6` is ~6.3:1 vs `#45516E` — already passes, so it is skipped.
     const layers: FakeLayer[] = [
       { id: 'background', type: 'background', layout: {}, paint: { 'background-color': '#45516E' } },
       {
@@ -642,12 +634,15 @@ describe('#1217 — dark-label recolor tiers ≥ 4.5 AA vs every dark-kind land'
     }
   });
 
-  // Deferred to C6 (recorded so its implementer is warned): when fiord is
-  // registered, its dark-label water must clear ≥4.5 vs #45516E — the shared
-  // #9db4d8 = 3.75:1 fails, so fiord needs its own AA-passing water (e.g. #b8cae6).
-  it.todo(
-    'C6: fiord descriptor must declare an AA-passing dark water vs #45516E (e.g. #b8cae6 = 4.76:1)',
-  );
+  it('includes fiord (C6) — the dark-kind matrix auto-extended to it', () => {
+    // C6 registered fiord; the per-tier ≥4.5:1 matrix below now grades its
+    // own AA-passing palette (water #b8cae6 = 4.76:1) against the navy land,
+    // NOT the shared dark #9db4d8 (3.75:1, a fail vs #45516E).
+    expect(DARK_DESCRIPTORS.map((d) => d.id)).toEqual(expect.arrayContaining(['dark', 'fiord']));
+    const fiord = DARK_DESCRIPTORS.find((d) => d.id === 'fiord')!;
+    expect(fiord.darkLabelTextColors!.water).not.toBe('#9db4d8');
+    expect(contrast('#9db4d8', fiord.landColor)).toBeLessThan(AA);
+  });
 
   for (const d of DARK_DESCRIPTORS) {
     const tiers = d.darkLabelTextColors!;

--- a/frontend/src/components/map/geometry/basemap-style.test.ts
+++ b/frontend/src/components/map/geometry/basemap-style.test.ts
@@ -2,15 +2,39 @@ import { describe, it, expect } from 'vitest';
 import {
   BASEMAP_LIGHT,
   BASEMAP_DARK,
-  basemapStyle,
-  basemapStyleLight,
-  basemapStyleDark,
   THEME_REGISTRY,
   LAND_COLORS,
   resolveDescriptor,
   isLabelLayer,
 } from './basemap-style.js';
 import type { ThemeId } from './basemap-style.js';
+
+/* ── Local WCAG sRGB contrast math (independent re-derivation, so the contrast
+   assertions below do not lean on app code to grade themselves). ──────────── */
+function parseHex(hex: string): [number, number, number] {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.replace(/(.)/g, '$1$1');
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+}
+function luminance(hex: string): number {
+  const [r, g, b] = parseHex(hex);
+  const lin = (c: number): number => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+function contrast(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+const ALL_IDS: ThemeId[] = ['positron', 'bright', 'liberty', 'dark', 'fiord'];
 
 describe('basemap-style', () => {
   it('exports BASEMAP_LIGHT pointing at OpenFreeMap positron', () => {
@@ -26,16 +50,11 @@ describe('basemap-style', () => {
     expect(BASEMAP_DARK).not.toBe(BASEMAP_LIGHT);
   });
 
-  it('keeps `basemapStyle` as a back-compat alias of BASEMAP_LIGHT', () => {
-    expect(basemapStyle).toBe(BASEMAP_LIGHT);
-  });
-
-  it('keeps `basemapStyleLight`/`basemapStyleDark` as back-compat aliases', () => {
-    expect(basemapStyleLight).toBe(BASEMAP_LIGHT);
-    expect(basemapStyleDark).toBe(BASEMAP_DARK);
-  });
-
   describe('THEME_REGISTRY', () => {
+    it('registers exactly the 5 theme ids', () => {
+      expect(Object.keys(THEME_REGISTRY).sort()).toEqual([...ALL_IDS].sort());
+    });
+
     it('contains both positron and dark descriptors with all required fields', () => {
       const positron = THEME_REGISTRY.positron;
       const dark = THEME_REGISTRY.dark;
@@ -55,13 +74,69 @@ describe('basemap-style', () => {
       expect(dark.floatColors).toEqual({ outline: '#e8edf4', halo: '#7fd0ff' });
     });
 
-    it('gives the dark descriptor darkLabelTextColors and the light one none', () => {
+    it('registers the 3 new descriptors (bright, liberty, fiord) with required fields', () => {
+      const bright = THEME_REGISTRY.bright;
+      expect(bright.id).toBe('bright');
+      expect(bright.url).toBe('https://tiles.openfreemap.org/styles/bright');
+      expect(bright.kind).toBe('light');
+      expect(bright.landColor).toBe('#f8f4f0');
+      expect(bright.markerHaloColor).toBe('#ffffff');
+      expect(bright.floatColors).toEqual({ outline: '#1a1d24', halo: '#3a3f4a' });
+
+      const liberty = THEME_REGISTRY.liberty;
+      expect(liberty.id).toBe('liberty');
+      expect(liberty.url).toBe('https://tiles.openfreemap.org/styles/liberty');
+      expect(liberty.kind).toBe('light');
+      expect(liberty.landColor).toBe('#f8f4f0');
+      expect(liberty.markerHaloColor).toBe('#ffffff');
+      expect(liberty.floatColors).toEqual({ outline: '#1a1d24', halo: '#3a3f4a' });
+
+      const fiord = THEME_REGISTRY.fiord;
+      expect(fiord.id).toBe('fiord');
+      expect(fiord.url).toBe('https://tiles.openfreemap.org/styles/fiord');
+      expect(fiord.kind).toBe('dark');
+      expect(fiord.landColor).toBe('#45516E');
+      expect(fiord.markerHaloColor).toBe('#ffffff');
+      expect(fiord.floatColors).toEqual({ outline: '#e8edf4', halo: '#7fd0ff' });
+    });
+
+    it('every descriptor has a valid OpenFreeMap url matching its id', () => {
+      for (const id of ALL_IDS) {
+        expect(THEME_REGISTRY[id].url).toBe(`https://tiles.openfreemap.org/styles/${id}`);
+      }
+    });
+
+    it('gives the dark-kind descriptors darkLabelTextColors and the light ones none', () => {
       expect(THEME_REGISTRY.dark.darkLabelTextColors).toEqual({
         road: '#d8d8d8',
         place: '#c4c4c4',
         water: '#9db4d8',
       });
+      expect(THEME_REGISTRY.fiord.darkLabelTextColors).toBeDefined();
+      // light-kind descriptors omit dark label colors
       expect(THEME_REGISTRY.positron.darkLabelTextColors).toBeUndefined();
+      expect(THEME_REGISTRY.bright.darkLabelTextColors).toBeUndefined();
+      expect(THEME_REGISTRY.liberty.darkLabelTextColors).toBeUndefined();
+    });
+
+    it("fiord's darkLabelTextColors clear ≥4.5:1 AA vs its land #45516E (NOT the shared #9db4d8 water = 3.75:1)", () => {
+      const fiord = THEME_REGISTRY.fiord;
+      const tiers = fiord.darkLabelTextColors!;
+      // The shared dark-theme water FAILS against fiord's land — fiord needs its own.
+      expect(tiers.water).not.toBe('#9db4d8');
+      expect(contrast('#9db4d8', fiord.landColor)).toBeLessThan(4.5);
+      for (const [tier, color] of Object.entries(tiers)) {
+        const ratio = contrast(color, fiord.landColor);
+        expect(
+          ratio,
+          `fiord ${tier} ${color} vs ${fiord.landColor} = ${ratio.toFixed(2)}:1 must clear AA 4.5`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    });
+
+    it("fiord's floatColors.outline clears ≥3:1 vs its land #45516E", () => {
+      const fiord = THEME_REGISTRY.fiord;
+      expect(contrast(fiord.floatColors.outline, fiord.landColor)).toBeGreaterThanOrEqual(3);
     });
 
     it('keeps registry urls byte-identical to the back-compat aliases', () => {
@@ -70,8 +145,9 @@ describe('basemap-style', () => {
     });
 
     it('keeps each descriptor landColor in sync with LAND_COLORS', () => {
-      (['positron', 'dark'] as ThemeId[]).forEach((id) => {
+      ALL_IDS.forEach((id) => {
         expect(THEME_REGISTRY[id].landColor).toBe(LAND_COLORS[id].land);
+        expect(THEME_REGISTRY[id].kind).toBe(LAND_COLORS[id].kind);
       });
     });
   });
@@ -96,8 +172,10 @@ describe('basemap-style', () => {
 
   describe('resolveDescriptor', () => {
     it('returns the matching descriptor object for each registered id', () => {
-      expect(resolveDescriptor('positron')).toBe(THEME_REGISTRY.positron);
-      expect(resolveDescriptor('dark')).toBe(THEME_REGISTRY.dark);
+      for (const id of ALL_IDS) {
+        expect(resolveDescriptor(id)).toBe(THEME_REGISTRY[id]);
+        expect(resolveDescriptor(id).id).toBe(id);
+      }
     });
   });
 

--- a/frontend/src/components/map/geometry/basemap-style.ts
+++ b/frontend/src/components/map/geometry/basemap-style.ts
@@ -9,21 +9,24 @@
  * where subsystems hardcoded facts about two specific styles.
  *
  * `LAND_COLORS` is the single source of truth for the land hex + kind of ALL
- * five OpenFreeMap styles (positron, bright, liberty, dark, fiord). It is
- * declared in full here — ahead of the descriptors for bright/liberty/fiord,
- * which land in a later child — so the contrast audit and the descriptor table
- * read one authority instead of duplicating literals. `THEME_REGISTRY`
- * descriptors derive their `landColor` from this table.
+ * five OpenFreeMap styles (positron, bright, liberty, dark, fiord). The
+ * contrast audit and the descriptor table both read this authority instead of
+ * duplicating literals; `THEME_REGISTRY` descriptors derive their `landColor`
+ * from this table.
  *
- * Only `positron` and `dark` are registered as descriptors right now, seeded
- * with the exact values already live so the rendered output is byte-identical:
- * no visible change. The other three descriptors are added in a follow-up.
+ * All FIVE descriptors are now registered (C6). The three added beyond the
+ * original positron/dark seed — bright, liberty, fiord — are DORMANT: no
+ * selector exposes them yet (C8) and boot-theme still resolves only
+ * `light → positron` / `dark → dark`, so the rendered output is unchanged.
+ * Their colors were validated against each style's own land by the family-
+ * palette, silhouette, and dark-label a11y audits (C5's ≥4.5:1 / ≥3:1 gates).
  *
  * Two named exports — BASEMAP_LIGHT and BASEMAP_DARK — remain as thin aliases
  * of the registered urls. They drive the basemap swap when `[data-theme]`
  * changes on <html>. The MutationObserver wired up in Phase 1 of the
  * adaptive-grid contrast epic (#575, MapCanvas.tsx) reads the current attribute
- * on every mutation and calls map.setStyle() with the matching URL.
+ * on every mutation and calls map.setStyle() with the matching URL. These are
+ * retired in C7 once the last `[data-theme]`-only callers are removed.
  *
  * Gate closure:
  * - G7 (family palette × basemap contrast): closed by Phase 1 PR #577.
@@ -33,17 +36,12 @@
  *   BASEMAP_DARK now points at the real OpenFreeMap dark tile URL.
  *   MutationObserver in MapCanvas.tsx drives the live swap on theme toggle.
  *
- * `basemapStyle`, `basemapStyleLight`, `basemapStyleDark` are preserved
- * as back-compat aliases so existing callers continue to type-check
- * during the rename sweep. Delete in a follow-up once grep confirms zero
- * callers outside this module.
- *
  * Spec: docs/design/01-spec/architecture.md §"Light / dark mode"
  * Gates: docs/design/01-spec/open-questions.md G7 (closed), G8 (closed)
  */
 
-/** Registered basemap theme ids. Widened to all 5 styles in a follow-up. */
-export type ThemeId = 'positron' | 'dark';
+/** Registered basemap theme ids — all 5 OpenFreeMap styles. */
+export type ThemeId = 'positron' | 'bright' | 'liberty' | 'dark' | 'fiord';
 
 /** Canvas polarity of a basemap — drives the `[data-theme]` attribute. */
 export type BasemapKind = 'light' | 'dark';
@@ -79,9 +77,19 @@ export const LAND_COLORS = {
 } as const;
 
 /**
- * Theme id → descriptor. Seeded with `positron`/`dark` only, using the exact
- * values already live so output is byte-identical. The other three descriptors
- * arrive in a follow-up (their LAND colors already live in `LAND_COLORS`).
+ * Theme id → descriptor for all FIVE OpenFreeMap styles. `positron`/`dark`
+ * carry the exact values already live; `bright`/`liberty`/`fiord` are added by
+ * C6 and remain DORMANT until a selector (C8) makes them reachable. Each
+ * descriptor's `landColor` derives from `LAND_COLORS`. Color choices are
+ * audit-gated: light floats clear ≥3:1 vs the light land, fiord's dark labels
+ * clear ≥4.5:1 AA and its float outline ≥3:1 vs the navy land #45516E.
+ *
+ * Pre-flight (curl, 2026-06-14): all three style.json load and are well-formed —
+ *   bright   119 layers, background ✓, 23 symbol+text-field, 0 fill-extrusion
+ *   liberty  111 layers, background ✓, 23 symbol+text-field, 1 fill-extrusion
+ *            (single building-extrusion layer; not matched by isLabelLayer
+ *            (`type === 'symbol'`), so it does not break the mask/float pipeline)
+ *   fiord     48 layers, background ✓, 14 symbol+text-field, 0 fill-extrusion
  */
 export const THEME_REGISTRY: Record<ThemeId, BasemapDescriptor> = {
   positron: {
@@ -92,6 +100,22 @@ export const THEME_REGISTRY: Record<ThemeId, BasemapDescriptor> = {
     markerHaloColor: '#ffffff', // observation-layers.ts icon-halo-color
     floatColors: { outline: '#1a1d24', halo: '#3a3f4a' }, // OUTLINE_LIGHT / HALO_LIGHT
   },
+  bright: {
+    id: 'bright',
+    url: 'https://tiles.openfreemap.org/styles/bright',
+    kind: 'light',
+    landColor: LAND_COLORS.bright.land, // '#f8f4f0'
+    markerHaloColor: '#ffffff', // white rings the family-colored silhouette (separation, not a land ratio)
+    floatColors: { outline: '#1a1d24', halo: '#3a3f4a' }, // outline 15.41:1 vs #f8f4f0 (≥3:1) — same as positron's light floats
+  },
+  liberty: {
+    id: 'liberty',
+    url: 'https://tiles.openfreemap.org/styles/liberty',
+    kind: 'light',
+    landColor: LAND_COLORS.liberty.land, // '#f8f4f0'
+    markerHaloColor: '#ffffff',
+    floatColors: { outline: '#1a1d24', halo: '#3a3f4a' }, // outline 15.41:1 vs #f8f4f0 (≥3:1); style ships 1 fill-extrusion layer (pre-flight), inert to isLabelLayer
+  },
   dark: {
     id: 'dark',
     url: 'https://tiles.openfreemap.org/styles/dark',
@@ -100,6 +124,18 @@ export const THEME_REGISTRY: Record<ThemeId, BasemapDescriptor> = {
     markerHaloColor: '#ffffff',
     floatColors: { outline: '#e8edf4', halo: '#7fd0ff' }, // OUTLINE_DARK / HALO_DARK
     darkLabelTextColors: { road: '#d8d8d8', place: '#c4c4c4', water: '#9db4d8' }, // ROAD/PLACE/WATER_TEXT
+  },
+  fiord: {
+    id: 'fiord',
+    url: 'https://tiles.openfreemap.org/styles/fiord',
+    kind: 'dark',
+    landColor: LAND_COLORS.fiord.land, // '#45516E' (navy mid-luminance dark land)
+    markerHaloColor: '#ffffff', // white rings the family-colored silhouette against the navy land (silhouette separation)
+    floatColors: { outline: '#e8edf4', halo: '#7fd0ff' }, // outline 6.72:1 vs #45516E (≥3:1) ✓
+    // C5-supplied AA-passing palette vs #45516E — water is LIGHTER than the shared
+    // dark #9db4d8 (3.75:1 = FAIL); all three tiers clear ≥4.5:1 AA:
+    //   road  #f2f2f2 = 7.06:1 | place #e6e6e6 = 6.34:1 | water #b8cae6 = 4.76:1
+    darkLabelTextColors: { road: '#f2f2f2', place: '#e6e6e6', water: '#b8cae6' },
   },
 };
 
@@ -129,12 +165,3 @@ export const BASEMAP_LIGHT: string = THEME_REGISTRY.positron.url;
 
 /** Real dark tile URL — G8 closed 2026-05-16 (Phase 4, PR #582, issue #573). */
 export const BASEMAP_DARK: string = THEME_REGISTRY.dark.url;
-
-/** @deprecated Use BASEMAP_LIGHT — alias preserved for back-compat. */
-export const basemapStyle = BASEMAP_LIGHT;
-
-/** @deprecated Use BASEMAP_LIGHT — alias preserved for back-compat. */
-export const basemapStyleLight = BASEMAP_LIGHT;
-
-/** @deprecated Use BASEMAP_DARK — alias preserved for back-compat. */
-export const basemapStyleDark = BASEMAP_DARK;

--- a/knip.ts
+++ b/knip.ts
@@ -199,27 +199,16 @@ const config: KnipConfig = {
       //             Re-audit 2026-07-27: remove if those types gain import
       //             sites knip can trace, or drop the types if still unused.
       //
-      // 2026-05-10: basemap-style.ts — basemapStyleLight and basemapStyleDark
-      //             both alias the same OpenFreeMap positron URL string. Knip
-      //             correctly detects the duplicate value and reports it as a
-      //             "Duplicate exports" finding. The aliasing is INTENTIONAL
-      //             and gated on G7/G8 (family-palette × dark-tile contrast):
-      //             dark resolves to the light URL until the gate closes, at
-      //             which point basemapStyleDark switches to the real dark URL
-      //             and the duplicate goes away. Until then, both names are
-      //             part of the public mechanism contract — the MapCanvas
-      //             MutationObserver imports both names by their semantic role,
-      //             so collapsing them would force a rename when G8 closes.
-      //             Risk: masks a genuine duplicate export added later under
-      //             this file. Re-audit 2026-07-27 by confirming both names
-      //             are still consumed by MapCanvas.tsx OR the dark URL has
-      //             diverged from the light one.
+      // 2026-06-14: basemap-style.ts ignore REMOVED (C6, #1218). It silenced
+      //             the "Duplicate exports" finding for basemapStyleLight/
+      //             basemapStyleDark, which both aliased the positron URL while
+      //             G7/G8 were open. G8 closed (dark URL diverged) and C6 now
+      //             registers all 5 descriptors and DELETES the three deprecated
+      //             basemapStyle* aliases (zero callers outside the module), so
+      //             there is no duplicate export left to silence — the ignore is
+      //             retired rather than reasoned about.
       ignore: [
         'src/tokens.ts',
-        // basemap-style.ts moved to map/geometry/ in the by-kind map split.
-        // Still ignored: basemapStyleLight/basemapStyleDark intentionally alias
-        // the same positron URL (gated on G7/G8) — see the note above.
-        'src/components/map/geometry/basemap-style.ts',
         // ds/index.ts barrel deleted in the map split (it had zero importers —
         // all consumers import ds/ primitives by direct path), so the ignore
         // entry that silenced its "unused barrel" finding is gone with it.


### PR DESCRIPTION
## Diagrams

```mermaid
graph LR
    L["LAND_COLORS (5 lands, frozen in C1)"] --> R["THEME_REGISTRY"]
    R --> P["positron — light (live)"]
    R --> B["bright — light (NEW, dormant)"]
    R --> Li["liberty — light (NEW, dormant)"]
    R --> D["dark — dark (live)"]
    R --> F["fiord — dark (NEW, dormant)"]
    F -.->|"AA-gated dark labels vs #45516E"| G["road #f2f2f2 / place #e6e6e6 / water #b8cae6"]
    R -.->|"no selector until C8"| N["nothing reachable — prod stays positron/dark"]
```

## Summary

- **Why:** the decoupling (C1–C5) made the basemap a swappable descriptor; this child populates the registry with the remaining three OpenFreeMap styles so C8's selector has all five to offer. Nothing is user-reachable yet — purely additive registration.
- Widen `ThemeId` to `'positron'|'bright'|'liberty'|'dark'|'fiord'` and add the three descriptors, each `landColor` sourced from C1's frozen `LAND_COLORS`. Colors are **audit-gated**: light floats clear ≥3:1 vs `#f8f4f0`; fiord's dark labels were lightened to clear ≥4.5 AA vs the navy `#45516E` (the shared `#9db4d8` water = 3.75:1 failed → `#b8cae6`).
- Satisfy the C5 fiord `it.todo` and re-point C2's `FIORD_LIKE` measured-gate test at `resolveDescriptor('fiord')`; delete the deprecated `basemapStyle*` aliases + their `knip.ts` ignore (zero callers, `knip` exit 0).

## Screenshots

N/A — registry only; no theme is reachable until the C8 selector, so there is **no visual change** on prod (positron/dark remain the only resolved themes).

## Test plan

- [x] `tsc -b frontend` exit 0 and `npm run test` (frontend) — **91 files / 1609 tests pass**
- [x] Contrast audits auto-extend to the 3 new descriptors and pass (fiord dark labels ≥4.5 AA vs `#45516E`; light floats ≥3:1 vs `#f8f4f0`; silhouette + notable-amber matrices green)
- [x] `npx knip` exit 0 **after** removing the `basemapStyle*` aliases + their ignore rule (cleanup, not a new ignore)
- [x] `npm run build` — clean
- [ ] e2e — N/A, behavior-preserving (no user-visible change; no theme reachable until C8)

## Plan reference

Out of plan — plans live in issues. Closes #1218 (child C6 of epic #1221).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
