### PR TITLE
feat(frontend): cap interactive max zoom at 17 (deliberate cap; was MapLibre's raw 22 default)

### DIFF
--- a/frontend/e2e/map/map-adaptive-grid.spec.ts
+++ b/frontend/e2e/map/map-adaptive-grid.spec.ts
@@ -148,19 +148,25 @@ test.describe('Adaptive-grid markers (epic #539)', () => {
     const webglReady = await waitForMapReady(page);
     test.skip(!webglReady, 'WebGL unavailable — map canvas did not paint');
 
-    await flyToTucson(page, 18);
+    // z=16 is CLUSTER_MAX_ZOOM (the deepest zoom at which supercluster still
+    // groups points). At z17 (= MAX_INTERACTIVE_ZOOM, the interactive cap)
+    // points fully de-cluster into individual unclustered silhouettes, so the
+    // clusters-hit-fed adaptive-grid markers vanish — z16 is the deepest zoom
+    // that still exercises the 1×1 grid path. (Was z=18 when clustering rode
+    // the old epic-#539 clusterMaxZoom of 22.)
+    await flyToTucson(page, 16);
 
-    // At high zoom a single observation should produce a 1×1 grid with
+    // At max-cluster zoom a single observation should produce a 1×1 grid with
     // a `rendered` cell (or `pending` until silhouettes load, but never
     // `fallback` unless the family genuinely has no art).
     const grids = page.locator('[data-testid=adaptive-grid-marker]');
     const gridCount = await grids.count();
     if (gridCount === 0) {
-      test.skip(true, 'No grid markers at z=18 — sparse data; AC8 covered by Phase 1 unit tests');
+      test.skip(true, 'No grid markers at z=16 — sparse data; AC8 covered by Phase 1 unit tests');
       return;
     }
     // Any 1×1 grid with a single observation must NOT be a fallback —
-    // if `fallback` cells render at z=18 the silhouette catalogue is
+    // if `fallback` cells render at z=16 the silhouette catalogue is
     // broken (Phylopic load failure or seed-data miss).
     const fallbacks = page.locator(
       '[data-testid=adaptive-grid-marker] [data-testid=adaptive-grid-marker-cell-fallback]',

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -12,6 +12,9 @@ import {
   MASK_FILL_LIGHT,
   MASK_FILL_DARK,
 } from './geometry/mask.js';
+// Deliberate interactive zoom cap (2026-06): assert the captured `<MapView maxZoom>`
+// prop against the single-source-of-truth constant, never a re-literal.
+import { MAX_INTERACTIVE_ZOOM } from './geometry/camera-config.js';
 // #1286: the cluster-list popover header renders `formatCount(totalCount)` /
 // `formatCount(uniqueFamilies)` — assert against the same formatter so the
 // merged-total header tests match the rendered string exactly, never a re-literal.
@@ -549,11 +552,16 @@ describe('MapCanvas', () => {
     expect(data.features).toHaveLength(1);
   });
 
-  it('Source carries cluster + clusterMaxZoom=22 + maxzoom=24 (epic #539 F4)', () => {
+  it('Source carries cluster + clusterMaxZoom=16 (= MAX_INTERACTIVE_ZOOM-1) + maxzoom=18 (> clusterMaxZoom)', () => {
+    // 2026-06 deliberate max-zoom cap: clusterMaxZoom = MAX_INTERACTIVE_ZOOM-1
+    // (16) so points de-cluster one level below the z17 wall; source maxzoom
+    // (18) must exceed clusterMaxZoom or MapLibre warns. (Was 22 / 24 under the
+    // old epic-#539 clusterMaxZoom of 22.)
     render(<MapCanvas observations={[makeObs()]} silhouettes={SILHOUETTES} />);
     expect(capturedSourceProps['cluster']).toBe(true);
-    expect(capturedSourceProps['clusterMaxZoom']).toBe(22);
-    expect(capturedSourceProps['maxzoom']).toBe(24);
+    expect(capturedSourceProps['clusterMaxZoom']).toBe(MAX_INTERACTIVE_ZOOM - 1);
+    expect(capturedSourceProps['clusterMaxZoom']).toBe(16);
+    expect(capturedSourceProps['maxzoom']).toBe(18);
   });
 
   it('renders EXACTLY the five observation Layers (no maskPolygon → no state-mask-fill leak)', async () => {
@@ -1753,12 +1761,13 @@ describe('MapCanvas', () => {
     }
 
     it('#717 — max-zoom pill click opens ClusterListPopover (targetZoom <= currentZoom)', async () => {
-      // Camera at CLUSTER_MAX_ZOOM (22); supercluster has exhausted its
-      // expansion budget → returns 22 as well. The old code would silently
-      // no-op here.
+      // Camera at MAX_INTERACTIVE_ZOOM (17, the interactive cap); supercluster
+      // has exhausted its expansion budget → returns 17 as well, and the fly-to
+      // cap is MAX_INTERACTIVE_ZOOM, so targetZoom === currentZoom and easeTo is
+      // suppressed. The old code would silently no-op here.
       const { pill, getClusterExpansionZoom } = await renderPillAtMaxZoom({
-        currentZoom: 22,
-        expansionZoom: 22,
+        currentZoom: 17,
+        expansionZoom: 17,
       });
 
       await act(async () => {
@@ -3431,6 +3440,23 @@ describe('MapCanvas state-artboard mask (#762)', () => {
       />,
     );
     expect(readMapProps().minZoom).toBe(2);
+  });
+
+  it('captured maxZoom === 17 (deliberate interactive cap; was MapLibre raw default 22)', () => {
+    // The camera maxZoom is the REAL interactive ceiling (scroll/dblclick/
+    // keyboard/pinch). It must equal the share-link decode clamp
+    // (MAX_INTERACTIVE_ZOOM) so every decoded camera is a reachable position.
+    render(
+      <MapCanvas
+        observations={[]}
+        bounds={AZ_BOUNDS}
+        boundsKey="US-AZ"
+        maskPolygon={AZ_POLYGON}
+        clampPad={ARTBOARD_PAD}
+      />,
+    );
+    expect(readMapProps().maxZoom).toBe(MAX_INTERACTIVE_ZOOM);
+    expect(readMapProps().maxZoom).toBe(17);
   });
 
   it('clamp/fit decouple: maxBounds === padBounds(bounds, ARTBOARD_PAD); fit target stays the tight bbox (finding 1)', async () => {

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -15,7 +15,7 @@ import type { AggregatedBucket, Observation } from '@bird-watch/shared-types';
 import { resolveDescriptor } from './geometry/basemap-style.js';
 import type { ThemeId } from './geometry/basemap-style.js';
 import { useActiveThemeId, setBasemapStyle } from './theme-state.js';
-import { INITIAL_VIEW, MIN_ZOOM } from './geometry/camera-config.js';
+import { INITIAL_VIEW, MIN_ZOOM, MAX_INTERACTIVE_ZOOM } from './geometry/camera-config.js';
 import {
   buildMaskFeature,
   MASK_FILL_LIGHT,
@@ -1806,8 +1806,8 @@ export function MapCanvas({
    *
    *   Multi-member case: click-time-lazy `getClusterExpansionZoom` over
    *     every memberId; easeTo target = `Math.max(...zooms)` (capped at
-   *     `CLUSTER_MAX_ZOOM`). Using max — not min — ensures the camera
-   *     reaches the zoom where the LAST overlapping cluster breaks apart,
+   *     `MAX_INTERACTIVE_ZOOM`, the camera ceiling). Using max — not min —
+   *     ensures the camera reaches the zoom where the LAST cluster breaks apart,
    *     so the user always sees real expansion. Matches the click-time-lazy
    *     pattern from the prior `handleClusterPillClick`.
    */
@@ -1921,7 +1921,7 @@ export function MapCanvas({
             const zooms = await Promise.all(
               clusterMemberIds.map((id) => src.getClusterExpansionZoom(id)),
             );
-            const targetZoom = Math.min(Math.max(...zooms), CLUSTER_MAX_ZOOM);
+            const targetZoom = Math.min(Math.max(...zooms), MAX_INTERACTIVE_ZOOM);
             const currentZoom = map.getZoom();
             const shouldEase =
               Number.isFinite(targetZoom) &&
@@ -1993,12 +1993,12 @@ export function MapCanvas({
         }
 
         // Max — not min — so the camera always reaches the zoom where every
-        // member separates. Capped at CLUSTER_MAX_ZOOM (22) for parity with
-        // the prior pill-click behavior.
+        // member separates. Capped at MAX_INTERACTIVE_ZOOM (17, the camera
+        // ceiling) — never fly past the interactive max zoom.
         const zooms = await Promise.all(
           clusterMemberIds.map((id) => src.getClusterExpansionZoom(id)),
         );
-        const targetZoom = Math.min(Math.max(...zooms), CLUSTER_MAX_ZOOM);
+        const targetZoom = Math.min(Math.max(...zooms), MAX_INTERACTIVE_ZOOM);
         const currentZoom = map.getZoom();
         // `Number.isFinite` rejects NaN (library-error guard, #717): if any
         // member's expansion zoom resolved to NaN, Math.max(NaN) === NaN,
@@ -2151,6 +2151,15 @@ export function MapCanvas({
         ref={mapRef}
         initialViewState={initialViewState}
         minZoom={MIN_ZOOM}
+        // Deliberate high-end interactive cap (2026-06 research recommendation):
+        // 17, NOT MapLibre's raw default of 22. This is the REAL interactive
+        // ceiling — it governs scroll, double-click, keyboard, and pinch zoom.
+        // The OpenFreeMap basemap is native vector z14 (blurry past ~z16-17, no
+        // satellite imagery) and eBird points are checklist-location centroids
+        // with ~1-3 km uncertainty, so z18+ implies precision the data lacks.
+        // Single source of truth in camera-config.ts; the share-link decode
+        // clamp and the cluster-expansion fly-to cap read the same constant.
+        maxZoom={MAX_INTERACTIVE_ZOOM}
         // Reactive scope clamp (#736 finding (a) + #760/#762 artboard):
         // `clampBounds` is the state envelope PADDED by `clampPad` (state scope)
         // so the user can zoom out onto the gray field, else the raw scope
@@ -2289,13 +2298,13 @@ export function MapCanvas({
           // default (2), so real Observation rows — which legitimately use `subId`
           // + the unclustered silhouette layer — are completely unchanged.
           clusterMinPoints={aggregated ? 1 : 2}
-          // Phase 0 finding F4: when clusterMaxZoom rises to 22 (epic #539
-          // cutover), maplibre warns that source `maxzoom` (default 18)
-          // must exceed clusterMaxZoom. Setting maxzoom=24 lifts the
-          // source ceiling above the cluster ceiling and silences the
-          // warning. Required to keep Gate 4 (zero console warnings)
-          // green on cold map init.
-          maxzoom={24}
+          // maplibre warns that a GeoJSON source's `maxzoom` must EXCEED
+          // `clusterMaxZoom`. With the deliberate max-zoom cap (CLUSTER_MAX_ZOOM
+          // = MAX_INTERACTIVE_ZOOM - 1 = 16) the source ceiling only needs to be
+          // > 16; 18 clears it with margin and keeps Gate 4 (zero console
+          // warnings) green on cold map init. (Was 24 when clusterMaxZoom rode
+          // the old epic-#539 value of 22.)
+          maxzoom={18}
           // promoteId="subId" surfaces the observation subId as the
           // feature.id, which is what setFeatureState({id, ...}) keys on.
           // The silhouette-displacement path (issue #554 scope expansion)

--- a/frontend/src/components/map/geometry/camera-config.ts
+++ b/frontend/src/components/map/geometry/camera-config.ts
@@ -80,6 +80,27 @@ export const CONUS_NARROW_BREAKPOINT_PX = 700;
  * above is unchanged.
  */
 export const MIN_ZOOM = 2;
+
+/**
+ * MAX_INTERACTIVE_ZOOM = 17 — the DELIBERATE high-end interactive zoom ceiling
+ * for bird-maps.com (research recommendation, 2026-06). Before this the camera
+ * rode MapLibre's raw default of 22; 17 is a deliberate cap because:
+ *   - the OpenFreeMap basemap is native vector z14 — overzoomed and blurry past
+ *     ~z16-17, with no satellite imagery to reward zooming deeper;
+ *   - eBird points are checklist-LOCATION centroids carrying ~1-3 km of spatial
+ *     uncertainty, so z18+ would imply a precision the source data lacks;
+ *   - clustering and the per-observation fetch both plateau by ~z16;
+ *   - comparable point-observation apps cap interactive zoom at 17-20.
+ *
+ * This is the single source of truth for the interactive ceiling. It governs
+ * the MapLibre camera `maxZoom` (the real scroll/dblclick/keyboard/pinch cap),
+ * the share-link decode clamp (`viewbox-link.ts` — a deep link to z20 reopens
+ * clamped to 17, gracefully), and the cluster-expansion fly-to cap (MapCanvas).
+ * `CLUSTER_MAX_ZOOM` (observation-layers.ts) is derived from this as
+ * `MAX_INTERACTIVE_ZOOM - 1` (= 16) so points fully de-cluster one level below
+ * the wall. Pairs with `MIN_ZOOM` above as the camera's zoom bounds.
+ */
+export const MAX_INTERACTIVE_ZOOM = 17;
 export const CONUS_BOUNDS: [[number, number], [number, number]] = [
   [-130, 20],
   [-65, 52],

--- a/frontend/src/components/map/geometry/obs-derive.ts
+++ b/frontend/src/components/map/geometry/obs-derive.ts
@@ -65,7 +65,8 @@ export function buildSilhouetteRenderById(
 
 /**
  * Hit-target layer markers: render hit targets at zoom >= CLUSTER_MAX_ZOOM
- * (now 22, post-cutover) for individual observations. The adaptive-grid
+ * (now 16 = MAX_INTERACTIVE_ZOOM - 1, the supercluster de-cluster threshold)
+ * for individual observations. The adaptive-grid
  * reconciler renders 1×1 grid markers for singletons at this zoom; the
  * hit layer is the wider clickable surface that survives small marker
  * sizes. Below CLUSTER_MAX_ZOOM, observations are clustered, so the

--- a/frontend/src/components/map/geometry/observation-layers.test.ts
+++ b/frontend/src/components/map/geometry/observation-layers.test.ts
@@ -12,6 +12,7 @@ import {
   CLUSTER_RADIUS,
   FALLBACK_SILHOUETTE_ID,
 } from './observation-layers.js';
+import { MAX_INTERACTIVE_ZOOM } from './camera-config.js';
 import { resolveDescriptor, type BasemapDescriptor } from './basemap-style.js';
 import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
 
@@ -426,8 +427,13 @@ describe('cluster defaults', () => {
     expect(CLUSTER_RADIUS).toBe(50);
   });
 
-  it('CLUSTER_MAX_ZOOM is 22 (epic #539 cutover: was 14, raised so adaptive-grid disambiguation extends through max user zoom)', () => {
-    expect(CLUSTER_MAX_ZOOM).toBe(22);
+  it('MAX_INTERACTIVE_ZOOM is 17 (deliberate 2026-06 cap; was MapLibre raw default 22)', () => {
+    expect(MAX_INTERACTIVE_ZOOM).toBe(17);
+  });
+
+  it('CLUSTER_MAX_ZOOM is 16 = MAX_INTERACTIVE_ZOOM - 1 (supercluster de-clusters one level below the interactive wall)', () => {
+    expect(CLUSTER_MAX_ZOOM).toBe(16);
+    expect(CLUSTER_MAX_ZOOM).toBe(MAX_INTERACTIVE_ZOOM - 1);
   });
 
   it('FALLBACK_SILHOUETTE_ID is "_FALLBACK"', () => {

--- a/frontend/src/components/map/geometry/observation-layers.ts
+++ b/frontend/src/components/map/geometry/observation-layers.ts
@@ -3,6 +3,7 @@ import type { LayerProps } from 'react-map-gl/maplibre';
 import type { BasemapDescriptor } from './basemap-style.js';
 import { FAMILY_COLOR_FALLBACK } from '@/data/family-color.js';
 import { CLUSTER_TIER_BOUNDARIES } from '@/config/cluster.js';
+import { MAX_INTERACTIVE_ZOOM } from './camera-config.js';
 
 // Epic #539 cutover: `inStack` plumbing is retired. The auto-spider
 // subsystem that produced it has been deleted along with its filter
@@ -215,16 +216,21 @@ export function notableColor(): string {
 /* ── Cluster source defaults ───────────────────────────────────────────── */
 
 /**
- * Epic #539 cutover: raised from 14 → 22. Above this zoom level the
- * supercluster source stops clustering and individual observations render
- * as unclustered points. The adaptive-grid approach disambiguates
- * coincident observations via grid shape (1×1, 2×1) up to the maximum
- * sane render zoom, so clustering remains active much longer than the
- * legacy 14-cap allowed. The companion `<Source>` JSX in MapCanvas must
- * also set `maxzoom={24}` (Phase 0 finding F4) — without it MapLibre
- * warns that source maxzoom (default 18) must exceed clusterMaxZoom.
+ * supercluster `clusterMaxZoom` = the max zoom at which points are still
+ * grouped. Derived as `MAX_INTERACTIVE_ZOOM - 1` (= 16) so that points fully
+ * de-cluster exactly ONE level below the interactive wall (`MAX_INTERACTIVE_ZOOM`
+ * = 17, camera-config.ts): clustering stays active through z16, then everything
+ * separates into individual unclustered points at the z17 cap.
+ *
+ * History: epic #539 raised this from 14 → 22 so adaptive-grid disambiguation
+ * extended through the (then-uncapped) max user zoom. The 2026-06 deliberate
+ * max-zoom cap (17) supersedes that — clustering is keyed to the new ceiling.
+ *
+ * The companion `<Source>` JSX in MapCanvas sets `maxzoom={18}` (> this value):
+ * MapLibre warns if a GeoJSON source's `maxzoom` does not exceed `clusterMaxZoom`,
+ * so the source ceiling must stay above the cluster ceiling.
  */
-export const CLUSTER_MAX_ZOOM = 22;
+export const CLUSTER_MAX_ZOOM = MAX_INTERACTIVE_ZOOM - 1;
 export const CLUSTER_RADIUS = 50;
 
 /* ── Layer specs ───────────────────────────────────────────────────────── */

--- a/frontend/src/state/viewbox-link.test.ts
+++ b/frontend/src/state/viewbox-link.test.ts
@@ -176,16 +176,26 @@ describe('viewbox-link codec', () => {
 
   // ── decode: clamp boundaries (clamp recoverable, do not reject) ──────────
   describe('decode — clamping', () => {
-    it('does NOT clamp a z16 link to the fitBounds cap of 12 (interactive max is 22)', () => {
+    it('does NOT clamp a z16 link to the fitBounds cap of 12 (interactive max is 17)', () => {
       // The critical AC (#1239): clamping zoom to 12 would silently defeat
       // epic #1238's exact-view premise. A z16 link must reopen at z16.
       const decoded = decodeViewbox('#map=16/34/-111');
       expect(decoded!.camera.zoom).toBe(16);
     });
 
-    it('clamps a z25 link to the interactive max CLUSTER_MAX_ZOOM (22)', () => {
+    it('keeps a z17 link at exactly the interactive max (MAX_INTERACTIVE_ZOOM = 17)', () => {
+      const decoded = decodeViewbox('#map=17/34/-111');
+      expect(decoded!.camera.zoom).toBe(17);
+    });
+
+    it('clamps a deep-link z20 down to the interactive max MAX_INTERACTIVE_ZOOM (17), gracefully — link still opens', () => {
+      const decoded = decodeViewbox('#map=20/34/-111');
+      expect(decoded!.camera.zoom).toBe(17);
+    });
+
+    it('clamps a z25 link to the interactive max MAX_INTERACTIVE_ZOOM (17)', () => {
       const decoded = decodeViewbox('#map=25/34/-111');
-      expect(decoded!.camera.zoom).toBe(22);
+      expect(decoded!.camera.zoom).toBe(17);
     });
 
     it('clamps zoom below MIN_ZOOM (2) up to 2', () => {

--- a/frontend/src/state/viewbox-link.ts
+++ b/frontend/src/state/viewbox-link.ts
@@ -1,5 +1,4 @@
-import { MIN_ZOOM } from '@/components/map/geometry/camera-config.js';
-import { CLUSTER_MAX_ZOOM } from '@/components/map/geometry/observation-layers.js';
+import { MIN_ZOOM, MAX_INTERACTIVE_ZOOM } from '@/components/map/geometry/camera-config.js';
 
 /**
  * viewbox-link — a pure, total-function codec that serializes a map camera
@@ -149,10 +148,13 @@ export function decodeViewbox(
   if (Number.isNaN(zoom) || Number.isNaN(lat) || Number.isNaN(lng)) return null;
 
   // 3. Clamp recoverable values rather than reject. Zoom ceiling is the
-  //    INTERACTIVE max (CLUSTER_MAX_ZOOM = 22), NOT the fitBounds framing cap
-  //    of 12 — a link captured at z16 must reopen at z16.
+  //    INTERACTIVE max (MAX_INTERACTIVE_ZOOM = 17, the camera `maxZoom` cap),
+  //    NOT the fitBounds framing cap of 12 — a link captured at z16 must reopen
+  //    at z16, and a hand-edited deep link to z20 clamps gracefully to 17
+  //    (it still opens, just at the wall). Must equal the camera cap so the
+  //    decoded camera is always a reachable position.
   const camera: ViewboxCamera = {
-    zoom: clamp(zoom, MIN_ZOOM, CLUSTER_MAX_ZOOM),
+    zoom: clamp(zoom, MIN_ZOOM, MAX_INTERACTIVE_ZOOM),
     lat: clamp(lat, -MERCATOR_LAT_LIMIT, MERCATOR_LAT_LIMIT),
     lng: clamp(lng, -180, 180),
   };


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart TD
    SRC["MAX_INTERACTIVE_ZOOM = 17<br/>(camera-config.ts — single source of truth,<br/>paired with MIN_ZOOM)"]
    SRC -->|"&lt;MapView maxZoom&gt;"| CAM["1 · MapLibre camera cap = 17<br/>real interactive ceiling:<br/>scroll / dblclick / keyboard / pinch"]
    SRC -->|"clamp(zoom, MIN_ZOOM, max)"| LINK["2 · share-link decode clamp = 17<br/>#map=20/… → reopens at 17 (graceful)"]
    SRC -->|"Math.min(expansionZoom, max)"| FLY["cluster-expansion fly-to cap = 17<br/>(never fly past the wall)"]
    SRC -->|"MAX_INTERACTIVE_ZOOM - 1"| CMZ["CLUSTER_MAX_ZOOM = 16"]
    CMZ -->|"&lt;Source clusterMaxZoom&gt;"| SC["3 · supercluster clusterMaxZoom = 16<br/>points de-cluster one level below the wall (z17)"]
    CMZ -.->|"must stay below"| MZ["4 · &lt;Source maxzoom&gt; = 18<br/>(&gt; clusterMaxZoom → no MapLibre warning)"]
    CMZ -->|"buildHitMarkers threshold (unchanged coupling)"| HIT["hit-target layer renders at z ≥ 16"]
```

## Summary

- The map rode MapLibre's **raw default `maxZoom` of 22** — far past where the data or basemap reward zooming. A 2026-06 research recommendation caps interactive zoom at **17**: OpenFreeMap is native vector z14 (blurry past ~z16-17, no satellite imagery); eBird points are checklist-LOCATION centroids with ~1-3 km uncertainty (z18+ implies precision the data lacks); clustering + the per-obs fetch both plateau by ~z16; comparable point-observation apps cap at 17-20.
- Consolidates the "accidental 22s" into **one source of truth** — `MAX_INTERACTIVE_ZOOM = 17` in `camera-config.ts` — and derives `CLUSTER_MAX_ZOOM = MAX_INTERACTIVE_ZOOM - 1` (16). Four coordinated values now read from it: camera `maxZoom` (17), share-link decode clamp (17), supercluster `clusterMaxZoom` (16), Source `maxzoom` (18, was 24). Cluster-expansion fly-to caps follow the camera ceiling (17). `minZoom` / the low-zoom + aggregated path are untouched.

## Screenshots

N/A — interactive zoom-cap behavior change, no visual/layout element; verified by codec-clamp + constant unit tests. Orchestrator will live-verify the camera stops at z17 post-deploy.

## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (96 files, 1808 tests)
- [x] New unit tests: `viewbox-link` z20 / z25 → 17, z17 stays 17, low zooms unaffected; `MAX_INTERACTIVE_ZOOM === 17` and `CLUSTER_MAX_ZOOM === 16 === MAX_INTERACTIVE_ZOOM - 1`; `<MapView maxZoom>` captured prop === 17; Source `clusterMaxZoom === 16` + `maxzoom === 18`
- [x] Updated `map-adaptive-grid.spec.ts` z=18 → z=16 (at z17 points de-cluster, leaving no adaptive-grid markers); no other e2e drives the camera past 17
- [x] `npm run build -w @bird-watch/frontend` — clean (`tsc -b` + `vite build`)
- [ ] (UI only) Playwright MCP smoke — N/A per Screenshots (zoom-LIMIT behavior, no visual/layout element); orchestrator live-verifies the z17 stop post-deploy

## Plan reference

Out of plan — research-recommendation max-zoom cap; supersedes the epic-#539 `clusterMaxZoom = 22` value with a deliberate interactive ceiling.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)