### PR TITLE
feat(frontend): restore camera from #map= hash on load + write-back

### DIFF
--- a/frontend/e2e/scope/viewbox-restore.spec.ts
+++ b/frontend/e2e/scope/viewbox-restore.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '../fixtures.js';
+import { AppPage } from '../pages/app-page.js';
+
+/**
+ * #1242 (C4 / epic #1238) — `#map=<z>/<lat>/<lng>` viewbox-restore on cold load
+ * + write-back. The map camera is otherwise scope-derived; a copied link makes
+ * an exact view self-restoring.
+ *
+ * GPU-FREE assertion (load-bearing): the restore is asserted via the
+ * `data-hash-camera` attribute MapCanvas emits on `[data-testid="map-canvas"]`
+ * (the wrapper nested inside `#map-layer`) carrying the APPLIED `zoom/lat/lng`.
+ * A `__birdMap` GL read would `test.skip` on the no-WebGL CI runner; the
+ * attribute does not. `data-camera-bounds` (App.tsx) only carries the scope key,
+ * never the camera, so it cannot distinguish a restored hash view.
+ *
+ * Determinism (no WebGL camera animation on the CI runner): drive cold-load
+ * links via `gotoRaw` (literal URL incl. the `#` fragment — `goto()` strips/
+ * mangles it), `emulateMedia({ reducedMotion: 'reduce' })`, latch on the
+ * attribute / URL hash, never `waitForTimeout` the write-back debounce.
+ *
+ * Navigation contract: every test issues its own `gotoRaw`; the data cases wait
+ * for `waitForAppReady()`. No DB writes (page.route stubs only).
+ */
+test.describe('viewbox-restore on cold load (#1242)', () => {
+  /** An AZ payload so a state scope yields a non-empty lede. */
+  const AZ_OBS = [
+    {
+      subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+      lat: 32.22, lng: -110.97,
+      obsDt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      locId: 'L1', locName: 'Tucson', howMany: 1, isNotable: false,
+      silhouetteId: 'tyrannidae', familyCode: 'tyrannidae',
+    },
+  ];
+
+  /** A camera INSIDE the AZ fixture envelope ([-114.82,31.33,-109.04,37.0]). */
+  const AZ_HASH = 'map=11.500/32.22100/-110.97400';
+  /** A camera OUTSIDE AZ (a Texas-ish center) — must NOT restore (AC5). */
+  const TEXAS_HASH = 'map=6.000/31.00000/-99.00000';
+
+  async function setup(
+    page: import('@playwright/test').Page,
+    apiStub: import('../fixtures.js').ApiStub,
+  ): Promise<{ app: AppPage }> {
+    await apiStub.stubStates();
+    await apiStub.stubZipIndex();
+    await apiStub.stubEmpty();
+    await apiStub.stubObservations(AZ_OBS);
+    // Reduced motion ⇒ instant camera settle (no animation to wait through).
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    return { app: new AppPage(page) };
+  }
+
+  test('AC1: cold ?state=US-AZ#map=… lands on the hash view (data-hash-camera) and survives /api/states', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+
+    // gotoRaw — literal URL preserves the `#map=` fragment (goto() would not).
+    await app.gotoRaw(`state=US-AZ#${AZ_HASH}`);
+
+    // The camera is restored to the hash view (the imperative restore lands once
+    // /api/states resolves the real AZ envelope and validates the center).
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+      { timeout: 10_000 },
+    );
+    // The real AZ envelope landed (the holding CONUS bounds resolved to US-AZ).
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
+    await app.waitForAppReady();
+
+    // The camera STAYS on the hash view: the holding→real-envelope transition
+    // keeps the same boundsKey, so the camera-intent effect must NOT re-frame
+    // and clobber the hash. Hold a beat and re-assert it is unchanged (AC1).
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+    );
+    await expect(app.mapLayer).toHaveAttribute('data-scope-fitted', 'true', {
+      timeout: 3_000,
+    });
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+    );
+    // And the URL hash is unchanged (the restore did not rewrite it).
+    expect(new URL(page.url()).hash).toBe(`#${AZ_HASH}`);
+  });
+
+  test('AC5: an OUT-OF-SCOPE hash (?state=US-AZ#<Texas>) falls back to the scope fit (no data-hash-camera)', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+
+    await app.gotoRaw(`state=US-AZ#${TEXAS_HASH}`);
+    await app.waitForAppReady();
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-AZ');
+
+    // The Texas hash is outside AZ → it must NOT be restored; the attribute is
+    // absent (the camera framed the AZ envelope instead, under the artboard).
+    await expect(app.mapCanvas).not.toHaveAttribute('data-hash-camera', /.*/);
+  });
+
+  test('AC2: a later in-app scope change reframes (ignores the consumed hash)', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+
+    // Land restored to the AZ hash view.
+    await app.gotoRaw(`state=US-AZ#${AZ_HASH}`);
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+      { timeout: 10_000 },
+    );
+
+    // Switch to Florida via the in-card scope control — a genuine scope change.
+    await app.openScopeDisclosure();
+    await app.switchStateViaScopeControl('US-FL');
+
+    // The camera reframes to FL (the consumed hash is ignored — first-run-only).
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'US-FL');
+    // The stale AZ hash-camera handle is gone (the new scope was framed, not the hash).
+    await expect(app.mapCanvas).not.toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+    );
+  });
+
+  test('AC3: a filter write preserves the #map= hash', async ({ page, apiStub }) => {
+    const { app } = await setup(page, apiStub);
+
+    await app.gotoRaw(`state=US-AZ#${AZ_HASH}`);
+    await app.waitForAppReady();
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '11.500/32.22100/-110.97400',
+      { timeout: 10_000 },
+    );
+
+    // Toggle a filter — writeUrl must preserve the hash (the C4 url-state fix).
+    await app.openFilters();
+    await page.getByLabel('Time window', { exact: true }).selectOption('1d');
+
+    // The search gains since=1d AND the #map= hash survives.
+    await expect(page).toHaveURL(/[?&]since=1d\b/);
+    expect(new URL(page.url()).hash).toBe(`#${AZ_HASH}`);
+  });
+
+  test('a bare ?scope=us (no #map=) load shows NO data-hash-camera (normal scope-derived path)', async ({
+    page,
+    apiStub,
+  }) => {
+    const { app } = await setup(page, apiStub);
+
+    await app.gotoRaw('scope=us');
+    await app.waitForAppReady();
+    await expect(app.mapLayer).toHaveAttribute('data-camera-bounds', 'us');
+    // No hash ⇒ no restore handle.
+    await expect(app.mapCanvas).not.toHaveAttribute('data-hash-camera', /.*/);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import { analytics } from '@/analytics.js';
 import { ApiClient, ApiError } from '@/api/client.js';
 import { useUrlState, DEFAULTS } from '@/state/url-state.js';
 import type { Scope } from '@/state/url-state.js';
+import { decodeViewbox } from '@/state/viewbox-link.js';
+import type { ViewboxCamera } from '@/state/viewbox-link.js';
 import type { ScopeResolution } from '@/state/scope-types.js';
 import { useBirdData } from '@/data/use-bird-data.js';
 import { useSilhouettes } from '@/data/use-silhouettes.js';
@@ -209,6 +211,22 @@ function focusFirstMarker(): void {
 
 export function App() {
   const { state, set } = useUrlState();
+
+  // #1242 (C4) — parse the `#map=` viewbox camera ONCE, non-reactively, at mount.
+  // The map camera is otherwise scope-derived; a copied `#map=<z>/<lat>/<lng>`
+  // link makes an exact view self-restoring (epic #1238). This MUST be a
+  // `useRef` initializer (NOT a `useMemo`/`useEffect`) so it reads the cold-load
+  // hash exactly once and never re-fires when the write-back later rewrites the
+  // hash via `replaceState` (which does NOT re-render, but a later render must
+  // not re-parse a moved camera and yank the view). `decodeViewbox` is total —
+  // any garbage degrades to `null` ("normal scope-derived load"). The validation
+  // against the active scope envelope (AC5) happens reactively below, once
+  // `/api/states` resolves the real bounds; this is just the raw parse.
+  const rawHashCameraRef = useRef<ViewboxCamera | null>(
+    decodeViewbox(window.location.hash)?.camera ?? null,
+  );
+  const rawHashCamera = rawHashCameraRef.current;
+
   const isCompact = useIsCompact();
   // O5 (#783): phone-scoped signal keyed to ≤480px (P1's overlay breakpoint).
   // Distinct from isCompact (≤1199px): the phone-scoped force-collapse signals
@@ -828,6 +846,50 @@ export function App() {
       if (scopeFittedTimerRef.current !== null) clearTimeout(scopeFittedTimerRef.current);
     };
   }, [boundsKey, flyTo?.key]);
+
+  // #1242 (C4) — validate the parsed hash camera against the RESOLVED scope
+  // envelope, the same way `readUrl` validates `?state=` against the CONUS
+  // allowlist (AC5). An out-of-scope hash (e.g. `?state=US-AZ#map=<Texas>`) must
+  // fall back to the scope `fitBounds`, NOT show the wrong region under the
+  // artboard mask. Verdict semantics (consumed by `useScopeCamera`):
+  //   - `null`  → undecided: no hash, OR a state scope whose REAL envelope has
+  //               not yet arrived from `/api/states` (the `scopeBounds` memo is
+  //               still the CONUS holding value). The hook suppresses the scope
+  //               fit while undecided so the first paint (already the hash view)
+  //               does not flash, then re-decides when this resolves.
+  //   - `true`  → the hash center lies inside the real scope envelope → restore.
+  //   - `false` → outside → fall back to the scope fit.
+  // For `?scope=us` the envelope is CONUS immediately (no holding window), so the
+  // verdict resolves on the first render.
+  const hashCameraInScope = useMemo<boolean | null>(() => {
+    if (!rawHashCamera) return null;
+    // A state scope is "holding" until its real envelope is in the states table;
+    // validating against the CONUS holding bounds could wrongly admit an
+    // out-of-state center, so defer the verdict until the real bounds resolve.
+    if (state.scope.kind === 'state') {
+      const { stateCode } = state.scope;
+      const resolved = states.some(s => s.stateCode === stateCode);
+      if (!resolved) return null;
+    }
+    if (!scopeBounds) return null;
+    const [[w, s], [e, n]] = scopeBounds;
+    const { lng, lat } = rawHashCamera;
+    return lng >= w && lng <= e && lat >= s && lat <= n;
+  }, [rawHashCamera, scopeBounds, state.scope, states]);
+
+  // #1242 (C4) — live gate inputs for the idle write-back, evaluated at `idle`
+  // time inside the hook (NOT at render time — the settle window closes between
+  // renders, so a render-time boolean would be stale). The write-back fires only
+  // on a genuine user pan: a scope is active (`scopeActiveRef`, already a live
+  // mirror) AND the programmatic-camera settle window (`scopeMoveUntilRef`,
+  // shared with the one-fetch-per-scope-change guard) has closed. Memoized so the
+  // object identity is stable across renders (the hook registers the idle
+  // listener once per map load).
+  const writeBackGate = useMemo(
+    () => ({ scopeActiveRef, scopeMoveUntilRef }),
+    [],
+  );
+
   const onViewportChange = useCallback((bounds: LngLatBounds, zoom: number) => {
     // S4 (#769) — hard scope-gate. #761 (S1) made the map persistently mounted
     // behind the chooser scrim, so a still-UNSCOPED map keeps emitting `idle`.
@@ -1470,6 +1532,9 @@ export function App() {
             {...(isStateScope ? { clampPad: ARTBOARD_PAD } : {})}
             detailOpen={!!(scopeActive && state.detail)}
             activeThemeId={activeThemeId}
+            {...(rawHashCamera ? { initialHashCamera: rawHashCamera } : {})}
+            hashCameraInScope={hashCameraInScope}
+            writeBackGate={writeBackGate}
           />
         </div>
       )}

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import type { RefObject } from 'react';
 import type { LngLatBounds } from 'maplibre-gl';
 // GeoJSON `MultiPolygon` comes from `geojson` (@types/geojson), NOT maplibre-gl
 // (5.x does not re-export it). `import type`, erased at build — see mask.ts.
 import type { MultiPolygon } from 'geojson';
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import type { SpeciesDictionary } from '../data/use-species-dictionary.js';
+import type { ViewboxCamera } from '../state/viewbox-link.js';
 import type { ThemeId } from './map/geometry/basemap-style.js';
 import { ErrorBoundary } from './ErrorBoundary.js';
 
@@ -96,6 +98,19 @@ export interface MapSurfaceProps {
    * its internal `[data-theme]`-seeded hook.
    */
   activeThemeId?: ThemeId;
+  /**
+   * #1242 (C4) — viewbox-restore wiring, forwarded VERBATIM to <MapCanvas>. App
+   * parses `initialHashCamera` once from the URL hash, validates it against the
+   * resolved scope envelope (`hashCameraInScope`), and gates the idle write-back
+   * (`writeBackGate`). MapSurface is a thin pass-through; all optional
+   * (legacy/test callers omit them → no hash behavior).
+   */
+  initialHashCamera?: ViewboxCamera;
+  hashCameraInScope?: boolean | null;
+  writeBackGate?: {
+    scopeActiveRef: RefObject<boolean>;
+    scopeMoveUntilRef: RefObject<number>;
+  };
 }
 
 /**
@@ -128,6 +143,9 @@ export function MapSurface({
   clampPad,
   detailOpen = false,
   activeThemeId,
+  initialHashCamera,
+  hashCameraInScope,
+  writeBackGate,
 }: MapSurfaceProps) {
   /**
    * O7 (#786): GL-recovery counter. Bumping this key clears the ErrorBoundary's
@@ -195,6 +213,9 @@ export function MapSurface({
             {...(clampPad !== undefined ? { clampPad } : {})}
             detailOpen={detailOpen}
             {...(activeThemeId !== undefined ? { activeThemeId } : {})}
+            {...(initialHashCamera ? { initialHashCamera } : {})}
+            {...(hashCameraInScope !== undefined ? { hashCameraInScope } : {})}
+            {...(writeBackGate ? { writeBackGate } : {})}
           />
         </React.Suspense>
       </div>

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -364,6 +364,9 @@ export function MapCanvas({
   clampPad,
   detailOpen = false,
   activeThemeId: activeThemeIdProp,
+  initialHashCamera,
+  hashCameraInScope,
+  writeBackGate,
 }: MapCanvasProps) {
   const aggregated = mode === 'aggregated';
   const mapRef = useRef<MapRef>(null);
@@ -558,7 +561,7 @@ export function MapCanvas({
   // is the mount first-paint frame. Both feed the JSX below. The hook's JSDoc
   // carries the full rationale (mapReady load-gating, flyTo-preference,
   // essential:true reduced-motion bypass, and the #848 transform-clone clobber).
-  const { clampBounds, initialViewState } = useScopeCamera(
+  const { clampBounds, initialViewState, restoredHashCamera } = useScopeCamera(
     mapRef,
     mapReady,
     bounds,
@@ -570,6 +573,12 @@ export function MapCanvas({
     // `clampBounds` change on zoom re-applies reactively via the `maxBounds`
     // prop (no remount), same mechanism as the static clamp.
     viewportSpan,
+    // #1242 (C4) — viewbox-restore: cold-load camera from `#map=` + idle write-back.
+    {
+      ...(initialHashCamera ? { camera: initialHashCamera } : {}),
+      inScope: hashCameraInScope ?? null,
+      ...(writeBackGate ? { writeBackGate } : {}),
+    },
   );
 
   // Corrective `map.resize()` on the S2 flex→fixed container transition (#737,
@@ -2041,6 +2050,22 @@ export function MapCanvas({
     <div
       ref={mapWrapperRef}
       data-testid="map-canvas"
+      // #1242 (C4) — GPU-FREE e2e restore handle. When the `#map=` hash camera
+      // is restored (in-scope), emit the APPLIED `zoom/lat/lng` (5-decimal,
+      // matching the codec) on this stable wrapper. A no-WebGL CI runner can
+      // assert the camera landed on the hash view WITHOUT a `__birdMap` GL read
+      // (which `test.skip`s on GPU-less CI). Absent when no hash was restored
+      // (no `#map=`, or an out-of-scope hash that fell back to the scope fit, so
+      // the attribute never lies about the active view). The issue pins
+      // `#map-layer` (App.tsx); the restored value is only known here, so the
+      // attribute lives on the map-canvas wrapper nested INSIDE `#map-layer`.
+      {...(restoredHashCamera
+        ? {
+            'data-hash-camera': `${restoredHashCamera.zoom.toFixed(3)}/${restoredHashCamera.lat.toFixed(
+              5,
+            )}/${restoredHashCamera.lng.toFixed(5)}`,
+          }
+        : {})}
       // #1031: programmatically focusable, but OUT of the keyboard tab order.
       // ObservationPopover.returnFocus() falls back to `.focus()`-ing this
       // wrapper when the originating marker has left the DOM/viewport; a plain

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -10,8 +10,10 @@
 // (5.x does not re-export them). All imports below are `import type`, erased at
 // build — see mask.ts for the same idiom.
 import type { MultiPolygon } from 'geojson';
+import type { RefObject } from 'react';
 import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watch/shared-types';
 import type { SpeciesDictionary } from '@/data/use-species-dictionary.js';
+import type { ViewboxCamera } from '@/state/viewbox-link.js';
 import type { AdaptiveTile, ResolvedGrid } from './geometry/adaptive-grid.js';
 import type { ThemeId } from './geometry/basemap-style.js';
 
@@ -178,6 +180,28 @@ export interface MapCanvasProps {
    * `[data-theme]` attribute — behavior-identical to pre-C8. Optional.
    */
   activeThemeId?: ThemeId;
+  /**
+   * #1242 (C4) — viewbox-restore wiring, forwarded VERBATIM from App.tsx via
+   * MapSurface into `useScopeCamera`. The map camera is otherwise scope-derived;
+   * these make a copied `#map=<z>/<lat>/<lng>` link self-restoring on cold load
+   * and write the live camera back to the hash on user pan. All optional —
+   * legacy/test callers omit them and the camera stays purely scope-driven.
+   *   - `initialHashCamera` — the RAW camera App parsed ONCE (non-reactive) from
+   *     `window.location.hash`; drives the first-paint frame + the imperative
+   *     restore. `undefined` when there is no `#map=`.
+   *   - `hashCameraInScope` — App's validation verdict of that camera's center
+   *     against the resolved scope envelope (`null` while `/api/states` holds,
+   *     `true` in-scope, `false` out-of-scope → fall back to the scope fit).
+   *   - `writeBackGate` — App's live gate refs (`scopeActiveRef` +
+   *     `scopeMoveUntilRef`) for the idle write-back; evaluated at `idle` time
+   *     so the settle-window verdict is fresh, never stale-at-render.
+   */
+  initialHashCamera?: ViewboxCamera;
+  hashCameraInScope?: boolean | null;
+  writeBackGate?: {
+    scopeActiveRef: RefObject<boolean>;
+    scopeMoveUntilRef: RefObject<number>;
+  };
 }
 
 /**

--- a/frontend/src/components/map/hooks/use-scope-camera.test.ts
+++ b/frontend/src/components/map/hooks/use-scope-camera.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { computeScopeBounds } from './use-scope-camera.js';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import type { RefObject } from 'react';
+import { computeScopeBounds, useScopeCamera } from './use-scope-camera.js';
+import type {
+  ScopeCameraMap,
+  ScopeCameraMapRef,
+  HashRestoreOptions,
+} from './use-scope-camera.js';
 import {
   CONUS_BOUNDS,
   FIT_BOUNDS_PADDING,
@@ -9,6 +17,7 @@ import {
 } from '@/components/map/geometry/camera-config.js';
 import { padBounds } from '@/components/map/geometry/mask.js';
 import type { LngLatBounds } from '@/components/map/geometry/mask.js';
+import { encodeViewbox } from '@/state/viewbox-link.js';
 
 /* ── computeScopeBounds — pure scope bounds-math (U12 / #897) ─────────────────
    The three derived camera values factored out of MapCanvas.tsx's render body:
@@ -135,5 +144,313 @@ describe('computeScopeBounds', () => {
       const { initialViewState } = computeScopeBounds(undefined, undefined);
       expect(initialViewState).toBe(INITIAL_VIEW);
     });
+
+    // #1242 (C4) — a `#map=` hash camera is the HIGHEST-PRECEDENCE first-paint
+    // frame: it wins over the scope bounds frame AND the legacy CONUS view so a
+    // copied link's captured view shows with no flash. It touches ONLY the mount
+    // frame — activeBounds / clampBounds stay scope-derived (AC5).
+    describe('hash-camera precedence (#1242)', () => {
+      const HASH_CAM = { zoom: 11.5, lat: 32.221, lng: -110.974 };
+
+      it('frames the first paint on the hash camera (lng/lat/zoom) when present, over scope bounds', () => {
+        const { initialViewState } = computeScopeBounds(AZ_BOUNDS, 1.0, undefined, HASH_CAM);
+        expect(initialViewState).toEqual({
+          longitude: -110.974,
+          latitude: 32.221,
+          zoom: 11.5,
+        });
+      });
+
+      it('carries optional bearing/pitch into the first paint (AC6)', () => {
+        const { initialViewState } = computeScopeBounds(AZ_BOUNDS, 1.0, undefined, {
+          ...HASH_CAM,
+          bearing: 45,
+          pitch: 30,
+        });
+        expect(initialViewState).toEqual({
+          longitude: -110.974,
+          latitude: 32.221,
+          zoom: 11.5,
+          bearing: 45,
+          pitch: 30,
+        });
+      });
+
+      it('leaves activeBounds + clampBounds scope-derived (hash does NOT touch the fit target / clamp)', () => {
+        const { activeBounds, clampBounds } = computeScopeBounds(
+          AZ_BOUNDS,
+          1.0,
+          undefined,
+          HASH_CAM,
+        );
+        // The fit target stays the tight scope envelope and the clamp stays the
+        // padded artboard — both unaffected by the hash camera (AC5 maxBounds).
+        expect(activeBounds).toEqual(AZ_BOUNDS);
+        expect(clampBounds).toEqual(padBounds(AZ_BOUNDS, 1.0));
+      });
+
+      it('falls back to the scope bounds frame when no hash camera is supplied', () => {
+        const { initialViewState } = computeScopeBounds(AZ_BOUNDS, 1.0, undefined, undefined);
+        expect(initialViewState).toEqual({
+          bounds: AZ_BOUNDS,
+          fitBoundsOptions: { padding: FIT_BOUNDS_PADDING, maxZoom: 12 },
+        });
+      });
+    });
+  });
+});
+
+/* ── useScopeCamera — #1242 (C4) hash restore + write-back ────────────────────
+   The imperative effect's third (highest-precedence) hash branch and the
+   debounced idle write-back. A hand-rolled fake map (the narrow
+   `ScopeCameraMap` surface) spies the camera methods; `idle` listeners are
+   captured so a test can fire a settle. */
+
+/** Build a fake `ScopeCameraMap` + a ref to it, capturing the `idle` listeners. */
+function makeFakeMap(center = { lng: -110.974, lat: 32.221 }) {
+  const idleListeners: Array<() => void> = [];
+  const map = {
+    flyTo: vi.fn(),
+    cameraForBounds: vi.fn(() => ({ center: { lng: -111.93, lat: 34 }, zoom: 6 })),
+    fitBounds: vi.fn(),
+    getCenter: vi.fn(() => center),
+    setMaxBounds: vi.fn(),
+    jumpTo: vi.fn(),
+    once: vi.fn(),
+    off: vi.fn(),
+    getZoom: vi.fn(() => 11.5),
+    getBearing: vi.fn(() => 0),
+    getPitch: vi.fn(() => 0),
+    on: vi.fn((type: 'idle', listener: () => void) => {
+      if (type === 'idle') idleListeners.push(listener);
+    }),
+  } satisfies ScopeCameraMap;
+  const ref: RefObject<ScopeCameraMapRef | null> = createRef<ScopeCameraMapRef>();
+  ref.current = { getMap: () => map };
+  const fireIdle = () => idleListeners.forEach(l => l());
+  return { map, ref, fireIdle };
+}
+
+const PRM_FALSE: RefObject<boolean> = { current: false };
+// AZ_BOUNDS already declared above; a hash camera inside it.
+const AZ_HASH = { zoom: 11.5, lat: 32.221, lng: -110.974 };
+
+describe('useScopeCamera — hash restore (#1242)', () => {
+  it('jumpTo the hash camera on first run when in-scope, and SUPPRESSES the scope fitBounds (AC1)', () => {
+    const { map, ref } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        camera: AZ_HASH,
+        inScope: true,
+      } satisfies HashRestoreOptions),
+    );
+    expect(map.jumpTo).toHaveBeenCalledTimes(1);
+    expect(map.jumpTo).toHaveBeenCalledWith({
+      center: { lng: AZ_HASH.lng, lat: AZ_HASH.lat },
+      zoom: AZ_HASH.zoom,
+    });
+    // The scope fit is suppressed on the first run (the hash wins).
+    expect(map.fitBounds).not.toHaveBeenCalled();
+    expect(map.flyTo).not.toHaveBeenCalled();
+  });
+
+  it('applies bearing/pitch via jumpTo when the hash carries rotation (AC6)', () => {
+    const { map, ref } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        camera: { ...AZ_HASH, bearing: 45, pitch: 30 },
+        inScope: true,
+      }),
+    );
+    expect(map.jumpTo).toHaveBeenCalledWith({
+      center: { lng: AZ_HASH.lng, lat: AZ_HASH.lat },
+      zoom: AZ_HASH.zoom,
+      bearing: 45,
+      pitch: 30,
+    });
+  });
+
+  it('returns restoredHashCamera = the applied camera (drives the data-hash-camera handle)', () => {
+    const { ref } = makeFakeMap();
+    const { result } = renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        camera: AZ_HASH,
+        inScope: true,
+      }),
+    );
+    expect(result.current.restoredHashCamera).toEqual(AZ_HASH);
+  });
+
+  it('falls back to the scope fitBounds when the hash is OUT of scope (AC5)', () => {
+    const { map, ref } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        camera: { zoom: 6, lat: 31.0, lng: -99.0 }, // a Texas center, outside AZ
+        inScope: false,
+      }),
+    );
+    // No restore — the scope fit runs instead, framing the AZ envelope.
+    expect(map.jumpTo).not.toHaveBeenCalled();
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    expect(map.fitBounds.mock.calls[0]?.[0]).toEqual(AZ_BOUNDS);
+  });
+
+  it('SUPPRESSES the scope fit while validation is pending (inScope=null) — no flash before /api/states (AC1)', () => {
+    const { map, ref } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, CONUS_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        camera: AZ_HASH,
+        inScope: null,
+      }),
+    );
+    // Neither restored NOR scope-fit — the first paint (hash) holds while undecided.
+    expect(map.jumpTo).not.toHaveBeenCalled();
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
+  it('restores on the holding→real transition: inScope null→true re-runs and jumps the hash (load beats /api/states)', () => {
+    const { map, ref } = makeFakeMap();
+    const props = {
+      camera: AZ_HASH as typeof AZ_HASH,
+      inScope: null as boolean | null,
+    };
+    const { rerender } = renderHook(
+      (p: { camera: typeof AZ_HASH; inScope: boolean | null }) =>
+        useScopeCamera(ref, true, CONUS_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+          camera: p.camera,
+          inScope: p.inScope,
+        }),
+      { initialProps: props },
+    );
+    // Pending: suppressed.
+    expect(map.jumpTo).not.toHaveBeenCalled();
+    // /api/states resolves AZ in-scope.
+    rerender({ camera: AZ_HASH, inScope: true });
+    expect(map.jumpTo).toHaveBeenCalledTimes(1);
+    expect(map.fitBounds).not.toHaveBeenCalled();
+  });
+
+  it('a genuine LATER scope change ignores the consumed hash and reframes via fitBounds (AC2)', () => {
+    const { map, ref } = makeFakeMap();
+    const { rerender } = renderHook(
+      (p: { boundsKey: string; bounds: LngLatBounds }) =>
+        useScopeCamera(ref, true, p.bounds, p.boundsKey, undefined, 1.0, PRM_FALSE, undefined, {
+          camera: AZ_HASH,
+          inScope: true,
+        }),
+      { initialProps: { boundsKey: 'US-AZ', bounds: AZ_BOUNDS } },
+    );
+    expect(map.jumpTo).toHaveBeenCalledTimes(1); // restored AZ
+    expect(map.fitBounds).not.toHaveBeenCalled();
+
+    // User switches to a different state — a new boundsKey. The hash is ignored.
+    const FL_BOUNDS: LngLatBounds = [
+      [-87.63, 24.52],
+      [-80.03, 31.0],
+    ];
+    rerender({ boundsKey: 'US-FL', bounds: FL_BOUNDS });
+    expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    expect(map.fitBounds.mock.calls[0]?.[0]).toEqual(FL_BOUNDS);
+  });
+
+  it('does NOT restore until mapReady (the load gate still holds)', () => {
+    const { map, ref } = makeFakeMap();
+    const { rerender } = renderHook(
+      (p: { ready: boolean }) =>
+        useScopeCamera(ref, p.ready, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+          camera: AZ_HASH,
+          inScope: true,
+        }),
+      { initialProps: { ready: false } },
+    );
+    expect(map.jumpTo).not.toHaveBeenCalled();
+    rerender({ ready: true });
+    expect(map.jumpTo).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useScopeCamera — idle write-back (#1242)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const gate = (active: boolean, until: number) => ({
+    scopeActiveRef: { current: active } as RefObject<boolean>,
+    scopeMoveUntilRef: { current: until } as RefObject<number>,
+  });
+
+  it('writes the live camera to the hash via replaceState on idle when the gate is open', () => {
+    const replaceSpy = vi.spyOn(window.history, 'replaceState');
+    window.location.hash = '';
+    const { ref, fireIdle } = makeFakeMap({ lng: -111.5, lat: 33.0 });
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        writeBackGate: gate(true, 0), // active + settle window already closed
+      }),
+    );
+    fireIdle();
+    vi.advanceTimersByTime(300); // debounce
+    const expected = `#${encodeViewbox({ zoom: 11.5, lat: 33.0, lng: -111.5 })}`;
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy.mock.calls[0]?.[2]).toBe(expected);
+    replaceSpy.mockRestore();
+  });
+
+  it('NEVER pushState (replaceState only — no history growth)', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    const { ref, fireIdle } = makeFakeMap({ lng: -111.5, lat: 33.0 });
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        writeBackGate: gate(true, 0),
+      }),
+    );
+    fireIdle();
+    vi.advanceTimersByTime(300);
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+
+  it('does NOT write while the scope-move settle window is still open (gated on scopeMoveUntilRef)', () => {
+    const replaceSpy = vi.spyOn(window.history, 'replaceState');
+    const { ref, fireIdle } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        writeBackGate: gate(true, Date.now() + 5000), // window open for 5s
+      }),
+    );
+    fireIdle();
+    vi.advanceTimersByTime(300);
+    expect(replaceSpy).not.toHaveBeenCalled();
+    replaceSpy.mockRestore();
+  });
+
+  it('does NOT write while unscoped (scopeActive false)', () => {
+    const replaceSpy = vi.spyOn(window.history, 'replaceState');
+    const { ref, fireIdle } = makeFakeMap();
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        writeBackGate: gate(false, 0),
+      }),
+    );
+    fireIdle();
+    vi.advanceTimersByTime(300);
+    expect(replaceSpy).not.toHaveBeenCalled();
+    replaceSpy.mockRestore();
+  });
+
+  it('is idempotent — skips the write when the encoded hash is unchanged', () => {
+    const { ref, fireIdle } = makeFakeMap({ lng: -111.5, lat: 33.0 });
+    // Pre-set the hash to exactly what the live camera encodes.
+    window.location.hash = `#${encodeViewbox({ zoom: 11.5, lat: 33.0, lng: -111.5 })}`;
+    const replaceSpy = vi.spyOn(window.history, 'replaceState');
+    renderHook(() =>
+      useScopeCamera(ref, true, AZ_BOUNDS, 'US-AZ', undefined, 1.0, PRM_FALSE, undefined, {
+        writeBackGate: gate(true, 0),
+      }),
+    );
+    fireIdle();
+    vi.advanceTimersByTime(300);
+    expect(replaceSpy).not.toHaveBeenCalled();
+    replaceSpy.mockRestore();
+    window.location.hash = '';
   });
 });

--- a/frontend/src/components/map/hooks/use-scope-camera.ts
+++ b/frontend/src/components/map/hooks/use-scope-camera.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 import { ZIP_FLYTO_ZOOM } from '@/state/scope-types.js';
 import {
@@ -8,6 +8,8 @@ import {
   zoomAwareClampBounds,
 } from '@/components/map/geometry/camera-config.js';
 import type { LngLatBounds } from '@/components/map/geometry/mask.js';
+import { encodeViewbox } from '@/state/viewbox-link.js';
+import type { ViewboxCamera } from '@/state/viewbox-link.js';
 
 /**
  * Scope-camera hook (extracted verbatim from `MapCanvas.tsx`, epic #884 · U12 /
@@ -63,9 +65,26 @@ export interface ScopeCameraMap {
   ) => void;
   getCenter: () => { lng: number; lat: number };
   setMaxBounds: (bounds: LngLatBounds) => void;
-  jumpTo: (options: { center: { lng: number; lat: number }; zoom: number }) => void;
+  // #1242 (C4) — `jumpTo` gained optional `bearing`/`pitch` so the hash-camera
+  // restore can apply a rotated/tilted viewbox (the codec carries them, AC6).
+  // The scope-reframe corrector still calls it with only `{ center, zoom }`
+  // (north-up), so both fields stay optional.
+  jumpTo: (options: {
+    center: { lng: number; lat: number };
+    zoom: number;
+    bearing?: number;
+    pitch?: number;
+  }) => void;
   once: (type: 'moveend', listener: () => void) => void;
-  off: (type: 'moveend', listener: () => void) => void;
+  // #1242 (C4) — `off` now also detaches the `idle` write-back listener.
+  off: (type: 'idle' | 'moveend', listener: () => void) => void;
+  // #1242 (C4) — read-back surface for the idle write-back: the live camera the
+  // encoder serializes into the `#map=` hash. `on('idle')` registers the
+  // debounced writer; the getters read the settled camera.
+  getZoom: () => number;
+  getBearing: () => number;
+  getPitch: () => number;
+  on: (type: 'idle', listener: () => void) => void;
 }
 
 /**
@@ -76,8 +95,26 @@ export interface ScopeCameraMapRef {
   getMap: () => ScopeCameraMap;
 }
 
+/**
+ * #1242 (C4) — first-paint camera reconstructed from a `#map=` viewbox hash.
+ * Highest-precedence `initialViewState` variant: when a (raw, mount-known) hash
+ * camera is present, the FIRST PAINT lands directly on it — so a copied link's
+ * captured view shows with no CONUS/scope flash, BEFORE `/api/states` resolves
+ * and independent of the imperative effect (AC1). `longitude`/`latitude`/`zoom`
+ * (+ optional `bearing`/`pitch`, AC6) is the uncontrolled react-map-gl shape,
+ * mirroring `INITIAL_VIEW`.
+ */
+export interface HashInitialViewState {
+  longitude: number;
+  latitude: number;
+  zoom: number;
+  bearing?: number;
+  pitch?: number;
+}
+
 /** The mount `initialViewState` the `<Map>` is constructed with. */
 export type ScopeInitialViewState =
+  | HashInitialViewState
   | {
       bounds: LngLatBounds;
       fitBoundsOptions: { padding: typeof FIT_BOUNDS_PADDING; maxZoom: number };
@@ -136,20 +173,45 @@ export interface ScopeBounds {
  * @param viewportSpan live `[lngSpan, latSpan]` in degrees (from the last camera
  *                     settle) for the zoom-aware clamp; undefined at mount, where
  *                     the clamp reduces to the static `padBounds(bounds, clampPad)`.
+ * @param initialHashCamera #1242 (C4) — RAW camera parsed from a `#map=` hash
+ *                     (App.tsx, once at mount). HIGHEST PRECEDENCE for the
+ *                     first-paint `initialViewState` only: when present it frames
+ *                     the first paint on the captured view (no scope/CONUS flash),
+ *                     regardless of `bounds`. Does NOT touch `activeBounds`/
+ *                     `clampBounds` — those stay scope-derived so `maxBounds` and
+ *                     the imperative fit target remain the scope envelope (AC5).
  */
 export function computeScopeBounds(
   bounds: LngLatBounds | undefined,
   clampPad: number | undefined,
   viewportSpan?: [number, number],
+  initialHashCamera?: ViewboxCamera,
 ): ScopeBounds {
   const activeBounds = bounds ?? CONUS_BOUNDS;
   const clampBounds =
     bounds && clampPad
       ? zoomAwareClampBounds(bounds, clampPad, viewportSpan)
       : activeBounds;
-  const initialViewState: ScopeInitialViewState = bounds
-    ? { bounds, fitBoundsOptions: { padding: FIT_BOUNDS_PADDING, maxZoom: 12 } }
-    : INITIAL_VIEW;
+  // First-paint precedence: hash camera > scope bounds frame > legacy CONUS.
+  // Only the mount frame is affected; the clamp + fit target stay scope-derived.
+  let initialViewState: ScopeInitialViewState;
+  if (initialHashCamera) {
+    initialViewState = {
+      longitude: initialHashCamera.lng,
+      latitude: initialHashCamera.lat,
+      zoom: initialHashCamera.zoom,
+      ...(initialHashCamera.bearing !== undefined
+        ? { bearing: initialHashCamera.bearing }
+        : {}),
+      ...(initialHashCamera.pitch !== undefined
+        ? { pitch: initialHashCamera.pitch }
+        : {}),
+    };
+  } else if (bounds) {
+    initialViewState = { bounds, fitBoundsOptions: { padding: FIT_BOUNDS_PADDING, maxZoom: 12 } };
+  } else {
+    initialViewState = INITIAL_VIEW;
+  }
   return { activeBounds, clampBounds, initialViewState };
 }
 
@@ -191,7 +253,48 @@ export function computeScopeBounds(
  * @param viewportSpan        live `[lngSpan, latSpan]` (deg) from the last camera
  *                            settle, feeding the #1059 zoom-aware clamp; undefined
  *                            at mount (clamp falls back to the static padded value)
+ * @param hashRestore         #1242 (C4) — the viewbox-restore wiring. Optional;
+ *                            absent for legacy/test callers (no hash behavior).
+ *                            See {@link HashRestoreOptions}.
  */
+export interface HashRestoreOptions {
+  /**
+   * RAW camera parsed once from the `#map=` hash (App.tsx, non-reactive). Drives
+   * the first-paint `initialViewState` AND the imperative first-run suppression
+   * — both mount-known, so a copied link never flashes the scope/CONUS view.
+   * `undefined` when there is no `#map=` (normal scope-derived load).
+   */
+  camera?: ViewboxCamera;
+  /**
+   * VALIDATION verdict of `camera`'s center against the RESOLVED scope envelope
+   * (App.tsx, reactive — `null` while `/api/states` is still holding CONUS,
+   * `true` once validated in-scope, `false` once validated out-of-scope). The
+   * imperative restore waits for a non-null verdict so it never locks onto a
+   * transient holding-CONUS pass (AC5: an out-of-scope hash must fall back to
+   * the scope `fitBounds`, not stick under the artboard mask). Drives the
+   * effect's re-fire (it is in the dep array) so the decision lands even if the
+   * map `load` event beats `/api/states`.
+   */
+  inScope?: boolean | null;
+  /**
+   * Live gate inputs for the idle WRITE-BACK, read at `idle` time (NOT render
+   * time) so the verdict is always fresh:
+   *   - `scopeActiveRef`     — true while a scope is active (App's live mirror).
+   *   - `scopeMoveUntilRef`  — timestamp through which the programmatic-camera
+   *                            settle window is open; the write-back fires only
+   *                            once `Date.now()` has passed it.
+   * The write-back therefore fires ONLY on a genuine user pan, never during the
+   * scope reframe / hash restore animation. Absent ⇒ no write-back (legacy/test
+   * callers). Passing the two refs (rather than a pre-computed boolean) is
+   * load-bearing: a boolean computed at render time would be stale at `idle`
+   * time, since the settle window closes between renders.
+   */
+  writeBackGate?: {
+    scopeActiveRef: RefObject<boolean>;
+    scopeMoveUntilRef: RefObject<number>;
+  };
+}
+
 export function useScopeCamera(
   mapRef: RefObject<ScopeCameraMapRef | null>,
   mapReady: boolean,
@@ -201,11 +304,19 @@ export function useScopeCamera(
   clampPad: number | undefined,
   prefersReducedMotionRef: RefObject<boolean>,
   viewportSpan?: [number, number],
-): { clampBounds: LngLatBounds; initialViewState: ScopeInitialViewState } {
+  hashRestore?: HashRestoreOptions,
+): {
+  clampBounds: LngLatBounds;
+  initialViewState: ScopeInitialViewState;
+  restoredHashCamera: ViewboxCamera | null;
+} {
+  const hashCamera = hashRestore?.camera;
+  const hashInScope = hashRestore?.inScope ?? null;
   const { activeBounds, clampBounds, initialViewState } = computeScopeBounds(
     bounds,
     clampPad,
     viewportSpan,
+    hashCamera,
   );
 
   /**
@@ -217,8 +328,77 @@ export function useScopeCamera(
    */
   const initialViewStateRef = useRef(initialViewState);
 
+  // #1242 (C4) — hash-restore state. `hashSettledRef` latches the one-time
+  // decision (restore the hash OR fall back to the scope fit) so a later
+  // SAME-scope effect re-run (e.g. the #850 framing churn) can't clobber it.
+  // `mountBoundsKeyRef` pins the `boundsKey` AT MOUNT: the holding→real-envelope
+  // transition keeps the SAME key (App.tsx), so `boundsKey === mountBoundsKey`
+  // is the "still the initial scope" test (AC2 — a genuine later scope change
+  // flips the key and is NOT suppressed). `restoredCameraRef` holds the camera
+  // we actually applied, surfaced for the `data-hash-camera` e2e handle.
+  const hashSettledRef = useRef(false);
+  const mountBoundsKeyRef = useRef(boundsKey);
+  // STATE (not a ref) so a restore triggers a re-render — MapCanvas then emits
+  // the `data-hash-camera` attribute for the GPU-free e2e assertion (a ref
+  // mutation would not re-render and the attribute would never appear).
+  const [restoredHashCamera, setRestoredHashCamera] = useState<ViewboxCamera | null>(null);
+  // MIRROR of the above in a ref, for the EFFECT's internal reads. The effect
+  // must NOT depend on `restoredHashCamera` (state) — listing it would re-fire
+  // the camera effect when the restore sets it, double-running fitBounds on a
+  // genuine scope change (the clear→re-run→fitBounds-again class). A ref carries
+  // the value into the effect without participating in the trigger set.
+  const restoredHashCameraRef = useRef<ViewboxCamera | null>(null);
+  const setRestoredHashBoth = (cam: ViewboxCamera | null) => {
+    restoredHashCameraRef.current = cam;
+    setRestoredHashCamera(cam);
+  };
+
   useEffect(() => {
     if (!mapReady) return;
+    const atMountScope = boundsKey === mountBoundsKeyRef.current;
+
+    // ── #1242 (C4) third, HIGHEST-PRECEDENCE branch: restore the `#map=` hash ──
+    // Runs only on the INITIAL scope (mount-value `boundsKey` guard) and only
+    // once (`hashSettledRef`). It precedes flyTo/fitBounds so a copied link wins
+    // over the scope framing on cold load.
+    if (hashCamera && atMountScope && !hashSettledRef.current) {
+      const map = mapRef.current?.getMap();
+      if (!map) return;
+      if (hashInScope === null) {
+        // Validation pending (states table still holding CONUS). SUPPRESS the
+        // scope fit so there is no CONUS flash — the first paint already shows
+        // the hash camera. We re-run when `inScope` resolves (it is a dep).
+        return;
+      }
+      hashSettledRef.current = true;
+      if (hashInScope === true) {
+        // In-scope: lock onto the captured view. `jumpTo` (synchronous, no
+        // animation) lands exactly on it — rotation/tilt included (AC6).
+        map.jumpTo({
+          center: { lng: hashCamera.lng, lat: hashCamera.lat },
+          zoom: hashCamera.zoom,
+          ...(hashCamera.bearing !== undefined ? { bearing: hashCamera.bearing } : {}),
+          ...(hashCamera.pitch !== undefined ? { pitch: hashCamera.pitch } : {}),
+        });
+        setRestoredHashBoth(hashCamera);
+        return; // suppress the scope fitBounds on this first run (AC1)
+      }
+      // hashInScope === false → out of scope (AC5): fall through to the normal
+      // scope flyTo/fitBounds so the camera frames the scope, not the stray hash.
+    } else if (hashSettledRef.current && atMountScope && restoredHashCameraRef.current) {
+      // The hash was restored for this initial scope; a later same-scope
+      // re-run (framing churn) must NOT re-frame over it. A genuine scope change
+      // flips `boundsKey` (atMountScope false) and skips this guard (AC2).
+      return;
+    } else if (!atMountScope && restoredHashCameraRef.current) {
+      // AC2 — a GENUINE scope change reframes via fitBounds/flyTo below; the
+      // restored hash camera is now stale (the camera no longer shows it), so
+      // clear the `data-hash-camera` handle. Falls through to the scope reframe.
+      // The ref clears synchronously (no re-fire); the state clears for the
+      // attribute on the consequent render.
+      setRestoredHashBoth(null);
+    }
+
     if (boundsKey === undefined && flyTo === undefined) return;
     const map = mapRef.current?.getMap();
     if (!map) return;
@@ -362,7 +542,72 @@ export function useScopeCamera(
     // preference on the NEXT reframe while the effect stays keyed only on real
     // scope changes. The ref is intentionally NOT listed (refs are stable; ESLint
     // would not require it anyway).
-  }, [mapReady, boundsKey, flyTo?.key]);
+    //
+    // #1242 (C4): `hashInScope` IS a dep — the hash-restore branch above must
+    // re-run when the validation verdict resolves (null→true/false) so the
+    // decision lands even when the map `load` event beats `/api/states`. The
+    // mount-value `boundsKey` guard keeps that re-run scoped to the initial
+    // scope; a genuine scope change is still the `boundsKey` trigger. The
+    // restored camera is read through `restoredHashCameraRef` (NOT the state) so
+    // a restore does not re-fire the effect and double-run fitBounds.
+  }, [mapReady, boundsKey, flyTo?.key, hashCamera, hashInScope]);
 
-  return { clampBounds, initialViewState: initialViewStateRef.current };
+  // #1242 (C4) — debounced idle WRITE-BACK. A `map.on('idle')` listener
+  // serializes the live camera into the `#map=` hash via `replaceState` only
+  // (never pushState / synthetic popstate — a viewbox write must not grow the
+  // history stack or re-fire `useUrlState`'s popstate read). Idempotent: skips
+  // when the encoded hash equals the live one. Gated on `writeBackEnabledRef`
+  // (App: `scopeActive` AND past the scope-move settle window) so it fires only
+  // on genuine user pans, never during the scope reframe / hash restore.
+  const writeBackGate = hashRestore?.writeBackGate;
+  useEffect(() => {
+    if (!mapReady) return;
+    if (!writeBackGate) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const { scopeActiveRef, scopeMoveUntilRef } = writeBackGate;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const WRITE_DEBOUNCE_MS = 300;
+    const writeHash = () => {
+      // Evaluate the gate LIVE (the settle window closes between renders): only
+      // write on a genuine user pan — scope active AND past the camera-settle
+      // window. Never during the scope reframe / hash restore animation.
+      if (!scopeActiveRef.current) return;
+      if (Date.now() < (scopeMoveUntilRef.current ?? 0)) return;
+      const center = map.getCenter();
+      const camera: ViewboxCamera = {
+        zoom: map.getZoom(),
+        lat: center.lat,
+        lng: center.lng,
+      };
+      const bearing = map.getBearing();
+      const pitch = map.getPitch();
+      if (bearing !== 0) camera.bearing = bearing;
+      if (pitch !== 0) camera.pitch = pitch;
+      const next = `#${encodeViewbox(camera)}`;
+      // Idempotent no-op guard: skip the write (and the history churn) when the
+      // serialized camera is byte-identical to what is already in the bar.
+      if (window.location.hash === next) return;
+      window.history.replaceState(window.history.state, '', next);
+    };
+    const onIdle = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(writeHash, WRITE_DEBOUNCE_MS);
+    };
+    map.on('idle', onIdle);
+    return () => {
+      if (timer) clearTimeout(timer);
+      map.off('idle', onIdle);
+    };
+    // mapReady is the gate; writeBackEnabledRef is a stable ref (read live in
+    // writeHash). No other deps — the listener is registered once per map load.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapReady]);
+
+  return {
+    clampBounds,
+    initialViewState: initialViewStateRef.current,
+    restoredHashCamera,
+  };
 }

--- a/frontend/src/state/url-state.test.ts
+++ b/frontend/src/state/url-state.test.ts
@@ -555,4 +555,50 @@ describe('useUrlState', () => {
       expect(result.current.state.since).toBe('7d');
     });
   });
+
+  // --- #1242 (C4) — writeUrl preserves the camera viewbox hash ---
+  // The viewbox link (`#map=<z>/<lat>/<lng>`, epic #1238) lives in the URL hash.
+  // writeUrl rebuilds only pathname+search, so before the fix EVERY filter /
+  // scope / detail set() silently wiped the hash. These pin the preserve-hash
+  // contract (AC3): a set() must keep a pre-existing `#map=` in window.location.hash.
+  describe('writeUrl preserves the #map= camera hash (#1242 AC3)', () => {
+    beforeEach(() => {
+      window.history.replaceState({}, '', '/');
+    });
+
+    it('a filter change (since:1d) keeps a pre-existing #map= hash', () => {
+      window.history.replaceState({}, '', '/?state=US-AZ#map=8.000/32.22000/-110.97000');
+      const { result } = renderHook(() => useUrlState());
+      act(() => result.current.set({ since: '1d' }));
+      // The hash survives the filter write…
+      expect(window.location.hash).toBe('#map=8.000/32.22000/-110.97000');
+      // …and the new filter still landed in the search.
+      expect(window.location.search).toContain('since=1d');
+      expect(window.location.search).toContain('state=US-AZ');
+    });
+
+    it('a scope change keeps the #map= hash', () => {
+      window.history.replaceState({}, '', '/?scope=us#map=4.000/39.50000/-98.00000');
+      const { result } = renderHook(() => useUrlState());
+      act(() => result.current.set({ scope: { kind: 'state', stateCode: 'US-AZ' } }));
+      expect(window.location.hash).toBe('#map=4.000/39.50000/-98.00000');
+      expect(window.location.search).toContain('state=US-AZ');
+    });
+
+    it('a detail-surface push keeps the #map= hash', () => {
+      window.history.replaceState({}, '', '/?state=US-AZ#map=8.000/32.22000/-110.97000');
+      const { result } = renderHook(() => useUrlState());
+      act(() => result.current.set({ view: 'detail', detail: 'vermfly' }));
+      expect(window.location.hash).toBe('#map=8.000/32.22000/-110.97000');
+      expect(window.location.search).toContain('detail=vermfly');
+      expect(window.location.search).toContain('view=detail');
+    });
+
+    it('does not invent a hash when none is present (bare set stays hashless)', () => {
+      window.history.replaceState({}, '', '/?state=US-AZ');
+      const { result } = renderHook(() => useUrlState());
+      act(() => result.current.set({ since: '1d' }));
+      expect(window.location.hash).toBe('');
+    });
+  });
 });

--- a/frontend/src/state/url-state.ts
+++ b/frontend/src/state/url-state.ts
@@ -200,8 +200,20 @@ function writeUrl(state: UrlState, push: boolean = false): void {
     p.set('scope', 'us');
   }
   const q = p.toString();
-  const newUrl = q ? `${window.location.pathname}?${q}` : window.location.pathname;
-  if (newUrl !== window.location.pathname + window.location.search) {
+  // #1242 (C4) — PRESERVE `window.location.hash`. The camera viewbox link
+  // (`#map=<z>/<lat>/<lng>`, epic #1238) lives ENTIRELY in the hash; the
+  // pathname+search this function rebuilds never contains it. Before this fix
+  // `newUrl` was `pathname[?search]` with no hash, so every filter / scope /
+  // detail `set()` `replaceState`'d to a hash-LESS URL and silently wiped the
+  // viewbox — a copied link's restored camera vanished the moment the user
+  // toggled any filter. Append the live hash so it rides through unchanged. The
+  // change-guard below compares against `pathname+search+hash` for the same
+  // reason (a search-only diff would still skip the write that re-attaches the
+  // hash on a no-op search change, but a hash drift alone never triggers a
+  // write — writeUrl is never the hash's writer; the camera write-back owns it).
+  const hash = window.location.hash;
+  const newUrl = (q ? `${window.location.pathname}?${q}` : window.location.pathname) + hash;
+  if (newUrl !== window.location.pathname + window.location.search + hash) {
     if (push) {
       // Detail-surface entry: push so browser-back returns to the prior
       // surface. All other navigations replace (filter changes, tab switches,


### PR DESCRIPTION
## Diagrams

Cold-load restore + write-back across the App → MapSurface → useScopeCamera seam:

```mermaid
sequenceDiagram
    participant URL as URL hash (#map=)
    participant App as App.tsx
    participant Hook as useScopeCamera
    participant Map as MapLibre

    Note over URL,Map: Cold load — ?state=US-AZ#map=z/lat/lng
    App->>App: parse hash ONCE (useRef init) → rawHashCamera
    App->>Hook: initialHashCamera (first paint) + hashCameraInScope (null→validated)
    Hook->>Map: initialViewState = hash camera (no scope/CONUS flash)
    Note over App: /api/states resolves real AZ envelope
    App->>Hook: hashCameraInScope = true (center inside AZ)
    Hook->>Map: jumpTo(hash) + SUPPRESS scope fitBounds (first run only)
    Hook-->>App: restoredHashCamera → data-hash-camera attribute

    Note over URL,Map: User pans (settle window closed, scope active)
    Map->>Hook: idle
    Hook->>URL: replaceState(encodeViewbox(live camera)) — debounced, idempotent

    Note over URL,Map: Out-of-scope hash (Texas under AZ) OR a later scope change
    App->>Hook: hashCameraInScope = false / boundsKey flips
    Hook->>Map: fitBounds(scope envelope) — hash ignored
```

## Summary

- **Why:** Part 2 of epic #1238 (#1242 / C4). A copied `#map=<z>/<lat>/<lng>` viewbox link should be self-restoring — a teammate opens it in a normal browser and sees exactly the captured view, no replay tool needed. The camera must cooperate with the scope `fitBounds`/`maxBounds` machinery and survive subsequent in-app navigation.
- **The camera seam is `use-scope-camera.ts`** (the `fitBounds`/`flyTo` effect was extracted there in #884). A third, highest-precedence branch restores the hash on the FIRST run only (`hashSettledRef` + a mount-value `boundsKey` guard so the holding→real `/api/states` transition keeps the same key and never clobbers it); a genuine later scope change flips `boundsKey` and reframes normally. The debounced idle write-back is `replaceState`-only + idempotent, gated on `scopeActive` + the existing `scopeMoveUntilRef` settle window. `maxBounds` stays scope-derived (untouched).
- **`writeUrl` now preserves `window.location.hash`** — it built the URL from pathname+search only, so every filter/scope/detail write silently wiped `#map=`. App parses the hash once (non-reactive) and validates the center against the resolved scope envelope (like `readUrl` validates `?state=`): an out-of-scope hash falls back to the scope fit. MapCanvas emits a GPU-free `data-hash-camera` attribute for deterministic e2e (no `__birdMap` GL read).

## Screenshots

Live UI verification (orchestrator) — the full **capture→restore loop** on the merged build (C2's Copy-link button is merged into this branch). **Console 0 errors / 0 warnings throughout.**

**End-to-end proof:** opened `?scope=us#map=8.5/33.45/-112.07` → camera restored to exactly **Phoenix (zoom 8.5, 33.45 / -112.07)**; the merged-in 🔗 Copy-link button is present, and clicking it copied `#map=8.500/33.45000/-112.07000&v=1458x860@2` — the same camera. The complete loop **open → restore → copy → identical link** works. `data-hash-camera` emitted; hash write-back canonicalizes; `viewbox-restore.spec.ts` 5/5; **1730 unit tests pass** on the merged build.

5 canonical viewports × 2 themes (restored Phoenix view + the Copy-link button):

| Viewport | Light | Dark |
|---|---|---|
| **390×844** | ![390 light](https://github.com/user-attachments/assets/fd2697d7-5ca2-42e3-b8dd-16161dbbcad6) | ![390 dark](https://github.com/user-attachments/assets/e88e4b64-dade-467e-b62c-0f36078cf186) |
| **768×1024** | ![768 light](https://github.com/user-attachments/assets/ddbcba4e-73e8-4529-88d9-d19ba68d4461) | ![768 dark](https://github.com/user-attachments/assets/be238c73-3058-4c63-8908-6b37d4f75cd7) |
| **1024×768** | ![1024 light](https://github.com/user-attachments/assets/a53a4ee4-1d24-47bb-aa9d-8d619b1ee754) | ![1024 dark](https://github.com/user-attachments/assets/57211954-4da7-4f54-b6ed-5a6d624c1ca1) |
| **1440×900** | ![1440 light](https://github.com/user-attachments/assets/ff234ff6-9765-4f54-a719-65a13a35c86d) | ![1440 dark](https://github.com/user-attachments/assets/94c9ff60-e6a7-4060-9d44-0f5469ec4516) |
| **1920×1080** | ![1920 light](https://github.com/user-attachments/assets/dde15b5b-1b1e-4621-a140-eaacd0c3247e) | ![1920 dark](https://github.com/user-attachments/assets/e9019308-9cb0-4412-8dfe-10999bd3cc0f) |

- [x] Every new/renamed `className` in this PR has a matching CSS rule — `N/A — no className added (camera/state wiring + one data-* attribute only)`
- [x] Multi-viewport design QA — `N/A — not UI (no new visible element; load-time camera behavior). Orchestrator captures the cold-load restore stills.`

## Test plan

- [x] `npm run typecheck && npm run -w @bird-watch/frontend test` — green (1722 passed, 93 files). Includes the new `writeUrl` preserve-hash regression (4), `computeScopeBounds` hash-precedence + `useScopeCamera` restore/write-back behavior (12).
- [x] New unit / integration tests added — `url-state.test.ts` (+4), `use-scope-camera.test.ts` (+16: 4 pure + 12 hook-behavior).
- [x] New Playwright e2e spec added — `frontend/e2e/scope/viewbox-restore.spec.ts` (5 tests: AC1 cold restore survives `/api/states`, AC2 later scope change reframes, AC3 filter write preserves the hash, AC5 out-of-scope fallback, plus a no-hash control). Asserts via the GPU-free `data-hash-camera` attribute; drives `jumpTo`/`emulateMedia({reducedMotion:'reduce'})`, latches on the attribute + URL hash, never `waitForTimeout` the debounce. All 5 green locally on an isolated Vite port (5191). Re-ran the full `e2e/scope/` directory (state-scope / zip-scope / deep-link / midmotion-longitude / state-artboard) with the read-api up — no regression on the shared camera path.
- [x] `npm run build` — clean production build.
- [ ] (UI only) Playwright MCP smoke — subagent cannot drive a browser; the orchestrator captures the cold-load camera stills. e2e exercises the behavior headlessly via the GPU-free attribute.

No DB writes (CLAUDE.md grep clean — `page.route` stubs only).

## Plan reference

Part of epic #1238 (out-of-plan program), child #1242 / C4. Depends on C1 (the `decodeViewbox`/`encodeViewbox` codec in `@/state/viewbox-link`), already merged on `main`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1242


