### PR TITLE
fix(frontend): de-flake copy-view-link e2e — isolate the click assertion from the #1249 camera write-back

### DIFF
--- a/frontend/e2e/chrome/copy-view-link.spec.ts
+++ b/frontend/e2e/chrome/copy-view-link.spec.ts
@@ -129,7 +129,9 @@ test.describe('Copy link to this view (C2 · #1240)', () => {
     ).toHaveCount(1);
   });
 
-  test('does NOT mutate the app URL bar (clipboard only — Part 2 owns URL writes)', async ({ page }) => {
+  test('the Copy-link CLICK does not mutate the app URL bar (clipboard only — #1249 write-back owns URL writes)', async ({
+    page,
+  }) => {
     await installClipboardSpy(page);
     const app = new AppPage(page);
     await app.goto();
@@ -137,13 +139,35 @@ test.describe('Copy link to this view (C2 · #1240)', () => {
     await app.waitForMapLoad();
     await app.waitForCameraReady();
 
+    // The camera→hash write-back (#1249, use-scope-camera.ts) is an INDEPENDENT
+    // `map.on('idle')` listener that serializes the live camera into `#map=` via
+    // `replaceState` once the scope-settle window closes. It fires regardless of
+    // any Copy-link interaction. This test owns the COPY-CLICK contract — that the
+    // click is clipboard-only and does NOT itself touch `location`/`history` — so
+    // we must first let the independent write-back settle, THEN measure the URL
+    // delta caused by the click alone. Asserting "URL never contains `#map=`"
+    // (the pre-#1249 premise) is now provably wrong and races the write-back.
+    //
+    // Settle the write-back: wait until `#map=` lands on the bar (it will, on the
+    // first post-fit idle), then snapshot both the URL and the history length.
+    await expect
+      .poll(() => page.url(), { timeout: 10_000 })
+      .toContain('#map=');
     const before = page.url();
+    const lengthBefore = await page.evaluate(() => window.history.length);
+
     await app.copyViewLinkButton.click();
     await expect.poll(async () => (await readCopied(page)).length, { timeout: 5_000 }).toBe(1);
+    // Give any (illegitimate) click-driven URL write a chance to land before we
+    // assert it did NOT happen — longer than the write-back's 300ms idle debounce.
+    await page.waitForTimeout(500);
 
-    // The location must be unchanged — no `#map=` pushed onto the app's own URL.
+    // The click added nothing to the URL: the location is byte-identical to the
+    // post-write-back snapshot, and no `pushState` grew the history stack. If
+    // Copy-link ever starts writing the URL (the regression this guards), one of
+    // these fails — the value would differ, or a pushState would bump the length.
     expect(page.url()).toBe(before);
-    expect(page.url()).not.toContain('#map=');
+    expect(await page.evaluate(() => window.history.length)).toBe(lengthBefore);
   });
 
   test('icon-only below wide; labeled at wide', async ({ page }) => {


### PR DESCRIPTION
## Diagrams

The failing assertion races two independent URL actors. The Copy-link click is clipboard-only; the #1249 write-back independently writes `#map=`. The old test conflated them; the fix synchronizes on the write-back, then measures the click's delta alone.

```mermaid
sequenceDiagram
    participant Test as e2e spec
    participant Btn as CopyViewLinkButton click
    participant Clip as navigator clipboard
    participant WB as use-scope-camera write-back
    participant URL as window location and history

    Note over WB,URL: independent of any click, fires once the scope-settle window closes
    WB-->>URL: replaceState writes the map hash

    rect rgb(230,245,230)
        Note over Test: FIX poll until the map hash lands, THEN snapshot
        Test->>URL: capture before-url and before-history-length
    end

    Test->>Btn: click
    Btn->>Clip: writeText link, clipboard ONLY
    Note over Btn,URL: click NEVER touches location or history

    Test->>URL: assert url equals before-url
    Test->>URL: assert history length equals before-history-length
```

## Summary

- **Why it failed:** `copy-view-link.spec.ts:132` captured `before = "…/?scope=us"` and asserted the URL never contains `#map=`. But the #1249 camera→hash write-back (an independent `map.on('idle')` listener in `use-scope-camera.ts`) serializes the live camera into `#map=` via `replaceState` regardless of any Copy-link interaction — so the bar legitimately becomes `…/?scope=us#map=3.791/38.56065/-97.50000` between snapshot and assertion. Ordering bug: #1246 introduced the test when nothing wrote `#map=`, then #1249 added the write-back and invalidated its premise. The e2e check has failed on every main push since (689a289 #1246, ec56752 #1249, 85fc5c4 #1250).
- **Why it's test-only:** the `CopyViewLinkButton` click handler reads the live camera and writes the clipboard (+ execCommand fallback) — it never touches `location`/`history`. Verified by reading the handler. No app coupling bug; this is a test-isolation race.
- **The fix:** synchronize on the independent write-back first (`expect.poll(page.url).toContain('#map=')`), snapshot URL + `history.length`, click, wait past the 300ms idle debounce, then assert the click changed NEITHER. The test now asserts its real contract — the copy CLICK does not further mutate the URL — and still fails if Copy-link ever starts writing the bar (value would differ, or a `pushState` would bump `history.length`). Drops the now-incompatible `not.toContain('#map=')` line.

## Screenshots

N/A — not UI (test-only). The only change is `frontend/e2e/chrome/copy-view-link.spec.ts`; no `frontend/src/**` and no visual/CSS surface is touched, so the canonical-viewport Playwright-MCP capture protocol is exempt per CLAUDE.md ("Test-only … PRs under `frontend/**` are exempt").

## Test plan

- [x] Reproduced the CI failure from the e2e run log on main (85fc5c4): `Received "http://localhost:5173/?scope=us#map=3.791/38.56065/-97.50000"` at `copy-view-link.spec.ts:145`.
- [x] Ran the fixed spec against a real local stack (read-api on 8787 + Vite on 5173 + chromium): **all 4 copy-view-link tests pass**, including the previously-failing line 132 (`the Copy-link CLICK does not mutate the app URL bar`).
- [x] `npm run lint` — no-op for this change (no workspace `lint` script; the lint-guard greps only `frontend/src/`, untouched here).
- [ ] N/A — no new unit/integration test (the existing e2e is the behavior under repair).
- [ ] N/A — no new e2e spec (this repairs an existing one); no user-visible behavior change.
- [x] Authoritative gate is this PR's CI `e2e` check.

## Plan reference

Out of plan — bug fix. De-flakes the e2e regression introduced by the viewbox-links epic (#1238: #1246 / #1249 / #1250) that has been failing the required `e2e` check on main since 2026-06-18.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
