### PR TITLE
fix(frontend): reset success-check on idle so the Copied checkmark doesn't stick

### DIFF
--- a/frontend/src/components/CopyViewLinkButton.test.tsx
+++ b/frontend/src/components/CopyViewLinkButton.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CopyViewLinkButton } from './CopyViewLinkButton.js';
 import type { ViewboxCamera } from '@/state/viewbox-link.js';
@@ -182,4 +182,69 @@ describe('<CopyViewLinkButton>', () => {
     // No camera → nothing to copy; the control must not throw or write garbage.
     expect(writeText).not.toHaveBeenCalled();
   });
+
+  it('resets the success-check to "out" after the copied dwell so it does not stick over the link', async () => {
+    // Regression: the recipe-10 success check runs `t-check-fade … forwards`,
+    // which pins it at opacity:1 with FILL-MODE forwards. On the idle reset the
+    // OUTER icon-swap flips back to 'a' (static opacity:0 for the now-hidden
+    // check), but a forwards animation value overrides that static opacity — so
+    // without ALSO resetting the inner wrapper's `data-state` from "in" → "out",
+    // the drawn check stays stuck on top of the link glyph. This pins both the
+    // entry (→ "in" during `copied`) and the exit (→ "out" after COPIED_MS).
+    // Fake timers so we advance past COPIED_MS without a wall-clock sleep.
+    // requestAnimationFrame is NOT faked by vitest's default `toFake` list, so
+    // we list it (and cancelAnimationFrame) explicitly — otherwise the
+    // component's `requestAnimationFrame(replayCheck)` runs on jsdom's real
+    // ~16ms clock and never fires under our fake-clock advances, leaving the
+    // check stuck at "out" and the "in" assertion hanging. We dispatch the
+    // click with fireEvent (synchronous — user-event schedules its own timers
+    // and deadlocks under fake timers) and advance the clock deterministically
+    // instead of using waitFor (whose internal poll never ticks the fake clock).
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'requestAnimationFrame', 'cancelAnimationFrame'],
+    });
+    try {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      render(<CopyViewLinkButton getCamera={fixedCamera} labeled={false} />);
+
+      const button = screen.getByTestId('copy-view-link');
+      // Query the recipe-10 wrapper by class (it carries no own testid). Always
+      // mounted inside the button; `data-state` starts "out".
+      const check = button.querySelector('.t-success-check') as HTMLElement;
+      expect(check).not.toBeNull();
+      expect(check).toHaveAttribute('data-state', 'out');
+
+      fireEvent.click(button);
+      // Flush the click handler's async clipboard write (a resolved microtask)
+      // then fire the queued requestAnimationFrame that calls replayCheck (which
+      // sets data-state → "in"). Advancing by a small amount fires the rAF
+      // without reaching the COPIED_MS reset; the act() wraps the React updates.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20);
+      });
+
+      // During `copied`, the check has entered: data-state flipped to "in".
+      expect(check).toHaveAttribute('data-state', 'in');
+      expect(button).toHaveAttribute('data-state', 'copied');
+
+      // Advance past the dwell — the idle reset must drop the check back to
+      // "out" (the fix) so the static opacity:0 wins and the check disappears.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COPIED_MS + 1);
+      });
+
+      expect(check).toHaveAttribute('data-state', 'out');
+      expect(button).toHaveAttribute('data-state', 'idle');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
+
+// COPIED_MS dwell window from CopyViewLinkButton (kept in sync; the component
+// does not export it). The regression test advances fake timers past this.
+const COPIED_MS = 1600;

--- a/frontend/src/components/CopyViewLinkButton.tsx
+++ b/frontend/src/components/CopyViewLinkButton.tsx
@@ -287,6 +287,14 @@ export function CopyViewLinkButton({ getCamera, labeled }: CopyViewLinkButtonPro
       resetTimerRef.current = setTimeout(() => {
         setCopyState('idle');
         setStatus('');
+        // Recipe-10 exit: clear the success-check's `data-state="in"`. That
+        // state runs `t-check-fade … forwards`, which pins the check at
+        // opacity:1 with FILL-MODE forwards — and a forwards animation value
+        // overrides the icon-swap's static `opacity:0` for the now-hidden icon.
+        // So flipping the OUTER wrapper back to 'a' alone leaves the drawn check
+        // stuck on top of the link glyph; we must drop `data-state` back to
+        // 'out' here so the static `opacity:0` wins and the check fades away.
+        checkRef.current?.setAttribute('data-state', 'out');
       }, COPIED_MS);
     } else {
       // Last resort: surface the link as a selectable, prefilled field and
@@ -299,6 +307,11 @@ export function CopyViewLinkButton({ getCamera, labeled }: CopyViewLinkButtonPro
         setCopyState('idle');
         setStatus('');
         setFallbackLink(null);
+        // Symmetric with the success reset above. The check never entered 'in'
+        // on the error path (failure must not read as success), so this is a
+        // harmless no-op here — kept only so both reset callbacks return the
+        // check wrapper to a known 'out' state.
+        checkRef.current?.setAttribute('data-state', 'out');
       }, ERROR_MS);
     }
   }, [getCamera, replayCheck]);


### PR DESCRIPTION
## Diagrams

State of the two nested transitions-dev recipes on the `copied → idle` reset. The OUTER `.t-icon-swap` was reset; the INNER `.t-success-check` was not — and its `forwards`-fill `opacity:1` out-ranks the outer's static `opacity:0`, so the drawn check stuck on top of the link glyph. The fix adds the inner reset.

```mermaid
stateDiagram-v2
    direction LR
    state "copied (dwell)" as Copied {
        outer_b: outer .t-icon-swap data-state b (show check)
        inner_in: inner .t-success-check data-state in (forwards opacity 1)
    }
    state "BEFORE fix (idle)" as Before {
        outer_a1: outer reset to a (static opacity 0 for check)
        inner_stuck: inner STILL in (forwards opacity 1 wins) - check stuck
    }
    state "AFTER fix (idle)" as After {
        outer_a2: outer reset to a (static opacity 0 for check)
        inner_out: inner reset to out - static opacity 0 wins, check fades
    }
    Copied --> Before: setCopyState('idle') only
    Copied --> After: setCopyState('idle') + checkRef -> data-state 'out'
```

## Summary

- **Why:** clicking "Copy link to this view" left a stuck checkmark overlapping the link glyph after the "Copied" confirmation finished. The animation in (link → drawn check) was fine; only the *return to the link* was broken.
- **Root cause:** recipe 09 (icon-swap, link⇄check) wraps recipe 10 (success-check). On copy, `replayCheck()` sets the inner `.t-success-check` wrapper's `data-state="in"`, which runs `t-check-fade … forwards` — pinning the check at `opacity:1` and KEEPING it via the `forwards` fill. The idle-reset callback (`setTimeout(…, COPIED_MS)`) only called `setCopyState('idle')`, flipping the OUTER `.t-icon-swap` back to `'a'` (static `opacity:0` for the now-hidden check icon). A `forwards` animation value overrides a static `opacity:0`, and nothing reset the inner wrapper's `data-state` from `"in"` back to `"out"` — so the drawn check stayed at `opacity:1` on top of the link.
- **Fix:** in both reset-timer callbacks (the `copied` branch and the `error` branch), reset the check wrapper with `checkRef.current?.setAttribute('data-state', 'out')` alongside `setCopyState('idle')`. Dropping the `data-state="in"` removes the `forwards`-opacity so the icon-swap's static `opacity:0` wins and the check fades cleanly back to the link. `replayCheck` (out→in on copy) is unchanged, and recipe 10's `forwards` stays so the check remains DRAWN during the dwell — the bug was only the missing reset on exit.

## Screenshots

Live verification (orchestrator). This is a **JS state-reset motion fix — no chrome / layout / theme change** — so the 5-viewport × 2-theme matrix is N/A; the meaningful evidence is the *temporal* behavior (the check must vanish after the 1.6s dwell) + the deterministic regression test.

**Before** (the reported bug): after clicking, the success-check stayed painted over the link glyph. **After** (this fix): click → confirmation plays → after the dwell the check returns cleanly to the link, `checkDataState` reset to `"out"` (was stuck at `"in"`). Verified live, both themes (`checkDataState==='out'` + `data-state` swap back to `a` confirmed):

| Light (rested after click) | Dark (rested after click) |
|---|---|
| ![rested light](https://github.com/user-attachments/assets/4da6380c-1fac-40e1-824a-b22c72a007b4) | ![rested dark](https://github.com/user-attachments/assets/9f721cc1-48ab-450c-84fd-a9d0f70ce85b) |

The regression test in `CopyViewLinkButton.test.tsx` asserts the check returns to `"out"` after `COPIED_MS` — **fails on the un-fixed code, passes with the fix**. Console 0/0; the during-dwell animation is unchanged (recipe-10 `forwards`-fill still keeps the check drawn through the dwell — only the missing exit-reset was added).

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — **N/A — no className added/renamed; this is a JS state-reset fix, no CSS or markup change.**
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445) — **PENDING — orchestrator captures and attaches.**

## Test plan

- [x] `npm run -w @bird-watch/frontend test` — green (1731 passed / 94 files; CopyViewLinkButton suite 9 passed)
- [x] New unit test added — regression test for the stuck-check exit (asserts `.t-success-check` reaches `data-state="in"` during `copied`, then returns to `"out"` after `COPIED_MS`). Verified it FAILS with the fix reverted (check stays `"in"`) and PASSES with it, while the other 8 button tests are unaffected.
- [ ] New Playwright e2e spec added (if user-visible behavior changed) — N/A; the unit test deterministically pins the `data-state` lifecycle, which is the exact mechanism of the bug.
- [x] `npm run -w @bird-watch/frontend build` — clean production build (`tsc -b && vite build`, typechecks the test changes)
- [x] `npm run lint` — green (repo `lint` runs `npm run lint --workspaces --if-present`; no workspace defines a lint script, so it is a no-op, plus the forbidden-token grep — unaffected, no CSS token usage touched)
- [ ] (UI only) Playwright MCP smoke — **PENDING — orchestrator drives the motion fix live (subagents cannot drive a browser).**

## Plan reference

Out of plan — small UI motion bug fix on the C2 CopyViewLinkButton (#1240, epic #1238): the success-check is not reset on the idle return, leaving a stuck checkmark over the link glyph.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
