### PR TITLE
feat(frontend): chrome [data-theme] derived from descriptor.kind; generalize boot-theme; shared applyTheme write path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -71,41 +71,69 @@
     }
     </script>
     <!--
-      Inline blocking script: sets [data-theme] on <html> before first paint
-      to prevent FOUC. Reads localStorage['theme']; falls back to
-      prefers-color-scheme on first visit. User's explicit toggle takes
-      precedence over the OS preference after first load.
+      Inline blocking script: sets [data-theme] (chrome polarity) on <html>
+      before first paint to prevent FOUC. The active THEME ID is the source of
+      truth; [data-theme] is DERIVED from the id's kind. Resolution:
+        1. localStorage['theme'] → a known ThemeId, or the legacy chrome values
+           'light'→'positron' / 'dark'→'dark' via the back-compat shim;
+        2. prefers-color-scheme: dark → the 'dark' id;
+        3. 'positron' — the light default (C7 keeps positron; C8 flips to bright).
+      Then [data-theme] = ID_TO_KIND[id].
 
       Both localStorage and matchMedia are wrapped in try/catch:
       Safari Private Browsing and sandboxed iframes throw SecurityError
       on storage access. Without the wrap the script would abort and
       [data-theme] would never be set, producing a FOUC.
 
-      The resolution rules are mirrored in src/utils/boot-theme.ts and
-      unit-tested there; any change to the rules MUST be applied in both
-      places.
+      The resolution rules — including the ID_TO_KIND map below — are mirrored
+      in src/utils/boot-theme.ts and unit-tested there. THEME_REGISTRY (in
+      src/components/map/geometry/basemap-style.ts) is the SOURCE OF TRUTH for
+      the id→kind kinds; this object literal duplicates them because the inline
+      script can't import the module. boot-theme.test.ts imports BOTH this map
+      and the module's ID_TO_KIND and asserts equality so they can never drift.
+      Any change to the rules MUST be applied in both places.
 
-      Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+      Spec: docs/design/01-spec/tokens.md §Light/dark mechanic — Epic #1221 (C7 · #1219)
     -->
     <script>
       (function () {
-        var t = null;
+        // id → kind. SOURCE OF TRUTH: THEME_REGISTRY in
+        // src/components/map/geometry/basemap-style.ts (duplicated here because
+        // this blocking script cannot import the module; kept in sync by a test).
+        var ID_TO_KIND = {
+          positron: 'light',
+          bright: 'light',
+          liberty: 'light',
+          dark: 'dark',
+          fiord: 'dark'
+        };
+        var stored = null;
         try {
-          t = localStorage.getItem('theme');
+          stored = localStorage.getItem('theme');
         } catch (e) {
           // SecurityError (Safari Private Browsing, sandboxed iframe)
           // — fall through to the prefers-color-scheme branch.
         }
-        if (t !== 'light' && t !== 'dark') {
+        // Resolve the active id. Back-compat shim (READ path only): legacy
+        // chrome values 'light'→'positron', 'dark'→'dark'.
+        var id = null;
+        if (stored && ID_TO_KIND.hasOwnProperty(stored)) {
+          id = stored;
+        } else if (stored === 'light') {
+          id = 'positron';
+        } else if (stored === 'dark') {
+          id = 'dark';
+        }
+        if (id === null) {
           try {
-            t = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+            id = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
               ? 'dark'
-              : 'light';
+              : 'positron';
           } catch (e) {
-            t = 'light';
+            id = 'positron';
           }
         }
-        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.setAttribute('data-theme', ID_TO_KIND[id]);
       })();
     </script>
   </head>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,20 +1,31 @@
 import { useState, useCallback, useRef } from 'react';
-
-type Theme = 'light' | 'dark';
+import { applyTheme, type Theme } from '../utils/boot-theme.js';
+import type { ThemeId } from '@/components/map/geometry/basemap-style.js';
 
 function readCurrentTheme(): Theme {
   const attr = document.documentElement.getAttribute('data-theme');
   return attr === 'dark' ? 'dark' : 'light';
 }
 
+// The two themes reachable through the toggle (C7): the light/dark polarity it
+// flips between maps to these ids. The selector (C8) replaces this binary with
+// the full registry; until then the toggle is light↔dark = positron↔dark.
+const POLARITY_TO_ID: Record<Theme, ThemeId> = {
+  light: 'positron',
+  dark: 'dark',
+};
+
 /**
- * ThemeToggle — header button that flips [data-theme] on <html>.
+ * ThemeToggle — header button that flips the chrome polarity light↔dark.
  *
- * Writes both localStorage['theme'] (for persistence across page loads,
- * read by the inline blocking script in index.html) and the attribute on
- * document.documentElement (so CSS responds immediately without a reload).
+ * Routes its click through the single `applyTheme` write path (boot-theme.ts):
+ * it maps the next polarity to a ThemeId (positron↔dark), and `applyTheme`
+ * derives `[data-theme]` from that descriptor's kind and persists the ID under
+ * localStorage['theme'] (read on next load by the inline blocking script in
+ * index.html). C8 may replace this toggle with the full theme selector; until
+ * then it shares the ONE write path so chrome + basemap stay in lockstep.
  *
- * The MutationObserver in MapCanvas.tsx observes data-theme changes and
+ * The MutationObserver in `useStateArtboard` observes data-theme changes and
  * swaps the basemap style accordingly — no prop-drilling needed.
  *
  * A11y (#416): the live-region is a visually-hidden <span> sibling to the
@@ -25,7 +36,7 @@ function readCurrentTheme(): Theme {
  * has NO aria-live — that's the fix.
  *
  * Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
- * Spec: docs/design/01-spec/architecture.md §Persistent chrome
+ * Spec: docs/design/01-spec/architecture.md §Persistent chrome — Epic #1221 (C7 · #1219)
  */
 export function ThemeToggle() {
   const [theme, setTheme] = useState<Theme>(readCurrentTheme);
@@ -33,14 +44,10 @@ export function ThemeToggle() {
 
   const toggle = useCallback(() => {
     const next: Theme = theme === 'light' ? 'dark' : 'light';
-    document.documentElement.setAttribute('data-theme', next);
-    try {
-      localStorage.setItem('theme', next);
-    } catch {
-      // Storage failures (Safari Private Browsing, sandboxed iframe,
-      // quota exceeded) are non-fatal — [data-theme] is the in-session
-      // source of truth, the only loss is persistence across reloads.
-    }
+    // Single write path: applyTheme resolves the descriptor, writes
+    // [data-theme] from its kind (== `next` here, positron→light / dark→dark),
+    // and persists the id. Storage failures are swallowed inside applyTheme.
+    applyTheme(POLARITY_TO_ID[next]);
     // Announce the new theme to screen readers via the sibling live region
     // (NOT via aria-live on the button — see #416).
     if (liveRef.current) {

--- a/frontend/src/components/map/hooks/use-state-artboard.test.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.test.ts
@@ -578,6 +578,28 @@ const SYN_DARK_B: BasemapDescriptor = {
   floatColors: { outline: '#fff', halo: '#fff' },
 };
 
+// Two SAME-KIND (light) synthetic descriptors keyed by DISTINCT light ids. Used
+// by the belt-re-seed regression: a `positron`→`bright`-style change keeps
+// `[data-theme]` === 'light', so the belt observer that re-seeds the de-dup ref
+// from the ATTRIBUTE (pre-C7) would collapse the active id to its kind-bridge
+// value ('positron') and desync the ref from the actually-swapped id.
+const SYN_LIGHT_POSITRON: BasemapDescriptor = {
+  id: 'positron',
+  url: 'syn://light-positron',
+  kind: 'light',
+  landColor: '#ffffff',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#000', halo: '#000' },
+};
+const SYN_LIGHT_BRIGHT: BasemapDescriptor = {
+  id: 'bright',
+  url: 'syn://light-bright',
+  kind: 'light',
+  landColor: '#ffffff',
+  markerHaloColor: '#ffffff',
+  floatColors: { outline: '#000', halo: '#000' },
+};
+
 describe('useStateArtboard — id-driven basemap swap (C1.5 · #1213)', () => {
   beforeEach(() => {
     document.documentElement.removeAttribute('data-theme');
@@ -658,5 +680,50 @@ describe('useStateArtboard — id-driven basemap swap (C1.5 · #1213)', () => {
         'https://tiles.openfreemap.org/styles/dark',
       ),
     );
+  });
+
+  // ── C7 (#1219) belt-re-seed regression ────────────────────────────────────
+  // The belt MutationObserver effect re-seeds `prevThemeIdRef` on every run. C7
+  // re-seeds it from the ACTIVE THEME ID (the id the primary effect swapped to),
+  // NOT from `attrToThemeId([data-theme])`. The trap: a SAME-KIND id change keeps
+  // `[data-theme]` === 'light', so the old attribute re-seed would set the ref to
+  // 'positron' (the kind bridge) even when the live basemap is `bright` — a
+  // desync that would wrongly de-dup the next swap back to positron. With the
+  // active-id re-seed the ref stays consistent with the live basemap.
+  it('belt re-seed from the active id: a SAME-KIND id change still swaps the basemap (the desync trap)', () => {
+    // [data-theme] stays 'light' throughout — the kind never changes, so the
+    // OLD belt re-seed `attrToThemeId('light')` always produced 'positron'.
+    document.documentElement.setAttribute('data-theme', 'light');
+    const fake = makeFakeMap({ withMask: false });
+    const ref = makeRef(fake.map);
+
+    const synRegistry: Record<string, BasemapDescriptor> = {
+      positron: SYN_LIGHT_POSITRON,
+      bright: SYN_LIGHT_BRIGHT,
+    };
+    const resolver = (id: ThemeId): BasemapDescriptor =>
+      synRegistry[id as string] ?? SYN_LIGHT_POSITRON;
+
+    // Mount with the NON-positron light id `bright`. The primary effect swaps to
+    // bright and sets prevThemeIdRef='bright'. The OLD belt effect (which ran on
+    // mount) then re-seeded prevThemeIdRef = attrToThemeId('light') = 'positron'
+    // — CLOBBERING the correct 'bright' even though the live basemap is bright.
+    const { rerender } = renderHook(
+      ({ id }: { id: ThemeId }) =>
+        useStateArtboard(ref, true, null, id, resolver),
+      { initialProps: { id: 'bright' as ThemeId } },
+    );
+
+    expect(SYN_LIGHT_POSITRON.kind).toBe(SYN_LIGHT_BRIGHT.kind); // same-kind
+    expect(fake.map.setStyle).toHaveBeenCalledWith('syn://light-bright');
+    (fake.map.setStyle as ReturnType<typeof vi.fn>).mockClear();
+
+    // bright → positron: SAME kind ('light'), [data-theme] unchanged. With the
+    // OLD attribute re-seed the ref was clobbered to 'positron' at mount, so
+    // this swap is WRONGLY de-duped ('positron' === ref) and sticks on bright.
+    // With the active-id re-seed the ref tracked 'bright', so positron swaps.
+    rerender({ id: 'positron' as ThemeId });
+    expect(fake.map.setStyle).toHaveBeenCalledTimes(1);
+    expect(fake.map.setStyle).toHaveBeenCalledWith('syn://light-positron');
   });
 });

--- a/frontend/src/components/map/hooks/use-state-artboard.ts
+++ b/frontend/src/components/map/hooks/use-state-artboard.ts
@@ -434,11 +434,17 @@ export function useStateArtboard(
     const map = mapRef.current?.getMap();
     if (!map) return;
 
-    // Seed the de-dup ref with the current attribute's id so the first observed
-    // mutation only swaps when the id genuinely changes.
-    prevThemeIdRef.current = attrToThemeId(
-      document.documentElement.getAttribute('data-theme'),
-    );
+    // Seed the de-dup ref with the ACTIVE THEME ID — NOT `attrToThemeId(attr)`
+    // (C7 · #1219). Now that C7 lets the active id DIVERGE from `[data-theme]`
+    // (which only holds the kind), re-seeding from the attribute would collapse
+    // the active id to its kind-consistent bridge value (`'dark'`→dark, else
+    // `'positron'`). For a non-positron light id (e.g. `bright`) that desyncs
+    // the ref from the actually-swapped id, so a later attribute write that
+    // resolves to the SAME id is wrongly de-duped — sticking a swap. Seeding
+    // from `activeThemeId` (the id the primary effect already swapped to) keeps
+    // the ref consistent with the live basemap. `activeThemeId` is in the deps
+    // so this re-seeds whenever the active id changes.
+    prevThemeIdRef.current = activeThemeId;
 
     const observer = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
@@ -461,7 +467,7 @@ export function useStateArtboard(
     });
 
     return () => observer.disconnect();
-  }, [mapReady]);
+  }, [mapReady, activeThemeId]);
 
   return { maskTheme };
 }

--- a/frontend/src/utils/boot-theme.test.ts
+++ b/frontend/src/utils/boot-theme.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { resolveInitialTheme, applyInitialTheme } from './boot-theme.js';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  resolveInitialTheme,
+  applyInitialTheme,
+  applyTheme,
+  ID_TO_KIND,
+  THEME_STORAGE_KEY,
+} from './boot-theme.js';
+import { THEME_REGISTRY } from '@/components/map/geometry/basemap-style.js';
 import { setMatchMedia, resetMatchMedia } from '../test-setup.js';
 
 /**
- * Tests for the theme-boot resolution logic. Mirrors what the inline
- * blocking script in index.html does — any change to the rules must be
- * applied in both places.
+ * Tests for the theme-boot resolution + the single `applyTheme` write path
+ * (C7 · #1219). The active THEME ID is the source of truth; `[data-theme]` is
+ * DERIVED from the id's kind. These tests mirror what the inline blocking
+ * script in index.html does — any change to the rules must be applied in both
+ * places, and the import-both-and-assert-equal test below pins the duplicated
+ * id→kind map so it can never drift.
  *
  * The SecurityError tests guard the Safari Private Browsing / sandboxed-
  * iframe failure mode where localStorage.getItem throws synchronously.
@@ -26,24 +38,47 @@ describe('resolveInitialTheme', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns the stored value when localStorage has "light"', () => {
-    localStorage.setItem('theme', 'light');
-    expect(resolveInitialTheme()).toBe('light');
+  it('returns the persisted id verbatim when localStorage has a known ThemeId ("positron")', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'positron');
+    expect(resolveInitialTheme()).toBe('positron');
   });
 
-  it('returns the stored value when localStorage has "dark"', () => {
-    localStorage.setItem('theme', 'dark');
+  it('returns the persisted id verbatim when localStorage has "dark"', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     expect(resolveInitialTheme()).toBe('dark');
   });
 
-  it('falls back to prefers-color-scheme when localStorage is empty', () => {
+  it('returns the persisted id verbatim for a non-default registered id ("bright")', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'bright');
+    expect(resolveInitialTheme()).toBe('bright');
+  });
+
+  it('back-compat: legacy persisted "light" maps to the "positron" id', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    expect(resolveInitialTheme()).toBe('positron');
+  });
+
+  it('back-compat: legacy persisted "dark" maps to the "dark" id', () => {
+    // 'dark' is both a legacy chrome value AND a registered id; either path
+    // resolves to the dark id.
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  it('ignores an unknown persisted value and falls through to OS preference', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'sepia');
     setMatchMedia((q) => q === '(prefers-color-scheme: dark)');
     expect(resolveInitialTheme()).toBe('dark');
   });
 
-  it('returns "light" when localStorage is empty and OS prefers light', () => {
+  it('falls back to the "dark" id when localStorage is empty and OS prefers dark', () => {
+    setMatchMedia((q) => q === '(prefers-color-scheme: dark)');
+    expect(resolveInitialTheme()).toBe('dark');
+  });
+
+  it('returns "positron" (the C7 light default) when localStorage is empty and OS prefers light', () => {
     setMatchMedia(() => false);
-    expect(resolveInitialTheme()).toBe('light');
+    expect(resolveInitialTheme()).toBe('positron');
   });
 
   it('does not crash and falls through to OS preference when localStorage.getItem throws SecurityError', () => {
@@ -57,7 +92,7 @@ describe('resolveInitialTheme', () => {
     expect(resolveInitialTheme()).toBe('dark');
   });
 
-  it('returns "light" as last resort when both localStorage and matchMedia throw', () => {
+  it('returns "positron" as last resort when both localStorage and matchMedia throw', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('Storage access denied', 'SecurityError');
     });
@@ -71,7 +106,54 @@ describe('resolveInitialTheme', () => {
     });
 
     expect(() => resolveInitialTheme()).not.toThrow();
-    expect(resolveInitialTheme()).toBe('light');
+    expect(resolveInitialTheme()).toBe('positron');
+  });
+});
+
+describe('applyTheme (single write path)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+  });
+
+  it('sets [data-theme] to the descriptor kind and persists the ID (positron → light)', () => {
+    const descriptor = applyTheme('positron');
+    expect(descriptor.id).toBe('positron');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('positron');
+  });
+
+  it('sets [data-theme] to the descriptor kind and persists the ID (dark → dark)', () => {
+    applyTheme('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+  });
+
+  it('a light-KIND non-positron id derives [data-theme]=light but persists its OWN id (bright)', () => {
+    // The chrome attribute diverges from the id here — the C7 contract.
+    applyTheme('bright');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('bright');
+  });
+
+  it('a dark-KIND non-dark id derives [data-theme]=dark but persists its OWN id (fiord)', () => {
+    applyTheme('fiord');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('fiord');
+  });
+
+  it('still writes [data-theme] when localStorage.setItem throws — no crash, persistence forfeit', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage access denied', 'SecurityError');
+    });
+    expect(() => applyTheme('dark')).not.toThrow();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 });
 
@@ -84,24 +166,87 @@ describe('applyInitialTheme', () => {
   afterEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
+    resetMatchMedia();
     vi.restoreAllMocks();
   });
 
-  it('sets [data-theme] on documentElement to the resolved value', () => {
-    localStorage.setItem('theme', 'dark');
-    applyInitialTheme();
+  it('sets [data-theme] on documentElement to the resolved id\'s kind', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    expect(applyInitialTheme()).toBe('dark');
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('legacy persisted "light" resolves to positron and writes [data-theme]=light', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    expect(applyInitialTheme()).toBe('positron');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
   it('still sets [data-theme] when localStorage throws — no FOUC', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new DOMException('Storage access denied', 'SecurityError');
     });
+    setMatchMedia(() => false);
 
     expect(() => applyInitialTheme()).not.toThrow();
     // The attribute MUST be set so first-paint CSS resolves correctly,
     // even when persistence is unavailable.
     const attr = document.documentElement.getAttribute('data-theme');
     expect(attr === 'light' || attr === 'dark').toBe(true);
+  });
+});
+
+describe('ID_TO_KIND is derived from THEME_REGISTRY', () => {
+  it('matches every registered descriptor\'s kind', () => {
+    const fromRegistry = Object.fromEntries(
+      Object.values(THEME_REGISTRY).map((d) => [d.id, d.kind]),
+    );
+    expect(ID_TO_KIND).toEqual(fromRegistry);
+  });
+});
+
+describe('inline FOUC script mirrors the module (no drift)', () => {
+  /**
+   * Parse the `ID_TO_KIND` object literal out of the inline blocking
+   * <script> in index.html. The inline script CANNOT import the module, so it
+   * duplicates the map verbatim; this test imports BOTH and asserts equality so
+   * a future edit to one (and not the other) fails CI rather than shipping a
+   * FOUC/wrong-polarity drift.
+   */
+  function readInlineIdToKind(): Record<string, string> {
+    // Resolve index.html relative to the working directory. vitest runs from the
+    // frontend workspace root (`<repo>/frontend`); the `frontend/` fallback keeps
+    // this green if invoked from the repo root.
+    const candidates = [
+      join(process.cwd(), 'index.html'),
+      join(process.cwd(), 'frontend', 'index.html'),
+    ];
+    const indexHtmlPath = candidates.find((p) => existsSync(p));
+    if (!indexHtmlPath) {
+      throw new Error(
+        `Could not locate index.html (looked in: ${candidates.join(', ')}).`,
+      );
+    }
+    const html = readFileSync(indexHtmlPath, 'utf8');
+    const match = html.match(/var ID_TO_KIND = (\{[^}]*\})/);
+    if (!match) {
+      throw new Error(
+        'Could not locate `var ID_TO_KIND = {…}` in index.html — the inline ' +
+          'FOUC script must declare the id→kind map for the mirror test.',
+      );
+    }
+    // The literal uses unquoted keys + single quotes — wrap to JS-eval it.
+    // eslint-disable-next-line no-new-func
+    return Function(`return (${match[1]});`)() as Record<string, string>;
+  }
+
+  it('the inline script id→kind map equals the module ID_TO_KIND', () => {
+    expect(readInlineIdToKind()).toEqual(ID_TO_KIND);
+  });
+
+  it('the inline script id→kind map covers all 5 registered ids', () => {
+    expect(Object.keys(readInlineIdToKind()).sort()).toEqual(
+      Object.keys(THEME_REGISTRY).sort(),
+    );
   });
 });

--- a/frontend/src/utils/boot-theme.ts
+++ b/frontend/src/utils/boot-theme.ts
@@ -1,17 +1,29 @@
 /**
- * Theme boot logic — resolves the initial [data-theme] value before first
- * paint to prevent FOUC.
+ * Theme boot + apply logic — resolves the initial theme id before first
+ * paint to prevent FOUC, and owns the single `applyTheme` write path that
+ * derives `[data-theme]` (chrome polarity) from the active descriptor's kind.
  *
  * Mirrors the inline blocking script in index.html. The inline script is
  * load-bearing (must execute before first paint, can't be a deferred
- * module), so it duplicates this logic verbatim. This module exists so
- * the resolution rules are unit-testable; any change to the rules MUST
- * be applied in both places.
+ * module), so it duplicates the RESOLUTION logic verbatim — including the
+ * id→kind lookup. This module exists so the resolution rules are
+ * unit-testable; any change to the rules MUST be applied in both places, and
+ * `ID_TO_KIND` below is the map the inline script duplicates (a test imports
+ * both and asserts equality so they can never drift).
  *
- * Resolution order:
- *   1. localStorage['theme']  → 'light' | 'dark' (explicit user preference)
- *   2. prefers-color-scheme   → OS-level preference fallback
- *   3. 'light'                → safe default when both sources fail
+ * The active THEME ID is the source of truth (C1.5 · #1213): `[data-theme]`
+ * is DERIVED from `resolveDescriptor(id).kind`. The persisted value lives under
+ * `localStorage['theme']` and is now the ID (`'positron'`, `'dark'`, …), with a
+ * back-compat shim that maps the legacy `'light'`/`'dark'` chrome values to the
+ * `'positron'`/`'dark'` ids on the READ path only — so existing users keep
+ * their choice across the key-value change.
+ *
+ * Resolution order (`resolveInitialTheme`):
+ *   1. localStorage['theme']  → a known ThemeId, OR a legacy 'light'/'dark'
+ *                               value mapped via the back-compat shim.
+ *   2. prefers-color-scheme   → 'dark' when the OS prefers dark.
+ *   3. 'positron'             → safe light default (C7 keeps positron; the flip
+ *                               to 'bright' is C8's job — do NOT change here).
  *
  * Both localStorage access and matchMedia access can throw:
  *   - localStorage throws SecurityError in Safari Private Browsing and
@@ -19,26 +31,83 @@
  *   - matchMedia is undefined in older test environments.
  *
  * Storage failures are non-fatal — the theme falls through to the OS
- * preference (or 'light' as last resort), and the in-session [data-theme]
- * attribute remains the source of truth until the next page load.
+ * preference (or the positron default), and the in-session [data-theme]
+ * attribute remains the chrome source of truth until the next page load.
  *
  * Spec: docs/design/01-spec/tokens.md §Light/dark mechanic
+ * Epic #1221 (C7 · #1219).
  */
 
-export type Theme = 'light' | 'dark';
+import {
+  THEME_REGISTRY,
+  resolveDescriptor,
+  type ThemeId,
+  type BasemapDescriptor,
+  type BasemapKind,
+} from '@/components/map/geometry/basemap-style.js';
 
-export function resolveInitialTheme(): Theme {
+/**
+ * Chrome polarity. `[data-theme]` only ever holds one of these two values —
+ * it is DERIVED from the active descriptor's `kind`. Re-exported (and re-used
+ * by `use-theme.ts`, which reads the derived attribute) as the canonical
+ * polarity type. Distinct from `ThemeId`, which names a specific basemap style.
+ */
+export type Theme = BasemapKind;
+
+/** The `localStorage` key the persisted theme id lives under (legacy key, kept). */
+export const THEME_STORAGE_KEY = 'theme';
+
+/** The known theme ids — derived from the registry so it can never go stale. */
+const KNOWN_THEME_IDS = Object.keys(THEME_REGISTRY) as ThemeId[];
+
+/**
+ * id → kind map. The single source of truth is `THEME_REGISTRY` (each
+ * descriptor's `kind`); this is the flattened lookup the chrome boot path
+ * needs. The inline blocking `<script>` in index.html DUPLICATES this object
+ * literal verbatim (it cannot import the module) — `boot-theme.test.ts` imports
+ * BOTH and asserts equality so they can never drift.
+ */
+export const ID_TO_KIND: Record<ThemeId, BasemapKind> = Object.fromEntries(
+  KNOWN_THEME_IDS.map((id) => [id, THEME_REGISTRY[id].kind]),
+) as Record<ThemeId, BasemapKind>;
+
+/** Type guard: is `value` a registered `ThemeId`? */
+function isThemeId(value: string | null): value is ThemeId {
+  return value !== null && Object.prototype.hasOwnProperty.call(ID_TO_KIND, value);
+}
+
+/**
+ * Back-compat shim (READ path only): map a persisted value to a `ThemeId`.
+ * Returns a known id unchanged; maps the legacy chrome values `'light'` →
+ * `'positron'` and `'dark'` → the `'dark'` id; returns `null` for anything
+ * unrecognized so the caller falls through to OS preference / default.
+ */
+function persistedToThemeId(value: string | null): ThemeId | null {
+  if (isThemeId(value)) return value;
+  if (value === 'light') return 'positron'; // legacy chrome value → positron id
+  if (value === 'dark') return 'dark'; // legacy chrome value → dark id (id === kind)
+  return null;
+}
+
+/**
+ * Resolve the initial active `ThemeId` before first paint.
+ *
+ *   1. persisted `localStorage['theme']` (known id, or legacy 'light'/'dark'
+ *      via the back-compat shim);
+ *   2. `prefers-color-scheme: dark` → the `'dark'` id;
+ *   3. `'positron'` — the light default (C7 keeps positron; C8 flips to bright).
+ */
+export function resolveInitialTheme(): ThemeId {
   let stored: string | null = null;
   try {
-    stored = window.localStorage.getItem('theme');
+    stored = window.localStorage.getItem(THEME_STORAGE_KEY);
   } catch {
     // SecurityError (Safari Private Browsing, sandboxed iframe) — fall
     // through to the prefers-color-scheme branch.
   }
 
-  if (stored === 'dark' || stored === 'light') {
-    return stored;
-  }
+  const fromStorage = persistedToThemeId(stored);
+  if (fromStorage !== null) return fromStorage;
 
   try {
     if (
@@ -51,11 +120,40 @@ export function resolveInitialTheme(): Theme {
     // matchMedia rarely throws but is defensively wrapped — fall through.
   }
 
-  return 'light';
+  return 'positron';
 }
 
-export function applyInitialTheme(): Theme {
-  const theme = resolveInitialTheme();
-  document.documentElement.setAttribute('data-theme', theme);
-  return theme;
+/**
+ * The single theme write path (C7 · #1219). Used by the toggle (C7) and the
+ * selector (C8): resolves the descriptor, writes `[data-theme]` from its
+ * `kind`, and persists the ID under `localStorage['theme']`. Returns the
+ * resolved descriptor so callers can drive the id-keyed basemap swap.
+ *
+ * The active-theme-id React state (`useActiveThemeId`, C1.5) reads the derived
+ * `[data-theme]` via its mount seed + the belt MutationObserver, so writing the
+ * attribute here keeps the basemap swap in lockstep without a setter injection.
+ */
+export function applyTheme(id: ThemeId): BasemapDescriptor {
+  const descriptor = resolveDescriptor(id);
+  document.documentElement.setAttribute('data-theme', descriptor.kind);
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, id);
+  } catch {
+    // Storage failures (Safari Private Browsing, sandboxed iframe, quota
+    // exceeded) are non-fatal — [data-theme] is the in-session source of
+    // truth; the only loss is persistence across reloads.
+  }
+  return descriptor;
+}
+
+/**
+ * Resolve the initial id and write `[data-theme]` from its descriptor kind
+ * before first paint. Does NOT persist (the resolved value may BE the persisted
+ * value, or an OS/default fallback that should not overwrite an empty store).
+ * Returns the resolved id.
+ */
+export function applyInitialTheme(): ThemeId {
+  const id = resolveInitialTheme();
+  document.documentElement.setAttribute('data-theme', ID_TO_KIND[id]);
+  return id;
 }


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph Boot["Boot (FOUC-free, before first paint)"]
        IH["index.html inline script<br/>(mirrors resolveInitialTheme)"]
        IH -->|"read localStorage['theme']"| SHIM["back-compat shim:<br/>known id OR 'light'→positron / 'dark'→dark"]
        SHIM -->|"none → prefers-color-scheme:<br/>dark→dark, else positron"| KIND["ID_TO_KIND[id]"]
        KIND --> ATTR["set [data-theme] = kind"]
    end

    subgraph Apply["applyTheme(id) — the ONE write path"]
        AT["applyTheme(id)"] --> RES["resolveDescriptor(id)"]
        RES --> W1["[data-theme] = descriptor.kind"]
        RES --> W2["localStorage['theme'] = id"]
    end

    Toggle["ThemeToggle click<br/>(positron ↔ dark)"] --> AT
    C8["theme selector (C8, future)"] -.-> AT

    W1 --> BELT["belt MutationObserver<br/>(use-state-artboard)"]
    BELT -->|"attrToThemeId(attr) → performSwap"| SWAP["basemap setStyle + mask re-tint"]
    PRIM["primary effect keyed on activeThemeId"] --> SWAP
    PRIM -.->|"belt re-seeds prevThemeIdRef<br/>from ACTIVE ID, not attr (C7 fix)"| BELT
```

## Summary

- **Why:** the active THEME ID is the source of truth (C1.5); `[data-theme]` (chrome polarity) must be *derived* from `resolveDescriptor(id).kind`, not written as a raw `'light'|'dark'` literal. This child generalizes the chrome/boot plumbing so one `applyTheme(id)` call drives the chrome attribute + persistence (and, via the existing belt observer, the basemap swap) — **without yet adding the selector UI**.
- **Behavior-preserving:** with only `positron`/`dark` reachable, the toggle flips `[data-theme]` light↔dark and swaps the basemap exactly as today. The default stays **`positron`** (the flip to `bright` is C8's job, #1220 — not changed here). Every existing theme-flip e2e (`basemap-dark-flip.spec.ts`) drives via `setAttribute('data-theme', …)` — an *attribute* write, immune to the localStorage key/value change (which touches only the read/persist path).
- **localStorage key decision:** the `'theme'` key is kept but now stores the **id** (`'positron'`,`'dark'`,…); a legacy `'light'→'positron'`/`'dark'→'dark'` shim lives **only in the read path**, so existing users keep their choice. The inline `index.html` script and `boot-theme.ts` agree by construction — a unit test imports both id→kind maps and asserts equality.
- **C1.5 carry-over fix:** the belt MutationObserver in `use-state-artboard.ts` now re-seeds the id-keyed de-dup ref (`prevThemeIdRef`) from the **active theme id**, not `[data-theme]`. Now that the id can diverge from the attribute kind, an attribute re-seed would collapse a non-positron light id (e.g. `bright`) to `positron` and stick a later swap. New regression test fails on the old attribute re-seed, passes on the active-id re-seed.

## Screenshots

N/A — behavior-preserving; toggle unchanged, no theme reachable until C8. The toggle looks and acts identically (same ☀/☾ glyph-swap, same `aria-label`/`aria-pressed`, same #416 live region); `[data-theme]` still flips `light`↔`dark` and the basemap swaps exactly as on `main`. No theme beyond `positron`/`dark` is reachable until the C8 selector lands.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className added/renamed` (logic + boot only)
- [x] Multi-viewport design QA — `N/A — not UI` (behavior-preserving; no visual delta)

## Test plan

- [x] `npm run test --workspace @bird-watch/frontend` — green (91 files, 1623 tests)
- [x] New unit / integration tests added — generalized `boot-theme.test.ts` (resolver returns `ThemeId`, legacy shim, `applyTheme` derive+persist incl. divergent `bright`/`fiord`, inline-script id→kind **import-both-and-assert-equal**), + belt-re-seed regression in `use-state-artboard.test.ts` (verified failing on the old attribute re-seed, passing on the active-id re-seed)
- [x] New Playwright e2e spec — `N/A` (behavior-preserving; existing attribute-driven theme specs pass unchanged)
- [x] `npm run build --workspace @bird-watch/frontend` — clean production build
- [x] `bash scripts/ci/check-orphan-classnames.sh` — PASS; `npx knip` — exit 0; `npx tsc -b frontend` — exit 0; `npm run lint` + forbidden-token guard — PASS
- [x] (UI only) Playwright MCP smoke — `N/A — behavior-preserving, no UI delta`

## Plan reference

Part of #1221 (epic), child C7. Closes #1219. Depends on C1 (#1212), C1.5 (#1213), C6 (#1218) — all merged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
