### PR TITLE
fix(frontend): conserve deconflict group count across all members (#1277)

### DIFF
--- a/frontend/src/components/map/geometry/deconflict.test.ts
+++ b/frontend/src/components/map/geometry/deconflict.test.ts
@@ -168,6 +168,68 @@ describe('deconflict', () => {
     expect(buildGroups([], 8)).toEqual([]);
   });
 
+  // ---- renderedTotal conservation (issue #1277) ----
+  //
+  // buildGroups renders ONE marker per overlap component (the anchor). The
+  // badge must reflect EVERY cluster the Union-Find absorbed, not just the
+  // anchor's point_count — otherwise a single-family filtered view silently
+  // drops the non-anchor members' counts (`Σ rendered < stated`).
+
+  // Test 13
+  it('renderedTotal sums ALL member point_counts, not just the anchor (#1277)', () => {
+    // Two single-family clusters overlap at z8: anchor 32 + nearby 12 = 44.
+    // The deconflict layer renders only the anchor marker — its badge must
+    // carry the full 44, not the anchor's 32.
+    const A = cluster(1, 100, 100, grid4x4, /* count */ 32);
+    const B = cluster(2, 110, 100, grid2x2, /* count */ 12);
+    const groups = buildGroups([A, B], 8);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].anchor.cluster_id).toBe(1);
+    expect(groups[0].anchor.point_count).toBe(32); // anchor unchanged
+    expect(groups[0].renderedTotal).toBe(44); // conserved group total
+  });
+
+  // Test 13b
+  it('renderedTotal of a solo group equals the anchor point_count (no merge → no change)', () => {
+    const A = cluster(1, 0, 0, grid4x4, /* count */ 17);
+    const B = cluster(2, 1000, 0, grid4x4, /* count */ 9); // far away, no overlap
+    const groups = buildGroups([A, B], 8);
+    expect(groups).toHaveLength(2);
+    for (const g of groups) {
+      expect(g.renderedTotal).toBe(g.anchor.point_count);
+    }
+  });
+
+  // Test 13c — the conservation invariant the RCA prescribes for the audit
+  it('Σ renderedTotal === Σ input point_count for clustered (non-silhouette) inputs (#1277)', () => {
+    // A 3-cluster chain (one merged component) + one isolated cluster.
+    const inputs = [
+      cluster(1, 100, 100, grid4x4, 32),
+      cluster(2, 110, 100, grid2x2, 12),
+      cluster(3, 120, 100, grid2x2, 8),
+      cluster(4, 1000, 100, grid4x4, 50),
+    ];
+    const groups = buildGroups(inputs, 8);
+    const sumRendered = groups.reduce((s, g) => s + g.renderedTotal, 0);
+    const sumInput = inputs.reduce((s, c) => s + c.point_count, 0);
+    expect(sumRendered).toBe(sumInput); // 32+12+8+50 = 102, conserved
+  });
+
+  // Test 13d — silhouettes are EXCLUDED so the badge doesn't double-count the
+  // separately-painted (displaced) silhouette symbol.
+  it('renderedTotal excludes silhouette members (they paint their own symbol)', () => {
+    const anchor = cluster(1, 100, 100, grid4x4, /* count */ 32, /* uniqueFamilies */ 16);
+    const sil: DeconflictInput = {
+      cluster_id: -100, px: 105, py: 100, rendered: { kind: 'silhouette' },
+      point_count: 1, uniqueFamilies: 1, longitude: 0, latitude: 0, subId: 'OBS-AAA',
+    };
+    const groups = buildGroups([anchor, sil], 8);
+    expect(groups).toHaveLength(1);
+    // Only the cluster's 32 counts toward the badge; the silhouette renders
+    // its own (displaced) marker, so adding its point_count would double-count.
+    expect(groups[0].renderedTotal).toBe(32);
+  });
+
   // ---- supporting unit tests for the primitives (intersect, aabbForShape, unionFind, bucketKey) ----
 
   it('aabbForShape — grid centered at (100, 100) for 4×4 → 50px half-extent each way', () => {

--- a/frontend/src/components/map/geometry/deconflict.ts
+++ b/frontend/src/components/map/geometry/deconflict.ts
@@ -105,6 +105,20 @@ export interface DeconflictInput {
 export interface DeconflictGroup {
   /** The anchor cluster (the one whose marker actually renders). */
   anchor: DeconflictInput;
+  /**
+   * Sum of `point_count` over EVERY non-silhouette member of the group — not
+   * just the anchor (issue #1277). `buildGroups` renders one marker per overlap
+   * component (the anchor), so a naïve `anchor.point_count` badge silently drops
+   * the counts of every other cluster the Union-Find absorbed into this group.
+   * The render layer reads `renderedTotal` for the badge so a filtered view
+   * conserves its count: `Σ groups.renderedTotal === Σ inputs.point_count` over
+   * all clustered (non-silhouette) inputs.
+   *
+   * Silhouettes are EXCLUDED from this sum: each silhouette paints its own
+   * symbol (displaced, never suppressed — see `displaceSilhouettes`), so folding
+   * its `point_count` (always 1) into the anchor badge would double-count it.
+   */
+  renderedTotal: number;
   /** Real cluster_ids of every group member (1 if solo, 2+ if merged). */
   memberIds: number[];
   /** Stable React key derived from anchor's spatial bucket. */
@@ -300,11 +314,20 @@ export function buildGroups(
     }) as DeconflictInput;
     const others = members.filter((m): m is DeconflictInput => m.cluster_id !== anchor.cluster_id);
     const memberIds = members.map((m) => m.cluster_id).sort((a, b) => a - b);
+    // Conserve the count (issue #1277): the rendered marker is one anchor, but
+    // its badge must reflect EVERY cluster the component absorbed. Sum over
+    // non-silhouette members only — silhouettes render their own (displaced)
+    // symbol, so including their point_count here would double-count them.
+    const renderedTotal = members.reduce(
+      (sum, m) => (m.rendered.kind === 'silhouette' ? sum : sum + m.point_count),
+      0,
+    );
     const leaves = members
       .filter((m) => m.longitude !== undefined && m.latitude !== undefined)
       .map((m) => ({ lng: m.longitude as number, lat: m.latitude as number }));
     groups.push({
       anchor,
+      renderedTotal,
       memberIds,
       key: bucketKey(anchor.px, anchor.py, zoom, BUCKET_PX),
       ariaLabel: ariaLabelFor(anchor, others),

--- a/frontend/src/components/map/layers/GroupMarkerLayer.test.tsx
+++ b/frontend/src/components/map/layers/GroupMarkerLayer.test.tsx
@@ -30,11 +30,12 @@ vi.mock('react-map-gl/maplibre', () => ({
 
 vi.mock('./AdaptiveGridMarker.js', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AdaptiveGridMarker: ({ onClick, onDrillIn, onSelectSpecies, ariaLabel }: any) => (
+  AdaptiveGridMarker: ({ onClick, onDrillIn, onSelectSpecies, ariaLabel, totalCount }: any) => (
     <button
       type="button"
       data-testid="mock-grid-marker"
       data-aria={ariaLabel}
+      data-total={totalCount}
       data-has-drill={onDrillIn ? 'yes' : 'no'}
       data-has-select={onSelectSpecies ? 'yes' : 'no'}
       onClick={onClick}
@@ -76,8 +77,12 @@ function group(
   rendered: RenderedShape,
   over: Partial<DeconflictInput> = {},
 ): DeconflictGroup {
+  const anchor = input(rendered, over);
   return {
-    anchor: input(rendered, over),
+    anchor,
+    // Solo-group default: renderedTotal mirrors the anchor's count (#1277).
+    // Override per-test to exercise the merged-group conservation path.
+    renderedTotal: over.point_count ?? anchor.point_count,
     memberIds: [1],
     key,
     ariaLabel: `aria-${key}`,
@@ -155,6 +160,36 @@ describe('GroupMarkerLayer', () => {
     expect(screen.getAllByTestId('mock-grid-marker')).toHaveLength(1);
     // pill + grid render markers; silhouette renders none → 2 markers total.
     expect(screen.getAllByTestId('mock-marker')).toHaveLength(2);
+  });
+
+  it('pill badge reads g.renderedTotal — conserves merged member counts, not just the anchor (#1277)', () => {
+    // Anchor point_count is 32 but the deconflict group absorbed nearby
+    // clusters → renderedTotal 44. The pill badge must show 44.
+    const g = group('g-merged-pill', { kind: 'pill', count: 32 }, { point_count: 32 });
+    render(
+      <GroupMarkerLayer
+        groups={[{ ...g, renderedTotal: 44, memberIds: [1, 2] }]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.getByTestId('mock-cluster-pill')).toHaveAttribute('data-count', '44');
+  });
+
+  it('grid marker totalCount reads g.renderedTotal — conserves merged member counts (#1277)', () => {
+    const g = group('g-merged-grid', { kind: 'grid', shape: GRID_1x1 }, { point_count: 32 });
+    render(
+      <GroupMarkerLayer
+        groups={[{ ...g, renderedTotal: 51, memberIds: [1, 2] }]}
+        isCoarsePointer={false}
+        detailOpen={false}
+        onGroupClick={noop}
+        onDrillIn={noop}
+      />,
+    );
+    expect(screen.getByTestId('mock-grid-marker')).toHaveAttribute('data-total', '51');
   });
 
   it('keys each marker on g.key — stable identity under re-render (#552 churn class)', () => {

--- a/frontend/src/components/map/layers/GroupMarkerLayer.tsx
+++ b/frontend/src/components/map/layers/GroupMarkerLayer.tsx
@@ -56,7 +56,12 @@ export function GroupMarkerLayer({
               anchor="center"
             >
               <ClusterPill
-                count={anchor.point_count}
+                // #1277: the pill badge reflects EVERY cluster the deconflict
+                // group absorbed, not just the anchor — otherwise a filtered
+                // view drops the non-anchor members' counts. For a solo group
+                // `renderedTotal === anchor.point_count`, so unmerged pills are
+                // unchanged.
+                count={g.renderedTotal}
                 onClick={(e) => onGroupClick(g, e.currentTarget)}
               />
             </PresentationMarker>
@@ -79,7 +84,10 @@ export function GroupMarkerLayer({
             <AdaptiveGridMarker
               shape={anchor.rendered.shape}
               tiles={anchor.tiles ?? []}
-              totalCount={anchor.point_count}
+              // #1277: conserve the group's full count — sum of every absorbed
+              // cluster, not just the anchor. For a solo group this equals
+              // `anchor.point_count`, so unmerged grid markers are unchanged.
+              totalCount={g.renderedTotal}
               uniqueFamilies={anchor.uniqueFamilies}
               ariaLabel={g.ariaLabel}
               isCoarsePointer={isCoarsePointer}


### PR DESCRIPTION
Fixes #1277

## Diagrams

How the deconflict layer dropped non-anchor counts, and where `renderedTotal` restores them:

```mermaid
flowchart TD
    subgraph before["Before — count lost"]
        I1["inputs: cluster A (32) + cluster B (12)<br/>overlap in pixel space"] --> BG1["buildGroups: Union-Find<br/>→ one component, anchor = A (min id)"]
        BG1 --> R1["GroupMarkerLayer<br/>badge = anchor.point_count = 32"]
        R1 --> X1["rendered 32 &lt; stated 44<br/>B's 12 vanishes (MR-10 fires)"]
    end

    subgraph after["After — count conserved"]
        I2["inputs: cluster A (32) + cluster B (12)"] --> BG2["buildGroups<br/>renderedTotal = Σ non-silhouette members<br/>= 32 + 12 = 44"]
        BG2 --> R2["GroupMarkerLayer<br/>badge = g.renderedTotal = 44"]
        R2 --> OK2["Σ groups.renderedTotal == Σ inputs.point_count<br/>filtered view conserves its count"]
    end
```

## Summary

- **Why:** `buildGroups` Union-Finds nearby overlapping clusters into one component and renders only the anchor (`min(cluster_id)`). The marker badge read `anchor.point_count`, so every non-anchor member's count silently vanished — a single-family filtered view then rendered fewer observations than the server stated (`Σ rendered < stated`), the exact shortfall the map-consistency audit's MR-10 flags (woodpeckers lost 20, tyrant flycatchers lost 19).
- **What:** Add `DeconflictGroup.renderedTotal` = Σ `point_count` over every **non-silhouette** member, computed in `buildGroups`, and read it for the badge in `GroupMarkerLayer` (`ClusterPill count` + `AdaptiveGridMarker totalCount`). Silhouettes are excluded because each paints its own displaced symbol — folding their `point_count` into the anchor would double-count. For a solo (unmerged) group `renderedTotal === anchor.point_count`, so unmerged markers are byte-unchanged.
- **Invariant:** the deconflict layer now conserves the count by construction — `Σ groups.renderedTotal === Σ inputs.point_count` over clustered inputs (RCA option 1, the most faithful fix).

## Screenshots

**Count-correctness fix with no layout/visual change.** The deconflict-merged marker badge now sums all members' counts (was: anchor-only). No `className`/style/layout change — the only on-screen difference is a *corrected number* on markers where 2+ clusters overlap within the deconflict radius.

Verified:
- **48/48 deconflict unit tests pass** (`deconflict.test.ts`), incl. the conservation locks (32+12 → 44; 3-cluster chain conserves; displaced silhouettes don't double-count).
- **Live no-regression** (chrome-devtools MCP, `?family=picidae` z8 Montana repro): the filtered view renders the identical marker set as prod (138 markers) — the fix changes only the merged-badge *count*, never which markers render or their layout.

> Note: the audit's MR-10 picidae symptom (stated 163 / rendered 138) is **not** this bug — that's the lede counting the snapped fetch-bbox vs the viewport, filed separately as #1283. This PR fixes the genuine deconflict-merge under-count (dense-overlap case).

- [x] No new/renamed `className` in this PR (logic + badge wiring only)
- [x] Multi-viewport design QA — N/A for a non-layout count fix; verified by 48/48 unit tests + live no-regression above ([#1283](https://github.com/julianken/bird-sight-system/issues/1283) tracks the separate lede/viewport confound).

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (96 files, 1785 tests) after building `@bird-watch/shared-types` (a pre-existing env quirk: the unbuilt `dist/` made two unrelated suites — `App.seed.test.ts`, `url-state.test.ts` — fail to resolve `@bird-watch/shared-types`; both pass once built and neither touches deconflict)
- [x] New unit tests added: 4 in `deconflict.test.ts` (merged-group sum, solo-group equivalence, Σ-conservation invariant, silhouette exclusion) + 2 in `GroupMarkerLayer.test.tsx` (pill + grid badge read `renderedTotal`)
- [ ] New Playwright e2e spec — N/A; MR-10 in the map-consistency audit already guards this seam, and the unit-level conservation invariant pins the root cause
- [x] `npm run build -w @bird-watch/frontend` — clean production build (tsc + vite)
- [ ] (UI only) Playwright MCP smoke — pending orchestrator (subagents cannot drive MCP)

## Plan reference

Out of plan — bug fix for #1277 (RCA-driven; deconflict anchor-drop count loss). MR-10 audit lineage: epic #1266, PR #1273.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

