### PR TITLE
fix(frontend): silhouette icon-image falls back to _FALLBACK via coalesce — no missing-image warning (#1232)

### DIFF
--- a/frontend/src/components/map/geometry/observation-layers.test.ts
+++ b/frontend/src/components/map/geometry/observation-layers.test.ts
@@ -219,8 +219,15 @@ describe('layer specs', () => {
 
     const layout = spec.layout as Record<string, unknown>;
     // icon-image reads the per-feature silhouette id (resolved to a sprite
-    // registered with map.addImage(...) in MapCanvas).
-    expect(layout['icon-image']).toEqual(['get', 'silhouetteId']);
+    // registered with map.addImage(...) in MapCanvas), falling back to the
+    // always-present `_FALLBACK` sprite via `coalesce`/`image` when that sprite
+    // isn't registered — so a registration race/failure renders the fallback
+    // instead of warning (#1232).
+    expect(layout['icon-image']).toEqual([
+      'coalesce',
+      ['image', ['get', 'silhouetteId']],
+      ['image', FALLBACK_SILHOUETTE_ID],
+    ]);
     // Avoid clipping at high marker density — overlapping silhouettes
     // are an acceptable tradeoff vs dropping markers entirely.
     expect(layout['icon-allow-overlap']).toBe(true);

--- a/frontend/src/components/map/geometry/observation-layers.ts
+++ b/frontend/src/components/map/geometry/observation-layers.ts
@@ -345,7 +345,20 @@ export function buildUnclusteredPointLayerSpec(descriptor: BasemapDescriptor): L
     // Epic #539 cutover: inStack filter removed alongside auto-spider.
     filter: ['!', ['has', 'point_count']],
     layout: {
-      'icon-image': ['get', 'silhouetteId'],
+      // #1232: `['coalesce', ['image', id], ['image', '_FALLBACK']]` instead of a
+      // bare `['get', 'silhouetteId']`. The `image` operator returns NULL (not a
+      // "Image \"<family>\" could not be loaded" warning) when the named sprite
+      // isn't registered, so a family whose silhouette is still mid-registration
+      // — or whose svgData/decode failed and never registered — gracefully renders
+      // the always-present `_FALLBACK` sprite instead of dirtying the console.
+      // Once the real sprite registers, the expression re-resolves to it. A bare
+      // `['get','silhouetteId']` treats the id as a REQUIRED image and warns on
+      // the cold-load registration race (the prod `procellariidae` warning, #1232).
+      'icon-image': [
+        'coalesce',
+        ['image', ['get', 'silhouetteId']],
+        ['image', FALLBACK_SILHOUETTE_ID],
+      ],
       // Scale chain (E6 / #1058): the sprite SVG has a 24-unit viewBox
       // rastered into a 64px shell (silhouette-sprite.ts), registered with
       // `pixelRatio: 2` so maplibre lays it down at 32 CSS px; ×0.85 here ≈


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A["observation symbol layer paints<br/>icon-image needs the family sprite"] --> B{"silhouetteId sprite<br/>registered?"}
    B -->|yes| C["render the family silhouette<br/>(pixel-identical to before)"]
    B -->|"no (cold-load race / decode/addImage failed)"| D["bare ['get','silhouetteId']:<br/>maplibre warns 'Image X could not be loaded'"]
    B -->|"no — NEW: ['coalesce',['image',id],['image','_FALLBACK']]"| E["['image', id] returns NULL (no warning)<br/>→ coalesce → render _FALLBACK sprite"]
    D -.->|replaced by| E
```

## Summary

- Fixes the intermittent `Image "procellariidae" could not be loaded …` console warning on bird-maps.com (#1232). Prod silhouette data is **valid** (procellariidae ships a 7552-char CC0 path) — it's a registration **race/failure**, not missing data. The `unclustered-point` layer's `icon-image` was a bare `['get','silhouetteId']`, which maplibre treats as a **required** image and warns about when that family's sprite hasn't registered (the async `registerSilhouetteSprite` Promise.all can flip `spritesReady` even when one sprite failed to register).
- The fix makes the expression resilient: `['coalesce', ['image', ['get','silhouetteId']], ['image', '_FALLBACK']]`. maplibre's `image` operator returns **null** (not a warning) for an absent sprite, so a missing family gracefully renders the always-present `_FALLBACK` silhouette and the console stays clean; once the real sprite registers the expression re-resolves to it. **Registered families render pixel-identically** (coalesce resolves to the same image).

## Screenshots

The visible effect is **not locally reproducible** and pixel-identical for the common case, so this is effectively non-visual:
- **Registered silhouettes** (the overwhelmingly common case) resolve to the exact same image via `coalesce` → no pixel change.
- The only visible difference is the **rare missing-sprite case** rendering `_FALLBACK` instead of nothing — and the dev seed DB has no missing sprites (all register), so it can't be staged locally; prod's map handle is env-gated (`__birdMap` is non-prod only), so it can't be driven there either.

**Mechanism verified via a live synthetic maplibre test** on the dev map instead (the decisive evidence): a layer with `icon-image: ['coalesce', ['image', '<missing>'], ['image', '_FALLBACK']]` produced **NO** "could not be loaded" warning and rendered the `_FALLBACK` sprite, while a sibling layer with a bare `'<missing>'` icon-image **DID** warn — confirming the `image`-operator suppression that this fix relies on. Fresh app load (AZ + national) console is clean; legend + cluster-mosaic silhouettes render unchanged.

- [x] Every new/renamed `className` — N/A (no className change)
- [x] Multi-viewport design QA — `N/A — visible effect not locally reproducible (no missing sprites in dev data); fix verified via the synthetic maplibre test above + 122 unit tests`

## Test plan

- [x] `observation-layers.test.ts` layer-spec assertion updated to pin the new `coalesce`/`image` icon-image expression.
- [x] Live synthetic maplibre test (above) — `coalesce`/`image` with a missing primary: no warning + renders `_FALLBACK`; bare missing string: warns. Proves the suppression.
- [x] `tsc -b frontend`, frontend tests (observation-layers + MapCanvas, 122/122), `npm run build`, `npm run lint`, `bash scripts/ci/check-orphan-classnames.sh` (PASS), `npx knip` (exit 0) — all green.

## Plan reference

Out of plan — prod console-hygiene bug surfaced during the C8 (#1230) live-verify. Closes #1232.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
