### PR TITLE
feat(frontend): self-healing marker convergence — scope changes repopulate without a manual pan

### DIFF
--- a/frontend/e2e/map/map-adaptive-grid.spec.ts
+++ b/frontend/e2e/map/map-adaptive-grid.spec.ts
@@ -227,6 +227,59 @@ test.describe('Adaptive-grid markers (epic #539)', () => {
   });
 });
 
+test.describe('Marker-convergence watchdog wiring (#1236)', () => {
+  /**
+   * Wiring guard: scope switch repopulates markers without a manual pan.
+   *
+   * This test is the end-to-end complement to the unit tests in
+   * use-marker-convergence.test.ts. It verifies the hook is actually wired into
+   * MapCanvas (the "one call line" in the removability contract) by asserting
+   * that a state→state scope switch causes new-scope markers to appear without
+   * any camera event (flyTo / pan / zoom) between the switch and the assertion.
+   *
+   * On unpatched main the markers strand until the user pans — this test would
+   * fail there. The deterministic proof is in the unit tests (the timing race is
+   * non-deterministic under SwiftShader); this guards the wiring.
+   *
+   * WebGL-guarded per the file convention: headless Chromium in some CI
+   * environments has no WebGL backend → map canvas never paints → skip.
+   */
+  test('state→state scope switch repopulates markers without a manual pan', async ({ page }) => {
+    const app = new AppPage(page);
+    // Start in AZ so there are known observations to render.
+    await app.goto('state=US-AZ');
+    await app.waitForAppReady();
+    const webglReady = await waitForMapReady(page);
+    test.skip(!webglReady, 'WebGL unavailable — map canvas did not paint');
+
+    // Fly to Tucson to get into a region with dense observations.
+    await flyToTucson(page, 10);
+
+    // Assert ≥1 adaptive-grid marker in AZ at this zoom.
+    const markers = page.locator('[data-testid=adaptive-grid-marker]');
+    await expect.poll(() => markers.count(), { timeout: 8_000 }).toBeGreaterThanOrEqual(1);
+
+    // Switch scope to CA via the in-state scope control (no flyTo/pan/zoom from
+    // the test — the convergence watchdog is what drives the marker refresh).
+    await app.openScopeDisclosure();
+    await app.switchStateViaScopeControl('US-CA');
+
+    // Wait for markers to appear for the new scope WITHOUT any manual camera move.
+    // On unpatched main this would time out because idle never re-fires on a
+    // quiescent map after the scope change. With #1236 the watchdog drives the
+    // refresh via triggerRepaint → idle → reconcile.
+    //
+    // We poll the marker count: we expect it to become non-zero (CA has data
+    // at every zoom >= 6), not necessarily equal to the AZ count.
+    await expect
+      .poll(() => markers.count(), {
+        timeout: 10_000,
+        message: 'Expected adaptive-grid markers to appear after scope switch without a manual pan',
+      })
+      .toBeGreaterThanOrEqual(1);
+  });
+});
+
 test.describe('@perf adaptive-grid (perf-gate only)', () => {
   // Tagged tests run only when invoked via `npx playwright test --grep @perf`
   // in the dedicated perf-gate CI workflow. The default `npm run test:e2e`

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -48,6 +48,8 @@ import { DisplacedSilhouetteLayer } from './layers/DisplacedSilhouetteLayer.js';
 import { registerSilhouetteSprite } from './geometry/silhouette-sprite.js';
 import { useSilhouetteCatalogue } from './hooks/use-silhouette-catalogue.js';
 import { useMapResize } from './hooks/use-map-resize.js';
+import { useMarkerConvergence } from './hooks/use-marker-convergence.js';
+import { analytics } from '../../analytics.js';
 import { useScopeCamera } from './hooks/use-scope-camera.js';
 import { useStateArtboard } from './hooks/use-state-artboard.js';
 import { loadSanitizedStyle } from './geometry/basemap-style-sanitizer.js';
@@ -777,6 +779,17 @@ export function MapCanvas({
         : observationsToGeoJson(observations, silhouettes),
     [aggregated, buckets, observations, silhouettes],
   );
+
+  // Marker-convergence watchdog (#1236) — self-contained; see use-marker-convergence.ts.
+  // Removability: this one call + that file ARE the whole feature; reconcile is untouched.
+  useMarkerConvergence(mapRef, mapReady, geojson, {
+    onTelemetry: ({ attempts, elapsedMs }) =>
+      analytics.capture('marker_convergence_backstop', {
+        attempts,
+        elapsedMs: Math.round(elapsedMs),
+        mode: aggregated ? 'aggregated' : 'observations',
+      }),
+  });
 
   // Tracks the map's current zoom for hit-target gating. The hit-layer
   // (#247, #277) renders DOM `<button>` overlays for auto-spider stacks +

--- a/frontend/src/components/map/hooks/use-marker-convergence.test.ts
+++ b/frontend/src/components/map/hooks/use-marker-convergence.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMarkerConvergence } from './use-marker-convergence.js';
+import type { ConvergenceMap, ConvergenceMapRef, MarkerConvergenceTelemetry } from './use-marker-convergence.js';
+import type { MapSourceDataEvent } from 'maplibre-gl';
+
+/**
+ * Unit tests for the marker-convergence watchdog (#1236).
+ *
+ * Design invariants locked here:
+ *   1. Cold-mount is a no-op (FP-safety: dataGen===committedGen===0 → no repaint).
+ *   2. STAMP only on `idle` — `sourcedata` DRIVES only, never stamps.
+ *      (False-convergence guard: a stamp on sourcedata would record health
+ *       against an unpainted frame — `idle` is the only painted-frame signal.)
+ *   3. `sourcedata` fires exactly one rAF-coalesced `triggerRepaint` per burst.
+ *   4. Watchdog heals: bumping `dataVersion` starts the loop; `idle` stamps →
+ *      loop self-cancels with no telemetry.
+ *   5. Backstop: budget expiry → one final `triggerRepaint` + telemetry once.
+ *   6. Re-arm: bumping `dataVersion` twice clears the prior timer.
+ *   7. Cleanup: unmount removes both listeners, cancels timer + rAF.
+ */
+
+// ---------------------------------------------------------------------------
+// Fake map — spy-testable narrow surface matching ConvergenceMap.
+// Captures `idle` and `sourcedata` handlers so tests can fire them.
+// ---------------------------------------------------------------------------
+type IdleListener = () => void;
+type SourceDataListener = (e: MapSourceDataEvent) => void;
+
+function makeFakeMap() {
+  const idleListeners: IdleListener[] = [];
+  const sourceDataListeners: SourceDataListener[] = [];
+
+  const map = {
+    triggerRepaint: vi.fn(),
+    on: vi.fn((type: string, listener: IdleListener | SourceDataListener) => {
+      if (type === 'idle') idleListeners.push(listener as IdleListener);
+      if (type === 'sourcedata') sourceDataListeners.push(listener as SourceDataListener);
+    }),
+    off: vi.fn((type: string, listener: IdleListener | SourceDataListener) => {
+      if (type === 'idle') {
+        const idx = idleListeners.indexOf(listener as IdleListener);
+        if (idx !== -1) idleListeners.splice(idx, 1);
+      }
+      if (type === 'sourcedata') {
+        const idx = sourceDataListeners.indexOf(listener as SourceDataListener);
+        if (idx !== -1) sourceDataListeners.splice(idx, 1);
+      }
+    }),
+    // Test-only helpers to fire captured events.
+    __fireIdle: () => { for (const fn of [...idleListeners]) fn(); },
+    __fireSourceData: (e: Partial<MapSourceDataEvent>) => {
+      for (const fn of [...sourceDataListeners]) fn(e as MapSourceDataEvent);
+    },
+    __idleListeners: idleListeners,
+    __sourceDataListeners: sourceDataListeners,
+  };
+  return map;
+}
+
+type FakeMap = ReturnType<typeof makeFakeMap>;
+
+function makeMapRef(map: FakeMap) {
+  const ref = {
+    current: {
+      getMap: () => map as unknown as ConvergenceMap,
+    } as ConvergenceMapRef,
+  };
+  return ref;
+}
+
+// ---------------------------------------------------------------------------
+// A qualifying sourcedata event payload (the fast-path trigger).
+// ---------------------------------------------------------------------------
+function observationsContent(overrides: Partial<MapSourceDataEvent> = {}): Partial<MapSourceDataEvent> {
+  return {
+    sourceId: 'observations',
+    isSourceLoaded: true,
+    sourceDataType: 'content',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('useMarkerConvergence', () => {
+  let rafQueue: Array<{ id: number; cb: FrameRequestCallback }>;
+  let rafIdSeq: number;
+  let cancelledRafIds: number[];
+  let fakeNow: () => number;
+  let currentTime: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    currentTime = 0;
+    rafQueue = [];
+    cancelledRafIds = [];
+    rafIdSeq = 0;
+    fakeNow = () => currentTime;
+
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafIdSeq += 1;
+      const id = rafIdSeq;
+      rafQueue.push({ id, cb });
+      return id;
+    });
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      cancelledRafIds.push(id);
+      const idx = rafQueue.findIndex(e => e.id === id);
+      if (idx !== -1) rafQueue.splice(idx, 1);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function flushRaf(): void {
+    const pending = [...rafQueue];
+    rafQueue = [];
+    for (const { cb } of pending) cb(currentTime);
+  }
+
+  function advanceTime(ms: number): void {
+    currentTime += ms;
+    vi.advanceTimersByTime(ms);
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Cold-mount no-op (FP-safety)
+  // -------------------------------------------------------------------------
+  it('cold-mount: dataGen===0, committedGen===0 → no triggerRepaint, no telemetry', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+    const onTelemetry = vi.fn();
+    const dataVersion = {};
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, dataVersion, { now: fakeNow, onTelemetry }),
+    );
+
+    // Watchdog exits immediately (reflected() === true at mount).
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+    expect(onTelemetry).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Stamp only on `idle` (false-convergence guard)
+  // -------------------------------------------------------------------------
+  it('sourcedata does NOT advance committedGen; idle DOES stamp committedGen', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+    const onTelemetry = vi.fn();
+
+    // Use a stable first version so dataGen=0 at mount.
+    const v0 = {};
+    const { rerender } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, true, dv, { now: fakeNow, onTelemetry }),
+      { initialProps: { dv: v0 } },
+    );
+
+    // Bump dataVersion to dataGen=1 — watchdog arms.
+    const v1 = {};
+    rerender({ dv: v1 });
+    // Advance past first backoff tick but stay under budget.
+    advanceTime(100);
+
+    // Fire sourcedata — should trigger repaint but NOT stamp.
+    map.__fireSourceData(observationsContent());
+    flushRaf();
+    expect(map.triggerRepaint).toHaveBeenCalled();
+
+    // Now fire idle — should stamp committedGen=1 → watchdog self-cancels.
+    map.__fireIdle();
+    map.triggerRepaint.mockClear();
+
+    // Advance more time — after stamp, watchdog should be gone.
+    advanceTime(500);
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+    // No telemetry (healed before budget).
+    expect(onTelemetry).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. sourcedata drive + filter
+  // -------------------------------------------------------------------------
+  it('qualifying sourcedata event triggers one rAF-coalesced triggerRepaint', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
+    );
+
+    // Fire 3 qualifying events in one burst — should coalesce to ONE repaint.
+    map.__fireSourceData(observationsContent());
+    map.__fireSourceData(observationsContent());
+    map.__fireSourceData(observationsContent());
+
+    expect(map.triggerRepaint).not.toHaveBeenCalled(); // rAF pending
+    flushRaf();
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+  });
+
+  it('sourcedata with wrong sourceId → no triggerRepaint', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
+    );
+
+    map.__fireSourceData(observationsContent({ sourceId: 'state-mask' }));
+    flushRaf();
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+  });
+
+  it('sourcedata with sourceDataType=metadata → no triggerRepaint', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
+    );
+
+    map.__fireSourceData(observationsContent({ sourceDataType: 'metadata' }));
+    flushRaf();
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+  });
+
+  it('sourcedata with isSourceLoaded=false → no triggerRepaint', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
+    );
+
+    map.__fireSourceData(observationsContent({ isSourceLoaded: false }));
+    flushRaf();
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Heal-on-retry: watchdog fires → idle stamps mid-loop → stops, no telemetry
+  // -------------------------------------------------------------------------
+  it('heal-on-retry: watchdog triggerRepaints; idle stamp stops loop with no telemetry', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+    const onTelemetry = vi.fn();
+    const backoffMs = [100, 200, 400] as const;
+
+    const v0 = {};
+    const { rerender } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, true, dv, { now: fakeNow, onTelemetry, backoffMs, budgetMs: 2000 }),
+      { initialProps: { dv: v0 } },
+    );
+
+    // Bump dataVersion → dataGen=1, watchdog arms.
+    const v1 = {};
+    rerender({ dv: v1 });
+
+    // First tick fires immediately (attempts=1, first repaint).
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+
+    // Advance to second tick.
+    advanceTime(100);
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(2);
+
+    // Fire idle mid-loop → stamps committedGen=1.
+    map.__fireIdle();
+    map.triggerRepaint.mockClear();
+
+    // Advance past third tick — should NOT fire because watchdog stopped.
+    advanceTime(200);
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+    expect(onTelemetry).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Backstop: budget expiry → one final triggerRepaint + telemetry, no double-fire
+  // -------------------------------------------------------------------------
+  it('backstop: budget expiry triggers one final repaint + onTelemetry exactly once', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+    const onTelemetry = vi.fn<[MarkerConvergenceTelemetry], void>();
+    const budgetMs = 1000;
+    const backoffMs = [100, 200, 400, 800] as const;
+
+    const v0 = {};
+    const { rerender } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, true, dv, { now: fakeNow, onTelemetry, backoffMs, budgetMs }),
+      { initialProps: { dv: v0 } },
+    );
+
+    // Bump dataVersion → watchdog arms. Do NOT fire idle (never stamp).
+    const v1 = {};
+    rerender({ dv: v1 });
+
+    // Drain the watchdog loop through the budget without stamping.
+    // t=0: tick → repaint(1), schedule 100ms
+    // t=100: tick → repaint(2), schedule 200ms
+    // t=300: tick → repaint(3), schedule 400ms
+    // t=700: tick → repaint(4), schedule 800ms (but budget=1000 so t=1500 > 1000)
+    // Actually at t=700+800=1500 tick fires but elapsed=1500>=1000 → backstop.
+    // Let's just advance past the budget and drain all pending ticks.
+    advanceTime(100); // t=100
+    advanceTime(200); // t=300
+    advanceTime(400); // t=700
+    // At t=700, next tick scheduled for 800ms delay → fires at t=1500
+    // But budget=1000ms, so when the tick at t=1500 checks elapsed=1500>=1000 → backstop.
+    advanceTime(800); // t=1500 → backstop fires
+
+    // Backstop: one additional repaint + telemetry.
+    expect(onTelemetry).toHaveBeenCalledTimes(1);
+    const telemetry = onTelemetry.mock.calls[0][0];
+    expect(telemetry.attempts).toBeGreaterThan(0);
+    expect(telemetry.elapsedMs).toBeGreaterThanOrEqual(budgetMs);
+
+    // Advance further — no more repaints or telemetry.
+    const repaintCountAtBackstop = map.triggerRepaint.mock.calls.length;
+    advanceTime(5000);
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(repaintCountAtBackstop);
+    expect(onTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Re-arm + thrash: bump twice → only latest watchdog active, prior timer cleared
+  // -------------------------------------------------------------------------
+  it('re-arm/thrash: second dataVersion bump clears the first watchdog timer', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+    const onTelemetry = vi.fn();
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const v0 = {};
+    const { rerender } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, true, dv, { now: fakeNow, onTelemetry, budgetMs: 2000 }),
+      { initialProps: { dv: v0 } },
+    );
+
+    // First bump → watchdog 1 starts.
+    const v1 = {};
+    rerender({ dv: v1 });
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+
+    // Second bump (no idle in between) → watchdog 2 starts; watchdog 1 cleanup called.
+    const v2 = {};
+    rerender({ dv: v2 });
+
+    // The second watchdog arms. clearTimeout should have been called (cleanup of first).
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    // Only the latest watchdog is active.
+    const repaintsBefore = map.triggerRepaint.mock.calls.length;
+
+    // Fire idle → stamp→ only latest watchdog stops.
+    map.__fireIdle();
+    map.triggerRepaint.mockClear();
+    advanceTime(2000);
+    expect(onTelemetry).not.toHaveBeenCalled();
+    // No more repaints after stamp.
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+    expect(repaintsBefore).toBeGreaterThanOrEqual(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Cleanup: unmount removes listeners, cancels timer + rAF
+  // -------------------------------------------------------------------------
+  it('cleanup: unmount removes idle+sourcedata listeners and cancels pending timer/rAF', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    const v0 = {};
+    const { rerender, unmount } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, true, dv, { now: fakeNow, budgetMs: 2000 }),
+      { initialProps: { dv: v0 } },
+    );
+
+    // Bump dataVersion to arm the watchdog.
+    const v1 = {};
+    rerender({ dv: v1 });
+
+    // Fire sourcedata to queue a rAF.
+    map.__fireSourceData(observationsContent());
+    expect(rafQueue).toHaveLength(1);
+
+    // Now unmount — should clear pending timer, cancel pending rAF, remove listeners.
+    unmount();
+
+    // map.off should have been called for both idle and sourcedata.
+    const offCalls = map.off.mock.calls;
+    const offTypes = offCalls.map(c => c[0]);
+    expect(offTypes).toContain('idle');
+    expect(offTypes).toContain('sourcedata');
+
+    // The rAF that was queued should be cancelled.
+    expect(cancelledRafIds).toHaveLength(1);
+
+    // After unmount, advancing time should not trigger any repaint or error.
+    map.triggerRepaint.mockClear();
+    advanceTime(5000);
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Extra: mapReady=false → no listeners, no watchdog
+  // -------------------------------------------------------------------------
+  it('does nothing when mapReady is false', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    const v0 = {};
+    const { rerender } = renderHook(
+      ({ dv }: { dv: unknown }) =>
+        useMarkerConvergence(mapRef, false, dv, { now: fakeNow }),
+      { initialProps: { dv: v0 } },
+    );
+
+    expect(map.on).not.toHaveBeenCalled();
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+
+    // Bump version — still no-op because mapReady=false.
+    rerender({ dv: {} });
+    expect(map.triggerRepaint).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/hooks/use-marker-convergence.test.ts
+++ b/frontend/src/components/map/hooks/use-marker-convergence.test.ts
@@ -288,7 +288,7 @@ describe('useMarkerConvergence', () => {
   it('backstop: budget expiry triggers one final repaint + onTelemetry exactly once', () => {
     const map = makeFakeMap();
     const mapRef = makeMapRef(map);
-    const onTelemetry = vi.fn<[MarkerConvergenceTelemetry], void>();
+    const onTelemetry = vi.fn<(t: MarkerConvergenceTelemetry) => void>();
     const budgetMs = 1000;
     const backoffMs = [100, 200, 400, 800] as const;
 

--- a/frontend/src/components/map/hooks/use-marker-convergence.test.ts
+++ b/frontend/src/components/map/hooks/use-marker-convergence.test.ts
@@ -71,12 +71,14 @@ function makeMapRef(map: FakeMap) {
 
 // ---------------------------------------------------------------------------
 // A qualifying sourcedata event payload (the fast-path trigger).
+// Verified live: the worker-done event for the observations source arrives
+// with sourceDataType UNDEFINED — gate is sourceId + isSourceLoaded only.
 // ---------------------------------------------------------------------------
-function observationsContent(overrides: Partial<MapSourceDataEvent> = {}): Partial<MapSourceDataEvent> {
+function observationsLoaded(overrides: Partial<MapSourceDataEvent> = {}): Partial<MapSourceDataEvent> {
   return {
     sourceId: 'observations',
     isSourceLoaded: true,
-    sourceDataType: 'content',
+    // sourceDataType intentionally absent — matches live MapLibre behaviour.
     ...overrides,
   };
 }
@@ -170,7 +172,7 @@ describe('useMarkerConvergence', () => {
     advanceTime(100);
 
     // Fire sourcedata — should trigger repaint but NOT stamp.
-    map.__fireSourceData(observationsContent());
+    map.__fireSourceData(observationsLoaded());
     flushRaf();
     expect(map.triggerRepaint).toHaveBeenCalled();
 
@@ -197,9 +199,9 @@ describe('useMarkerConvergence', () => {
     );
 
     // Fire 3 qualifying events in one burst — should coalesce to ONE repaint.
-    map.__fireSourceData(observationsContent());
-    map.__fireSourceData(observationsContent());
-    map.__fireSourceData(observationsContent());
+    map.__fireSourceData(observationsLoaded());
+    map.__fireSourceData(observationsLoaded());
+    map.__fireSourceData(observationsLoaded());
 
     expect(map.triggerRepaint).not.toHaveBeenCalled(); // rAF pending
     flushRaf();
@@ -214,12 +216,12 @@ describe('useMarkerConvergence', () => {
       useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
     );
 
-    map.__fireSourceData(observationsContent({ sourceId: 'state-mask' }));
+    map.__fireSourceData(observationsLoaded({ sourceId: 'state-mask' }));
     flushRaf();
     expect(map.triggerRepaint).not.toHaveBeenCalled();
   });
 
-  it('sourcedata with sourceDataType=metadata → no triggerRepaint', () => {
+  it('sourcedata with undefined sourceDataType + isSourceLoaded=true → triggers repaint (live MapLibre behaviour)', () => {
     const map = makeFakeMap();
     const mapRef = makeMapRef(map);
 
@@ -227,9 +229,26 @@ describe('useMarkerConvergence', () => {
       useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
     );
 
-    map.__fireSourceData(observationsContent({ sourceDataType: 'metadata' }));
+    // Verified live: the worker-done event arrives with sourceDataType undefined.
+    // The filter gates only on sourceId + isSourceLoaded, so this must fire.
+    map.__fireSourceData(observationsLoaded()); // no sourceDataType override → undefined
     flushRaf();
-    expect(map.triggerRepaint).not.toHaveBeenCalled();
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
+  });
+
+  it('sourcedata with sourceDataType=metadata + isSourceLoaded=true → triggers repaint (subtype no longer gated)', () => {
+    const map = makeFakeMap();
+    const mapRef = makeMapRef(map);
+
+    renderHook(() =>
+      useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
+    );
+
+    // Under the new subtype-agnostic filter, any isSourceLoaded=true event on
+    // the observations source fires the fast-path. rAF-coalesce absorbs extra events.
+    map.__fireSourceData(observationsLoaded({ sourceDataType: 'metadata' }));
+    flushRaf();
+    expect(map.triggerRepaint).toHaveBeenCalledTimes(1);
   });
 
   it('sourcedata with isSourceLoaded=false → no triggerRepaint', () => {
@@ -240,7 +259,7 @@ describe('useMarkerConvergence', () => {
       useMarkerConvergence(mapRef, true, {}, { now: fakeNow }),
     );
 
-    map.__fireSourceData(observationsContent({ isSourceLoaded: false }));
+    map.__fireSourceData(observationsLoaded({ isSourceLoaded: false }));
     flushRaf();
     expect(map.triggerRepaint).not.toHaveBeenCalled();
   });
@@ -389,7 +408,7 @@ describe('useMarkerConvergence', () => {
     rerender({ dv: v1 });
 
     // Fire sourcedata to queue a rAF.
-    map.__fireSourceData(observationsContent());
+    map.__fireSourceData(observationsLoaded());
     expect(rafQueue).toHaveLength(1);
 
     // Now unmount — should clear pending timer, cancel pending rAF, remove listeners.

--- a/frontend/src/components/map/hooks/use-marker-convergence.ts
+++ b/frontend/src/components/map/hooks/use-marker-convergence.ts
@@ -109,11 +109,11 @@ export function useMarkerConvergence(
     let sourceDataFrame = 0;
     const onSourceData = (e: MapSourceDataEvent) => {
       if (e.sourceId !== 'observations' || !e.isSourceLoaded) return;
-      // 'content' = the setData/recluster signal (MapLibre docs). If the live
-      // fast-path check (see ACs) shows this never matches for this source, drop
-      // this line and gate only on sourceId+isSourceLoaded (the canonical
-      // MapLibre HTML-cluster pattern; coalesce + watchdog absorb the extra events).
-      if (e.sourceDataType !== 'content') return;
+      // The worker-done signal for the clustered observations GeoJSON source is
+      // `isSourceLoaded` flipping true — verified live to arrive with
+      // sourceDataType UNDEFINED (the `content` subtype fires earlier, while the
+      // source is still unloaded). So gate ONLY on sourceId + isSourceLoaded (the
+      // canonical MapLibre HTML-cluster pattern); rAF-coalesce absorbs the rest.
       if (sourceDataFrame !== 0) return;
       // Drive: provoke the EXISTING idle->reconcile the instant the worker
       // finishes (re)clustering. rAF-coalesced (sourcedata is chatty).

--- a/frontend/src/components/map/hooks/use-marker-convergence.ts
+++ b/frontend/src/components/map/hooks/use-marker-convergence.ts
@@ -1,0 +1,183 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import type { MapSourceDataEvent } from 'maplibre-gl';
+
+/**
+ * Marker-convergence watchdog (#1236) — fully self-contained.
+ *
+ * THE BUG: after a scope change, the adaptive-grid reconciler (MapCanvas) only
+ * reconnects to a z>=6 `observations` swap via the camera `idle` event, which
+ * can fire too early or never re-fire on a quiescent map — stranding the prior
+ * scope's markers until the user pans.
+ *
+ * THIS HOOK owns everything end-to-end and touches NO existing map code:
+ *   - its OWN `idle` listener STAMPS convergence (idle => settled + PAINTED =>
+ *     MapCanvas's own idle->reconcile reflects the latest data => safe to record
+ *     "current data is on screen");
+ *   - its OWN `sourcedata` listener DRIVES a refresh via `map.triggerRepaint()`
+ *     the instant the worker finishes (re)clustering — provoking the EXISTING
+ *     idle->reconcile, with no reach into it;
+ *   - a bounded watchdog `triggerRepaint`s until convergence, so the refresh
+ *     happens without a user pan.
+ *
+ * REMOVABILITY: the whole feature is THIS FILE + ONE call line in MapCanvas.
+ * `reconcile`/`onIdle`/`onLoad`/the commit are untouched. To turn it off, revert
+ * the PR (or delete this file + the call line). Nothing to un-thread.
+ *
+ * WHY STAMP ONLY ON `idle`: `isSourceLoaded` is the worker "clustering done"
+ * flag, NOT a paint signal; `queryRenderedFeatures` reads the painted frame.
+ * `idle` (fired only at `!isMoving() && loaded()`) is the only settled+painted
+ * signal — so `sourcedata`/the watchdog only DRIVE, never stamp.
+ */
+
+/** Narrow maplibre surface this hook touches — keeps it spy-testable. */
+export interface ConvergenceMap {
+  triggerRepaint(): void;
+  on(type: 'idle', listener: () => void): unknown;
+  on(type: 'sourcedata', listener: (e: MapSourceDataEvent) => void): unknown;
+  off(type: 'idle', listener: () => void): unknown;
+  off(type: 'sourcedata', listener: (e: MapSourceDataEvent) => void): unknown;
+}
+
+/** Minimal react-map-gl MapRef surface: `getMap()` → {@link ConvergenceMap}. */
+export interface ConvergenceMapRef {
+  getMap(): ConvergenceMap | undefined;
+}
+
+export interface MarkerConvergenceTelemetry {
+  attempts: number;
+  elapsedMs: number;
+}
+
+export interface MarkerConvergenceOptions {
+  budgetMs?: number;
+  backoffMs?: readonly number[];
+  onTelemetry?: (t: MarkerConvergenceTelemetry) => void;
+  now?: () => number;
+}
+
+const DEFAULT_BACKOFF = [100, 200, 400, 800] as const;
+const DEFAULT_BUDGET_MS = 2000;
+
+/**
+ * @param mapRef      react-map-gl MapRef (`getMap()` → maplibre handle)
+ * @param mapReady    gate: only wire listeners/watchdog once `getMap()` is live
+ * @param dataVersion any value whose IDENTITY changes when the rendered data
+ *                    changes (pass the `geojson` FeatureCollection). The hook
+ *                    only compares identity; it never reads it.
+ */
+export function useMarkerConvergence(
+  mapRef: RefObject<ConvergenceMapRef | null>,
+  mapReady: boolean,
+  dataVersion: unknown,
+  options: MarkerConvergenceOptions = {},
+): void {
+  const {
+    budgetMs = DEFAULT_BUDGET_MS,
+    backoffMs = DEFAULT_BACKOFF,
+    onTelemetry,
+    now,
+  } = options;
+
+  // Render-phase data-generation counter: bumps when the rendered data identity
+  // changes. The "expected" side. (Same "compare-prev-prop-in-render" idiom the
+  // MapCanvas #872 boundsKey clear uses; no setState.)
+  const dataGenRef = useRef(0);
+  const prevDataVersionRef = useRef(dataVersion);
+  if (prevDataVersionRef.current !== dataVersion) {
+    prevDataVersionRef.current = dataVersion;
+    dataGenRef.current += 1;
+  }
+  const dataGen = dataGenRef.current;
+
+  // The "displayed" side: stamped by THIS hook's own idle listener.
+  const committedGenRef = useRef(0);
+
+  // Listeners — own `idle` (stamp) + `sourcedata` (drive). Registered once the
+  // map is live; touches no existing map code.
+  useEffect(() => {
+    if (!mapReady) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    // idle => settled + PAINTED => MapCanvas's own idle->reconcile reflects the
+    // latest data on this frame => safe to record dataGen as displayed.
+    const onIdle = () => {
+      committedGenRef.current = dataGenRef.current;
+    };
+
+    let sourceDataFrame = 0;
+    const onSourceData = (e: MapSourceDataEvent) => {
+      if (e.sourceId !== 'observations' || !e.isSourceLoaded) return;
+      // 'content' = the setData/recluster signal (MapLibre docs). If the live
+      // fast-path check (see ACs) shows this never matches for this source, drop
+      // this line and gate only on sourceId+isSourceLoaded (the canonical
+      // MapLibre HTML-cluster pattern; coalesce + watchdog absorb the extra events).
+      if (e.sourceDataType !== 'content') return;
+      if (sourceDataFrame !== 0) return;
+      // Drive: provoke the EXISTING idle->reconcile the instant the worker
+      // finishes (re)clustering. rAF-coalesced (sourcedata is chatty).
+      sourceDataFrame = requestAnimationFrame(() => {
+        sourceDataFrame = 0;
+        map.triggerRepaint();
+      });
+    };
+
+    map.on('idle', onIdle);
+    map.on('sourcedata', onSourceData);
+    return () => {
+      map.off('idle', onIdle);
+      map.off('sourcedata', onSourceData);
+      if (sourceDataFrame !== 0) cancelAnimationFrame(sourceDataFrame);
+    };
+  }, [mapReady]);
+
+  // Watchdog — re-arms per data generation; triggerRepaints (manufacturing
+  // stamping idles) until committedGen catches up, then self-cancels.
+  useEffect(() => {
+    if (!mapReady) return;
+    const reflected = () => committedGenRef.current >= dataGen;
+    // Zero-cost exit: already reflected (the common case, incl. cold-mount
+    // dataGen===0). No repaint, no telemetry.
+    if (reflected()) return;
+
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    const clock = now ?? (() => performance.now());
+    const start = clock();
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const stop = () => {
+      cancelled = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const tick = () => {
+      timer = null;
+      if (cancelled || reflected()) return stop();
+      if (clock() - start >= budgetMs) {
+        // Backstop: one more repaint (guaranteed-refresh attempt via the
+        // existing idle->reconcile — no camera move, no refetch) + record it.
+        map.triggerRepaint();
+        onTelemetry?.({ attempts, elapsedMs: clock() - start });
+        return stop();
+      }
+      attempts += 1;
+      map.triggerRepaint();
+      const delay = backoffMs[Math.min(attempts - 1, backoffMs.length - 1)] ?? 0;
+      timer = setTimeout(tick, delay);
+    };
+
+    tick();
+    return stop;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- dataGen is the
+    // intentional re-arm key; mapReady gates liveness. mapRef/committedGenRef
+    // are stable ref containers read imperatively; options read once.
+  }, [dataGen, mapReady]);
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[scope change] --> B[setData new geojson]
    B --> C[GL worker re-clusters]
    C --> D[sourcedata isSourceLoaded]
    D -->|DRIVE| E[triggerRepaint]
    E --> F[idle: settled and painted]
    F --> G[reconcile commits markers]
    F -->|STAMP| H[committedGen = dataGen]
    H --> I[watchdog self-cancels]
```

Self-contained hook. `sourcedata` and the watchdog **DRIVE** reconciles via `triggerRepaint`; only the post-paint `idle` listener may **STAMP** convergence (`idle` implies a settled, painted frame, so the query is truthful). `reconcile` / `onIdle` / `onLoad` are byte-unchanged.

## Summary

- **Why:** scope changes (national→state, state→state, filter apply) sometimes stranded the prior scope's markers until the user panned the map — a recurring correctness bug four prior point-fixes (#847/#872/#875/#901) each chipped at. This adds a self-healing layer so markers reconverge on their own, no pan required.
- **How (removable by design):** the whole feature is one new file (`use-marker-convergence.ts`) + **one call line** in `MapCanvas.tsx`. The hook owns its own `idle` (stamp) and `sourcedata` (drive) listeners + a bounded watchdog. To turn it off: revert/delete the hook + the one call — no runtime flag, nothing threaded into existing code.
- **Live-found fix:** the `sourcedata` fast-path's `sourceDataType === 'content'` filter was dead-on-arrival. Live capture of a real switch proved the `observations` source emits `content` while still **unloaded**, and the worker-done event carries `sourceDataType: undefined`. Relaxed to the canonical `sourceId + isSourceLoaded` (the fallback documented in #1236); re-verified the fast-path then fires.

## Screenshots

National map · 5 canonical viewports × 2 themes (Bright + Dark) · driven live via Playwright MCP. Scope switch (national→Arizona) repopulated markers with **no manual pan**; console clean.

| Viewport | Bright (light) | Dark |
|---|---|---|
| **390×844** · mobile | <img alt="national bright 390x844" width="230" src="https://github.com/user-attachments/assets/0e521bad-ee74-4346-b75f-7108927f90e2"> | <img alt="national dark 390x844" width="230" src="https://github.com/user-attachments/assets/306fa728-e88b-4bca-ac98-b2453eb6de19"> |
| **768×1024** · tablet | <img alt="national bright 768x1024" width="230" src="https://github.com/user-attachments/assets/64ca0f5e-6a5b-4617-ac39-ba2a4a36d64c"> | <img alt="national dark 768x1024" width="230" src="https://github.com/user-attachments/assets/c23176ce-607c-48a6-af07-35d0d208fb96"> |
| **1024×768** · landscape | <img alt="national bright 1024x768" width="230" src="https://github.com/user-attachments/assets/b57df367-552e-4742-b18d-7ceea89f80b9"> | <img alt="national dark 1024x768" width="230" src="https://github.com/user-attachments/assets/64ec7039-9396-4efd-93d5-90de8458027a"> |
| **1440×900** · desktop | <img alt="national bright 1440x900" width="230" src="https://github.com/user-attachments/assets/ace7dc84-19a2-461a-8ff4-b0b92fac22ce"> | <img alt="national dark 1440x900" width="230" src="https://github.com/user-attachments/assets/053896e3-b56b-4492-944f-dff4c4a2bc2c"> |
| **1920×1080** · wide | <img alt="national bright 1920x1080" width="230" src="https://github.com/user-attachments/assets/1d7b0416-07c5-4fdc-a5e8-efb65b046848"> | <img alt="national dark 1920x1080" width="230" src="https://github.com/user-attachments/assets/ddb6122c-6684-4cbe-b3fa-dfe1b3884cd1"> |

- [x] Every new/renamed `className` has a matching CSS rule — **N/A — behavior-only hook, no `className` added.**
- [x] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs (5 viewports × 2 themes).

## Test plan

- [x] `tsc -b` + `vitest run` — green (**1654 tests, 0 failures**)
- [x] New unit/integration tests — `use-marker-convergence.test.ts` (cold-mount no-op, stamp-only-on-`idle`, `sourcedata` drive + filter, heal-on-retry, backstop fires once, re-arm/thrash, cleanup)
- [x] New Playwright e2e spec — `e2e/map/map-adaptive-grid.spec.ts` (scope switch repopulates markers, no manual pan)
- [x] `vite build` — clean
- [x] Playwright MCP smoke — national→Arizona switch at 390×844 + 1440×900 (and 768/1024/1920), **no pan**; markers repopulated; fast-path fired (2 `observations`+`isSourceLoaded` events matched post-fix); `browser_console_messages` **0 errors / 0 warnings**; screenshots above captured from these runs.

## Plan reference

Implements **#1236** (bot-approved). Self-healing marker convergence; the `sourceDataType` relaxation follows the fast-path fallback documented in that issue, confirmed by live capture.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
