### PR TITLE
fix(frontend): theme-selector full-width rows + distinct selected fill (#1230 follow-up)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -930,6 +930,13 @@ body {
   gap: 2px;
 }
 .theme-selector-group[data-form='popover'] {
+  /* `display: flex` (not the base `inline-flex`) + `width: 100%` so the group
+     fills the popover's inner content box. As an inline-flex shrink-to-fit box
+     it only reached its widest label (~102px), leaving the `width: 100%` rows
+     below pinned to that narrow track instead of spanning the popover — the
+     "cells aren't full width" report (#1230 follow-up). */
+  display: flex;
+  width: 100%;
   flex-direction: column;
   align-items: stretch;
   gap: var(--space-xs);
@@ -991,27 +998,40 @@ body {
   outline: 2px solid var(--color-text-strong);
   outline-offset: 2px;
 }
-/* Selected (checked) row: a FULL-WIDTH accent tint spanning the whole row, plus
-   the leading checkmark — reads unambiguously as SELECTED, distinct from the
-   hover lift (--color-bg-tint) and the keyboard focus ring. --color-bg-inset is
-   theme-paired (light #f0ebe0 / dark #253050), a touch stronger than the hover
-   tint so selected sits clearly above hover. Label stays strong-text weight. */
+/* Selected (checked) row: a FULL-WIDTH tint spanning the whole row, plus the
+   leading checkmark — reads unambiguously as SELECTED, distinct from the hover
+   lift (--color-bg-tint) and the keyboard focus ring. Uses the dedicated
+   --theme-option-selected-bg (light #e7ddc4 / dark #253050), which is theme-
+   paired to sit a clear step ABOVE the hover tint in BOTH modes — reusing
+   --color-bg-inset made selected≡hover in light (both resolve to #f0ebe0).
+   Label stays strong-text weight. */
 .theme-selector-option[aria-checked='true'] {
-  background: var(--color-bg-inset);
+  background: var(--theme-option-selected-bg);
   color: var(--color-text-strong);
   font-weight: var(--font-weight-semibold);
 }
 .theme-selector-option[aria-checked='true'] .theme-selector-option-check {
   visibility: visible;
 }
-/* Keep the hover lift visible on a selected row (combined hover+selected reads
-   as the inset tint, not a flat blend). */
+/* Keep the selected row reading as selected on hover (combined hover+selected
+   stays the stronger selected fill, not a flat blend with the hover tint). */
 .theme-selector-option[aria-checked='true']:hover {
-  background: var(--color-bg-inset);
+  background: var(--theme-option-selected-bg);
 }
-/* In the popover the options are full-width rows sharing one left + right edge. */
+/* In the popover the options are full-width rows sharing one left + right edge.
+   This selector (0,3,0 — two classes `.theme-selector-group` + `.theme-selector-
+   option` plus the attribute selector `[data-form='popover']`, which counts in
+   the class column) MUST also restate `display: grid` + `text-align: start`
+   because the shared `.app-header-controls-pill button` rule (0,1,1) otherwise
+   out-ranks the base `.theme-selector-option { display: grid }` (0,1,0) and
+   forces `display: inline-flex; justify-content: center`, collapsing the
+   intended 2-col layout (checkmark gutter + left-aligned label) into a centered
+   content-width pill. Restoring grid here wins the cascade and revives the
+   authored full-width row. */
 .theme-selector-group[data-form='popover'] .theme-selector-option {
   width: 100%;
+  display: grid;
+  text-align: start;
 }
 /* ≤480px: comfortable touch rows. 44px min target + a hair more block padding so
    the 5-row column isn't cramped to line-height. */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -325,6 +325,13 @@
      is pixel-identical in light — only dark gains a new value (#253050).
      --color-text-body (#444 → #444444) on #f0ebe0 = 8.19:1 (AA). */
   --color-bg-inset:   #f0ebe0;
+  /* Theme-picker SELECTED row fill. Must sit a clear step ABOVE the hover tint
+     (--color-bg-tint #f0ebe0) so the active theme reads as selected, not merely
+     hovered — in light both --color-bg-tint and --color-bg-inset resolve to the
+     SAME #f0ebe0, so reusing inset made selected≡hover (the original #1230
+     "selected is a touch stronger" intent held only in dark). Deeper cream,
+     same hue family; --color-text-strong #1a1a1a on #e7ddc4 ≈ 12.7:1 (AAA). */
+  --theme-option-selected-bg: #e7ddc4;
 
   --color-text-strong: #1a1a1a; /* preserve existing */
   --color-text-body:   #444;    /* preserve existing — AA-tuned */
@@ -429,6 +436,11 @@
      Card-vs-chip lift: #253050 / #1b2742 = 1.14:1 (visible separation).
      Invisible predecessor was --color-bg-tint #1c2640 vs card #1b2742 = 1.01:1. */
   --color-bg-inset:   #253050;
+  /* Theme-picker SELECTED row fill (dark). #253050 already lifts a clear 1.14:1
+     above the navy card AND above the hover tint (--color-bg-tint #1c2640), so
+     dark keeps the proven inset value — only light needed a distinct, stronger
+     value. --color-text-strong #f5f7fb on #253050 ≈ 13:1 (AAA). */
+  --theme-option-selected-bg: #253050;
 
   --color-text-strong: #f5f7fb;
   --color-text-body:   #d8dee8;


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    R1["theme-selector-option<br/>display grid - spec 0,1,0"]
    R2["app-header-controls-pill button<br/>display inline-flex, justify center - spec 0,1,1"]
    GRP["group stays inline-flex<br/>shrink-to-fit about 102px"]
    R1 -->|"out-ranked by higher specificity"| R2
    R2 --> BAD["centered, content-width pills"]
    GRP -->|"caps the width-100pct rows"| BAD
    BAD --> WHY["cells are NOT full width<br/>and selected fill equals hover in light"]
    FIX1["restate display grid + text-align start<br/>on popover option selector - spec 0,3,0"]
    FIX2["popover group display flex + width 100pct"]
    FIX3["new token theme-option-selected-bg<br/>light e7ddc4 / dark 253050"]
    FIX1 --> GOOD["full-width left-aligned rows<br/>checkmark gutter, selected above hover"]
    FIX2 --> GOOD
    FIX3 --> GOOD
    WHY ==>|"this PR"| GOOD
```

## Summary

- **Why it looked wrong:** the 5-theme popover rendered as centered, content-width pills, not the authored full-width left-aligned rows. The shared `.app-header-controls-pill button` rule (specificity 0,1,1) silently out-ranks `.theme-selector-option { display: grid }` (0,1,0), forcing `display: inline-flex; justify-content: center` — so the intended 2-col grid (checkmark gutter + label) collapsed. Compounding it, `.theme-selector-group` stayed `inline-flex` (shrink-to-fit ~102px), so the `width: 100%` rows never reached the popover edges. This was a live regression in `#1230`, not a cache issue.
- **Layout fix:** restate `display: grid; text-align: start` on the `(0,3,0)` popover-scoped option selector (`.theme-selector-group` + `[data-form='popover']` + `.theme-selector-option` — the attribute selector counts in the class column) so it wins the cascade, and make the popover group `display: flex; width: 100%` so rows span the full surface.
- **Selected-state fix:** in light theme the selected fill (`--color-bg-inset`) and hover tint (`--color-bg-tint`) both resolve to `#f0ebe0`, so selected was indistinguishable from hover (the `#1230` "selected is a touch stronger" intent held only in dark). New theme-paired `--theme-option-selected-bg` (light `#e7ddc4` / dark `#253050`) sits a clear step above hover in both modes; AAA contrast for the strong-text label.

## Screenshots

Theme popover, full-width rows, captured live across all 5 canonical viewports × 2 themes (Bright = default light, Dark).

| Viewport | Bright (light) | Dark |
|---|---|---|
| 390×844 (mobile) | ![390 light](https://github.com/user-attachments/assets/fa888773-4628-4330-8955-9694d0c2c5b3) | ![390 dark](https://github.com/user-attachments/assets/d5e4b1e4-ba6d-4073-bc9f-bddd0cb88ccb) |
| 768×1024 (tablet) | ![768 light](https://github.com/user-attachments/assets/1d6b4ab0-8fc6-46c4-9ca3-355a97615603) | ![768 dark](https://github.com/user-attachments/assets/a9822a9c-4db4-40eb-861f-b63e093fa2f8) |
| 1024×768 | ![1024 light](https://github.com/user-attachments/assets/b71195fa-a991-4164-b86a-922c887b2765) | ![1024 dark](https://github.com/user-attachments/assets/4a709686-aed6-485b-9d48-418bb7f1292b) |
| 1440×900 (desktop) | ![1440 light](https://github.com/user-attachments/assets/da6e41df-c563-4291-abbb-6aa698f73d33) | ![1440 dark](https://github.com/user-attachments/assets/7de6ae17-4937-4f53-aa27-e759cc9678f0) |
| 1920×1080 (wide) | ![1920 light](https://github.com/user-attachments/assets/b048f754-28ef-4b15-8401-b06f81867ad1) | ![1920 dark](https://github.com/user-attachments/assets/0753b821-9c6f-4793-bab8-9e4dadb78403) |

- [x] No new/renamed `className` in this PR — CSS-only change to existing `.theme-selector-*` rules + one new token. Orphan-classname check unaffected (green in CI).
- [x] Multi-viewport design QA: PR body has 10 `user-attachments` URLs (5 viewports × 2 themes).

## Test plan

- [x] `npm run build` — clean production build (tsc -b && vite build, new CSS bundle hash emitted).
- [x] `npx vitest run ThemeSelector.test AppHeader.test` — 51/51 green (CSS-only change; structure/behavior assertions unaffected).
- [x] `npm run lint` — clean (green in CI).
- [x] Playwright/chrome-devtools MCP smoke — drove the live popover on `npm run dev` at all 5 viewports in both Bright and Dark. Verified `display: grid`, full-width 142px rows, left-aligned labels, 44px mobile touch targets, and the selected fill distinct from hover in both modes. `browser_console_messages`: no errors/warnings attributable to this change (only local `/api` 502s — no read-api running — and one MapLibre "style not done loading" notice from rapid automated theme-switching, which is pre-existing imperative-`setStyle` behavior, not introduced here).
- [x] e2e (`frontend/e2e/map/theme-selector.spec.ts`) — green in CI; asserts data-theme/persistence/aria + basemap pixels, none of which this CSS change touches.

## Plan reference

Out of plan — CSS specificity + token-collision follow-up to the C8 5-theme selector (#1230, epic #1221).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)