### PR TITLE
feat(map-consistency): MR-10 filtered render-completeness — catch the 'filter says N, shows M' bug (#1274)

### DIFF
--- a/.claude/skills/map-consistency-audit/DESIGN.md
+++ b/.claude/skills/map-consistency-audit/DESIGN.md
@@ -119,6 +119,13 @@ Each relation: definition, the comparison, tolerance, and carve-outs (conditions
 - **Since-window monotonicity:** at a fixed camera, `count(14d) ≥ count(7d) ≥ count(1d)` (windows are nested).
 - **Carve-out:** species/family codes with `null` joins are excluded from species-count lines by design — reconcile against the same filtered set the UI uses.
 
+### MR-10 — Filtered render-completeness (the "filter says N, only M render" catcher)
+*For each `?family=F` view, `Σ rendered marker totals ≈ view.network.total`.*
+- Filter by family F → the stated count (the server's F count at this camera = `view.network.total`) must be conserved by what RENDERS. Filtered to one family there is **no overflow tail** (every cluster is that family — a single-family cluster pills out with its full count), so `Σ marker totals == total F` when rendering is correct.
+- **Violation:** a shortfall beyond `max(2, round(stated·10%))` = the map dropped birds the filter counted — the reported "**filter says 7, only 3 render**" bug. Severity high; repro = the filtered `#map=` URL.
+- **Why it's needed:** MR-2b (render-completeness) runs ONLY on the **unfiltered** ladder; MR-4 compares filtered count NUMBERS against the unfiltered slice (legend-vs-legend), never `stated count vs Σ rendered markers`. The filtered "says N, shows M" scenario lives in that untested seam — MR-10 closes it.
+- **Carve-outs:** `inconclusive` filtered capture (capture failed — not a render verdict; MR-4 still reports the consistency miss separately); `stated == 0` (nothing to render — MR-4(a) covers the 0-vs-baseline case).
+
 ### MR-5 — Lede vs scope-total (conditional)
 *The lede equals the scope-wide total, not the viewport.*
 - Compare lede to the **scope-wide** network total, not the viewport sum. **Only** assert lede==viewport when `data-scope-fitted="true"` AND the camera ⊇ all scope data. Otherwise lede≠viewport is expected, not a bug.
@@ -146,6 +153,7 @@ Corrected relations (supersede the naive bullets above):
 - **MR-3 (server↔client family, aggregated-mode only):** in `mode:aggregated`, `legend[fam] ≈ network.familyCounts[fam]` (both common-name). Skipped in observations mode (no per-family network + code↔name mismatch). NO legend-vs-rendered.
 - **MR-5 (lede vs viewport):** `lede ≈ network.total` (viewport, not scope). `scopeTotal` dropped.
 - **MR-8 (directional pill-collapse — THE bug detector):** keep the legend-intersection; fire ONLY when `mobile renders F && desktop does NOT` (desktop under-rendering = the reported "desktop pills disappear, mobile splits out" bug). Suppress the reverse (desktop renders more = its larger 4×4 capacity — legit, was the 21 residual artifacts).
+- **MR-10 (filtered render-completeness — the "filter says N, only M render" catcher, #1274):** for each `?family=F` view, `Σ rendered marker totals ≈ view.network.total`. A real `--samples 6` run MISSED the reported "filter says 7, shows 3" bug because MR-2b runs only on the unfiltered ladder and MR-4 is legend-vs-legend — neither compares `stated count vs Σ rendered markers` on a filtered view. MR-10 closes that seam. Carve-outs: inconclusive capture, `stated == 0`. **Filter-capture hardening lands with it:** probe the **top-4** families (up from 2), distinguish a 200-but-EMPTY filtered response (a REAL "filter returned 0" signal — kept so MR-4/MR-10 flag it) from a fetch timeout (marked `inconclusive`, retried once), and bump `FILTER_BUNDLE_VIEWS` 6→8 (1 unfiltered + 4 family + 3 since) with the pacing-guard estimate.
 - **Unchanged:** MR-0, MR-1, MR-4, MR-6, MR-7. (MR-6 already caught a genuine prod CORS error on the national `zoom=3` prefetch — `No 'Access-Control-Allow-Origin'`, filed for independent follow-up.)
 
 ### 5.2 Two render modes — `cluster-pill` vs `adaptive-grid-marker` (THE actual bug surface)

--- a/.claude/skills/map-consistency-audit/SKILL.md
+++ b/.claude/skills/map-consistency-audit/SKILL.md
@@ -26,6 +26,7 @@ MR-0 drill-down conservation · MR-8 desktop↔mobile parity (headlines) ·
 MR-9 pill-split parity (desktop↔mobile cluster-split asymmetry — the reported bug) ·
 MR-1 zoom non-vanishing · MR-2 stated-vs-rendered · MR-2b render-completeness (low-total "says 7, shows 3") ·
 MR-3 per-family · MR-4 filter consistency + since-monotonicity ·
+MR-10 filtered render-completeness (the "filter says 7, shows 3" catcher) ·
 MR-5 lede-vs-viewport-total (conditional) · MR-6 clean console · MR-7 idempotence/intermittency.
 
 ## Carve-outs (do NOT flag these)

--- a/frontend/scripts/map-consistency/audit.ts
+++ b/frontend/scripts/map-consistency/audit.ts
@@ -17,7 +17,12 @@ interface Opts { samples: number; scope: string; seed: number; ladder: number[];
 const OBS_PER_VIEW = 2;
 const CF_SAFE_PER_MIN = 55; // margin under Cloudflare's 60/min/IP
 // C4 loop additions (paced like every other view):
-const FILTER_BUNDLE_VIEWS = 6; // 1 unfiltered + 2 family + 3 since (first sample only)
+// 1 unfiltered + 4 family (top-4 by unfiltered-legend count, #1274) + 3 since
+// (first sample only). NOTE: the at-most-one retry of a timed-out `?family=` capture
+// (#1274) is NOT counted here — it fires only on a transient miss, so the steady-state
+// projection stays at 8; an occasional retry is well within the CF margin.
+const FILTER_BUNDLE_VIEWS = 8; // 1 unfiltered + 4 family + 3 since (first sample only)
+const FILTER_TOP_FAMILIES = 4; // probe the top-4 families by unfiltered-legend count (#1274)
 const RECAPTURE_VIEWS_PER_SAMPLE = 1; // one extra capture of one camera per sample
 
 function parse(argv: string[]): Opts {
@@ -137,6 +142,25 @@ async function run(o: Opts): Promise<void> {
       }
     };
 
+    // Capture one `?family=` view, retrying ONCE on an inconclusive result (a
+    // transient matched-fetch timeout). A 200-but-EMPTY filtered response comes back
+    // NON-inconclusive (openView returns a real RawView with `emptyMatched`) — so it
+    // is KEPT as-is, never retried: that empty is a REAL "filter returned 0" signal
+    // MR-4/MR-10 must see, not a capture failure to paper over. Only an actual
+    // timeout (which throws → inconclusive snapshot) triggers the single retry. (#1274)
+    const captureFamilyWithRetry = async (
+      seed: { lng: number; lat: number },
+      zoom: number,
+      code: string,
+      persistStem: string,
+    ): Promise<ViewSnapshot> => {
+      const first = await capture(seed, zoom, 'desktop', { family: code }, persistStem);
+      if (!first.inconclusive) return first; // success (incl. a real 200-empty) — keep it
+      process.stderr.write(`  ↻ retrying family="${code}" filter capture once (first attempt: ${first.inconclusive.reason})\n`);
+      const second = await capture(seed, zoom, 'desktop', { family: code }, persistStem);
+      return second; // whatever the retry yields (success, 200-empty, or still inconclusive)
+    };
+
     const midZoom = o.ladder[Math.floor(o.ladder.length / 2)]!;
 
     // 2. For each sample, walk the ladder × viewports (paced).
@@ -151,20 +175,21 @@ async function run(o: Opts): Promise<void> {
         }
       }
 
-      // Filter bundle (first sample only): unfiltered + top-2 families + since 1d/7d/14d
-      // at a single mid-ladder desktop camera. MR-4 reconciles the variants. The
-      // legend gives common NAMES; the URL filter needs the family CODE (mapped via
-      // the seed fetch). Families with no resolvable code are skipped (can't filter).
+      // Filter bundle (first sample only): unfiltered + top-4 families (#1274) +
+      // since 1d/7d/14d at a single mid-ladder desktop camera. MR-4 reconciles the
+      // variants; MR-10 checks each filtered view's Σ rendered vs stated. The legend
+      // gives common NAMES; the URL filter needs the family CODE (mapped via the seed
+      // fetch). Families with no resolvable code are skipped (can't filter).
       let filterBundle: FilterBundle | undefined;
       if (s === 0) {
         const unfiltered = await capture(seed, midZoom, 'desktop', undefined, `${sampleId}-fb-unfiltered`);
-        const top2 = [...unfiltered.legend]
+        const top4 = [...unfiltered.legend]
           .sort((a, b) => b.count - a.count)
           .map((f) => ({ name: f.family, code: familyNameToCode.get(f.family) }))
           .filter((f): f is { name: string; code: string } => f.code != null)
-          .slice(0, 2);
+          .slice(0, FILTER_TOP_FAMILIES);
         const byFamily: FilterBundle['byFamily'] = [];
-        for (const { name, code } of top2) byFamily.push({ family: name, view: await capture(seed, midZoom, 'desktop', { family: code }, `${sampleId}-fb-family-${code}`) });
+        for (const { name, code } of top4) byFamily.push({ family: name, view: await captureFamilyWithRetry(seed, midZoom, code, `${sampleId}-fb-family-${code}`) });
         const bySince: FilterBundle['bySince'] = [];
         for (const since of ['1d', '7d', '14d'] as const) bySince.push({ since, view: await capture(seed, midZoom, 'desktop', { since }, `${sampleId}-fb-since-${since}`) });
         filterBundle = { unfiltered, byFamily, bySince };

--- a/frontend/scripts/map-consistency/camera.ts
+++ b/frontend/scripts/map-consistency/camera.ts
@@ -18,6 +18,14 @@ export interface RawView {
   responseBody: unknown;
   consoleErrors: string[];
   consoleWarnings: string[];
+  /** True when the matched `/api/observations` response arrived with a 200 but ZERO
+   *  results (no buckets / no data rows). This is a REAL "the filter returned 0"
+   *  signal — NOT a capture failure — so the caller must keep it (let MR-4/MR-10
+   *  flag it) rather than mark it `inconclusive`. A genuine fetch timeout throws from
+   *  `waitForMatchingObs` instead, which is the only path that becomes inconclusive.
+   *  Splitting the two is the #1274 filter-capture hardening: today an empty filter
+   *  result and a timeout look the same (the `Tyrant Flycatchers` empty snapshot). */
+  emptyMatched: boolean;
 }
 
 function buildUrl(baseUrl: string, p: OpenViewParams): string {
@@ -98,5 +106,22 @@ export async function openView(
   await page.waitForTimeout(opts?.settleMs ?? 2500); // let markers + legend re-render post-match
   const { bbox, zoom } = parseObsParams(response.url());
   const responseBody = await response.json().catch(() => null);
-  return { page, raw: { url, requestUrl: response.url(), requestBbox: bbox!, requestZoom: zoom!, responseBody, consoleErrors, consoleWarnings } };
+  // The matched fetch ARRIVED (a real 200) — classify whether its body is empty.
+  // A 200-but-empty filtered response is a genuine "filter returned 0" signal, not a
+  // capture failure: the caller keeps it (so MR-4/MR-10 can flag it) instead of
+  // marking it inconclusive (which is reserved for an actual fetch timeout/throw).
+  const emptyMatched = responseBodyIsEmpty(responseBody);
+  return { page, raw: { url, requestUrl: response.url(), requestBbox: bbox!, requestZoom: zoom!, responseBody, consoleErrors, consoleWarnings, emptyMatched } };
+}
+
+/** A matched /api/observations 200 body that carries no results — aggregated with no
+ *  buckets, or observations with no data rows. (A null/unparseable body is treated as
+ *  non-empty here: the matched fetch still arrived, so it's a parse anomaly, not a
+ *  zero-result filter — `normalizeNetwork` will surface it as `mode:'unknown'`.) */
+function responseBodyIsEmpty(body: unknown): boolean {
+  if (!body || typeof body !== 'object' || !('mode' in body)) return false;
+  const r = body as { mode?: string; buckets?: unknown[]; data?: unknown[] };
+  if (r.mode === 'aggregated') return (r.buckets?.length ?? 0) === 0;
+  if (r.mode === 'observations') return (r.data?.length ?? 0) === 0;
+  return false;
 }

--- a/frontend/scripts/map-consistency/relations.test.ts
+++ b/frontend/scripts/map-consistency/relations.test.ts
@@ -326,6 +326,54 @@ describe('MR-4 filter consistency', () => {
   });
 });
 
+describe('MR-10 filtered render-completeness (the "filter says N, only M render" catcher)', () => {
+  const baseUnfiltered = view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 100, points: [] }), legend: [{ family: 'Hawks', count: 60 }, { family: 'Falcons', count: 40 }], markers: [] });
+
+  it('fires when a filtered view renders fewer than the stated count (stated 7, rendered 3)', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [{ family: 'Hawks', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 3 }])] }) }],
+      bySince: [],
+    };
+    const f = fails(sampleOf(baseUnfiltered, { filterBundle: bundle }), 'MR-10');
+    expect(f).toHaveLength(1);
+    expect(f[0].severity).toBe('high');
+    expect(f[0].numbers).toMatchObject({ stated: 7, rendered: 3, delta: -4 });
+    expect(f[0].symptom).toContain('family="Hawks"');
+  });
+
+  it('passes when the filtered render conserves the stated count (stated 7, rendered 7)', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [{ family: 'Hawks', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 7, points: [] }), legend: [{ family: 'Hawks', count: 7 }], markers: [marker([{ family: 'Hawks', count: 7 }])] }) }],
+      bySince: [],
+    };
+    expect(fails(sampleOf(baseUnfiltered, { filterBundle: bundle }), 'MR-10')).toHaveLength(0);
+  });
+
+  it('skips an inconclusive filtered capture (the empty Tyrant-Flycatchers case stays MR-4-only, not a false render verdict)', () => {
+    const bundle: FilterBundle = {
+      unfiltered: baseUnfiltered,
+      byFamily: [{ family: 'Tyrant Flycatchers', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ bbox: BB, total: 0, points: [] }), markers: [], inconclusive: { reason: 'matched-fetch timeout' } }) }],
+      bySince: [],
+    };
+    expect(fails(sampleOf(baseUnfiltered, { filterBundle: bundle }), 'MR-10')).toHaveLength(0);
+  });
+
+  it('does NOT false-fire on a legitimately-pilled HIGH-count single family (stated 800, one pill of 800)', () => {
+    // The premise MR-10 rests on: filtered to one family, a dense cluster pills OUT
+    // with its FULL count (no overflow tail — every cluster is that one family). So a
+    // single `pill(800)` conserves the stated 800. This pins that a high-count pilled
+    // family PASSES — MR-10 must not confuse pill-collapse with render loss.
+    const bundle: FilterBundle = {
+      unfiltered: view({ viewport: 'desktop', requestedZoom: 7, network: net({ mode: 'aggregated', bbox: BB, total: 800, points: [] }), legend: [{ family: 'Gulls', count: 800 }], markers: [] }),
+      byFamily: [{ family: 'Gulls', view: view({ viewport: 'desktop', requestedZoom: 7, network: net({ mode: 'aggregated', bbox: BB, total: 800, points: [] }), legend: [{ family: 'Gulls', count: 800 }], markers: [pill(800)] }) }],
+      bySince: [],
+    };
+    expect(fails(sampleOf(baseUnfiltered, { filterBundle: bundle }), 'MR-10')).toHaveLength(0);
+  });
+});
+
 describe('MR-5 lede vs viewport total (#1270)', () => {
   it('flags lede materially off the viewport network total', () => {
     const v = view({ viewport: 'desktop', requestedZoom: 9, network: net({ bbox: BB, total: 1000, points: [] }), lede: { text: '500 sightings', firstInt: 500, unit: 'sightings' }, markers: [] });

--- a/frontend/scripts/map-consistency/relations.ts
+++ b/frontend/scripts/map-consistency/relations.ts
@@ -412,6 +412,44 @@ export function checkFilterConsistency(bundle: FilterBundle): Verdict[] {
   return verdicts;
 }
 
+// ── MR-10: filtered render-completeness ("filter says N, only M render") ───────
+/** The reported bug MR-2b/MR-4 structurally miss: filter by family F → the count
+ *  says N (e.g. 7) but only M < N markers render. MR-2b runs ONLY on the unfiltered
+ *  ladder; MR-4 compares filtered-count NUMBERS against the unfiltered slice
+ *  (legend-vs-legend), never `stated count vs Σ rendered markers`. This relation
+ *  closes that seam.
+ *
+ *  For each `?family=F` view, the STATED count (the server's F count at this camera =
+ *  `view.network.total`) must be conserved by what RENDERS. Filtered to one family
+ *  there is no overflow tail (every cluster is that family — a single-family cluster
+ *  pills out with its full count), so `Σ marker totals == total F` when rendering is
+ *  correct. A shortfall = the map dropped birds the filter counted — the reported
+ *  "says 7, shows 3" bug. Repro = the filtered `#map=` URL. */
+export function checkFilteredRenderCompleteness(bundle: FilterBundle): Verdict[] {
+  const verdicts: Verdict[] = [];
+  for (const { family, view } of bundle.byFamily) {
+    if (view.inconclusive) continue; // capture failed — not a render verdict
+    const stated = view.network.total;
+    if (stated === 0) continue; // nothing to render; MR-4(a) covers the 0-vs-baseline case
+    const rendered = renderedTotal(view);
+    const shortfall = stated - rendered;
+    const ok = shortfall <= Math.max(2, Math.round(stated * 0.1));
+    verdicts.push({
+      relation: 'MR-10',
+      status: ok ? 'pass' : 'fail',
+      sampleId: '',
+      severity: ok ? undefined : 'high',
+      symptom: ok
+        ? undefined
+        : `filter family="${family}": stated ${stated} sightings but only ${rendered} rendered on screen (lost ${shortfall})`,
+      numbers: { stated, rendered, delta: rendered - stated },
+      evidence: { kind: 'filtered-render-completeness', family, url: view.url },
+    });
+  }
+  if (verdicts.length === 0) verdicts.push({ relation: 'MR-10', status: 'pass', sampleId: '', evidence: { kind: 'no-filtered-views' } });
+  return verdicts;
+}
+
 // ── MR-5: lede vs VIEWPORT total (conditional) ────────────────────────────────
 /** The lede tracks the VIEWPORT total, NOT the scope (#1270 §5.1 — the earlier
  *  "lede is scope-total" reading was the two-stage-load interstitial). Compare
@@ -518,8 +556,11 @@ export function evaluateSample(sample: Sample): Verdict[] {
     out.push(...checkLedeVsScope(v));
   }
 
-  // MR-4 over the filter bundle (one per sample when captured).
-  if (sample.filterBundle) out.push(...checkFilterConsistency(sample.filterBundle));
+  // MR-4 + MR-10 over the filter bundle (one per sample when captured).
+  if (sample.filterBundle) {
+    out.push(...checkFilterConsistency(sample.filterBundle));
+    out.push(...checkFilteredRenderCompleteness(sample.filterBundle)); // MR-10
+  }
 
   // MR-7 over re-capture pairs.
   for (const rc of sample.recaptures ?? []) out.push(...checkIdempotence(rc));


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A["filtered view: ?family=F at #map= camera"] --> B["stated = view.network.total"]
    A --> C["rendered = sum of marker totals (pills + grid cells)"]
    B --> D{"shortfall beyond max(2, 10pct)?"}
    C --> D
    D -->|yes| E["MR-10 FAIL — filter says N, only M render"]
    D -->|no| F["pass"]
```

## Summary

- **Why:** the map-consistency audit (epic #1266, merged in #1273) had a blind spot for the reported *"filter by family F → the count says N but only M < N render visually"* bug. MR-2b (render-completeness) runs only on **unfiltered** views, and MR-4 compares filtered *count numbers*, never *stated-vs-rendered markers* — so a `--samples 6` run could not catch it (and the one family that would have exercised it, `Tyrant Flycatchers`, returned an empty filtered snapshot that was silently swallowed).
- **What:** adds **MR-10 — filtered render-completeness**: for each `?family=F` view, `Σ rendered marker totals ≈ view.network.total`; a shortfall *is* "says N, shows M" (high severity, with the filtered `#map=` viewbox URL as repro). Single-family views have no overflow tail, so a pilled cluster's full count is conserved — verified by a fixture (`pill(800)` → pass). Plus hardens the fragile filter capture: probe top-4 families (was 2), retry once on a matched-fetch timeout, and distinguish a real 200-but-empty filter result (kept, diagnosable) from a timeout (inconclusive).
- **It catches the bug:** the implementation smoke (`--samples 1 --seed 101 --zoom-ladder 8`) flagged two genuine instances — **Woodpeckers** stated 168 / rendered 148, and **Tyrant Flycatchers** stated 155 / rendered 136 — each with its filtered `#map=` repro. `Tyrant Flycatchers` (the family that returned empty before) now captures cleanly and is correctly flagged.

## Screenshots

N/A — not UI. Adds a metamorphic relation + capture hardening to the audit tool under `frontend/scripts/map-consistency/` plus its DESIGN/SKILL docs. No visible UI surface.

- [ ] N/A — not UI (no new/renamed `className`)
- [ ] N/A — not UI

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (**1779 passed / 96 files**); `relations` includes **45** tests with **4 new MR-10 fixtures**: fires (stated 7 / rendered 3 → high), passes when conserved (7/7), skips an `inconclusive` capture (no false-fire on the empty-filter case), and passes a legitimately-pilled high-count family (`pill(800)` → conserves — pins the single-family premise).
- [x] New unit tests added — `relations.test.ts` (MR-10 block).
- [x] `npm run build` — clean (files live under `frontend/scripts/`, outside `tsc -b`'s `include:["src"]` and the Playwright `testDir:'e2e'`; the `build`/`e2e` gates are unaffected).
- [x] Live prod smoke — the hardened filter bundle captured top-4 families with no spurious empty snapshot (the retry recovered two timed-out families into real data), and MR-10 caught two real "stated > rendered" families with filtered `#map=` repros.
- [ ] N/A — not UI (no Playwright MCP design smoke).

## Plan reference

Implements **#1274** (bot-approved at the issue stage). Extends the audit tool from epic #1266 / PR #1273. Design: `.claude/skills/map-consistency-audit/DESIGN.md` §5 (MR-10 catalog entry).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
