### PR TITLE
feat(frontend): Sightings Log in the species-detail Rail (#1301)

### DIFF
--- a/frontend/e2e/species/sightings-log.spec.ts
+++ b/frontend/e2e/species/sightings-log.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../fixtures.js';
+import { AppPage } from '../pages/app-page.js';
+import type { Observation, SpeciesMeta } from '@bird-watch/shared-types';
+
+/**
+ * #1301 (epic #1299) — the Sightings Log inside the desktop species-detail Rail.
+ *
+ * DETERMINISTIC happy path: drive the single-observation `ObservationPopover`
+ * seam (`handlePopoverSelectSpecies`), where the threaded Sightings-Log context
+ * is a KNOWN single `Observation`. This avoids relying on real MapLibre
+ * clustering to materialize `getClusterLeaves` at a specific coordinate/zoom
+ * (fragile under `retries:0` / `fullyParallel`). Multi-leaf species filtering,
+ * the visible-row cap, and newest-first ordering are covered at the unit/RTL
+ * level (sightings-context / use-sightings-rows / SightingsLog specs).
+ *
+ * Mirrors `map-symbol-layer.spec.ts`'s hit-layer→popover→detail-link walk; the
+ * WebGL-less headless run is tolerated the same way (probe + skip), since the
+ * hit-layer only mounts after maplibre fires `load`.
+ */
+
+const SILHOUETTES = [
+  {
+    familyCode: 'tyrannidae',
+    color: '#C77A2E',
+    svgData: 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+    source: null,
+    license: null,
+    commonName: 'Tyrant Flycatchers',
+    creator: null,
+  },
+  {
+    familyCode: '_FALLBACK',
+    color: '#555555',
+    svgData: 'M 6 12 C 6 9 8 7 11 7 C 13 7 14 8 15 9 L 18 8 L 18 10 L 16 11 L 16 14 L 14 16 L 9 16 L 6 14 Z',
+    source: null,
+    license: null,
+    commonName: 'Unknown family',
+    creator: null,
+  },
+];
+
+function observationFixture(): Observation[] {
+  return [
+    {
+      subId: 'S-LOG-1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.27,
+      lng: -110.85,
+      obsDt: '2026-04-15T10:00:00Z',
+      locId: 'L99',
+      locName: 'Sweetwater Wetlands',
+      howMany: 4,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+  ];
+}
+
+const speciesMetaFixture: SpeciesMeta = {
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus',
+  familyCode: 'tyrannidae',
+  familyName: 'Tyrannidae',
+  taxonOrder: 12345,
+};
+
+test.describe('Sightings Log (desktop Rail) — popover seam', () => {
+  test.beforeEach(async ({ page, apiStub }) => {
+    await page.route('**/api/silhouettes', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SILHOUETTES),
+      });
+    });
+    await apiStub.stubObservations(observationFixture());
+    await apiStub.stubSpecies('vermfly', speciesMetaFixture);
+  });
+
+  test('marker → popover → "See species details" renders the single sightings row (1440×900)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const app = new AppPage(page);
+    await app.goto('view=map');
+    await app.waitForAppReady();
+
+    // The hit-layer overlay mounts only after maplibre fires `load`; in
+    // WebGL-less headless runs it never fires — tolerate that (probe + skip),
+    // matching map-symbol-layer.spec.ts. The unit/RTL specs carry the
+    // hard coverage; the orchestrator's live Playwright pass covers the rest.
+    const hitLayer = page.locator('.map-marker-hit-layer');
+    try {
+      await hitLayer.waitFor({ state: 'attached', timeout: 5_000 });
+    } catch {
+      test.skip(true, 'map onLoad did not fire — likely WebGL unavailable in headless run');
+      return;
+    }
+    const hitButton = hitLayer.locator('button').first();
+    if ((await hitButton.count()) === 0) {
+      test.skip(true, 'hit-layer mounted but no markers projected');
+      return;
+    }
+
+    await hitButton.click();
+
+    // ObservationPopover → "See species details" drills into the Rail.
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await dialog.getByRole('button', { name: /see species details/i }).click();
+
+    // The Rail mounts in place over the still-rendered map (?detail=vermfly).
+    await expect.poll(() => app.getUrlParams().get('detail'), { timeout: 5_000 }).toBe('vermfly');
+
+    // The Sightings Log renders the clicked observation as exactly one static
+    // row carrying its exact location.
+    const log = page.getByRole('region', { name: /sightings under this marker/i });
+    await expect(log).toBeVisible({ timeout: 5_000 });
+    await expect(log.locator('.detail-fg-sighting-row')).toHaveCount(1);
+    await expect(log.getByText('Sweetwater Wetlands')).toBeVisible();
+    // howMany 4 > 1 → the ×4 count column renders.
+    await expect(log.locator('.detail-fg-sighting-count')).toHaveText('×4');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { analytics } from '@/analytics.js';
 import { ApiClient, ApiError } from '@/api/client.js';
 import { useUrlState, DEFAULTS } from '@/state/url-state.js';
 import type { Scope } from '@/state/url-state.js';
+import type { SightingsContext } from '@/components/sightings-context.js';
 import { decodeViewbox } from '@/state/viewbox-link.js';
 import type { ViewboxCamera } from '@/state/viewbox-link.js';
 import type { ScopeResolution } from '@/state/scope-types.js';
@@ -1381,8 +1382,17 @@ export function App() {
   // `?detail=`; it does NOT write `?view=detail`. Old shared URLs that
   // include `?view=detail` continue to work via url-state's
   // backward-compat handling — see state/url-state.ts.
+  // #1299 (F2 #1301) — the Sightings-Log context for the open detail surface.
+  // Set on the marker click that selects the species (a zoom>=6 leaf context, or
+  // a zoom<6 single-bucket cell context wired in F3), cleared on close. App holds
+  // it (not the URL) because it is per-click marker state, not a shareable view.
+  const [sightingsContext, setSightingsContext] = useState<SightingsContext | null>(null);
+
   const onSelectSpecies = useCallback(
-    (speciesCode: string) => set({ detail: speciesCode }),
+    (speciesCode: string, context?: SightingsContext) => {
+      set({ detail: speciesCode });
+      setSightingsContext(context ?? null);
+    },
     [set],
   );
 
@@ -1393,7 +1403,10 @@ export function App() {
   // detail-view shell with no detail code. The View union is now just
   // 'map' | 'detail', so 'map' is always the surface underneath.
   const onCloseDetail = useCallback(
-    () => set({ view: state.view === 'detail' ? 'map' : state.view, detail: null }),
+    () => {
+      set({ view: state.view === 'detail' ? 'map' : state.view, detail: null });
+      setSightingsContext(null);
+    },
     [set, state.view],
   );
 
@@ -1777,6 +1790,8 @@ export function App() {
           speciesCode={state.detail}
           apiClient={apiClient}
           onClose={onCloseDetail}
+          {...(sightingsContext ? { sightingsContext } : {})}
+          since={state.since}
         />
       )}
       {scopeActive && state.detail && isCompact && (

--- a/frontend/src/components/MapSurface.tsx
+++ b/frontend/src/components/MapSurface.tsx
@@ -8,6 +8,7 @@ import type { AggregatedBucket, FamilySilhouette, Observation } from '@bird-watc
 import type { SpeciesDictionary } from '../data/use-species-dictionary.js';
 import type { ViewboxCamera } from '../state/viewbox-link.js';
 import type { ThemeId } from './map/geometry/basemap-style.js';
+import type { SightingsContext } from './sightings-context.js';
 import { ErrorBoundary } from './ErrorBoundary.js';
 
 /**
@@ -41,7 +42,7 @@ export interface MapSurfaceProps {
    * (already exposed for map marker clicks). Optional — when
    * absent, the popover hides the "See species details" link.
    */
-  onSelectSpecies?: (speciesCode: string) => void;
+  onSelectSpecies?: (speciesCode: string, context?: SightingsContext) => void;
   /**
    * Issue #351: passthrough for MapCanvas's onViewportChange callback.
    * App.tsx threads this so it can update its `viewportBounds` state on

--- a/frontend/src/components/SightingsLog.test.tsx
+++ b/frontend/src/components/SightingsLog.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ApiClient } from '@/api/client.js';
+import type { SightingRow, SightingsContext } from './sightings-context.js';
+import { SightingsLog } from './SightingsLog.js';
+
+const apiClient = new ApiClient({ baseUrl: '' });
+
+function row(over: Partial<SightingRow> & { subId: string; obsDt: string }): SightingRow {
+  return { speciesCode: 'vermfly', locName: null, howMany: null, isNotable: false, ...over };
+}
+
+function renderLog(context: SightingsContext | null, speciesCode = 'vermfly') {
+  return render(
+    <SightingsLog apiClient={apiClient} speciesCode={speciesCode} context={context} />,
+  );
+}
+
+describe('SightingsLog', () => {
+  it('renders nothing when the context is null (unsupported)', () => {
+    const { container } = renderLog(null);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for a cell context (cell wired in F3)', () => {
+    const { container } = renderLog({
+      kind: 'cell',
+      lngBucket: -110.5,
+      latBucket: 32.5,
+      gridMultiplier: 2,
+      scopeKey: 'US-AZ',
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no leaf matches the selected species', () => {
+    const { container } = renderLog({
+      kind: 'leaves',
+      rows: [row({ subId: 'A', obsDt: '2026-04-15T08:00:00Z', speciesCode: 'verdin' })],
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one row for a single-sighting marker (popover seam)', () => {
+    renderLog({
+      kind: 'leaves',
+      rows: [row({ subId: 'A', obsDt: '2026-04-15T08:00:00Z', locName: 'Sweetwater Wetlands' })],
+    });
+    const section = screen.getByRole('region', { name: /sightings under this marker/i });
+    expect(section).toBeInTheDocument();
+    const rows = section.querySelectorAll('.detail-fg-sighting-row');
+    expect(rows).toHaveLength(1);
+    expect(screen.getByText('Sweetwater Wetlands')).toBeInTheDocument();
+  });
+
+  it('renders two rows newest-first for a 2-observation stack (cluster-list seam)', () => {
+    const { container } = renderLog({
+      kind: 'leaves',
+      rows: [
+        row({ subId: 'OLD', obsDt: '2026-04-15T08:00:00Z', locName: 'Patch A' }),
+        row({ subId: 'NEW', obsDt: '2026-04-15T12:00:00Z', locName: 'Patch B' }),
+      ],
+    });
+    const locations = Array.from(container.querySelectorAll('.detail-fg-sighting-location')).map(
+      (n) => n.textContent,
+    );
+    expect(locations).toEqual(['Patch B', 'Patch A']);
+  });
+
+  it('shows the count column ONLY when howMany > 1 (divergence from the popover)', () => {
+    const { container } = renderLog({
+      kind: 'leaves',
+      rows: [
+        row({ subId: 'one', obsDt: '2026-04-15T12:00:00Z', howMany: 1 }),
+        row({ subId: 'three', obsDt: '2026-04-15T11:00:00Z', howMany: 3 }),
+        row({ subId: 'null', obsDt: '2026-04-15T10:00:00Z', howMany: null }),
+      ],
+    });
+    const counts = Array.from(container.querySelectorAll('.detail-fg-sighting-count')).map(
+      (n) => n.textContent,
+    );
+    // Only the howMany:3 row renders a count cell.
+    expect(counts).toEqual(['×3']);
+  });
+
+  it('renders the notable badge only for notable rows', () => {
+    const { container } = renderLog({
+      kind: 'leaves',
+      rows: [
+        row({ subId: 'plain', obsDt: '2026-04-15T12:00:00Z', isNotable: false }),
+        row({ subId: 'note', obsDt: '2026-04-15T11:00:00Z', isNotable: true }),
+      ],
+    });
+    expect(container.querySelectorAll('.detail-fg-sighting-notable')).toHaveLength(1);
+  });
+
+  it('caps at 50 visible rows and shows a static "Showing latest 50 of M" banner', () => {
+    const rows = Array.from({ length: 63 }, (_, i) =>
+      row({
+        subId: `S${i}`,
+        // descending ISO times so the newest 50 are deterministic
+        obsDt: `2026-04-${String(2 + (i % 27)).padStart(2, '0')}T${String(i % 24).padStart(2, '0')}:00:00Z`,
+      }),
+    );
+    const { container } = renderLog({ kind: 'leaves', rows });
+    expect(container.querySelectorAll('.detail-fg-sighting-row')).toHaveLength(50);
+    const banner = container.querySelector('.detail-fg-sightings-truncation');
+    expect(banner?.textContent).toBe('Showing latest 50 of 63');
+  });
+
+  it('renders no truncation banner at exactly the cap', () => {
+    const rows = Array.from({ length: 50 }, (_, i) =>
+      row({ subId: `S${i}`, obsDt: `2026-04-15T${String(i % 24).padStart(2, '0')}:00:00Z` }),
+    );
+    const { container } = renderLog({ kind: 'leaves', rows });
+    expect(container.querySelectorAll('.detail-fg-sighting-row')).toHaveLength(50);
+    expect(container.querySelector('.detail-fg-sightings-truncation')).toBeNull();
+  });
+});

--- a/frontend/src/components/SightingsLog.tsx
+++ b/frontend/src/components/SightingsLog.tsx
@@ -1,0 +1,83 @@
+import type { ApiClient } from '../api/client.js';
+import type { Since } from '../state/url-state.js';
+import type { SightingsContext } from './sightings-context.js';
+import { useSightingsRows } from '../data/use-sightings-rows.js';
+
+/**
+ * Client-side visible-row cap for the zoom>=6 leaf path (epic #1299 Decisions
+ * §5). A busy single-species cluster could otherwise materialize an arbitrarily
+ * long list in the desktop Rail. The cap is a plain `slice` (no virtualization,
+ * no count animation — #953); the same banner the F3 zoom<6 server-truncation
+ * path renders carries the overflow signal.
+ */
+const MAX_VISIBLE_ROWS = 50;
+
+export interface SightingsLogProps {
+  apiClient: ApiClient;
+  speciesCode: string;
+  context: SightingsContext | null;
+  since?: Since;
+}
+
+/**
+ * Per-sighting log shown inside the species-detail surface (epic #1299, F2
+ * #1301). After a marker click selects a species, it lists that species'
+ * individual sightings under the clicked marker — one static row each:
+ * time · exact location · count (only when >1) · notable "!". Rows are
+ * display-only and NEVER animated (the counts are camera-coupled — #953).
+ *
+ * Row formatting mirrors `ObservationPopover` for time + location, but the
+ * count column is a DELIBERATE divergence: the popover shows count whenever
+ * `howMany != null` (it can show "Count: 1"); the log shows the count column
+ * ONLY when `howMany > 1`.
+ *
+ * This is a SECTION of the existing Transient detail surface — it claims no new
+ * floating corner (four-corner anchor contract, CLAUDE.md / spec §3).
+ */
+export function SightingsLog({ apiClient, speciesCode, context, since }: SightingsLogProps) {
+  const { rows, total, truncated, loading, error, supported } = useSightingsRows(
+    apiClient,
+    speciesCode,
+    context,
+    since,
+  );
+  // cell pre-F3 / no context / zoom<6 cluster-list → nothing to show.
+  if (!supported) return null;
+  // loading/error states are refined in F3 (the cell fetch); the leaf path is synchronous.
+  if (loading || error || rows.length === 0) return null;
+
+  const visibleRows = rows.slice(0, MAX_VISIBLE_ROWS);
+  const overflow = rows.length > MAX_VISIBLE_ROWS;
+
+  return (
+    <section className="detail-fg-sightings" aria-label="Sightings under this marker">
+      <h2 className="detail-fg-sightings-eyebrow">Sightings here</h2>
+      <ul className="detail-fg-sightings-list">
+        {visibleRows.map((r) => (
+          <li className="detail-fg-sighting-row" key={r.subId}>
+            <span className="detail-fg-sighting-time">
+              {new Date(r.obsDt).toLocaleString(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'short',
+              })}
+            </span>
+            {r.locName && <span className="detail-fg-sighting-location">{r.locName}</span>}
+            {r.howMany != null && r.howMany > 1 && (
+              <span className="detail-fg-sighting-count">{`×${r.howMany}`}</span>
+            )}
+            {r.isNotable && (
+              <span className="detail-fg-sighting-notable" aria-label="Notable">
+                !
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {(truncated || overflow) && (
+        <p className="detail-fg-sightings-truncation">
+          Showing latest {visibleRows.length} of {total}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SpeciesDetailRail.tsx
+++ b/frontend/src/components/SpeciesDetailRail.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { ApiClient } from '../api/client.js';
 import { SpeciesDetailSurface } from './SpeciesDetailSurface.js';
+import type { SightingsContext } from './sightings-context.js';
+import type { Since } from '../state/url-state.js';
 
 export interface SpeciesDetailRailProps {
   speciesCode: string;
@@ -24,6 +26,14 @@ export interface SpeciesDetailRailProps {
    * dropped focus onto <body> — a WCAG 2.4.3 regression. Restored here.)
    */
   fallbackFocusSelector?: string;
+  /**
+   * Sightings-Log context (epic #1299, F2 #1301) — threaded verbatim into the
+   * shared <SpeciesDetailSurface> so the in-panel log knows which sightings to
+   * show. App owns it (set on the marker click that opened the rail).
+   */
+  sightingsContext?: SightingsContext;
+  /** Active since-window (url-state), forwarded to the surface for the F3 cell fetch. */
+  since?: Since;
 }
 
 /**
@@ -55,6 +65,8 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
     onClose,
     triggerRef,
     fallbackFocusSelector = '#main-surface',
+    sightingsContext,
+    since,
   } = props;
   const asideRef = useRef<HTMLElement | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -155,6 +167,8 @@ export function SpeciesDetailRail(props: SpeciesDetailRailProps) {
         speciesCode={speciesCode}
         apiClient={apiClient}
         revealed={revealed}
+        {...(sightingsContext ? { sightingsContext } : {})}
+        {...(since !== undefined ? { since } : {})}
       />
     </aside>
   );

--- a/frontend/src/components/SpeciesDetailSurface.tsx
+++ b/frontend/src/components/SpeciesDetailSurface.tsx
@@ -5,9 +5,12 @@ import { useSilhouettes } from '../data/use-silhouettes.js';
 import { buildFamilyColorResolver, buildFamilyPathResolver, buildFamilyImgUrlResolver } from '../data/family-color.js';
 import { analytics } from '../analytics.js';
 import { SpeciesDescription } from './SpeciesDescription.js';
+import { SightingsLog } from './SightingsLog.js';
 import { Photo } from './ds/Photo.js';
 import { StatusBlock } from './ds/StatusBlock.js';
 import type { FamilyCode } from '../config/family-palette.js';
+import type { SightingsContext } from './sightings-context.js';
+import type { Since } from '../state/url-state.js';
 
 export interface SpeciesDetailSurfaceProps {
   speciesCode: string;
@@ -21,6 +24,16 @@ export interface SpeciesDetailSurfaceProps {
    * the unit tests) shows the resting end-state immediately.
    */
   revealed?: boolean;
+  /**
+   * Sightings-Log context (epic #1299, F2 #1301) — threaded from the marker
+   * click that opened the surface (via SpeciesDetailRail on desktop). Identifies
+   * WHICH sightings the in-panel log shows. Absent ⇒ the log renders nothing
+   * (e.g. the mobile Sheet does not thread it until M4 #1303, and a deep-linked
+   * detail open carries no marker context).
+   */
+  sightingsContext?: SightingsContext;
+  /** The active since-window (url-state). Unused by the leaf path; F3 forwards it to the cell fetch. */
+  since?: Since;
 }
 
 /**
@@ -46,7 +59,7 @@ export interface SpeciesDetailSurfaceProps {
  * inside the wrapper's scroll container (modal or sheet), not <main>.
  */
 export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
-  const { speciesCode, apiClient, revealed = true } = props;
+  const { speciesCode, apiClient, revealed = true, sightingsContext, since } = props;
   const detail = useSpeciesDetail(apiClient, speciesCode);
   const { loading, error, data, retry } = detail;
   // useSilhouettes provides the family-color payload. The data is cached at
@@ -220,6 +233,18 @@ export function SpeciesDetailSurface(props: SpeciesDetailSurfaceProps) {
         className="detail-fg-rule"
         aria-hidden="true"
         style={{ background: famColor }}
+      />
+
+      {/* E2. Sightings Log (#1299 / F2 #1301) — per-sighting recency for the
+          clicked marker outranks formal taxonomy reference data, so it sits
+          immediately after the family-accent rule and ABOVE the taxonomy <dl>.
+          Renders nothing unless a marker-click context was threaded in (a
+          zoom>=6 leaf context today; the zoom<6 cell path lands in F3). */}
+      <SightingsLog
+        apiClient={apiClient}
+        speciesCode={speciesCode}
+        context={sightingsContext ?? null}
+        {...(since !== undefined ? { since } : {})}
       />
 
       {/* F. Taxonomy — real <dl> so AT ties label→value. Intentionally restates

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -4475,3 +4475,341 @@ describe('#1296 bot-review — grid-singleton member appears in the merged clust
     expect(rowSum).toBe(18);
   });
 });
+
+/* ── #1301 — Sightings-Log marker-context threading (epic #1299) ─────────────
+ *
+ * Each marker-click seam constructs a STRUCTURALLY DIFFERENT onSelectSpecies
+ * context (single Observation vs. filtered leaves vs. cell coords). These tests
+ * pin the threading so a regression turns a test red (the named seam-fragility
+ * risk). The leaf-row sorting/capping is covered at the hook/component level.
+ */
+describe('#1301 — Sightings-Log marker-context threading', () => {
+  // ── (A)+(B): static-import seams (default pointer) ──────────────────────────
+  describe('leaf seams', () => {
+    beforeEach(() => {
+      capturedSourceProps = {};
+      capturedLayerFilters = {};
+      capturedSourcesById = {};
+      capturedLayerPaint = {};
+      registeredHandlers = {};
+      bareHandlers = {};
+      bareHandlersAll = {};
+      deferMapLoad = false;
+      deferredOnLoad = null;
+      fakeMap = makeFakeMap();
+      document.documentElement.removeAttribute('data-theme');
+      __resetAdaptiveGridCacheForTesting();
+    });
+
+    it('ObservationPopover seam threads a 1-element {kind:"leaves"} context', async () => {
+      const obs = makeObs({
+        subId: 'S-POP',
+        speciesCode: 'vermfly',
+        comName: 'Vermilion Flycatcher',
+        locName: 'Sweetwater Wetlands',
+        howMany: 4,
+        isNotable: true,
+      });
+      const onSelectSpecies = vi.fn();
+      render(
+        <MapCanvas
+          observations={[obs]}
+          silhouettes={SILHOUETTES}
+          onSelectSpecies={onSelectSpecies}
+        />,
+      );
+      await waitFor(() =>
+        expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+      );
+      fakeMap.queryRenderedFeatures.mockImplementation(
+        (_: unknown, opts?: { layers?: string[] }) =>
+          opts?.layers?.includes('unclustered-point')
+            ? [
+                {
+                  type: 'Feature',
+                  geometry: { type: 'Point', coordinates: [obs.lng, obs.lat] },
+                  properties: { subId: 'S-POP' },
+                },
+              ]
+            : [],
+      );
+      const handler = registeredHandlers['click:unclustered-point'];
+      if (!handler) throw new Error('click:unclustered-point handler missing');
+      await act(async () => {
+        handler({ point: [120, 120] });
+        await Promise.resolve();
+      });
+      await screen.findByRole('dialog', { name: /Details for Vermilion Flycatcher/ });
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /see species details/i }),
+      );
+
+      expect(onSelectSpecies).toHaveBeenCalledTimes(1);
+      const [code, context] = onSelectSpecies.mock.calls[0];
+      expect(code).toBe('vermfly');
+      // Exactly one row — the clicked observation, narrowed to SightingRow (no
+      // locId / silhouetteId).
+      expect(context).toEqual({
+        kind: 'leaves',
+        rows: [
+          {
+            subId: 'S-POP',
+            speciesCode: 'vermfly',
+            obsDt: obs.obsDt,
+            locName: 'Sweetwater Wetlands',
+            howMany: 4,
+            isNotable: true,
+          },
+        ],
+      });
+    });
+
+    it('zoom>=6 ClusterListPopover seam threads a {kind:"leaves"} context filtered by species', async () => {
+      const pill = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [-110.95, 32.25] },
+        properties: { cluster: true, cluster_id: 88, point_count: 50 },
+      };
+      fakeMap.queryRenderedFeatures.mockReturnValue([pill]);
+      // 18 families ⇒ pill fallback. Tyrannidae carries TWO real sightings of the
+      // SAME species (wewp) so the species filter yields 2 rows.
+      const leaves: Array<Record<string, unknown>> = [
+        {
+          type: 'Feature',
+          properties: {
+            familyCode: 'tyrannidae',
+            speciesCode: 'wewp',
+            comName: 'Western Wood-Pewee',
+            subId: 'W1',
+            obsDt: '2026-04-15T08:00:00Z',
+            locName: 'Patch A',
+            howMany: 1,
+            isNotable: false,
+          },
+        },
+        {
+          type: 'Feature',
+          properties: {
+            familyCode: 'tyrannidae',
+            speciesCode: 'wewp',
+            comName: 'Western Wood-Pewee',
+            subId: 'W2',
+            obsDt: '2026-04-15T12:00:00Z',
+            locName: 'Patch B',
+            howMany: 2,
+            isNotable: false,
+          },
+        },
+      ];
+      for (let i = 0; i < 17; i++) {
+        leaves.push({
+          type: 'Feature',
+          properties: { familyCode: `fam${i}`, speciesCode: `sp${i}`, comName: `Species ${i}` },
+        });
+      }
+      fakeMap.getSource.mockReturnValue({
+        getClusterLeaves: vi.fn().mockResolvedValue(leaves),
+        getClusterExpansionZoom: vi.fn().mockResolvedValue(17),
+      });
+      fakeMap.getZoom.mockReturnValue(17); // zoom >= 6
+
+      const onSelectSpecies = vi.fn();
+      render(
+        <MapCanvas
+          observations={[makeObs()]}
+          silhouettes={SILHOUETTES}
+          onSelectSpecies={onSelectSpecies}
+        />,
+      );
+      await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+      await act(async () => { await bareHandlers['idle']?.(); });
+      await act(async () => { await Promise.resolve(); });
+
+      const pillBtn = await waitFor(() => {
+        const found = screen
+          .queryAllByRole('button', { name: /sightings$/ })
+          .find((p) => p.classList.contains('cluster-pill'));
+        if (!found) throw new Error('cluster-pill not rendered');
+        return found;
+      });
+      await act(async () => {
+        fireEvent.click(pillBtn);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await screen.findByTestId('cluster-list-popover');
+
+      // Expand the tyrannidae family, then click the Western Wood-Pewee row.
+      const familyToggle = screen.getByTestId('cluster-list-popover-family-tyrannidae');
+      await act(async () => {
+        fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
+        await Promise.resolve();
+      });
+      const wewpRow = screen
+        .getAllByTestId('cluster-list-popover-row')
+        .find((r) => /Western Wood-Pewee/.test(r.textContent ?? ''));
+      if (!wewpRow) throw new Error('wewp row not rendered');
+      fireEvent.click(wewpRow.querySelector('button') ?? wewpRow);
+
+      expect(onSelectSpecies).toHaveBeenCalledTimes(1);
+      const [code, context] = onSelectSpecies.mock.calls[0];
+      expect(code).toBe('wewp');
+      expect(context.kind).toBe('leaves');
+      // Both wewp leaves; newest-first ordering is applied by the hook, not here.
+      expect(context.rows.map((r: { subId: string }) => r.subId).sort()).toEqual(['W1', 'W2']);
+      expect(context.rows.every((r: { speciesCode: string }) => r.speciesCode === 'wewp')).toBe(true);
+    });
+  });
+
+  // ── (C)+(D): aggregated cell seam (fresh module, coarse pointer) ────────────
+  describe('cell seam (aggregated)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let MapCanvasFresh: any;
+
+    const FAMILIES = [
+      {
+        code: 'tyrannidae',
+        count: 7,
+        speciesCount: 2,
+        species: [
+          { code: 'wewp', count: 5 },
+          { code: 'sayphoebe', count: 2 },
+        ],
+      },
+    ];
+    const DICT = new Map<string, { comName: string; familyCode: string }>([
+      ['wewp', { comName: 'Western Wood-Pewee', familyCode: 'tyrannidae' }],
+      ['sayphoebe', { comName: "Say's Phoebe", familyCode: 'tyrannidae' }],
+    ]);
+
+    beforeEach(async () => {
+      capturedSourceProps = {};
+      capturedLayerFilters = {};
+      capturedSourcesById = {};
+      capturedLayerPaint = {};
+      registeredHandlers = {};
+      bareHandlers = {};
+      bareHandlersAll = {};
+      deferMapLoad = false;
+      deferredOnLoad = null;
+      fakeMap = makeFakeMap();
+      document.documentElement.removeAttribute('data-theme');
+      window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+        matches: q === '(pointer: coarse)',
+        media: q,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia;
+      vi.resetModules();
+      const mod = await import('./MapCanvas.js');
+      MapCanvasFresh = mod.MapCanvas;
+      mod.__resetAdaptiveGridCacheForTesting();
+    });
+
+    afterEach(() => { vi.resetModules(); });
+
+    async function openLoneBucketPopover(opts: {
+      pointCount: number;
+      zoom: number;
+      boundsKey: string;
+      onSelectSpecies: ReturnType<typeof vi.fn>;
+    }) {
+      const bucket: AggregatedBucket = {
+        lat: 46.0,
+        lng: -110.0,
+        count: 7,
+        speciesCount: 2,
+        families: FAMILIES,
+      };
+      const clustered = {
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [bucket.lng, bucket.lat] },
+        properties: {
+          cluster: true,
+          cluster_id: 501,
+          point_count: opts.pointCount,
+          sumCount: bucket.count,
+          sumSpeciesCount: bucket.speciesCount,
+        },
+      };
+      fakeMap.queryRenderedFeatures.mockImplementation(
+        (_: unknown, o?: { layers?: string[] }) =>
+          o?.layers?.includes('clusters-hit') ? [clustered] : [],
+      );
+      fakeMap.getSource.mockReturnValue({
+        getClusterLeaves: vi.fn().mockResolvedValue([
+          { type: 'Feature', properties: { familiesJson: JSON.stringify(bucket.families) } },
+        ]),
+        getClusterExpansionZoom: vi.fn().mockResolvedValue(11),
+      });
+      fakeMap.getZoom.mockReturnValue(opts.zoom);
+
+      render(
+        <MapCanvasFresh
+          observations={[]}
+          buckets={[bucket]}
+          mode="aggregated"
+          dictionary={DICT}
+          silhouettes={SILHOUETTES}
+          boundsKey={opts.boundsKey}
+          onSelectSpecies={opts.onSelectSpecies}
+        />,
+      );
+      await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+      await act(async () => { await fireAllIdleHandlers(); });
+      await act(async () => { await Promise.resolve(); });
+
+      const marker = await waitFor(() => {
+        const btn = screen
+          .queryAllByRole('button')
+          .find((b) => b.className.includes('adaptive-grid-marker'));
+        if (!btn) throw new Error('lone bucket did not render an interactive marker');
+        return btn;
+      });
+      await act(async () => { fireEvent.click(marker); await Promise.resolve(); });
+      await screen.findByTestId('cluster-list-popover');
+      const familyToggle = screen.getByTestId('cluster-list-popover-family-tyrannidae');
+      await act(async () => {
+        fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
+        await Promise.resolve();
+      });
+      const wewpRow = screen
+        .getAllByTestId('cluster-list-popover-row')
+        .find((r) => /Western Wood-Pewee/.test(r.textContent ?? ''));
+      if (!wewpRow) throw new Error('wewp row not rendered');
+      fireEvent.click(wewpRow.querySelector('button') ?? wewpRow);
+    }
+
+    it('single aggregated bucket → {kind:"cell"} whose gridMultiplier is the zoom->m single source', async () => {
+      const onSelectSpecies = vi.fn();
+      // zoom 4 ⇒ gridMultiplierForZoom(4) === 4 (the read-api zoom->{2,4,8} switch).
+      await openLoneBucketPopover({ pointCount: 1, zoom: 4, boundsKey: 'US-AZ', onSelectSpecies });
+
+      expect(onSelectSpecies).toHaveBeenCalledTimes(1);
+      const [code, context] = onSelectSpecies.mock.calls[0];
+      expect(code).toBe('wewp');
+      expect(context).toEqual({
+        kind: 'cell',
+        lngBucket: -110.0,
+        latBucket: 46.0,
+        gridMultiplier: 4,
+        scopeKey: 'US-AZ',
+      });
+    });
+
+    it('multi-bucket aggregated cluster threads NO context (single-bucket only — Decisions §4)', async () => {
+      const onSelectSpecies = vi.fn();
+      // point_count 2 ⇒ not a single bucket ⇒ no cell context (1-arg call).
+      await openLoneBucketPopover({ pointCount: 2, zoom: 3, boundsKey: 'US-AZ', onSelectSpecies });
+
+      expect(onSelectSpecies).toHaveBeenCalledTimes(1);
+      expect(onSelectSpecies).toHaveBeenCalledWith('wewp');
+      expect(onSelectSpecies.mock.calls[0]).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -65,6 +65,15 @@ import {
   type SpeciesAggregate,
 } from './geometry/adaptive-grid.js';
 import { type HitTargetMarker } from './layers/MapMarkerHitLayer.js';
+// #1301 — Sightings-Log marker-context seam (epic #1299). The leaf/observation
+// mappers + the zoom->grid_multiplier single source live in sightings-context.
+import {
+  observationToSightingRow,
+  leafToSightingRow,
+  gridMultiplierForZoom,
+  type SightingsContext,
+  type SightingRow,
+} from '@/components/sightings-context.js';
 import {
   isSyntheticSingleId,
   type DeconflictGroup,
@@ -445,6 +454,15 @@ export function MapCanvas({
     anchorEl: HTMLElement;
     /** Camera center the "+N more" drill-in escalates into (the group anchor). */
     drillCenter?: [number, number];
+    /**
+     * #1301 — the cluster's raw leaves projected to Sightings-Log rows, stashed
+     * so the species pick can thread a `{kind:'leaves'}` context filtered by the
+     * chosen species. Present ONLY on the zoom>=6 per-observation path (each leaf
+     * is a real sighting); ABSENT on the zoom<6 aggregated path (each leaf is a
+     * bucket, not a sighting), where the species pick threads NO context (epic
+     * #1299 Decisions §4: the multi-bucket cluster-list seam is unsupported).
+     */
+    sightingRows?: SightingRow[];
   } | null>(null);
   // E1 (#1053): close the canvas-owned transient popovers on the RISING edge of
   // `detailOpen`. Opening a species detail must dismiss any open
@@ -1642,6 +1660,7 @@ export function MapCanvas({
                 py,
                 rendered: { kind: 'pill', count: pointCount },
                 point_count: pointCount,
+                bucketCount: rawPointCount,
                 uniqueFamilies: resolved.uniqueFamilies,
                 longitude,
                 latitude,
@@ -1653,6 +1672,7 @@ export function MapCanvas({
                 py,
                 rendered: { kind: 'grid', shape: resolved.shape },
                 point_count: pointCount,
+                bucketCount: rawPointCount,
                 uniqueFamilies: resolved.uniqueFamilies,
                 longitude,
                 latitude,
@@ -2036,10 +2056,15 @@ export function MapCanvas({
         const allLeaves = [...realLeaves, ...singletonLeaves];
         const families = aggregateClusterFamilies(allLeaves);
         const speciesByFamily = aggregateClusterSpecies(allLeaves);
+        // #1301 — at zoom>=6 each leaf is a real sighting, so stash the projected
+        // rows; the species pick threads a `{kind:'leaves'}` context filtered by
+        // the chosen species into the Sightings Log.
+        const sightingRows = allLeaves.map(leafToSightingRow);
         setClusterList({
           group,
           families,
           speciesByFamily,
+          sightingRows,
           // #1286: as above — the header counts the whole merged group. `families`
           // is `aggregateClusterFamilies(allLeaves)` over EVERY member's flattened
           // leaves (incl. grid singletons), so `families.length` is the merged
@@ -2224,13 +2249,74 @@ export function MapCanvas({
 
   const handlePopoverSelectSpecies = useCallback(
     (speciesCode: string) => {
-      onSelectSpecies?.(speciesCode);
+      // #1301 — the ObservationPopover seam holds exactly one full `Observation`
+      // (the clicked sighting), so the Sightings-Log context is a single-row
+      // `leaves` payload. The hook filters it by the selected species (a no-op
+      // here — it's already that species) and the log shows one row.
+      const obs = selectedObs?.obs;
+      const context: SightingsContext | undefined = obs
+        ? { kind: 'leaves', rows: [observationToSightingRow(obs)] }
+        : undefined;
+      // Call with the 2nd arg ONLY when a context exists, so seams with no
+      // context keep their historical single-arg call shape.
+      if (context) onSelectSpecies?.(speciesCode, context);
+      else onSelectSpecies?.(speciesCode);
       // Close the popover after the navigation — the user has expressed
       // intent to leave the map view; the dialog hanging open during the
       // surface switch is a stale state.
       setSelectedObs(null);
     },
-    [onSelectSpecies],
+    [onSelectSpecies, selectedObs],
+  );
+
+  /**
+   * #1301 — the per-family `<CellPopover>` species-select seam (inside an
+   * `<AdaptiveGridMarker>`, via `<GroupMarkerLayer>`). Builds a `{kind:'cell'}`
+   * Sightings-Log context ONLY for a genuine SINGLE aggregated bucket: its
+   * marker anchor IS a true `round(coord*m)/m` bucket center, so the derived
+   * cell aligns with the server's bucketing by construction. A multi-bucket
+   * cluster (anchor = supercluster centroid) or a zoom>=6 per-observation marker
+   * threads NO context — epic #1299 Decisions §4 forbids deriving a cell from a
+   * non-bucket center. INERT in F2 (`useSightingsRows` is `supported:false` for
+   * `cell`); wired now so F3 (#1302) adds the fetch without re-threading.
+   *
+   * `gridMultiplier` reads `gridMultiplierForZoom(Math.floor(map.getZoom()))` —
+   * the SINGLE frontend copy of the read-api zoom->{2,4,8} switch, fed the
+   * FLOORED integer zoom (never a raw float). `scopeKey` mirrors the server's
+   * `resolveScopeKey` base ('US' national, else the state code) off the
+   * scope-change `boundsKey` MapCanvas already holds.
+   */
+  const handleGridSelectSpecies = useCallback(
+    (speciesCode: string, group: DeconflictGroup) => {
+      if (!onSelectSpecies) return;
+      let context: SightingsContext | undefined;
+      const map = mapRef.current?.getMap();
+      const { anchor, memberIds } = group;
+      if (
+        aggregated &&
+        map &&
+        memberIds.length === 1 &&
+        // A genuine SINGLE bucket carries exactly one supercluster leaf. (The
+        // #859 sumCount overwrite makes `anchor.point_count` the summed obs count,
+        // so it cannot gate this — `bucketCount` preserves the raw leaf count.)
+        anchor.bucketCount === 1 &&
+        anchor.longitude !== undefined &&
+        anchor.latitude !== undefined
+      ) {
+        context = {
+          kind: 'cell',
+          lngBucket: anchor.longitude,
+          latBucket: anchor.latitude,
+          gridMultiplier: gridMultiplierForZoom(Math.floor(map.getZoom())),
+          scopeKey: boundsKey && boundsKey !== 'us' ? boundsKey : 'US',
+        };
+      }
+      // Call with the 2nd arg ONLY when a single-bucket cell context was built,
+      // so the per-observation / multi-bucket path keeps its single-arg shape.
+      if (context) onSelectSpecies(speciesCode, context);
+      else onSelectSpecies(speciesCode);
+    },
+    [onSelectSpecies, aggregated, boundsKey],
   );
 
   /**
@@ -2526,7 +2612,7 @@ export function MapCanvas({
           isCoarsePointer={isCoarsePointer}
           detailOpen={detailOpen}
           onGroupClick={handleGroupClick}
-          {...(onSelectSpecies ? { onSelectSpecies } : {})}
+          {...(onSelectSpecies ? { onSelectSpecies: handleGridSelectSpecies } : {})}
           onDrillIn={handleDrillInToCenter}
         />
         {/*
@@ -2574,7 +2660,17 @@ export function MapCanvas({
           onDismiss={() => setClusterList(null)}
           onSelectSpecies={(code) => {
             if (onSelectSpecies) {
-              onSelectSpecies(code);
+              // #1301 — zoom>=6 stuck-cluster seam: thread the cluster's leaves
+              // for the chosen species as a `{kind:'leaves'}` context. At zoom<6
+              // (aggregated) `sightingRows` is absent, so NO context is threaded
+              // (the multi-bucket cluster-list seam is unsupported — epic #1299
+              // Decisions §4); the log then renders nothing.
+              const rows = clusterList.sightingRows;
+              const context: SightingsContext | undefined = rows
+                ? { kind: 'leaves', rows: rows.filter((r) => r.speciesCode === code) }
+                : undefined;
+              if (context) onSelectSpecies(code, context);
+              else onSelectSpecies(code);
             }
             setClusterList(null);
           }}

--- a/frontend/src/components/map/MapCanvas.types.ts
+++ b/frontend/src/components/map/MapCanvas.types.ts
@@ -17,6 +17,7 @@ import type { SpeciesDictionary } from '@/data/use-species-dictionary.js';
 import type { ViewboxCamera } from '@/state/viewbox-link.js';
 import type { AdaptiveTile, ResolvedGrid } from './geometry/adaptive-grid.js';
 import type { ThemeId } from './geometry/basemap-style.js';
+import type { SightingsContext } from '@/components/sightings-context.js';
 
 /**
  * Resolved per-cluster adaptive data — the unit the Concern B cache stores
@@ -79,8 +80,14 @@ export interface MapCanvasProps {
    * the ObservationPopover. App.tsx wires this to
    * `set({ view: 'detail', detail: code })` via `useUrlState`. Optional
    * — when absent, the popover hides the link.
+   *
+   * #1301 — the optional second arg threads the Sightings-Log marker context
+   * (epic #1299): a zoom>=6 leaf context (from the popover / stuck-cluster
+   * seam) or a zoom<6 single-bucket cell context. Absent ⇒ the in-panel log
+   * renders nothing (the clean incremental for the zoom<6 cluster-list seam and
+   * the pre-F3 cell path).
    */
-  onSelectSpecies?: (speciesCode: string) => void;
+  onSelectSpecies?: (speciesCode: string, context?: SightingsContext) => void;
   /**
    * Issue #351: invoked on every map `idle` (camera-change settle) with
    * the current `map.getBounds()`. App.tsx threads this so the

--- a/frontend/src/components/map/geometry/adaptive-grid.ts
+++ b/frontend/src/components/map/geometry/adaptive-grid.ts
@@ -145,6 +145,18 @@ export interface ClusterLeafFeature {
     comName: string;
     /** Whether this observation is in eBird's notable list. */
     isNotable?: boolean;
+    /**
+     * #1301 — the remaining fields `observationsToGeoJson` stamps onto every
+     * feature (all already on the wire; the adaptive-grid aggregation reads only
+     * `familyCode`, so these are purely additive). They back the leaf->SightingRow
+     * projection (`leafToSightingRow`) for the Sightings Log. Declared OPTIONAL so
+     * the module's existing leaf fixtures (which only set family/species/comName)
+     * still type-check; production leaves always carry them.
+     */
+    subId?: string;
+    locName?: string | null;
+    obsDt?: string;
+    howMany?: number | null;
   };
 }
 

--- a/frontend/src/components/map/geometry/deconflict.ts
+++ b/frontend/src/components/map/geometry/deconflict.ts
@@ -75,6 +75,16 @@ export interface DeconflictInput {
   rendered: RenderedShape;
   /** Total observations in this cluster. */
   point_count: number;
+  /**
+   * #1301 — the RAW supercluster `point_count` (number of LEAVES the cluster
+   * carries). In aggregated mode `point_count` above is overwritten with the
+   * summed observation count (`sumCount`, #859), which erases the leaf count; a
+   * single aggregated bucket is exactly `bucketCount === 1`. The Sightings-Log
+   * cell seam reads this to derive a `{kind:'cell'}` context ONLY for a genuine
+   * single bucket (whose anchor is a true `round(coord*m)/m` center). Optional:
+   * per-observation inputs and Task-2 unit fixtures omit it.
+   */
+  bucketCount?: number;
   /** Unique families (for aria-label aggregation). */
   uniqueFamilies: number;
   /**

--- a/frontend/src/components/map/layers/GroupMarkerLayer.tsx
+++ b/frontend/src/components/map/layers/GroupMarkerLayer.tsx
@@ -24,8 +24,15 @@ interface GroupMarkerLayerProps {
   detailOpen: boolean;
   /** `MapCanvas.handleGroupClick` — receives the group + (for pills) the clicked element. */
   onGroupClick: (group: DeconflictGroup, anchorEl?: HTMLElement | null) => void;
-  /** `MapCanvas`'s `onSelectSpecies` prop, threaded through to grid markers. */
-  onSelectSpecies?: (speciesCode: string) => void;
+  /**
+   * `MapCanvas`'s grid-marker species-select handler (#1301). The second arg is
+   * the clicked group, so MapCanvas — which holds the map ref + scope — decides
+   * whether the marker is a genuine single aggregated bucket that yields a
+   * `{kind:'cell'}` Sightings-Log context (a multi-bucket centroid / per-obs
+   * marker yields none). This layer stays presentational: it forwards the group
+   * it already iterates and inspects no shape to pick a domain action.
+   */
+  onSelectSpecies?: (speciesCode: string, group: DeconflictGroup) => void;
   /** `MapCanvas.handleDrillInToCenter`, invoked from the grid marker's "+N more". */
   onDrillIn: (center: [number, number]) => void;
 }
@@ -95,7 +102,7 @@ export function GroupMarkerLayer({
               detailOpen={detailOpen}
               onClick={() => onGroupClick(g)}
               {...(onSelectSpecies ? {
-                onSelectSpecies: (code: string) => onSelectSpecies(code),
+                onSelectSpecies: (code: string) => onSelectSpecies(code, g),
               } : {})}
               {...(anchor.longitude !== undefined && anchor.latitude !== undefined
                 ? {

--- a/frontend/src/components/sightings-context.test.ts
+++ b/frontend/src/components/sightings-context.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import type { Observation } from '@bird-watch/shared-types';
+import {
+  observationToSightingRow,
+  leafToSightingRow,
+  gridMultiplierForZoom,
+  type SightingRow,
+} from './sightings-context.js';
+
+/**
+ * A full Observation as returned by /api/observations (zoom >= 6 per-observation
+ * path). `locId` is present here — but the narrow SightingRow deliberately drops
+ * it (cluster leaves never carry it, so the two seams must agree on the same
+ * narrow projection).
+ */
+const OBS: Observation = {
+  subId: 'OBS-1',
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  lat: 32.22,
+  lng: -110.97,
+  obsDt: '2026-04-15T10:00:00Z',
+  locId: 'L9',
+  locName: 'Sweetwater Wetlands',
+  howMany: 3,
+  isNotable: true,
+  silhouetteId: 'tyrannidae',
+  familyCode: 'tyrannidae',
+  taxonOrder: 4400,
+};
+
+describe('observationToSightingRow', () => {
+  it('projects the six rendered fields from a full Observation', () => {
+    const row = observationToSightingRow(OBS);
+    expect(row).toEqual<SightingRow>({
+      subId: 'OBS-1',
+      speciesCode: 'vermfly',
+      obsDt: '2026-04-15T10:00:00Z',
+      locName: 'Sweetwater Wetlands',
+      howMany: 3,
+      isNotable: true,
+    });
+  });
+
+  it('does NOT carry locId or silhouetteId onto the narrow row', () => {
+    const row = observationToSightingRow(OBS) as Record<string, unknown>;
+    expect('locId' in row).toBe(false);
+    expect('silhouetteId' in row).toBe(false);
+  });
+
+  it('preserves a null locName / null howMany', () => {
+    const row = observationToSightingRow({ ...OBS, locName: null, howMany: null });
+    expect(row.locName).toBeNull();
+    expect(row.howMany).toBeNull();
+  });
+});
+
+describe('leafToSightingRow', () => {
+  it('reads subId/speciesCode/obsDt/locName/howMany/isNotable off stamped leaf properties', () => {
+    const row = leafToSightingRow({
+      geometry: { coordinates: [-110.85, 32.27] },
+      properties: {
+        subId: 'S001',
+        speciesCode: 'verdin',
+        comName: 'Verdin',
+        obsDt: '2026-04-15T11:30:00Z',
+        locName: 'Tucson, AZ',
+        howMany: 2,
+        isNotable: false,
+        // sprite-remapped fallback id — must NOT be trusted/used.
+        silhouetteId: '_FALLBACK',
+        familyCode: 'remizidae',
+      },
+    });
+    expect(row).toEqual<SightingRow>({
+      subId: 'S001',
+      speciesCode: 'verdin',
+      obsDt: '2026-04-15T11:30:00Z',
+      locName: 'Tucson, AZ',
+      howMany: 2,
+      isNotable: false,
+    });
+  });
+
+  it('tolerates a null locName / null howMany / null speciesCode (spuh leaf)', () => {
+    const row = leafToSightingRow({
+      geometry: { coordinates: [0, 0] },
+      properties: {
+        subId: 'S002',
+        speciesCode: null,
+        comName: 'gull sp.',
+        obsDt: '2026-04-15T09:00:00Z',
+        locName: null,
+        howMany: null,
+        isNotable: false,
+      },
+    });
+    expect(row.locName).toBeNull();
+    expect(row.howMany).toBeNull();
+    // a null species code maps to '' — it can never match a real species code,
+    // so such a leaf is silently excluded from any per-species log.
+    expect(row.speciesCode).toBe('');
+  });
+});
+
+describe('gridMultiplierForZoom', () => {
+  // The SINGLE frontend copy of the read-api app.ts zoom->grid_multiplier switch
+  // (`zoom <= 3 ? 2 : zoom === 4 ? 4 : 8`). These cases pin it byte-for-byte
+  // against that switch so it can never silently drift into a half/double cell.
+  it('maps zoom <= 3 to 2', () => {
+    expect(gridMultiplierForZoom(0)).toBe(2);
+    expect(gridMultiplierForZoom(3)).toBe(2);
+  });
+  it('maps zoom === 4 to 4', () => {
+    expect(gridMultiplierForZoom(4)).toBe(4);
+  });
+  it('maps zoom 5 (and above) to 8', () => {
+    expect(gridMultiplierForZoom(5)).toBe(8);
+    expect(gridMultiplierForZoom(17)).toBe(8);
+  });
+  it('requires the FLOORED integer zoom: a raw 4.7 float misclassifies', () => {
+    // Documents the input contract — callers MUST pass Math.floor(zoom). A raw
+    // 4.7 would resolve to 8 instead of the correct 4 for the bucketing tier.
+    expect(gridMultiplierForZoom(4.7)).toBe(8);
+    expect(gridMultiplierForZoom(Math.floor(4.7))).toBe(4);
+  });
+});

--- a/frontend/src/components/sightings-context.ts
+++ b/frontend/src/components/sightings-context.ts
@@ -1,0 +1,91 @@
+import type { Observation } from '@bird-watch/shared-types';
+
+/**
+ * The exact fields the SightingsLog renders (epic #1299, F2 #1301). Narrower
+ * than `Observation` on purpose: maplibre cluster leaves never carry `locId`
+ * (the wire never stamps it — see `observation-layers.ts`), so a full
+ * `Observation` cannot be reconstructed from the zoom>=6 leaf path. Both seams
+ * (the single-Observation popover seam and the cluster-leaf seam) therefore
+ * agree on this same six-field projection.
+ */
+export interface SightingRow {
+  subId: string;
+  speciesCode: string;
+  obsDt: string; // ISO
+  locName: string | null;
+  howMany: number | null;
+  isNotable: boolean;
+}
+
+/**
+ * What gets threaded from a marker click into the species-detail surface so the
+ * log knows WHICH sightings to show.
+ *
+ *  - `leaves`  — zoom>=6: the rows are already on the client (cached cluster
+ *    leaves / the clicked observation), no fetch.
+ *  - `cell`    — zoom<6 single-bucket: identifies a `round(coord*m)/m` cell that
+ *    F3 (#1302) fetches per-sighting rows for. INERT in F2 — `useSightingsRows`
+ *    returns `supported: false` for it (the component renders nothing).
+ */
+export type SightingsContext =
+  | { kind: 'leaves'; rows: SightingRow[] }
+  | {
+      kind: 'cell';
+      lngBucket: number;
+      latBucket: number;
+      gridMultiplier: number;
+      scopeKey: string;
+    };
+
+/** Map a full Observation (the single-Observation popover seam) to the narrow row. */
+export function observationToSightingRow(o: Observation): SightingRow {
+  return {
+    subId: o.subId,
+    speciesCode: o.speciesCode,
+    obsDt: o.obsDt,
+    locName: o.locName,
+    howMany: o.howMany,
+    isNotable: o.isNotable,
+  };
+}
+
+/**
+ * Map a `getClusterLeaves` feature's stamped properties (+ geometry) to a
+ * SightingRow. Reads exactly the six fields `observation-layers.ts` stamps onto
+ * every feature; it does NOT read `locId` (never on the wire) nor trust the
+ * leaf's `silhouetteId` (a sprite-remapped fallback id, not the species' own).
+ * Defensive narrowing keeps it total against a cold/partial leaf — a spuh leaf
+ * with a `null` speciesCode maps to `''`, which can never match a real species
+ * code, so it is silently excluded from any per-species log.
+ */
+export function leafToSightingRow(feature: {
+  geometry: { coordinates: [number, number] };
+  properties: Record<string, unknown>;
+}): SightingRow {
+  const p = feature.properties;
+  return {
+    subId: typeof p.subId === 'string' ? p.subId : '',
+    speciesCode: typeof p.speciesCode === 'string' ? p.speciesCode : '',
+    obsDt: typeof p.obsDt === 'string' ? p.obsDt : '',
+    locName: typeof p.locName === 'string' ? p.locName : null,
+    howMany: typeof p.howMany === 'number' ? p.howMany : null,
+    isNotable: p.isNotable === true,
+  };
+}
+
+/**
+ * zoom -> grid_multiplier. This is the SAME mapping as the read-api's closed
+ * switch (`services/read-api/src/app.ts`: `zoom <= 3 ? 2 : zoom === 4 ? 4 : 8`)
+ * and is the SINGLE frontend copy of it — there is deliberately no second
+ * frontend instance to drift against (the aggregated /api/observations request
+ * sends only `zoom`; the server derives `m`). The `{kind:'cell'}` seam reads
+ * THIS helper so its cell center and `gridMultiplier` agree with the server's
+ * bucketing by construction.
+ *
+ * INPUT CONTRACT: must be the FLOORED integer zoom (`Math.floor(map.getZoom())`)
+ * — the same integer the aggregated request sent. A raw float misclassifies the
+ * switch (4.7 -> 8 instead of 4) and yields a half/double-sized cell.
+ */
+export function gridMultiplierForZoom(zoom: number): number {
+  return zoom <= 3 ? 2 : zoom === 4 ? 4 : 8;
+}

--- a/frontend/src/data/use-sightings-rows.test.tsx
+++ b/frontend/src/data/use-sightings-rows.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { ApiClient } from '@/api/client.js';
+import type { SightingRow, SightingsContext } from '@/components/sightings-context.js';
+import { useSightingsRows } from './use-sightings-rows.js';
+
+const apiClient = new ApiClient({ baseUrl: '' });
+
+function row(over: Partial<SightingRow> & { subId: string; speciesCode: string; obsDt: string }): SightingRow {
+  return { locName: null, howMany: null, isNotable: false, ...over };
+}
+
+describe('useSightingsRows — leaves branch', () => {
+  it('filters to the selected species and sorts newest-first', () => {
+    const context: SightingsContext = {
+      kind: 'leaves',
+      rows: [
+        row({ subId: 'A', speciesCode: 'vermfly', obsDt: '2026-04-15T08:00:00Z' }),
+        row({ subId: 'B', speciesCode: 'verdin', obsDt: '2026-04-15T09:00:00Z' }),
+        row({ subId: 'C', speciesCode: 'vermfly', obsDt: '2026-04-15T12:00:00Z' }),
+        row({ subId: 'D', speciesCode: 'vermfly', obsDt: '2026-04-15T10:00:00Z' }),
+      ],
+    };
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', context));
+    expect(result.current.supported).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.truncated).toBe(false);
+    // Only vermfly rows, ordered C (12:00) > D (10:00) > A (08:00).
+    expect(result.current.rows.map((r) => r.subId)).toEqual(['C', 'D', 'A']);
+    expect(result.current.total).toBe(3);
+  });
+
+  it('total stays the full pre-cap count (the component owns the visible cap)', () => {
+    const rows = Array.from({ length: 70 }, (_, i) =>
+      row({ subId: `S${i}`, speciesCode: 'vermfly', obsDt: `2026-04-15T${String(i % 24).padStart(2, '0')}:00:00Z` }),
+    );
+    const { result } = renderHook(() =>
+      useSightingsRows(apiClient, 'vermfly', { kind: 'leaves', rows }),
+    );
+    expect(result.current.rows).toHaveLength(70);
+    expect(result.current.total).toBe(70);
+    expect(result.current.truncated).toBe(false);
+  });
+
+  it('returns an empty supported state when no leaf matches the species', () => {
+    const { result } = renderHook(() =>
+      useSightingsRows(apiClient, 'amerob', {
+        kind: 'leaves',
+        rows: [row({ subId: 'A', speciesCode: 'vermfly', obsDt: '2026-04-15T08:00:00Z' })],
+      }),
+    );
+    expect(result.current.supported).toBe(true);
+    expect(result.current.rows).toEqual([]);
+    expect(result.current.total).toBe(0);
+  });
+});
+
+describe('useSightingsRows — unsupported branches (cell wired in F3)', () => {
+  it('returns supported:false for a null context', () => {
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', null));
+    expect(result.current).toEqual({
+      rows: [],
+      total: 0,
+      truncated: false,
+      loading: false,
+      error: null,
+      supported: false,
+    });
+  });
+
+  it('returns supported:false for a cell context (no fetch in F2)', () => {
+    const context: SightingsContext = {
+      kind: 'cell',
+      lngBucket: -110.5,
+      latBucket: 32.5,
+      gridMultiplier: 2,
+      scopeKey: 'US-AZ',
+    };
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', context, '7d'));
+    expect(result.current.supported).toBe(false);
+    expect(result.current.rows).toEqual([]);
+    expect(result.current.total).toBe(0);
+  });
+});

--- a/frontend/src/data/use-sightings-rows.ts
+++ b/frontend/src/data/use-sightings-rows.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import type { ApiClient } from '@/api/client.js';
+import type { Since } from '@/state/url-state.js';
+import type { SightingRow, SightingsContext } from '@/components/sightings-context.js';
+
+export interface SightingsRowsState {
+  rows: SightingRow[];
+  /** M for the truncation banner — the FULL pre-cap count (the visible cap lives in the component). */
+  total: number;
+  truncated: boolean;
+  loading: boolean;
+  error: Error | null;
+  /** `false` for a null / cell context — the cell fetch is wired in F3 (#1302). */
+  supported: boolean;
+}
+
+const UNSUPPORTED: SightingsRowsState = {
+  rows: [],
+  total: 0,
+  truncated: false,
+  loading: false,
+  error: null,
+  supported: false,
+};
+
+/**
+ * The Sightings-Log data hook (epic #1299, F2 #1301).
+ *
+ * F2 implements ONLY the `leaves` branch — the rows are already on the client
+ * (cached cluster leaves at zoom>=6), so this filters by species + sorts
+ * newest-first with no fetch. A `null` or `cell` context is `supported: false`
+ * (the cell fetch lands in F3, which replaces the cell arm). `apiClient` and
+ * `since` are unused this PR but stay in the signature so F3 adds the fetch
+ * WITHOUT a signature change. The hook does NOT apply the visible-row cap —
+ * `total` is the full pre-cap count; the cap lives in `<SightingsLog>` so it
+ * bounds both the leaf path and the F3 cell path identically.
+ */
+export function useSightingsRows(
+  apiClient: ApiClient,
+  speciesCode: string,
+  context: SightingsContext | null,
+  since?: Since,
+): SightingsRowsState {
+  // F2: not yet consumed — F3 forwards both to the cell fetch.
+  void apiClient;
+  void since;
+  return useMemo<SightingsRowsState>(() => {
+    if (context && context.kind === 'leaves') {
+      const rows = context.rows
+        .filter((r) => r.speciesCode === speciesCode)
+        .sort((a, b) => b.obsDt.localeCompare(a.obsDt));
+      return { rows, total: rows.length, truncated: false, loading: false, error: null, supported: true };
+    }
+    return UNSUPPORTED;
+  }, [context, speciesCode]);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1676,6 +1676,78 @@ body {
   letter-spacing: var(--tracking-eyebrow);
   color: var(--color-text-muted);
 }
+
+/* Sightings Log (#1299 / F2 #1301) — a SECTION of the Transient detail surface
+   (claims no new floating corner). Inserted between the family-accent rule and
+   the taxonomy <dl>. Static, display-only rows (no count/row animation — #953).
+   Reuses existing tokens only — NO new colors. */
+.detail-fg-sightings {
+  margin: var(--space-md) 0 0;
+}
+/* Eyebrow matches .detail-fg-about-eyebrow. */
+.detail-fg-sightings-eyebrow {
+  margin: var(--space-sm) 0 2px;
+  font-size: var(--type-xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--color-text-muted);
+}
+.detail-fg-sightings-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.detail-fg-sighting-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
+  font-size: var(--type-sm);
+  border-bottom: 1px solid rgba(127, 127, 127, 0.22);
+}
+.detail-fg-sighting-row:first-child {
+  border-top: 1px solid rgba(127, 127, 127, 0.22);
+}
+.detail-fg-sighting-time {
+  flex: none;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-strong);
+}
+.detail-fg-sighting-location {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-body);
+}
+.detail-fg-sighting-count {
+  flex: none;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-muted);
+}
+.detail-fg-sighting-notable {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  font-size: var(--type-xs);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent-notable-fg);
+  background: var(--color-accent-notable-bg);
+  /* 1px non-text-contrast ring (WCAG 1.4.11) — the SAME --sheet-dot-ring the
+     family dot uses, so the badge reads on both card surfaces in either theme. */
+  box-shadow: 0 0 0 1px var(--sheet-dot-ring);
+}
+.detail-fg-sightings-truncation {
+  margin: var(--space-sm) 0 0;
+  font-size: var(--type-xs);
+  color: var(--color-text-muted);
+}
 .species-detail-loading { color: var(--color-text-muted); font-size: var(--type-sm); margin: 8px 0 0 0; }
 .species-detail-error {
   margin-top: 8px;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant U as User
    participant Map as MapCanvas
    participant Pop as Observation / Cluster popover
    participant Ctx as sightingsContext
    participant Log as SightingsLog (Rail)
    U->>Map: click a marker (zoom 6 or higher)
    Map->>Pop: open popover with the marker's cached leaves
    U->>Pop: pick species / See species details
    Pop->>Ctx: thread marker context, filter leaves by speciesCode
    Ctx->>Log: SightingRow array (time, location, count, notable)
    Log-->>U: "Sightings under this marker" rows in the detail Rail
```

## Summary

- **Why:** epic #1299 — inside the species detail panel, show a log of that species' individual sightings under the clicked marker (time · exact location · count when >1 · notable). This PR (F2) delivers the desktop Rail + the **zoom ≥ 6 leaf path**; F3 (#1302) wires zoom < 6 (the cell fetch from #1300), M4 (#1303) adds the mobile Sheet.
- **What:** new `SightingsLog` + `useSightingsRows` (filters the clicked cluster's cached MapLibre leaves by the selected species — **no fetch** at zoom ≥ 6) + the marker-context seam threaded through `MapCanvas` / `GroupMarkerLayer` + integration into `SpeciesDetailSurface` (Rail), placed **after the family rule, above taxonomy**. Rows mirror `ObservationPopover`'s vocabulary but show the count column **only when `howMany > 1`**; capped at `MAX_VISIBLE_ROWS = 50` with a "latest N of M" line; rendered **statically** (no count animation, #953).
- **Note:** to make the single-bucket guard correct, this adds an optional `bucketCount` to `DeconflictInput` (the raw supercluster `point_count`, which #859 overwrites with the summed obs count). The cell-context seam is built but **inert (`supported: false`)** here — F3 (#1302) activates the zoom < 6 fetch.

## Screenshots

Live Playwright MCP run against a locally-seeded stack, 5 canonical viewports × 2 themes. Desktop Rail (≥1200px) shows the **Sightings Log**; tablet/mobile (≤1199px) show the Sheet **without** the log — the correct pre-M4 state.

**Desktop Rail — Sightings Log visible (≥ 1200px).** The row `Jun 28, 2026, 8:42 PM · Phoenix, AZ · ×3` renders after the family-accent rule, above the taxonomy `<dl>`.

| Viewport | Light | Dark |
|---|---|---|
| **1440 × 900** | <img width="420" alt="1440 light" src="https://github.com/user-attachments/assets/64c4656f-d432-4e69-8388-455da6302314" /> | <img width="420" alt="1440 dark" src="https://github.com/user-attachments/assets/379ffdf4-1420-42c7-bac0-69f1c8e37aaa" /> |
| **1920 × 1080** | <img width="420" alt="1920 light" src="https://github.com/user-attachments/assets/bea665eb-2f66-47c4-a102-0d0b6f55b660" /> | <img width="420" alt="1920 dark" src="https://github.com/user-attachments/assets/b748b226-5ad7-4b0d-ab35-f7d95de317f8" /> |

**Tablet / mobile — detail Sheet *without* the log (≤ 1199px) — the correct pre-M4 state; M4 (#1303) adds the mobile log.**

| Viewport | Light | Dark |
|---|---|---|
| **1024 × 768** | <img width="420" alt="1024 light" src="https://github.com/user-attachments/assets/7b2e0afc-9373-4e2f-9b68-11e508a1f18f" /> | <img width="420" alt="1024 dark" src="https://github.com/user-attachments/assets/a4cb20aa-337b-400f-a6fd-c4aa92f86623" /> |
| **768 × 1024** | <img width="300" alt="768 light" src="https://github.com/user-attachments/assets/f72538e5-2b5e-4da1-8c7f-8c8948edd2af" /> | <img width="300" alt="768 dark" src="https://github.com/user-attachments/assets/483d85f4-0fc1-499a-b2f4-e0385b2cc58b" /> |
| **390 × 844** | <img width="220" alt="390 light" src="https://github.com/user-attachments/assets/b45da14a-d9b6-4968-8f18-87e0f4050236" /> | <img width="220" alt="390 dark" src="https://github.com/user-attachments/assets/32c201ad-b8db-4b2f-86da-48c62605135c" /> |

- [x] Every new/renamed `className` has a matching CSS rule (orphan-classname check green locally + CI).
- [x] Multi-viewport design QA: ≥10 `user-attachments` URLs (5 viewports × 2 themes).

## Test plan

- [x] `npm test -w @bird-watch/frontend` — 1839 pass (33 new across `sightings-context` / `use-sightings-rows` / `SightingsLog` + MapCanvas per-seam threading).
- [x] New unit/RTL + a deterministic `ObservationPopover`-seam e2e (`frontend/e2e/species/sightings-log.spec.ts`).
- [x] `npm run build` (tsc -b + vite) — clean; orphan-classname check pass.
- [x] **Playwright MCP live UI verification (orchestrator-driven)** — 5 viewports × 2 themes (above). Drove the active leaf path: clicked the Great Egret obs at zoom 15 → `ObservationPopover` → "See species details" → the Rail's `region` "Sightings under this marker" renders one static row **"Jun 28, 2026, 8:42 PM · Phoenix, AZ · ×3"** (count shows since `howMany` 3 > 1), positioned after the family rule and above the taxonomy `<dl>`. Tablet+mobile render the Sheet without the log (pre-M4). **Zero console errors**; the only warnings are pre-existing MapLibre `styleimagemissing` for basemap POI sprite icons at high zoom (Bright basemap), present on `main` and unrelated to this PR.

## Plan reference

Implements #1301; part of epic #1299 (Sightings Log). Build order: **B1 #1300 ∥ F2 (this) → F3 #1302 → M4 #1303 → D5 #1304**.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
