### PR TITLE
fix(frontend): guard clusters-hit queryRenderedFeatures against an absent layer (#1231)

### DIFF
--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -94,6 +94,13 @@ function makeFakeMap() {
     // Stray basemap line/fill layers painted ABOVE the mask (sink targets).
     layers.push({ id: 'boundary_country', type: 'line' });
     layers.push({ id: 'landcover_glacier', type: 'fill' });
+    // The `clusters-hit` overlay layer (added at runtime by the React <Layer>;
+    // the mocked react-map-gl <Layer> renders a DOM marker but does NOT register
+    // with getLayer). Seed it so the #1231 `getLayer('clusters-hit')` guard lets
+    // the cluster reconciler's queryRenderedFeatures through — matching the real
+    // app, where the layer exists except during a transient scope/style rebuild.
+    // `source: 'observations'` + no text-field keeps it out of isLabelLayer.
+    layers.push({ id: 'clusters-hit', type: 'circle', source: 'observations' });
     return layers;
   };
   let styleLayers = baseStyleLayers();
@@ -966,6 +973,51 @@ describe('MapCanvas', () => {
     });
 
     // No idle fired since the rerender → the prior-scope markers must be gone.
+    expect(
+      document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
+    ).toBe(0);
+  });
+
+  // #1231 — the invisible `clusters-hit` overlay layer is transiently absent
+  // while a scope flyTo / basemap rebuild tears it down and re-adds it. The
+  // reconciler's queryRenderedFeatures MUST be SKIPPED then: naming an absent
+  // layer makes maplibre log "layer 'clusters-hit' does not exist … cannot be
+  // queried", dirtying the console. The `getLayer` guard treats an absent layer
+  // as zero clusters; the next idle after it re-adds reconciles the pills.
+  it('#1231: skips the clusters-hit query (no layer-missing error) when the layer is absent', async () => {
+    const cluster = {
+      id: 1,
+      properties: { cluster_id: 1, point_count: 3 },
+      geometry: { type: 'Point', coordinates: [-110.9, 32.2] },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [cluster] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familyCode: 'tyrannidae' } },
+      ]),
+    });
+
+    // The layer is absent from the START (the transient teardown window) so NO
+    // reconcile — initial or idle-driven — ever queries it.
+    fakeMap.removeLayer('clusters-hit');
+
+    render(<MapCanvas observations={[makeObs({ subId: 'A1' })]} silhouettes={SILHOUETTES} />);
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+    await act(async () => {
+      await bareHandlers['idle']?.();
+    });
+
+    // The guard short-circuited: queryRenderedFeatures was NEVER asked for the
+    // absent clusters-hit layer (no maplibre layer-missing error), and no cluster
+    // marker reconciled.
+    const queriedClustersHit = fakeMap.queryRenderedFeatures.mock.calls.some(
+      ([, opts]: [unknown, { layers?: string[] } | undefined]) =>
+        opts?.layers?.includes('clusters-hit'),
+    );
+    expect(queriedClustersHit).toBe(false);
     expect(
       document.querySelectorAll('[data-testid="adaptive-grid-marker"]').length,
     ).toBe(0);

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1319,9 +1319,19 @@ export function MapCanvas({
       // are absent). Default to [] defensively — the maplibre instance can
       // return undefined when the map isn't ready yet (race between initial
       // idle event and the style having a renderable source).
-      const features = (map.queryRenderedFeatures(undefined, {
-        layers: ['clusters-hit'],
-      }) ?? []) as Array<{
+      //
+      // Defensive `getLayer` guard (#1231, mirrors the `unclustered-point`
+      // query below): during a scope `flyTo` or a basemap rebuild the custom
+      // `clusters-hit` layer is briefly torn down/re-added, and naming an absent
+      // layer in `queryRenderedFeatures` makes maplibre `console.error` "layer
+      // 'clusters-hit' does not exist … and cannot be queried". Treat an absent
+      // layer as zero features — the next idle after the layer re-adds reconciles
+      // the pills.
+      const features = ((
+        map.getLayer && map.getLayer('clusters-hit')
+          ? map.queryRenderedFeatures(undefined, { layers: ['clusters-hit'] })
+          : []
+      ) ?? []) as Array<{
         properties?: Record<string, unknown>;
         geometry?: unknown;
         id?: number;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Reconciler as cluster reconciler (idle/moveend)
    participant Map as maplibre map
    Note over Map: scope flyTo / basemap rebuild briefly tears down + re-adds clusters-hit
    Reconciler->>Map: getLayer('clusters-hit')
    alt layer present (normal)
        Map-->>Reconciler: layer
        Reconciler->>Map: queryRenderedFeatures({layers:['clusters-hit']})
        Map-->>Reconciler: cluster features → reconcile pills
    else layer absent (transient rebuild window)
        Map-->>Reconciler: undefined
        Note over Reconciler: SKIP the query → 0 clusters this pass (no console.error).<br/>next idle after the layer re-adds reconciles the pills
    end
```

## Summary

- Fixes the `Error: The layer 'clusters-hit' does not exist in the map's style and cannot be queried for features.` console.error seen on bird-maps.com after a scope transition (#1231). The cluster-pill reconciler queried the invisible `clusters-hit` overlay on every `idle`; the `?? []` it carried guards a maplibre **undefined return** but not the layer being **absent** during the transient teardown/re-add of a scope `flyTo` / basemap rebuild.
- The fix mirrors the `getLayer` guard the **sibling `unclustered-point` query a few lines below already uses** — skip the query when the layer is absent and treat it as zero clusters. Pure console hygiene; no rendering change (the result is `[]` either way when the layer is absent).

## Screenshots

N/A — non-visual console-hygiene change. The guard only affects whether `queryRenderedFeatures` is *called* during the transient layer-absent window; rendering is identical (the query already resolved to `[]` in that window, just with a logged error). No UI/pixels change.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — N/A (no className change)
- [x] Multi-viewport design QA — `N/A — not UI` (non-visual logic + test change)

## Test plan

- [x] New unit test `MapCanvas.test.tsx` `#1231: skips the clusters-hit query … when the layer is absent` — asserts `queryRenderedFeatures` is NOT called for `clusters-hit` (no maplibre layer-missing error) and no cluster marker reconciles.
- [x] The mock's `getLayer` registry now seeds `clusters-hit` (the mocked react-map-gl `<Layer>` doesn't self-register), so the 95 existing cluster-reconcile tests exercise the guard's pass-through path.
- [x] `tsc -b frontend`, frontend test (96/96), `npm run build`, `npm run lint`, `bash scripts/ci/check-orphan-classnames.sh` (PASS), `npx knip` (exit 0) — all green.

## Plan reference

Out of plan — prod console-hygiene bug surfaced during the C8 (#1230) live-verify. Closes #1231.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

