### PR TITLE
feat(read-api): GET /api/observations/cell for the low-zoom sightings log (#1300)

### DIFF
--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -7,6 +7,10 @@ export {
   // #878 — precomputed per-scope aggregation grid.
   refreshGridAgg, getAggregatedGridFromCache, isPrecomputeEligible,
   resolveScopeKey, NATIONAL_SCOPE_KEY, STANDARD_GRID_MULTIPLIERS,
+  // #1300 (B1) — single-cell sightings-log query (consumed by the
+  // GET /api/observations/cell route). CELL_OBSERVATIONS_LIMIT and
+  // buildCellObservationsQuery stay module-local (test-only consumers).
+  getCellObservations, type CellObservationsParams,
   type ObservationInput,
 } from './observations.js';
 export {

--- a/packages/db-client/src/observations-cell-perf.test.ts
+++ b/packages/db-client/src/observations-cell-perf.test.ts
@@ -1,0 +1,242 @@
+/**
+ * PROD-SCALE PERF + INDEX-USAGE GUARD for the single-cell sightings-log query
+ * (#1300, epic #1299).
+ *
+ * Why a falsifiable index assertion and NOT a wall-clock-only guard: a
+ * single-species, single-cell slice is small (≤ a few thousand rows), so it
+ * stays fast even on a SEQ SCAN at modest volume — a wall-clock-only threshold
+ * here would be non-falsifiable ceremony (it would pass with or without the
+ * indexes). The real risk is the `count(*) OVER ()` denominator: because the
+ * window must touch EVERY matched (windowed) row before LIMIT applies, a query
+ * that fails to drive off `obs_geom_idx` (tight cell envelope) + `obs_species_idx`
+ * (species filter) degrades to a full table scan at prod scale. This guard makes
+ * that regression RED two ways:
+ *
+ *   (a) PROD-SCALE SEED — ~100k background observations across CONUS plus a
+ *       dense single-species `m=2` (coarsest, 0.5°×0.5°) cell, so a missing
+ *       index actually blows wall-clock (best-of-N min under a generous guard).
+ *   (b) EXPLAIN (ANALYZE) — asserts the plan for the EXACT query
+ *       getCellObservations runs (via buildCellObservationsQuery) uses an
+ *       Index/Bitmap scan on `obs_geom_idx`/`obs_species_idx` and NEVER a
+ *       `Seq Scan on observations`.
+ *
+ * RED case this is designed to fail on: dropping `obs_species_idx`/`obs_geom_idx`
+ * (migration 1700000006000), or any query rewrite where the `count(*) OVER ()`
+ * windowed set forces a full unindexed `Seq Scan on observations`. Both flip
+ * the EXPLAIN assertion (and, at this volume, the wall-clock guard) RED.
+ *
+ * Real-Postgres+PostGIS testcontainer (no DB mocks, per repo convention); runs
+ * its OWN container so the heavy seed never touches the shared observations.test
+ * fixtures.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import pg from 'pg';
+// Side-effect import: registers pool-wide type parsers (NUMERIC → number).
+import './pool.js';
+import {
+  getCellObservations,
+  buildCellObservationsQuery,
+  CELL_OBSERVATIONS_LIMIT,
+  NATIONAL_SCOPE_KEY,
+  type CellObservationsParams,
+} from './observations.js';
+
+// Background volume. Large enough that a `Seq Scan on observations` is both
+// measurably slow AND cost-uncompetitive with the selective indexes (so the
+// planner is forced onto them), small enough to keep CI quick. Env-overridable.
+const BG_ROWS = Number(process.env.CELL_PERF_BG_ROWS ?? 100_000);
+
+// Dense single-species cell. > CELL_OBSERVATIONS_LIMIT so the LIMIT brake fires
+// and the truncation denominator is exercised at scale.
+const CELL_FRESH = 1_500; // in-cell, fresh (within 14d)
+const CELL_OLD = 50;      // in-cell, OLD (>14d) — dropped by the since window
+const TARGET_SCATTERED = 300; // same species, OUTSIDE the cell (geom filter must prune)
+
+// Coarsest grid (m=2 → 0.5° cell). Bucket center round(-100*2)/2 = -100,
+// round(38*2)/2 = 38 → cell [-100.25, 37.75, -99.75, 38.25].
+const M = 2;
+const LNG_BUCKET = -100.0;
+const LAT_BUCKET = 38.0;
+
+// Generous wall-clock ceiling — the selective query is tens of ms; this only
+// trips on a catastrophic full-scan regression at BG_ROWS scale. Best-of-N min
+// de-noises one-sided CI contention (same rationale as the aggregated guard).
+const PERF_THRESHOLD_MS = 5_000;
+const PERF_RUNS = Number(process.env.CELL_PERF_RUNS ?? 3);
+
+async function fastestOf<T>(
+  runs: number,
+  fn: () => Promise<T>,
+): Promise<{ result: T; minMs: number; samples: number[] }> {
+  const samples: number[] = [];
+  let result!: T;
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    result = await fn();
+    samples.push(performance.now() - t0);
+  }
+  return { result, minMs: Math.min(...samples), samples };
+}
+
+let container: StartedPostgreSqlContainer;
+let pool: pg.Pool;
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer('postgis/postgis:16-3.4').start();
+  pool = new pg.Pool({ connectionString: container.getConnectionUri(), max: 4 });
+
+  // Apply all Up migrations in numeric order (same as test-helpers.startTestDb).
+  const migrationsDir = resolve(process.cwd(), '../../migrations');
+  for (const f of readdirSync(migrationsDir).filter(x => x.endsWith('.sql')).sort()) {
+    const sql = readFileSync(join(migrationsDir, f), 'utf-8');
+    const [rawUp = ''] = sql.split(/-- Down Migration/i);
+    const up = rawUp.replace(/-- Up Migration/i, '');
+    if (up.trim()) await pool.query(up);
+  }
+
+  // 40 background species + the target species.
+  await pool.query(`
+    INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+    SELECT 'bg-' || lpad(g::text, 3, '0'), 'BG ' || g, 'Bgus ' || g, 'bgfam', 'Background Family', 10000 + g
+    FROM generate_series(0, 39) g
+    ON CONFLICT (species_code) DO NOTHING
+  `);
+  await pool.query(`
+    INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name, taxon_order)
+    VALUES ('targsp', 'Target Bird', 'Targus avis', 'targfam', 'Target Family', 55555)
+    ON CONFLICT (species_code) DO NOTHING
+  `);
+
+  // ~100k background rows across CONUS (lat 25..49, lng -125..-67), all fresh.
+  await pool.query(
+    `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+     SELECT
+       'BG-' || g::text,
+       'bg-' || lpad((g % 40)::text, 3, '0'),
+       25 + (g % 2400) * 0.01,
+       -125 + (g % 5800) * 0.01,
+       now() - ((g % 13) * interval '1 day') - interval '1 hour',
+       'L-bg', NULL, 1, false
+     FROM generate_series(1, $1) g`,
+    [BG_ROWS],
+  );
+  // Dense fresh target species AT the cell center.
+  await pool.query(
+    `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+     SELECT 'TC-' || g::text, 'targsp', $1::float8, $2::float8,
+            now() - (g * interval '1 second'), 'L-tc', 'TargetCell', 1, false
+     FROM generate_series(1, $3) g`,
+    [LAT_BUCKET, LNG_BUCKET, CELL_FRESH],
+  );
+  // OLD target species in the cell (>14d) — must drop from the since=14d window.
+  await pool.query(
+    `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+     SELECT 'TCOLD-' || g::text, 'targsp', $1::float8, $2::float8,
+            now() - interval '20 days' - (g * interval '1 second'), 'L-tco', 'TargetCellOld', 1, false
+     FROM generate_series(1, $3) g`,
+    [LAT_BUCKET, LNG_BUCKET, CELL_OLD],
+  );
+  // Same species, scattered OUTSIDE the cell (lat ~30, lng ~-117) — the geom
+  // envelope must prune these, so the cell bbox filter is load-bearing.
+  await pool.query(
+    `INSERT INTO observations (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+     SELECT 'TS-' || g::text, 'targsp', 30 + (g % 5) * 0.3, -117 + (g % 5) * 0.3,
+            now() - ((g % 10) * interval '1 day') - interval '1 hour', 'L-ts', 'TargetScattered', 1, false
+     FROM generate_series(1, $1) g`,
+    [TARGET_SCATTERED],
+  );
+
+  // Plan-quality stats — without ANALYZE the planner mis-estimates and the
+  // index-choice / perf numbers are not representative of prod (autovacuum).
+  await pool.query('ANALYZE observations');
+  await pool.query('ANALYZE species_meta');
+
+  // Sanity: the seed reached scale and the target species is selective (rare).
+  const { rows: tot } = await pool.query<{ c: string }>(
+    'SELECT count(*)::text AS c FROM observations',
+  );
+  expect(Number(tot[0]!.c)).toBeGreaterThanOrEqual(BG_ROWS + CELL_FRESH);
+  const { rows: targ } = await pool.query<{ c: string }>(
+    "SELECT count(*)::text AS c FROM observations WHERE species_code = 'targsp'",
+  );
+  // Target species must be a small fraction so the index is the cheap path.
+  expect(Number(targ[0]!.c)).toBeLessThan(BG_ROWS * 0.1);
+}, 180_000);
+
+afterAll(async () => {
+  await pool?.end();
+  await container?.stop();
+});
+
+const CELL_PARAMS: CellObservationsParams = {
+  scopeKey: NATIONAL_SCOPE_KEY,
+  gridMultiplier: M,
+  lngBucket: LNG_BUCKET,
+  latBucket: LAT_BUCKET,
+  speciesCode: 'targsp',
+  since: '14d',
+};
+
+describe('getCellObservations single-cell perf + index-usage guard (#1300)', () => {
+  it(
+    'drives the dense single-species cell off obs_geom_idx/obs_species_idx — never a Seq Scan on observations',
+    async () => {
+      // EXPLAIN the EXACT query getCellObservations runs (same builder → no
+      // drift from a hand-written copy). EXPLAIN ANALYZE executes it.
+      const { sql, params } = buildCellObservationsQuery(CELL_PARAMS);
+      const { rows } = await pool.query<{ 'QUERY PLAN': string }>(
+        `EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${sql}`,
+        params,
+      );
+      const plan = rows.map(r => r['QUERY PLAN']).join('\n');
+
+      // eslint-disable-next-line no-console
+      console.log(`[#1300 cell index guard] plan:\n${plan}`);
+
+      // FALSIFIABLE: the plan must use a named index on observations and must
+      // NOT seq-scan the table. Dropping either index (or a rewrite that forces
+      // a full windowed scan) flips this RED.
+      expect(plan).toMatch(/obs_geom_idx|obs_species_idx/);
+      expect(plan).not.toMatch(/Seq Scan on observations/);
+    },
+    120_000,
+  );
+
+  it(
+    'returns the LIMIT-capped latest page with the exact windowed denominator, well under the timeout',
+    async () => {
+      const { result, minMs, samples } = await fastestOf(PERF_RUNS, () =>
+        getCellObservations(pool, CELL_PARAMS),
+      );
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[#1300 cell perf guard] min ${minMs.toFixed(0)}ms of [${samples
+          .map(s => s.toFixed(0))
+          .join(', ')}]ms over ${BG_ROWS} bg rows → ${result.data.length} rows, count ${result.cellObservationCount} (threshold ${PERF_THRESHOLD_MS}ms)`,
+      );
+
+      // PERF — selective query stays fast at prod scale; trips on a full-scan
+      // regression.
+      expect(minMs).toBeLessThan(PERF_THRESHOLD_MS);
+
+      // LIMIT honored: the page is capped, truncation flagged, and the
+      // denominator is the EXACT pre-LIMIT windowed count (the 1500 fresh
+      // in-cell rows — NOT the 50 old ones, NOT the 300 scattered, NOT capped to
+      // the page length).
+      expect(result.data.length).toBeLessThanOrEqual(CELL_OBSERVATIONS_LIMIT);
+      expect(result.data).toHaveLength(CELL_OBSERVATIONS_LIMIT);
+      expect(result.truncated).toBe(true);
+      expect(result.cellObservationCount).toBe(CELL_FRESH);
+      // Rows are ordered obs_dt DESC.
+      for (let i = 1; i < result.data.length; i++) {
+        expect(result.data[i - 1]!.obsDt >= result.data[i]!.obsDt).toBe(true);
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/db-client/src/observations-cell-perf.test.ts
+++ b/packages/db-client/src/observations-cell-perf.test.ts
@@ -16,14 +16,19 @@
  *       dense single-species `m=2` (coarsest, 0.5°×0.5°) cell, so a missing
  *       index actually blows wall-clock (best-of-N min under a generous guard).
  *   (b) EXPLAIN (ANALYZE) — asserts the plan for the EXACT query
- *       getCellObservations runs (via buildCellObservationsQuery) uses an
- *       Index/Bitmap scan on `obs_geom_idx`/`obs_species_idx` and NEVER a
- *       `Seq Scan on observations`.
+ *       getCellObservations runs (via buildCellObservationsQuery) names BOTH
+ *       `obs_geom_idx` AND `obs_species_idx` (the happy-path plan is a
+ *       `BitmapAnd` of the two) and NEVER `Seq Scan on observations`. The two
+ *       index names are asserted INDEPENDENTLY — not as an
+ *       `obs_geom_idx|obs_species_idx` OR — precisely so that dropping EITHER
+ *       index flips the guard RED. An OR would stay green when one index is
+ *       dropped because the planner falls back to the surviving index.
  *
- * RED case this is designed to fail on: dropping `obs_species_idx`/`obs_geom_idx`
- * (migration 1700000006000), or any query rewrite where the `count(*) OVER ()`
- * windowed set forces a full unindexed `Seq Scan on observations`. Both flip
- * the EXPLAIN assertion (and, at this volume, the wall-clock guard) RED.
+ * RED case this is designed to fail on: dropping `obs_species_idx` OR
+ * `obs_geom_idx` (migration 1700000006000) — each independently fails its own
+ * assertion — or any query rewrite where the `count(*) OVER ()` windowed set
+ * forces a full unindexed `Seq Scan on observations`. All flip the EXPLAIN
+ * assertion (and, at this volume, the wall-clock guard) RED.
  *
  * Real-Postgres+PostGIS testcontainer (no DB mocks, per repo convention); runs
  * its OWN container so the heavy seed never touches the shared observations.test
@@ -197,10 +202,15 @@ describe('getCellObservations single-cell perf + index-usage guard (#1300)', () 
       // eslint-disable-next-line no-console
       console.log(`[#1300 cell index guard] plan:\n${plan}`);
 
-      // FALSIFIABLE: the plan must use a named index on observations and must
-      // NOT seq-scan the table. Dropping either index (or a rewrite that forces
-      // a full windowed scan) flips this RED.
-      expect(plan).toMatch(/obs_geom_idx|obs_species_idx/);
+      // FALSIFIABLE: the happy-path plan is a BitmapAnd of BOTH indexes, so the
+      // plan text must name each one INDEPENDENTLY — asserting them separately
+      // (not as an `obs_geom_idx|obs_species_idx` OR) is what makes dropping
+      // EITHER index flip this RED. Under an OR the planner falls back to the
+      // surviving index and the guard stays green even with one index gone; two
+      // separate assertions close that gap. The plan must also NOT seq-scan the
+      // table (a rewrite forcing a full windowed scan flips this RED too).
+      expect(plan).toMatch(/obs_geom_idx/);
+      expect(plan).toMatch(/obs_species_idx/);
       expect(plan).not.toMatch(/Seq Scan on observations/);
     },
     120_000,

--- a/packages/db-client/src/observations-cell.test.ts
+++ b/packages/db-client/src/observations-cell.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { startTestDb, type TestDb } from './test-helpers.js';
+import {
+  upsertObservations,
+  getCellObservations,
+  CELL_OBSERVATIONS_LIMIT,
+  NATIONAL_SCOPE_KEY,
+  type ObservationInput,
+} from './observations.js';
+
+// B1 (#1300) — getCellObservations: the bounded, single-grid-cell, single-
+// species per-observation query that backs the zoom<6 sightings log (epic
+// #1299). The cell bbox for a bucket centered (lngBucket, latBucket) at
+// gridMultiplier m is [lngBucket ± 0.5/m, latBucket ± 0.5/m]; bucketing is
+// round(coord*m)/m, so a clicked CellPopover marker's coords are a true bucket
+// center. NO DB mocks — real Postgres+PostGIS via testcontainers (repo rule).
+
+let db: TestDb;
+beforeAll(async () => {
+  db = await startTestDb();
+  await db.pool.query(
+    `INSERT INTO species_meta (species_code, com_name, sci_name, family_code, family_name)
+     VALUES
+       ('vermfly', 'Vermilion Flycatcher', 'Pyrocephalus rubinus', 'tyrannidae', 'Tyrant Flycatchers'),
+       ('annhum', 'Anna''s Hummingbird', 'Calypte anna', 'trochilidae', 'Hummingbirds')`,
+  );
+}, 90_000);
+
+afterAll(async () => { await db?.stop(); });
+
+// ── Cell-bbox + species + ordering + since-window ────────────────────────────
+//
+// Target cell: gridMultiplier 2 (the coarsest grid), bucket center
+// (-111.0, 32.0) — an Arizona interior cell. half = 0.5/2 = 0.25, so the cell
+// envelope is [-111.25, 31.75, -110.75, 32.25]. Rows are placed at the cell
+// CENTER (-111.0, 32.0) so the since/species assertions don't depend on the
+// boundary, plus deliberate decoys: a different species in the same cell, a
+// same-species row in the ADJACENT cell, and a same-species row JUST OUTSIDE
+// the east edge (boundary correctness).
+describe('getCellObservations — cell bbox, species filter, ordering, since', () => {
+  const M = 2;
+  const LNG_BUCKET = -111.0;
+  const LAT_BUCKET = 32.0;
+
+  beforeEach(async () => {
+    await db.pool.query('TRUNCATE observations');
+    const rows: ObservationInput[] = [
+      // Four vermfly rows AT the cell center, with distinct ages so DESC
+      // ordering + the since-window are both observable.
+      { subId: 'IN-6h', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: LNG_BUCKET, obsDt: new Date(Date.now() - 6 * 3_600_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 2, isNotable: false },
+      { subId: 'IN-2d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: LNG_BUCKET, obsDt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      { subId: 'IN-3d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: LNG_BUCKET, obsDt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: true },
+      { subId: 'IN-10d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: LNG_BUCKET, obsDt: new Date(Date.now() - 10 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      // Different species, same cell → excluded by the species filter.
+      { subId: 'OTHER-SP', speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        lat: LAT_BUCKET, lng: LNG_BUCKET, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      // Same species, ADJACENT cell (bucket center -110.5) → outside the
+      // target envelope (-110.5 > -110.75 east edge).
+      { subId: 'ADJ-CELL', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: -110.5, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L2', locName: 'Adjacent', howMany: 1, isNotable: false },
+      // Same species, JUST OUTSIDE the east edge (-110.70 > -110.75) → excluded.
+      { subId: 'JUST-OUT', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: -110.70, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L3', locName: 'JustOutside', howMany: 1, isNotable: false },
+    ];
+    await upsertObservations(db.pool, rows);
+  });
+
+  it('returns ONLY the target species inside the derived cell bbox, ordered obs_dt DESC', async () => {
+    const { data, truncated, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    // The four center vermfly rows only — annhum (species), the adjacent-cell
+    // row and the just-outside row are all excluded. Ordered newest-first.
+    expect(data.map(r => r.subId)).toEqual(['IN-6h', 'IN-2d', 'IN-3d', 'IN-10d']);
+    expect(cellObservationCount).toBe(4);
+    expect(truncated).toBe(false);
+    // Row projection mirrors getObservations (comName/familyCode joined).
+    expect(data[0]!.comName).toBe('Vermilion Flycatcher');
+    expect(data[0]!.familyCode).toBe('tyrannidae');
+    expect(data[0]!.howMany).toBe(2);
+    expect(data[0]!.obsDt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('excludes the row just outside 0.5/m and the adjacent-cell row (bbox boundary)', async () => {
+    const { data } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    const ids = data.map(r => r.subId);
+    expect(ids).not.toContain('ADJ-CELL');
+    expect(ids).not.toContain('JUST-OUT');
+  });
+
+  it('since="7d" AND-s obs_dt into BOTH data AND the cellObservationCount denominator', async () => {
+    const { data, cellObservationCount, truncated } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+      since: '7d',
+    });
+    // The 10-day row drops from BOTH the returned rows AND the count (the
+    // windowed set, not all-time).
+    expect(data.map(r => r.subId)).toEqual(['IN-6h', 'IN-2d', 'IN-3d']);
+    expect(cellObservationCount).toBe(3);
+    expect(truncated).toBe(false);
+  });
+
+  it('since="1d" narrows the window to the freshest row only', async () => {
+    const { data, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+      since: '1d',
+    });
+    expect(data.map(r => r.subId)).toEqual(['IN-6h']);
+    expect(cellObservationCount).toBe(1);
+  });
+});
+
+// ── LIMIT brake + truncated/cellObservationCount above and below the cap ─────
+describe('getCellObservations — LIMIT brake and truncation denominator', () => {
+  const M = 2;
+  const LNG_BUCKET = -111.0;
+  const LAT_BUCKET = 32.0;
+
+  async function seedCellRows(n: number): Promise<void> {
+    await db.pool.query('TRUNCATE observations');
+    // Bulk insert via generate_series — fast vs row-by-row JS. All rows are the
+    // same species at the cell center, fresh (now()).
+    await db.pool.query(
+      `INSERT INTO observations
+         (sub_id, species_code, lat, lng, obs_dt, loc_id, loc_name, how_many, is_notable)
+       SELECT
+         'S-cell-' || g::text, 'vermfly',
+         $1::float8, $2::float8,
+         now() - (g * interval '1 second'),
+         'L-cell', 'Cell', 1, false
+       FROM generate_series(1, $3) g`,
+      [LAT_BUCKET, LNG_BUCKET, n],
+    );
+  }
+
+  it('caps data at CELL_OBSERVATIONS_LIMIT and flags truncated when the cell exceeds it', async () => {
+    await seedCellRows(CELL_OBSERVATIONS_LIMIT + 50);
+    const { data, truncated, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    expect(data).toHaveLength(CELL_OBSERVATIONS_LIMIT);
+    expect(truncated).toBe(true);
+    // The denominator is the EXACT pre-LIMIT count, not the capped page length.
+    expect(cellObservationCount).toBe(CELL_OBSERVATIONS_LIMIT + 50);
+  });
+
+  it('returns truncated=false when the cell is exactly at the cap', async () => {
+    await seedCellRows(CELL_OBSERVATIONS_LIMIT);
+    const { data, truncated, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    expect(data).toHaveLength(CELL_OBSERVATIONS_LIMIT);
+    expect(truncated).toBe(false);
+    expect(cellObservationCount).toBe(CELL_OBSERVATIONS_LIMIT);
+  });
+
+  it('honors an explicit limit override while keeping the full denominator', async () => {
+    await seedCellRows(20);
+    const { data, truncated, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+      limit: 5,
+    });
+    expect(data).toHaveLength(5);
+    expect(truncated).toBe(true);
+    expect(cellObservationCount).toBe(20);
+  });
+});
+
+// ── State clip (scopeKey) vs national no-clip ────────────────────────────────
+//
+// A cell straddling the AZ/NM border (the meridian -109.04522 is a literal
+// vertex of the seeded AZ MultiPolygon). Bucket center (-109.0, 32.0) at m=2 →
+// envelope [-109.25, 31.75, -108.75, 32.25], which spans both sides of the
+// border. A row at lng -109.1 is on the AZ side; a row at -109.0 is on the NM
+// side. Both sit inside the same cell bbox — the state clip is what separates
+// them, so an out-of-state row in the same bbox is excluded under US-AZ.
+describe('getCellObservations — state clip vs NATIONAL_SCOPE_KEY no-clip', () => {
+  const M = 2;
+  const LNG_BUCKET = -109.0;
+  const LAT_BUCKET = 32.0;
+
+  beforeEach(async () => {
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, [
+      { subId: 'AZ-SIDE', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: -109.1, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L-AZ', locName: 'AZ', howMany: 1, isNotable: false },
+      { subId: 'NM-SIDE', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: LAT_BUCKET, lng: -109.0, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L-NM', locName: 'NM', howMany: 1, isNotable: false },
+    ]);
+  });
+
+  it('scopeKey="US-AZ" applies the ST_Intersects clip, excluding the out-of-state row in the same bbox', async () => {
+    const { data, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: 'US-AZ',
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    expect(data.map(r => r.subId)).toEqual(['AZ-SIDE']);
+    expect(cellObservationCount).toBe(1);
+  });
+
+  it('scopeKey=NATIONAL_SCOPE_KEY applies NO clip — both border-straddling rows return', async () => {
+    const { data, cellObservationCount } = await getCellObservations(db.pool, {
+      scopeKey: NATIONAL_SCOPE_KEY,
+      gridMultiplier: M,
+      lngBucket: LNG_BUCKET,
+      latBucket: LAT_BUCKET,
+      speciesCode: 'vermfly',
+    });
+    expect(data.map(r => r.subId).sort()).toEqual(['AZ-SIDE', 'NM-SIDE']);
+    expect(cellObservationCount).toBe(2);
+  });
+});

--- a/packages/db-client/src/observations.ts
+++ b/packages/db-client/src/observations.ts
@@ -563,6 +563,175 @@ export const NATIONAL_SCOPE_KEY = 'US';
  */
 export const STANDARD_GRID_MULTIPLIERS: readonly number[] = [2, 4, 8];
 
+// ── #1300 (B1) — SINGLE-CELL, SINGLE-SPECIES PER-OBSERVATION QUERY ───────────
+//
+// Backs the zoom<6 sightings log (epic #1299). At low zoom the map renders the
+// precomputed `observation_grid_agg` grid, which keeps only counts — individual
+// sightings are discarded from the render path. When a user clicks a cell
+// marker AND selects a species, the log needs the raw rows for THAT species
+// inside THAT one grid cell. The raw `observations` table still has every
+// sighting; this query fetches the bounded slice. It deliberately does NOT
+// gate-lift the existing `/api/observations` low-zoom contract (which routes
+// `bbox && zoom<6` to the aggregated CTE before per-observation rows can
+// return) — it is a separate, additive read path behind a dedicated route.
+
+export interface CellObservationsParams {
+  /** NATIONAL_SCOPE_KEY ('US', no clip) or a 'US-XX' state code (ST_Intersects polygon clip). */
+  scopeKey: string;
+  /** Grid switch value; MUST be one of STANDARD_GRID_MULTIPLIERS (2 | 4 | 8). The
+   *  route validates it against that export before calling — an arbitrary
+   *  multiplier would widen the derived cell. */
+  gridMultiplier: number;
+  /** Grid-cell center (round(coord*m)/m), as sent by the frontend (a true bucket center). */
+  lngBucket: number;
+  latBucket: number;
+  speciesCode: string;
+  since?: '1d' | '7d' | '14d';
+  /** Hard row brake; default + cap = CELL_OBSERVATIONS_LIMIT. */
+  limit?: number;
+}
+
+/**
+ * Hard row brake on the single-cell sightings-log query. `LIMIT` bounds only
+ * client materialization, NOT scan cost — `count(*) OVER ()` still windows over
+ * every matched (windowed) row in the cell to produce the exact pre-LIMIT
+ * denominator (the "latest N of M" banner's M). Kept module-local (NOT
+ * barrel-exported): the route relies on the function's default, and the
+ * perf/integration tests import this constant from the module file to assert
+ * the cap directly — so nothing outside this package needs it.
+ */
+export const CELL_OBSERVATIONS_LIMIT = 200;
+
+type CellObservationRow = {
+  sub_id: string;
+  species_code: string;
+  com_name: string | null;
+  family_code: string | null;
+  lat: number;
+  lng: number;
+  obs_dt: Date;
+  loc_id: string;
+  loc_name: string | null;
+  how_many: number | null;
+  is_notable: boolean;
+  silhouette_id: string | null;
+  total_matched: string; // count(*) OVER () — bigint, returned as a string by pg.
+};
+
+/**
+ * Builds the parameterized single-cell query + bind list for a
+ * CellObservationsParams. Split out so the perf test can run the EXACT query
+ * the function executes through `EXPLAIN (ANALYZE)` and assert its access path
+ * (the GIST `obs_geom_idx` cell envelope + the `obs_species_idx` species
+ * filter) without the SQL drifting from a hand-written copy. NOT barrel-
+ * exported — consumed only by getCellObservations and the perf test.
+ *
+ * Cell envelope: `half = 0.5 / gridMultiplier`; the cell is
+ * `[lngBucket ± half, latBucket ± half]`. Mirrors getObservations' GIST-backed
+ * bbox pattern (`geom &&` for the index prune, `ST_Intersects` for the exact
+ * boundary test) and the #733 state-polygon clip (`ST_Intersects(polygon,
+ * point)`, arg order polygon-first). The since predicate AND-s an
+ * `obs_dt >= now() - k days` filter into BOTH the returned rows AND the
+ * `count(*) OVER ()` denominator (window functions run after WHERE, before
+ * LIMIT — so the count is over the full matched, since-windowed set). All
+ * inputs are bound parameters; `gridMultiplier` is consumed only to compute the
+ * numeric envelope, never interpolated into SQL.
+ */
+export function buildCellObservationsQuery(
+  p: CellObservationsParams,
+): { sql: string; params: unknown[]; limit: number } {
+  const limit = p.limit ?? CELL_OBSERVATIONS_LIMIT;
+  const half = 0.5 / p.gridMultiplier;
+  const minLng = p.lngBucket - half;
+  const minLat = p.latBucket - half;
+  const maxLng = p.lngBucket + half;
+  const maxLat = p.latBucket + half;
+
+  const params: unknown[] = [p.speciesCode, minLng, minLat, maxLng, maxLat];
+  const conditions: string[] = [
+    'o.species_code = $1',
+    'o.geom && ST_MakeEnvelope($2, $3, $4, $5, 4326)',
+    'ST_Intersects(o.geom, ST_MakeEnvelope($2, $3, $4, $5, 4326))',
+  ];
+
+  if (p.since !== undefined) {
+    const days = parseInt(p.since.replace('d', ''), 10);
+    conditions.push(`o.obs_dt >= now() - ($${params.length + 1}::int * interval '1 day')`);
+    params.push(days);
+  }
+
+  // National scope (NATIONAL_SCOPE_KEY) applies NO clip; a 'US-XX' code applies
+  // the same ST_Intersects state-polygon clip getObservations uses. Compared
+  // against the NATIONAL_SCOPE_KEY export (NOT a hardcoded 'US') so this branch
+  // and the precompute/aggregated paths never drift from one sentinel.
+  if (p.scopeKey !== NATIONAL_SCOPE_KEY) {
+    const si = params.length + 1;
+    conditions.push(`o.geom && (SELECT geom FROM state_boundaries WHERE state_code = $${si})`);
+    conditions.push(`ST_Intersects((SELECT geom FROM state_boundaries WHERE state_code = $${si}), o.geom)`);
+    params.push(p.scopeKey);
+  }
+
+  const limitIdx = params.length + 1;
+  params.push(limit + 1); // probe one past the cap to detect truncation (mirrors getObservations).
+
+  const sql = `
+    SELECT
+      o.sub_id, o.species_code, sm.com_name, sm.family_code,
+      o.lat, o.lng, o.obs_dt, o.loc_id, o.loc_name, o.how_many,
+      o.is_notable, o.silhouette_id,
+      count(*) OVER () AS total_matched
+    FROM observations o
+    LEFT JOIN species_meta sm ON sm.species_code = o.species_code
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY o.obs_dt DESC
+    LIMIT $${limitIdx}
+  `;
+
+  return { sql, params, limit };
+}
+
+/**
+ * Fetches the per-species, single-grid-cell observation rows for the sightings
+ * log (#1300). Returns the latest `data` rows (ordered `obs_dt DESC`, hard-
+ * capped at `CELL_OBSERVATIONS_LIMIT`), `truncated` (true iff matching rows
+ * exceed the cap), and `cellObservationCount` — the EXACT pre-LIMIT count of
+ * matching rows in the cell within the since-window (the "latest N of M"
+ * denominator M, from `count(*) OVER ()`). Row mapping mirrors getObservations
+ * exactly (`comName: com_name ?? species_code`, `obsDt` as ISO, `familyCode`
+ * passed through as-is).
+ */
+export async function getCellObservations(
+  pool: Pool,
+  p: CellObservationsParams,
+): Promise<{ data: Observation[]; truncated: boolean; cellObservationCount: number }> {
+  const { sql, params, limit } = buildCellObservationsQuery(p);
+  const { rows } = await pool.query<CellObservationRow>(sql, params);
+
+  // `limit + 1` came back ⇒ more rows than the cap allows; slice back and flag.
+  // (rows.length > limit ⟺ cellObservationCount > limit, since the probe LIMIT
+  // is limit+1.)
+  const truncated = rows.length > limit;
+  const capped = truncated ? rows.slice(0, limit) : rows;
+  const cellObservationCount = Number(rows[0]?.total_matched ?? 0);
+
+  const data = capped.map(r => ({
+    subId: r.sub_id,
+    speciesCode: r.species_code,
+    comName: r.com_name ?? r.species_code,
+    lat: r.lat,
+    lng: r.lng,
+    obsDt: r.obs_dt.toISOString(),
+    locId: r.loc_id,
+    locName: r.loc_name,
+    howMany: r.how_many,
+    isNotable: r.is_notable,
+    silhouetteId: r.silhouette_id,
+    familyCode: r.family_code,
+  }));
+
+  return { data, truncated, cellObservationCount };
+}
+
 /**
  * The `since` windows the precompute covers (#1209). Originally only 14d was
  * precomputed, so a `since=7d`/`1d` low-zoom state view fell through to the live

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -395,3 +395,29 @@ export type ObservationsResponse =
       buckets: AggregatedBucket[];
       meta: { freshestObservationAt: string | null; truncated?: boolean };
     };
+
+/**
+ * Response from GET /api/observations/cell (sightings-log epic #1299, B1
+ * #1300). The per-species, single-grid-cell per-observation rows backing the
+ * low-zoom (zoom<6) sightings log: at zoom<6 the map renders the precomputed
+ * `observation_grid_agg` grid which keeps only counts, so the raw rows for one
+ * species inside one clicked grid cell must be fetched on demand.
+ *
+ * `meta.cellObservationCount` is the EXACT count of matching rows in the cell
+ * (within the since-window) BEFORE the LIMIT — the truncation-banner
+ * denominator M (the "latest N of M" line). `meta.truncated` is true when the
+ * row brake fired (the matched count exceeds the hard `LIMIT`, so `data` is the
+ * latest N of a larger set).
+ *
+ * `meta` is exactly `{ cellObservationCount, truncated }` — there is NO
+ * freshest-timestamp field: the db function produces only those two values, and
+ * the log derives recency from the rows it already renders, so a
+ * `freshestObservationAt` key would have no producer.
+ */
+export interface CellObservationsResponse {
+  data: Observation[];
+  meta: {
+    cellObservationCount: number;
+    truncated: boolean;
+  };
+}

--- a/services/read-api/src/app.test.ts
+++ b/services/read-api/src/app.test.ts
@@ -1655,3 +1655,131 @@ describe('CORS middleware', () => {
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
   });
 });
+
+// #1300 (B1) — the single-cell sightings-log route. A thin adapter over
+// getCellObservations: validates species/scope/m/lng/lat/since, derives the
+// cell, and returns CellObservationsResponse ({ data, meta: {
+// cellObservationCount, truncated } }). All SQL lives in db-client; this only
+// pins the route contract (param validation + the meta shape + cache tier).
+describe('GET /api/observations/cell (#1300)', () => {
+  // m=2 cell, bucket center (-111.0, 32.0) — an Arizona interior cell. half =
+  // 0.5/2 = 0.25 → envelope [-111.25, 31.75, -110.75, 32.25].
+  const CELL = 'species=vermfly&scope=US&m=2&lng=-111.0&lat=32.0';
+
+  beforeAll(async () => {
+    await upsertSpeciesMeta(db.pool, [
+      { speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        sciName: 'Pyrocephalus rubinus', familyCode: 'tyrannidae',
+        familyName: 'Tyrant Flycatchers', taxonOrder: 30501 },
+      { speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        sciName: 'Calypte anna', familyCode: 'trochilidae',
+        familyName: 'Hummingbirds', taxonOrder: 6000 },
+    ]);
+    await db.pool.query('TRUNCATE observations');
+    await upsertObservations(db.pool, [
+      // Four vermfly rows AT the cell center, distinct ages (DESC + since).
+      { subId: 'C-6h', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.0, lng: -111.0, obsDt: new Date(Date.now() - 6 * 3_600_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 2, isNotable: false },
+      { subId: 'C-2d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.0, lng: -111.0, obsDt: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      { subId: 'C-3d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.0, lng: -111.0, obsDt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: true },
+      { subId: 'C-10d', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.0, lng: -111.0, obsDt: new Date(Date.now() - 10 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      // Different species, same cell → excluded by the species filter.
+      { subId: 'C-OTHER', speciesCode: 'annhum', comName: "Anna's Hummingbird",
+        lat: 32.0, lng: -111.0, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L1', locName: 'Center', howMany: 1, isNotable: false },
+      // Same species, adjacent cell → outside the target envelope.
+      { subId: 'C-ADJ', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+        lat: 32.0, lng: -110.5, obsDt: new Date(Date.now() - 1 * 86_400_000).toISOString(),
+        locId: 'L2', locName: 'Adjacent', howMany: 1, isNotable: false },
+    ]);
+  });
+
+  type CellEnvelope = {
+    data: Array<{ subId: string; familyCode?: string | null; [k: string]: unknown }>;
+    meta: { cellObservationCount: number; truncated: boolean };
+  };
+
+  it('returns the target species in the cell with the observations cache tier', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(`/api/observations/cell?${CELL}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control'))
+      .toBe('public, s-maxage=2400, stale-while-revalidate=2400');
+    const body = await res.json() as CellEnvelope;
+    // Four center vermfly rows (annhum + adjacent excluded), newest-first.
+    expect(body.data.map(o => o.subId)).toEqual(['C-6h', 'C-2d', 'C-3d', 'C-10d']);
+    expect(body.data[0]!.familyCode).toBe('tyrannidae');
+  });
+
+  it('returns meta exactly { cellObservationCount, truncated } — no freshest field', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(`/api/observations/cell?${CELL}`);
+    const body = await res.json() as CellEnvelope;
+    expect(body.meta).toEqual({ cellObservationCount: 4, truncated: false });
+    expect('freshestObservationAt' in body.meta).toBe(false);
+  });
+
+  it('forwards since to the query (since=1d returns only the windowed rows)', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(`/api/observations/cell?${CELL}&since=1d`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as CellEnvelope;
+    // Only the 6h-old row is within 1d; the denominator drops to the window.
+    expect(body.data.map(o => o.subId)).toEqual(['C-6h']);
+    expect(body.meta.cellObservationCount).toBe(1);
+  });
+
+  it('applies the state clip when scope is a US-XX code', async () => {
+    const app = createApp({ pool: db.pool });
+    // All four center rows are in Arizona, so US-AZ returns the same set.
+    const res = await app.request(`/api/observations/cell?species=vermfly&scope=US-AZ&m=2&lng=-111.0&lat=32.0`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as CellEnvelope;
+    expect(body.data.map(o => o.subId)).toEqual(['C-6h', 'C-2d', 'C-3d', 'C-10d']);
+  });
+
+  it('400s when species is missing', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations/cell?scope=US&m=2&lng=-111.0&lat=32.0');
+    expect(res.status).toBe(400);
+  });
+
+  it('400s when m is not in STANDARD_GRID_MULTIPLIERS (m=3)', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations/cell?species=vermfly&scope=US&m=3&lng=-111.0&lat=32.0');
+    expect(res.status).toBe(400);
+  });
+
+  it.each(['abc', '', 'NaN', 'Infinity'])('400s on non-finite lng=%s', async (lng) => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(
+      `/api/observations/cell?species=vermfly&scope=US&m=2&lng=${encodeURIComponent(lng)}&lat=32.0`,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('400s on non-finite lat', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations/cell?species=vermfly&scope=US&m=2&lng=-111.0&lat=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('400s on a bad since value', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request(`/api/observations/cell?${CELL}&since=banana`);
+    expect(res.status).toBe(400);
+  });
+
+  it('400s on an invalid scope', async () => {
+    const app = createApp({ pool: db.pool });
+    const res = await app.request('/api/observations/cell?species=vermfly&scope=US-ZZ&m=2&lng=-111.0&lat=32.0');
+    expect(res.status).toBe(400);
+  });
+});

--- a/services/read-api/src/app.ts
+++ b/services/read-api/src/app.ts
@@ -10,8 +10,11 @@ import {
   listStatesWithBbox,
   // #878 — precomputed per-scope aggregation grid.
   isPrecomputeEligible, getAggregatedGridFromCache, resolveScopeKey,
+  // #1300 (B1) — single-cell sightings-log query + its source-of-truth sentinels.
+  getCellObservations, NATIONAL_SCOPE_KEY, STANDARD_GRID_MULTIPLIERS,
+  type CellObservationsParams,
 } from '@bird-watch/db-client';
-import type { ObservationsResponse } from '@bird-watch/shared-types';
+import type { ObservationsResponse, CellObservationsResponse } from '@bird-watch/shared-types';
 import { cacheControlFor } from './cache-headers.js';
 import { rateLimitFromEnv } from './rate-limit.js';
 import {
@@ -374,6 +377,101 @@ export function createApp(deps: AppDeps): Hono {
       meta: {
         freshestObservationAt,
         ...(obsResult.truncated ? { truncated: true } : {}),
+      },
+    };
+    return c.json(body);
+  });
+
+  // #1300 (B1) — single grid-cell, single-species per-observation rows for the
+  // zoom<6 sightings log (epic #1299). A dedicated route (NOT a gate-lift of
+  // /api/observations, whose `bbox && zoom<6` contract routes to the aggregated
+  // CTE before per-observation rows can return). Thin adapter: validate params,
+  // delegate to getCellObservations (all SQL lives in db-client), return
+  // CellObservationsResponse. The frontend sends the clicked CellPopover
+  // marker's coords (a true round(coord*m)/m bucket center) as lng/lat.
+  app.get('/api/observations/cell', async c => {
+    // species — REQUIRED (the log is per-species). Same allowlist as
+    // /api/observations; absence is a 400 (not an unbounded query).
+    const speciesResult = parseSpecies(c.req.query('species'));
+    if (!speciesResult.ok) {
+      console.log(JSON.stringify(speciesResult.log));
+      return c.json({ error: speciesResult.error }, 400);
+    }
+    const speciesCode = speciesResult.value;
+    if (speciesCode === undefined) {
+      return c.json({ error: 'missing species' }, 400);
+    }
+
+    // scope — NATIONAL_SCOPE_KEY (no clip) OR a CONUS US-XX code (state clip).
+    // Compared against the NATIONAL_SCOPE_KEY export, not a hardcoded 'US', so
+    // the no-clip sentinel never drifts from the aggregated/precompute paths.
+    // Absent scope is treated as national. parseState rejects the bare national
+    // key, so it MUST be short-circuited before the state validator runs.
+    const scopeRaw = c.req.query('scope');
+    let scopeKey: string;
+    if (scopeRaw === undefined || scopeRaw === NATIONAL_SCOPE_KEY) {
+      scopeKey = NATIONAL_SCOPE_KEY;
+    } else {
+      const stateResult = parseState(scopeRaw);
+      if (!stateResult.ok) {
+        console.log(JSON.stringify(stateResult.log));
+        return c.json({ error: stateResult.error }, 400);
+      }
+      // scopeRaw was defined and not the national key, so parseState yields a
+      // normalized US-XX string here; the ?? branch is unreachable.
+      scopeKey = stateResult.value ?? NATIONAL_SCOPE_KEY;
+    }
+
+    // m — the grid multiplier. Restricted to STANDARD_GRID_MULTIPLIERS (the same
+    // set the aggregated path emits) so an arbitrary multiplier can never widen
+    // the derived cell. Number('') === 0 is finite but not in the set → 400.
+    const mRaw = c.req.query('m');
+    const m = mRaw === undefined ? NaN : Number(mRaw);
+    if (!Number.isFinite(m) || !STANDARD_GRID_MULTIPLIERS.includes(m)) {
+      return c.json({ error: 'invalid m: expected a standard grid multiplier (2|4|8)' }, 400);
+    }
+
+    // lng / lat — finite floats (the clicked cell-bucket center). Guard the
+    // empty string explicitly: Number('') === 0 would otherwise pass as finite.
+    const lngRaw = c.req.query('lng');
+    const lng = lngRaw === undefined || lngRaw.trim() === '' ? NaN : Number(lngRaw);
+    if (!Number.isFinite(lng)) {
+      return c.json({ error: 'invalid lng: expected a finite number' }, 400);
+    }
+    const latRaw = c.req.query('lat');
+    const lat = latRaw === undefined || latRaw.trim() === '' ? NaN : Number(latRaw);
+    if (!Number.isFinite(lat)) {
+      return c.json({ error: 'invalid lat: expected a finite number' }, 400);
+    }
+
+    // since — optional; same validator as /api/observations.
+    const sinceResult = parseSince(c.req.query('since'));
+    if (!sinceResult.ok) {
+      console.log(JSON.stringify(sinceResult.log));
+      return c.json({ error: sinceResult.error }, 400);
+    }
+    const since = sinceResult.value;
+
+    // Build the params with conditional optional assignment
+    // (exactOptionalPropertyTypes — never place T|undefined into an
+    // optional-but-not-undefined key via a literal/spread). limit is omitted so
+    // the query uses CELL_OBSERVATIONS_LIMIT.
+    const cellParams: CellObservationsParams = {
+      scopeKey,
+      gridMultiplier: m,
+      lngBucket: lng,
+      latBucket: lat,
+      speciesCode,
+    };
+    if (since !== undefined) cellParams.since = since;
+
+    const result = await getCellObservations(deps.pool, cellParams);
+    c.header('Cache-Control', cacheControlFor('observations'));
+    const body: CellObservationsResponse = {
+      data: result.data,
+      meta: {
+        cellObservationCount: result.cellObservationCount,
+        truncated: result.truncated,
       },
     };
     return c.json(body);


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant FE as Frontend (zoom<6 cell click)
    participant API as read-api
    participant DB as db-client
    participant PG as Postgres+PostGIS
    FE->>API: GET /api/observations/cell?species&scope&m&lng&lat&since
    API->>DB: getCellObservations(bucket, m, opts)
    DB->>PG: SELECT obs in cell envelope (bucket +/- 0.5/m) by species and since-window, newest-first, LIMIT 200
    PG-->>DB: rows + count(*) OVER() pre-LIMIT denominator
    DB-->>API: { data, meta: { cellObservationCount, truncated } }
    API-->>FE: 200 CellObservationsResponse
```

## Summary

- **Why:** at low zoom (`zoom < 6`) the map renders the precomputed `observation_grid_agg` grid, which stores only counts and discards individual observations — so the upcoming in-panel Sightings Log has no source for a clicked cell's per-sighting rows. The raw `observations` table still retains every sighting; this adds the bounded read path to reach them.
- **What:** new `getCellObservations` (single-cell query: envelope `[bucket ± 0.5/m]` + `species_code` + since-window + scope/state clip, `ORDER BY obs_dt DESC`, hard `LIMIT 200`, `count(*) OVER()` for the exact pre-LIMIT denominator) → `GET /api/observations/cell` → `CellObservationsResponse { data, meta: { cellObservationCount, truncated } }`.
- **Safety:** index-backed — the perf guard seeds prod-scale data and asserts via `EXPLAIN (ANALYZE)` that the plan uses a `BitmapAnd` of the geom + species indexes with **no `Seq Scan on observations`** (flips red if either index is dropped). Single-species + single-cell scope makes this far cheaper than the all-species mega-cell scan behind the 2026-06-14 503 incident. No schema change / no migration; `NATIONAL_SCOPE_KEY` (not a literal) is the no-clip sentinel.

## Screenshots

N/A — not UI (backend only; no `frontend/**` files touched).

## Test plan

- [x] `npm run build && npm test` — green (no separate `npm run typecheck` in this repo; `build` runs `tsc`). db-client: 203 passed (+1 todo) incl. 9 new cell integration tests + 2 prod-scale perf/index guards; read-api: 199 passed incl. 13 new `GET /api/observations/cell` route tests.
- [x] New unit / integration tests added — testcontainers against real Postgres+PostGIS (no DB mocks).
- [ ] New Playwright e2e spec added — N/A (backend only, no user-visible UI change).
- [x] `npm run build` — clean production build (all workspaces incl. frontend `tsc -b` + vite).
- [ ] (UI only) Playwright MCP smoke — N/A — not UI.

## Plan reference

Implements #1300; part of epic #1299 (Sightings Log). Per repo convention, the plan lives in the issues (self-contained), not `docs/plans/`. Build order: **B1 (this) ∥ F2 → F3 → M4 → D5**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
