### PR TITLE
feat(map-consistency): automated metamorphic consistency audit for bird-maps.com (epic #1266)

### DIFF
--- a/.claude/agents/map-consistency-auditor.md
+++ b/.claude/agents/map-consistency-auditor.md
@@ -27,6 +27,12 @@ NOT file issues, open PRs, or merge. Loaded skill: `map-consistency-audit`.
 3. **Parse `findings.json`.** Apply the skill's carve-outs as the final real-vs-noise
    pass; dedupe near-identical findings across samples; rank by severity then
    determinism (MR-7 stamp). Drop `inconclusive` (tile-CDN) views from the count.
+   **MR-8/MR-9 dedupe:** when a camera produces an MR-9 pill-split fail, treat that
+   camera's many per-family MR-8 fails as the SAME finding — they are the
+   downstream symptom of the one cluster-split asymmetry MR-9 reports once.
+   Collapse/annotate the MR-8 fails under the MR-9 result for that camera so the
+   brief isn't swamped by dozens of per-family rows and the actionable MR-9 signal
+   isn't diluted.
 4. **Curate the brief.** The harness wrote `brief.md` + `findings/F*/` bundles.
    **Every finding MUST carry its `#map=` viewbox link** (epic #1238) — the
    canonical one-click repro, with viewport + scope + filters baked in. Verify it
@@ -44,4 +50,4 @@ NOT file issues, open PRs, or merge. Loaded skill: `map-consistency-audit`.
 ## Guardrails
 - Prod only; pacing is load-bearing (Cloudflare 60/min/IP) — never bypass the guard.
 - A blank map from a tile-CDN failure is `inconclusive`, not a finding.
-- Never assert lede==viewport (lede is scope-total) — that carve-out is in the engine; don't re-introduce it.
+- MR-5 asserts lede ≈ network.total (the lede tracks the VIEWPORT total per DESIGN §5.1) — the species-count lede is the carve-out, not a scope-total one. Don't re-triage a real lede divergence as a non-bug.

--- a/.claude/agents/map-consistency-auditor.md
+++ b/.claude/agents/map-consistency-auditor.md
@@ -1,0 +1,47 @@
+---
+name: map-consistency-auditor
+description: >-
+  Runs the prod map-consistency audit (metamorphic sampler) on bird-maps.com and
+  produces a confirm-first findings brief. Use when Julian says "run a map
+  consistency audit", "audit the map for consistency", "check the bird counts",
+  "are the filter numbers adding up", or names a scope/sample count. Drives the
+  committed harness via Bash (no MCP); separates real violations from the
+  documented-legitimate divergences; STOPS at a brief for Julian to triage —
+  never files issues, never merges.
+tools: Bash, Read, Grep, Glob, TodoWrite
+model: inherit
+---
+
+You run the map-consistency audit and hand Julian a triage-ready brief. You do
+NOT file issues, open PRs, or merge. Loaded skill: `map-consistency-audit`.
+
+## Flow
+
+1. **Confirm scope + size.** Default `--scope US`. Surface `--samples` prominently
+   (small group = quick pass, large group = deep sweep). Echo the pacing-guard
+   estimate before a large run.
+2. **Run the harness** via Bash:
+   `npm run audit:map-consistency -w @bird-watch/frontend -- --samples <N> --scope <S> --seed <K>`
+   (add `--zoom-ladder`, `--viewports`, `--pace-ms` as asked). If the pacing
+   guard refuses, relay its remedy (raise `--pace-ms` / lower `--samples`).
+3. **Parse `findings.json`.** Apply the skill's carve-outs as the final real-vs-noise
+   pass; dedupe near-identical findings across samples; rank by severity then
+   determinism (MR-7 stamp). Drop `inconclusive` (tile-CDN) views from the count.
+4. **Curate the brief.** The harness wrote `brief.md` + `findings/F*/` bundles.
+   **Every finding MUST carry its `#map=` viewbox link** (epic #1238) — the
+   canonical one-click repro, with viewport + scope + filters baked in. Verify it
+   is present (alongside screenshots + raw payloads); if a finding is missing one,
+   reconstruct it from the finding's camera before reporting. Add hypothesis
+   pointers where the symptom matches a known seam (e.g. desktop `pickGridShape`
+   pill collapse for MR-8).
+5. **STOP.** Report the brief path + the top findings to Julian and wait. Do not
+   file anything. In the handoff, **remind Julian that every ticket he writes from
+   a finding must include that finding's `#map=` viewbox link** as the repro —
+   it is a recently-shipped feature (epic #1238) and is the reproduction primitive
+   for any bird-maps map/data bug. Julian (or the orchestrator) does the MCP
+   screenshot confirmation + ticketing.
+
+## Guardrails
+- Prod only; pacing is load-bearing (Cloudflare 60/min/IP) — never bypass the guard.
+- A blank map from a tile-CDN failure is `inconclusive`, not a finding.
+- Never assert lede==viewport (lede is scope-total) — that carve-out is in the engine; don't re-introduce it.

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -1,0 +1,245 @@
+# Design — `map-consistency-audit`
+
+- **Date:** 2026-06-23
+- **Status:** Approved design; pending implementation plan
+- **Author:** Julian (brainstormed with Claude)
+- **Repo:** `julianken/bird-sight-system` (local `bird-watch/`)
+- **Artifacts produced:** a committed Playwright harness (`frontend/audits/map-consistency/`), a project agent (`.claude/agents/map-consistency-auditor.md`), and a project skill (`.claude/skills/map-consistency-audit/SKILL.md`).
+
+---
+
+## 1. Problem
+
+bird-maps.com shows the same underlying eBird data through several numeric and visual surfaces that are computed independently, and they can disagree. Observed symptoms:
+
+- **Pills disappear at zoom on desktop** and never "split out" the way they correctly do on mobile.
+- **A stated count and the rendered count diverge** — e.g. the filter/lede says *7 sightings* but only *3* are visible on screen.
+- **Counts are not conserved when zooming in** — a sub-region that the zoomed-out view counted as N does not show N when you zoom into exactly that box.
+
+There is no ground-truth oracle: for a random patch of map, nobody knows the "true" bird count. This is the classic **test oracle problem**. The solution is **metamorphic testing** — assert *relations that must hold between related views*, even without knowing the absolute right answer. The relations below are the conservation / monotonicity / parity invariants the app's own design implies.
+
+We want this **automated, repeatable, and delegatable**: a tool that randomly samples real prod data at a **configurable sample count**, walks a zoom ladder at desktop and mobile, and produces a **preserved findings brief** (screenshots + reliable repro + raw data) that Julian uses for ticket-writing, triage, and analysis. The agent **stops at the brief** and never files anything itself.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Detect real consistency violations on **live prod** (bird-maps.com) using metamorphic relations.
+- **Configurable scale** via `--samples N` (small group for a quick pass, large group for a deep sweep) plus `--scope`, `--seed`, `--zoom-ladder`, `--viewports`, `--pace-ms`.
+- Distinguish **real bugs** from the app's **documented-legitimate divergences** (lede is scope-total not viewport; aggregated vs per-observation mode switch at zoom 6; per-observation row cap → `truncated`).
+- Produce a **self-contained, durable brief**: every finding bundles screenshots, exact `#map=` repro URL(s), the raw `/api/observations` payloads, console logs, and the stated/rendered/network numbers — so it stays analyzable after prod data shifts.
+- Be runnable by a **subagent** (via Bash; no MCP browser dependency) and in principle by CI.
+
+**Non-goals**
+- Not a fix for any bug it finds (detection only; the brief points at hypotheses).
+- Not a replacement for the stubbed `frontend/e2e/*.spec.ts` suite (those are deterministic unit-style e2e against seeded local data; this is a real-data audit against prod).
+- No auto-filing of GitHub issues. No DB writes. No `gh pr merge`.
+
+## 3. Architecture
+
+Three artifacts plus one human-in-the-loop orchestrator touchpoint.
+
+| Artifact | Path | Role |
+|---|---|---|
+| **Harness** (engine) | `frontend/audits/map-consistency/` | Standalone headless-Playwright script (run via `tsx`, **not** a `*.spec.ts`). Drives prod, captures evidence, evaluates relations, writes the brief. A subagent can run it via Bash — that is what makes it delegatable; MCP browsers cannot be driven by subagents. |
+| **Agent** | `.claude/agents/map-consistency-auditor.md` | Project subagent (mirrors the `dependabot` agent). Runs the harness, applies triage judgment + carve-outs, ranks findings, writes/curates the brief, **stops for Julian's confirmation**. Tools: Bash, Read, Grep, Glob, TodoWrite (no MCP). |
+| **Skill** | `.claude/skills/map-consistency-audit/SKILL.md` | Runbook + knowledge: the MR catalog with tolerances/carve-outs, the CF pacing guard, the two-stage hash-wait protocol, the legend-expand step, the brief schema, and the triage→confirm→file flow. Loaded by the agent and the orchestrator. |
+| **Orchestrator MCP** (confirm) | — | On a flagged finding, the orchestrator opens the `#map=` repro URL in chrome-devtools/Playwright MCP, eyeballs it, and captures the canonical screenshot for the eventual ticket. Human-in-loop, after the brief, before any GitHub action. |
+
+### Data flow
+
+```
+Julian/orchestrator → "audit, N samples, scope S"
+  → map-consistency-auditor agent
+      → runs harness via Bash (npm run audit:map-consistency -- --samples N --scope S --seed K)
+          → Sampler: 1 national/scope low-zoom fetch → density-weighted seeded sample points
+          → for each (sample × zoom-ladder × viewport):
+                Camera driver: navigate ?scope=…#map=z/lat/lng ; wait for the matching /api/observations
+                Capture: network payload + DOM (lede, expanded legend, marker/cell aria) + console
+          → Relations engine (pure): evaluate MR-0..MR-8 with tolerances + carve-outs
+          → Reporter: write brief.md + findings.json + per-finding evidence bundles (+ screenshots on fail)
+      → agent parses findings.json → ranks, dedupes, writes the human brief, STOPS
+  → Julian reviews brief → confirms → orchestrator MCP screenshot pass → Julian files tickets
+```
+
+## 4. Live-verified prod facts (ground truth, 2026-06-23)
+
+Verified directly against bird-maps.com (the local primary tree is stale at #930 and gave wrong answers; these supersede it):
+
+1. **`#map=` hash restore works on prod**, two-stage: `?scope=us` fits national and fetches first (`zoom=3`), **then** the hash camera flies in and fetches again (`zoom=9` at the hash bbox). Therefore `data-render-complete="true"` (which flips on the national interstitial) is **not** a sufficient "settled" signal.
+2. **Hash format:** `#map=<zoom>/<lat>/<lng>` — zoom `toFixed(3)`, lat/lng `toFixed(5)`; optional `/bearing/pitch` and `&v=WxH@dpr`. Field order is **ZOOM / LAT / LNG**. Scope is a **separate query param**: `?scope=us` (national) or `?state=US-AZ`. Filters are query params too: `?since=7d&family=CODE&species=CODE&notable=true`.
+   - Example: `https://bird-maps.com/?scope=us#map=9.000/32.22175/-110.97648`
+3. **Ground-truth viewport = the `/api/observations` request `bbox=` + `zoom=` params.** `data-camera-bounds` is the **scope code** (`"us"`), not real bounds — do not use it for geometry.
+4. **Mode switch at zoom 6** confirmed live: `zoom<6` → `mode:"aggregated"` buckets; `zoom>=6` → `mode:"observations"` rows (row-capped, `meta.truncated`).
+5. **Per-family marker counts are readable from the DOM via `aria-label`** — **no instrumentation change needed**:
+   - Cell: `aria-label="Falcons & Caracaras, 2 observations"` — parses to `{family, count}`, **including count-1 cells that have no badge** (`"Hawks, Eagles & Kites, 1 observation"`). Regex: `/^(?<family>.+),\s+(?<count>\d+)\s+observations?$/`.
+   - Marker: `aria-label="Cluster: 7 observations, 5 families. Activate to zoom in."` — parses to `{markerTotal, familyCount}`.
+   - Cell testids: `adaptive-grid-marker-cell-rendered` / `-cell-fallback` / `-cell-pending`; badge `adaptive-grid-marker-badge` (only when count>1); marker `adaptive-grid-marker`.
+6. **Legend is collapsed by default on desktop:** `<aside class="family-legend">` with toggle `#family-legend-toggle`; entries mount only when expanded. The harness **clicks the toggle** before reading rows. (Local-tree testid `family-legend-entry` must be re-confirmed post-expand during implementation; container/title/toggle selectors are confirmed live.)
+7. **Lede is scope-total, not viewport** — stayed `"2,300 sightings"` (national) at zoom-9 Tucson. `data-testid="map-lede"`; integer has thousands separators in the rendered string (`"2,300"`), so strip commas before parsing.
+8. **`window.__birdMap` is absent on prod** (gated to `MODE !== 'production'`). DOM + network only.
+
+## 5. Metamorphic relation catalog
+
+Each relation: definition, the comparison, tolerance, and carve-outs (conditions under which a difference is legitimate and must NOT be flagged).
+
+### MR-0 — Drill-down bbox conservation (HEADLINE)
+*Zooming into a sub-region must conserve the count attributed to it.*
+- **MR-0a (server truth):** pick a parent view; choose a child bbox inside it; `expected = Σ parent network counts geographically inside child bbox`. Navigate to the child bbox; `actual = child view network total`. Assert `actual == expected`.
+- **MR-0b (rendered truth):** `parentClusterCount over the child area == Σ rendered cell counts after zooming into the child bbox`.
+- **Tolerance:** exact within a same-mode drill-down (both `aggregated`, or both `observations`). Across the **zoom-6 mode switch** or when `meta.truncated`, compare within a tolerance band and annotate the cause instead of flagging.
+- **Carve-outs:** `meta.truncated` on either side; `freshestObservationAt` differs between parent and child fetch (prod ingested new data mid-sample) → annotate as freshness-skew, downgrade severity.
+
+### MR-8 — Desktop ↔ mobile parity (HEADLINE)
+*Same `#map=` camera must render the same coverage on desktop (1440×900) and mobile (390×844).*
+- Compare the **family set** and **per-family rendered totals** (from cell aria-labels) between viewports at the same camera.
+- **Violation:** a family/pill present on mobile but absent on desktop (or vice-versa); a marker that renders content on mobile but is empty/collapsed on desktop.
+- **Emits the desktop−mobile delta per sample** as the evidence for porting mobile's split logic.
+- **Leading hypothesis (from code):** `pickGridShape(uniqueFamilies, pointCount, isMobile)` where `isMobile = containerWidth < 768`. Mobile has a `grid-overflow` 3×3+"+N" path that always renders; desktop in the same density range can fall to a bare `{tag:'pill'}` that renders empty. (`frontend/src/components/map/adaptive-grid.ts`, `MapCanvas.tsx` reconciler ~L1843.)
+- **Carve-out:** legitimate layout differences (grid shape, "+N" overflow affordance) are fine **as long as coverage is conserved** — the check is on *which families/counts render*, not pixel layout.
+
+### MR-1 — Zoom non-vanishing
+*Zooming in over an area with positive count must not collapse to ~0.*
+- Along a sample's zoom ladder, if zoom Z shows count>0 over a point, deeper zooms covering that point must not show ~0.
+- **Carve-outs:** the point leaves the viewport as you zoom; `meta.truncated`.
+
+### MR-2 — Stated vs rendered
+*A stated count must equal what is rendered in the same viewport.*
+- `stated (lede/legend/filter) == Σ rendered cell counts in viewport` (within rounding ε).
+- This is the **"says 7, shows 3"** check. When `stated` is the lede, apply MR-5's scope-vs-viewport carve-out; when `stated` is the (viewport-scoped) legend or a filtered result, equality is expected.
+
+### MR-3 — Per-family conservation
+*Each family reconciles across panel, markers, and network.*
+- For each family: `expanded-legend count == Σ that family's cell counts == network family slice` (viewport-scoped).
+
+### MR-4 — Filter consistency (family/species/notable/since)
+*Filters partition and bound the data coherently.* Applied via URL params (not clicks).
+- Family/species/notable filtered view: `stated == Σ rendered` (MR-2 under filter).
+- `Σ over families (filter=family_i) == unfiltered total`.
+- `count(species S) ≤ count(family of S)`; `count(notable) ≤ count(all)`.
+- **Since-window monotonicity:** at a fixed camera, `count(14d) ≥ count(7d) ≥ count(1d)` (windows are nested).
+- **Carve-out:** species/family codes with `null` joins are excluded from species-count lines by design — reconcile against the same filtered set the UI uses.
+
+### MR-5 — Lede vs scope-total (conditional)
+*The lede equals the scope-wide total, not the viewport.*
+- Compare lede to the **scope-wide** network total, not the viewport sum. **Only** assert lede==viewport when `data-scope-fitted="true"` AND the camera ⊇ all scope data. Otherwise lede≠viewport is expected, not a bug.
+
+### MR-6 — Clean console
+*Zero console errors/warnings across the whole sweep.*
+- Catches `clusters-hit` layer-missing errors, `styleimagemissing` warnings, etc.
+- **Carve-out:** OpenFreeMap basemap-tile fetch failures (CDN flake) → mark the sample **inconclusive**, not a violation (a blank map from a tile error is not a data bug).
+
+### MR-7 — Idempotence / intermittency probe
+*Same camera twice → same counts.*
+- Re-request a settled camera; counts should be stable. Used both as its own relation (catches precompute-vs-live + cache-key drift) and to tag every other finding **deterministic vs intermittent**.
+- **Carve-out:** `freshestObservationAt` changed between the two reads → freshness-skew, not a bug.
+
+## 6. The harness
+
+`frontend/audits/map-consistency/` (TypeScript, run with `tsx`):
+
+| Module | Responsibility |
+|---|---|
+| `audit.ts` | CLI entry; parses flags; orchestrates sampler → driver → capture → relations → reporter; enforces the pacing guard. |
+| `sampler.ts` | One low-zoom scope fetch → **density-weighted seeded** sample points (PRNG seeded by `--seed`) so samples land where birds are. Also emits a few **uniform** points to catch "empty area shows phantom count". |
+| `camera.ts` | Builds `?scope=…#map=z/lat/lng[&v=…]` URLs; navigates; **waits for the `/api/observations` whose `zoom`+`bbox` match the requested camera** (two-stage hash-restore protocol); paces ≥ `--pace-ms`. |
+| `capture.ts` | Per cell: intercept the matching `/api/observations` response (`mode`, `buckets`/`observations`, `meta.truncated`, `freshestObservationAt`); expand legend + read rows; read lede; read marker/cell aria-labels → `{family,count}`; collect console messages. |
+| `relations.ts` | **Pure** `(captured snapshots) → verdicts`. No browser. This is the TDD core. |
+| `report.ts` | Writes `brief.md` + `findings.json` + per-finding evidence bundles + screenshots-on-fail. |
+| `relations.test.ts` | Vitest unit tests for `relations.ts` against good + violating fixtures. |
+
+**CLI** (npm script `audit:map-consistency` in `frontend/package.json`):
+```
+npm run audit:map-consistency --workspace @bird-watch/frontend -- \
+  --samples 20 --scope US --seed 42 \
+  --zoom-ladder 3,5,7,10,13 --viewports desktop,mobile \
+  --pace-ms 1200 --base-url https://bird-maps.com
+```
+- `--samples N` (required, the headline knob), `--scope US|US-XX`, `--seed`, `--zoom-ladder`, `--viewports`, `--pace-ms`, `--base-url` (default prod), `--out` (default the gitignored `out/`).
+- Browser: headless `chromium` from `@playwright/test` (already a devDep).
+
+**Placement guard:** the file lives under `frontend/audits/` (NOT `frontend/e2e/`) and is named `audit.ts`, so the Playwright test runner's `testMatch` never picks it up. `out/` is gitignored.
+
+## 7. The findings brief (primary deliverable)
+
+```
+frontend/audits/map-consistency/out/<UTC-timestamp>-seed<N>/
+  brief.md                      # human brief: run metadata + summary table + per-finding writeups
+  findings.json                 # machine-readable: every number, param, verdict, carve-out applied
+  findings/<finding-id>/
+    repro.md                    # exact #map= URL(s), scope/filter params, viewport, zoom, click steps
+    desktop.png  mobile.png     # screenshots (both viewports for parity findings)
+    observations-parent.json    # raw /api/observations payload(s) — the evidence
+    observations-child.json
+    console.log                 # console errors/warnings at capture time
+    meta.json                   # relation, severity, stated/rendered/network + delta, deterministic?, freshestObservationAt
+```
+
+**Per-finding fields:** `id`, `relation` (MR-x), `severity`, one-line `symptom`, `repro` (URLs + params + steps), the **three numbers** (stated / rendered / network) + `delta`, `deterministic` (from MR-7 re-check), `carveOutsApplied`, `screenshots`, `rawPayloads`, optional `hypothesis`.
+
+**Brief summary:** counts by relation, by severity, by determinism; the run's `freshestObservationAt` range; the exact command + seed to reproduce the run.
+
+**Data-preservation guarantee:** every finding is self-contained (raw payloads + DOM numbers + screenshots + repro URL), so it remains analyzable months later even though prod data has moved on.
+
+## 8. The agent
+
+`.claude/agents/map-consistency-auditor.md` — project subagent.
+- **When:** Julian says "run a map consistency audit", "audit the map for consistency", "check the bird counts", or names a scope/sample count.
+- **Tools:** Bash, Read, Grep, Glob, TodoWrite. **No MCP** (so it runs as a real subagent).
+- **Flow:** confirm scope + sample count (surfacing `--samples` prominently) → run the harness via Bash → parse `findings.json` → apply final real-vs-noise triage + dedupe + severity ranking → write/curate `brief.md` → **stop and hand the brief path to Julian**. Never files issues; never merges.
+- **Loads** the `map-consistency-audit` skill for the MR catalog, carve-outs, and brief schema.
+
+## 9. The skill
+
+`.claude/skills/map-consistency-audit/SKILL.md` — house style matches `pr-workflow` / `curating-fallback-silhouettes` (frontmatter `name` + `description` with triggers; numbered runbook; gotchas; references).
+- The MR catalog (§5) with tolerances and carve-outs.
+- The **two-stage hash-wait protocol** and the **legend-expand** step (§4).
+- The **CF pacing guard** (§10).
+- The **brief schema** (§7) and the triage → confirm → orchestrator-MCP-screenshot → Julian-files flow.
+- The live-verified selector/format reference (§4).
+
+## 10. Error handling & prod landmines
+
+- **Cloudflare 60/min/IP.** Each settled camera triggers ≥1 `/api/observations`. The harness computes projected request rate from `samples × |zoom-ladder| × |viewports| × (1 + filter probes + idempotence re-checks)` and **refuses to start** if it would exceed the CF budget, instructing the user to lower `--samples` or raise `--pace-ms`. Default `--pace-ms` conservative (≥1100ms between camera navigations).
+- **Flaky OpenFreeMap basemap CDN.** Blank map from a tile error ≠ data bug → detect the tile-fetch failure in console and mark the sample **inconclusive** (MR-6 carve-out).
+- **Non-determinism (prod data shifts).** Every finding saves raw payloads + `freshestObservationAt`; `--seed` fixes sample points; the `#map=` URL is the human repro. Findings stay reproducible from the saved artifact.
+- **Retries: 0** (repo law). Environment faults → `inconclusive`, never pass/fail.
+- **Two-stage hash settle.** Always wait on the network request whose `zoom`+`bbox` match the requested camera; never trust `data-render-complete` alone.
+
+## 11. Testing strategy
+
+- **`relations.ts` is pure and unit-tested** (vitest) against fixtures: a captured-good snapshot passes; hand-crafted violating snapshots (vanishing desktop pill; stated-7/rendered-3; broken drill-down) fail. This is the TDD core and the bulk of the confidence.
+- **Browser glue** gets a `--samples 2 --pace-ms 1500` smoke run against prod in the implementer's verification step (and the agent's first run), proving the two-stage wait + selectors + brief generation end-to-end.
+- **No DB writes; no stubs** (deliberately a real-data audit, unlike `e2e/*.spec.ts`).
+
+## 12. Sequencing (phases)
+
+1. **Phase 1 — drill-down + parity skeleton.** Harness scaffold (`audit.ts`, `sampler.ts`, `camera.ts`, `capture.ts`), the pure `relations.ts` with **MR-0** and **MR-8** + tests, the brief reporter, the npm script. First runnable slice targets the two headline bugs (drill-down conservation + desktop/mobile pills). Smoke-run on prod.
+2. **Phase 2 — full relation catalog.** Add MR-1/2/3/4/5/6/7 + tests, filter-param driving, idempotence/intermittency tagging, the CF pacing guard.
+3. **Phase 3 — agent + skill.** `map-consistency-auditor.md` + `SKILL.md`; wire the triage→confirm→brief flow; document the orchestrator MCP screenshot pass.
+
+(Effort expressed per repo norm as fan-out/sequence, not calendar — see writing-plans output.)
+
+## 13. Open questions / risks
+
+- **Child-bbox choice for MR-0:** start with "zoom into one parent grid cell" (clean same-mode case) and "zoom into a viewport quadrant"; tune from first-run signal.
+- **Legend entry testid** (`family-legend-entry`) needs post-expand re-confirmation live during Phase 2 (container/toggle confirmed; entries weren't in the collapsed DOM).
+- **Sampling weight** balance (density vs uniform) — start ~80/20, adjust from how much signal uniform points add.
+- **CF tolerance** for larger `--samples` runs — the pacing guard makes this safe but caps practical sweep size; document the math in the skill.
+
+## 14. File manifest (what implementation creates)
+
+```
+frontend/audits/map-consistency/audit.ts
+frontend/audits/map-consistency/sampler.ts
+frontend/audits/map-consistency/camera.ts
+frontend/audits/map-consistency/capture.ts
+frontend/audits/map-consistency/relations.ts
+frontend/audits/map-consistency/relations.test.ts
+frontend/audits/map-consistency/report.ts
+frontend/audits/map-consistency/README.md
+.claude/agents/map-consistency-auditor.md
+.claude/skills/map-consistency-audit/SKILL.md
+.claude/skills/map-consistency-audit/DESIGN.md   # this file
+frontend/package.json                            # + "audit:map-consistency" script
+.gitignore                                       # + frontend/audits/map-consistency/out/
+```

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -141,12 +141,26 @@ The first `--samples` run falsified three assumptions baked into the naive relat
 - **Rendered cells are LOSSY, not a conservation bound:** the adaptive grid renders a capacity-limited top-K-by-count subset of families (9–29% of legend at z9; ~2 cells at a z4 national cluster). So `legend == rendered` and `Σrendered == total` are false whenever families exceed grid capacity (overflow/pill drops the tail) — asserting them produced 317 MR-3 + 6 MR-2 capacity artifacts.
 
 Corrected relations (supersede the naive bullets above):
-- **MR-2 (conservation):** `|Σlegend − network.total| ≤ ε` AND `|lede − network.total| ≤ ε`, ε = max(3, total·2%). (Was legend-vs-rendered.)
+- **MR-2 (conservation):** **lede leg (always):** `|lede − network.total| ≤ ε`. **legend leg (per-observation mode only):** `|Σlegend − network.total| ≤ ε`, ε = max(3, total·2%). The **lede tracks the API RESPONSE total** (= viewport extent in per-obs mode; = scope extent in aggregated mode, where the fetch uses the scope-envelope bbox, so the lede shows the national total). The legend is always **viewport-scoped**, so it equals the response total ONLY in per-obs mode — in aggregated mode the response is scope-wide, so skip the legend leg (carve-out `aggregated-response-scopewide`). (Same guard MR-3 needs; corrects the 2 residual MR-2 z4-mobile artifacts.)
 - **MR-2b (render-completeness — the "says 7, shows 3" catcher):** when `network.total ≤ 50` AND no marker overflow, `Σ rendered cell counts ≈ network.total`. At low counts everything fits the grid, so rendered must conserve; a shortfall = render loss. Skipped at high totals (capacity).
 - **MR-3 (server↔client family, aggregated-mode only):** in `mode:aggregated`, `legend[fam] ≈ network.familyCounts[fam]` (both common-name). Skipped in observations mode (no per-family network + code↔name mismatch). NO legend-vs-rendered.
 - **MR-5 (lede vs viewport):** `lede ≈ network.total` (viewport, not scope). `scopeTotal` dropped.
 - **MR-8 (directional pill-collapse — THE bug detector):** keep the legend-intersection; fire ONLY when `mobile renders F && desktop does NOT` (desktop under-rendering = the reported "desktop pills disappear, mobile splits out" bug). Suppress the reverse (desktop renders more = its larger 4×4 capacity — legit, was the 21 residual artifacts).
 - **Unchanged:** MR-0, MR-1, MR-4, MR-6, MR-7. (MR-6 already caught a genuine prod CORS error on the national `zoom=3` prefetch — `No 'Access-Control-Allow-Origin'`, filed for independent follow-up.)
+
+### 5.2 Two render modes — `cluster-pill` vs `adaptive-grid-marker` (THE actual bug surface)
+
+Live MCP inspection of the MR-1 candidate (`#map=4.000/36.5/-84.5&v=390x844@2`, mobile) revealed the capture was **blind to half the map.** A cluster renders in one of two DOM forms:
+
+- **`cluster-pill`** — a collapsed pill: `<button class="cluster-pill cluster-pill--ember" aria-label="1,164 sightings">1,164</button>`. Shows the total count, NO family breakdown. (16 of these were on screen where the capture read 0 markers.)
+- **`adaptive-grid-marker`** — the "split out" form: the family-silhouette grid with per-family `-cell` aria-labels.
+
+`pickGridShape` returns `{tag:'pill'}` when a cluster exceeds the family/point cap. That cap is viewport-independent, **but desktop's wider bbox aggregates MORE points per cluster** → more clusters exceed the cap → **desktop collapses to pills where mobile (narrower clusters) splits into grids.** This is precisely the reported bug: *"desktop pills disappear and never split out like they do on mobile."* The capture only ever read `adaptive-grid-marker`, so it could not see pills at all — causing the MR-1 false-fire and the "rendered = 9–29% of legend" undercount (pills hold most of the low-zoom count).
+
+**Required fixes (land in the capture + relations — task C4c):**
+1. **Capture pills.** `readMarkers` must also read `.cluster-pill` markers: `kind:'pill'`, `total` = parsed `aria-label "N sightings"`, `color` = the `cluster-pill--<x>` modifier, `cells:[]`. `adaptive-grid-marker` markers become `kind:'grid'`. Add `kind: 'pill' | 'grid'` and `total: number` to `MarkerRead`.
+2. **Conservation counts pills.** `renderedTotal` = Σ pill totals + Σ grid cell counts. This fixes MR-1 (pills count as rendered) and MR-2b (low-zoom conservation).
+3. **MR-9 (NEW — pill-split parity, the user's bug):** at the same camera, flag when **mobile splits materially more clusters than desktop** (`mobileGridMarkers − desktopGridMarkers > threshold`, i.e. desktop leaves as pills clusters mobile splits into grids). Severity high — this is the reported defect. (The implementer must empirically confirm the asymmetry direction in the smoke before fixing the threshold — capture desktop vs mobile pill/grid counts across z5–z10.)
 
 ## 6. The harness
 

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -180,6 +180,8 @@ frontend/audit-out/<UTC-timestamp>-seed<N>/
 
 **Data-preservation guarantee:** every finding is self-contained (raw payloads + DOM numbers + screenshots + repro URL), so it remains analyzable months later even though prod data has moved on.
 
+**Viewbox link is the repro primitive (epic #1238 — always include it):** each finding's repro is a `#map=` viewbox link that bakes in the camera, viewport, scope, and active filters — open it and you land on the exact broken view. Because the viewbox feature is recent and easy to forget, the convention is explicit and mandatory: `brief.md` surfaces the `#map=` link per finding (a `🔗 viewbox repro:` line), `repro.md` instructs including it, and **every ticket written from a finding (and any hand-written bird-maps map/data bug ticket) must lead with the viewbox link** as the canonical one-click reproduction.
+
 ## 8. The agent
 
 `.claude/agents/map-consistency-auditor.md` — project subagent.

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -4,7 +4,7 @@
 - **Status:** Approved design; pending implementation plan
 - **Author:** Julian (brainstormed with Claude)
 - **Repo:** `julianken/bird-sight-system` (local `bird-watch/`)
-- **Artifacts produced:** a committed Playwright harness (`frontend/audits/map-consistency/`), a project agent (`.claude/agents/map-consistency-auditor.md`), and a project skill (`.claude/skills/map-consistency-audit/SKILL.md`).
+- **Artifacts produced:** a committed Playwright harness (`frontend/scripts/map-consistency/`), a project agent (`.claude/agents/map-consistency-auditor.md`), and a project skill (`.claude/skills/map-consistency-audit/SKILL.md`).
 
 ---
 
@@ -40,7 +40,7 @@ Three artifacts plus one human-in-the-loop orchestrator touchpoint.
 
 | Artifact | Path | Role |
 |---|---|---|
-| **Harness** (engine) | `frontend/audits/map-consistency/` | Standalone headless-Playwright script (run via `tsx`, **not** a `*.spec.ts`). Drives prod, captures evidence, evaluates relations, writes the brief. A subagent can run it via Bash — that is what makes it delegatable; MCP browsers cannot be driven by subagents. |
+| **Harness** (engine) | `frontend/scripts/map-consistency/` | Standalone headless-Playwright script (run via `tsx`, **not** a `*.spec.ts`). Drives prod, captures evidence, evaluates relations, writes the brief. A subagent can run it via Bash — that is what makes it delegatable; MCP browsers cannot be driven by subagents. |
 | **Agent** | `.claude/agents/map-consistency-auditor.md` | Project subagent (mirrors the `dependabot` agent). Runs the harness, applies triage judgment + carve-outs, ranks findings, writes/curates the brief, **stops for Julian's confirmation**. Tools: Bash, Read, Grep, Glob, TodoWrite (no MCP). |
 | **Skill** | `.claude/skills/map-consistency-audit/SKILL.md` | Runbook + knowledge: the MR catalog with tolerances/carve-outs, the CF pacing guard, the two-stage hash-wait protocol, the legend-expand step, the brief schema, and the triage→confirm→file flow. Loaded by the agent and the orchestrator. |
 | **Orchestrator MCP** (confirm) | — | On a flagged finding, the orchestrator opens the `#map=` repro URL in chrome-devtools/Playwright MCP, eyeballs it, and captures the canonical screenshot for the eventual ticket. Human-in-loop, after the brief, before any GitHub action. |
@@ -86,8 +86,8 @@ Each relation: definition, the comparison, tolerance, and carve-outs (conditions
 *Zooming into a sub-region must conserve the count attributed to it.*
 - **MR-0a (server truth):** pick a parent view; choose a child bbox inside it; `expected = Σ parent network counts geographically inside child bbox`. Navigate to the child bbox; `actual = child view network total`. Assert `actual == expected`.
 - **MR-0b (rendered truth):** `parentClusterCount over the child area == Σ rendered cell counts after zooming into the child bbox`.
-- **Tolerance:** exact within a same-mode drill-down (both `aggregated`, or both `observations`). Across the **zoom-6 mode switch** or when `meta.truncated`, compare within a tolerance band and annotate the cause instead of flagging.
-- **Carve-outs:** `meta.truncated` on either side; `freshestObservationAt` differs between parent and child fetch (prod ingested new data mid-sample) → annotate as freshness-skew, downgrade severity.
+- **Tolerance:** exact (tol=0) **only** for observations↔observations drill-down (discrete points). Aggregated views use **centroids**, so a boundary bucket bins all-or-nothing → aggregated (and cross-mode / `truncated` / freshness-skewed) drill-downs use a tolerance band and only flag **LOSS** (`child < parent`); a **GAIN** is parent-grid coarseness or a row-capped parent, never a conservation bug. (Refined per bot review of #1267.)
+- **Carve-outs:** `meta.truncated` on either side; aggregated-centroid binning; `freshestObservationAt` differs between parent and child fetch (prod ingested new data mid-sample) → annotate as freshness-skew, downgrade severity.
 
 ### MR-8 — Desktop ↔ mobile parity (HEADLINE)
 *Same `#map=` camera must render the same coverage on desktop (1440×900) and mobile (390×844).*
@@ -135,7 +135,7 @@ Each relation: definition, the comparison, tolerance, and carve-outs (conditions
 
 ## 6. The harness
 
-`frontend/audits/map-consistency/` (TypeScript, run with `tsx`):
+`frontend/scripts/map-consistency/` (TypeScript, run with `tsx`):
 
 | Module | Responsibility |
 |---|---|
@@ -157,12 +157,12 @@ npm run audit:map-consistency --workspace @bird-watch/frontend -- \
 - `--samples N` (required, the headline knob), `--scope US|US-XX`, `--seed`, `--zoom-ladder`, `--viewports`, `--pace-ms`, `--base-url` (default prod), `--out` (default the gitignored `out/`).
 - Browser: headless `chromium` from `@playwright/test` (already a devDep).
 
-**Placement guard:** the file lives under `frontend/audits/` (NOT `frontend/e2e/`) and is named `audit.ts`, so the Playwright test runner's `testMatch` never picks it up. `out/` is gitignored.
+**Placement guard:** the file lives under `frontend/scripts/` (NOT `frontend/e2e/`) and is named `audit.ts`, so the Playwright test runner's `testMatch` never picks it up. `out/` is gitignored.
 
 ## 7. The findings brief (primary deliverable)
 
 ```
-frontend/audits/map-consistency/out/<UTC-timestamp>-seed<N>/
+frontend/audit-out/<UTC-timestamp>-seed<N>/
   brief.md                      # human brief: run metadata + summary table + per-finding writeups
   findings.json                 # machine-readable: every number, param, verdict, carve-out applied
   findings/<finding-id>/
@@ -229,17 +229,17 @@ frontend/audits/map-consistency/out/<UTC-timestamp>-seed<N>/
 ## 14. File manifest (what implementation creates)
 
 ```
-frontend/audits/map-consistency/audit.ts
-frontend/audits/map-consistency/sampler.ts
-frontend/audits/map-consistency/camera.ts
-frontend/audits/map-consistency/capture.ts
-frontend/audits/map-consistency/relations.ts
-frontend/audits/map-consistency/relations.test.ts
-frontend/audits/map-consistency/report.ts
-frontend/audits/map-consistency/README.md
+frontend/scripts/map-consistency/audit.ts
+frontend/scripts/map-consistency/sampler.ts
+frontend/scripts/map-consistency/camera.ts
+frontend/scripts/map-consistency/capture.ts
+frontend/scripts/map-consistency/relations.ts
+frontend/scripts/map-consistency/relations.test.ts
+frontend/scripts/map-consistency/report.ts
+frontend/scripts/map-consistency/README.md
 .claude/agents/map-consistency-auditor.md
 .claude/skills/map-consistency-audit/SKILL.md
 .claude/skills/map-consistency-audit/DESIGN.md   # this file
 frontend/package.json                            # + "audit:map-consistency" script
-.gitignore                                       # + frontend/audits/map-consistency/out/
+.gitignore                                       # + frontend/audit-out/
 ```

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -91,8 +91,8 @@ Each relation: definition, the comparison, tolerance, and carve-outs (conditions
 
 ### MR-8 — Desktop ↔ mobile parity (HEADLINE)
 *Same `#map=` camera must render the same coverage on desktop (1440×900) and mobile (390×844).*
-- Compare the **family set** and **per-family rendered totals** (from cell aria-labels) between viewports at the same camera.
-- **Violation:** a family/pill present on mobile but absent on desktop (or vice-versa); a marker that renders content on mobile but is empty/collapsed on desktop.
+- Compare rendered family presence between viewports at the same camera, **restricted to families present in BOTH viewports' (viewport-scoped) legends** — the coverage-controlled common ground. *Viewport-coverage normalization is load-bearing: desktop (1440×900) and mobile (390×844) cover different geographic bboxes at the same zoom, so an un-normalized raw family-set comparison emits one-directional false positives — desktop's wider frame legitimately sees coastal/edge families mobile's bbox excludes. Proven by the first prod run (#1269); fixed in C4.*
+- **Violation:** a family present in BOTH legends (so both viewports have the data) that renders on only one side — a real rendering disparity, not a coverage difference.
 - **Emits the desktop−mobile delta per sample** as the evidence for porting mobile's split logic.
 - **Leading hypothesis (from code):** `pickGridShape(uniqueFamilies, pointCount, isMobile)` where `isMobile = containerWidth < 768`. Mobile has a `grid-overflow` 3×3+"+N" path that always renders; desktop in the same density range can fall to a bare `{tag:'pill'}` that renders empty. (`frontend/src/components/map/adaptive-grid.ts`, `MapCanvas.tsx` reconciler ~L1843.)
 - **Carve-out:** legitimate layout differences (grid shape, "+N" overflow affordance) are fine **as long as coverage is conserved** — the check is on *which families/counts render*, not pixel layout.

--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -133,6 +133,21 @@ Each relation: definition, the comparison, tolerance, and carve-outs (conditions
 - Re-request a settled camera; counts should be stable. Used both as its own relation (catches precompute-vs-live + cache-key drift) and to tag every other finding **deterministic vs intermittent**.
 - **Carve-out:** `freshestObservationAt` changed between the two reads → freshness-skew, not a bug.
 
+### 5.1 Relation model correction (empirical — from the first full prod run, #1270)
+
+The first `--samples` run falsified three assumptions baked into the naive relations (45→0 coastal MR-8 artifacts confirmed the viewport-normalization fix, but exposed deeper gaps). Corrected, prod-verified model:
+
+- **The conservation law (reliable):** `Σ legend ≈ network.total ≈ lede` — all three track the **viewport** total (verified z9: lede 872 = network.total 872 = legend-sum 869). **The lede tracks the viewport, NOT the scope** (this overturns the earlier "lede is scope-total" reading — that was the two-stage load *interstitial*).
+- **Rendered cells are LOSSY, not a conservation bound:** the adaptive grid renders a capacity-limited top-K-by-count subset of families (9–29% of legend at z9; ~2 cells at a z4 national cluster). So `legend == rendered` and `Σrendered == total` are false whenever families exceed grid capacity (overflow/pill drops the tail) — asserting them produced 317 MR-3 + 6 MR-2 capacity artifacts.
+
+Corrected relations (supersede the naive bullets above):
+- **MR-2 (conservation):** `|Σlegend − network.total| ≤ ε` AND `|lede − network.total| ≤ ε`, ε = max(3, total·2%). (Was legend-vs-rendered.)
+- **MR-2b (render-completeness — the "says 7, shows 3" catcher):** when `network.total ≤ 50` AND no marker overflow, `Σ rendered cell counts ≈ network.total`. At low counts everything fits the grid, so rendered must conserve; a shortfall = render loss. Skipped at high totals (capacity).
+- **MR-3 (server↔client family, aggregated-mode only):** in `mode:aggregated`, `legend[fam] ≈ network.familyCounts[fam]` (both common-name). Skipped in observations mode (no per-family network + code↔name mismatch). NO legend-vs-rendered.
+- **MR-5 (lede vs viewport):** `lede ≈ network.total` (viewport, not scope). `scopeTotal` dropped.
+- **MR-8 (directional pill-collapse — THE bug detector):** keep the legend-intersection; fire ONLY when `mobile renders F && desktop does NOT` (desktop under-rendering = the reported "desktop pills disappear, mobile splits out" bug). Suppress the reverse (desktop renders more = its larger 4×4 capacity — legit, was the 21 residual artifacts).
+- **Unchanged:** MR-0, MR-1, MR-4, MR-6, MR-7. (MR-6 already caught a genuine prod CORS error on the national `zoom=3` prefetch — `No 'Access-Control-Allow-Origin'`, filed for independent follow-up.)
+
 ## 6. The harness
 
 `frontend/scripts/map-consistency/` (TypeScript, run with `tsx`):

--- a/.claude/skills/map-consistency-audit/SKILL.md
+++ b/.claude/skills/map-consistency-audit/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: map-consistency-audit
+description: >-
+  Use when running or interpreting the bird-maps.com prod consistency audit, or
+  dispatching the map-consistency-auditor agent. Triggers on "map consistency
+  audit", "audit the map", "check bird counts", "filter numbers don't add up",
+  "birds disappear at zoom", "desktop pills vanish". Encodes the metamorphic
+  relation catalog, the carve-outs that prevent false positives, the Cloudflare
+  pacing rules, the two-stage hash-wait, and the confirm-first triage flow.
+---
+
+# Map consistency audit
+
+Metamorphic-testing harness that samples bird-maps.com at a configurable count,
+walks a zoom ladder on desktop + mobile, and emits a preserved findings brief.
+Full design: `.claude/skills/map-consistency-audit/DESIGN.md`.
+
+## Run it
+`npm run audit:map-consistency -w @bird-watch/frontend -- --samples N --scope US --seed K`
+Flags: `--samples` (size), `--scope US|US-XX`, `--seed`, `--zoom-ladder`,
+`--viewports desktop,mobile`, `--pace-ms` (default 2500), `--base-url` (default prod).
+Probe one view: `... -- --probe '<#map= url>'`.
+
+## What it checks (catalog → DESIGN.md §5)
+MR-0 drill-down conservation · MR-8 desktop↔mobile parity (headlines) ·
+MR-9 pill-split parity (desktop↔mobile cluster-split asymmetry — the reported bug) ·
+MR-1 zoom non-vanishing · MR-2 stated-vs-rendered · MR-2b render-completeness (low-total "says 7, shows 3") ·
+MR-3 per-family · MR-4 filter consistency + since-monotonicity ·
+MR-5 lede-vs-scope-total (conditional) · MR-6 clean console · MR-7 idempotence/intermittency.
+
+## Carve-outs (do NOT flag these)
+- Lede is scope-total, not viewport — MR-5 only fires vs the scope total.
+- Zoom-6 mode switch (aggregated↔observations) + row-cap `truncated` → drill-down uses tolerance, annotated.
+- Mobile `grid-overflow` "+N" legitimately hides families → MR-2/MR-3 relax to `rendered ≤ stated`.
+- OpenFreeMap tile-CDN failure → `inconclusive`, never a finding.
+- `freshestObservationAt` differs between two reads → freshness skew, not a bug.
+
+## Pacing (load-bearing)
+Cloudflare = 60 req/min/IP. The guard refuses runs whose projected rate exceeds
+~55/min; raise `--pace-ms` or lower `--samples`. Never bypass it (bursting /api
+breaks bird-maps.com in the same session).
+
+## The `#map=` viewbox link is the repro primitive (epic #1238 — always include it)
+Every finding carries a `#map=` viewbox link that bakes in the camera, viewport,
+scope, and active filters — open it and you land on the exact broken view. It is
+a recently-shipped feature, so it is easy to forget it exists. **Rule: every
+finding in the brief, and every ticket written from a finding, MUST include its
+`#map=` viewbox link** as the canonical one-click reproduction. The same applies
+to any hand-written bird-maps map/data bug ticket — lead with the viewbox link.
+
+## Triage → confirm → file (the flow)
+1. Agent runs the harness, curates `brief.md` + `findings/F*/` bundles, STOPS.
+2. Julian reviews the brief (each finding shows its `#map=` viewbox link).
+3. Orchestrator opens each confirmed finding's `#map=` viewbox link in chrome-devtools
+   MCP, captures the canonical screenshot.
+4. Julian files the ticket — **with the `#map=` viewbox link as the repro**. The agent never files.

--- a/.claude/skills/map-consistency-audit/SKILL.md
+++ b/.claude/skills/map-consistency-audit/SKILL.md
@@ -26,10 +26,13 @@ MR-0 drill-down conservation · MR-8 desktop↔mobile parity (headlines) ·
 MR-9 pill-split parity (desktop↔mobile cluster-split asymmetry — the reported bug) ·
 MR-1 zoom non-vanishing · MR-2 stated-vs-rendered · MR-2b render-completeness (low-total "says 7, shows 3") ·
 MR-3 per-family · MR-4 filter consistency + since-monotonicity ·
-MR-5 lede-vs-scope-total (conditional) · MR-6 clean console · MR-7 idempotence/intermittency.
+MR-5 lede-vs-viewport-total (conditional) · MR-6 clean console · MR-7 idempotence/intermittency.
 
 ## Carve-outs (do NOT flag these)
-- Lede is scope-total, not viewport — MR-5 only fires vs the scope total.
+- MR-5: lede ≈ `network.total` (the VIEWPORT total — the lede tracks the API
+  response total, which is viewport-extent in observations mode; DESIGN §5.1).
+  Conditional — the only carve-outs are a species-count lede (different unit) and
+  the unparsed two-stage-load placeholder. There is NO scope-total carve-out.
 - Zoom-6 mode switch (aggregated↔observations) + row-cap `truncated` → drill-down uses tolerance, annotated.
 - Mobile `grid-overflow` "+N" legitimately hides families → MR-2/MR-3 relax to `rendered ≤ stated`.
 - OpenFreeMap tile-CDN failure → `inconclusive`, never a finding.
@@ -49,6 +52,11 @@ finding in the brief, and every ticket written from a finding, MUST include its
 to any hand-written bird-maps map/data bug ticket — lead with the viewbox link.
 
 ## Triage → confirm → file (the flow)
+0. **MR-8/MR-9 dedupe.** At a low-zoom national camera MR-8 can emit dozens of
+   per-family high-severity verdicts for the same phenomenon MR-9 reports once. When
+   a camera produces an MR-9 pill-split fail, treat that camera's many MR-8 per-family
+   fails as the SAME finding — collapse/annotate them under the MR-9 result so the
+   brief isn't swamped and the actionable MR-9 signal isn't diluted.
 1. Agent runs the harness, curates `brief.md` + `findings/F*/` bundles, STOPS.
 2. Julian reviews the brief (each finding shows its `#map=` viewbox link).
 3. Orchestrator opens each confirmed finding's `#map=` viewbox link in chrome-devtools

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ frontend/playwright-report/
 # regenerable — never commit.
 frontend/replay-out/
 
+# map-consistency audit run output (#1269) — per-run findings.json the
+# `audit:map-consistency` operator tool writes (default
+# ./audit-out/<timestamp>-seed<N> under the frontend workspace). Operator-local
+# and regenerable — never commit.
+frontend/audit-out/
+
 # Playwright MCP runtime artifacts — may contain page snapshots of credential
 # flows (API key creation, OAuth callbacks). Never commit.
 .playwright-mcp/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "replay:viewbox": "tsx scripts/replay-viewbox.ts"
+    "replay:viewbox": "tsx scripts/replay-viewbox.ts",
+    "audit:map-consistency": "tsx scripts/map-consistency/audit.ts"
   },
   "dependencies": {
     "@bird-watch/geo": "*",

--- a/frontend/scripts/map-consistency/README.md
+++ b/frontend/scripts/map-consistency/README.md
@@ -1,0 +1,26 @@
+# map-consistency
+
+A metamorphic-testing harness that samples bird-maps.com at a configurable count,
+walks a zoom ladder on desktop + mobile, and emits a preserved findings brief that
+separates real map/data consistency bugs (counts that don't conserve across a
+drill-down, desktop pills that don't split like mobile's, a lede that disagrees
+with the viewport total, a dirty console) from the app's documented-legitimate
+divergences. It is a pure metamorphic-relation engine (`relations.ts`) driven by a
+Playwright capture layer; it never mutates prod and stops at a brief for triage.
+
+## Run it
+
+```sh
+npm run audit:map-consistency -w @bird-watch/frontend -- --samples N --scope US
+```
+
+Useful flags: `--scope US|US-XX`, `--seed K`, `--zoom-ladder 3,5,7,10,13`,
+`--viewports desktop,mobile`, `--pace-ms` (default 2500 — Cloudflare is 60 req/min/IP,
+so the pacing guard refuses runs that would exceed ~55/min), `--base-url` (default
+`https://bird-maps.com`). Probe a single view: `... -- --probe '<#map= url>'`.
+
+## Design
+
+Full architecture, the metamorphic-relation catalog (MR-0…MR-9), the carve-outs
+that suppress false positives, and the pacing math live in
+[`.claude/skills/map-consistency-audit/DESIGN.md`](../../../.claude/skills/map-consistency-audit/DESIGN.md).

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -9,7 +9,7 @@ import { evaluateSample } from './relations.js';
 import { writeBrief } from './report.js';
 import type { FilterBundle, Recapture, Sample, ViewSnapshot, Verdict, Viewport } from './types.js';
 
-interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; }
+interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; uniformFrac: number; }
 
 const OBS_PER_VIEW = 2; // national interstitial + matched hash fetch (worst case)
 const CF_SAFE_PER_MIN = 55; // margin under Cloudflare's 60/min/IP
@@ -30,6 +30,9 @@ function parse(argv: string[]): Opts {
     paceMs: Number(get('--pace-ms', '2500')),
     baseUrl: get('--base-url', 'https://bird-maps.com')!,
     out: get('--out', path.resolve(process.cwd(), 'audit-out', `${stamp}-seed${seed}`))!,
+    // Pure density-weighted by default (uniform sampling is opt-in; it can seed an
+    // ocean/empty point with no /api/observations fetch → per-view timeout stall).
+    uniformFrac: Number(get('--uniform-frac', '0')),
   };
 }
 
@@ -86,7 +89,7 @@ async function run(o: Opts): Promise<void> {
     // camera matcher times out. The z3 seed fetch is aggregated, so its buckets carry
     // both AggregatedFamily.code AND .name → build a name→code map once here.
     const familyNameToCode = familyCodeMap(seedView.raw.responseBody);
-    const seeds = sampleSeedPoints(seedSnap.network.points, o.samples, o.seed);
+    const seeds = sampleSeedPoints(seedSnap.network.points, o.samples, o.seed, o.uniformFrac);
 
     // Helper: capture one view at a camera (paced). A transient fetch hiccup
     // (occasional cold-edge `waitForResponse` timeout) must NOT abort the whole

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -1,0 +1,28 @@
+// frontend/scripts/map-consistency/audit.ts
+import { chromium } from '@playwright/test';
+import { openView } from './camera.js';
+import { captureView } from './capture.js';
+
+async function probe(url: string): Promise<void> {
+  const parsed = new URL(url);
+  const scope = parsed.searchParams.get('state') ?? 'us';
+  const [zoom, lat, lng] = parsed.hash.replace('#map=', '').split('/').map(Number);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const center = { lng, lat };
+    const { page, raw } = await openView(context, `${parsed.protocol}//${parsed.host}`, { scope, center, zoom, viewport: 'desktop' });
+    console.log(JSON.stringify(await captureView(page, raw, { scope, viewport: 'desktop', zoom, center }), null, 2));
+  } finally {
+    await browser.close();
+  }
+}
+
+const argv = process.argv.slice(2);
+const i = argv.indexOf('--probe');
+if (i >= 0 && argv[i + 1]) {
+  probe(argv[i + 1]).catch((e) => { console.error(e); process.exit(1); });
+} else {
+  console.error('C2: --probe <url>. Full --samples loop lands in C3 (#…).');
+  process.exit(1);
+}

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -11,7 +11,10 @@ import type { FilterBundle, Recapture, Sample, ViewSnapshot, Verdict, Viewport }
 
 interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; uniformFrac: number; }
 
-const OBS_PER_VIEW = 2; // national interstitial + matched hash fetch (worst case)
+// 2 /api/observations fetches per view = the national worst case (the low-zoom
+// interstitial + the matched hash fetch). This is the intentional pacing ceiling
+// the guard sizes against — don't lower it without re-checking the CF math.
+const OBS_PER_VIEW = 2;
 const CF_SAFE_PER_MIN = 55; // margin under Cloudflare's 60/min/IP
 // C4 loop additions (paced like every other view):
 const FILTER_BUNDLE_VIEWS = 6; // 1 unfiltered + 2 family + 3 since (first sample only)
@@ -64,6 +67,9 @@ function familyCodeMap(body: unknown): Map<string, string> {
 }
 
 async function run(o: Opts): Promise<void> {
+  // Surface the resolved target host up front so a non-prod base-url isn't hammered
+  // unnoticed (the pacing guard protects prod; this makes the destination explicit).
+  process.stderr.write(`Base URL: ${o.baseUrl} (scope ${o.scope})\n`);
   pacingGuard(o);
   await mkdir(o.out, { recursive: true });
   // Persist every view's raw payload + screenshot so any finding stays reproducible

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -1,28 +1,98 @@
 // frontend/scripts/map-consistency/audit.ts
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { chromium } from '@playwright/test';
 import { openView } from './camera.js';
 import { captureView } from './capture.js';
+import { sampleSeedPoints } from './sampler.js';
+import { evaluateSample } from './relations.js';
+import type { Sample, ViewSnapshot, Verdict, Viewport } from './types.js';
 
-async function probe(url: string): Promise<void> {
-  const parsed = new URL(url);
-  const scope = parsed.searchParams.get('state') ?? 'us';
-  const [zoom, lat, lng] = parsed.hash.replace('#map=', '').split('/').map(Number);
+interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; }
+
+const OBS_PER_VIEW = 2; // national interstitial + matched hash fetch (worst case)
+const CF_SAFE_PER_MIN = 55; // margin under Cloudflare's 60/min/IP
+
+function parse(argv: string[]): Opts {
+  const get = (f: string, d?: string) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : d; };
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const seed = Number(get('--seed', '1'));
+  const scope = get('--scope', 'US')!;
+  return {
+    samples: Number(get('--samples', '10')),
+    scope, seed,
+    ladder: (get('--zoom-ladder', '3,5,7,10,13')!).split(',').map(Number),
+    viewports: (get('--viewports', 'desktop,mobile')!).split(',') as Viewport[],
+    paceMs: Number(get('--pace-ms', '2500')),
+    baseUrl: get('--base-url', 'https://bird-maps.com')!,
+    out: get('--out', path.resolve(process.cwd(), 'audit-out', `${stamp}-seed${seed}`))!,
+  };
+}
+
+function pacingGuard(o: Opts): void {
+  const minPace = Math.ceil((60000 * OBS_PER_VIEW) / CF_SAFE_PER_MIN); // ~2182ms
+  const obsPerMin = Math.round((60000 / o.paceMs) * OBS_PER_VIEW);
+  if (obsPerMin > CF_SAFE_PER_MIN) {
+    throw new Error(`Pacing too aggressive: ~${obsPerMin} obs/min > ${CF_SAFE_PER_MIN}/min (Cloudflare 60/min/IP). Raise --pace-ms to >= ${minPace}, or lower --samples.`);
+  }
+  const totalViews = o.samples * o.ladder.length * o.viewports.length;
+  process.stderr.write(`Plan: ${o.samples} samples × ${o.ladder.length} zooms × ${o.viewports.length} viewports = ${totalViews} views; ~${Math.ceil((totalViews * o.paceMs) / 1000)}s wall at ${o.paceMs}ms pace.\n`);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function run(o: Opts): Promise<void> {
+  pacingGuard(o);
+  await mkdir(o.out, { recursive: true });
   const browser = await chromium.launch({ headless: true });
+  const verdicts: Verdict[] = [];
+  const freshSeen = new Set<string>();
   try {
     const context = await browser.newContext();
-    const center = { lng, lat };
-    const { page, raw } = await openView(context, `${parsed.protocol}//${parsed.host}`, { scope, center, zoom, viewport: 'desktop' });
-    console.log(JSON.stringify(await captureView(page, raw, { scope, viewport: 'desktop', zoom, center }), null, 2));
+    // 1. Scope-wide low-zoom fetch → bucket points to sample from.
+    const center0 = o.scope === 'US' ? { lng: -97, lat: 39 } : { lng: -111.5, lat: 34 }; // US center; refine per state in C4
+    const seedView = await openView(context, o.baseUrl, { scope: o.scope, center: center0, zoom: 3, viewport: 'desktop' });
+    const seedSnap = await captureView(seedView.page, seedView.raw, { scope: o.scope, viewport: 'desktop', zoom: 3, center: center0 });
+    await seedView.page.close();
+    const seeds = sampleSeedPoints(seedSnap.network.points, o.samples, o.seed);
+
+    // 2. For each sample, walk the ladder × viewports (paced).
+    for (let s = 0; s < seeds.length; s++) {
+      const views: ViewSnapshot[] = [];
+      for (const vp of o.viewports) {
+        for (const zoom of o.ladder) {
+          await sleep(o.paceMs);
+          const { page, raw } = await openView(context, o.baseUrl, { scope: o.scope, center: seeds[s]!, zoom, viewport: vp });
+          const snap = await captureView(page, raw, { scope: o.scope, viewport: vp, zoom, center: seeds[s]! });
+          await page.close();
+          if (snap.network.freshestObservationAt) freshSeen.add(snap.network.freshestObservationAt);
+          views.push(snap);
+        }
+      }
+      const sample: Sample = { id: `s${s + 1}`, seedPoint: seeds[s]!, scope: o.scope, views };
+      verdicts.push(...evaluateSample(sample));
+      process.stderr.write(`sample ${s + 1}/${seeds.length} done (${verdicts.filter((v) => v.status === 'fail').length} fails so far)\n`);
+    }
   } finally {
     await browser.close();
   }
+
+  const fails = verdicts.filter((v) => v.status === 'fail');
+  const findings = {
+    runMeta: { generatedAtNote: 'stamp set by caller', seed: o.seed, scope: o.scope, samples: o.samples, zoomLadder: o.ladder, viewports: o.viewports, paceMs: o.paceMs, baseUrl: o.baseUrl, freshestRange: [...freshSeen].sort(), command: `--samples ${o.samples} --scope ${o.scope} --seed ${o.seed}` },
+    summary: { total: verdicts.length, fails: fails.length, byRelation: Object.fromEntries([...new Set(fails.map((v) => v.relation))].map((r) => [r, fails.filter((v) => v.relation === r).length])) },
+    verdicts,
+  };
+  await writeFile(path.join(o.out, 'findings.json'), JSON.stringify(findings, null, 2));
+  process.stderr.write(`\nWrote ${path.join(o.out, 'findings.json')} — ${fails.length} fails / ${verdicts.length} checks.\n`);
 }
 
+// ── entry: --probe <url> (C2) OR the full --samples loop ──────────────────────
 const argv = process.argv.slice(2);
-const i = argv.indexOf('--probe');
-if (i >= 0 && argv[i + 1]) {
-  probe(argv[i + 1]).catch((e) => { console.error(e); process.exit(1); });
+const pi = argv.indexOf('--probe');
+if (pi >= 0 && argv[pi + 1]) {
+  const { probe } = await import('./probe.js'); // move C2's probe() into probe.ts in this step
+  await probe(argv[pi + 1]!).catch((e) => { console.error(e); process.exit(1); });
 } else {
-  console.error('C2: --probe <url>. Full --samples loop lands in C3 (#…).');
-  process.exit(1);
+  await run(parse(argv)).catch((e) => { console.error(String(e)); process.exit(1); });
 }

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -6,6 +6,7 @@ import { openView } from './camera.js';
 import { captureView } from './capture.js';
 import { sampleSeedPoints } from './sampler.js';
 import { evaluateSample } from './relations.js';
+import { writeBrief } from './report.js';
 import type { FilterBundle, Recapture, Sample, ViewSnapshot, Verdict, Viewport } from './types.js';
 
 interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; }
@@ -62,8 +63,13 @@ function familyCodeMap(body: unknown): Map<string, string> {
 async function run(o: Opts): Promise<void> {
   pacingGuard(o);
   await mkdir(o.out, { recursive: true });
+  // Persist every view's raw payload + screenshot so any finding stays reproducible
+  // from disk after prod data shifts (C5 #1271). The reporter reads these dirs.
+  await mkdir(path.join(o.out, 'raw'), { recursive: true });
+  await mkdir(path.join(o.out, 'shots'), { recursive: true });
   const browser = await chromium.launch({ headless: true });
   const verdicts: Verdict[] = [];
+  const samples: Sample[] = [];
   const freshSeen = new Set<string>();
   try {
     const context = await browser.newContext();
@@ -91,11 +97,22 @@ async function run(o: Opts): Promise<void> {
       zoom: number,
       vp: Viewport,
       filters?: { since?: string; family?: string },
+      // `stem` keys the persisted raw/<stem>.json + shots/<stem>.png. Ladder views
+      // pass `${sample.id}-${vp}-z${zoom}` so the reporter (which recomputes that
+      // exact stem) can resolve a finding's evidence files; filter/recapture extras
+      // pass a suffixed stem so they don't clobber the ladder's persisted files.
+      persistStem?: string,
     ): Promise<ViewSnapshot> => {
       await sleep(o.paceMs);
       try {
         const { page, raw } = await openView(context, o.baseUrl, { scope: o.scope, center: seed, zoom, viewport: vp, ...(filters ? { filters } : {}) });
         const snap = await captureView(page, raw, { scope: o.scope, viewport: vp, zoom, center: seed });
+        // Persist evidence (raw /api/observations payload + screenshot) BEFORE close.
+        if (persistStem) {
+          await writeFile(path.join(o.out, 'raw', `${persistStem}.json`), JSON.stringify(raw.responseBody, null, 2)).catch(() => {});
+          await page.screenshot({ path: path.join(o.out, 'shots', `${persistStem}.png`), fullPage: false }).catch(() => {});
+          snap.network.rawPath = path.join('raw', `${persistStem}.json`);
+        }
         await page.close();
         if (snap.network.freshestObservationAt) freshSeen.add(snap.network.freshestObservationAt);
         return snap;
@@ -116,10 +133,12 @@ async function run(o: Opts): Promise<void> {
     // 2. For each sample, walk the ladder × viewports (paced).
     for (let s = 0; s < seeds.length; s++) {
       const seed = seeds[s]!;
+      const sampleId = `s${s + 1}`;
       const views: ViewSnapshot[] = [];
       for (const vp of o.viewports) {
         for (const zoom of o.ladder) {
-          views.push(await capture(seed, zoom, vp));
+          // Ladder views persist under the canonical stem the reporter recomputes.
+          views.push(await capture(seed, zoom, vp, undefined, `${sampleId}-${vp}-z${zoom}`));
         }
       }
 
@@ -129,25 +148,26 @@ async function run(o: Opts): Promise<void> {
       // the seed fetch). Families with no resolvable code are skipped (can't filter).
       let filterBundle: FilterBundle | undefined;
       if (s === 0) {
-        const unfiltered = await capture(seed, midZoom, 'desktop');
+        const unfiltered = await capture(seed, midZoom, 'desktop', undefined, `${sampleId}-fb-unfiltered`);
         const top2 = [...unfiltered.legend]
           .sort((a, b) => b.count - a.count)
           .map((f) => ({ name: f.family, code: familyNameToCode.get(f.family) }))
           .filter((f): f is { name: string; code: string } => f.code != null)
           .slice(0, 2);
         const byFamily: FilterBundle['byFamily'] = [];
-        for (const { name, code } of top2) byFamily.push({ family: name, view: await capture(seed, midZoom, 'desktop', { family: code }) });
+        for (const { name, code } of top2) byFamily.push({ family: name, view: await capture(seed, midZoom, 'desktop', { family: code }, `${sampleId}-fb-family-${code}`) });
         const bySince: FilterBundle['bySince'] = [];
-        for (const since of ['1d', '7d', '14d'] as const) bySince.push({ since, view: await capture(seed, midZoom, 'desktop', { since }) });
+        for (const since of ['1d', '7d', '14d'] as const) bySince.push({ since, view: await capture(seed, midZoom, 'desktop', { since }, `${sampleId}-fb-since-${since}`) });
         filterBundle = { unfiltered, byFamily, bySince };
       }
 
       // Idempotence: re-capture one camera (mid-ladder desktop) once.
       const ra = views.find((v) => v.viewport === 'desktop' && v.requestedZoom === midZoom) ?? views[0]!;
-      const rb = await capture(seed, ra.requestedZoom, 'desktop');
+      const rb = await capture(seed, ra.requestedZoom, 'desktop', undefined, `${sampleId}-recapture-z${ra.requestedZoom}`);
       const recaptures: Recapture[] = [{ a: ra, b: rb }];
 
-      const sample: Sample = { id: `s${s + 1}`, seedPoint: seed, scope: o.scope, views, recaptures, ...(filterBundle ? { filterBundle } : {}) };
+      const sample: Sample = { id: sampleId, seedPoint: seed, scope: o.scope, views, recaptures, ...(filterBundle ? { filterBundle } : {}) };
+      samples.push(sample);
       verdicts.push(...evaluateSample(sample));
       process.stderr.write(`sample ${s + 1}/${seeds.length} done (${verdicts.filter((v) => v.status === 'fail').length} fails so far)\n`);
     }
@@ -162,7 +182,10 @@ async function run(o: Opts): Promise<void> {
     verdicts,
   };
   await writeFile(path.join(o.out, 'findings.json'), JSON.stringify(findings, null, 2));
-  process.stderr.write(`\nWrote ${path.join(o.out, 'findings.json')} — ${fails.length} fails / ${verdicts.length} checks.\n`);
+  // Assemble the preserved findings brief: brief.md + one evidence bundle per fail
+  // (screenshots both viewports, raw payloads, repro.md with the #map= viewbox link).
+  await writeBrief(findings, o.out, samples);
+  process.stderr.write(`\nWrote ${path.join(o.out, 'findings.json')} + brief.md — ${fails.length} fails / ${verdicts.length} checks.\n`);
 }
 
 // ── entry: --probe <url> (C2) OR the full --samples loop ──────────────────────

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -6,12 +6,15 @@ import { openView } from './camera.js';
 import { captureView } from './capture.js';
 import { sampleSeedPoints } from './sampler.js';
 import { evaluateSample } from './relations.js';
-import type { Sample, ViewSnapshot, Verdict, Viewport } from './types.js';
+import type { FilterBundle, Recapture, Sample, ViewSnapshot, Verdict, Viewport } from './types.js';
 
 interface Opts { samples: number; scope: string; seed: number; ladder: number[]; viewports: Viewport[]; paceMs: number; baseUrl: string; out: string; }
 
 const OBS_PER_VIEW = 2; // national interstitial + matched hash fetch (worst case)
 const CF_SAFE_PER_MIN = 55; // margin under Cloudflare's 60/min/IP
+// C4 loop additions (paced like every other view):
+const FILTER_BUNDLE_VIEWS = 6; // 1 unfiltered + 2 family + 3 since (first sample only)
+const RECAPTURE_VIEWS_PER_SAMPLE = 1; // one extra capture of one camera per sample
 
 function parse(argv: string[]): Opts {
   const get = (f: string, d?: string) => { const i = argv.indexOf(f); return i >= 0 ? argv[i + 1] : d; };
@@ -35,11 +38,26 @@ function pacingGuard(o: Opts): void {
   if (obsPerMin > CF_SAFE_PER_MIN) {
     throw new Error(`Pacing too aggressive: ~${obsPerMin} obs/min > ${CF_SAFE_PER_MIN}/min (Cloudflare 60/min/IP). Raise --pace-ms to >= ${minPace}, or lower --samples.`);
   }
-  const totalViews = o.samples * o.ladder.length * o.viewports.length;
-  process.stderr.write(`Plan: ${o.samples} samples × ${o.ladder.length} zooms × ${o.viewports.length} viewports = ${totalViews} views; ~${Math.ceil((totalViews * o.paceMs) / 1000)}s wall at ${o.paceMs}ms pace.\n`);
+  const ladderViews = o.samples * o.ladder.length * o.viewports.length;
+  const extraViews = FILTER_BUNDLE_VIEWS + o.samples * RECAPTURE_VIEWS_PER_SAMPLE + 1; // +1 seed fetch
+  const totalViews = ladderViews + extraViews;
+  process.stderr.write(`Plan: ${o.samples} samples × ${o.ladder.length} zooms × ${o.viewports.length} viewports = ${ladderViews} ladder views + ${extraViews} (seed + filter bundle + recaptures) = ${totalViews} views; ~${Math.ceil((totalViews * o.paceMs) / 1000)}s wall at ${o.paceMs}ms pace.\n`);
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Build a family common-name → family-code map from an AGGREGATED observations
+ *  response (the z3 seed). Buckets carry AggregatedFamily.{code,name}; the URL
+ *  `?family=` param needs the code. Returns an empty map for a non-aggregated body. */
+function familyCodeMap(body: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!body || typeof body !== 'object' || (body as { mode?: string }).mode !== 'aggregated') return out;
+  const buckets = (body as { buckets?: { families?: { code?: string; name?: string }[] }[] }).buckets ?? [];
+  for (const b of buckets) for (const f of b.families ?? []) {
+    if (f.name && f.code && !out.has(f.name)) out.set(f.name, f.code);
+  }
+  return out;
+}
 
 async function run(o: Opts): Promise<void> {
   pacingGuard(o);
@@ -54,22 +72,81 @@ async function run(o: Opts): Promise<void> {
     const seedView = await openView(context, o.baseUrl, { scope: o.scope, center: center0, zoom: 3, viewport: 'desktop' });
     const seedSnap = await captureView(seedView.page, seedView.raw, { scope: o.scope, viewport: 'desktop', zoom: 3, center: center0 });
     await seedView.page.close();
+    if (seedSnap.network.freshestObservationAt) freshSeen.add(seedSnap.network.freshestObservationAt);
+    const scopeTotal = seedSnap.network.total; // scope-wide total for MR-5
+    // The `?family=` URL param is a family CODE (e.g. "anatidae"), not the legend's
+    // common name — passing a name yields no matching /api/observations fetch and the
+    // camera matcher times out. The z3 seed fetch is aggregated, so its buckets carry
+    // both AggregatedFamily.code AND .name → build a name→code map once here.
+    const familyNameToCode = familyCodeMap(seedView.raw.responseBody);
     const seeds = sampleSeedPoints(seedSnap.network.points, o.samples, o.seed);
+
+    // Helper: capture one view at a camera (paced). A transient fetch hiccup
+    // (occasional cold-edge `waitForResponse` timeout) must NOT abort the whole
+    // paced run — return an `inconclusive` placeholder (relations skip those) and
+    // press on. This mirrors the tile-CDN carve-out already in captureView.
+    const capture = async (
+      seed: { lng: number; lat: number },
+      zoom: number,
+      vp: Viewport,
+      filters?: { since?: string; family?: string },
+    ): Promise<ViewSnapshot> => {
+      await sleep(o.paceMs);
+      try {
+        const { page, raw } = await openView(context, o.baseUrl, { scope: o.scope, center: seed, zoom, viewport: vp, ...(filters ? { filters } : {}) });
+        const snap = await captureView(page, raw, { scope: o.scope, viewport: vp, zoom, center: seed });
+        await page.close();
+        if (snap.network.freshestObservationAt) freshSeen.add(snap.network.freshestObservationAt);
+        return snap;
+      } catch (e) {
+        const reason = `capture failed (${(e as Error).message.split('\n')[0]})`;
+        process.stderr.write(`  ⚠ ${vp} z${zoom} @${seed.lng.toFixed(2)},${seed.lat.toFixed(2)}${filters ? ` ${JSON.stringify(filters)}` : ''}: ${reason}\n`);
+        return {
+          url: '', scope: o.scope, viewport: vp, requestedZoom: zoom, requestedCenter: seed,
+          network: { mode: 'unknown', bbox: [0, 0, 0, 0], zoom, truncated: false, freshestObservationAt: null, total: 0, familyCounts: [], points: [], speciesCount: null },
+          lede: { text: '', firstInt: null, unit: null }, legend: [], markers: [], consoleErrors: [], consoleWarnings: [],
+          inconclusive: { reason },
+        };
+      }
+    };
+
+    const midZoom = o.ladder[Math.floor(o.ladder.length / 2)]!;
 
     // 2. For each sample, walk the ladder × viewports (paced).
     for (let s = 0; s < seeds.length; s++) {
+      const seed = seeds[s]!;
       const views: ViewSnapshot[] = [];
       for (const vp of o.viewports) {
         for (const zoom of o.ladder) {
-          await sleep(o.paceMs);
-          const { page, raw } = await openView(context, o.baseUrl, { scope: o.scope, center: seeds[s]!, zoom, viewport: vp });
-          const snap = await captureView(page, raw, { scope: o.scope, viewport: vp, zoom, center: seeds[s]! });
-          await page.close();
-          if (snap.network.freshestObservationAt) freshSeen.add(snap.network.freshestObservationAt);
-          views.push(snap);
+          views.push(await capture(seed, zoom, vp));
         }
       }
-      const sample: Sample = { id: `s${s + 1}`, seedPoint: seeds[s]!, scope: o.scope, views };
+
+      // Filter bundle (first sample only): unfiltered + top-2 families + since 1d/7d/14d
+      // at a single mid-ladder desktop camera. MR-4 reconciles the variants. The
+      // legend gives common NAMES; the URL filter needs the family CODE (mapped via
+      // the seed fetch). Families with no resolvable code are skipped (can't filter).
+      let filterBundle: FilterBundle | undefined;
+      if (s === 0) {
+        const unfiltered = await capture(seed, midZoom, 'desktop');
+        const top2 = [...unfiltered.legend]
+          .sort((a, b) => b.count - a.count)
+          .map((f) => ({ name: f.family, code: familyNameToCode.get(f.family) }))
+          .filter((f): f is { name: string; code: string } => f.code != null)
+          .slice(0, 2);
+        const byFamily: FilterBundle['byFamily'] = [];
+        for (const { name, code } of top2) byFamily.push({ family: name, view: await capture(seed, midZoom, 'desktop', { family: code }) });
+        const bySince: FilterBundle['bySince'] = [];
+        for (const since of ['1d', '7d', '14d'] as const) bySince.push({ since, view: await capture(seed, midZoom, 'desktop', { since }) });
+        filterBundle = { unfiltered, byFamily, bySince };
+      }
+
+      // Idempotence: re-capture one camera (mid-ladder desktop) once.
+      const ra = views.find((v) => v.viewport === 'desktop' && v.requestedZoom === midZoom) ?? views[0]!;
+      const rb = await capture(seed, ra.requestedZoom, 'desktop');
+      const recaptures: Recapture[] = [{ a: ra, b: rb }];
+
+      const sample: Sample = { id: `s${s + 1}`, seedPoint: seed, scope: o.scope, views, scopeTotal, recaptures, ...(filterBundle ? { filterBundle } : {}) };
       verdicts.push(...evaluateSample(sample));
       process.stderr.write(`sample ${s + 1}/${seeds.length} done (${verdicts.filter((v) => v.status === 'fail').length} fails so far)\n`);
     }

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -73,7 +73,8 @@ async function run(o: Opts): Promise<void> {
     const seedSnap = await captureView(seedView.page, seedView.raw, { scope: o.scope, viewport: 'desktop', zoom: 3, center: center0 });
     await seedView.page.close();
     if (seedSnap.network.freshestObservationAt) freshSeen.add(seedSnap.network.freshestObservationAt);
-    const scopeTotal = seedSnap.network.total; // scope-wide total for MR-5
+    // (#1270 §5.1) MR-5 now compares the lede to each view's OWN viewport network
+    // total, so the seed-fetch scope total is no longer threaded into samples.
     // The `?family=` URL param is a family CODE (e.g. "anatidae"), not the legend's
     // common name — passing a name yields no matching /api/observations fetch and the
     // camera matcher times out. The z3 seed fetch is aggregated, so its buckets carry
@@ -146,7 +147,7 @@ async function run(o: Opts): Promise<void> {
       const rb = await capture(seed, ra.requestedZoom, 'desktop');
       const recaptures: Recapture[] = [{ a: ra, b: rb }];
 
-      const sample: Sample = { id: `s${s + 1}`, seedPoint: seed, scope: o.scope, views, scopeTotal, recaptures, ...(filterBundle ? { filterBundle } : {}) };
+      const sample: Sample = { id: `s${s + 1}`, seedPoint: seed, scope: o.scope, views, recaptures, ...(filterBundle ? { filterBundle } : {}) };
       verdicts.push(...evaluateSample(sample));
       process.stderr.write(`sample ${s + 1}/${seeds.length} done (${verdicts.filter((v) => v.status === 'fail').length} fails so far)\n`);
     }

--- a/frontend/scripts/map-consistency/camera.ts
+++ b/frontend/scripts/map-consistency/camera.ts
@@ -87,7 +87,7 @@ export async function openView(
     else if (m.type() === 'warning') consoleWarnings.push(m.text());
   });
   const url = buildUrl(baseUrl, p);
-  const matched = waitForMatchingObs(page, p, opts?.timeoutMs ?? 25000);
+  const matched = waitForMatchingObs(page, p, opts?.timeoutMs ?? 15000);
   await page.goto(url, { waitUntil: 'commit' });
   const response = await matched;
   // Settle long enough for the adaptive-grid markers AND the family legend list

--- a/frontend/scripts/map-consistency/camera.ts
+++ b/frontend/scripts/map-consistency/camera.ts
@@ -1,0 +1,102 @@
+// frontend/scripts/map-consistency/camera.ts
+import type { BrowserContext, Page, Response } from '@playwright/test';
+import { encodeViewbox, type ViewboxCamera } from '@/state/viewbox-link.js';
+import { VIEWPORTS, type Bbox, type Viewport } from './types.js';
+
+export interface OpenViewParams {
+  scope: string; // 'us' | 'US-AZ'
+  center: { lng: number; lat: number };
+  zoom: number;
+  viewport: Viewport;
+  filters?: { since?: string; family?: string; species?: string; notable?: boolean };
+}
+export interface RawView {
+  url: string;
+  requestUrl: string;
+  requestBbox: Bbox;
+  requestZoom: number;
+  responseBody: unknown;
+  consoleErrors: string[];
+  consoleWarnings: string[];
+}
+
+function buildUrl(baseUrl: string, p: OpenViewParams): string {
+  const cam: ViewboxCamera = { zoom: p.zoom, lat: p.center.lat, lng: p.center.lng };
+  const q = new URLSearchParams();
+  if (p.scope === 'us' || p.scope === 'US') q.set('scope', 'us');
+  else q.set('state', p.scope);
+  if (p.filters?.since) q.set('since', p.filters.since);
+  if (p.filters?.family) q.set('family', p.filters.family);
+  if (p.filters?.species) q.set('species', p.filters.species);
+  if (p.filters?.notable) q.set('notable', 'true');
+  const vp = VIEWPORTS[p.viewport];
+  // ViewboxViewport is { w, h, dpr } (NOT width/height), and encodeViewbox returns
+  // the fragment WITHOUT a leading '#' — e.g. "map=9.000/32.22175/-110.97648&v=1440x900@1".
+  // (bot review #1268: wrong field names silently emit &v=undefinedxundefined@1.)
+  let hash = encodeViewbox(cam, { w: vp.width, h: vp.height, dpr: vp.dpr });
+  if (!hash.startsWith('#')) hash = `#${hash}`;
+  return `${baseUrl.replace(/\/$/, '')}/?${q.toString()}${hash}`;
+}
+
+function parseObsParams(reqUrl: string): { bbox?: Bbox; zoom?: number } {
+  const u = new URL(reqUrl);
+  const b = u.searchParams.get('bbox');
+  const z = u.searchParams.get('zoom');
+  return { bbox: b ? (b.split(',').map(Number) as Bbox) : undefined, zoom: z != null ? Number(z) : undefined };
+}
+const bboxCenter = (b: Bbox) => ({ lng: (b[0] + b[2]) / 2, lat: (b[1] + b[3]) / 2 });
+
+function waitForMatchingObs(page: Page, p: OpenViewParams, timeoutMs: number): Promise<Response> {
+  const ZOOM_EPS = 0.6;
+  // Absolute floor for the center match (governs high zoom, where the view is
+  // small and a near-exact center is expected). At LOW zoom the camera snaps to
+  // the scope's fitBounds bounds — e.g. a z3 national view frames the whole US
+  // (bbox lat 20–52, center 36), so the hash's requested center (39) is off by
+  // ~3°. A fixed 0.75° floor wrongly rejects that genuine match. So the
+  // tolerance also scales with HALF the request's own bbox span: the wider the
+  // served view, the more center drift is normal. half-span at z3 ≈ 16° lng /
+  // 8° lat — comfortably admits the 0.5°/3° national drift while still rejecting
+  // a differently-framed fetch. (Live-tuned: C2 z3 smoke timed out at 0.75°.)
+  const CENTER_FLOOR_DEG = 0.75;
+  const SPAN_FRACTION = 0.5;
+  return page.waitForResponse((res) => {
+    if (!/\/api\/observations\b/.test(res.url())) return false;
+    const { bbox, zoom } = parseObsParams(res.url());
+    if (bbox === undefined || zoom === undefined) return false;
+    if (Math.abs(zoom - p.zoom) > ZOOM_EPS) return false;
+    const c = bboxCenter(bbox);
+    const lngTol = Math.max(CENTER_FLOOR_DEG, Math.abs(bbox[2] - bbox[0]) * SPAN_FRACTION);
+    const latTol = Math.max(CENTER_FLOOR_DEG, Math.abs(bbox[3] - bbox[1]) * SPAN_FRACTION);
+    return Math.abs(c.lng - p.center.lng) <= lngTol && Math.abs(c.lat - p.center.lat) <= latTol;
+  }, { timeout: timeoutMs });
+}
+
+export async function openView(
+  context: BrowserContext,
+  baseUrl: string,
+  p: OpenViewParams,
+  opts?: { settleMs?: number; timeoutMs?: number },
+): Promise<{ page: Page; raw: RawView }> {
+  const vp = VIEWPORTS[p.viewport];
+  const page = await context.newPage();
+  await page.setViewportSize({ width: vp.width, height: vp.height });
+  const consoleErrors: string[] = [];
+  const consoleWarnings: string[] = [];
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text());
+    else if (m.type() === 'warning') consoleWarnings.push(m.text());
+  });
+  const url = buildUrl(baseUrl, p);
+  const matched = waitForMatchingObs(page, p, opts?.timeoutMs ?? 25000);
+  await page.goto(url, { waitUntil: 'commit' });
+  const response = await matched;
+  // Settle long enough for the adaptive-grid markers AND the family legend list
+  // to finish rendering post-match before capture reads the DOM. Live-tuned
+  // against prod (C2 smoke): at 1200ms both the legend `<ul>` and the markers
+  // were still empty; 2500ms reliably yields the full set (19 markers / 49
+  // legend rows at the z9 Tucson camera).
+  await page.waitForTimeout(opts?.settleMs ?? 2500); // let markers + legend re-render post-match
+  const { bbox, zoom } = parseObsParams(response.url());
+  const responseBody = await response.json().catch(() => null);
+  return { page, raw: { url, requestUrl: response.url(), requestBbox: bbox!, requestZoom: zoom!, responseBody, consoleErrors, consoleWarnings } };
+}

--- a/frontend/scripts/map-consistency/capture.ts
+++ b/frontend/scripts/map-consistency/capture.ts
@@ -1,0 +1,86 @@
+// frontend/scripts/map-consistency/capture.ts
+import type { Page } from '@playwright/test';
+import type { ObservationsResponse } from '@bird-watch/shared-types';
+import type { Bbox, FamilyCount, GeoPoint, LedeRead, MarkerRead, NetworkView, ViewSnapshot, Viewport } from './types.js';
+import type { RawView } from './camera.js';
+
+const CELL_ARIA = /^(?<family>.+),\s+(?<count>\d+)\s+observations?$/;
+const MARKER_ARIA = /^Cluster:\s+(?<total>\d+)\s+observations?,\s+(?<families>\d+)\s+families/;
+const TILE_FAIL = /openfreemap|ERR_CONNECTION|failed to fetch.*tile/i;
+
+export function normalizeNetwork(body: unknown, bbox: Bbox, zoom: number): NetworkView {
+  const empty: NetworkView = { mode: 'unknown', bbox, zoom, truncated: false, freshestObservationAt: null, total: 0, familyCounts: [], points: [], speciesCount: null };
+  if (!body || typeof body !== 'object' || !('mode' in body)) return empty;
+  const r = body as ObservationsResponse;
+  const fams = new Map<string, number>();
+  const points: GeoPoint[] = [];
+  let total = 0;
+  let truncated = false;
+  let freshest: string | null = null;
+  if (r.mode === 'aggregated') {
+    for (const b of r.buckets ?? []) {
+      total += b.count;
+      points.push({ lng: b.lng, lat: b.lat, count: b.count });
+      for (const f of b.families ?? []) {
+        const key = f.name ?? f.code;
+        fams.set(key, (fams.get(key) ?? 0) + f.count);
+      }
+    }
+    freshest = r.meta?.freshestObservationAt ?? null;
+  } else if (r.mode === 'observations') {
+    for (const o of r.data ?? []) { total += 1; points.push({ lng: o.lng, lat: o.lat, count: 1 }); }
+    truncated = r.meta?.truncated === true;
+    freshest = r.meta?.freshestObservationAt ?? null;
+  }
+  return { mode: r.mode, bbox, zoom, truncated, freshestObservationAt: freshest, total, familyCounts: [...fams].map(([family, count]) => ({ family, count })), points, speciesCount: null };
+}
+
+export async function readLede(page: Page): Promise<LedeRead> {
+  const text = (await page.locator('[data-testid="map-lede"]').first().textContent().catch(() => '')) ?? '';
+  const m = text.replace(/,/g, '').match(/(\d+)/);
+  return { text: text.trim(), firstInt: m ? Number(m[1]) : null, unit: /species/.test(text) ? 'species' : /sighting/.test(text) ? 'sightings' : null };
+}
+
+export async function readLegend(page: Page): Promise<FamilyCount[]> {
+  const toggle = page.locator('#family-legend-toggle');
+  if (await toggle.count()) {
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click().catch(() => {});
+    await page.waitForTimeout(150);
+  }
+  // Confirm the row testid live in the smoke (stale local tree: `family-legend-entry`).
+  const rows = page.locator('aside.family-legend [data-testid="family-legend-entry"]');
+  const out: FamilyCount[] = [];
+  const n = await rows.count();
+  for (let i = 0; i < n; i++) {
+    const label = (await rows.nth(i).locator('.family-legend-entry-label').textContent().catch(() => '')) ?? '';
+    const c = (await rows.nth(i).locator('.family-legend-entry-count').textContent().catch(() => '')) ?? '';
+    out.push({ family: label.trim(), count: Number(c.replace(/,/g, '')) || 0 });
+  }
+  return out;
+}
+
+export async function readMarkers(page: Page): Promise<MarkerRead[]> {
+  const markers = page.locator('[data-testid="adaptive-grid-marker"]');
+  const out: MarkerRead[] = [];
+  const n = await markers.count();
+  for (let i = 0; i < n; i++) {
+    const mk = markers.nth(i);
+    const ma = ((await mk.getAttribute('aria-label')) ?? '').match(MARKER_ARIA);
+    const cells = mk.locator('[data-testid^="adaptive-grid-marker-cell"]');
+    const cellOut: FamilyCount[] = [];
+    const cn = await cells.count();
+    for (let j = 0; j < cn; j++) {
+      const cm = ((await cells.nth(j).getAttribute('aria-label')) ?? '').match(CELL_ARIA);
+      if (cm?.groups) cellOut.push({ family: cm.groups.family.trim(), count: Number(cm.groups.count) });
+    }
+    out.push({ markerTotal: ma?.groups ? Number(ma.groups.total) : null, familyCount: ma?.groups ? Number(ma.groups.families) : null, cells: cellOut });
+  }
+  return out;
+}
+
+export async function captureView(page: Page, raw: RawView, p: { scope: string; viewport: Viewport; zoom: number; center: { lng: number; lat: number } }): Promise<ViewSnapshot> {
+  const network = normalizeNetwork(raw.responseBody, raw.requestBbox, raw.requestZoom);
+  const [lede, legend, markers] = await Promise.all([readLede(page), readLegend(page), readMarkers(page)]);
+  const inconclusive = raw.consoleErrors.some((e) => TILE_FAIL.test(e)) ? { reason: 'basemap tile CDN failure' } : undefined;
+  return { url: raw.url, scope: p.scope, viewport: p.viewport, requestedZoom: p.zoom, requestedCenter: p.center, network, lede, legend, markers, consoleErrors: raw.consoleErrors, consoleWarnings: raw.consoleWarnings, inconclusive };
+}

--- a/frontend/scripts/map-consistency/capture.ts
+++ b/frontend/scripts/map-consistency/capture.ts
@@ -73,7 +73,11 @@ export async function readMarkers(page: Page): Promise<MarkerRead[]> {
       const cm = ((await cells.nth(j).getAttribute('aria-label')) ?? '').match(CELL_ARIA);
       if (cm?.groups) cellOut.push({ family: cm.groups.family.trim(), count: Number(cm.groups.count) });
     }
-    out.push({ markerTotal: ma?.groups ? Number(ma.groups.total) : null, familyCount: ma?.groups ? Number(ma.groups.families) : null, cells: cellOut });
+    // Mobile markers collapse extra families into a "+N" overflow pill — its
+    // presence means rendered cells legitimately under-count the marker's
+    // families (MR-2/MR-3 carve-out `mobile-overflow`).
+    const overflow = (await mk.locator('[data-testid="adaptive-grid-marker-overflow"]').count()) > 0;
+    out.push({ markerTotal: ma?.groups ? Number(ma.groups.total) : null, familyCount: ma?.groups ? Number(ma.groups.families) : null, cells: cellOut, overflow });
   }
   return out;
 }

--- a/frontend/scripts/map-consistency/capture.ts
+++ b/frontend/scripts/map-consistency/capture.ts
@@ -6,6 +6,11 @@ import type { RawView } from './camera.js';
 
 const CELL_ARIA = /^(?<family>.+),\s+(?<count>\d+)\s+observations?$/;
 const MARKER_ARIA = /^Cluster:\s+(?<total>\d+)\s+observations?,\s+(?<families>\d+)\s+families/;
+// A cluster-pill's aria-label is `countNoun(count, 'sighting')` →
+// "1,164 sightings" (thousands-separator commas, singular "sighting" at 1).
+const PILL_ARIA = /^(?<total>[\d,]+)\s+sightings?$/;
+// "cluster-pill cluster-pill--ember" → modifier "ember" (one of sky / sand / ember).
+const PILL_MODIFIER = /\bcluster-pill--(?<color>[a-z]+)\b/;
 const TILE_FAIL = /openfreemap|ERR_CONNECTION|failed to fetch.*tile/i;
 
 export function normalizeNetwork(body: unknown, bbox: Bbox, zoom: number): NetworkView {
@@ -60,11 +65,13 @@ export async function readLegend(page: Page): Promise<FamilyCount[]> {
 }
 
 export async function readMarkers(page: Page): Promise<MarkerRead[]> {
-  const markers = page.locator('[data-testid="adaptive-grid-marker"]');
   const out: MarkerRead[] = [];
-  const n = await markers.count();
+
+  // (1) Grid markers — the family-cell `adaptive-grid-marker` form (kind:'grid').
+  const grids = page.locator('[data-testid="adaptive-grid-marker"]');
+  const n = await grids.count();
   for (let i = 0; i < n; i++) {
-    const mk = markers.nth(i);
+    const mk = grids.nth(i);
     const ma = ((await mk.getAttribute('aria-label')) ?? '').match(MARKER_ARIA);
     const cells = mk.locator('[data-testid^="adaptive-grid-marker-cell"]');
     const cellOut: FamilyCount[] = [];
@@ -77,8 +84,40 @@ export async function readMarkers(page: Page): Promise<MarkerRead[]> {
     // presence means rendered cells legitimately under-count the marker's
     // families (MR-2/MR-3 carve-out `mobile-overflow`).
     const overflow = (await mk.locator('[data-testid="adaptive-grid-marker-overflow"]').count()) > 0;
-    out.push({ markerTotal: ma?.groups ? Number(ma.groups.total) : null, familyCount: ma?.groups ? Number(ma.groups.families) : null, cells: cellOut, overflow });
+    out.push({
+      kind: 'grid',
+      total: cellOut.reduce((s, c) => s + c.count, 0),
+      markerTotal: ma?.groups ? Number(ma.groups.total) : null,
+      familyCount: ma?.groups ? Number(ma.groups.families) : null,
+      cells: cellOut,
+      overflow,
+    });
   }
+
+  // (2) Cluster pills — the collapsed `.cluster-pill` form (kind:'pill', §5.2).
+  // The capture was previously BLIND to these, so it read 0 markers at low zoom
+  // (false MR-1) and undercounted rendered totals. A pill carries only a total
+  // count (no family breakdown) in its aria-label "N sightings".
+  const pills = page.locator('.cluster-pill');
+  const pn = await pills.count();
+  for (let i = 0; i < pn; i++) {
+    const pl = pills.nth(i);
+    const label = (await pl.getAttribute('aria-label')) ?? '';
+    const pm = label.match(PILL_ARIA);
+    const total = pm?.groups ? Number(pm.groups.total.replace(/,/g, '')) : 0;
+    const cls = (await pl.getAttribute('class')) ?? '';
+    const color = cls.match(PILL_MODIFIER)?.groups?.color;
+    out.push({
+      kind: 'pill',
+      total,
+      ...(color ? { color } : {}),
+      markerTotal: total,
+      familyCount: null,
+      cells: [],
+      overflow: false,
+    });
+  }
+
   return out;
 }
 

--- a/frontend/scripts/map-consistency/probe.ts
+++ b/frontend/scripts/map-consistency/probe.ts
@@ -1,0 +1,21 @@
+// frontend/scripts/map-consistency/probe.ts
+// C2 single-view probe, extracted from audit.ts (#1269) so audit.ts stays small.
+import { chromium } from '@playwright/test';
+import { openView } from './camera.js';
+import { captureView } from './capture.js';
+
+/** Open one view at the camera encoded in `url` and print its ViewSnapshot. */
+export async function probe(url: string): Promise<void> {
+  const parsed = new URL(url);
+  const scope = parsed.searchParams.get('state') ?? 'us';
+  const [zoom, lat, lng] = parsed.hash.replace('#map=', '').split('/').map(Number);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext();
+    const center = { lng, lat };
+    const { page, raw } = await openView(context, `${parsed.protocol}//${parsed.host}`, { scope, center, zoom, viewport: 'desktop' });
+    console.log(JSON.stringify(await captureView(page, raw, { scope, viewport: 'desktop', zoom, center }), null, 2));
+  } finally {
+    await browser.close();
+  }
+}

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -1,6 +1,6 @@
 // frontend/scripts/map-consistency/relations.test.ts
 import { describe, it, expect } from 'vitest';
-import { evaluateSample, sumPointsInBbox, bboxInside, renderedFamilyCounts } from './relations.js';
+import { evaluateSample, sumPointsInBbox, bboxInside, renderedFamilyCounts, renderedTotal } from './relations.js';
 import type { Sample, ViewSnapshot, NetworkView, MarkerRead, Bbox, FilterBundle, Recapture } from './types.js';
 
 const BB: Bbox = [-111, 31, -109, 33];
@@ -9,7 +9,12 @@ function net(p: Partial<NetworkView> & { bbox: Bbox; total: number; points: Netw
   return { mode: 'observations', zoom: 9, truncated: false, freshestObservationAt: 't0', familyCounts: [], speciesCount: null, ...p };
 }
 function marker(cells: { family: string; count: number }[], overflow = false): MarkerRead {
-  return { markerTotal: cells.reduce((s, c) => s + c.count, 0), familyCount: cells.length, cells, overflow };
+  const total = cells.reduce((s, c) => s + c.count, 0);
+  return { kind: 'grid', total, markerTotal: total, familyCount: cells.length, cells, overflow };
+}
+/** A collapsed cluster-pill marker (kind:'pill', §5.2): a total count, no family cells. */
+function pill(total: number, color = 'ember'): MarkerRead {
+  return { kind: 'pill', total, color, markerTotal: total, familyCount: null, cells: [], overflow: false };
 }
 function view(o: Partial<ViewSnapshot> & { viewport: ViewSnapshot['viewport']; requestedZoom: number; network: NetworkView; markers: MarkerRead[] }): ViewSnapshot {
   return { url: `u${o.requestedZoom}-${o.viewport}`, scope: 'us', requestedCenter: { lng: -110, lat: 32 }, lede: { text: '', firstInt: null, unit: null }, legend: [], consoleErrors: [], consoleWarnings: [], ...o };
@@ -31,6 +36,11 @@ describe('helpers', () => {
   it('renderedFamilyCounts sums cells across markers', () => {
     const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: [-111, 31, -109, 33], total: 0, points: [] }), markers: [marker([{ family: 'Hawks', count: 1 }]), marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 1 }])] });
     expect(renderedFamilyCounts(v)).toEqual(expect.arrayContaining([{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 1 }]));
+  });
+  it('renderedTotal counts pill totals + grid cell counts (§5.2 — pills now count)', () => {
+    // A pill (1164) + a grid (3 + 1) → 1168. Pills were previously invisible.
+    const v = view({ viewport: 'desktop', requestedZoom: 4, network: net({ bbox: [-111, 31, -109, 33], total: 1168, points: [] }), markers: [pill(1164), marker([{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 1 }])] });
+    expect(renderedTotal(v)).toBe(1168);
   });
 });
 
@@ -90,6 +100,59 @@ describe('MR-8 parity (directional pill-collapse, #1270)', () => {
   });
 });
 
+describe('MR-9 pill-split parity (the reported bug, §5.2)', () => {
+  it('flags desktop-all-pill vs mobile-all-grid at the same camera (desktop under-splits)', () => {
+    // Same camera (z6). Mobile splits every cluster into a grid (gridFraction 1.0);
+    // desktop leaves every cluster as a pill (gridFraction 0.0). Δ 1.0 > 0.2 → fail.
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 3000, points: [] }),
+      markers: [pill(1164), pill(820), pill(1016)],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 3000, points: [] }),
+      markers: [marker([{ family: 'Hawks', count: 12 }]), marker([{ family: 'Falcons', count: 8 }]), marker([{ family: 'Gulls', count: 5 }])],
+    });
+    const f = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-9' && v.status === 'fail');
+    expect(f).toHaveLength(1);
+    expect(f[0].severity).toBe('high');
+    expect(f[0].numbers).toMatchObject({ desktopGridFraction: 0, mobileGridFraction: 1 });
+    expect(f[0].symptom).toContain('under-splits');
+  });
+
+  it('passes when both viewports split all clusters into grids (equal fractions)', () => {
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 30, points: [] }),
+      markers: [marker([{ family: 'Hawks', count: 12 }]), marker([{ family: 'Falcons', count: 8 }])],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 30, points: [] }),
+      markers: [marker([{ family: 'Hawks', count: 12 }]), marker([{ family: 'Falcons', count: 8 }])],
+    });
+    expect(evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-9' && v.status === 'fail')).toHaveLength(0);
+  });
+
+  it('suppresses the reverse direction (desktop splits MORE than mobile → not the bug)', () => {
+    // Desktop all-grid, mobile all-pill. gap = mobileFraction(0) − desktopFraction(1) = −1 < threshold → pass.
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 30, points: [] }),
+      markers: [marker([{ family: 'Hawks', count: 12 }]), marker([{ family: 'Falcons', count: 8 }])],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 3000, points: [] }),
+      markers: [pill(1500), pill(1500)],
+    });
+    expect(evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-9' && v.status === 'fail')).toHaveLength(0);
+  });
+
+  it('passes with a carve-out when a viewport has no clusters (divide-by-zero guard)', () => {
+    const desktop = view({ viewport: 'desktop', requestedZoom: 6, network: net({ bbox: BB, total: 0, points: [] }), markers: [] });
+    const mobile = view({ viewport: 'mobile', requestedZoom: 6, network: net({ bbox: BB, total: 30, points: [] }), markers: [marker([{ family: 'Hawks', count: 30 }])] });
+    const mr9 = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-9');
+    expect(mr9.every((v) => v.status === 'pass')).toBe(true);
+    expect(mr9.some((v) => v.carveOuts?.includes('no-clusters'))).toBe(true);
+  });
+});
+
 describe('MR-0 drill-down', () => {
   it('passes when same-mode drill-down conserves the count exactly', () => {
     const parent = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: [-112, 30, -108, 34], zoom: 7, total: 4, points: [{ lng: -110, lat: 32, count: 2 }, { lng: -110.5, lat: 32.1, count: 1 }, { lng: -120, lat: 40, count: 1 }] }), markers: [] });
@@ -124,6 +187,13 @@ describe('MR-1 zoom non-vanishing', () => {
   });
   it('passes when birds render', () => {
     const v = view({ viewport: 'desktop', requestedZoom: 12, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 5 }], markers: [marker([{ family: 'Hawks', count: 5 }])] });
+    expect(fails(sampleOf(v), 'MR-1')).toHaveLength(0);
+  });
+  it('passes at low zoom when only cluster-pills render (§5.2 — pills are rendered, no false MR-1)', () => {
+    // The literal false-fire: network served 1164 birds, the map shows a single
+    // cluster-pill (no grid). Pre-§5.2 the capture read 0 markers → false MR-1.
+    // Now the pill counts as rendered, so MR-1 must pass.
+    const v = view({ viewport: 'mobile', requestedZoom: 4, network: net({ mode: 'aggregated', bbox: BB, total: 1164, points: [] }), markers: [pill(1164)] });
     expect(fails(sampleOf(v), 'MR-1')).toHaveLength(0);
   });
 });

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -103,7 +103,7 @@ describe('MR-8 parity (directional pill-collapse, #1270)', () => {
 describe('MR-9 pill-split parity (the reported bug, §5.2)', () => {
   it('flags desktop-all-pill vs mobile-all-grid at the same camera (desktop under-splits)', () => {
     // Same camera (z6). Mobile splits every cluster into a grid (gridFraction 1.0);
-    // desktop leaves every cluster as a pill (gridFraction 0.0). Δ 1.0 > 0.2 → fail.
+    // desktop leaves every cluster as a pill (gridFraction 0.0). Δ 1.0 > MR9_THRESHOLD (0.12) → fail.
     const desktop = view({
       viewport: 'desktop', requestedZoom: 6, network: net({ mode: 'aggregated', bbox: BB, total: 3000, points: [] }),
       markers: [pill(1164), pill(820), pill(1016)],
@@ -173,6 +173,23 @@ describe('MR-0 drill-down', () => {
     const child = view({ viewport: 'desktop', requestedZoom: 5, network: net({ mode: 'aggregated', bbox: [-111, 31, -109, 33], zoom: 5, total: 18, points: [] }), markers: [marker([{ family: 'Hawks', count: 18 }])] });
     const sample: Sample = { id: 's4', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
     expect(evaluateSample(sample).filter((v) => v.relation.startsWith('MR-0') && v.status === 'fail')).toHaveLength(0);
+  });
+  it('MR-0b does NOT fire when a dense, grid-overflowing child renders fewer than conservation (rendered-capacity-limited)', () => {
+    // Exact obs↔obs drill-down (same mode, untruncated, fresh-aligned → tol=0): the
+    // parent counts ~600 inside the child bbox and the child returns 600, but the
+    // adaptive grid only renders a 50-bird subset behind a "+N" overflow pill. MR-0a
+    // (server-truth) conserves; MR-0b's rendered count is a lossy capacity subset, so
+    // it must PASS with the carve-out — NOT false-fire a high-severity "lost 550".
+    const parent = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: [-112, 30, -108, 34], zoom: 7, total: 600, points: [{ lng: -110, lat: 32, count: 600 }] }), markers: [] });
+    const child = view({ viewport: 'desktop', requestedZoom: 10, network: net({ bbox: [-111, 31, -109, 33], zoom: 10, total: 600, points: [] }), markers: [marker([{ family: 'Hawks', count: 50 }], true)] });
+    const sample: Sample = { id: 's5', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
+    const verdicts = evaluateSample(sample);
+    expect(verdicts.filter((v) => v.relation === 'MR-0b' && v.status === 'fail')).toHaveLength(0);
+    const mr0b = verdicts.find((v) => v.relation === 'MR-0b');
+    expect(mr0b?.status).toBe('pass');
+    expect(mr0b?.carveOuts).toContain('rendered-capacity-limited');
+    // MR-0a (server-truth) still conserves and passes too.
+    expect(verdicts.filter((v) => v.relation === 'MR-0a' && v.status === 'fail')).toHaveLength(0);
   });
 });
 

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -1,16 +1,22 @@
 // frontend/scripts/map-consistency/relations.test.ts
 import { describe, it, expect } from 'vitest';
 import { evaluateSample, sumPointsInBbox, bboxInside, renderedFamilyCounts } from './relations.js';
-import type { Sample, ViewSnapshot, NetworkView, MarkerRead, Bbox } from './types.js';
+import type { Sample, ViewSnapshot, NetworkView, MarkerRead, Bbox, FilterBundle, Recapture } from './types.js';
+
+const BB: Bbox = [-111, 31, -109, 33];
 
 function net(p: Partial<NetworkView> & { bbox: Bbox; total: number; points: NetworkView['points'] }): NetworkView {
   return { mode: 'observations', zoom: 9, truncated: false, freshestObservationAt: 't0', familyCounts: [], speciesCount: null, ...p };
 }
-function marker(cells: { family: string; count: number }[]): MarkerRead {
-  return { markerTotal: cells.reduce((s, c) => s + c.count, 0), familyCount: cells.length, cells };
+function marker(cells: { family: string; count: number }[], overflow = false): MarkerRead {
+  return { markerTotal: cells.reduce((s, c) => s + c.count, 0), familyCount: cells.length, cells, overflow };
 }
 function view(o: Partial<ViewSnapshot> & { viewport: ViewSnapshot['viewport']; requestedZoom: number; network: NetworkView; markers: MarkerRead[] }): ViewSnapshot {
   return { url: `u${o.requestedZoom}-${o.viewport}`, scope: 'us', requestedCenter: { lng: -110, lat: 32 }, lede: { text: '', firstInt: null, unit: null }, legend: [], consoleErrors: [], consoleWarnings: [], ...o };
+}
+/** A minimal one-view sample for per-view relation tests. */
+function sampleOf(v: ViewSnapshot, extra: Partial<Sample> = {}): Sample {
+  return { id: 's', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [v], ...extra };
 }
 
 describe('helpers', () => {
@@ -28,15 +34,41 @@ describe('helpers', () => {
   });
 });
 
-describe('MR-8 parity', () => {
-  it('flags a family present on mobile but absent on desktop', () => {
-    const bbox: Bbox = [-111, 31, -109, 33];
-    const desktop = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox, total: 2, points: [] }), markers: [marker([{ family: 'Hawks', count: 2 }])] });
-    const mobile = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox, total: 5, points: [] }), markers: [marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }])] });
-    const sample: Sample = { id: 's1', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [desktop, mobile] };
-    const fails = evaluateSample(sample).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
+describe('MR-8 parity (viewport-coverage normalized)', () => {
+  it('flags a family in BOTH legends that renders on only one side (genuine pill-collapse)', () => {
+    // Falcons is in both viewports' legends (so it's in `common`) but renders only
+    // on mobile → desktop dropped it → real bug, still fails.
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }])],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }])],
+    });
+    const fails = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
     expect(fails).toHaveLength(1);
     expect(fails[0].symptom).toContain('Falcons');
+  });
+
+  it('suppresses a desktop-only-legend coastal family (viewport-coverage artifact #1269)', () => {
+    // Albatrosses is in desktop's legend+render but NOT in mobile's legend (mobile's
+    // narrower bbox never contained it). The pre-fix engine flagged this; now it's
+    // excluded from `common` → no MR-8 fail.
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 4, network: net({ bbox: BB, total: 5, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }, { family: 'Albatrosses', count: 1 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }, { family: 'Albatrosses', count: 1 }])],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 4, network: net({ bbox: BB, total: 2, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }])],
+    });
+    const fails = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
+    expect(fails).toHaveLength(0);
   });
 });
 
@@ -60,5 +92,142 @@ describe('MR-0 drill-down', () => {
     const child = view({ viewport: 'desktop', requestedZoom: 5, network: net({ mode: 'aggregated', bbox: [-111, 31, -109, 33], zoom: 5, total: 18, points: [] }), markers: [marker([{ family: 'Hawks', count: 18 }])] });
     const sample: Sample = { id: 's4', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
     expect(evaluateSample(sample).filter((v) => v.relation.startsWith('MR-0') && v.status === 'fail')).toHaveLength(0);
+  });
+});
+
+const fails = (s: Sample, rel: string) => evaluateSample(s).filter((v) => v.relation === rel && v.status === 'fail');
+
+describe('MR-1 zoom non-vanishing', () => {
+  it('flags network birds with nothing rendered', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 12, network: net({ bbox: BB, total: 5, points: [] }), markers: [] });
+    const f = fails(sampleOf(v), 'MR-1');
+    expect(f).toHaveLength(1);
+    expect(f[0].symptom).toContain('5 birds');
+  });
+  it('passes when birds render', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 12, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 5 }], markers: [marker([{ family: 'Hawks', count: 5 }])] });
+    expect(fails(sampleOf(v), 'MR-1')).toHaveLength(0);
+  });
+});
+
+describe('MR-2 stated vs rendered', () => {
+  it('flags legend states more than markers render (says 7, shows 3)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }])] });
+    const f = fails(sampleOf(v), 'MR-2');
+    expect(f).toHaveLength(1);
+    expect(f[0].numbers).toMatchObject({ stated: 7, rendered: 3 });
+  });
+  it('passes with an overflow pill present (overflow legitimately hides families)', () => {
+    const v = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }], true)] });
+    expect(fails(sampleOf(v), 'MR-2')).toHaveLength(0);
+  });
+});
+
+describe('MR-3 per-family conservation', () => {
+  it('flags a legend family that renders no cell', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }])] });
+    const f = fails(sampleOf(v), 'MR-3');
+    expect(f).toHaveLength(1);
+    expect(f[0].symptom).toContain('Falcons');
+  });
+  it('passes when every legend family renders', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }])] });
+    expect(fails(sampleOf(v), 'MR-3')).toHaveLength(0);
+  });
+  it('carves out overflow-hidden families', () => {
+    const v = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }], true)] });
+    expect(fails(sampleOf(v), 'MR-3')).toHaveLength(0);
+  });
+});
+
+describe('MR-4 filter consistency', () => {
+  const baseUnfiltered = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 100, points: [] }), legend: [{ family: 'Hawks', count: 60 }, { family: 'Falcons', count: 40 }], markers: [] });
+  const sinceView = (total: number) => view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total, points: [] }), markers: [] });
+
+  it('flags non-monotone since windows (1d > 7d)', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [],
+      bySince: [{ since: '1d', view: sinceView(80) }, { since: '7d', view: sinceView(30) }, { since: '14d', view: sinceView(50) }],
+    };
+    const s = sampleOf(baseUnfiltered, { filterBundle: bundle });
+    const f = fails(s, 'MR-4');
+    expect(f.some((x) => x.symptom?.includes('monotonicity'))).toBe(true);
+  });
+
+  it('flags a filtered family sum that diverges from the unfiltered legend', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [{ family: 'Hawks', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 10, points: [] }), legend: [{ family: 'Hawks', count: 10 }], markers: [] }) }],
+      bySince: [],
+    };
+    const s = sampleOf(baseUnfiltered, { filterBundle: bundle });
+    expect(fails(s, 'MR-4').some((x) => x.symptom?.includes('family="Hawks"'))).toBe(true);
+  });
+
+  it('passes a consistent filtered family sum', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [
+        { family: 'Hawks', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 60, points: [] }), legend: [{ family: 'Hawks', count: 60 }], markers: [] }) },
+        { family: 'Falcons', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 40, points: [] }), legend: [{ family: 'Falcons', count: 40 }], markers: [] }) },
+      ],
+      bySince: [{ since: '1d', view: sinceView(10) }, { since: '7d', view: sinceView(30) }, { since: '14d', view: sinceView(50) }],
+    };
+    const s = sampleOf(baseUnfiltered, { filterBundle: bundle });
+    expect(fails(s, 'MR-4')).toHaveLength(0);
+  });
+});
+
+describe('MR-5 lede vs scope total', () => {
+  it('flags lede materially off the scope total', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '500 sightings', firstInt: 500, unit: 'sightings' }, markers: [] });
+    const f = fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5');
+    expect(f).toHaveLength(1);
+    expect(f[0].numbers).toMatchObject({ ledeFirstInt: 500, scopeTotal: 1000 });
+  });
+  it('passes when lede matches the scope total within tolerance', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '1000 sightings', firstInt: 1000, unit: 'sightings' }, markers: [] });
+    expect(fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5')).toHaveLength(0);
+  });
+  it('carves out a species-unit lede (not comparable to a sightings scope total)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '300 species', firstInt: 300, unit: 'species' }, markers: [] });
+    expect(fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5')).toHaveLength(0);
+  });
+});
+
+describe('MR-6 clean console', () => {
+  it('flags a console error', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 0, points: [] }), markers: [], consoleErrors: ['TypeError: x is undefined'] });
+    const f = fails(sampleOf(v), 'MR-6');
+    expect(f).toHaveLength(1);
+    expect(f[0].symptom).toContain('TypeError');
+  });
+  it('passes with a clean console', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 0, points: [] }), markers: [] });
+    expect(fails(sampleOf(v), 'MR-6')).toHaveLength(0);
+  });
+});
+
+describe('MR-7 idempotence', () => {
+  const cap = (total: number, fresh = 't0') => view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total, freshestObservationAt: fresh, points: [] }), markers: [marker([{ family: 'Hawks', count: total }])] });
+
+  it('flags a re-capture whose network total drifts', () => {
+    const rc: Recapture = { a: cap(50), b: cap(60) };
+    const s = sampleOf(cap(50), { recaptures: [rc] });
+    const f = fails(s, 'MR-7');
+    expect(f).toHaveLength(1);
+    expect(f[0].symptom).toContain('non-idempotent');
+  });
+  it('passes an identical re-capture', () => {
+    const rc: Recapture = { a: cap(50), b: cap(50) };
+    expect(fails(sampleOf(cap(50), { recaptures: [rc] }), 'MR-7')).toHaveLength(0);
+  });
+  it('downgrades drift to a freshness-skew note when freshest changed', () => {
+    const rc: Recapture = { a: cap(50, 't0'), b: cap(60, 't1') };
+    const verdicts = evaluateSample(sampleOf(cap(50), { recaptures: [rc] }));
+    const mr7 = verdicts.filter((v) => v.relation === 'MR-7');
+    expect(mr7.every((v) => v.status === 'pass')).toBe(true);
+    expect(mr7.some((v) => v.carveOuts?.includes('freshness-skew'))).toBe(true);
   });
 });

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -34,10 +34,10 @@ describe('helpers', () => {
   });
 });
 
-describe('MR-8 parity (viewport-coverage normalized)', () => {
-  it('flags a family in BOTH legends that renders on only one side (genuine pill-collapse)', () => {
-    // Falcons is in both viewports' legends (so it's in `common`) but renders only
-    // on mobile → desktop dropped it → real bug, still fails.
+describe('MR-8 parity (directional pill-collapse, #1270)', () => {
+  it('flags mobile-renders / desktop-absent (the reported desktop pill-collapse bug)', () => {
+    // Falcons is in both viewports' legends (so it's in `common`), renders on mobile
+    // but NOT on desktop → desktop under-rendered the family → real bug, fails.
     const desktop = view({
       viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }),
       legend: [{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }],
@@ -51,12 +51,30 @@ describe('MR-8 parity (viewport-coverage normalized)', () => {
     const fails = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
     expect(fails).toHaveLength(1);
     expect(fails[0].symptom).toContain('Falcons');
+    expect(fails[0].symptom).toContain('NOT on desktop');
+  });
+
+  it('SUPPRESSES desktop-renders / mobile-absent (desktop’s larger 4×4 capacity, not a bug)', () => {
+    // Falcons in both legends, renders on desktop but NOT mobile → desktop's bigger
+    // grid legitimately surfaced the tail mobile's smaller grid drops. Directional
+    // rule (#1270) suppresses this reverse direction → no MR-8 fail.
+    const desktop = view({
+      viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }])],
+    });
+    const mobile = view({
+      viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }),
+      legend: [{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }],
+      markers: [marker([{ family: 'Hawks', count: 2 }])],
+    });
+    const fails = evaluateSample(sampleOf(desktop, { views: [desktop, mobile] })).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
+    expect(fails).toHaveLength(0);
   });
 
   it('suppresses a desktop-only-legend coastal family (viewport-coverage artifact #1269)', () => {
     // Albatrosses is in desktop's legend+render but NOT in mobile's legend (mobile's
-    // narrower bbox never contained it). The pre-fix engine flagged this; now it's
-    // excluded from `common` → no MR-8 fail.
+    // narrower bbox never contained it). Excluded from `common` → no MR-8 fail.
     const desktop = view({
       viewport: 'desktop', requestedZoom: 4, network: net({ bbox: BB, total: 5, points: [] }),
       legend: [{ family: 'Hawks', count: 2 }, { family: 'Albatrosses', count: 1 }],
@@ -110,32 +128,74 @@ describe('MR-1 zoom non-vanishing', () => {
   });
 });
 
-describe('MR-2 stated vs rendered', () => {
-  it('flags legend states more than markers render (says 7, shows 3)', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }])] });
+describe('MR-2 conservation law (Σlegend ≈ network.total ≈ lede)', () => {
+  it('flags Σlegend diverging from network.total', () => {
+    // legend sums to 100 but network served 7 → conservation broken.
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 100 }], markers: [marker([{ family: 'Hawks', count: 7 }])] });
     const f = fails(sampleOf(v), 'MR-2');
     expect(f).toHaveLength(1);
-    expect(f[0].numbers).toMatchObject({ stated: 7, rendered: 3 });
+    expect(f[0].numbers).toMatchObject({ legendSum: 100, networkTotal: 7 });
   });
-  it('passes with an overflow pill present (overflow legitimately hides families)', () => {
-    const v = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }], true)] });
+  it('flags the lede diverging from network.total', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 872, points: [] }), legend: [{ family: 'Hawks', count: 869 }], lede: { text: '500 sightings', firstInt: 500, unit: 'sightings' }, markers: [marker([{ family: 'Hawks', count: 255 }])] });
+    const f = fails(sampleOf(v), 'MR-2');
+    expect(f).toHaveLength(1);
+    expect(f[0].symptom).toContain('lede 500');
+  });
+  it('PASSES the z9 conservation triple even though rendered is a lossy subset', () => {
+    // Real prod shape (#1270): lede 872 = network 872, Σlegend 869 (within ε),
+    // markers render only 255 (capacity). Old engine fired MR-2 here; now PASSES.
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 872, points: [] }), legend: [{ family: 'Hawks', count: 869 }], lede: { text: '872 sightings', firstInt: 872, unit: 'sightings' }, markers: [marker([{ family: 'Hawks', count: 255 }])] });
     expect(fails(sampleOf(v), 'MR-2')).toHaveLength(0);
   });
 });
 
-describe('MR-3 per-family conservation', () => {
-  it('flags a legend family that renders no cell', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }])] });
-    const f = fails(sampleOf(v), 'MR-3');
+describe('MR-2b render-completeness (low-total render-loss catcher)', () => {
+  it('flags render loss at a low total (total 7, rendered 3 — "says 7, shows 3")', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }])] });
+    const f = fails(sampleOf(v), 'MR-2b');
     expect(f).toHaveLength(1);
-    expect(f[0].symptom).toContain('Falcons');
+    expect(f[0].numbers).toMatchObject({ networkTotal: 7, rendered: 3 });
   });
-  it('passes when every legend family renders', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }])] });
+  it('passes a conserved low total (everything fits the grid)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 7 }])] });
+    expect(fails(sampleOf(v), 'MR-2b')).toHaveLength(0);
+  });
+  it('SKIPS the capacity case at a high total (legend 601 / rendered 0 → PASS, not a fail)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 601, points: [] }), legend: [{ family: 'Hawks', count: 601 }], markers: [] });
+    expect(fails(sampleOf(v), 'MR-2b')).toHaveLength(0);
+  });
+  it('skips when an overflow pill is present (capacity-limited)', () => {
+    const v = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 30, points: [] }), legend: [{ family: 'Hawks', count: 30 }], markers: [marker([{ family: 'Hawks', count: 3 }], true)] });
+    expect(fails(sampleOf(v), 'MR-2b')).toHaveLength(0);
+  });
+});
+
+describe('MR-3 server↔client per-family (aggregated mode only)', () => {
+  it('flags a client legend family diverging from the server count (aggregated, same scope)', () => {
+    // Σlegend (53) == network.total (53) → passes the scope guard; per-family then
+    // fires: server Hawks 30 ≠ legend Hawks 23 (counts swapped between the two families).
+    const v = view({ viewport: 'desktop', requestedZoom: 5, network: net({ mode: 'aggregated', bbox: BB, total: 53, points: [], familyCounts: [{ family: 'Hawks', count: 30 }, { family: 'Falcons', count: 23 }] }), legend: [{ family: 'Hawks', count: 23 }, { family: 'Falcons', count: 30 }], markers: [marker([{ family: 'Hawks', count: 23 }])] });
+    const f = fails(sampleOf(v), 'MR-3');
+    expect(f.length).toBeGreaterThanOrEqual(1);
+    expect(f[0].symptom).toMatch(/Hawks|Falcons/);
+  });
+  it('passes when the legend matches the server per-family counts (aggregated)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 5, network: net({ mode: 'aggregated', bbox: BB, total: 53, points: [], familyCounts: [{ family: 'Hawks', count: 30 }, { family: 'Falcons', count: 23 }] }), legend: [{ family: 'Hawks', count: 30 }, { family: 'Falcons', count: 23 }], markers: [marker([{ family: 'Hawks', count: 30 }])] });
     expect(fails(sampleOf(v), 'MR-3')).toHaveLength(0);
   });
-  it('carves out overflow-hidden families', () => {
-    const v = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), legend: [{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 2 }], markers: [marker([{ family: 'Hawks', count: 3 }], true)] });
+  it('SKIPS via the viewport-coverage guard when legend (viewport) ≠ network total (response)', () => {
+    // The mobile-z4 artifact class (#1270 re-run): server familyCounts are national
+    // (total 298) but the legend is the narrow viewport subset (30) → different scope,
+    // skipped with a carve-out rather than fired as 100s of false per-family diffs.
+    const v = view({ viewport: 'mobile', requestedZoom: 4, network: net({ mode: 'aggregated', bbox: BB, total: 298, points: [], familyCounts: [{ family: 'Hawks', count: 200 }, { family: 'Falcons', count: 98 }] }), legend: [{ family: 'Hawks', count: 30 }], markers: [marker([{ family: 'Hawks', count: 30 }])] });
+    const v3 = evaluateSample(sampleOf(v)).filter((x) => x.relation === 'MR-3');
+    expect(v3.every((x) => x.status === 'pass')).toBe(true);
+    expect(v3.some((x) => x.carveOuts?.includes('viewport-coverage-mismatch'))).toBe(true);
+  });
+  it('SKIPS the capacity artifact: observations mode is a no-op pass (legend 601 / rendered 0)', () => {
+    // Old engine compared legend vs rendered here and fired 317 capacity artifacts.
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ mode: 'observations', bbox: BB, total: 601, points: [] }), legend: [{ family: 'Hawks', count: 601 }], markers: [] });
     expect(fails(sampleOf(v), 'MR-3')).toHaveLength(0);
   });
 });
@@ -179,20 +239,24 @@ describe('MR-4 filter consistency', () => {
   });
 });
 
-describe('MR-5 lede vs scope total', () => {
-  it('flags lede materially off the scope total', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '500 sightings', firstInt: 500, unit: 'sightings' }, markers: [] });
-    const f = fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5');
+describe('MR-5 lede vs viewport total (#1270)', () => {
+  it('flags lede materially off the viewport network total', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 1000, points: [] }), lede: { text: '500 sightings', firstInt: 500, unit: 'sightings' }, markers: [] });
+    const f = fails(sampleOf(v), 'MR-5');
     expect(f).toHaveLength(1);
-    expect(f[0].numbers).toMatchObject({ ledeFirstInt: 500, scopeTotal: 1000 });
+    expect(f[0].numbers).toMatchObject({ ledeFirstInt: 500, networkTotal: 1000 });
   });
-  it('passes when lede matches the scope total within tolerance', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '1000 sightings', firstInt: 1000, unit: 'sightings' }, markers: [] });
-    expect(fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5')).toHaveLength(0);
+  it('passes when lede matches the viewport total within tolerance (prod z9: lede 872 = network 872)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 872, points: [] }), lede: { text: '872 sightings', firstInt: 872, unit: 'sightings' }, markers: [] });
+    expect(fails(sampleOf(v), 'MR-5')).toHaveLength(0);
   });
-  it('carves out a species-unit lede (not comparable to a sightings scope total)', () => {
-    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 5, points: [] }), lede: { text: '300 species', firstInt: 300, unit: 'species' }, markers: [] });
-    expect(fails(sampleOf(v, { scopeTotal: 1000 }), 'MR-5')).toHaveLength(0);
+  it('carves out a species-unit lede (not comparable to a sightings total)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 1000, points: [] }), lede: { text: '300 species', firstInt: 300, unit: 'species' }, markers: [] });
+    expect(fails(sampleOf(v), 'MR-5')).toHaveLength(0);
+  });
+  it('skips a loading-placeholder lede (no parsed unit)', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 1000, points: [] }), markers: [] });
+    expect(fails(sampleOf(v), 'MR-5')).toHaveLength(0);
   });
 });
 

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -1,0 +1,64 @@
+// frontend/scripts/map-consistency/relations.test.ts
+import { describe, it, expect } from 'vitest';
+import { evaluateSample, sumPointsInBbox, bboxInside, renderedFamilyCounts } from './relations.js';
+import type { Sample, ViewSnapshot, NetworkView, MarkerRead, Bbox } from './types.js';
+
+function net(p: Partial<NetworkView> & { bbox: Bbox; total: number; points: NetworkView['points'] }): NetworkView {
+  return { mode: 'observations', zoom: 9, truncated: false, freshestObservationAt: 't0', familyCounts: [], speciesCount: null, ...p };
+}
+function marker(cells: { family: string; count: number }[]): MarkerRead {
+  return { markerTotal: cells.reduce((s, c) => s + c.count, 0), familyCount: cells.length, cells };
+}
+function view(o: Partial<ViewSnapshot> & { viewport: ViewSnapshot['viewport']; requestedZoom: number; network: NetworkView; markers: MarkerRead[] }): ViewSnapshot {
+  return { url: `u${o.requestedZoom}-${o.viewport}`, scope: 'us', requestedCenter: { lng: -110, lat: 32 }, lede: { text: '', firstInt: null, unit: null }, legend: [], consoleErrors: [], consoleWarnings: [], ...o };
+}
+
+describe('helpers', () => {
+  it('sumPointsInBbox sums only points inside the box', () => {
+    const pts = [{ lng: -110, lat: 32, count: 3 }, { lng: -120, lat: 40, count: 5 }];
+    expect(sumPointsInBbox(pts, [-111, 31, -109, 33])).toBe(3);
+  });
+  it('bboxInside detects containment', () => {
+    expect(bboxInside([-111, 31, -109, 33], [-120, 20, -100, 40])).toBe(true);
+    expect(bboxInside([-130, 31, -109, 33], [-120, 20, -100, 40])).toBe(false);
+  });
+  it('renderedFamilyCounts sums cells across markers', () => {
+    const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: [-111, 31, -109, 33], total: 0, points: [] }), markers: [marker([{ family: 'Hawks', count: 1 }]), marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 1 }])] });
+    expect(renderedFamilyCounts(v)).toEqual(expect.arrayContaining([{ family: 'Hawks', count: 3 }, { family: 'Falcons', count: 1 }]));
+  });
+});
+
+describe('MR-8 parity', () => {
+  it('flags a family present on mobile but absent on desktop', () => {
+    const bbox: Bbox = [-111, 31, -109, 33];
+    const desktop = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox, total: 2, points: [] }), markers: [marker([{ family: 'Hawks', count: 2 }])] });
+    const mobile = view({ viewport: 'mobile', requestedZoom: 9, network: net({ bbox, total: 5, points: [] }), markers: [marker([{ family: 'Hawks', count: 2 }, { family: 'Falcons', count: 3 }])] });
+    const sample: Sample = { id: 's1', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [desktop, mobile] };
+    const fails = evaluateSample(sample).filter((v) => v.relation === 'MR-8' && v.status === 'fail');
+    expect(fails).toHaveLength(1);
+    expect(fails[0].symptom).toContain('Falcons');
+  });
+});
+
+describe('MR-0 drill-down', () => {
+  it('passes when same-mode drill-down conserves the count exactly', () => {
+    const parent = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: [-112, 30, -108, 34], zoom: 7, total: 4, points: [{ lng: -110, lat: 32, count: 2 }, { lng: -110.5, lat: 32.1, count: 1 }, { lng: -120, lat: 40, count: 1 }] }), markers: [] });
+    const child = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: [-111, 31, -109, 33], zoom: 9, total: 3, points: [] }), markers: [marker([{ family: 'Hawks', count: 3 }])] });
+    const sample: Sample = { id: 's2', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
+    expect(evaluateSample(sample).filter((v) => v.relation.startsWith('MR-0') && v.status === 'fail')).toHaveLength(0);
+  });
+  it('flags lost birds when child returns fewer than the parent counted in the child bbox', () => {
+    const parent = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: [-112, 30, -108, 34], zoom: 7, total: 7, points: [{ lng: -110, lat: 32, count: 7 }] }), markers: [] });
+    const child = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: [-111, 31, -109, 33], zoom: 9, total: 3, points: [] }), markers: [marker([{ family: 'Hawks', count: 3 }])] });
+    const sample: Sample = { id: 's3', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
+    const fail = evaluateSample(sample).find((v) => v.relation === 'MR-0a' && v.status === 'fail');
+    expect(fail).toBeDefined();
+    expect(fail!.numbers).toMatchObject({ expected: 7, actual: 3, delta: -4 });
+  });
+  it('tolerates aggregated-centroid jitter: a small loss within the band does not fire', () => {
+    const parent = view({ viewport: 'desktop', requestedZoom: 4, network: net({ mode: 'aggregated', bbox: [-112, 30, -108, 34], zoom: 4, total: 20, points: [{ lng: -110, lat: 32, count: 20 }] }), markers: [] });
+    const child = view({ viewport: 'desktop', requestedZoom: 5, network: net({ mode: 'aggregated', bbox: [-111, 31, -109, 33], zoom: 5, total: 18, points: [] }), markers: [marker([{ family: 'Hawks', count: 18 }])] });
+    const sample: Sample = { id: 's4', seedPoint: { lng: -110, lat: 32 }, scope: 'us', views: [parent, child] };
+    expect(evaluateSample(sample).filter((v) => v.relation.startsWith('MR-0') && v.status === 'fail')).toHaveLength(0);
+  });
+});

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -1,0 +1,112 @@
+// frontend/scripts/map-consistency/relations.ts
+// Pure metamorphic-relation engine (epic #1266). NO browser imports.
+import type { Bbox, FamilyCount, GeoPoint, Sample, ViewSnapshot, Verdict } from './types.js';
+
+// MR-0 drill-down tolerance is computed inline (checkDrillDown): exact (0) only
+// for observations↔observations; banded when aggregated/cross-mode/truncated.
+
+export function bboxContainsPoint(b: Bbox, lng: number, lat: number): boolean {
+  return lng >= b[0] && lng <= b[2] && lat >= b[1] && lat <= b[3];
+}
+export function bboxInside(inner: Bbox, outer: Bbox, eps = 1e-6): boolean {
+  return inner[0] >= outer[0] - eps && inner[1] >= outer[1] - eps && inner[2] <= outer[2] + eps && inner[3] <= outer[3] + eps;
+}
+export function sumPointsInBbox(points: GeoPoint[], b: Bbox): number {
+  let s = 0;
+  for (const p of points) if (bboxContainsPoint(b, p.lng, p.lat)) s += p.count;
+  return s;
+}
+export function renderedFamilyCounts(view: ViewSnapshot): FamilyCount[] {
+  const m = new Map<string, number>();
+  for (const mk of view.markers) for (const c of mk.cells) m.set(c.family, (m.get(c.family) ?? 0) + c.count);
+  return [...m].map(([family, count]) => ({ family, count }));
+}
+export function renderedTotal(view: ViewSnapshot): number {
+  return view.markers.reduce((s, mk) => s + mk.cells.reduce((c, cell) => c + cell.count, 0), 0);
+}
+function familyMap(fcs: FamilyCount[]): Map<string, number> {
+  return new Map(fcs.map((f) => [f.family, f.count]));
+}
+
+// ── MR-8: desktop ↔ mobile parity ────────────────────────────────────────────
+export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdict[] {
+  const d = familyMap(renderedFamilyCounts(desktop));
+  const m = familyMap(renderedFamilyCounts(mobile));
+  const verdicts: Verdict[] = [];
+  for (const fam of new Set<string>([...d.keys(), ...m.keys()])) {
+    const dc = d.get(fam) ?? 0;
+    const mc = m.get(fam) ?? 0;
+    if ((dc === 0) !== (mc === 0)) {
+      verdicts.push({
+        relation: 'MR-8', status: 'fail', sampleId: '', severity: 'high',
+        symptom: `Family "${fam}" renders on ${mc > 0 ? 'mobile' : 'desktop'} (${Math.max(dc, mc)}) but is absent on ${mc > 0 ? 'desktop' : 'mobile'}`,
+        numbers: { desktop: dc, mobile: mc },
+        evidence: { family: fam, desktopUrl: desktop.url, mobileUrl: mobile.url, zoom: desktop.requestedZoom },
+      });
+    }
+  }
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-8', status: 'pass', sampleId: '', evidence: { zoom: desktop.requestedZoom } });
+  return verdicts;
+}
+
+// ── MR-0: drill-down bbox conservation ───────────────────────────────────────
+export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdict[] {
+  const expected = sumPointsInBbox(parent.network.points, child.network.bbox);
+  const aggregated = parent.network.mode === 'aggregated' || child.network.mode === 'aggregated';
+  const carveOuts: string[] = [];
+  if (parent.network.mode !== child.network.mode) carveOuts.push('cross-mode (zoom-6 switch)');
+  if (parent.network.truncated || child.network.truncated) carveOuts.push('row-cap truncated');
+  if (parent.network.freshestObservationAt !== child.network.freshestObservationAt) carveOuts.push('freshness skew');
+  // Aggregated buckets are CENTROIDS — a boundary bucket's centroid can fall just
+  // outside the child bbox while representing obs inside it (and vice-versa). So
+  // exact (tol=0) conservation only holds observations↔observations; any
+  // aggregated view forces a band. (bot review #1267)
+  if (aggregated) carveOuts.push('aggregated-centroid binning');
+  const exact = carveOuts.length === 0; // obs↔obs, untruncated, fresh-aligned
+  const tol = exact ? 0 : Math.max(3, Math.round(expected * (aggregated ? 0.15 : 0.05)));
+  const mk = (relation: string, actual: number): Verdict => {
+    const delta = actual - expected; // negative = child shows fewer (lost birds)
+    // Exact drill-down: ANY mismatch is a violation. Tolerant drill-down
+    // (aggregated / cross-mode / truncation / freshness): flag LOSS beyond the
+    // band only — a GAIN is parent-grid coarseness or a row-capped parent, not
+    // a conservation bug. (bot review #1267)
+    const ok = exact ? delta === 0 : -delta <= tol;
+    return {
+      relation, status: ok ? 'pass' : 'fail', sampleId: '',
+      severity: ok ? undefined : !exact ? 'medium' : delta < 0 ? 'high' : 'medium',
+      symptom: ok ? undefined : `Drill-down ${delta < 0 ? `lost ${-delta}` : `gained ${delta}`} (parent counted ${expected} inside child bbox; child ${relation === 'MR-0b' ? 'rendered' : 'returned'} ${actual})`,
+      numbers: { expected, actual, delta, tolerance: tol },
+      carveOuts: carveOuts.length ? carveOuts : undefined,
+      evidence: { parentUrl: parent.url, childUrl: child.url, childBbox: child.network.bbox },
+    };
+  };
+  return [mk('MR-0a', child.network.total), mk('MR-0b', renderedTotal(child))];
+}
+
+// ── Sample dispatch (C1: parity + drill-down only; C4 adds MR-1..7) ──────────
+export function evaluateSample(sample: Sample): Verdict[] {
+  const views = sample.views.filter((v) => !v.inconclusive);
+  const out: Verdict[] = [];
+
+  const byCamera = new Map<string, ViewSnapshot[]>();
+  for (const v of views) {
+    const key = `${v.requestedZoom}@${v.requestedCenter.lng},${v.requestedCenter.lat}`;
+    const arr = byCamera.get(key) ?? [];
+    arr.push(v);
+    byCamera.set(key, arr);
+  }
+  for (const group of byCamera.values()) {
+    const desktop = group.find((v) => v.viewport === 'desktop');
+    const mobile = group.find((v) => v.viewport === 'mobile');
+    if (desktop && mobile) out.push(...checkParity(desktop, mobile));
+  }
+
+  for (const vp of ['desktop', 'mobile'] as const) {
+    const ladder = views.filter((v) => v.viewport === vp).sort((a, b) => a.network.zoom - b.network.zoom);
+    for (let i = 0; i < ladder.length; i++)
+      for (let j = i + 1; j < ladder.length; j++)
+        if (bboxInside(ladder[j].network.bbox, ladder[i].network.bbox)) out.push(...checkDrillDown(ladder[i], ladder[j]));
+  }
+
+  return out.map((v) => ({ ...v, sampleId: v.sampleId || sample.id }));
+}

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -160,7 +160,23 @@ export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdi
   // cross-mode jump warrants the wider band (tol 155 at expected ~775 → passes).
   // Same-mode obs↔obs stays exact (tol 0).
   const tol = exact ? 0 : Math.max(3, Math.round(expected * (aggregated ? 0.2 : 0.05)));
+  // MR-0b compares against the child's RENDERED total (Σ visible cells), which
+  // excludes the "+N" overflow tail. When the child is capacity-limited (an
+  // overflow pill or simply more birds than the adaptive grid renders), that
+  // rendered count is a lossy subset, not a conservation bound — asserting it
+  // here false-fires a "lost K" even though conservation holds (mirrors the
+  // MR-2b capacity carve-out, same `hasOverflow`/`>50` guard). MR-0a's server
+  // -truth leg still asserts the real conservation. (bot review)
+  const childCapacityLimited = hasOverflow(child) || child.network.total > 50;
   const mk = (relation: string, actual: number): Verdict => {
+    if (relation === 'MR-0b' && childCapacityLimited) {
+      return {
+        relation, status: 'pass', sampleId: '',
+        carveOuts: ['rendered-capacity-limited'],
+        numbers: { expected, actual, networkTotal: child.network.total },
+        evidence: { parentUrl: parent.url, childUrl: child.url, childBbox: child.network.bbox },
+      };
+    }
     const delta = actual - expected; // negative = child shows fewer (lost birds)
     // Exact drill-down: ANY mismatch is a violation. Tolerant drill-down
     // (aggregated / cross-mode / truncation / freshness): flag LOSS beyond the
@@ -304,8 +320,19 @@ export function checkFamilyConservation(view: ViewSnapshot): Verdict[] {
   const legendByFamily = familyMap(view.legend);
   const verdicts: Verdict[] = [];
   const within = (a: number, b: number) => Math.abs(a - b) <= Math.max(2, Math.max(a, b) * 0.05);
+  // A stale aggregated payload can carry `name: null` buckets, which key by the raw
+  // family CODE (e.g. "tyrannidae") while the legend shows the colloquial name
+  // ("Tyrant Flycatchers") — `legendByFamily.get(code)` returns 0, a false
+  // "server N ≠ client 0". When a server key is absent from the legend AND looks
+  // like a raw lowercase code (no spaces, `[a-z-]+` only), it's an unresolved
+  // code↔name key, not a real divergence — skip it.
+  const looksLikeRawCode = (key: string) => /^[a-z-]+$/.test(key);
   for (const [family, serverCount] of serverByFamily) {
     if (serverCount <= 0) continue;
+    if (!legendByFamily.has(family) && looksLikeRawCode(family)) {
+      verdicts.push({ relation: 'MR-3', status: 'pass', sampleId: '', carveOuts: ['family-key-unresolved'], numbers: { server: serverCount }, evidence: { family, url: view.url, viewport: view.viewport, zoom: view.requestedZoom } });
+      continue;
+    }
     const legendCount = legendByFamily.get(family) ?? 0;
     if (!within(legendCount, serverCount)) {
       verdicts.push({

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -35,13 +35,8 @@ function legendSum(view: ViewSnapshot): number {
 function hasOverflow(view: ViewSnapshot): boolean {
   return view.markers.some((m) => m.overflow);
 }
-/** Families hidden behind an overflow pill can't be asserted on; build the set of
- *  rendered family names so MR-3 can tell "absent" from "overflow-hidden". */
-function renderedFamilySet(view: ViewSnapshot): Set<string> {
-  return new Set(renderedFamilyCounts(view).filter((f) => f.count > 0).map((f) => f.family));
-}
 
-// ── MR-8: desktop ↔ mobile parity (viewport-coverage normalized) ──────────────
+// ── MR-8: desktop ↔ mobile parity (DIRECTIONAL pill-collapse detector) ─────────
 export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdict[] {
   // Viewport-coverage normalization (#1269): desktop (1440×900) and mobile (390×844)
   // cover DIFFERENT bboxes at the same zoom, so comparing raw rendered family SETS
@@ -49,8 +44,14 @@ export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdic
   // families mobile's bbox excludes — empirically verified at z4: Albatrosses,
   // Southern Storm-Petrels, Tropicbirds appear in desktop's legend but not mobile's).
   // Restrict to families in BOTH viewports' (viewport-scoped, common-name) legends —
-  // the coverage-controlled common ground. A genuine pill-collapse bug = a family in
-  // BOTH legends rendered on only one side.
+  // the coverage-controlled common ground.
+  //
+  // DIRECTIONAL (#1270 §5.1): the reported bug is "desktop pills disappear, mobile
+  // splits them out" — i.e. DESKTOP under-rendering. So fire ONLY when
+  //   mobile renders F (cell>0) && desktop does NOT (cell 0).
+  // Suppress the reverse (desktop renders, mobile doesn't): that is desktop's larger
+  // 4×4 grid capacity legitimately surfacing the tail mobile's smaller grid drops —
+  // it was the 21 residual MR-8 artifacts in the first prod run, NOT a bug.
   const dLegend = familyMap(desktop.legend);
   const mLegend = familyMap(mobile.legend);
   const dRender = familyMap(renderedFamilyCounts(desktop));
@@ -60,10 +61,11 @@ export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdic
   for (const fam of common) {
     const dShown = (dRender.get(fam) ?? 0) > 0;
     const mShown = (mRender.get(fam) ?? 0) > 0;
-    if (dShown !== mShown) {
+    // Only the desktop-under-rendering direction is a violation.
+    if (mShown && !dShown) {
       verdicts.push({
         relation: 'MR-8', status: 'fail', sampleId: '', severity: 'high',
-        symptom: `Family "${fam}" is in both viewports' data (legend desktop ${dLegend.get(fam)}, mobile ${mLegend.get(fam)}) but renders only on ${dShown ? 'desktop' : 'mobile'} — absent on ${dShown ? 'mobile' : 'desktop'}`,
+        symptom: `Family "${fam}" is in both viewports' data (legend desktop ${dLegend.get(fam)}, mobile ${mLegend.get(fam)}) and renders on mobile but NOT on desktop — desktop pill-collapse`,
         numbers: { desktopLegend: dLegend.get(fam) ?? 0, mobileLegend: mLegend.get(fam) ?? 0, desktopRendered: dRender.get(fam) ?? 0, mobileRendered: mRender.get(fam) ?? 0 },
         evidence: { family: fam, desktopUrl: desktop.url, mobileUrl: mobile.url, zoom: desktop.requestedZoom },
       });
@@ -126,53 +128,118 @@ export function checkZoomNonVanishing(view: ViewSnapshot): Verdict[] {
   }];
 }
 
-// ── MR-2: stated (Σ legend) vs rendered (per view) ────────────────────────────
-/** The "says 7, shows 3" bug: viewport-scoped legend states more than the markers
- *  render. A collapsed desktop pill gives rendered=0, stated>0 → fires. Overflow
- *  relaxes the bound (a "+N" pill legitimately hides families). */
-export function checkStatedVsRendered(view: ViewSnapshot): Verdict[] {
-  const stated = legendSum(view);
-  const rendered = renderedTotal(view);
-  const overflow = hasOverflow(view);
-  const carveOuts = overflow ? ['mobile-overflow'] : undefined;
-  // Default: rendered materially under stated. With overflow, only fail if rendered
-  // EXCEEDS stated (overflow can hide families so under-counting is expected).
-  const tol = Math.max(2, stated * 0.1);
-  const fail = overflow ? rendered > stated + tol : stated - rendered > tol;
+// ── MR-2: conservation law (per view) ─────────────────────────────────────────
+/** The reliable invariant (#1270 §5.1): the three viewport-scoped totals agree —
+ *  `Σ legend ≈ network.total ≈ lede`. The legend and the lede both report the
+ *  viewport total the network served; a divergence between any of them is a real
+ *  defect. (This SUPERSEDES the old legend-vs-rendered check — rendered cells are a
+ *  lossy capacity-limited subset, not a conservation bound; see MR-2b for the
+ *  render-completeness check that only applies where capacity is not a factor.) */
+export function checkConservation(view: ViewSnapshot): Verdict[] {
+  const legend = legendSum(view);
+  const total = view.network.total;
+  const eps = Math.max(3, Math.round(total * 0.02));
+  const { firstInt: lede, unit } = view.lede;
+  // The lede leg is only comparable when a real sightings lede has been parsed —
+  // skip a loading placeholder (unit null) or a species-count lede (different unit).
+  const ledeComparable = lede != null && unit === 'sightings';
+  const legendDelta = Math.abs(legend - total);
+  const ledeDelta = ledeComparable ? Math.abs((lede as number) - total) : 0;
+  const legendBad = legendDelta > eps;
+  const ledeBad = ledeComparable && ledeDelta > eps;
+  const fail = legendBad || ledeBad;
+  const parts: string[] = [];
+  if (legendBad) parts.push(`Σlegend ${legend} vs network.total ${total} (Δ ${legend - total})`);
+  if (ledeBad) parts.push(`lede ${lede} vs network.total ${total} (Δ ${(lede as number) - total})`);
   return [{
     relation: 'MR-2', status: fail ? 'fail' : 'pass', sampleId: '',
     severity: fail ? 'high' : undefined,
-    symptom: fail ? `legend states ${stated} but markers rendered ${rendered} at zoom ${view.requestedZoom}${overflow ? ' (overflow present)' : ''}` : undefined,
-    numbers: { stated, rendered, tolerance: Math.round(tol) },
-    carveOuts,
+    symptom: fail ? `conservation broken at zoom ${view.requestedZoom}: ${parts.join('; ')} (ε ${eps})` : undefined,
+    numbers: { legendSum: legend, networkTotal: total, ledeFirstInt: lede, epsilon: eps },
     evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
   }];
 }
 
-// ── MR-3: per-family conservation (per view) ──────────────────────────────────
-/** Reconcile legend[fam] vs rendered[fam] ONLY — both common-name keyed, so they
- *  match directly. Do NOT use network.familyCounts (code↔name mismatch in
- *  observations mode would false-fire). A family in the legend (count>0) that
- *  renders nothing (and isn't overflow-hidden) is a per-family drop. */
-export function checkFamilyConservation(view: ViewSnapshot): Verdict[] {
+// ── MR-2b: render-completeness (per view, low-total only) ─────────────────────
+/** The "says 7, shows 3" catcher (#1270 §5.1). Rendered cells are normally a
+ *  capacity-limited subset of the legend, so `Σrendered == total` is false at high
+ *  counts. BUT when `network.total ≤ 50` and NO marker is in overflow, everything
+ *  fits the adaptive grid — so the rendered cells MUST conserve the total. A
+ *  shortfall there is genuine render loss (the literal "shows fewer than there are"
+ *  bug). Skipped at high totals or any overflow (capacity-limited, expected loss). */
+export function checkRenderCompleteness(view: ViewSnapshot): Verdict[] {
+  const total = view.network.total;
   const overflow = hasOverflow(view);
-  const renderedSet = renderedFamilySet(view);
+  if (total > 50 || overflow) {
+    return [{
+      relation: 'MR-2b', status: 'pass', sampleId: '',
+      carveOuts: total > 50 ? ['capacity-limited'] : ['mobile-overflow'],
+      evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom, networkTotal: total },
+    }];
+  }
+  const rendered = renderedTotal(view);
+  const eps = Math.max(2, total * 0.1);
+  // Only a SHORTFALL is render loss; a rendered-over-total would be a different
+  // (and not-observed) anomaly, left to MR-2's conservation leg.
+  const fail = total - rendered > eps;
+  return [{
+    relation: 'MR-2b', status: fail ? 'fail' : 'pass', sampleId: '',
+    severity: fail ? 'high' : undefined,
+    symptom: fail ? `render loss at zoom ${view.requestedZoom}: network served ${total} but markers rendered ${rendered} (everything should fit at total ≤ 50, ε ${Math.round(eps)})` : undefined,
+    numbers: { networkTotal: total, rendered, tolerance: Math.round(eps) },
+    evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
+  }];
+}
+
+// ── MR-3: server ↔ client per-family agreement (aggregated mode only) ─────────
+/** Reconcile the client legend against the server's per-family counts (#1270 §5.1).
+ *  ONLY meaningful in aggregated mode: there `network.familyCounts` is populated and
+ *  common-name keyed, so `legend[fam] ≈ network.familyCounts[fam]` is a true
+ *  server↔client invariant. In observations mode `network.familyCounts` is empty /
+ *  code-keyed (code↔name mismatch would false-fire), so this is a no-op pass.
+ *
+ *  This SUPERSEDES the old legend-vs-rendered check, which compared the legend to
+ *  the capacity-limited rendered subset and produced 317 capacity artifacts in the
+ *  first prod run (legend 601 / rendered 0 at a high total is normal grid overflow,
+ *  not a drop).
+ *
+ *  Viewport-coverage guard (#1270 prod re-run): `network.familyCounts`/`network.total`
+ *  are RESPONSE-scoped (the whole /api/observations body), whereas the legend is
+ *  VIEWPORT-scoped (only families inside the visible frame). At low zoom on the narrow
+ *  mobile viewport the response covers a far wider bbox than the rendered frame, so the
+ *  two are scoped differently and a per-family comparison is apples-to-oranges (it
+ *  produced 166 mobile-z4 artifacts — server-national vs legend-viewport). Only run the
+ *  per-family check when conservation holds between Σlegend and network.total — i.e.
+ *  legend and network cover the SAME scope (the §5.1 "both viewport-scoped" premise). */
+export function checkFamilyConservation(view: ViewSnapshot): Verdict[] {
+  if (view.network.mode !== 'aggregated') {
+    return [{ relation: 'MR-3', status: 'pass', sampleId: '', carveOuts: ['observations-mode'], evidence: { url: view.url, viewport: view.viewport, mode: view.network.mode } }];
+  }
+  // Scope guard: skip when the legend (viewport) and network (response) totals diverge
+  // beyond the conservation ε — they cover different bboxes, so per-family is meaningless.
+  const legendTotal = legendSum(view);
+  const total = view.network.total;
+  const scopeEps = Math.max(3, Math.round(total * 0.02));
+  if (Math.abs(legendTotal - total) > scopeEps) {
+    return [{ relation: 'MR-3', status: 'pass', sampleId: '', carveOuts: ['viewport-coverage-mismatch'], numbers: { legendSum: legendTotal, networkTotal: total }, evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom } }];
+  }
+  const serverByFamily = familyMap(view.network.familyCounts);
+  const legendByFamily = familyMap(view.legend);
   const verdicts: Verdict[] = [];
-  for (const { family, count } of view.legend) {
-    if (count <= 0) continue;
-    if (!renderedSet.has(family)) {
-      // Overflow-hidden families are a legitimate non-render → carve out.
+  const within = (a: number, b: number) => Math.abs(a - b) <= Math.max(2, Math.max(a, b) * 0.05);
+  for (const [family, serverCount] of serverByFamily) {
+    if (serverCount <= 0) continue;
+    const legendCount = legendByFamily.get(family) ?? 0;
+    if (!within(legendCount, serverCount)) {
       verdicts.push({
-        relation: 'MR-3', status: overflow ? 'pass' : 'fail', sampleId: '',
-        severity: overflow ? undefined : 'high',
-        symptom: overflow ? undefined : `family "${family}" is in the legend (${count}) but renders no cell at zoom ${view.requestedZoom}`,
-        numbers: { legend: count, rendered: 0 },
-        carveOuts: overflow ? ['mobile-overflow'] : undefined,
+        relation: 'MR-3', status: 'fail', sampleId: '', severity: 'high',
+        symptom: `family "${family}" server count ${serverCount} ≠ client legend ${legendCount} at zoom ${view.requestedZoom}`,
+        numbers: { server: serverCount, legend: legendCount },
         evidence: { family, url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
       });
     }
   }
-  if (verdicts.length === 0) verdicts.push({ relation: 'MR-3', status: 'pass', sampleId: '', evidence: { url: view.url, viewport: view.viewport, families: view.legend.length } });
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-3', status: 'pass', sampleId: '', evidence: { url: view.url, viewport: view.viewport, families: serverByFamily.size } });
   return verdicts;
 }
 
@@ -241,25 +308,26 @@ export function checkFilterConsistency(bundle: FilterBundle): Verdict[] {
   return verdicts;
 }
 
-// ── MR-5: lede vs scope-total (conditional) ───────────────────────────────────
-/** The lede states a SCOPE-WIDE total (per MR-5 / spec), NOT the viewport. Compare
- *  lede.firstInt to the seed-fetch scope total. Only evaluate a real, parsed lede;
- *  skip the loading placeholder and unit-mismatched comparisons. */
-export function checkLedeVsScope(view: ViewSnapshot, scopeTotal: number | undefined): Verdict[] {
-  if (scopeTotal == null) return [];
+// ── MR-5: lede vs VIEWPORT total (conditional) ────────────────────────────────
+/** The lede tracks the VIEWPORT total, NOT the scope (#1270 §5.1 — the earlier
+ *  "lede is scope-total" reading was the two-stage-load interstitial). Compare
+ *  lede.firstInt to `view.network.total`. Only evaluate a real, parsed sightings
+ *  lede; skip the loading placeholder and a species-count lede (different unit). */
+export function checkLedeVsScope(view: ViewSnapshot): Verdict[] {
   const { firstInt, unit } = view.lede;
   if (firstInt == null || unit == null) return []; // loading placeholder / unparsed
-  // Carve-out: a species-count lede is not comparable to a sightings scope total.
+  // Carve-out: a species-count lede is not comparable to a sightings total.
   if (unit === 'species') {
     return [{ relation: 'MR-5', status: 'pass', sampleId: '', carveOuts: ['lede-unit-species'], evidence: { url: view.url, ledeUnit: unit } }];
   }
-  const tol = Math.max(2, scopeTotal * 0.02);
-  const ok = Math.abs(firstInt - scopeTotal) <= tol;
+  const total = view.network.total;
+  const tol = Math.max(3, total * 0.02);
+  const ok = Math.abs(firstInt - total) <= tol;
   return [{
     relation: 'MR-5', status: ok ? 'pass' : 'fail', sampleId: '',
     severity: ok ? undefined : 'medium',
-    symptom: ok ? undefined : `lede states ${firstInt} ${unit} but scope total is ${scopeTotal} (Δ ${firstInt - scopeTotal})`,
-    numbers: { ledeFirstInt: firstInt, scopeTotal, tolerance: Math.round(tol) },
+    symptom: ok ? undefined : `lede states ${firstInt} ${unit} but viewport network total is ${total} (Δ ${firstInt - total})`,
+    numbers: { ledeFirstInt: firstInt, networkTotal: total, tolerance: Math.round(tol) },
     evidence: { url: view.url, viewport: view.viewport, ledeUnit: unit },
   }];
 }
@@ -333,13 +401,14 @@ export function evaluateSample(sample: Sample): Verdict[] {
         if (bboxInside(ladder[j].network.bbox, ladder[i].network.bbox)) out.push(...checkDrillDown(ladder[i], ladder[j]));
   }
 
-  // Per-view relations: MR-1/2/3/6 always; MR-5 against the scope-wide total.
+  // Per-view relations: MR-1/2/2b/3/5/6 (all viewport-scoped, per #1270 §5.1).
   for (const v of views) {
     out.push(...checkZoomNonVanishing(v));
-    out.push(...checkStatedVsRendered(v));
+    out.push(...checkConservation(v));
+    out.push(...checkRenderCompleteness(v));
     out.push(...checkFamilyConservation(v));
     out.push(...checkCleanConsole(v));
-    out.push(...checkLedeVsScope(v, sample.scopeTotal));
+    out.push(...checkLedeVsScope(v));
   }
 
   // MR-4 over the filter bundle (one per sample when captured).
@@ -376,9 +445,11 @@ function relationFiresOnView(relation: string, view: ViewSnapshot): boolean {
   const run = (vs: Verdict[]) => vs.some((x) => x.status === 'fail');
   switch (relation) {
     case 'MR-1': return run(checkZoomNonVanishing(view));
-    case 'MR-2': return run(checkStatedVsRendered(view));
+    case 'MR-2': return run(checkConservation(view));
+    case 'MR-2b': return run(checkRenderCompleteness(view));
     case 'MR-3': return run(checkFamilyConservation(view));
+    case 'MR-5': return run(checkLedeVsScope(view));
     case 'MR-6': return run(checkCleanConsole(view));
-    default: return false; // cross-view relations (MR-0/MR-5/MR-8) aren't single-view reproducible
+    default: return false; // cross-view relations (MR-0/MR-8) aren't single-view reproducible
   }
 }

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -1,6 +1,6 @@
 // frontend/scripts/map-consistency/relations.ts
 // Pure metamorphic-relation engine (epic #1266). NO browser imports.
-import type { Bbox, FamilyCount, GeoPoint, Sample, ViewSnapshot, Verdict } from './types.js';
+import type { Bbox, FamilyCount, FilterBundle, GeoPoint, Recapture, Sample, ViewSnapshot, Verdict } from './types.js';
 
 // MR-0 drill-down tolerance is computed inline (checkDrillDown): exact (0) only
 // for observations↔observations; banded when aggregated/cross-mode/truncated.
@@ -27,25 +27,49 @@ export function renderedTotal(view: ViewSnapshot): number {
 function familyMap(fcs: FamilyCount[]): Map<string, number> {
   return new Map(fcs.map((f) => [f.family, f.count]));
 }
+/** Σ legend counts — the viewport-scoped "stated" total (NOT the lede, which is scope-wide). */
+function legendSum(view: ViewSnapshot): number {
+  return view.legend.reduce((s, f) => s + f.count, 0);
+}
+/** A mobile "+N" overflow pill on any marker → some families are legitimately hidden. */
+function hasOverflow(view: ViewSnapshot): boolean {
+  return view.markers.some((m) => m.overflow);
+}
+/** Families hidden behind an overflow pill can't be asserted on; build the set of
+ *  rendered family names so MR-3 can tell "absent" from "overflow-hidden". */
+function renderedFamilySet(view: ViewSnapshot): Set<string> {
+  return new Set(renderedFamilyCounts(view).filter((f) => f.count > 0).map((f) => f.family));
+}
 
-// ── MR-8: desktop ↔ mobile parity ────────────────────────────────────────────
+// ── MR-8: desktop ↔ mobile parity (viewport-coverage normalized) ──────────────
 export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdict[] {
-  const d = familyMap(renderedFamilyCounts(desktop));
-  const m = familyMap(renderedFamilyCounts(mobile));
+  // Viewport-coverage normalization (#1269): desktop (1440×900) and mobile (390×844)
+  // cover DIFFERENT bboxes at the same zoom, so comparing raw rendered family SETS
+  // yields one-directional false positives (desktop's wider frame sees coastal/edge
+  // families mobile's bbox excludes — empirically verified at z4: Albatrosses,
+  // Southern Storm-Petrels, Tropicbirds appear in desktop's legend but not mobile's).
+  // Restrict to families in BOTH viewports' (viewport-scoped, common-name) legends —
+  // the coverage-controlled common ground. A genuine pill-collapse bug = a family in
+  // BOTH legends rendered on only one side.
+  const dLegend = familyMap(desktop.legend);
+  const mLegend = familyMap(mobile.legend);
+  const dRender = familyMap(renderedFamilyCounts(desktop));
+  const mRender = familyMap(renderedFamilyCounts(mobile));
+  const common = [...dLegend.keys()].filter((f) => mLegend.has(f) && (dLegend.get(f) ?? 0) > 0 && (mLegend.get(f) ?? 0) > 0);
   const verdicts: Verdict[] = [];
-  for (const fam of new Set<string>([...d.keys(), ...m.keys()])) {
-    const dc = d.get(fam) ?? 0;
-    const mc = m.get(fam) ?? 0;
-    if ((dc === 0) !== (mc === 0)) {
+  for (const fam of common) {
+    const dShown = (dRender.get(fam) ?? 0) > 0;
+    const mShown = (mRender.get(fam) ?? 0) > 0;
+    if (dShown !== mShown) {
       verdicts.push({
         relation: 'MR-8', status: 'fail', sampleId: '', severity: 'high',
-        symptom: `Family "${fam}" renders on ${mc > 0 ? 'mobile' : 'desktop'} (${Math.max(dc, mc)}) but is absent on ${mc > 0 ? 'desktop' : 'mobile'}`,
-        numbers: { desktop: dc, mobile: mc },
+        symptom: `Family "${fam}" is in both viewports' data (legend desktop ${dLegend.get(fam)}, mobile ${mLegend.get(fam)}) but renders only on ${dShown ? 'desktop' : 'mobile'} — absent on ${dShown ? 'mobile' : 'desktop'}`,
+        numbers: { desktopLegend: dLegend.get(fam) ?? 0, mobileLegend: mLegend.get(fam) ?? 0, desktopRendered: dRender.get(fam) ?? 0, mobileRendered: mRender.get(fam) ?? 0 },
         evidence: { family: fam, desktopUrl: desktop.url, mobileUrl: mobile.url, zoom: desktop.requestedZoom },
       });
     }
   }
-  if (verdicts.length === 0) verdicts.push({ relation: 'MR-8', status: 'pass', sampleId: '', evidence: { zoom: desktop.requestedZoom } });
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-8', status: 'pass', sampleId: '', evidence: { zoom: desktop.requestedZoom, comparedFamilies: common.length } });
   return verdicts;
 }
 
@@ -63,7 +87,11 @@ export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdi
   // aggregated view forces a band. (bot review #1267)
   if (aggregated) carveOuts.push('aggregated-centroid binning');
   const exact = carveOuts.length === 0; // obs↔obs, untruncated, fresh-aligned
-  const tol = exact ? 0 : Math.max(3, Math.round(expected * (aggregated ? 0.15 : 0.05)));
+  // Aggregated/cross-mode band widened 15% → 20% (#1270): the first prod smoke lost
+  // 118 vs a 116 tol on a z4→z9 cross-mode jump — centroid binning across a 5-zoom
+  // cross-mode jump warrants the wider band (tol 155 at expected ~775 → passes).
+  // Same-mode obs↔obs stays exact (tol 0).
+  const tol = exact ? 0 : Math.max(3, Math.round(expected * (aggregated ? 0.2 : 0.05)));
   const mk = (relation: string, actual: number): Verdict => {
     const delta = actual - expected; // negative = child shows fewer (lost birds)
     // Exact drill-down: ANY mismatch is a violation. Tolerant drill-down
@@ -83,7 +111,204 @@ export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdi
   return [mk('MR-0a', child.network.total), mk('MR-0b', renderedTotal(child))];
 }
 
-// ── Sample dispatch (C1: parity + drill-down only; C4 adds MR-1..7) ──────────
+// ── MR-1: zoom non-vanishing (per view) ───────────────────────────────────────
+/** The literal "zoom in → empty map though data exists" bug: network served birds
+ *  but nothing rendered. `inconclusive` views are already filtered out upstream. */
+export function checkZoomNonVanishing(view: ViewSnapshot): Verdict[] {
+  const rendered = renderedTotal(view);
+  const vanished = view.network.total > 0 && rendered === 0 && view.markers.length === 0;
+  return [{
+    relation: 'MR-1', status: vanished ? 'fail' : 'pass', sampleId: '',
+    severity: vanished ? 'high' : undefined,
+    symptom: vanished ? `network has ${view.network.total} birds but the map rendered none at zoom ${view.requestedZoom}` : undefined,
+    numbers: { networkTotal: view.network.total, rendered, markers: view.markers.length },
+    evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
+  }];
+}
+
+// ── MR-2: stated (Σ legend) vs rendered (per view) ────────────────────────────
+/** The "says 7, shows 3" bug: viewport-scoped legend states more than the markers
+ *  render. A collapsed desktop pill gives rendered=0, stated>0 → fires. Overflow
+ *  relaxes the bound (a "+N" pill legitimately hides families). */
+export function checkStatedVsRendered(view: ViewSnapshot): Verdict[] {
+  const stated = legendSum(view);
+  const rendered = renderedTotal(view);
+  const overflow = hasOverflow(view);
+  const carveOuts = overflow ? ['mobile-overflow'] : undefined;
+  // Default: rendered materially under stated. With overflow, only fail if rendered
+  // EXCEEDS stated (overflow can hide families so under-counting is expected).
+  const tol = Math.max(2, stated * 0.1);
+  const fail = overflow ? rendered > stated + tol : stated - rendered > tol;
+  return [{
+    relation: 'MR-2', status: fail ? 'fail' : 'pass', sampleId: '',
+    severity: fail ? 'high' : undefined,
+    symptom: fail ? `legend states ${stated} but markers rendered ${rendered} at zoom ${view.requestedZoom}${overflow ? ' (overflow present)' : ''}` : undefined,
+    numbers: { stated, rendered, tolerance: Math.round(tol) },
+    carveOuts,
+    evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
+  }];
+}
+
+// ── MR-3: per-family conservation (per view) ──────────────────────────────────
+/** Reconcile legend[fam] vs rendered[fam] ONLY — both common-name keyed, so they
+ *  match directly. Do NOT use network.familyCounts (code↔name mismatch in
+ *  observations mode would false-fire). A family in the legend (count>0) that
+ *  renders nothing (and isn't overflow-hidden) is a per-family drop. */
+export function checkFamilyConservation(view: ViewSnapshot): Verdict[] {
+  const overflow = hasOverflow(view);
+  const renderedSet = renderedFamilySet(view);
+  const verdicts: Verdict[] = [];
+  for (const { family, count } of view.legend) {
+    if (count <= 0) continue;
+    if (!renderedSet.has(family)) {
+      // Overflow-hidden families are a legitimate non-render → carve out.
+      verdicts.push({
+        relation: 'MR-3', status: overflow ? 'pass' : 'fail', sampleId: '',
+        severity: overflow ? undefined : 'high',
+        symptom: overflow ? undefined : `family "${family}" is in the legend (${count}) but renders no cell at zoom ${view.requestedZoom}`,
+        numbers: { legend: count, rendered: 0 },
+        carveOuts: overflow ? ['mobile-overflow'] : undefined,
+        evidence: { family, url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
+      });
+    }
+  }
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-3', status: 'pass', sampleId: '', evidence: { url: view.url, viewport: view.viewport, families: view.legend.length } });
+  return verdicts;
+}
+
+// ── MR-4: filter consistency (filter bundle) ──────────────────────────────────
+/** Reconcile filtered variants against the unfiltered baseline at one camera:
+ *  (a) each `?family=F` view's legendSum ≈ unfiltered.legend[F];
+ *  (b) Σ filtered totals ≈ unfiltered.total over probed families (partial coverage
+ *      is noted, not failed); (c) `since` monotonicity 1d ≤ 7d ≤ 14d. */
+export function checkFilterConsistency(bundle: FilterBundle): Verdict[] {
+  const verdicts: Verdict[] = [];
+  const within = (x: number, y: number) => Math.abs(x - y) <= Math.max(2, Math.max(x, y) * 0.05);
+  const baseLegend = familyMap(bundle.unfiltered.legend);
+
+  // (a) per-family: filtered legendSum ≈ unfiltered legend[F]
+  for (const { family, view } of bundle.byFamily) {
+    const filteredSum = legendSum(view);
+    const expected = baseLegend.get(family) ?? 0;
+    const ok = within(filteredSum, expected);
+    verdicts.push({
+      relation: 'MR-4', status: ok ? 'pass' : 'fail', sampleId: '',
+      severity: ok ? undefined : 'medium',
+      symptom: ok ? undefined : `filter family="${family}" legend sum ${filteredSum} ≠ unfiltered legend[${family}] ${expected}`,
+      numbers: { filteredLegendSum: filteredSum, unfilteredFamily: expected },
+      evidence: { kind: 'family-consistency', family, url: view.url },
+    });
+  }
+
+  // (b) Σ filtered totals ≈ unfiltered.total over probed families (partial → note)
+  if (bundle.byFamily.length > 0) {
+    const probedSum = bundle.byFamily.reduce((s, b) => s + legendSum(b.view), 0);
+    const probedFamilies = bundle.byFamily.map((b) => b.family);
+    const baselineProbed = probedFamilies.reduce((s, f) => s + (baseLegend.get(f) ?? 0), 0);
+    const fullCoverage = probedFamilies.length >= bundle.unfiltered.legend.length;
+    const ok = within(probedSum, baselineProbed);
+    verdicts.push({
+      relation: 'MR-4', status: ok ? 'pass' : 'fail', sampleId: '',
+      severity: ok ? undefined : 'medium',
+      symptom: ok ? undefined : `Σ filtered totals ${probedSum} ≠ unfiltered probed total ${baselineProbed}${fullCoverage ? '' : ` (partial coverage: ${probedFamilies.length}/${bundle.unfiltered.legend.length} families probed)`}`,
+      numbers: { probedSum, baselineProbed, probedFamilies: probedFamilies.length, totalFamilies: bundle.unfiltered.legend.length },
+      carveOuts: fullCoverage ? undefined : ['partial-family-coverage'],
+      evidence: { kind: 'sum-consistency', url: bundle.unfiltered.url },
+    });
+  }
+
+  // (c) since monotonicity: 14d ≥ 7d ≥ 1d at the same camera
+  const sinceTotal = (w: '1d' | '7d' | '14d') => {
+    const hit = bundle.bySince.find((s) => s.since === w);
+    return hit ? hit.view.network.total : null;
+  };
+  const t1 = sinceTotal('1d'); const t7 = sinceTotal('7d'); const t14 = sinceTotal('14d');
+  if (t1 != null && t7 != null && t14 != null) {
+    const slack = (a: number, b: number) => a - b > Math.max(2, b * 0.05); // a should be ≤ b
+    const v1 = slack(t1, t7); // 1d > 7d → violation
+    const v7 = slack(t7, t14); // 7d > 14d → violation
+    const ok = !v1 && !v7;
+    verdicts.push({
+      relation: 'MR-4', status: ok ? 'pass' : 'fail', sampleId: '',
+      severity: ok ? undefined : 'medium',
+      symptom: ok ? undefined : `since-window monotonicity violated: 1d=${t1}, 7d=${t7}, 14d=${t14} (expected 1d ≤ 7d ≤ 14d)`,
+      numbers: { since1d: t1, since7d: t7, since14d: t14 },
+      evidence: { kind: 'since-monotonicity', url: bundle.unfiltered.url },
+    });
+  }
+
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-4', status: 'pass', sampleId: '', evidence: { kind: 'empty-bundle' } });
+  return verdicts;
+}
+
+// ── MR-5: lede vs scope-total (conditional) ───────────────────────────────────
+/** The lede states a SCOPE-WIDE total (per MR-5 / spec), NOT the viewport. Compare
+ *  lede.firstInt to the seed-fetch scope total. Only evaluate a real, parsed lede;
+ *  skip the loading placeholder and unit-mismatched comparisons. */
+export function checkLedeVsScope(view: ViewSnapshot, scopeTotal: number | undefined): Verdict[] {
+  if (scopeTotal == null) return [];
+  const { firstInt, unit } = view.lede;
+  if (firstInt == null || unit == null) return []; // loading placeholder / unparsed
+  // Carve-out: a species-count lede is not comparable to a sightings scope total.
+  if (unit === 'species') {
+    return [{ relation: 'MR-5', status: 'pass', sampleId: '', carveOuts: ['lede-unit-species'], evidence: { url: view.url, ledeUnit: unit } }];
+  }
+  const tol = Math.max(2, scopeTotal * 0.02);
+  const ok = Math.abs(firstInt - scopeTotal) <= tol;
+  return [{
+    relation: 'MR-5', status: ok ? 'pass' : 'fail', sampleId: '',
+    severity: ok ? undefined : 'medium',
+    symptom: ok ? undefined : `lede states ${firstInt} ${unit} but scope total is ${scopeTotal} (Δ ${firstInt - scopeTotal})`,
+    numbers: { ledeFirstInt: firstInt, scopeTotal, tolerance: Math.round(tol) },
+    evidence: { url: view.url, viewport: view.viewport, ledeUnit: unit },
+  }];
+}
+
+// ── MR-6: clean console (per view) ────────────────────────────────────────────
+/** Any console error or warning (tile-CDN failures already routed to inconclusive
+ *  upstream). A dirty console at render time is a real defect. */
+export function checkCleanConsole(view: ViewSnapshot): Verdict[] {
+  const first = view.consoleErrors[0] ?? view.consoleWarnings[0];
+  const dirty = view.consoleErrors.length > 0 || view.consoleWarnings.length > 0;
+  return [{
+    relation: 'MR-6', status: dirty ? 'fail' : 'pass', sampleId: '',
+    severity: dirty ? (view.consoleErrors.length > 0 ? 'high' : 'medium') : undefined,
+    symptom: dirty ? `console not clean (${view.consoleErrors.length} errors, ${view.consoleWarnings.length} warnings): ${first}` : undefined,
+    numbers: { errors: view.consoleErrors.length, warnings: view.consoleWarnings.length },
+    evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
+  }];
+}
+
+// ── MR-7: idempotence / intermittency (re-capture pair) ───────────────────────
+/** Two captures of the same camera should agree. A network or rendered-total drift
+ *  is intermittency. A freshness change (new ingest landed between captures) is a
+ *  legitimate skew → downgrade to a note. */
+export function checkIdempotence(rc: Recapture): Verdict[] {
+  const { a, b } = rc;
+  const freshSkew = a.network.freshestObservationAt !== b.network.freshestObservationAt;
+  const netDelta = Math.abs(a.network.total - b.network.total);
+  const ra = renderedTotal(a); const rb = renderedTotal(b);
+  const renderDelta = Math.abs(ra - rb);
+  const renderTol = Math.max(2, Math.max(ra, rb) * 0.05);
+  const drifted = netDelta > 0 || renderDelta > renderTol;
+  if (drifted && freshSkew) {
+    return [{
+      relation: 'MR-7', status: 'pass', sampleId: '', carveOuts: ['freshness-skew'],
+      symptom: `re-capture drift attributed to freshness skew (network ${a.network.total}→${b.network.total}, rendered ${ra}→${rb}; freshest ${a.network.freshestObservationAt} → ${b.network.freshestObservationAt})`,
+      numbers: { netDelta, renderDelta },
+      evidence: { url: a.url, kind: 'freshness-skew-note' },
+    }];
+  }
+  return [{
+    relation: 'MR-7', status: drifted ? 'fail' : 'pass', sampleId: '',
+    severity: drifted ? 'medium' : undefined,
+    symptom: drifted ? `non-idempotent: re-capture at the same camera differs (network ${a.network.total}→${b.network.total}, rendered ${ra}→${rb})` : undefined,
+    numbers: { netA: a.network.total, netB: b.network.total, netDelta, renderedA: ra, renderedB: rb, renderDelta },
+    evidence: { url: a.url, viewport: a.viewport, zoom: a.requestedZoom },
+  }];
+}
+
+// ── Sample dispatch (MR-0 + MR-1..8) ─────────────────────────────────────────
 export function evaluateSample(sample: Sample): Verdict[] {
   const views = sample.views.filter((v) => !v.inconclusive);
   const out: Verdict[] = [];
@@ -108,5 +333,52 @@ export function evaluateSample(sample: Sample): Verdict[] {
         if (bboxInside(ladder[j].network.bbox, ladder[i].network.bbox)) out.push(...checkDrillDown(ladder[i], ladder[j]));
   }
 
-  return out.map((v) => ({ ...v, sampleId: v.sampleId || sample.id }));
+  // Per-view relations: MR-1/2/3/6 always; MR-5 against the scope-wide total.
+  for (const v of views) {
+    out.push(...checkZoomNonVanishing(v));
+    out.push(...checkStatedVsRendered(v));
+    out.push(...checkFamilyConservation(v));
+    out.push(...checkCleanConsole(v));
+    out.push(...checkLedeVsScope(v, sample.scopeTotal));
+  }
+
+  // MR-4 over the filter bundle (one per sample when captured).
+  if (sample.filterBundle) out.push(...checkFilterConsistency(sample.filterBundle));
+
+  // MR-7 over re-capture pairs.
+  for (const rc of sample.recaptures ?? []) out.push(...checkIdempotence(rc));
+
+  // Stamp every non-MR-7 fail with whether its camera's re-capture reproduced it.
+  // A re-capture exists when both members of a pair sit at the verdict's camera.
+  const stamped = out.map((v) => stampDeterminism(v, sample.recaptures ?? []));
+
+  return stamped.map((v) => ({ ...v, sampleId: v.sampleId || sample.id }));
+}
+
+/** Thread a `deterministic` flag onto a fail's evidence: did the camera's
+ *  re-capture reproduce the same symptom? Only meaningful for fails at a camera
+ *  that was re-captured; left undefined otherwise. MR-7 itself is the source of
+ *  the determinism signal, so it is not re-stamped. */
+function stampDeterminism(v: Verdict, recaptures: Recapture[]): Verdict {
+  if (v.status !== 'fail' || v.relation === 'MR-7' || recaptures.length === 0) return v;
+  const url = (v.evidence?.url ?? v.evidence?.childUrl ?? v.evidence?.desktopUrl) as string | undefined;
+  if (!url) return v;
+  const rc = recaptures.find((r) => r.a.url === url || r.b.url === url);
+  if (!rc) return v;
+  // Re-run the same per-view relation against the OTHER capture to see if it repeats.
+  const other = rc.a.url === url ? rc.b : rc.a;
+  const repeats = relationFiresOnView(v.relation, other);
+  return { ...v, evidence: { ...v.evidence, deterministic: repeats } };
+}
+
+/** Re-evaluate a single per-view relation against one view (for determinism stamping). */
+function relationFiresOnView(relation: string, view: ViewSnapshot): boolean {
+  const run = (vs: Verdict[]) => vs.some((x) => x.status === 'fail');
+  switch (relation) {
+    case 'MR-1': return run(checkZoomNonVanishing(view));
+    case 'MR-2': return run(checkStatedVsRendered(view));
+    case 'MR-3': return run(checkFamilyConservation(view));
+    case 'MR-6': return run(checkCleanConsole(view));
+    default: return false; // cross-view relations (MR-0/MR-5/MR-8) aren't single-view reproducible
+  }
 }

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -21,8 +21,12 @@ export function renderedFamilyCounts(view: ViewSnapshot): FamilyCount[] {
   for (const mk of view.markers) for (const c of mk.cells) m.set(c.family, (m.get(c.family) ?? 0) + c.count);
   return [...m].map(([family, count]) => ({ family, count }));
 }
+/** Σ pill totals + Σ grid cell counts (§5.2). Pills now count toward the rendered
+ *  total — they carry the bulk of the low-zoom count and were previously invisible,
+ *  causing the MR-1 false-fire and the MR-2b undercount. For a grid marker
+ *  `mk.total === Σ mk.cells.count`, so a single `mk.total` sum covers both kinds. */
 export function renderedTotal(view: ViewSnapshot): number {
-  return view.markers.reduce((s, mk) => s + mk.cells.reduce((c, cell) => c + cell.count, 0), 0);
+  return view.markers.reduce((s, mk) => s + mk.total, 0);
 }
 function familyMap(fcs: FamilyCount[]): Map<string, number> {
   return new Map(fcs.map((f) => [f.family, f.count]));
@@ -75,6 +79,68 @@ export function checkParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdic
   return verdicts;
 }
 
+// ── MR-9: pill-split parity (desktop ↔ mobile, THE reported bug) ──────────────
+/** The user's literal bug (§5.2): "desktop pills disappear and never split out
+ *  like they do on mobile." `pickGridShape` collapses a cluster to a `.cluster-pill`
+ *  above a point/family cap, and desktop's wider bbox aggregates MORE points per
+ *  cluster → more clusters exceed the cap → desktop stays a pill where mobile splits
+ *  into a family grid.
+ *
+ *  Measured as the FRACTION of each viewport's clusters that are split into grids
+ *  (`gridFraction = #grid / (#grid + #pill)`), NOT raw counts — desktop's wider
+ *  frame sees more clusters total, so a raw `#grid` comparison conflates "more
+ *  clusters" with "under-splitting". The fraction normalizes that away. Fire when
+ *  mobile splits a MATERIALLY larger fraction than desktop:
+ *    `mobileGridFraction − desktopGridFraction > MR9_THRESHOLD`.
+ *  Severity high — this is the reported defect.
+ *
+ *  THRESHOLD (0.12) tuned from a paced live probe (2026-06-23) over LA / SF / NYC /
+ *  FL-gulf at z5–z10. The asymmetry is camera-dependent, NOT uniformly in the bug
+ *  direction: at z7–z9 in some metros desktop's wider frame pushes its OWN clusters
+ *  over the split cap too, REVERSING the gap to ~−0.12 (desktop splits a larger
+ *  fraction). The canonical bug signature ("desktop leaves clusters as pills, mobile
+ *  splits") peaked at +0.15 (NYC z8: desktop 0.09 = 5 grids/51 pills vs mobile 0.24
+ *  = 9 grids/28 pills). 0.12 sits at the reverse-direction noise FLOOR magnitude but
+ *  fires only in the positive (bug) direction, so it catches NYC-z8-class cameras
+ *  while never tripping on the benign reverse cases or near-parity high zooms. */
+export const MR9_THRESHOLD = 0.12;
+
+function gridFraction(view: ViewSnapshot): { grids: number; pills: number; fraction: number | null } {
+  const grids = view.markers.filter((m) => m.kind === 'grid').length;
+  const pills = view.markers.filter((m) => m.kind === 'pill').length;
+  const denom = grids + pills;
+  return { grids, pills, fraction: denom === 0 ? null : grids / denom };
+}
+
+export function checkPillSplitParity(desktop: ViewSnapshot, mobile: ViewSnapshot): Verdict[] {
+  const d = gridFraction(desktop);
+  const m = gridFraction(mobile);
+  // Guard divide-by-zero: a viewport with no clusters at all has no split fraction
+  // to compare, so the parity is undefined → pass with a carve-out.
+  if (d.fraction === null || m.fraction === null) {
+    return [{
+      relation: 'MR-9', status: 'pass', sampleId: '', carveOuts: ['no-clusters'],
+      numbers: { desktopGrids: d.grids, desktopPills: d.pills, mobileGrids: m.grids, mobilePills: m.pills },
+      evidence: { zoom: desktop.requestedZoom, desktopUrl: desktop.url, mobileUrl: mobile.url },
+    }];
+  }
+  const gap = m.fraction - d.fraction; // positive = mobile splits a larger fraction (desktop under-splits)
+  const fail = gap > MR9_THRESHOLD;
+  return [{
+    relation: 'MR-9', status: fail ? 'fail' : 'pass', sampleId: '',
+    severity: fail ? 'high' : undefined,
+    symptom: fail
+      ? `desktop under-splits clusters at zoom ${desktop.requestedZoom}: mobile splits ${(m.fraction * 100).toFixed(0)}% of its clusters into grids (${m.grids}/${m.grids + m.pills}) but desktop only ${(d.fraction * 100).toFixed(0)}% (${d.grids}/${d.grids + d.pills}) — Δ ${(gap * 100).toFixed(0)}pp > ${(MR9_THRESHOLD * 100).toFixed(0)}pp threshold`
+      : undefined,
+    numbers: {
+      desktopGridFraction: Number(d.fraction.toFixed(3)), mobileGridFraction: Number(m.fraction.toFixed(3)),
+      gap: Number(gap.toFixed(3)), threshold: MR9_THRESHOLD,
+      desktopGrids: d.grids, desktopPills: d.pills, mobileGrids: m.grids, mobilePills: m.pills,
+    },
+    evidence: { zoom: desktop.requestedZoom, desktopUrl: desktop.url, mobileUrl: mobile.url },
+  }];
+}
+
 // ── MR-0: drill-down bbox conservation ───────────────────────────────────────
 export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdict[] {
   const expected = sumPointsInBbox(parent.network.points, child.network.bbox);
@@ -115,7 +181,10 @@ export function checkDrillDown(parent: ViewSnapshot, child: ViewSnapshot): Verdi
 
 // ── MR-1: zoom non-vanishing (per view) ───────────────────────────────────────
 /** The literal "zoom in → empty map though data exists" bug: network served birds
- *  but nothing rendered. `inconclusive` views are already filtered out upstream. */
+ *  but nothing rendered. `inconclusive` views are already filtered out upstream.
+ *  Uses the FULL marker set (pills + grids, §5.2): pills carry the low-zoom count
+ *  and were previously invisible to the capture, which is what produced the false
+ *  MR-1 fires at low zoom (16 pills on-screen where the capture read 0 markers). */
 export function checkZoomNonVanishing(view: ViewSnapshot): Verdict[] {
   const rendered = renderedTotal(view);
   const vanished = view.network.total > 0 && rendered === 0 && view.markers.length === 0;
@@ -143,9 +212,16 @@ export function checkConservation(view: ViewSnapshot): Verdict[] {
   // The lede leg is only comparable when a real sightings lede has been parsed —
   // skip a loading placeholder (unit null) or a species-count lede (different unit).
   const ledeComparable = lede != null && unit === 'sightings';
+  // Legend-leg guard (§5.1 amendment): assert `|Σlegend − network.total| ≤ ε` ONLY
+  // in observations mode. In aggregated mode the /api/observations response is
+  // SCOPE-WIDE (the whole region) while the legend is VIEWPORT-scoped (only the
+  // visible frame), so the two legitimately diverge — comparing them is
+  // apples-to-oranges and would false-fire. Carve it out (`aggregated-response-scopewide`).
+  // The lede leg stays UNCONDITIONAL: the lede tracks the same total either way.
+  const legendComparable = view.network.mode === 'observations';
   const legendDelta = Math.abs(legend - total);
   const ledeDelta = ledeComparable ? Math.abs((lede as number) - total) : 0;
-  const legendBad = legendDelta > eps;
+  const legendBad = legendComparable && legendDelta > eps;
   const ledeBad = ledeComparable && ledeDelta > eps;
   const fail = legendBad || ledeBad;
   const parts: string[] = [];
@@ -156,6 +232,7 @@ export function checkConservation(view: ViewSnapshot): Verdict[] {
     severity: fail ? 'high' : undefined,
     symptom: fail ? `conservation broken at zoom ${view.requestedZoom}: ${parts.join('; ')} (ε ${eps})` : undefined,
     numbers: { legendSum: legend, networkTotal: total, ledeFirstInt: lede, epsilon: eps },
+    carveOuts: legendComparable ? undefined : ['aggregated-response-scopewide'],
     evidence: { url: view.url, viewport: view.viewport, zoom: view.requestedZoom },
   }];
 }
@@ -391,7 +468,10 @@ export function evaluateSample(sample: Sample): Verdict[] {
   for (const group of byCamera.values()) {
     const desktop = group.find((v) => v.viewport === 'desktop');
     const mobile = group.find((v) => v.viewport === 'mobile');
-    if (desktop && mobile) out.push(...checkParity(desktop, mobile));
+    if (desktop && mobile) {
+      out.push(...checkParity(desktop, mobile));
+      out.push(...checkPillSplitParity(desktop, mobile));
+    }
   }
 
   for (const vp of ['desktop', 'mobile'] as const) {

--- a/frontend/scripts/map-consistency/report.ts
+++ b/frontend/scripts/map-consistency/report.ts
@@ -1,0 +1,108 @@
+// frontend/scripts/map-consistency/report.ts
+// C5 (#1271): turn findings.json into the preserved findings brief — a durable,
+// self-contained evidence bundle per FAIL so the run stays analyzable after prod
+// data shifts. Pure node fs; no Playwright, no network. Reads the run's `raw/` +
+// `shots/` (persisted per-view by audit.ts) and assembles `brief.md` plus one
+// `findings/<F-id>/` bundle per fail.
+import { mkdir, copyFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Sample, Verdict } from './types.js';
+
+export interface Findings {
+  runMeta: Record<string, unknown>;
+  summary: Record<string, unknown>;
+  verdicts: Verdict[];
+}
+
+/** Per-view evidence stem — MUST match the stem audit.ts persists under raw/ + shots/. */
+const stem = (sampleId: string, vp: string, zoom: number): string => `${sampleId}-${vp}-z${zoom}`;
+
+/** The #map= viewbox links a verdict carries (epic #1238). Cross-view relations
+ *  (MR-8/MR-9 pill-collapse) carry BOTH desktopUrl + mobileUrl — a pill-collapse
+ *  finding is only reproducible with the desktop AND the mobile camera, so both are
+ *  surfaced. Drill-down (MR-0) carries parentUrl + childUrl. Per-view relations
+ *  carry a single `url`. */
+function reproUrls(v: Verdict): string[] {
+  const e = v.evidence ?? {};
+  return [e.parentUrl, e.childUrl, e.desktopUrl, e.mobileUrl, e.url].filter(
+    (u): u is string => typeof u === 'string' && u.length > 0,
+  );
+}
+
+/** Assemble brief.md + one evidence bundle per FAIL verdict. */
+export async function writeBrief(f: Findings, outDir: string, samples: Sample[]): Promise<void> {
+  const fails = f.verdicts.filter((v) => v.status === 'fail');
+  const lines: string[] = [];
+  lines.push(`# Map consistency audit — ${f.runMeta.scope}, ${f.runMeta.samples} samples, seed ${f.runMeta.seed}`);
+  const fresh = (f.runMeta.freshestRange as string[] | undefined) ?? [];
+  lines.push(`Run: \`${f.runMeta.command}\` · prod freshest range: ${fresh.join(' … ') || 'n/a'}`);
+  lines.push(`\n## Summary\n`);
+  lines.push(`${fails.length} findings / ${f.verdicts.length} checks. By relation: ${JSON.stringify(f.summary.byRelation ?? {})}`);
+  lines.push(`\n| # | Relation | Severity | Deterministic | Symptom |`);
+  lines.push(`|---|---|---|---|---|`);
+
+  for (let i = 0; i < fails.length; i++) {
+    const v = fails[i]!;
+    const id = `F${i + 1}`;
+    const det = v.evidence?.deterministic;
+    lines.push(`| ${id} | ${v.relation} | ${v.severity ?? '-'} | ${det === undefined ? '?' : det} | ${(v.symptom ?? '').replace(/\|/g, '\\|')} |`);
+    await writeFindingBundle(id, v, outDir, samples);
+  }
+
+  lines.push(`\n## Findings\n`);
+  if (fails.length === 0) {
+    lines.push(`_No fails in this run._\n`);
+  }
+  for (let i = 0; i < fails.length; i++) {
+    const v = fails[i]!;
+    const id = `F${i + 1}`;
+    lines.push(`### ${id} — ${v.relation} — ${v.severity ?? ''}`);
+    lines.push(`${v.symptom ?? ''}`);
+    lines.push(`- Numbers: \`${JSON.stringify(v.numbers ?? {})}\`${v.carveOuts ? ` · carve-outs: ${v.carveOuts.join(', ')}` : ''}`);
+    // The #map= viewbox link (epic #1238) IS the canonical one-click repro — it
+    // bakes in viewport + scope + filters. Surface it in the brief itself so any
+    // ticket written from this finding can carry it verbatim. A pill-collapse
+    // (MR-8/MR-9) emits BOTH the desktop and mobile viewbox link.
+    for (const u of reproUrls(v)) lines.push(`- 🔗 viewbox repro: ${u}`);
+    lines.push(`- Evidence bundle: \`findings/${id}/\` · Sample: ${v.sampleId}\n`);
+  }
+  await writeFile(path.join(outDir, 'brief.md'), lines.join('\n'));
+}
+
+export async function writeFindingBundle(id: string, v: Verdict, outDir: string, samples: Sample[]): Promise<void> {
+  const dir = path.join(outDir, 'findings', id);
+  await mkdir(dir, { recursive: true });
+  const sample = samples.find((s) => s.id === v.sampleId);
+  const urls = reproUrls(v);
+  await writeFile(
+    path.join(dir, 'repro.md'),
+    [
+      `# ${id} — ${v.relation}`,
+      v.symptom ?? '',
+      '',
+      '## Reproduce — open the #map= viewbox link(s) below (epic #1238; viewport + scope + filters are baked in):',
+      ...urls.map((u) => `- ${u}`),
+      '',
+      '> When filing a ticket from this finding, INCLUDE the viewbox link above — it is the canonical one-click reproduction.',
+      '',
+      `Numbers: ${JSON.stringify(v.numbers ?? {})}`,
+    ].join('\n'),
+  );
+  await writeFile(path.join(dir, 'meta.json'), JSON.stringify(v, null, 2));
+  // Copy the relevant screenshots + raw payloads from the run dirs (best-effort).
+  // For a cross-view fail (MR-8/MR-9), `urls` holds both the desktop and mobile
+  // viewbox links, so BOTH viewports' screenshots + payloads are copied. For a
+  // drill-down (MR-0) the parent view lands as observations-parent.json and the
+  // failing (deeper) view as observations-child.json.
+  if (sample) {
+    const minZoom = Math.min(...sample.views.map((x) => x.requestedZoom));
+    for (const view of sample.views) {
+      if (!urls.includes(view.url)) continue;
+      const s = stem(sample.id, view.viewport, view.requestedZoom);
+      await copyFile(path.join(outDir, 'shots', `${s}.png`), path.join(dir, `${view.viewport}.png`)).catch(() => {});
+      const payloadName = view.requestedZoom === minZoom ? 'observations-parent.json' : 'observations-child.json';
+      await copyFile(path.join(outDir, 'raw', `${s}.json`), path.join(dir, payloadName)).catch(() => {});
+      await writeFile(path.join(dir, 'console.log'), [...view.consoleErrors, ...view.consoleWarnings].join('\n')).catch(() => {});
+    }
+  }
+}

--- a/frontend/scripts/map-consistency/sampler.test.ts
+++ b/frontend/scripts/map-consistency/sampler.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { mulberry32, sampleSeedPoints } from './sampler.js';
+import type { GeoPoint } from './types.js';
+
+describe('sampler', () => {
+  const pts: GeoPoint[] = [{ lng: -110, lat: 32, count: 100 }, { lng: -120, lat: 40, count: 1 }];
+  it('is deterministic for a fixed seed', () => {
+    expect(sampleSeedPoints(pts, 10, 7)).toEqual(sampleSeedPoints(pts, 10, 7));
+  });
+  it('weights by count (the count-100 point dominates the density share)', () => {
+    const s = sampleSeedPoints(pts, 50, 7, 0); // uniformFrac 0 → all density-weighted
+    const near110 = s.filter((p) => p.lng === -110).length;
+    expect(near110).toBeGreaterThan(40);
+  });
+  it('mulberry32 is in [0,1)', () => {
+    const r = mulberry32(1); for (let i = 0; i < 100; i++) { const v = r(); expect(v).toBeGreaterThanOrEqual(0); expect(v).toBeLessThan(1); }
+  });
+});

--- a/frontend/scripts/map-consistency/sampler.ts
+++ b/frontend/scripts/map-consistency/sampler.ts
@@ -1,0 +1,37 @@
+// frontend/scripts/map-consistency/sampler.ts
+import type { GeoPoint } from './types.js';
+
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface SeedPoint { lng: number; lat: number; }
+
+/** 80% density-weighted (by count) + 20% uniform-in-extent seeded sampling from
+ *  the scope's low-zoom bucket centroids — most samples land where birds are,
+ *  a few land anywhere (catches "empty area shows phantom count"). */
+export function sampleSeedPoints(points: GeoPoint[], n: number, seed: number, uniformFrac = 0.2): SeedPoint[] {
+  const rnd = mulberry32(seed);
+  if (points.length === 0) return [];
+  const total = points.reduce((s, p) => s + p.count, 0);
+  const lngs = points.map((p) => p.lng); const lats = points.map((p) => p.lat);
+  const ext = { minLng: Math.min(...lngs), maxLng: Math.max(...lngs), minLat: Math.min(...lats), maxLat: Math.max(...lats) };
+  const nUniform = Math.round(n * uniformFrac);
+  const out: SeedPoint[] = [];
+  for (let i = 0; i < n; i++) {
+    if (i < nUniform) {
+      out.push({ lng: ext.minLng + rnd() * (ext.maxLng - ext.minLng), lat: ext.minLat + rnd() * (ext.maxLat - ext.minLat) });
+    } else {
+      let r = rnd() * total; let pick = points[points.length - 1]!;
+      for (const p of points) { r -= p.count; if (r <= 0) { pick = p; break; } }
+      out.push({ lng: pick.lng, lat: pick.lat });
+    }
+  }
+  return out;
+}

--- a/frontend/scripts/map-consistency/sampler.ts
+++ b/frontend/scripts/map-consistency/sampler.ts
@@ -13,10 +13,12 @@ export function mulberry32(seed: number): () => number {
 
 export interface SeedPoint { lng: number; lat: number; }
 
-/** 80% density-weighted (by count) + 20% uniform-in-extent seeded sampling from
- *  the scope's low-zoom bucket centroids — most samples land where birds are,
- *  a few land anywhere (catches "empty area shows phantom count"). */
-export function sampleSeedPoints(points: GeoPoint[], n: number, seed: number, uniformFrac = 0.2): SeedPoint[] {
+/** Pure density-weighted (by count) seeded sampling from the scope's low-zoom
+ *  bucket centroids — every sample lands on real data (a bucket centroid), so a
+ *  seed never falls in the ocean / an empty area where there's nothing to fetch.
+ *  Pass `uniformFrac > 0` to mix in uniform-in-extent samples (catches "empty
+ *  area shows phantom count") at the cost of occasional ocean/empty seeds. */
+export function sampleSeedPoints(points: GeoPoint[], n: number, seed: number, uniformFrac = 0): SeedPoint[] {
   const rnd = mulberry32(seed);
   if (points.length === 0) return [];
   const total = points.reduce((s, p) => s + p.count, 0);

--- a/frontend/scripts/map-consistency/types.ts
+++ b/frontend/scripts/map-consistency/types.ts
@@ -1,0 +1,75 @@
+// frontend/scripts/map-consistency/types.ts
+// Shared shapes for the map-consistency audit (epic #1266).
+
+export type Viewport = 'desktop' | 'mobile';
+
+export const VIEWPORTS: Record<Viewport, { width: number; height: number; dpr: number }> = {
+  desktop: { width: 1440, height: 900, dpr: 1 },
+  mobile: { width: 390, height: 844, dpr: 2 },
+};
+
+/** [minLng, minLat, maxLng, maxLat] — the /api/observations bbox param order. */
+export type Bbox = [number, number, number, number];
+
+export interface FamilyCount { family: string; count: number; }
+
+/** A geo-located count: a bucket centroid (aggregated) or one observation (count 1). */
+export interface GeoPoint { lng: number; lat: number; count: number; }
+
+/** Normalized truth from the /api/observations response that served a view. */
+export interface NetworkView {
+  mode: 'aggregated' | 'observations' | 'unknown';
+  bbox: Bbox;
+  zoom: number;
+  truncated: boolean;
+  freshestObservationAt: string | null;
+  /** Σ bucket.count (aggregated) or data.length (observations). */
+  total: number;
+  familyCounts: FamilyCount[];
+  /** Geo-located counts for drill-down conservation (MR-0). */
+  points: GeoPoint[];
+  speciesCount: number | null;
+  rawPath?: string;
+}
+
+export interface LedeRead { text: string; firstInt: number | null; unit: 'species' | 'sightings' | null; }
+
+export interface MarkerRead {
+  /** From "Cluster: N observations, M families". null for a single-family marker. */
+  markerTotal: number | null;
+  familyCount: number | null;
+  /** Per-cell {family,count} from cell aria-labels. */
+  cells: FamilyCount[];
+}
+
+export interface ViewSnapshot {
+  url: string;
+  scope: string;
+  viewport: Viewport;
+  requestedZoom: number;
+  requestedCenter: { lng: number; lat: number };
+  network: NetworkView;
+  lede: LedeRead;
+  legend: FamilyCount[];
+  markers: MarkerRead[];
+  consoleErrors: string[];
+  consoleWarnings: string[];
+  /** Set when the view can't be trusted (e.g. basemap tile-CDN failure). */
+  inconclusive?: { reason: string };
+}
+
+export interface Sample { id: string; seedPoint: { lng: number; lat: number }; scope: string; views: ViewSnapshot[]; }
+
+export type VerdictStatus = 'pass' | 'fail' | 'inconclusive';
+export type Severity = 'high' | 'medium' | 'low';
+
+export interface Verdict {
+  relation: string;
+  status: VerdictStatus;
+  sampleId: string;
+  severity?: Severity;
+  symptom?: string;
+  numbers?: Record<string, number | null>;
+  carveOuts?: string[];
+  evidence?: Record<string, unknown>;
+}

--- a/frontend/scripts/map-consistency/types.ts
+++ b/frontend/scripts/map-consistency/types.ts
@@ -40,6 +40,10 @@ export interface MarkerRead {
   familyCount: number | null;
   /** Per-cell {family,count} from cell aria-labels. */
   cells: FamilyCount[];
+  /** True when this marker shows a mobile "+N" overflow pill
+   *  ([data-testid="adaptive-grid-marker-overflow"]) — families are hidden, so
+   *  rendered < stated is legitimate for MR-2/MR-3 (carve-out `mobile-overflow`). */
+  overflow: boolean;
 }
 
 export interface ViewSnapshot {
@@ -58,7 +62,31 @@ export interface ViewSnapshot {
   inconclusive?: { reason: string };
 }
 
-export interface Sample { id: string; seedPoint: { lng: number; lat: number }; scope: string; views: ViewSnapshot[]; }
+/** One filter probe: an unfiltered baseline view plus its filtered variants at a
+ *  single shared camera. MR-4 reconciles the variants against the baseline. */
+export interface FilterBundle {
+  unfiltered: ViewSnapshot;
+  /** Per-family variants: `?family=<F>` at the same camera, keyed by family name. */
+  byFamily: { family: string; view: ViewSnapshot }[];
+  /** `?since=1d|7d|14d` variants at the same camera, for the monotonicity check. */
+  bySince: { since: '1d' | '7d' | '14d'; view: ViewSnapshot }[];
+}
+
+/** Two captures of the SAME camera (MR-7 idempotence / intermittency). */
+export interface Recapture { a: ViewSnapshot; b: ViewSnapshot; }
+
+export interface Sample {
+  id: string;
+  seedPoint: { lng: number; lat: number };
+  scope: string;
+  views: ViewSnapshot[];
+  /** Scope-wide network total from the seed fetch (MR-5 compares lede to THIS, not viewport). */
+  scopeTotal?: number;
+  /** MR-4 filter probe (captured for ~one sample at a mid-ladder zoom). */
+  filterBundle?: FilterBundle;
+  /** MR-7 re-capture pairs (~one camera per sample captured twice). */
+  recaptures?: Recapture[];
+}
 
 export type VerdictStatus = 'pass' | 'fail' | 'inconclusive';
 export type Severity = 'high' | 'medium' | 'low';

--- a/frontend/scripts/map-consistency/types.ts
+++ b/frontend/scripts/map-consistency/types.ts
@@ -80,8 +80,6 @@ export interface Sample {
   seedPoint: { lng: number; lat: number };
   scope: string;
   views: ViewSnapshot[];
-  /** Scope-wide network total from the seed fetch (MR-5 compares lede to THIS, not viewport). */
-  scopeTotal?: number;
   /** MR-4 filter probe (captured for ~one sample at a mid-ladder zoom). */
   filterBundle?: FilterBundle;
   /** MR-7 re-capture pairs (~one camera per sample captured twice). */

--- a/frontend/scripts/map-consistency/types.ts
+++ b/frontend/scripts/map-consistency/types.ts
@@ -35,10 +35,23 @@ export interface NetworkView {
 export interface LedeRead { text: string; firstInt: number | null; unit: 'species' | 'sightings' | null; }
 
 export interface MarkerRead {
-  /** From "Cluster: N observations, M families". null for a single-family marker. */
+  /** Which DOM form this cluster rendered as (§5.2): `grid` = the family-cell
+   *  `adaptive-grid-marker` the capture has always read; `pill` = the collapsed
+   *  `.cluster-pill` button (total count, NO family breakdown). pickGridShape
+   *  collapses a cluster to a pill above a point/family cap, so desktop's wider
+   *  bbox aggregates more points/cluster and stays a pill where mobile splits
+   *  into a grid — the reported "desktop pills don't split out" bug. */
+  kind: 'pill' | 'grid';
+  /** The marker's own total: a pill's `aria-label "N sightings"` count, or the
+   *  Σ of a grid's per-cell counts. Counts toward `renderedTotal` for both kinds. */
+  total: number;
+  /** The `cluster-pill--<x>` modifier (sky / sand / ember) for a pill; undefined for grids. */
+  color?: string;
+  /** From "Cluster: N observations, M families". null for a single-family marker
+   *  and for pills (no family breakdown). */
   markerTotal: number | null;
   familyCount: number | null;
-  /** Per-cell {family,count} from cell aria-labels. */
+  /** Per-cell {family,count} from cell aria-labels. Empty for pills (collapsed, no cells). */
   cells: FamilyCount[];
   /** True when this marker shows a mobile "+N" overflow pill
    *  ([data-testid="adaptive-grid-marker-overflow"]) — families are hidden, so


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    A[npm run audit:map-consistency -- --samples N --scope US] --> B[Sampler: one national low-zoom fetch, then density-weighted seeded points]
    B --> C{per sample x zoom-ladder x viewport desktop+mobile}
    C --> D[Camera: navigate scope + #map= hash; wait for the /api/observations whose zoom+bbox match]
    D --> E[Capture: network payload + DOM cluster-pills and adaptive-grids and lede and legend via aria + console]
    E --> F[Relations engine MR-0..MR-9: conservation law, directional desktop/mobile parity, pill-split, drill-down]
    F --> G[Reporter: brief.md + per-finding evidence bundles, each with its #map= viewbox repro link]
    G --> H[map-consistency-auditor agent triages real findings vs carve-outs, STOPS for Julian to ticket]
```

## Summary

- **Why:** bird-maps.com renders the same eBird data through several independently-computed surfaces (lede, legend, marker pills/grids) that can silently diverge — "pills disappear at zoom and never split out", "the filter says 7 but only 3 show". There is no ground-truth oracle for a random map patch, so this uses **metamorphic testing**: assert relations that must hold between related views.
- **What:** a prod-only sampler (configurable `--samples`) that drives bird-maps.com via the `#map=` viewbox hash on desktop **and** mobile, evaluates 11 metamorphic relations (conservation `Σlegend ≈ network.total ≈ lede`; **directional desktop↔mobile parity**; **MR-9 pill-split** — the reported bug; drill-down conservation; clean-console; idempotence), and emits a **preserved findings brief** where every finding carries its `#map=` viewbox repro link + screenshots + raw payloads. Ships the `map-consistency-auditor` agent + `map-consistency-audit` skill (confirm-first; never files).
- **Already earned its keep:** the relations were refined across three live prod runs (45→0 coastal-family artifacts; 355→handful after the conservation-law + capacity-aware correction). It caught a **genuine prod CORS error** on the national `zoom=3` prefetch, and live MCP triage pinned the **pill-split mechanism** (desktop's wider bbox aggregates more points/cluster → collapses to a count-pill where mobile splits into a family grid). Lives under `frontend/scripts/` (like `replay-viewbox.ts`) so `tsc -b`/`playwright test` ignore it; the pure relation + sampler engines are vitest-covered.

## Screenshots

N/A — not UI. This adds a Node + Playwright **audit tool** under `frontend/scripts/map-consistency/` and a project agent/skill under `.claude/`. It reads the live UI but adds no visible surface.

- [ ] N/A — not UI (no new/renamed `className`)
- [ ] N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (**1775 passed / 96 files**); pure `relations` + `sampler` engines unit-tested (**44** of those), incl. fixtures for the conservation law, directional MR-8, MR-9 pill-split, MR-2b render-completeness, MR-0 aggregated-centroid tolerance, and the MR-0b rendered-capacity carve-out.
- [x] New unit tests added — `relations.test.ts`, `sampler.test.ts`.
- [x] `npm run build` — clean (the harness is under `frontend/scripts/`, outside `tsc -b`'s `include:["src"]` and the Playwright `testDir:'e2e'`, so the `build`/`e2e` gates are unaffected — same profile as the existing `replay-viewbox.ts`).
- [x] Live prod verification — `--probe` returns real data at z9 (observations) and z3 (aggregated); `--samples` runs complete against prod within the Cloudflare 60/min/IP budget (pacing guard refuses unsafe paces); a seed-42 run produced a 7-finding `brief.md` with 9 `🔗 viewbox repro` lines + full evidence bundles.
- [ ] N/A — not UI (no Playwright MCP design smoke; the tool drives the UI, it does not change it).

## Plan reference

Part of epic **#1266** (automated metamorphic consistency audit). Implements children **#1267** (C1 engine), **#1268** (C2 camera+capture), **#1269** (C3 sampler+loop+pacing), **#1270** (C4 catalog + MR-8 normalization), **#1271** (C5 brief generator), **#1272** (C6 agent+skill). Design: `.claude/skills/map-consistency-audit/DESIGN.md` (§5.1/§5.2 record the prod-driven relation corrections). Per repo convention, plans live in issues, not `docs/plans/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
