### PR TITLE
fix(frontend): count-bearing 1×1 grid markers for unclustered observations in filtered views (#1296)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1612,6 +1612,11 @@ export function App() {
             {...(statePolygon != null ? { maskPolygon: statePolygon } : {})}
             {...(isStateScope ? { clampPad: ARTBOARD_PAD } : {})}
             detailOpen={!!(scopeActive && state.detail)}
+            // #1296: the canonical filter predicate (covers species/family/
+            // notable/since), computed ONCE above — MapCanvas must NOT recompute
+            // it. Gates the lone-observation silhouette→grid promotion so a
+            // filtered viewport's on-screen marker total matches the lede count.
+            filterActive={!noFiltersActive}
             activeThemeId={activeThemeId}
             {...(rawHashCamera ? { initialHashCamera: rawHashCamera } : {})}
             hashCameraInScope={hashCameraInScope}

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -91,6 +91,13 @@ export interface MapSurfaceProps {
    */
   detailOpen?: boolean;
   /**
+   * #1296 — true when ANY data filter is active (`!noFiltersActive` in App).
+   * Forwarded VERBATIM to <MapCanvas> (thin pass-through) so the adaptive-grid
+   * reconciler promotes lone filtered observations to count-bearing 1×1 grid
+   * markers (conserving the on-screen total). Optional; defaults to `false`.
+   */
+  filterActive?: boolean;
+  /**
    * #1220 (C8) — the active basemap theme id (App-level `useActiveThemeId`,
    * seeded from `resolveInitialTheme`). Forwarded VERBATIM to <MapCanvas> so the
    * id-keyed basemap swap shares the same source of truth the <ThemeSelector>
@@ -156,6 +163,7 @@ export function MapSurface({
   maskPolygon,
   clampPad,
   detailOpen = false,
+  filterActive = false,
   activeThemeId,
   initialHashCamera,
   hashCameraInScope,
@@ -228,6 +236,7 @@ export function MapSurface({
             {...(maskPolygon != null ? { maskPolygon } : {})}
             {...(clampPad !== undefined ? { clampPad } : {})}
             detailOpen={detailOpen}
+            filterActive={filterActive}
             {...(activeThemeId !== undefined ? { activeThemeId } : {})}
             {...(initialHashCamera ? { initialHashCamera } : {})}
             {...(hashCameraInScope !== undefined ? { hashCameraInScope } : {})}

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -4296,3 +4296,156 @@ describe('#1286 — cluster-list popover header reflects the merged group total'
     expect(heading.textContent).not.toContain(`${formatCount(24)} observations`);
   });
 });
+
+/* ── #1296 bot-review: a grid-singleton merged into a real cluster must appear
+ *    in the cluster-list popover ROWS so Σ rows === header (renderedTotal) ─────
+ *
+ * In a FILTERED view a lone observation is promoted to a count-bearing 1×1 grid
+ * marker carrying a synthetic high-band pseudo-id; deconflict SUMS its +1 into
+ * the group's `renderedTotal` (#1296). When it deconflict-MERGES into a real
+ * supercluster cluster and the cluster-list popover opens (#717 stuck-pill /
+ * `targetZoom <= currentZoom`), the header reads `renderedTotal` (= cluster + 1)
+ * but the rows are built from `getClusterLeaves(realIds)`, which EXCLUDES the
+ * synthetic id — so pre-fix the singleton's species was DROPPED: header N+1,
+ * rows N (the #1286 header≠rows conservation bug, re-opened for grid singletons).
+ *
+ * The cluster and the singleton share IDENTICAL coords; the project() mock maps
+ * them to the same pixel → their AABBs intersect → deconflict folds them into ONE
+ * group. The cluster (17 single-obs families) wins the pill shape and the
+ * min(cluster_id) anchor; the click escalates into the cluster list because the
+ * cluster's expansion zoom == the current zoom. The fix stashes the singleton's
+ * own leaf at input-build time (keyed by its synthetic id) and folds it into the
+ * popover rows so the enumerated families total the header.
+ *
+ * This exercises the FULL MapCanvas wiring (filterActive → buildUnclusteredInput →
+ * grid promotion → reconcile-committed leaf map → openClusterListFromGroup), so a
+ * regression that stopped threading `filterActive` (no grid promotion) would also
+ * fail it — the SUGGESTION's wiring guard, paid for by the same test.
+ */
+describe('#1296 bot-review — grid-singleton member appears in the merged cluster-list', () => {
+  beforeEach(() => {
+    capturedSourceProps = {};
+    capturedLayerFilters = {};
+    capturedSourcesById = {};
+    capturedLayerPaint = {};
+    registeredHandlers = {};
+    bareHandlers = {};
+    bareHandlersAll = {};
+    deferMapLoad = false;
+    deferredOnLoad = null;
+    fakeMap = makeFakeMap();
+    document.documentElement.removeAttribute('data-theme');
+    __resetAdaptiveGridCacheForTesting();
+  });
+
+  // 17 single-obs families → the real cluster falls through to pill shape
+  // (uniqueFamilies > 16) and its 17 leaves total 17 observations (point_count 17).
+  function clusterLeaves17() {
+    return Array.from({ length: 17 }, (_, i) => ({
+      type: 'Feature',
+      properties: {
+        familyCode: `afam${i}`,
+        speciesCode: `asp${i}`,
+        comName: `A Species ${i}`,
+      },
+    }));
+  }
+
+  it('non-aggregated: the merged singleton species is enumerated and Σ family rows === header total (18), not 17', async () => {
+    const COORD: [number, number] = [-110.95, 32.25];
+    // Real cluster (17 obs across 17 families) + a FILTERED lone obs at the SAME
+    // coordinate → one merged group. renderedTotal = 17 + 1 = 18.
+    const clusterFeat = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: COORD },
+      properties: { cluster: true, cluster_id: 77, point_count: 17 },
+    };
+    const soloObs = makeObs({
+      subId: 'SOLO-1',
+      familyCode: 'zsingle',
+      speciesCode: 'zsp',
+      comName: 'Solo Phoebe',
+      lng: COORD[0],
+      lat: COORD[1],
+    });
+    // The promoted lone obs as the `unclustered-point` symbol layer paints it
+    // (per-observation properties, WITH a subId).
+    const soloFeat = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: COORD },
+      properties: {
+        subId: soloObs.subId,
+        familyCode: soloObs.familyCode,
+        speciesCode: soloObs.speciesCode,
+        comName: soloObs.comName,
+        isNotable: false,
+      },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) => {
+        if (opts?.layers?.includes('clusters-hit')) return [clusterFeat];
+        if (opts?.layers?.includes('unclustered-point')) return [soloFeat];
+        return [];
+      },
+    );
+    // getLayer truthy for unclustered-point so the reconciler's unclustered query
+    // runs (baseStyleLayers only seeds clusters-hit).
+    fakeMap.getLayer.mockReturnValue({ id: 'unclustered-point' });
+    const getClusterLeaves = vi.fn().mockResolvedValue(clusterLeaves17());
+    // expansion zoom == current zoom → easeTo no-ops → openClusterListFromGroup.
+    const getClusterExpansionZoom = vi.fn().mockResolvedValue(22);
+    fakeMap.getSource.mockReturnValue({ getClusterLeaves, getClusterExpansionZoom });
+    fakeMap.getZoom.mockReturnValue(22);
+    // Grid promotion hides the canvas twin via feature-state; stub the setters.
+    fakeMap.setFeatureState = vi.fn();
+    fakeMap.removeFeatureState = vi.fn();
+
+    render(
+      <MapCanvas observations={[soloObs]} filterActive silhouettes={SILHOUETTES} />,
+    );
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+    await act(async () => { await fireAllIdleHandlers(); });
+    await act(async () => { await Promise.resolve(); });
+
+    // The merged group renders ONE pill whose conserved badge already counts the
+    // singleton (#1296): "18 sightings".
+    const pill = await waitFor(() => {
+      const found = screen
+        .queryAllByRole('button', { name: /sightings$/ })
+        .find((p) => p.classList.contains('cluster-pill'));
+      if (!found) throw new Error('merged cluster-pill not rendered');
+      return found;
+    });
+    expect(pill).toHaveAttribute('aria-label', '18 sightings');
+
+    await act(async () => {
+      fireEvent.click(pill);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const heading = await waitFor(() =>
+      screen.getByTestId('cluster-list-popover-heading'),
+    );
+    // Header conserves the merged total (18 obs) AND the merged family count must
+    // now INCLUDE the singleton's family (18, not the 17 real-cluster families).
+    expect(heading.textContent).toContain(`${formatCount(18)} observations`);
+    expect(heading.textContent).toContain(`${formatCount(18)} families`);
+
+    // The grid-singleton's OWN family is now an enumerated row (pre-fix it was
+    // dropped — getClusterLeaves excludes the synthetic high-band id).
+    expect(
+      screen.getByTestId('cluster-list-popover-family-zsingle'),
+    ).toBeInTheDocument();
+
+    // Conservation: Σ of the per-family counts shown in the popover === the header
+    // total (18). Pre-fix the rows summed to 17 while the header read 18.
+    const popover = screen.getByTestId('cluster-list-popover');
+    const toggles = popover.querySelectorAll('.cluster-list-popover__family-toggle');
+    const rowSum = Array.from(toggles).reduce((sum, btn) => {
+      const m = /\(([\d,]+)\)\s*$/.exec(btn.textContent ?? '');
+      return sum + (m ? Number(m[1].replace(/,/g, '')) : 0);
+    }, 0);
+    expect(rowSum).toBe(18);
+  });
+});

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -66,10 +66,14 @@ import {
 } from './geometry/adaptive-grid.js';
 import { type HitTargetMarker } from './layers/MapMarkerHitLayer.js';
 import {
-  hashSubId,
+  isSyntheticSingleId,
   type DeconflictGroup,
   type DeconflictInput,
 } from './geometry/deconflict.js';
+// #1296: per-feature silhouette-vs-grid input builder for VISIBLE unclustered
+// observations. In a FILTERED view a lone obs is promoted to a count-bearing
+// 1×1 grid marker so it is summed into the group's `renderedTotal`.
+import { buildUnclusteredInput } from './geometry/unclustered-input.js';
 // Reconciler pure middle (deconflict → displace → unproject → feature-state
 // diff) extracted to reconcile-viewport.ts (epic #884 · U10, #895). The shell
 // in the adaptive-grid reconciler effect below assembles `inputs` (owning both
@@ -363,6 +367,7 @@ export function MapCanvas({
   maskPolygon,
   clampPad,
   detailOpen = false,
+  filterActive = false,
   activeThemeId: activeThemeIdProp,
   initialHashCamera,
   hashCameraInScope,
@@ -471,6 +476,17 @@ export function MapCanvas({
    * silhouette would stay invisible after the displacement clears.
    */
   const prevHiddenSubIdsRef = useRef<Set<string>>(new Set());
+  /**
+   * #1296: subIds whose canvas twin was hidden on the prior pass because the
+   * observation was promoted to a count-bearing 1×1 grid marker (FILTERED views
+   * only). Tracked separately from `prevHiddenSubIdsRef` (displaced silhouettes)
+   * so each ref clears its OWN feature-state when the condition lapses (filter
+   * turned off, obs panned off-screen). The two sets are disjoint by
+   * construction — a filtered view produces grid inputs (no silhouettes to
+   * displace), an unfiltered view produces silhouettes (no grid promotion) — so
+   * they never set/clear the same `hidden` flag in one pass.
+   */
+  const prevGridHiddenSubIdsRef = useRef<Set<string>>(new Set());
   /**
    * Silhouette data lookup for the displaced-silhouette render path.
    * `silhouettesById` (below) is keyed by lowercased familyCode for the
@@ -715,6 +731,7 @@ export function MapCanvas({
     setGroups([]);
     setSilhouetteOffsets(new Map());
     prevHiddenSubIdsRef.current = new Set();
+    prevGridHiddenSubIdsRef.current = new Set(); // #1296
   }
 
   /**
@@ -1617,22 +1634,30 @@ export function MapCanvas({
         }),
       );
 
-      // ── Silhouette inputs (issue #554 scope expansion 2026-05-15) ────
+      // ── Unclustered-observation inputs (issue #554; #1296) ───────────
       //
-      // Query every visible unclustered-point feature, project its
-      // lng/lat, and push it onto the deconflict input list as a
-      // silhouette variant. The negative pseudo-cluster_id derived from
-      // the subId hash keeps silhouette ids out of the positive cluster
-      // namespace so `min(cluster_id)` tiebreaks behave; `buildGroups`
-      // additionally prefers any non-silhouette over a silhouette as
-      // the anchor (see deconflict.ts buildGroups rule).
+      // Query every visible unclustered-point feature and project its lng/lat.
+      // The PER-FEATURE input shape is decided by `buildUnclusteredInput`:
       //
-      // Defensive: the `unclustered-point` symbol layer mounts only
-      // once `spritesReady` flips true, so on a cold reconcile the
-      // layer can be absent — `getLayer` guards against the maplibre
-      // "layer does not exist in the map's style and cannot be queried
-      // for features" error. Subsequent idle reconciles after the
-      // sprite-registration effect settles will pick up the layer.
+      //   - UNFILTERED (`!filterActive`): a `silhouette` variant with a NEGATIVE
+      //     pseudo-cluster_id (`-hashSubId(subId)`). Keeps silhouette ids out of
+      //     the positive cluster namespace so `min(cluster_id)` tiebreaks behave;
+      //     `buildGroups` also prefers any non-silhouette over a silhouette as
+      //     the anchor, and EXCLUDES silhouettes from `renderedTotal` (each paints
+      //     its own displaced symbol). Lone obs stay bare canvas dots — exactly
+      //     as before (no "1"-badge spam across thousands of unfiltered birds).
+      //
+      //   - FILTERED (`filterActive`): a count-bearing 1×1 family `grid` marker
+      //     with a POSITIVE high-band id (#1296). `kind:'grid'` ⇒ `buildGroups`
+      //     SUMS its `point_count` (1) into `renderedTotal`, so a filtered
+      //     viewport's Σ renderedTotal === the obs count the lede shows — closing
+      //     the "lede says N, only M<N render, worse on zoom-in" drop. The canvas
+      //     SDF twin is hidden below (feature-state) so it doesn't double-render.
+      //
+      // Defensive: the `unclustered-point` symbol layer mounts only once
+      // `spritesReady` flips true, so on a cold reconcile the layer can be absent
+      // — `getLayer` guards against the maplibre "layer does not exist … and
+      // cannot be queried for features" error. A subsequent idle picks it up.
       const unclusteredFeats = (
         map.getLayer && map.getLayer('unclustered-point')
           ? map.queryRenderedFeatures(undefined, {
@@ -1640,11 +1665,20 @@ export function MapCanvas({
             })
           : []
       ) as Array<{
-        properties?: { subId?: string };
+        properties?: {
+          subId?: string;
+          familyCode?: string | null;
+          speciesCode?: string | null;
+          comName?: string;
+          isNotable?: boolean;
+        };
         geometry?: { type: 'Point'; coordinates: [number, number] };
         id?: number | string;
       }>;
       const silSubIdsSeen = new Set<string>();
+      // #1296: subIds promoted to grid markers THIS pass — their canvas twins are
+      // hidden below so the React grid marker doesn't double-render over them.
+      const gridHiddenSubIds = new Set<string>();
       for (const f of unclusteredFeats) {
         const subId = f.properties?.subId;
         if (!subId || silSubIdsSeen.has(subId)) continue;
@@ -1653,17 +1687,24 @@ export function MapCanvas({
         if (!geom || geom.type !== 'Point') continue;
         const [longitudeS, latitudeS] = geom.coordinates;
         const projectedS = map.project([longitudeS, latitudeS]);
-        inputs.push({
-          cluster_id: -hashSubId(subId),
-          px: projectedS.x,
-          py: projectedS.y,
-          rendered: { kind: 'silhouette' },
-          point_count: 1,
-          uniqueFamilies: 1,
-          longitude: longitudeS,
-          latitude: latitudeS,
-          subId,
-        });
+        const input = buildUnclusteredInput(
+          {
+            subId,
+            familyCode: f.properties?.familyCode ?? null,
+            speciesCode: f.properties?.speciesCode ?? null,
+            comName: f.properties?.comName ?? '',
+            isNotable: Boolean(f.properties?.isNotable),
+            longitude: longitudeS,
+            latitude: latitudeS,
+            px: projectedS.x,
+            py: projectedS.y,
+          },
+          filterActive,
+          isMobile,
+          silhouettesById,
+        );
+        inputs.push(input);
+        if (input.rendered.kind === 'grid') gridHiddenSubIds.add(subId);
       }
 
       // Spec §5.3 Concern C race-safe commit: if the catalogue refreshed
@@ -1738,6 +1779,31 @@ export function MapCanvas({
       // NOT own the ref — the shell advances it after applying the diff.
       prevHiddenSubIdsRef.current = new Set<string>(nextOffsets.keys());
 
+      // #1296: hide the canvas SDF twin of every lone observation promoted to a
+      // count-bearing 1×1 grid marker (FILTERED views). The React grid marker
+      // (GroupMarkerLayer) paints the family silhouette as an overlay (single-leaf,
+      // so AdaptiveGridMarker suppresses the count-1 badge per spec §4.3) and its
+      // count is conserved in `renderedTotal`; without this the `unclustered-point`
+      // dot would double-render under it.
+      // Reuses the SAME `hidden` feature-state the displaced-silhouette path uses
+      // (icon-opacity 0 AND notable-ring stroke-opacity 0, so the notable ring
+      // hides too) — and, unlike layout `visibility:'none'`, KEEPS the feature
+      // queryable so the next idle's `queryRenderedFeatures` still enumerates it
+      // (the same opacity-0-but-placed property the displaced path relies on).
+      // Disjoint from the displaced set above (a filtered pass has no silhouette
+      // inputs), so the two refs never fight over one feature's `hidden` flag.
+      for (const subId of gridHiddenSubIds) {
+        if (!prevGridHiddenSubIdsRef.current.has(subId)) {
+          map.setFeatureState({ source: 'observations', id: subId }, { hidden: true });
+        }
+      }
+      for (const subId of prevGridHiddenSubIdsRef.current) {
+        if (!gridHiddenSubIds.has(subId)) {
+          map.removeFeatureState({ source: 'observations', id: subId }, 'hidden');
+        }
+      }
+      prevGridHiddenSubIdsRef.current = gridHiddenSubIds;
+
       // End-of-idle eviction (spec §5.3 Concern B): drop cache entries
       // for clusters that no longer appear in the viewport. Bounds
       // worst-case memory at O(visible clusters), not O(every cluster
@@ -1769,7 +1835,13 @@ export function MapCanvas({
       map.off('idle', onIdle);
       // Clear orphaned `hidden` feature-state so silhouettes don't stay
       // invisible after the effect re-runs (e.g. catalogue swap, unmount).
-      for (const subId of prevHiddenSubIdsRef.current) {
+      // #1296: includes the grid-promoted singletons so toggling the filter OFF
+      // (a `filterActive` dep change re-runs this effect) un-hides every canvas
+      // twin before the unfiltered reconcile repaints them as silhouettes.
+      for (const subId of [
+        ...prevHiddenSubIdsRef.current,
+        ...prevGridHiddenSubIdsRef.current,
+      ]) {
         try {
           map.removeFeatureState({ source: 'observations', id: subId }, 'hidden');
         } catch {
@@ -1777,6 +1849,7 @@ export function MapCanvas({
         }
       }
       prevHiddenSubIdsRef.current = new Set();
+      prevGridHiddenSubIdsRef.current = new Set();
     };
     // Re-register when the silhouettes catalogue OR the resolved
     // silhouettesById map changes, OR when the map first becomes ready.
@@ -1787,7 +1860,9 @@ export function MapCanvas({
     // #859: `aggregated`, `buckets`, and `dictionary` are deps too — flipping
     // the data path (z<6 ↔ z>=6), swapping the bucket set, or the dictionary
     // first resolving must re-run the reconciler so markers reflect real data.
-  }, [silhouettes, silhouettesById, silhouettesVersion, mapReady, aggregated, buckets, dictionary]);
+    // #1296: `filterActive` is a dep so toggling a filter re-registers the
+    // closure with the fresh flag (and its cleanup un-hides the prior twins).
+  }, [silhouettes, silhouettesById, silhouettesVersion, mapReady, aggregated, buckets, dictionary, filterActive]);
 
   // The [data-theme] MutationObserver (basemap `setStyle` swap + mask-fill
   // re-tint via `setMaskTheme`, with the `prevThemeRef` no-op-write guard) was
@@ -1834,9 +1909,10 @@ export function MapCanvas({
         | undefined;
       if (!source?.getClusterLeaves) return;
 
-      // Silhouettes have negative pseudo-IDs and are not registered in
-      // supercluster — filter them out before requesting leaves.
-      const realIds = group.memberIds.filter((id) => id > 0);
+      // Silhouettes have negative pseudo-IDs; #1296 single-obs grid markers have
+      // positive HIGH-BAND pseudo-IDs. Neither is registered in supercluster, so
+      // exclude both before requesting leaves (a bad id rejects the whole batch).
+      const realIds = group.memberIds.filter((id) => id > 0 && !isSyntheticSingleId(id));
       if (realIds.length === 0) return;
 
       try {
@@ -1910,7 +1986,9 @@ export function MapCanvas({
         const map = mapRef.current?.getMap();
         if (!map) return;
         const source = map.getSource('observations');
-        const clusterMemberIds = memberIds.filter((id) => id > 0);
+        // Exclude silhouette (negative) and #1296 single-obs (high-band) pseudo-ids
+        // — only real supercluster ids are valid for getClusterExpansionZoom.
+        const clusterMemberIds = memberIds.filter((id) => id > 0 && !isSyntheticSingleId(id));
         if (
           clusterMemberIds.length > 0 &&
           source &&
@@ -1971,11 +2049,12 @@ export function MapCanvas({
       try {
         // Click-time-lazy: async expansion-zoom aggregation over cluster
         // members only. Silhouette pseudo-IDs are negative by construction
-        // (−hashSubId(subId)) and are not registered in supercluster's
+        // (−hashSubId(subId)); #1296 single-obs grid markers are positive but in
+        // the synthetic HIGH BAND. Neither is registered in supercluster's
         // index — passing them to getClusterExpansionZoom rejects, causing
         // the Promise.all to reject and the click to silently no-op.
-        // Bot review #554: filter to positive IDs (real cluster IDs) only.
-        const clusterMemberIds = memberIds.filter((id) => id > 0);
+        // Bot review #554: filter to real cluster IDs only.
+        const clusterMemberIds = memberIds.filter((id) => id > 0 && !isSyntheticSingleId(id));
 
         // Silhouette-only group: anchor is a silhouette, no cluster IDs
         // remain. Route to single-leaf path (open obs popover).

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -353,6 +353,25 @@ function useSanitizedBasemapStyle(themeId: ThemeId): StyleSpecification {
   return style ?? backgroundPlaceholderStyle(themeId);
 }
 
+/**
+ * #1296 bot-review: re-shape a grid-singleton's per-observation leaf into a
+ * one-family `familiesJson` bucket leaf so the AGGREGATED cluster-list branch
+ * (`mergeLeafBuckets`) can fold it through the same code path as real bucket
+ * leaves. `count`/`speciesCount` are 1 (a single observation); a null
+ * `speciesCode` (spuh/slash/hybrid) yields an empty species list so the family
+ * still counts but contributes no phantom species row. Matches the shape
+ * `bucketsToGeoJson` serializes (`AggregatedFamily[]`).
+ */
+function singletonLeafToBucketLeaf(
+  leaf: ClusterLeafFeature,
+): { properties: { familiesJson: string } } {
+  const { familyCode, speciesCode } = leaf.properties;
+  if (!familyCode) return { properties: { familiesJson: '[]' } };
+  const species = speciesCode ? [{ code: speciesCode, count: 1 }] : [];
+  const family = { code: familyCode, count: 1, speciesCount: species.length, species };
+  return { properties: { familiesJson: JSON.stringify([family]) } };
+}
+
 export function MapCanvas({
   observations,
   buckets = EMPTY_BUCKETS,
@@ -487,6 +506,20 @@ export function MapCanvas({
    * they never set/clear the same `hidden` flag in one pass.
    */
   const prevGridHiddenSubIdsRef = useRef<Set<string>>(new Set());
+  /**
+   * #1296 (bot-review follow-up): the originating observation leaf for every
+   * grid-promoted singleton, keyed by its synthetic high-band pseudo-id
+   * (`GRID_SINGLE_ID_BASE + hashSubId(subId)`). That pseudo-id is NOT registered
+   * in supercluster, so when a grid-singleton deconflict-MERGES into a real
+   * cluster, `openClusterListFromGroup` cannot recover its species via
+   * `getClusterLeaves` — leaving the popover header (= `group.renderedTotal`,
+   * which counts the singleton's +1) one ahead of the enumerated species rows
+   * (the same header≠rows conservation bug class as #1286). We stash the leaf
+   * here at input-build time so the popover can fold the singleton's species
+   * into its rows, keeping `Σ rows === header`. Re-committed wholesale each
+   * reconcile pass (alongside `prevGridHiddenSubIdsRef`).
+   */
+  const gridSingletonLeavesRef = useRef<Map<number, ClusterLeafFeature>>(new Map());
   /**
    * Silhouette data lookup for the displaced-silhouette render path.
    * `silhouettesById` (below) is keyed by lowercased familyCode for the
@@ -732,6 +765,7 @@ export function MapCanvas({
     setSilhouetteOffsets(new Map());
     prevHiddenSubIdsRef.current = new Set();
     prevGridHiddenSubIdsRef.current = new Set(); // #1296
+    gridSingletonLeavesRef.current = new Map(); // #1296 bot-review
   }
 
   /**
@@ -1679,6 +1713,11 @@ export function MapCanvas({
       // #1296: subIds promoted to grid markers THIS pass — their canvas twins are
       // hidden below so the React grid marker doesn't double-render over them.
       const gridHiddenSubIds = new Set<string>();
+      // #1296 bot-review: synthetic-id → originating obs leaf for the grid markers
+      // promoted THIS pass. Committed to `gridSingletonLeavesRef` after the
+      // empty-commit guard so the popover can enumerate a merged singleton's
+      // species (see the ref's doc comment).
+      const nextGridSingletonLeaves = new Map<number, ClusterLeafFeature>();
       for (const f of unclusteredFeats) {
         const subId = f.properties?.subId;
         if (!subId || silSubIdsSeen.has(subId)) continue;
@@ -1704,7 +1743,23 @@ export function MapCanvas({
           silhouettesById,
         );
         inputs.push(input);
-        if (input.rendered.kind === 'grid') gridHiddenSubIds.add(subId);
+        if (input.rendered.kind === 'grid') {
+          gridHiddenSubIds.add(subId);
+          // #1296 bot-review: stash this obs's own leaf under the synthetic
+          // pseudo-id `buildUnclusteredInput` assigned, so a cluster-list popover
+          // opened on a group this singleton merged into can enumerate its
+          // species. Mirrors the single leaf `buildUnclusteredInput` builds.
+          nextGridSingletonLeaves.set(input.cluster_id, {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [longitudeS, latitudeS] },
+            properties: {
+              familyCode: f.properties?.familyCode ?? null,
+              speciesCode: f.properties?.speciesCode ?? null,
+              comName: f.properties?.comName ?? '',
+              isNotable: Boolean(f.properties?.isNotable),
+            },
+          });
+        }
       }
 
       // Spec §5.3 Concern C race-safe commit: if the catalogue refreshed
@@ -1803,6 +1858,10 @@ export function MapCanvas({
         }
       }
       prevGridHiddenSubIdsRef.current = gridHiddenSubIds;
+      // #1296 bot-review: commit this pass's synthetic-id → leaf map in lockstep
+      // with the committed groups, so a click on any rendered grid-singleton
+      // resolves to the leaf that produced it.
+      gridSingletonLeavesRef.current = nextGridSingletonLeaves;
 
       // End-of-idle eviction (spec §5.3 Concern B): drop cache entries
       // for clusters that no longer appear in the viewport. Bounds
@@ -1850,6 +1909,7 @@ export function MapCanvas({
       }
       prevHiddenSubIdsRef.current = new Set();
       prevGridHiddenSubIdsRef.current = new Set();
+      gridSingletonLeavesRef.current = new Map(); // #1296 bot-review
     };
     // Re-register when the silhouettes catalogue OR the resolved
     // silhouettesById map changes, OR when the map first becomes ready.
@@ -1913,21 +1973,44 @@ export function MapCanvas({
       // positive HIGH-BAND pseudo-IDs. Neither is registered in supercluster, so
       // exclude both before requesting leaves (a bad id rejects the whole batch).
       const realIds = group.memberIds.filter((id) => id > 0 && !isSyntheticSingleId(id));
-      if (realIds.length === 0) return;
+      // #1296 bot-review: a grid-promoted singleton that deconflict-merged into
+      // this group contributes its +1 to `group.renderedTotal` (the header), so
+      // its species MUST appear in the rows too — else header reads N+1 while the
+      // enumerated rows total N (the #1286 header≠rows conservation bug, re-opened
+      // for grid singletons). Its synthetic id isn't a supercluster cluster, so
+      // recover the originating leaf we stashed at input-build time instead of
+      // `getClusterLeaves` (which would reject the whole batch on a bad id).
+      const singletonLeaves = group.memberIds
+        .filter((id) => isSyntheticSingleId(id))
+        .map((id) => gridSingletonLeavesRef.current.get(id))
+        .filter((leaf): leaf is ClusterLeafFeature => leaf !== undefined);
+      if (realIds.length === 0 && singletonLeaves.length === 0) return;
 
       try {
-        const leafBatches = await Promise.all(
-          realIds.map(
-            (id) =>
-              source.getClusterLeaves!(id, 64, 0) as Promise<ClusterLeafFeature[]>,
-          ),
-        );
-        const leaves = leafBatches.flat();
-        if (leaves.length === 0) return;
+        const leafBatches =
+          realIds.length > 0
+            ? await Promise.all(
+                realIds.map(
+                  (id) =>
+                    source.getClusterLeaves!(id, 64, 0) as Promise<ClusterLeafFeature[]>,
+                ),
+              )
+            : [];
+        const realLeaves = leafBatches.flat();
+        if (realLeaves.length === 0 && singletonLeaves.length === 0) return;
         if (aggregated) {
-          // #859: leaves are buckets — merge their real families/species.
+          // #859: real cluster leaves are buckets — merge their real
+          // families/species. #1296 bot-review: any grid-singleton member is a
+          // per-observation leaf, not a bucket, so re-shape it as a one-family
+          // `familiesJson` bucket leaf and merge it through the SAME path so the
+          // count stays conserved. (In practice this is empty in aggregated mode —
+          // bucket features carry no subId, so no obs is ever grid-promoted there —
+          // but folding keeps header==rows honest if that ever changes.)
           const merged = mergeLeafBuckets(
-            leaves as unknown as Array<{ properties?: { familiesJson?: unknown } }>,
+            [
+              ...(realLeaves as unknown as Array<{ properties?: { familiesJson?: unknown } }>),
+              ...singletonLeaves.map(singletonLeafToBucketLeaf),
+            ],
             dictionary,
           );
           setClusterList({
@@ -1948,17 +2031,21 @@ export function MapCanvas({
           });
           return;
         }
-        const families = aggregateClusterFamilies(leaves);
-        const speciesByFamily = aggregateClusterSpecies(leaves);
+        // #1296 bot-review: include the grid-singleton members' own leaves so the
+        // rows total the header (`group.renderedTotal`, which counts each +1).
+        const allLeaves = [...realLeaves, ...singletonLeaves];
+        const families = aggregateClusterFamilies(allLeaves);
+        const speciesByFamily = aggregateClusterSpecies(allLeaves);
         setClusterList({
           group,
           families,
           speciesByFamily,
           // #1286: as above — the header counts the whole merged group. `families`
-          // is `aggregateClusterFamilies(leaves)` over EVERY member's flattened
-          // leaves, so `families.length` is the merged unique-family count (the
-          // aggregated branch above already uses its `merged.families.length`);
-          // the anchor-only `group.anchor.uniqueFamilies` undercounts it.
+          // is `aggregateClusterFamilies(allLeaves)` over EVERY member's flattened
+          // leaves (incl. grid singletons), so `families.length` is the merged
+          // unique-family count (the aggregated branch above already uses its
+          // `merged.families.length`); the anchor-only `group.anchor.uniqueFamilies`
+          // undercounts it.
           totalCount: group.renderedTotal,
           uniqueFamilies: families.length,
           anchorEl,

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -173,6 +173,22 @@ export interface MapCanvasProps {
    */
   detailOpen?: boolean;
   /**
+   * #1296 — true when ANY data filter is active (`!noFiltersActive` in App.tsx:
+   * species/family/notable/since). Forwarded VERBATIM from App via MapSurface,
+   * following the `detailOpen`/#1283 viewport-filter prop pattern (the canonical
+   * predicate is computed ONCE in App; MapCanvas must NOT recompute filter state).
+   *
+   * Gates the lone-observation render path in the adaptive-grid reconciler: in a
+   * FILTERED view each visible UNCLUSTERED observation is promoted from a bare
+   * canvas silhouette to a count-bearing 1×1 family grid marker (`kind:'grid'`)
+   * so its count is SUMMED into the group's `renderedTotal` — fixing the
+   * "lede says N, only M<N render, worse on zoom-in" drop where de-clustered
+   * silhouette singletons were excluded from the on-screen total. UNFILTERED
+   * views are unchanged (lone obs stay bare silhouettes — no "1"-badge spam
+   * across thousands of birds). Defaults to `false` (legacy/test callers).
+   */
+  filterActive?: boolean;
+  /**
    * #1220 (C8) — the active basemap theme id, lifted to App.tsx (`useActiveThemeId`
    * seeded from `resolveInitialTheme`) so the <ThemeSelector> in <AppHeader> and
    * the id-keyed basemap swap here share ONE source of truth. When supplied it

--- a/frontend/src/components/map/geometry/deconflict.ts
+++ b/frontend/src/components/map/geometry/deconflict.ts
@@ -655,3 +655,36 @@ export function hashSubId(s: string): number {
   for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
   return Math.abs(h);
 }
+
+/**
+ * Reserved id band for SYNTHETIC single-observation grid markers (issue #1296).
+ *
+ * In a FILTERED view a lone unclustered observation is promoted from a bare
+ * canvas silhouette to a count-bearing 1×1 family grid marker so its count is
+ * conserved in the group's `renderedTotal` (the silhouette path EXCLUDES
+ * silhouettes from `renderedTotal`, so de-clustered singletons were silently
+ * dropped from the on-screen total — the bug). The promoted input carries a
+ * POSITIVE pseudo-`cluster_id` of `GRID_SINGLE_ID_BASE + hashSubId(subId)`:
+ *
+ *   - POSITIVE (vs the silhouette path's negative ids) so it reads as a real
+ *     cluster to `buildGroups` (non-silhouette → SUMMED into `renderedTotal`,
+ *     and eligible to be an anchor).
+ *   - In a HIGH band (1e9) so a real overlapping supercluster cluster — whose
+ *     ids are `(index << 5) + zoom`, bounded by the viewport's feature count and
+ *     therefore far below 1e9 in any filtered view — always wins the
+ *     `min(cluster_id)` anchor tiebreak. The lone obs never suppresses a true
+ *     cluster's richer marker; it only adds its own count.
+ *   - DISTINGUISHABLE so the click handlers can exclude it from
+ *     `getClusterLeaves` / `getClusterExpansionZoom` (it is NOT registered in
+ *     supercluster — passing it would reject the whole batch). `isSyntheticSingleId`
+ *     is the predicate those call sites filter on.
+ *
+ * `hashSubId` maxes out near `2^31`, so the band [1e9, ~3.15e9] stays well
+ * inside `Number.MAX_SAFE_INTEGER`.
+ */
+export const GRID_SINGLE_ID_BASE = 1_000_000_000;
+
+/** True when `id` is a synthetic single-observation grid pseudo-id (#1296). */
+export function isSyntheticSingleId(id: number): boolean {
+  return id >= GRID_SINGLE_ID_BASE;
+}

--- a/frontend/src/components/map/geometry/unclustered-input.test.ts
+++ b/frontend/src/components/map/geometry/unclustered-input.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { buildUnclusteredInput, type UnclusteredFeatureInput } from './unclustered-input.js';
+import {
+  buildGroups,
+  isSyntheticSingleId,
+  type DeconflictInput,
+} from './deconflict.js';
+import type { ResolvedGrid, SilhouettesById } from './adaptive-grid.js';
+
+/**
+ * Render-completeness regression for issue #1296.
+ *
+ * The "Greater Roadrunner, Phoenix AZ" repro: 8 observations, obs #1 & #4
+ * COINCIDENT. At tile zoom 10 the real `supercluster` (radius 800, extent 8192,
+ * maxZoom 22) decomposes the in-viewport subset (obs 1-7; obs 8 is out of the
+ * viewport) into TWO clusters + TWO raw singletons:
+ *
+ *   cluster(3) = [obs 1, 4, 7]   (point_count 3)
+ *   cluster(2) = [obs 2, 3]      (point_count 2)
+ *   raw idx5   = obs 5           (singleton)
+ *   raw idx6   = obs 6           (singleton)
+ *
+ * That decomposition is pinned here as deterministic fixtures (the proven
+ * values from the issue) so the test exercises EXACTLY the changed code — the
+ * reconciler's per-feature input-building + `buildGroups` — without a live map
+ * or the `supercluster`/`maplibre` worker.
+ *
+ * Before #1296 the two singletons were pushed as `kind:'silhouette'` inputs,
+ * which `buildGroups` EXCLUDES from `renderedTotal` → Σ renderedTotal = 5 while
+ * the lede counts 7 → 2 birds silently missing on screen, worsening as zoom
+ * de-clusters more singletons.
+ */
+
+// The 8-coordinate roadrunner fixture (issue #1296). 1-indexed in the issue;
+// obs #1 & #4 are coincident; obs #8 is the far-NW point outside the z10 viewport.
+const ROADRUNNER_COORDS: ReadonlyArray<[number, number]> = [
+  [33.4741, -111.9596], // 1
+  [33.43348, -111.94868], // 2
+  [33.44809, -111.93719], // 3
+  [33.4741, -111.9596], // 4  (coincident with #1)
+  [33.51206, -111.88502], // 5  raw singleton
+  [33.51743, -111.85052], // 6  raw singleton
+  [33.46182, -111.94363], // 7
+  [33.65492, -112.18361], // 8  out of viewport at z10
+];
+
+const CUCULIDAE: SilhouettesById = new Map([
+  ['cuculidae', { svgData: '<path d="M0 0" />', color: '#a33', colorDark: '#f88', commonName: 'Cuckoos' }],
+]);
+
+/** A clustered grid input as the clustered branch assembles it (real positive id). */
+function clusterGridInput(id: number, px: number, py: number, pointCount: number): DeconflictInput {
+  const shape: ResolvedGrid = { tag: 'grid', cols: 1, rows: 1 };
+  return {
+    cluster_id: id,
+    px,
+    py,
+    rendered: { kind: 'grid', shape },
+    point_count: pointCount,
+    uniqueFamilies: 1,
+    longitude: -111.94,
+    latitude: 33.46,
+  };
+}
+
+/** Singleton feature input (obs #5 / #6), with a deliberately well-separated px/py. */
+function singletonFeature(idx: number, px: number, py: number): UnclusteredFeatureInput {
+  const [lat, lng] = ROADRUNNER_COORDS[idx - 1] as [number, number];
+  return {
+    subId: `obsSL${idx}`,
+    familyCode: 'cuculidae',
+    speciesCode: 'greroa',
+    comName: 'Greater Roadrunner',
+    isNotable: false,
+    longitude: lng,
+    latitude: lat,
+    px,
+    py,
+  };
+}
+
+/**
+ * Build the full reconciler input list for the z10 decomposition. Positions are
+ * spread ≥300px apart so no marker AABBs overlap → 4 distinct deconflict groups.
+ */
+function buildInputs(filterActive: boolean): DeconflictInput[] {
+  return [
+    clusterGridInput(11, 100, 100, 3), // cluster(3) = [1,4,7]
+    clusterGridInput(12, 100, 400, 2), // cluster(2) = [2,3]
+    buildUnclusteredInput(singletonFeature(5, 400, 100), filterActive, false, CUCULIDAE),
+    buildUnclusteredInput(singletonFeature(6, 400, 400), filterActive, false, CUCULIDAE),
+  ];
+}
+
+function sumRenderedTotal(inputs: DeconflictInput[]): number {
+  return buildGroups(inputs, 10).reduce((sum, g) => sum + g.renderedTotal, 0);
+}
+
+describe('unclustered-input — filtered-view render completeness (#1296)', () => {
+  it('filterActive=true conserves the count: Σ renderedTotal === 7 (the 2 singletons now contribute)', () => {
+    expect(sumRenderedTotal(buildInputs(true))).toBe(7);
+  });
+
+  it('filterActive=false is UNCHANGED: singletons stay silhouettes, Σ renderedTotal === 5', () => {
+    expect(sumRenderedTotal(buildInputs(false))).toBe(5);
+  });
+
+  it('promotes each lone obs to a 1×1 family grid marker only when filtered', () => {
+    const filtered = buildUnclusteredInput(singletonFeature(5, 400, 100), true, false, CUCULIDAE);
+    expect(filtered.rendered.kind).toBe('grid');
+    expect(filtered.rendered).toEqual({ kind: 'grid', shape: { tag: 'grid', cols: 1, rows: 1 } });
+    expect(filtered.point_count).toBe(1);
+    expect(filtered.tiles).toHaveLength(1);
+    expect(filtered.tiles?.[0]).toMatchObject({ kind: 'rendered', familyCode: 'cuculidae' });
+    // Positive high-band id so a real overlapping cluster wins the min() anchor
+    // tiebreak, and the click handlers can exclude it from getClusterLeaves.
+    expect(filtered.cluster_id).toBeGreaterThan(0);
+    expect(isSyntheticSingleId(filtered.cluster_id)).toBe(true);
+
+    const unfiltered = buildUnclusteredInput(singletonFeature(5, 400, 100), false, false, CUCULIDAE);
+    expect(unfiltered.rendered.kind).toBe('silhouette');
+    expect(unfiltered.cluster_id).toBeLessThan(0); // negative pseudo-id (unchanged path)
+    expect(isSyntheticSingleId(unfiltered.cluster_id)).toBe(false);
+  });
+});

--- a/frontend/src/components/map/geometry/unclustered-input.ts
+++ b/frontend/src/components/map/geometry/unclustered-input.ts
@@ -1,0 +1,119 @@
+// Per-observation DeconflictInput builder for VISIBLE unclustered points
+// (issue #1296). Extracted from MapCanvas.tsx's reconciler so the
+// silhouette-vs-grid decision is pure + unit-testable.
+//
+// Background: the adaptive-grid reconciler queries every visible
+// `unclustered-point` feature and feeds each into `buildGroups`. Historically
+// EVERY such lone observation was pushed as a `kind:'silhouette'` input, and
+// `buildGroups` EXCLUDES silhouettes from `renderedTotal`. So as zoom de-clusters
+// a filtered view into more singletons, the on-screen Σ renderedTotal fell below
+// the obs count the lede shows — birds silently missing from the map.
+//
+// Fix (FILTERED views only): promote each lone observation to a count-bearing
+// 1×1 family grid marker. `kind:'grid'` ⇒ deconflict SUMS its `point_count` (1)
+// into `renderedTotal`, so Σ renderedTotal === the viewport obs count again. The
+// obs renders as a single-leaf family silhouette (AdaptiveGridMarker suppresses
+// the count-1 badge per spec §4.3) — a real React marker that is now COUNTED and
+// click-routes to the observation popover, instead of an uncounted bare dot.
+//
+// UNFILTERED views are UNCHANGED: lone obs stay bare silhouettes (no "1"-badge
+// spam across thousands of birds in dense high-zoom views).
+import {
+  buildAdaptiveTiles,
+  type ClusterLeafFeature,
+  type ResolvedGrid,
+  type SilhouettesById,
+} from './adaptive-grid.js';
+import {
+  GRID_SINGLE_ID_BASE,
+  hashSubId,
+  type DeconflictInput,
+} from './deconflict.js';
+
+/** The map-resolved properties a single visible unclustered feature carries. */
+export interface UnclusteredFeatureInput {
+  /** Observation subId (promoteId key — drives the canvas-twin feature-state). */
+  subId: string;
+  /** Family code (null when the silhouette join misses). */
+  familyCode: string | null;
+  /** eBird species code (null for spuh/slash/hybrid). */
+  speciesCode: string | null;
+  /** Display common name. */
+  comName: string;
+  /** Whether this observation is in eBird's notable list. */
+  isNotable: boolean;
+  /** Geographic position. */
+  longitude: number;
+  latitude: number;
+  /** Already-projected pixel center (the shell owns `map.project`). */
+  px: number;
+  py: number;
+}
+
+/** A lone observation is exactly one family → a 1×1 grid. */
+const SINGLE_OBS_SHAPE: ResolvedGrid = { tag: 'grid', cols: 1, rows: 1 };
+
+/**
+ * Build the `DeconflictInput` for one visible unclustered observation.
+ *
+ * - `filterActive === false` → a `kind:'silhouette'` input with a NEGATIVE
+ *   pseudo-id (`-hashSubId(subId)`), EXACTLY as the pre-#1296 reconciler built
+ *   it. Displaced (never suppressed) by deconflict; painted by the canvas
+ *   `unclustered-point` SDF layer; EXCLUDED from `renderedTotal`.
+ * - `filterActive === true` → a `kind:'grid'` input (1×1 family tile) with a
+ *   positive high-band id (see `GRID_SINGLE_ID_BASE`). SUMMED into
+ *   `renderedTotal`; the caller hides the canvas twin via feature-state so the
+ *   grid marker doesn't double-render over the SDF dot.
+ *
+ * `isMobile` is accepted for call-site parity with `pickGridShape`; a single
+ * family is always a clean 1×1 grid on both tiers, so it is currently unused.
+ */
+export function buildUnclusteredInput(
+  f: UnclusteredFeatureInput,
+  filterActive: boolean,
+  isMobile: boolean,
+  silhouettesById: SilhouettesById,
+): DeconflictInput {
+  void isMobile; // 1 family ⇒ 1×1 on every tier (see pickGridShape's table).
+  if (!filterActive) {
+    return {
+      cluster_id: -hashSubId(f.subId),
+      px: f.px,
+      py: f.py,
+      rendered: { kind: 'silhouette' },
+      point_count: 1,
+      uniqueFamilies: 1,
+      longitude: f.longitude,
+      latitude: f.latitude,
+      subId: f.subId,
+    };
+  }
+
+  // Single-leaf tile, built the SAME way the clustered branch builds its grid
+  // tiles (`buildAdaptiveTiles`) — one leaf = this observation's family.
+  const leaf: ClusterLeafFeature = {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [f.longitude, f.latitude] },
+    properties: {
+      familyCode: f.familyCode,
+      speciesCode: f.speciesCode,
+      comName: f.comName,
+      isNotable: f.isNotable,
+    },
+  };
+  const tiles = buildAdaptiveTiles([leaf], silhouettesById, SINGLE_OBS_SHAPE);
+
+  return {
+    cluster_id: GRID_SINGLE_ID_BASE + hashSubId(f.subId),
+    px: f.px,
+    py: f.py,
+    rendered: { kind: 'grid', shape: SINGLE_OBS_SHAPE },
+    point_count: 1,
+    uniqueFamilies: 1,
+    longitude: f.longitude,
+    latitude: f.latitude,
+    tiles,
+    isNotable: f.isNotable,
+    subId: f.subId,
+  };
+}


### PR DESCRIPTION

## Diagrams

```mermaid
flowchart TD
    QRF["reconciler: queryRenderedFeatures('unclustered-point')<br/>= every visible lone observation"] --> DEC{"buildUnclusteredInput<br/>filterActive?"}
    DEC -->|"false (UNCHANGED)"| SIL["kind:'silhouette'<br/>negative pseudo-id<br/>EXCLUDED from renderedTotal<br/>painted by canvas SDF layer"]
    DEC -->|"true (#1296)"| GRID["kind:'grid' 1×1 family tile<br/>POSITIVE high-band id<br/>SUMMED into renderedTotal<br/>canvas twin hidden (feature-state)"]
    SIL --> BG["buildGroups → Σ renderedTotal"]
    GRID --> BG
    BG --> R1["UNFILTERED: Σ = clusters only<br/>(singletons stay bare dots)"]
    BG --> R2["FILTERED: Σ = clusters + singletons<br/>= viewport total = lede count ✓"]
```

## Summary

- **Why:** in a filtered view the lede counted N but only M&lt;N markers' worth rendered, worsening on zoom-in. The reconciler pushed every visible **unclustered** observation as a `kind:'silhouette'` deconflict input, and `buildGroups` **excludes silhouettes from `renderedTotal`** — so `Σ renderedTotal === clusters only === viewport total − (#singletons)`, and de-clustering more singletons at higher zoom dropped more of them from the on-screen total (the MR-2b/MR-10 render-completeness class, fired in the wild on `?species=greroa`).
- **Fix (filtered views only):** promote each lone observation to a count-bearing **1×1 family grid marker**. `kind:'grid'` ⇒ deconflict **sums** its `point_count` (1) into `renderedTotal`, so a filtered viewport's `Σ renderedTotal` again equals the lede count. It renders as a single-leaf family silhouette (AdaptiveGridMarker suppresses the count-1 badge per spec §4.3) — a real, **counted**, clickable marker instead of an uncounted bare canvas dot. The canvas SDF twin is hidden via the **same `hidden` feature-state the displaced-silhouette path uses** (not layout `visibility:'none'`, which would also break the reconciler's own `queryRenderedFeatures` enumeration and orphan notable rings).
- **Scoped + safe:** unfiltered views are byte-identical (lone obs stay bare silhouettes — no badge/marker spam across thousands of birds). Gated on `filterActive = !noFiltersActive` (the app's canonical species/family/notable/since predicate), computed once in App and threaded App → MapSurface → MapCanvas (the #1283/`detailOpen` prop pattern). The promoted input uses a positive **high-band** pseudo-id so a real overlapping cluster always wins the `min(cluster_id)` anchor tiebreak; the three cluster-leaf/expansion-zoom click filters exclude that band (it isn't registered in supercluster).

## Screenshots

**Marker-conservation fix verified at the live `?species=greroa&family=cuculidae` z10.96 repro** (the issue's case). BEFORE (prod): 2 badged clusters summing to **5**, but the lede reads **7** — the 2 de-clustered singletons paint as un-counted bare silhouettes. AFTER (this PR, local dev on prod data): **4 markers** — the 2 clusters (`3` + `2`) PLUS the 2 singletons as `Cluster: 1 observation` count-bearing markers → **Σ = 7 = lede**. Holds on mobile.

| Before — prod (Σ badges 5, lede 7 → 2 missing) | After — #1298 desktop (Σ 7 = lede) | After — #1298 mobile (Σ 7) |
|---|---|---|
| ![before](https://github.com/user-attachments/assets/a3b4823e-21ca-4a60-9dc6-4e6778ed2cad) | ![after](https://github.com/user-attachments/assets/55f48e31-5318-41e0-8986-e18b3f6a2b23) | ![after-mobile](https://github.com/user-attachments/assets/ed4b85f1-992b-4d5c-8a01-301f5fca8a51) |

- [x] No new/renamed `className` (clustering/render logic + a new geometry module; no CSS).
- [x] Multi-viewport — non-design marker-CONSERVATION fix, verified live at the reported repro (desktop + mobile) + the Σ-conservation unit test (filtered 7 / unfiltered 5, RED→GREEN, bot-reproduced). The canonical 10-shot design-QA is calibrated for visual-design changes; before/after at the repro is the apt evidence for a count fix.


## Test plan

- [x] `npm run test -w @bird-watch/frontend` — green (1807 passed, incl. new `unclustered-input.test.ts`)
- [x] New unit tests added: `unclustered-input.test.ts` pins the 8-coord roadrunner fixture through the z10 decomposition + `buildGroups` — `filterActive=true` ⇒ Σ renderedTotal === **7** (red before fix at 5), `filterActive=false` ⇒ Σ === **5** (locks the unfiltered gate)
- [ ] New Playwright e2e spec added — N/A (behavior verified via the deterministic reconciler unit test; on-canvas marker counts aren't assertable in the e2e DOM)
- [x] `npm run build -w @bird-watch/frontend` — clean (`tsc -b && vite build`)
- [ ] (UI only) Playwright MCP smoke — orchestrator to drive `?species=greroa` before/after at the repro viewports (subagents can't drive MCP)

## Plan reference

Fixes #1296. Out of plan — user-reported render-completeness bug (filtered species view drops markers).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)