### PR TITLE
fix(frontend): scope disclosure opens as one accordion motion, not two

### DIFF
--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createRef } from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AppHeader } from './AppHeader.js';
 
@@ -198,6 +198,23 @@ describe('<AppHeader>', () => {
     await userEvent.click(screen.getByRole('button', { name: /change region/i }));
     const select = screen.getByRole('combobox', { name: /switch state/i });
     expect(document.activeElement).toBe(select);
+  });
+
+  it('clips the form during the reveal (data-opening), then releases it on the opacity transitionend', async () => {
+    // The clip-wipe accordion: while opening, the clip carries data-opening so
+    // styles.css keeps the form clipped by the growing card edge (overflow:hidden
+    // + the ±4px ring-room widen). The flag clears on the reveal's opacity
+    // transitionend so overflow returns to visible at rest and the auto-focused
+    // field's ring paints unclipped (#1063). Driven deterministically here — no
+    // timing — by firing the transitionend the open-edge effect listens for.
+    render(<AppHeader {...baseProps} {...stateProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /change region/i }));
+    const clip = document.querySelector('.app-header-scope-clip');
+    expect(clip).toHaveAttribute('data-opening', 'true');
+
+    const rows = document.querySelector('.app-header-scope-rows')!;
+    fireEvent.transitionEnd(rows, { propertyName: 'opacity' });
+    expect(clip).toHaveAttribute('data-opening', 'false');
   });
 
   it('Esc collapses the disclosure and restores focus to the trigger', async () => {

--- a/frontend/src/components/AppHeader.test.tsx
+++ b/frontend/src/components/AppHeader.test.tsx
@@ -217,6 +217,31 @@ describe('<AppHeader>', () => {
     expect(clip).toHaveAttribute('data-opening', 'false');
   });
 
+  it('skips the clip-wipe under prefers-reduced-motion (no data-opening, ring stays unclipped)', async () => {
+    // Under reduced-motion the wipe is zeroed (the card jumps open), so there is
+    // no growing edge to clip against — the open-edge effect must NOT set
+    // data-opening, else the 800ms backstop would hold overflow:hidden and clip
+    // the auto-focused field's focus ring (#1063). jsdom leaves matchMedia
+    // undefined (the other tests exercise the animated path), so stub it here.
+    vi.stubGlobal('matchMedia', (q: string) => ({
+      matches: /prefers-reduced-motion/.test(q),
+      media: q,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }));
+    try {
+      render(<AppHeader {...baseProps} {...stateProps} />);
+      await userEvent.click(screen.getByRole('button', { name: /change region/i }));
+      expect(document.querySelector('.app-header-scope-clip')).toHaveAttribute('data-opening', 'false');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('Esc collapses the disclosure and restores focus to the trigger', async () => {
     render(<AppHeader {...baseProps} {...stateProps} />);
     const trigger = screen.getByRole('button', { name: /change region/i });

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -193,6 +193,12 @@ export function AppHeader({
   // local — re-scoping is the persisted action, not the panel's open/closed
   // state, so this does NOT belong in the URL. Spec §7 (disclosure pattern).
   const [scopeOpen, setScopeOpen] = useState(false);
+  // Clip-wipe reveal (2026-06-16): true only WHILE the disclosure is opening.
+  // Drives `data-opening` on the clip so styles.css keeps the form clipped by
+  // the growing card edge (a true accordion) during the open transition, then
+  // releases to `overflow:visible` at rest so the focused field's ring is
+  // unclipped (#1063). See the open-edge effect below.
+  const [scopeOpening, setScopeOpening] = useState(false);
   // C8 rework: theme popover open-state is OWNED here (lifted out of
   // <ThemeSelector>, which is now a controlled disclosure) so AppHeader can
   // enforce the single-header-popover invariant — only one of {scope, filters,
@@ -214,6 +220,34 @@ export function AppHeader({
     if (scopeOpen) {
       firstScopeFieldRef.current?.focus();
     }
+  }, [scopeOpen]);
+
+  // Clip-wipe reveal (2026-06-16): hold `data-opening` for the open transition
+  // so the form is clipped by the growing card edge (accordion) instead of
+  // fading in at its final position while the card grows past it — the latter
+  // reads as two motions in different directions. Cleared on the rows' opacity
+  // `transitionend` (overflow → visible at rest so the focus ring paints
+  // unclipped, #1063). A timeout backstops a missed event (e.g. reduced-motion,
+  // where a 0ms transition may not emit transitionend); it is generous
+  // (> --panel-open-dur) and harmless if it lands after the event already fired.
+  // CLOSE needs no flag — styles.css clips it via [data-open='false'].
+  useEffect(() => {
+    if (!scopeOpen) {
+      setScopeOpening(false);
+      return;
+    }
+    setScopeOpening(true);
+    const rows = scopeRowsRef.current;
+    const clear = (): void => setScopeOpening(false);
+    const onEnd = (e: TransitionEvent): void => {
+      if (e.target === rows && e.propertyName === 'opacity') clear();
+    };
+    rows?.addEventListener('transitionend', onEnd);
+    const fallback = window.setTimeout(clear, 800);
+    return () => {
+      rows?.removeEventListener('transitionend', onEnd);
+      window.clearTimeout(fallback);
+    };
   }, [scopeOpen]);
 
   // If the scope goes inactive (→ unscoped chooser) while the disclosure is
@@ -423,38 +457,39 @@ export function AppHeader({
           </div>
         )}
 
-        {/* Scope disclosure body (§4.2 / #828 / #951) — MOUNTED whenever scope is
-            active (so aria-controls has a valid target) but CSS-collapsed until
-            the 🔍 trigger opens it. `data-open` drives the catalog #07
-            panel-reveal (.t-panel-slide, styles.css): the rows REST at the
-            VISIBLE open end-state and are only offset (translate/opacity/blur +
-            visibility:hidden) while closed, so the global reduced-motion guard —
-            which zeroes the interpolation, not the start value — lands them
-            fully visible on open. The element is always painted (visibility,
-            not display:none), so the synchronous data-open flip tweens without a
-            post-paint rAF. visibility:hidden at rest keeps the closed form out of
-            the a11y tree + tab order AND satisfies Playwright toBeHidden() (an
-            `inert`-only rest would still occupy layout and fail those #951 asserts).
-            The Esc handler lives here so a press from any field (or the trigger)
-            collapses + restores focus. NO click-outside (a stray map click must
-            not lose a typed ZIP). The divider only renders when open — the
-            resting card is two lines. */}
+        {/* Scope disclosure body (§4.2 / #828 / #951 / #975) — MOUNTED whenever
+            scope is active (so aria-controls has a valid target) but CSS-collapsed
+            until the 🔍 trigger opens it. `data-open` drives ONE motion: the
+            card-resize CLIP (.app-header-scope-clip, styles.css) grows the card
+            height, and the rows REST at the VISIBLE open end-state, only offset
+            (opacity + visibility:hidden) while closed, so the global
+            reduced-motion guard — which zeroes the interpolation, not the start
+            value — lands them fully visible on open. The element is always painted
+            (visibility, not display:none), so the synchronous data-open flip
+            tweens without a post-paint rAF. visibility:hidden at rest keeps the
+            closed form out of the a11y tree + tab order AND satisfies Playwright
+            toBeHidden() (an `inert`-only rest would still occupy layout and fail
+            those #951 asserts). The Esc handler lives here so a press from any
+            field (or the trigger) collapses + restores focus. NO click-outside (a
+            stray map click must not lose a typed ZIP). The divider only renders
+            when open — the resting card is two lines. */}
         {scopeActive && (
-          /* #975: grid 0fr↔1fr CLIP wrapper. The inner .t-panel-slide keeps the
-             UNCHANGED #07 reveal (transform/opacity/blur + visibility); this
-             wrapper is the height-collapse mechanism. Closed → 0fr track →
-             the in-flow form contributes ZERO layout height, so the identity
-             card shrinks to wordmark + lede + padding (no empty band). The
-             id/ref/aria-controls target stays on the INNER element so the a11y
-             contract + Page-Object selectors are untouched. The residual parent
-             flex `gap` band below the lede (which would survive a 0fr collapse)
-             is cancelled by a negative top-margin on the clip WHEN CLOSED — see
-             styles.css `.app-header-scope-clip[data-open='false']`. */
-          <div className="app-header-scope-clip" data-open={scopeOpen}>
+          /* #975: grid 0fr↔1fr CLIP wrapper — the single card-resize reveal.
+             This wrapper is the height-collapse mechanism; the inner
+             .app-header-scope-rows carries only a soft opacity crossfade (+
+             visibility) on the same clock. Closed → 0fr track → the in-flow form
+             contributes ZERO layout height, so the identity card shrinks to
+             wordmark + lede + padding (no empty band). The id/ref/aria-controls
+             target stays on the INNER element so the a11y contract + Page-Object
+             selectors are untouched. The residual parent flex `gap` band below
+             the lede (which would survive a 0fr collapse) is cancelled by a
+             negative top-margin on the clip WHEN CLOSED — see styles.css
+             `.app-header-scope-clip[data-open='false']`. */
+          <div className="app-header-scope-clip" data-open={scopeOpen} data-opening={scopeOpening}>
             <div
               id={scopeRegionId}
               ref={scopeRowsRef}
-              className="app-header-scope-rows t-panel-slide"
+              className="app-header-scope-rows"
               data-open={scopeOpen}
             >
               {/* Divider only renders when open — the resting card is two lines.

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -227,12 +227,21 @@ export function AppHeader({
   // fading in at its final position while the card grows past it — the latter
   // reads as two motions in different directions. Cleared on the rows' opacity
   // `transitionend` (overflow → visible at rest so the focus ring paints
-  // unclipped, #1063). A timeout backstops a missed event (e.g. reduced-motion,
-  // where a 0ms transition may not emit transitionend); it is generous
-  // (> --panel-open-dur) and harmless if it lands after the event already fired.
-  // CLOSE needs no flag — styles.css clips it via [data-open='false'].
+  // unclipped, #1063). A timeout backstops a missed transitionend; it is
+  // generous (> --panel-open-dur) and harmless if it lands after the event
+  // already fired. CLOSE needs no flag — styles.css clips it via [data-open='false'].
   useEffect(() => {
     if (!scopeOpen) {
+      setScopeOpening(false);
+      return;
+    }
+    // Reduced motion: the wipe is zeroed (the card jumps open), so there is no
+    // growing edge to clip against — skip the opening clip entirely. Otherwise
+    // the 800ms backstop would hold overflow:hidden with no wipe to justify it,
+    // deferring for ~800ms the at-rest overflow:visible the auto-focused field's
+    // ring relies on (#1063) — and transitionend is unreliable on a 0ms
+    // transition, so the backstop is the only thing that would clear it.
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches) {
       setScopeOpening(false);
       return;
     }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -564,15 +564,15 @@ body {
   border-top: 1px solid var(--color-border-ui);
 }
 
-/* Scope rows container (§4.2 / #828 / #951) — the scope form, collapsed behind
-   the 🔍 disclosure. Opening it plays catalog recipe #07 (panel-reveal): the
-   form slides a short distance into the card with transform/opacity/blur,
-   compositing cleanly (the identity card is position:absolute, so its growth
-   does not reflow the map canvas — #01 height-tween rejected, see #951). The
-   `[data-open]` hook drives the reveal with no JS class toggle. The container
-   itself is always `display:flex` — the open/close gating now lives on the
-   .t-panel-slide rules below (the old `hidden` prop + `display:none` rule are
-   removed; either left in force would clip the start frame and kill the tween). */
+/* Scope rows container (§4.2 / #828 / #951 / #975, revised 2026-06-16) — the
+   scope form, collapsed behind the 🔍 disclosure. ONE motion reveals it:
+   card-resize (#01), realized by the grid 0fr↔1fr CLIP wrapper
+   (.app-header-scope-clip, below) growing the card to its content height. The
+   rows themselves no longer slide or blur — see the crossfade note below. The
+   `[data-open]` hook drives both with no JS class toggle. The container is
+   always `display:flex` — the open/close gating lives on the opacity/visibility
+   rules below (an old `hidden` prop + `display:none` rule were removed in #951;
+   either left in force would clip the start frame and kill the tween). */
 .app-header-scope-rows {
   display: flex;
   flex-direction: column;
@@ -580,53 +580,41 @@ body {
      embedded scope form's own field gaps, so divider → select reads the same
      as every other row in the card (#837). */
   gap: var(--space-sm);
-}
 
-/* ── #951: scope disclosure open → recipe #07 (panel-reveal) ────────────────
-   Catalog snippet (~/.claude/skills/transitions-dev/07-panel-reveal.md) pasted
-   with the enumerated properties, will-change, and the same in-card overrides
-   the SpeciesDetailRail precedent uses (styles.css §#918): --panel-translate-y
-   shortened to a small in-card travel (this is a brief reveal of two/three
-   rows, not a full-height panel), --panel-open-dur / --panel-ease / --panel-blur
-   reused from tokens.css.
+  /* Soft same-clock OPACITY crossfade so the contents resolve in as the card
+     grows, rather than hard-wiping. The earlier build layered catalog #07
+     (panel-reveal: translateY(14px)→0 + blur(2px)→0) ON TOP of the height
+     growth — a SECOND, opposing motion: the content floated UP "from beneath"
+     while the card expanded DOWN, reading as two disjoint reveals. Removed; the
+     CLIP is now the sole structural motion and this fade is the only content
+     treatment (Julian, 2026-06-16).
 
-   REST = the VISIBLE open end-state (translateY(0)/opacity:1/blur(0)). The rows
-   are only offset while CLOSED ([data-open='false']) — that ordering is what
-   makes the GLOBAL reduced-motion guard (motion.css zeroes the INTERPOLATION,
-   not the start value) land the form fully visible on open instead of stuck
-   off-screen. No per-element prefers-reduced-motion query here (house policy).
+     REST = the VISIBLE open end-state (opacity:1/visibility:visible). The rows
+     are only hidden while CLOSED ([data-open='false']) — that ordering makes the
+     GLOBAL reduced-motion guard (motion.css zeroes the INTERPOLATION, not the
+     start value) land the form fully visible on open instead of stuck hidden.
+     No per-element prefers-reduced-motion query here (house policy).
 
-   Closed-state visibility:hidden (NOT inert alone, NOT opacity:0 alone): pulls
-   the collapsed form out of the a11y tree + tab order AND satisfies the e2e
-   `toBeHidden()` asserts (scope-disclosure.spec.ts :96/:97/:164/:178) — an
-   inert element still occupies layout and would fail toBeHidden(). visibility is
-   discrete (no tween), so the form's interactive surface flips on/off cleanly at
-   the open/close edges while transform/opacity/filter carry the visible motion.
-   The element is always painted (visibility, not display:none), so the
-   synchronous data-open flip tweens without a post-paint rAF. */
-.app-header-scope-rows.t-panel-slide {
-  /* A short in-card travel — a few rows revealing, not a full panel. */
-  --panel-translate-y: 14px;
-  transform: translateY(0);
+     Closed-state visibility:hidden (NOT opacity:0 alone): pulls the collapsed
+     form out of the a11y tree + tab order AND satisfies the e2e `toBeHidden()`
+     asserts (scope-disclosure.spec.ts :104/:105/:172/:215). visibility is
+     discrete (not transitioned), so the form's interactive surface flips on/off
+     cleanly at the open/close edges while opacity carries the visible fade. The
+     element is always painted (visibility, not display:none), so the synchronous
+     data-open flip tweens without a post-paint rAF. */
   opacity: 1;
-  filter: blur(0);
   visibility: visible;
-  transition:
-    transform var(--panel-open-dur) var(--panel-ease),
-    opacity   var(--panel-open-dur) var(--panel-ease),
-    filter    var(--panel-open-dur) var(--panel-ease);
-  will-change: transform, opacity, filter;
+  transition: opacity var(--panel-open-dur) var(--panel-ease);
+  will-change: opacity;
 }
-.app-header-scope-rows.t-panel-slide[data-open='false'] {
-  transform: translateY(var(--panel-translate-y));
+.app-header-scope-rows[data-open='false'] {
   opacity: 0;
-  filter: blur(var(--panel-blur));
   visibility: hidden;
 }
 
 /* ── #975: grid 0fr↔1fr CLIP wrapper — collapse the card height when closed ──
    #958 swapped the closed scope-rows lock from `display:none` to
-   `visibility:hidden` so the #07 reveal stays animatable + toBeHidden() passes.
+   `visibility:hidden` so the reveal stays animatable + toBeHidden() passes.
    But `visibility:hidden` keeps the element IN FLOW: a closed in-flow flex child
    of the vertical-column `.app-header-identity-card` still reserves the full
    ScopeControl box, so the card froze at its OPEN height — an empty band below
@@ -635,12 +623,12 @@ body {
    18-recipe catalog has no grid-template-rows tween. It is the JS-free "tween to
    content height" technique (the concrete answer to #01's "can't tween to auto",
    reviewed live in #975/#979); closed → a 0-height track, so the inner form
-   contributes ZERO layout height. The inner .t-panel-slide keeps the
-   UNCHANGED #07 transform/opacity/blur reveal on the SAME clock
-   (--panel-open-dur / --panel-ease), so both the height collapse and the visible
-   slide play together. No new per-element prefers-reduced-motion query — the
-   global motion.css guard zeroes BOTH transitions, so reduced-motion jumps the
-   track to 1fr and lands the form fully visible (rest = open). */
+   contributes ZERO layout height. The inner .app-header-scope-rows carries only
+   a soft opacity crossfade on the SAME clock (--panel-open-dur / --panel-ease),
+   so the height growth and the content fade play together as one motion. No new
+   per-element prefers-reduced-motion query — the global motion.css guard zeroes
+   BOTH transitions, so reduced-motion jumps the track to 1fr and lands the form
+   fully visible (rest = open). */
 .app-header-scope-clip {
   display: grid;
   grid-template-rows: 1fr;
@@ -670,11 +658,21 @@ body {
   margin-block-start: calc(-1 * var(--space-sm));
 }
 /* min-height:0 lets the grid item shrink below its content's min-content height
-   so the 0fr track collapses to a true 0. `overflow` IS the grid-rows clip — but
-   it also clips `outline` focus rings (drawn OUTSIDE the border-box) on the
-   first/last fields, so scope it to the CLOSED state only: once open the track is
-   content-height, nothing block-axis overflows, and dropping overflow lets a
-   keyboard focus ring paint in full. (The native <select> dropdown renders in the
+   so the 0fr track collapses to a true 0. `overflow` IS the grid-rows clip — and
+   it must be ACTIVE whenever the track is shorter than the content, i.e. CLOSED
+   *and* DURING THE OPEN TRANSITION ([data-opening]). That is what makes the
+   reveal a true accordion: the growing card edge WIPES the form into view
+   top-down. Without clipping mid-open (overflow left visible, the prior bug) the
+   full form is laid out immediately and just FADES IN AT ITS FINAL POSITION
+   while the card grows past it — content + card edge moving in different
+   directions, which reads as the disjoint "text appears from beneath" (Julian,
+   2026-06-16, follow-up to the translateY/blur removal which alone did not fix
+   it). At OPEN REST the track is content-height (nothing overflows) and
+   `data-opening` is cleared, so overflow returns to `visible` and the
+   auto-focused field's focus ring — box-shadow drawn OUTSIDE the border-box —
+   paints unclipped (#1063). CLOSE already clips via [data-open='false'].
+   `data-opening` is held for the open transition by AppHeader and cleared on the
+   rows' opacity `transitionend`. (The native <select> dropdown renders in the
    browser top layer, immune to ancestor overflow either way.)
    min-width:0 is the horizontal twin: making this a grid item gave it the default
    `min-width:auto`, which refuses to shrink below the embedded ScopeControl's
@@ -688,6 +686,25 @@ body {
 }
 .app-header-scope-clip[data-open='false'] > .app-header-scope-rows {
   overflow: hidden;
+}
+/* DURING THE OPEN TRANSITION the clip must spare the auto-focused field's focus
+   ring (a 2px box-shadow drawn OUTSIDE the field's border-box). Plain
+   overflow:hidden would clip that ring's left/right edges while the wipe runs,
+   then "pop" the clipped edge to full when overflow releases at rest — a 2-stage
+   reveal (Julian, 2026-06-16). Fix: widen the clip box ±4px horizontally with a
+   negative inline margin, offset by an equal inline padding so the content's
+   position AND width are unchanged (no shift, #842 cap unaffected — verified
+   live: select width + rows clientWidth identical with/without). The ring (2px)
+   now sits inside the widened box, so it is NOT clipped left/right; overflow:
+   hidden still clips the BOTTOM cleanly, so the wipe reveal stays intact (no
+   leaked sliver of the next row — unlike overflow-clip-margin, which leaks on
+   all edges). Block-axis is untouched, so the ring still reveals top-down WITH
+   the field. CLOSED uses plain overflow:hidden above (a 0-height row needs no
+   ring room). */
+.app-header-scope-clip[data-opening='true'] > .app-header-scope-rows {
+  overflow: hidden;
+  margin-inline: -4px;
+  padding-inline: 4px;
 }
 
 /* ── TOP-RIGHT: controls pill ───────────────────────────────────────────────


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant Clip as scope-clip
    participant Rows as scope-rows
    User->>Clip: click magnifier to open (data-open true, data-opening true)
    Note over Clip,Rows: ONE motion — grid 0fr to 1fr grows the card while overflow hidden clips content, so the growing edge wipes the form in top-down
    Note over Rows: inline margin and padding widen the clip box 4px so the focused select 2px ring is not clipped (no clip-then-pop)
    Rows-->>Clip: opacity transitionend clears data-opening (overflow visible, ring full at rest)
```

## Summary

- The identity-card scope disclosure (the magnifier form) opened with **two competing motions** — a transitions.dev recipe-07 panel-slide (`translateY`+`blur`) layered on the grid `0fr→1fr` height clip, so content rose "from beneath" while the card grew down. Removing the slide alone was **not enough**: the clip left `overflow: visible` during the open, so the form laid out fully and faded in at its final position while the card grew *past* it — a decoupled "two directions" reveal.
- Now it's **one accordion motion**: the growing card edge wipes the form into view top-down. `overflow:hidden` is held during the open via a new `data-opening` flag (set on open, cleared on the rows' opacity `transitionend` with a timeout backstop), then released to `overflow:visible` at rest so the auto-focused field's ring paints unclipped (#1063). The soft opacity crossfade now rides the clipped reveal.
- A secondary glitch (the focused select's 2px ring clipped left/right during the wipe, then "popping" to full at rest) is fixed by widening the clip box ±4px horizontally during the open — a negative inline margin offset by equal inline padding, so content position and width are unchanged.

## Screenshots

**Scope disclosure — open state**, captured live via Playwright MCP at the 5 canonical viewports × 2 themes. The change is the open *animation* (a single accordion clip-wipe); these stills show the resting open surface — the motion itself was verified frame-by-frame (see Test plan).

<details open><summary><b>Light (Bright)</b></summary>

| 390×844 | 768×1024 | 1024×768 | 1440×900 | 1920×1080 |
|---|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/ba293b6d-86cf-4068-87bb-ef66de6a3a2a" width="150"> | <img src="https://github.com/user-attachments/assets/f0d02b92-b54c-42c4-94f6-9d47c24ce855" width="150"> | <img src="https://github.com/user-attachments/assets/3f8c866b-5006-42ee-9fa0-f90fd38dcd8a" width="150"> | <img src="https://github.com/user-attachments/assets/566fe127-4ec7-48c5-9877-8245f5019208" width="150"> | <img src="https://github.com/user-attachments/assets/fe2bf3bc-ec35-4384-9220-b7b915970135" width="150"> |

</details>

<details open><summary><b>Dark</b></summary>

| 390×844 | 768×1024 | 1024×768 | 1440×900 | 1920×1080 |
|---|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/eeb9a4bd-c4e2-49ca-90eb-f8a63ee49e30" width="150"> | <img src="https://github.com/user-attachments/assets/cdac93cc-af52-4357-a29b-1f07292b598f" width="150"> | <img src="https://github.com/user-attachments/assets/ac0182b2-25c2-4e0b-85a8-1c975345dadc" width="150"> | <img src="https://github.com/user-attachments/assets/bc925e08-afc3-4dc7-9746-2634203c1d59" width="150"> | <img src="https://github.com/user-attachments/assets/426acdac-982a-4ab9-ac9f-a21e688ba311" width="150"> |

</details>

- [x] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (no new classNames; `t-panel-slide` removed from the scope rows, `data-opening`
      is a data-attribute not a class — orphan-classname-check passes)
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445) — 10 above

## Test plan

- [x] `tsc -b` (typecheck) + `vitest run` — green (1643 unit, incl. a new
      data-opening clip-wipe lifecycle test in `AppHeader.test.tsx`)
- [x] New unit test added — `AppHeader.test.tsx` guards the `data-opening`
      lifecycle (set on open, cleared on the opacity `transitionend`)
- [ ] New Playwright e2e spec — N/A; a 400ms overflow/clip transition is not
      suited to a `retries:0` assertion. The open/close/focus/visibility +
      `#842` ZIP-overflow + axe a11y contract is covered by the existing
      `scope/scope-disclosure.spec.ts` + `scope/state-artboard.spec.ts` (46
      scope e2e green), and the motion was verified live frame-by-frame.
- [x] `npm run build` — clean production build (+ orphan-classname-check PASS)
- [x] (UI only) Playwright MCP smoke — drove the disclosure open/close at all 5
      canonical viewports × 2 themes via `browser_*`; `browser_console_messages`
      returned 0 errors / 0 warnings on a clean load; screenshots above are from
      those runs. Frame-by-frame measurement confirmed: content clipped &
      revealed by the edge during open, focused select left edge 4px inside the
      clip box (ring clearance), `overflow:visible` + `margin:0` at rest.

## Plan reference

Out of plan — UX bugfix for the scope-disclosure open animation (floating-card four-corner contract, spec §3 / #761 #803), reported in-session.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
