### PR TITLE
fix(read-api): emit ACAO on no-Origin requests to stop edge cache poisoning (#1278)

### DIFF
--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1557,4 +1557,101 @@ describe('CORS middleware', () => {
     expect(res.headers.get('cache-control'))
       .toBe('public, max-age=604800');
   });
+
+  // #1278 — no-Origin cache poisoning. The cache-warm cron, uptime probes, and
+  // `curl` fetch the canonical `/api/observations` URLs with NO Origin header.
+  // Before the fix, Hono's cors set no ACAO on that path, so Cloudflare cached
+  // a header-less body under the `Vary: Origin` "(absent)" slot and (with
+  // tiered-cache variant collapse) served it to real browsers → intermittent
+  // CORS error on the national prefetch. The fix emits ACAO for the canonical
+  // origin whenever the request has no Origin header, so the warm-seeded cache
+  // entry is never header-less.
+  it('sets Access-Control-Allow-Origin to the canonical origin on a no-Origin request (#1278)', async () => {
+    delete process.env.FRONTEND_ORIGINS; // canonical = https://bird-maps.com
+    const app = createApp({ pool: db.pool });
+    // No Origin header — exactly what run-cache-warm.ts and probes send.
+    const res = await app.request('/api/hotspots');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin'))
+      .toBe('https://bird-maps.com');
+  });
+
+  it('keeps Access-Control-Allow-Origin on a no-Origin 503 from app.onError (#1278)', async () => {
+    delete process.env.FRONTEND_ORIGINS;
+    // A pool whose query rejects with a connection error → app.onError → 503.
+    // The CORS middleware runs before route handlers, so ACAO is set on the
+    // pre-next pass and must survive the error-path response. A cron-warmed
+    // 503/5xx that lacks ACAO is the worst poison — it both fails AND is
+    // cacheable on the stale-while-revalidate window.
+    const failingPool = {
+      query: () => Promise.reject(Object.assign(new Error('connection terminated'), { code: 'ECONNREFUSED' })),
+    } as unknown as Pool;
+    const app = createApp({ pool: failingPool });
+    const res = await app.request('/api/hotspots'); // no Origin header
+    expect(res.status).toBe(503);
+    expect(res.headers.get('access-control-allow-origin'))
+      .toBe('https://bird-maps.com');
+  });
+
+  it('keeps Access-Control-Allow-Origin on an allow-listed-Origin 503 (#1278)', async () => {
+    delete process.env.FRONTEND_ORIGINS;
+    const failingPool = {
+      query: () => Promise.reject(Object.assign(new Error('connection terminated'), { code: 'ECONNREFUSED' })),
+    } as unknown as Pool;
+    const app = createApp({ pool: failingPool });
+    const res = await app.request('/api/hotspots', {
+      headers: { Origin: 'https://bird-maps.com' },
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('access-control-allow-origin'))
+      .toBe('https://bird-maps.com');
+  });
+
+  it('keeps Access-Control-Allow-Origin on a 429 rate-limit response (#1278)', async () => {
+    // Lock in the origin guarantee on the rate-limit short-circuit path so a
+    // future refactor can't silently move CORS after the rate-limiter. CORS is
+    // registered before rateLimitFromEnv, so the 429 (built downstream) still
+    // carries the ACAO set on the cors pre-next pass.
+    const savedOrigins = process.env.FRONTEND_ORIGINS;
+    const savedEnabled = process.env.RATE_LIMIT_ENABLED;
+    const savedBurst = process.env.READ_API_RATE_BURST;
+    const savedRefill = process.env.READ_API_RATE_REFILL_PER_SEC;
+    delete process.env.FRONTEND_ORIGINS;
+    process.env.RATE_LIMIT_ENABLED = 'true';
+    process.env.READ_API_RATE_BURST = '1';
+    process.env.READ_API_RATE_REFILL_PER_SEC = '0';
+    try {
+      const app = createApp({ pool: db.pool });
+      const headers = { Origin: 'https://bird-maps.com' };
+      // First request consumes the single burst token (200).
+      const ok = await app.request('/api/hotspots', { headers });
+      expect(ok.status).toBe(200);
+      // Second request is rate-limited.
+      const limited = await app.request('/api/hotspots', { headers });
+      expect(limited.status).toBe(429);
+      expect(limited.headers.get('access-control-allow-origin'))
+        .toBe('https://bird-maps.com');
+    } finally {
+      if (savedOrigins === undefined) delete process.env.FRONTEND_ORIGINS;
+      else process.env.FRONTEND_ORIGINS = savedOrigins;
+      if (savedEnabled === undefined) delete process.env.RATE_LIMIT_ENABLED;
+      else process.env.RATE_LIMIT_ENABLED = savedEnabled;
+      if (savedBurst === undefined) delete process.env.READ_API_RATE_BURST;
+      else process.env.READ_API_RATE_BURST = savedBurst;
+      if (savedRefill === undefined) delete process.env.READ_API_RATE_REFILL_PER_SEC;
+      else process.env.READ_API_RATE_REFILL_PER_SEC = savedRefill;
+    }
+  });
+
+  it('still omits Access-Control-Allow-Origin for a present-but-disallowed origin (#1278)', async () => {
+    // The no-Origin fix must not weaken the disallowed-origin guarantee: a
+    // browser sending a non-allow-listed Origin still gets no ACAO so the
+    // browser blocks the cross-origin read.
+    delete process.env.FRONTEND_ORIGINS;
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/hotspots', {
+      headers: { Origin: 'https://evil.example' },
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
 });

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -49,14 +49,37 @@ export function createApp(deps: AppDeps): Hono {
   // /api/species/:code (no `immutable` — see cache-headers.ts comment): Hono
   // sets `Vary: Origin`, so a spec-compliant CDN keys the cache per-Origin.
   // That means the identical JSON body is stored N× for N allowed origins
-  // (currently 3 — trivial). Uptime probes and plain `curl` hit these routes
-  // without an Origin header, so the CDN also caches a no-ACAO entry;
-  // browsers never see that entry because Cloud CDN honors Vary. The cached
-  // bodies contain no Origin-derived data, so serving any cached entry across
-  // origins would still be correct — `Vary: Origin` is purely for header
-  // correctness.
+  // (currently 3 — trivial).
+  //
+  // #1278 — no-Origin cache poisoning. Uptime probes, plain `curl`, AND the
+  // cache-warm cron (services/ingestor/src/commands/run-cache-warm.ts fetches
+  // the warmed `/api/observations?...&zoom=3` CONUS URL with NO Origin header)
+  // hit these routes without an Origin header. With a plain array `origin`,
+  // Hono's cors resolves `findAllowOrigin("")` → null and sets NO
+  // Access-Control-Allow-Origin, but STILL emits `Vary: Origin`. Cloudflare
+  // (with tiered cache) then stores that header-less body under the
+  // `Vary: Origin` "(absent)" slot for the byte-identical canonical URL the
+  // browser later requests — and a tier that collapses the empty-Origin
+  // variant serves the no-ACAO body to a real browser, producing the
+  // intermittent CORS error on the national prefetch.
+  //
+  // Fix: resolve the origin via a function so a request with NO Origin header
+  // (empty string) still yields ACAO for the canonical primary origin. The
+  // warm/probe-seeded cache entry is therefore no longer header-less, so even
+  // a Vary-variant collapse serves a body carrying a valid ACAO. An
+  // allow-listed browser Origin is still echoed exactly (unchanged); a
+  // present-but-disallowed Origin still gets no ACAO (browser blocks it,
+  // unchanged). Bodies are Origin-agnostic, so emitting the canonical ACAO on
+  // the no-Origin path is correct, not a leak.
+  const canonicalOrigin = origins[0] ?? 'https://bird-maps.com';
   app.use('*', cors({
-    origin: origins,
+    origin: (origin) => {
+      // No Origin header (cron warm / uptime probe / curl): emit ACAO for the
+      // canonical origin so the cacheable response is never header-less.
+      if (!origin) return canonicalOrigin;
+      // Present Origin: echo it only if allow-listed (else null → no ACAO).
+      return origins.includes(origin) ? origin : null;
+    },
     allowMethods: ['GET'],
     maxAge: 86400,
   }));


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    subgraph warm[Cache-warm cron / uptime probe / curl]
      W["GET /api/observations?...zoom=3<br/>NO Origin header"]
    end
    subgraph browser[Real browser]
      B["GET same canonical URL<br/>Origin: https://bird-maps.com"]
    end

    W --> O[read-api Hono origin]
    B --> CF

    O -- before fix --> X["cors origin=array:<br/>findAllowOrigin('') = null<br/>NO ACAO, but Vary: Origin set"]
    O -- after fix --> Y["cors origin=fn:<br/>empty Origin returns canonical<br/>ACAO: https://bird-maps.com"]

    X --> CF[Cloudflare edge cache + tiered cache]
    Y --> CF

    CF -- before fix --> P["Vary:Origin '(absent)' slot<br/>caches header-less body;<br/>variant collapse serves it to B<br/>=> intermittent CORS error"]
    CF -- after fix --> G["warmed entry carries ACAO;<br/>even on variant collapse B gets<br/>a body with a valid ACAO => OK"]
```

## Summary

- **Why:** the national `zoom=3` CONUS `/api/observations` prefetch intermittently failed with a browser CORS error. Per the RCA on #1278, this is an **edge** problem: the cache-warm cron (`run-cache-warm.ts`), uptime probes, and `curl` fetch the warmed canonical URLs with **no `Origin` header**. Hono's `cors` resolved that empty Origin to `null`, emitting no `Access-Control-Allow-Origin` while still setting `Vary: Origin`. Cloudflare cached that header-less body under the `Vary: Origin` "(absent)" slot, and tiered-cache variant collapse served it to a real browser.
- **What:** resolve the CORS `origin` via a function so a request with no Origin header still yields ACAO for the canonical primary origin (`origins[0]`, i.e. `https://bird-maps.com`). The warm/probe-seeded cache entry is no longer header-less. Allow-listed browser Origins are still echoed exactly; a present-but-disallowed Origin still gets no ACAO. Bodies are Origin-agnostic, so the canonical ACAO on the no-Origin path is correct, not a leak.
- **Test gap closed:** adds the `app.test.ts` cases the RCA called for — ACAO on the no-Origin 200 path, on a no-Origin 503 (`app.onError`) and an allow-listed 503, and on a 429 rate-limit response — locking in that CORS runs before the rate-limit/error handlers so a future refactor can't silently drop the header.

**Follow-up (not in this PR):** the complementary Cloudflare-infra fix — set ACAO at the edge and/or drop `Vary: Origin` on `/api/*` (a `http_response_headers_transform` rule sibling to `cache-rule.tf`) — would structurally eliminate the per-Origin cache namespace and the no-Origin-variant poisoning. That is deferred because `terraform apply` is IAM-blocked (#298). This origin-side fix needs no infra change and lands now.

## Screenshots

N/A — not UI

## Test plan

- [x] `npm run test --workspace @bird-watch/read-api` — green (186 passed, incl. 5 new #1278 CORS cases)
- [x] New unit / integration tests added (5 cases: no-Origin 200, no-Origin 503, allow-listed 503, 429, disallowed-origin still blocked)
- [x] Verified load-bearing: reverting `app.ts` fails the two no-Origin cases (200 + 503); the fix is what makes them pass
- [x] `npm run build --workspace @bird-watch/read-api` — clean
- [x] `npm run lint` — clean across all workspaces
- [x] N/A — Playwright MCP smoke (not a UI change; no `frontend/**` files touched)

## Plan reference

Out of plan — bug fix for #1278 (national `zoom=3` prefetch CORS-blocked by no-Origin cron-warm edge cache poisoning).

Fixes #1278

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
