### PR TITLE
feat(frontend): viewbox-link codec — encode/decode camera in #map= hash

### DIFF
--- a/frontend/src/state/viewbox-link.test.ts
+++ b/frontend/src/state/viewbox-link.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  encodeViewbox,
+  decodeViewbox,
+  type ViewboxCamera,
+  type ViewboxViewport,
+} from './viewbox-link.js';
+
+// viewbox-link is a PURE, TOTAL-function codec (epic #1238 / C1, #1239):
+// camera (+ optional capture viewport) ↔ URL hash fragment. No DOM, no app
+// wiring — exhaustively unit-tested string ↔ object mapping. The decode path
+// must NEVER throw and must NEVER partial-apply a camera: a hand-edited or
+// truncated link degrades to a clean `null` ("normal load"), never a crash.
+//
+// Grammar: #map=<zoom>/<lat>/<lng>[/<bearing>[/<pitch>]][&v=<W>x<H>@<dpr>]
+// Field order is zoom/lat/lng (lat 2nd, lng 3rd — MapLibre hash order).
+
+describe('viewbox-link codec', () => {
+  // ── encode → decode round-trip table ────────────────────────────────────
+  describe('round-trip', () => {
+    const cases: Array<{ name: string; cam: ViewboxCamera; vp?: ViewboxViewport }> = [
+      {
+        name: 'north-up flat (no bearing/pitch, no viewport)',
+        cam: { zoom: 12.5, lat: 34.0489, lng: -111.0937 },
+      },
+      {
+        name: 'rotated (bearing ≠ 0)',
+        cam: { zoom: 14, lat: 40.7128, lng: -74.006, bearing: 45 },
+      },
+      {
+        name: 'pitched (pitch ≠ 0, bearing 0 — bearing still emitted)',
+        cam: { zoom: 9.25, lat: 47.6062, lng: -122.3321, pitch: 35 },
+      },
+      {
+        name: 'rotated + pitched',
+        cam: { zoom: 16.125, lat: 38.9072, lng: -77.0369, bearing: 270, pitch: 60 },
+      },
+      {
+        name: 'with viewport',
+        cam: { zoom: 11, lat: 33.4484, lng: -112.074 },
+        vp: { w: 1440, h: 900, dpr: 2 },
+      },
+      {
+        name: 'rotated + pitched + viewport',
+        cam: { zoom: 13.75, lat: 25.7617, lng: -80.1918, bearing: 123.4, pitch: 42.5 },
+        vp: { w: 390, h: 844, dpr: 3 },
+      },
+    ];
+
+    for (const { name, cam, vp } of cases) {
+      it(`round-trips: ${name}`, () => {
+        const decoded = decodeViewbox(encodeViewbox(cam, vp));
+        expect(decoded).not.toBeNull();
+        // Camera survives within toFixed precision.
+        expect(decoded!.camera.zoom).toBeCloseTo(cam.zoom, 3);
+        expect(decoded!.camera.lat).toBeCloseTo(cam.lat, 5);
+        expect(decoded!.camera.lng).toBeCloseTo(cam.lng, 5);
+        if (cam.bearing && cam.bearing !== 0) {
+          expect(decoded!.camera.bearing).toBeCloseTo(cam.bearing, 1);
+        }
+        if (cam.pitch && cam.pitch !== 0) {
+          expect(decoded!.camera.pitch).toBeCloseTo(cam.pitch, 1);
+        }
+        // Viewport survives exactly when supplied.
+        if (vp) {
+          expect(decoded!.viewport).toEqual(vp);
+        } else {
+          expect(decoded!.viewport).toBeUndefined();
+        }
+      });
+    }
+  });
+
+  // ── encode formatting rules ─────────────────────────────────────────────
+  describe('encode', () => {
+    it('returns the fragment WITHOUT a leading #', () => {
+      const out = encodeViewbox({ zoom: 12, lat: 34, lng: -111 });
+      expect(out.startsWith('#')).toBe(false);
+      expect(out.startsWith('map=')).toBe(true);
+    });
+
+    it('omits bearing AND pitch when both are 0 (no trailing /0/0)', () => {
+      expect(encodeViewbox({ zoom: 12, lat: 34, lng: -111, bearing: 0, pitch: 0 })).toBe(
+        'map=12.000/34.00000/-111.00000',
+      );
+    });
+
+    it('omits bearing/pitch when absent (north-up flat)', () => {
+      expect(encodeViewbox({ zoom: 12, lat: 34, lng: -111 })).toBe(
+        'map=12.000/34.00000/-111.00000',
+      );
+    });
+
+    it('emits bearing only (no trailing pitch) when pitch is 0 but bearing ≠ 0', () => {
+      expect(encodeViewbox({ zoom: 8, lat: 12, lng: 34, bearing: 90 })).toBe(
+        'map=8.000/12.00000/34.00000/90.0',
+      );
+    });
+
+    it('emits bearing as 0.0 when pitch ≠ 0 but bearing == 0 (slot disambiguation)', () => {
+      // Slash positions must stay unambiguous: a pitched view with bearing 0
+      // still emits the bearing field so pitch lands in the 5th slot.
+      expect(encodeViewbox({ zoom: 8, lat: 12, lng: 34, pitch: 30 })).toBe(
+        'map=8.000/12.00000/34.00000/0.0/30.0',
+      );
+    });
+
+    it('uses fixed decimals — zoom toFixed(3), lat/lng toFixed(5), bearing/pitch toFixed(1)', () => {
+      expect(encodeViewbox({ zoom: 6, lat: 1.5, lng: -2.5, bearing: 33, pitch: 12 })).toBe(
+        'map=6.000/1.50000/-2.50000/33.0/12.0',
+      );
+    });
+
+    it('serializes -110.9 and -110.90000 identically (fixed-decimal, never String(n))', () => {
+      const a = encodeViewbox({ zoom: 10, lat: 30, lng: -110.9 });
+      const b = encodeViewbox({ zoom: 10, lat: 30, lng: -110.9 });
+      expect(a).toBe(b);
+      expect(a).toContain('-110.90000');
+      // round-trips back to the same value
+      expect(decodeViewbox(a)!.camera.lng).toBeCloseTo(-110.9, 5);
+    });
+
+    it('appends the viewport as &v=<w>x<h>@<dpr>', () => {
+      expect(
+        encodeViewbox({ zoom: 12, lat: 34, lng: -111 }, { w: 1920, h: 1080, dpr: 1 }),
+      ).toBe('map=12.000/34.00000/-111.00000&v=1920x1080@1');
+    });
+
+    it('places lat 2nd and lng 3rd (MapLibre field order)', () => {
+      const out = encodeViewbox({ zoom: 5, lat: 11.11111, lng: 99.99999 });
+      // value part after `map=`
+      const fields = out.replace('map=', '').split('/');
+      expect(fields[0]).toBe('5.000'); // zoom
+      expect(fields[1]).toBe('11.11111'); // lat
+      expect(fields[2]).toBe('99.99999'); // lng
+    });
+  });
+
+  // ── decode: null on garbage (total, never throws, never partial-applies) ─
+  describe('decode — null on garbage', () => {
+    const garbage: Array<[string, string]> = [
+      ['empty string', ''],
+      ['bare hash', '#'],
+      ['unknown key only', '#foo=bar'],
+      ['empty map value', '#map='],
+      ['one field', '#map=14'],
+      ['all-NaN fields', '#map=a/b/c'],
+      ['NaN in a required field (lat)', '#map=14/abc/-110'],
+    ];
+
+    for (const [name, hash] of garbage) {
+      it(`returns null for ${name}: ${JSON.stringify(hash)}`, () => {
+        expect(decodeViewbox(hash)).toBeNull();
+      });
+    }
+
+    it('returns null when fewer than 3 fields (only zoom/lat)', () => {
+      expect(decodeViewbox('#map=14/34')).toBeNull();
+    });
+
+    it('rejects trailing garbage in a required field (Number(), not parseFloat)', () => {
+      // parseFloat('14abc') === 14 (lenient); Number('14abc') === NaN (strict).
+      // The codec must reject the corrupted field, returning null.
+      expect(decodeViewbox('#map=14abc/34/-111')).toBeNull();
+    });
+
+    it('never throws on arbitrary junk (total function)', () => {
+      const junk = ['#map=////', '#&&&', '#map=1/2/3/x/y/z/w', '#=', '#map', 'map=14/34/-111'];
+      for (const h of junk) {
+        expect(() => decodeViewbox(h)).not.toThrow();
+      }
+    });
+  });
+
+  // ── decode: clamp boundaries (clamp recoverable, do not reject) ──────────
+  describe('decode — clamping', () => {
+    it('does NOT clamp a z16 link to the fitBounds cap of 12 (interactive max is 22)', () => {
+      // The critical AC (#1239): clamping zoom to 12 would silently defeat
+      // epic #1238's exact-view premise. A z16 link must reopen at z16.
+      const decoded = decodeViewbox('#map=16/34/-111');
+      expect(decoded!.camera.zoom).toBe(16);
+    });
+
+    it('clamps a z25 link to the interactive max CLUSTER_MAX_ZOOM (22)', () => {
+      const decoded = decodeViewbox('#map=25/34/-111');
+      expect(decoded!.camera.zoom).toBe(22);
+    });
+
+    it('clamps zoom below MIN_ZOOM (2) up to 2', () => {
+      const decoded = decodeViewbox('#map=0.5/34/-111');
+      expect(decoded!.camera.zoom).toBe(2);
+    });
+
+    it('clamps lat beyond +85.05113 to the Web Mercator limit (NOT +90)', () => {
+      const decoded = decodeViewbox('#map=10/89/-111');
+      expect(decoded!.camera.lat).toBeCloseTo(85.05113, 5);
+      expect(decoded!.camera.lat).not.toBe(89);
+      expect(decoded!.camera.lat).not.toBe(90);
+    });
+
+    it('clamps lat beyond -85.05113 to the Web Mercator limit (NOT -90)', () => {
+      const decoded = decodeViewbox('#map=10/-89/-111');
+      expect(decoded!.camera.lat).toBeCloseTo(-85.05113, 5);
+      expect(decoded!.camera.lat).not.toBe(-90);
+    });
+
+    it('clamps lng beyond +180 to +180', () => {
+      const decoded = decodeViewbox('#map=10/34/200');
+      expect(decoded!.camera.lng).toBe(180);
+    });
+
+    it('clamps lng beyond -180 to -180', () => {
+      const decoded = decodeViewbox('#map=10/34/-200');
+      expect(decoded!.camera.lng).toBe(-180);
+    });
+
+    it('wraps an out-of-range bearing into [0,360)', () => {
+      // 450 % 360 === 90; normalize keeps z/lat/lng intact.
+      const decoded = decodeViewbox('#map=10/34/-111/450');
+      expect(decoded!.camera.bearing).toBeCloseTo(90, 1);
+      expect(decoded!.camera.zoom).toBe(10);
+      expect(decoded!.camera.lat).toBe(34);
+      expect(decoded!.camera.lng).toBe(-111);
+    });
+
+    it('wraps a negative bearing into [0,360)', () => {
+      // -90 → 270
+      const decoded = decodeViewbox('#map=10/34/-111/-90');
+      expect(decoded!.camera.bearing).toBeCloseTo(270, 1);
+    });
+
+    it('clamps pitch above 60 to 60', () => {
+      const decoded = decodeViewbox('#map=10/34/-111/0/85');
+      expect(decoded!.camera.pitch).toBe(60);
+    });
+
+    it('clamps pitch below 0 to 0', () => {
+      const decoded = decodeViewbox('#map=10/34/-111/0/-10');
+      expect(decoded!.camera.pitch).toBe(0);
+    });
+
+    it('drops a NaN bearing but keeps z/lat/lng', () => {
+      const decoded = decodeViewbox('#map=10/34/-111/notabearing');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.camera.bearing).toBeUndefined();
+      expect(decoded!.camera.zoom).toBe(10);
+      expect(decoded!.camera.lat).toBe(34);
+      expect(decoded!.camera.lng).toBe(-111);
+    });
+
+    it('drops a NaN pitch but keeps bearing + z/lat/lng', () => {
+      const decoded = decodeViewbox('#map=10/34/-111/45/notapitch');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.camera.bearing).toBeCloseTo(45, 1);
+      expect(decoded!.camera.pitch).toBeUndefined();
+      expect(decoded!.camera.zoom).toBe(10);
+    });
+  });
+
+  // ── decode: viewport + unknown-key tolerance ────────────────────────────
+  describe('decode — viewport and unknown keys', () => {
+    it('parses a valid &v=<w>x<h>@<dpr>', () => {
+      const decoded = decodeViewbox('#map=12/34/-111&v=1440x900@2');
+      expect(decoded!.viewport).toEqual({ w: 1440, h: 900, dpr: 2 });
+    });
+
+    it('parses a fractional dpr viewport', () => {
+      const decoded = decodeViewbox('#map=12/34/-111&v=800x600@1.5');
+      expect(decoded!.viewport).toEqual({ w: 800, h: 600, dpr: 1.5 });
+    });
+
+    it('ignores a malformed &v= WITHOUT nulling the camera', () => {
+      const malformed = [
+        '#map=12/34/-111&v=garbage',
+        '#map=12/34/-111&v=1440x900', // missing @dpr
+        '#map=12/34/-111&v=1440@2', // missing height
+        '#map=12/34/-111&v=0x900@2', // non-positive width
+        '#map=12/34/-111&v=1440x-900@2', // negative height
+        '#map=12/34/-111&v=1440x900@0', // non-positive dpr
+        '#map=12/34/-111&v=Infinityx900@2', // non-finite
+      ];
+      for (const h of malformed) {
+        const decoded = decodeViewbox(h);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.camera.zoom).toBe(12);
+        expect(decoded!.viewport).toBeUndefined();
+      }
+    });
+
+    it('ignores unknown sub-keys (forward-compatible)', () => {
+      const decoded = decodeViewbox('#map=12/34/-111&foo=1&bar=baz');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.camera).toEqual({ zoom: 12, lat: 34, lng: -111 });
+      expect(decoded!.viewport).toBeUndefined();
+    });
+
+    it('finds map= regardless of sub-key order', () => {
+      const decoded = decodeViewbox('#foo=1&v=800x600@1&map=12/34/-111');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.camera.zoom).toBe(12);
+      expect(decoded!.viewport).toEqual({ w: 800, h: 600, dpr: 1 });
+    });
+
+    it('tolerates a leading # being absent', () => {
+      const decoded = decodeViewbox('map=12/34/-111');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.camera.zoom).toBe(12);
+    });
+  });
+
+  // ── purity: no DOM access ───────────────────────────────────────────────
+  describe('purity', () => {
+    it('the module source references no window / document / DOM globals', () => {
+      // Resolve the sibling source from the frontend workspace root (vitest's
+      // cwd) rather than import.meta.url — under the vite transform the latter
+      // is not a file: URL, so fileURLToPath() rejects it.
+      const src = readFileSync(
+        path.resolve(process.cwd(), 'src/state/viewbox-link.ts'),
+        'utf8',
+      );
+      // Strip line + block comments so a "no DOM" comment can't trip the scan.
+      const code = src
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/[^\n]*/g, '');
+      expect(code).not.toMatch(/\bwindow\b/);
+      expect(code).not.toMatch(/\bdocument\b/);
+      expect(code).not.toMatch(/\blocation\b/);
+      expect(code).not.toMatch(/\blocalStorage\b/);
+    });
+  });
+});

--- a/frontend/src/state/viewbox-link.ts
+++ b/frontend/src/state/viewbox-link.ts
@@ -1,0 +1,179 @@
+import { MIN_ZOOM } from '@/components/map/geometry/camera-config.js';
+import { CLUSTER_MAX_ZOOM } from '@/components/map/geometry/observation-layers.js';
+
+/**
+ * viewbox-link — a pure, total-function codec that serializes a map camera
+ * (+ an optional capture viewport) into a URL hash fragment and back.
+ *
+ * WHY a hash: the map camera is never in the URL today — it is derived from
+ * scope via `fitBounds` in `App.tsx`. Epic #1238 makes an exact view a
+ * copyable link; this codec is the string ↔ object foundation the capture
+ * control (C2), the replay tool (C3), and the restore-on-load (C4) all build
+ * on. No DOM, no app wiring lives here — `encodeViewbox` returns the fragment
+ * (caller assigns it to `location.hash`); `decodeViewbox` takes a raw hash.
+ *
+ * WHY total decode: a shared link is hand-editable and truncatable. Decode
+ * must degrade ANY garbage to a clean `null` ("normal load — derive the
+ * camera from scope as usual"), and must NEVER throw and NEVER partial-apply
+ * a half-parsed camera (which would strand the map at a corrupt position with
+ * no affordance back). Recoverable-but-out-of-range values are CLAMPED, not
+ * rejected, so a slightly-off link still opens near the intended view.
+ *
+ * Grammar: #map=<zoom>/<lat>/<lng>[/<bearing>[/<pitch>]][&v=<W>x<H>@<dpr>]
+ * Field order is zoom/lat/lng (lat 2nd, lng 3rd — MapLibre hash order).
+ */
+
+export interface ViewboxCamera {
+  zoom: number;
+  lat: number;
+  lng: number;
+  bearing?: number; // omitted / 0 when north-up
+  pitch?: number; // omitted / 0 when flat
+}
+
+export interface ViewboxViewport {
+  w: number;
+  h: number;
+  dpr: number;
+}
+
+// Web Mercator latitude limit — the poles are unprojectable, so a link with a
+// lat past this clamps here rather than to ±90 (which a MapLibre camera cannot
+// represent). MapLibre uses the same ±85.051129 limit.
+const MERCATOR_LAT_LIMIT = 85.05113;
+const MAX_PITCH = 60;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Serialize a camera (+ optional viewport) into a hash fragment WITHOUT the
+ * leading `#`. Fixed-decimal throughout (never `String(n)`) so `-110.9` and
+ * `-110.90000` serialize identically and round-trip. Bearing/pitch are emitted
+ * only when non-zero; a non-zero pitch with a zero bearing still emits the
+ * bearing as `0.0` so the slash positions stay unambiguous.
+ */
+export function encodeViewbox(cam: ViewboxCamera, viewport?: ViewboxViewport): string {
+  const bearing = cam.bearing ?? 0;
+  const pitch = cam.pitch ?? 0;
+
+  let value = `${cam.zoom.toFixed(3)}/${cam.lat.toFixed(5)}/${cam.lng.toFixed(5)}`;
+
+  // A north-up flat view produces no trailing /0/0. Pitch implies a bearing
+  // slot so the 5th field stays unambiguous — emit bearing (possibly 0.0)
+  // whenever bearing OR pitch is non-zero.
+  if (bearing !== 0 || pitch !== 0) {
+    value += `/${bearing.toFixed(1)}`;
+    if (pitch !== 0) {
+      value += `/${pitch.toFixed(1)}`;
+    }
+  }
+
+  let out = `map=${value}`;
+  if (viewport) {
+    out += `&v=${viewport.w}x${viewport.h}@${viewport.dpr}`;
+  }
+  return out;
+}
+
+/**
+ * Parse a viewport from a `v=` sub-value (`<w>x<h>@<dpr>`). Returns the
+ * viewport only when all three are positive finite numbers; otherwise
+ * `undefined` (a malformed viewport is ignored, never an error).
+ */
+function parseViewport(raw: string): ViewboxViewport | undefined {
+  // Destructure (not index) so `noUncheckedIndexedAccess` narrows each part to
+  // `string | undefined`; the explicit `=== undefined` guards below then both
+  // satisfy the type checker AND reject a missing `@dpr` / `<h>` at runtime.
+  const [dimsPart, dprPart, ...restAt] = raw.split('@');
+  // dimsPart is always present at runtime (split yields ≥1 element); the
+  // explicit guard satisfies `noUncheckedIndexedAccess`. dprPart present +
+  // no extra '@' ⇒ exactly one '@'.
+  if (dimsPart === undefined || dprPart === undefined || restAt.length > 0) {
+    return undefined;
+  }
+  const [wPart, hPart, ...restX] = dimsPart.split('x');
+  if (wPart === undefined || hPart === undefined || restX.length > 0) {
+    return undefined; // exactly one 'x'
+  }
+
+  const w = Number(wPart);
+  const h = Number(hPart);
+  const dpr = Number(dprPart);
+  const positiveFinite = (n: number) => Number.isFinite(n) && n > 0;
+  if (!positiveFinite(w) || !positiveFinite(h) || !positiveFinite(dpr)) {
+    return undefined;
+  }
+  return { w, h, dpr };
+}
+
+/**
+ * Decode a hash fragment back into a camera (+ optional viewport). Total —
+ * never throws. Returns `null` when no camera is recoverable; otherwise clamps
+ * recoverable values into range. A malformed viewport or unknown sub-key is
+ * ignored without nulling the camera.
+ */
+export function decodeViewbox(
+  hash: string,
+): { camera: ViewboxCamera; viewport?: ViewboxViewport } | null {
+  // 1. Strip a leading '#', split on '&', find the map= pair.
+  const body = hash.startsWith('#') ? hash.slice(1) : hash;
+  const pairs = body.split('&');
+
+  let mapValue: string | null = null;
+  let viewportRaw: string | null = null;
+  for (const pair of pairs) {
+    // Only split on the FIRST '=' so a value containing '=' is preserved.
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    const key = pair.slice(0, eq);
+    const val = pair.slice(eq + 1);
+    if (key === 'map') {
+      mapValue = val;
+    } else if (key === 'v') {
+      viewportRaw = val;
+    }
+    // 6. All other / unknown sub-keys are ignored (forward-compatible).
+  }
+
+  if (mapValue === null) return null;
+
+  // 2. Split on '/', require ≥3 fields; Number() rejects trailing garbage.
+  const fields = mapValue.split('/');
+  if (fields.length < 3) return null;
+
+  const zoom = Number(fields[0]);
+  const lat = Number(fields[1]);
+  const lng = Number(fields[2]);
+  if (Number.isNaN(zoom) || Number.isNaN(lat) || Number.isNaN(lng)) return null;
+
+  // 3. Clamp recoverable values rather than reject. Zoom ceiling is the
+  //    INTERACTIVE max (CLUSTER_MAX_ZOOM = 22), NOT the fitBounds framing cap
+  //    of 12 — a link captured at z16 must reopen at z16.
+  const camera: ViewboxCamera = {
+    zoom: clamp(zoom, MIN_ZOOM, CLUSTER_MAX_ZOOM),
+    lat: clamp(lat, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT),
+    lng: clamp(lng, -180, 180),
+  };
+
+  // 4. Optional bearing: NaN → drop; else normalize into [0, 360).
+  if (fields.length >= 4) {
+    const bearing = Number(fields[3]);
+    if (!Number.isNaN(bearing)) {
+      camera.bearing = ((bearing % 360) + 360) % 360;
+    }
+  }
+  // Optional pitch: NaN → drop; else clamp into [0, 60].
+  if (fields.length >= 5) {
+    const pitch = Number(fields[4]);
+    if (!Number.isNaN(pitch)) {
+      camera.pitch = clamp(pitch, 0, MAX_PITCH);
+    }
+  }
+
+  // 5. Parse the viewport if present; ignore (don't null the camera) if malformed.
+  const viewport = viewportRaw !== null ? parseViewport(viewportRaw) : undefined;
+
+  return viewport ? { camera, viewport } : { camera };
+}

--- a/knip.ts
+++ b/knip.ts
@@ -209,6 +209,30 @@ const config: KnipConfig = {
       //             retired rather than reasoned about.
       ignore: [
         'src/tokens.ts',
+        // 2026-06-16 (C1, #1239 — SELF-HEALING): src/state/viewbox-link.ts is
+        //             the pure camera↔#map= hash codec (epic #1238). It has no
+        //             non-test `src` importer yet — its first production consumer
+        //             is C2 (#1240, the capture control), which is not merged.
+        //             This ignore is the AC-required guard against the file
+        //             reading as a true orphan: `knip (informational)` is a
+        //             required branch-protection check that reds the Mergify
+        //             queue on a NON-ZERO exit, and a src module with no src
+        //             consumer is a `--no-progress` unused-file finding (exit 1).
+        //             NOTE: as shipped, the co-located src/state/viewbox-link.test.ts
+        //             (a vitest target inside knip's src-only graph) already
+        //             counts as a consumer, so knip traces the file as USED and
+        //             currently emits a "Remove from ignore" CONFIGURATION HINT
+        //             for this entry (exit 0 — same harmless class as the kept
+        //             docs/plans/2026-04-22-map-v1-prototype/prototype/** entry
+        //             above; hints do not change the exit code or gate the queue).
+        //             The entry is kept deliberately so the file stays covered if
+        //             that test is ever thinned/removed before C2 lands. C2
+        //             REMOVES this entry the moment it adds the production import
+        //             (self-healing, like the tools/photo-curation entries Part B
+        //             retired). Re-audit 2026-07-27 — if #1240 has merged this is
+        //             already gone; otherwise confirm the codec is still the
+        //             intended C2 dependency before keeping it.
+        'src/state/viewbox-link.ts',
         // ds/index.ts barrel deleted in the map split (it had zero importers —
         // all consumers import ds/ primitives by direct path), so the ignore
         // entry that silenced its "unused barrel" finding is gone with it.


### PR DESCRIPTION
## Diagrams

`decodeViewbox` is a total function: every hash either yields a clamped-into-range camera or a clean `null` (never a throw, never a partial camera).

```mermaid
flowchart TD
    H["raw hash"] --> S["strip leading #, split on &"]
    S --> M{"map= pair present?"}
    M -- no --> N["return null"]
    M -- yes --> F{"≥3 slash fields?"}
    F -- no --> N
    F -- yes --> P{"zoom/lat/lng all Number()-parseable?"}
    P -- "any NaN" --> N
    P -- yes --> C["clamp: zoom to MIN_ZOOM..CLUSTER_MAX_ZOOM 2..22, lat to ±85.05113, lng to ±180"]
    C --> B["bearing? NaN drops it, else wrap into 0..360"]
    B --> T["pitch? NaN drops it, else clamp 0..60"]
    T --> V{"&v= present and well-formed positive finite?"}
    V -- "yes" --> R1["camera + viewport"]
    V -- "no / malformed / absent" --> R2["camera only (viewport ignored, camera kept)"]
```

`encodeViewbox` is the inverse: `map=<zoom toFixed3>/<lat toFixed5>/<lng toFixed5>[/<bearing toFixed1>[/<pitch toFixed1>]][&v=<w>x<h>@<dpr>]`, bearing/pitch emitted only when non-zero (a non-zero pitch with zero bearing still emits `0.0` so slot positions stay unambiguous), returned without a leading `#`.

## Summary

- Adds `frontend/src/state/viewbox-link.ts` — a pure, total-function codec (sibling to `url-state.ts`) that serializes a map camera (+ optional capture viewport) into a `#map=` hash and back. The camera is not in the URL today (it's derived from scope via `fitBounds`); this is the string ↔ object foundation epic #1238's capture (C2) / replay (C3) / restore (C4) build on. No DOM, no app wiring.
- **Total decode** is the load-bearing property: a hand-edited or truncated link degrades to a clean `null` ("normal load — derive from scope") and never throws or half-applies a camera that would strand the map at a corrupt position. Recoverable-but-out-of-range values are clamped, not rejected. Zoom clamps to the **interactive** max (`CLUSTER_MAX_ZOOM` = 22), **not** the `fitBounds` framing cap of 12 — a z16 link must reopen at z16.
- Adds a **self-healing** `knip.ts` ignore for the new module (no production `src` consumer until C2 #1240 imports it; C2 removes the entry).

## Screenshots

N/A — not UI. This is a pure-logic module (`frontend/src/state/viewbox-link.ts`) with no visible element — no `className`s, no rendered output, no Playwright surface.

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className introduced`
- [x] Multi-viewport design QA — `N/A — not UI`

## Test plan

`frontend/src/state/viewbox-link.test.ts` mirrors `url-state.test.ts`'s round-trip / edge-case style: a round-trip table (north-up / rotated / pitched / ±viewport), the full null-on-garbage set, every clamp boundary (incl. the explicit "z16 is NOT clamped to 12" and "z25 clamps to 22" assertions, lat-beyond-±85.05113-not-±90, bearing wrap, pitch clamp), fixed-decimal formatting, unknown-key tolerance, and a source-scan purity check (no `window`/`document`/`location`/`localStorage`). 45 tests.

- [x] `npm run -w @bird-watch/frontend test -- viewbox-link` — green (45 passed)
- [x] Full frontend suite `npm run -w @bird-watch/frontend test` — green (92 files / 1689 tests; the 2 transient failures on a cold worktree were `@bird-watch/shared-types` not yet built, unrelated to this change — green after `npm run build -w @bird-watch/shared-types`)
- [x] New unit tests added (behavior is new)
- [x] `npm run lint` (root CI gate) — green
- [x] `npm run -w @bird-watch/frontend build` (`tsc -b && vite build`) — clean production build
- [x] `npx knip --no-progress` (root, CI-equivalent) — exit 0
- [ ] New Playwright e2e spec — N/A (no user-visible behavior; codec is consumed by C2)
- [ ] (UI only) Playwright MCP smoke — N/A — not UI

```
# npm run -w @bird-watch/frontend test -- viewbox-link
 Test Files  1 passed (1)
      Tests  45 passed (45)

# npm run lint            → exit 0
# npm run -w @bird-watch/frontend build   → built in 469ms, exit 0
# npx knip --no-progress
Configuration hints (2)
docs/plans/2026-04-22-map-v1-prototype/prototype/**            knip.ts  Remove from ignore
src/state/viewbox-link.ts                            frontend  knip.ts  Remove from ignore
   → exit 0
```

Note on the knip hint: the co-located `viewbox-link.test.ts` (a vitest target inside knip's `src`-only graph) already counts as a consumer, so knip traces the file as used and emits a *configuration hint* ("Remove from ignore") for the new ignore entry — exit 0, the same harmless class as the pre-existing kept `docs/plans/.../prototype/**` entry. The ignore is kept deliberately per AC #7 as the self-healing guard against the file reading as a true orphan if that test is ever thinned before C2 lands; C2 (#1240) removes it when it adds the production import. The comment in `knip.ts` documents this honestly.

## Plan reference

Out of plan — child C1 of epic #1238 (camera-in-URL shareable views), filed as issue #1239 (labeled `out-of-plan`). Closes #1239. Part of #1238.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
