### PR TITLE
fix(frontend): seed the observations fetch from the restored hash camera so deep-linked high-zoom views load markers (#1289)

### DIFF
--- a/frontend/e2e/scope/viewbox-restore.spec.ts
+++ b/frontend/e2e/scope/viewbox-restore.spec.ts
@@ -164,4 +164,118 @@ test.describe('viewbox-restore on cold load (#1242)', () => {
     // No hash ⇒ no restore handle.
     await expect(app.mapCanvas).not.toHaveAttribute('data-hash-camera', /.*/);
   });
+
+  // #1289 — REGRESSION GUARD. The original viewbox-restore tests above assert
+  // ONLY the camera (`data-hash-camera`) + hash survival — never that the
+  // observations FETCH moved off the CONUS z3 seed to the restored viewport.
+  // That blind spot let the deep-link "zero markers at high zoom" bug ship: the
+  // camera restored but the fetch stayed pinned to the z3 seed (its settle idle
+  // swallowed by App's scope-move window), so the restored high-zoom rectangle —
+  // which shares no rows/cells with the z3 national aggregate — rendered empty.
+  //
+  // This test asserts the FETCH directly: a high-zoom `#map=` restore must fire
+  // an `/api/observations` request at zoom >= 6 with a bbox ENCLOSING the
+  // restored center. A marker-presence check follows, WebGL-guarded with
+  // `test.skip` (per the repo convention — full marker render needs a GPU the
+  // headless CI runner may lack; the fetch assertion is the GPU-free proof).
+  test('#1289: a high-zoom #map= restore fires the observations fetch at the restored viewport (not the z3 seed)', async ({
+    page,
+    apiStub,
+  }) => {
+    // A tiny high-zoom (z16) rectangle around Tucson, AZ — INSIDE the AZ scope
+    // envelope, so the restore validates + applies. The AZ_OBS fixture point
+    // (-110.974, 32.221) sits inside this rectangle, so the restored-viewport
+    // fetch is non-empty (and, with a GPU, paints a marker).
+    const HIGH_ZOOM_HASH = 'map=16.000/32.22100/-110.97400';
+    // The restored center, in the 2-decimal CANONICAL bbox space (#868/#873 —
+    // App/client quantize the bbox to ~2dp so the CF cache key collapses). A z16
+    // rectangle this tight collapses to a near-degenerate rounded bbox around the
+    // center, so the enclosure check is done at this rounded resolution: the
+    // restored fetch must be the tiny Tucson rectangle, NOT the CONUS z3 seed.
+    const RESTORED_CENTER = { lng: -110.97, lat: 32.22 };
+    const ENCLOSE_EPS = 0.02; // tolerate the 2dp canonical rounding either way
+
+    // Capture every /api/observations request URL BEFORE the stubs register, so
+    // we can inspect the {bbox, zoom} each fetch carried.
+    const obsRequests: Array<{ bbox: number[] | null; zoom: number | null }> = [];
+    page.on('request', req => {
+      const u = new URL(req.url());
+      if (!u.pathname.endsWith('/api/observations')) return;
+      const bboxParam = u.searchParams.get('bbox');
+      const zoomParam = u.searchParams.get('zoom');
+      obsRequests.push({
+        bbox: bboxParam ? bboxParam.split(',').map(Number) : null,
+        zoom: zoomParam !== null ? Number(zoomParam) : null,
+      });
+    });
+
+    const { app } = await setup(page, apiStub);
+    await app.gotoRaw(`state=US-AZ#${HIGH_ZOOM_HASH}`);
+
+    // The camera restores to the high-zoom hash view (the existing seam).
+    await expect(app.mapCanvas).toHaveAttribute(
+      'data-hash-camera',
+      '16.000/32.22100/-110.97400',
+      { timeout: 10_000 },
+    );
+    await app.waitForAppReady();
+
+    // THE FIX: at least one /api/observations fetch must carry zoom >= 6 (the
+    // per-observation path — the restored high-zoom view) AND a bbox enclosing
+    // the restored center. Pre-fix, the ONLY fetch is the z3 CONUS seed
+    // (zoom=3, bbox=-130,20,-65,52 — which does enclose the center but is the
+    // WRONG aggregated-mode read), and NO zoom>=6 fetch ever fires → empty map.
+    await expect
+      .poll(
+        () =>
+          obsRequests.some(
+            r =>
+              r.zoom !== null &&
+              r.zoom >= 6 &&
+              r.bbox !== null &&
+              r.bbox.length === 4 &&
+              // The (canonically-rounded) bbox brackets the restored center
+              // within the 2dp rounding tolerance — i.e. it is the tiny Tucson
+              // rectangle, decisively NOT the CONUS z3 seed (-130..-65).
+              r.bbox[0] <= RESTORED_CENTER.lng + ENCLOSE_EPS &&
+              r.bbox[2] >= RESTORED_CENTER.lng - ENCLOSE_EPS &&
+              r.bbox[1] <= RESTORED_CENTER.lat + ENCLOSE_EPS &&
+              r.bbox[3] >= RESTORED_CENTER.lat - ENCLOSE_EPS &&
+              // And the bbox is SMALL (a high-zoom viewport), not the wide seed:
+              // lng span well under the aggregated-seed CONUS span (65°).
+              r.bbox[2] - r.bbox[0] < 1,
+          ),
+        {
+          timeout: 10_000,
+          message:
+            'expected an /api/observations fetch at zoom>=6 with a small bbox enclosing the restored center',
+        },
+      )
+      .toBe(true);
+
+    // A redundant CONUS z3 seed fetch firing first is ACCEPTABLE (heavily
+    // CF-cached) — we only require that the restored-viewport fetch ALSO fires.
+    // Sanity-check the seed did fire (proves the assertion above is the FIX, not
+    // the seed being mistaken for it).
+    expect(obsRequests.some(r => r.zoom === 3)).toBe(true);
+
+    // Secondary: markers should render at the restored view. GPU-dependent, so
+    // skip (don't fail) when no marker paints — the headless CI runner may lack
+    // WebGL. The fetch assertion above is the load-bearing, GPU-free proof.
+    const marker = page
+      .locator('[data-testid="adaptive-grid-marker"], .cluster-pill')
+      .first();
+    const markerVisible = await marker
+      .waitFor({ state: 'visible', timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!markerVisible) {
+      test.skip(
+        true,
+        'No marker painted — likely WebGL unavailable in headless run (fetch assertion already proved the fix)',
+      );
+      return;
+    }
+    await expect(marker).toBeVisible();
+  });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -111,6 +111,13 @@ const {
     flyTo: undefined as
       | { center: [number, number]; zoom: number; key: string }
       | undefined,
+    // #1289: the restored-hash-camera fetch-seed callback. App passes this to
+    // MapSurface→MapCanvas; MapCanvas invokes it (with the live restored bounds +
+    // zoom) once the `#map=` hash camera is applied, so the data layer seeds the
+    // observations fetch from the restored viewport instead of the CONUS z3 seed.
+    onHashCameraRestored: null as
+      | ((bounds: unknown, zoom: number) => void)
+      | null,
     renderCount: 0,
   },
   // O8 (#784): render-count tracking for the two memoized App-root overlays.
@@ -161,12 +168,14 @@ vi.mock('./components/MapSurface.js', () => ({
     boundsKey?: string;
     scopeBounds?: [[number, number], [number, number]];
     flyTo?: { center: [number, number]; zoom: number; key: string };
+    onHashCameraRestored?: (bounds: unknown, zoom: number) => void;
   }) => {
     mapSurfaceRef.onViewportChange = props.onViewportChange ?? null;
     mapSurfaceRef.onSelectSpecies = props.onSelectSpecies ?? null;
     mapSurfaceRef.boundsKey = props.boundsKey;
     mapSurfaceRef.scopeBounds = props.scopeBounds;
     mapSurfaceRef.flyTo = props.flyTo;
+    mapSurfaceRef.onHashCameraRestored = props.onHashCameraRestored ?? null;
     mapSurfaceRef.renderCount += 1;
     return <div data-testid="map-surface-stub" />;
   },
@@ -1790,6 +1799,139 @@ describe('#847: state→state switch re-seeds debouncedBbox/zoom (render-phase)'
       expect(mockGetObservations).toHaveBeenCalledTimes(1);
     });
     expect(mockGetObservations).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('#1289: a restored `#map=` hash camera seeds the observations fetch', () => {
+  // The bug: deep-linking `#map=<highZoom>/<lat>/<lng>` restores the camera
+  // (jumpTo) but the observations fetch stays pinned to the CONUS z3 seed —
+  // `onViewportChange` swallows the restore's settle idle inside the scope-move
+  // window, and nothing else seeds `debouncedBbox`/`debouncedZoom` from the
+  // restored camera → zero markers. The fix: MapCanvas fires
+  // `onHashCameraRestored(liveBounds, liveZoom)` once the hash camera is applied,
+  // and App seeds the fetch inputs directly from it.
+  //
+  // The restored high-zoom rectangle around San Jose, CA (well inside the US
+  // scope envelope, z16). Disjoint from the z3 CONUS seed's served cell.
+  const RESTORED_BBOX: [number, number, number, number] = [
+    -121.96, 37.255, -121.945, 37.265,
+  ];
+  const RESTORED_ZOOM = 16;
+
+  function makeBounds(
+    west: number, south: number, east: number, north: number,
+  ): LngLatBounds {
+    return {
+      getWest: () => west,
+      getSouth: () => south,
+      getEast: () => east,
+      getNorth: () => north,
+    } as unknown as LngLatBounds;
+  }
+
+  beforeEach(() => {
+    __resetSilhouettesCache();
+    __resetSpeciesDictionaryCache();
+    __resetStatesCache();
+    __resetZipIndexCache();
+    mockGetHotspots.mockResolvedValue([]);
+    mockGetObservations.mockResolvedValue({ data: [], meta: { freshestObservationAt: null } });
+    mockGetSilhouettes.mockResolvedValue([]);
+    mockGetStates.mockResolvedValue([]);
+    mockGetObservations.mockClear();
+    mockGetHotspots.mockClear();
+    mockGetStates.mockClear();
+    mockGetSilhouettes.mockClear();
+    mockUrlState.set.mockClear();
+    mapSurfaceRef.onViewportChange = null;
+    mapSurfaceRef.onHashCameraRestored = null;
+    mapSurfaceRef.boundsKey = undefined;
+    mapSurfaceRef.scopeBounds = undefined;
+    mapSurfaceRef.flyTo = undefined;
+    mapSurfaceRef.renderCount = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // PRIMARY regression: a deep-linked restore must drive the observations fetch
+  // to the RESTORED bbox/zoom (zoom >= 6), not leave it pinned at the CONUS z3
+  // seed. This fails on pre-fix code: only the seed fetch ever fires.
+  it('seeds debouncedBbox/zoom from the restored camera so the fetch hits the restored viewport', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'us' },
+    };
+    render(<App />);
+
+    // The seed fetch fires first (CONUS z3 — acceptable, heavily CF-cached).
+    await waitFor(() => {
+      expect(mockGetObservations).toHaveBeenCalledTimes(1);
+    });
+    const seedCall = mockGetObservations.mock.calls[0]![0] as { zoom?: number };
+    expect(seedCall.zoom).toBe(3);
+
+    // The restore wiring must be threaded to MapSurface.
+    await waitFor(() => {
+      expect(mapSurfaceRef.onHashCameraRestored).not.toBeNull();
+    });
+
+    // Drive the restore: MapCanvas applied the hash camera and reports the LIVE
+    // restored bounds + zoom (the path that, on real code, would otherwise be
+    // swallowed by the scope-move settle window in onViewportChange).
+    await act(async () => {
+      mapSurfaceRef.onHashCameraRestored!(
+        makeBounds(...RESTORED_BBOX),
+        RESTORED_ZOOM,
+      );
+    });
+
+    // The fetch must now re-fire at the restored viewport — bbox enclosing the
+    // restored center and zoom >= 6 (per-observation mode, NOT the z3 seed).
+    await waitFor(() => {
+      const last = mockGetObservations.mock.calls.at(-1)![0] as {
+        bbox?: [number, number, number, number];
+        zoom?: number;
+      };
+      expect(last.zoom).toBe(RESTORED_ZOOM);
+      expect(last.zoom).toBeGreaterThanOrEqual(6);
+      expect(last.bbox).toEqual(RESTORED_BBOX);
+    });
+  });
+
+  // The restore seed is a ONE-SHOT: it fires exactly one extra fetch (the
+  // restored viewport), not a loop. A subsequent genuine user pan still flows
+  // through the normal onViewportChange path (asserted separately by the #690/
+  // #847 suites); here we just confirm no re-fire from a re-render.
+  it('fires the restore seed once (no double-fetch loop)', async () => {
+    mockUrlState.state = {
+      since: '14d', notable: false, speciesCode: null, familyCode: null,
+      view: 'map', scope: { kind: 'us' },
+    };
+    const { rerender } = render(<App />);
+    await waitFor(() => {
+      expect(mockGetObservations).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mapSurfaceRef.onHashCameraRestored).not.toBeNull();
+    });
+
+    await act(async () => {
+      mapSurfaceRef.onHashCameraRestored!(
+        makeBounds(...RESTORED_BBOX),
+        RESTORED_ZOOM,
+      );
+    });
+    await waitFor(() => {
+      expect(mockGetObservations).toHaveBeenCalledTimes(2);
+    });
+
+    // A plain re-render must NOT re-fire the restore seed (the guard holds).
+    await act(async () => { rerender(<App />); });
+    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    expect(mockGetObservations).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -963,6 +963,39 @@ export function App() {
     }, 250);
   }, []);
 
+  // #1289 — seed the observations fetch from a restored `#map=` deep-link camera.
+  // ROOT CAUSE: on a deep-link the camera restores (`useScopeCamera`'s `jumpTo`)
+  // but `debouncedBbox`/`debouncedZoom` stay at the CONUS z3 SEED. The restore's
+  // settle `idle` reaches `onViewportChange` INSIDE the `scopeMoveUntilRef` window
+  // (armed at mount whenever `boundsKey` is defined), where the bbox/zoom commit
+  // is deliberately swallowed (the scope-`fitBounds` over-fetch guard, #847). On a
+  // clean deep-link no later user gesture fires, so the seed is never superseded →
+  // 0 markers at the restored high-zoom view (whose tiny rectangle shares no
+  // rows/cells with the z3 national aggregate).
+  //
+  // FIX: MapCanvas fires this callback ONCE — with the LIVE restored
+  // `map.getBounds()` + `Math.floor(map.getZoom())` — the moment the hash camera
+  // is applied (`restoredHashCamera` goes null→non-null). We seed the fetch inputs
+  // DIRECTLY here, exactly the {bbox, zoom} pair `onViewportChange` would have
+  // committed for the restored viewport. This is the missing seam between the
+  // camera-restore and data-fetch subsystems. It mirrors the #847 render-phase
+  // reseed (which targets the SCOPE envelope at z3) but targets the RESTORED
+  // camera instead — and, crucially, it does NOT touch `scopeMoveUntilRef`, the
+  // 250ms debounce, the ~1e-4° epsilon no-op guard, or the canonical-key bbox
+  // machinery (all load-bearing for the scope one-fetch invariant + CF cache
+  // hit-rate). A genuine later user pan/zoom still flows through the normal
+  // `onViewportChange` path. One-shot per restore is enforced upstream in
+  // MapCanvas (`firedRestoreSeedRef`).
+  const onHashCameraRestored = useCallback((bounds: LngLatBounds, zoom: number) => {
+    setDebouncedBbox([
+      bounds.getWest(),
+      bounds.getSouth(),
+      bounds.getEast(),
+      bounds.getNorth(),
+    ]);
+    setDebouncedZoom(zoom);
+  }, []);
+
   // #859: species code→{comName} dictionary. Loaded once (tab-lifetime cache,
   // immutable Cache-Control) and threaded to MapSurface → MapCanvas so the
   // aggregated low-zoom popovers can resolve the real common names carried (as
@@ -1552,6 +1585,10 @@ export function App() {
             {...(rawHashCamera ? { initialHashCamera: rawHashCamera } : {})}
             hashCameraInScope={hashCameraInScope}
             writeBackGate={writeBackGate}
+            // #1289: MapCanvas fires this once the `#map=` deep-link camera is
+            // applied, with the live restored bounds + zoom, so the observations
+            // fetch seeds from the restored viewport instead of the CONUS z3 seed.
+            onHashCameraRestored={onHashCameraRestored}
             // C2 (#1240): MapCanvas populates this with a live-camera getter so
             // the "Copy link" pill (in AppHeader) reads the camera at click time.
             cameraRef={cameraRef}

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -112,6 +112,14 @@ export interface MapSurfaceProps {
     scopeMoveUntilRef: RefObject<number>;
   };
   /**
+   * #1289 — restored-hash-camera fetch-seed callback, forwarded VERBATIM to
+   * <MapCanvas>. Fired once (with the live restored bounds + zoom) when a `#map=`
+   * deep-link camera is applied, so App can seed `debouncedBbox`/`debouncedZoom`
+   * from the restored viewport instead of the CONUS z3 seed. Thin pass-through;
+   * optional (legacy/test callers + non-deep-link loads omit it).
+   */
+  onHashCameraRestored?: (bounds: LngLatBounds, zoom: number) => void;
+  /**
    * C2 (#1240) — live-camera exposure ref, forwarded VERBATIM to <MapCanvas>.
    * MapCanvas populates `.current` with a live getter so App's "Copy link"
    * control can read the camera at click time. Thin pass-through; optional.
@@ -152,6 +160,7 @@ export function MapSurface({
   initialHashCamera,
   hashCameraInScope,
   writeBackGate,
+  onHashCameraRestored,
   cameraRef,
 }: MapSurfaceProps) {
   /**
@@ -223,6 +232,7 @@ export function MapSurface({
             {...(initialHashCamera ? { initialHashCamera } : {})}
             {...(hashCameraInScope !== undefined ? { hashCameraInScope } : {})}
             {...(writeBackGate ? { writeBackGate } : {})}
+            {...(onHashCameraRestored ? { onHashCameraRestored } : {})}
             {...(cameraRef ? { cameraRef } : {})}
           />
         </React.Suspense>

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -367,6 +367,7 @@ export function MapCanvas({
   initialHashCamera,
   hashCameraInScope,
   writeBackGate,
+  onHashCameraRestored,
   cameraRef,
 }: MapCanvasProps) {
   const aggregated = mode === 'aggregated';
@@ -1157,6 +1158,34 @@ export function MapCanvas({
       cameraRef.current = null;
     };
   }, [cameraRef, mapReady]);
+
+  // ── #1289: seed the observations fetch from the restored hash camera ───────
+  // When `useScopeCamera` applies a `#map=` deep-link camera (`restoredHashCamera`
+  // goes null→non-null), fire `onHashCameraRestored` ONCE with the LIVE restored
+  // bounds + integer floor zoom — exactly the payload `onViewportChange` would
+  // have committed. App seeds `debouncedBbox`/`debouncedZoom` from it so the
+  // fetch hits the restored viewport instead of staying pinned to the CONUS z3
+  // seed (whose settle `idle` App's scope-move window swallows, #847). The
+  // `firedRestoreSeedRef` one-shot guard means a later re-render that keeps
+  // `restoredHashCamera` set never re-fires; a genuine scope change CLEARS it in
+  // `useScopeCamera` (null→…→non-null only happens once per restore). The
+  // callback is read through a ref so a fresh App identity per render still wins,
+  // mirroring `onViewportChangeRef` above. This effect touches ONLY the data
+  // seed — not the camera, the settle window, or the canonical-key machinery.
+  const firedRestoreSeedRef = useRef(false);
+  const onHashCameraRestoredRef = useRef(onHashCameraRestored);
+  onHashCameraRestoredRef.current = onHashCameraRestored;
+  useEffect(() => {
+    if (!restoredHashCamera || firedRestoreSeedRef.current) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+    const cb = onHashCameraRestoredRef.current;
+    if (!cb) return;
+    firedRestoreSeedRef.current = true;
+    // Live bounds/zoom of the just-applied (jumpTo) restored camera; same shape
+    // as the onViewportChange idle payload (#627 added the floor-zoom).
+    cb(map.getBounds(), Math.floor(map.getZoom()));
+  }, [restoredHashCamera]);
 
   // ── #1128: dark-label contrast fixup at style.load ────────────────────────
   // The null-numeric-comparison guard is NO LONGER applied here — it now runs

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -205,6 +205,26 @@ export interface MapCanvasProps {
     scopeMoveUntilRef: RefObject<number>;
   };
   /**
+   * #1289 — fired ONCE, with the LIVE restored bounds + integer floor zoom, the
+   * moment a `#map=` deep-link camera is applied (`restoredHashCamera` goes
+   * null→non-null in `useScopeCamera`). App seeds `debouncedBbox`/`debouncedZoom`
+   * directly from it so the observations fetch hits the RESTORED viewport instead
+   * of staying pinned to the CONUS z3 seed.
+   *
+   * Why a dedicated callback rather than the existing `onViewportChange` idle:
+   * the restore's `jumpTo` settle `idle` lands INSIDE App's `scopeMoveUntilRef`
+   * window (armed at mount when `boundsKey` is defined), where `onViewportChange`
+   * deliberately swallows the bbox/zoom commit (the scope-`fitBounds` over-fetch
+   * guard, #847). On a clean deep-link no later user gesture fires, so the seed
+   * is never superseded → 0 markers (#1289). This callback is the missing seam
+   * between the camera-restore and the data-fetch subsystems; it does NOT touch
+   * the settle window, the 250ms debounce, or the canonical-key machinery — it
+   * mirrors `onViewportChange`'s payload shape (same bounds + Math.floor(zoom)).
+   *
+   * Optional; legacy/test callers omit it (no `#map=` → never fires).
+   */
+  onHashCameraRestored?: (bounds: import('maplibre-gl').LngLatBounds, zoom: number) => void;
+  /**
    * C2 (#1240, epic #1238) — live-camera exposure for the "Copy link to this
    * view" control. `MapCanvas` holds the private MapLibre `getMap()` ref; the
    * header needs to read the LIVE camera (zoom/center/bearing/pitch) at click


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant URL as "#map= deep-link"
    participant SC as useScopeCamera
    participant MC as MapCanvas
    participant App
    participant Data as use-bird-data

    URL->>SC: parse #map=z/lat/lng
    SC->>MC: map.jumpTo(restored camera) + set restoredHashCamera
    Note over MC,App: BEFORE (#1289 bug): the restore's settle idle lands inside<br/>App's scopeMoveUntilRef window -> onViewportChange swallows it.<br/>debouncedBbox/zoom stay at the CONUS z3 SEED -> 0 markers.
    MC->>App: onHashCameraRestored(liveBounds, floorZoom)  [NEW seam]
    App->>App: setDebouncedBbox / setDebouncedZoom (restored viewport)
    App->>Data: filters = {bbox: restored, zoom: >=6}
    Data->>Data: GET /api/observations at the restored view -> markers render
```

## Summary

- **Why:** deep-linking / sharing a `#map=<z>/<lat>/<lng>` link to a high-zoom view (zoom >= ~6, every scope) rendered **zero markers** — the camera restored but the `/api/observations` fetch stayed pinned to the CONUS z3 seed. Regression in the just-shipped viewbox/share-link epic (#1238 / #1242).
- **Root cause:** the camera-restore and the data-fetch never connected on a deep-link. The restore's `jumpTo` settle `idle` reaches `onViewportChange` *inside* App's `scopeMoveUntilRef` window (the #847 scope-`fitBounds` over-fetch guard), where the bbox/zoom commit is deliberately swallowed. On a clean deep-link no later user gesture fires, so the seed is never superseded.
- **Fix (lowest-risk, additive-only):** `MapCanvas` fires a new `onHashCameraRestored(liveBounds, liveZoom)` callback **once** when `restoredHashCamera` goes null→non-null; App seeds `debouncedBbox`/`debouncedZoom` directly from it — exactly the `{bbox, zoom}` pair `onViewportChange` would have committed. Does **not** touch the settle window, the 250ms debounce, the ~1e-4° epsilon guard, the canonical-key bbox machinery, or the #847 reseed. One-shot per restore (`firedRestoreSeedRef`); a genuine later pan still flows through the normal path. A redundant CONUS z3 seed fetch firing first is acceptable.

## Screenshots

Pending — orchestrator will capture before/after at the repro deep-links via MCP (subagents cannot drive MCP).

- [ ] Every new/renamed `className` in this PR has a matching CSS rule in
      `frontend/src/styles.css` or `frontend/src/components/ds/ds-primitives.css`
      (or marked `N/A — class is consumed only by a primitive that ships its own CSS`) — N/A — no className / CSS changes (behavior-only; the change makes markers appear that were missing).
- [ ] Multi-viewport design QA: PR body has ≥10 `user-attachments` URLs
      (5 viewports × 2 themes per #445). Verify:
      `gh pr view <N> --repo julianken/bird-sight-system --json body --jq '.body | [scan("user-attachments/assets/[a-f0-9-]++")] | length'`
      returns ≥ 10 (or marked `N/A — not UI`)

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (1791 passed). Includes two new App-level units (`#1289`): the restored-viewport fetch fires at zoom>=6 with the restored bbox (not `{CONUS, 3}`), and the restore seed is one-shot (no double-fetch loop). Both confirmed RED on pre-fix code, GREEN after.
- [x] New unit / integration tests added (behavior changed) — `frontend/src/App.test.tsx`.
- [x] New Playwright e2e spec added (user-visible behavior changed) — `frontend/e2e/scope/viewbox-restore.spec.ts`: asserts the `/api/observations` **fetch** fired at zoom>=6 with a small bbox enclosing the restored center (the gap the existing `data-hash-camera`-only specs missed), plus a WebGL-guarded marker-presence check. Ran green locally against an isolated dev stack.
- [x] `npm run build -w @bird-watch/frontend` — clean production build.
- [ ] (UI only) Playwright MCP smoke — orchestrator to run the before/after live drive at the repro deep-links (subagents cannot drive MCP).

## Plan reference

Out of plan — HIGH-severity regression fix for #1289 (deep-linked high-zoom views render zero markers), regression in the shipped viewbox/share-link epic #1238 / #1242.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)