### PR TITLE
feat(frontend): wire the zoom<6 cell path for the Sightings Log (#1302)

### DIFF
--- a/frontend/e2e/species/sightings-log-cell.spec.ts
+++ b/frontend/e2e/species/sightings-log-cell.spec.ts
@@ -1,26 +1,36 @@
 import { test, expect } from '../fixtures.js';
 import { AppPage } from '../pages/app-page.js';
-import type { CellObservationsResponse, Observation, SpeciesMeta } from '@bird-watch/shared-types';
+import type {
+  AggregatedFamily,
+  CellObservationsResponse,
+  Observation,
+  SpeciesMeta,
+} from '@bird-watch/shared-types';
 
 /**
  * #1302 (F3, epic #1299) — the zoom<6 CELL path of the Sightings Log.
  *
- * At zoom<6 the map renders the precomputed count-only grid. Clicking a single
- * aggregated bucket and selecting a species in the `<CellPopover>` threads a
- * `{kind:'cell'}` context; the log then fetches that cell's per-sighting rows
- * from `GET /api/observations/cell` (B1) and renders them, including the
- * server-truncation banner.
+ * At zoom<6 the map renders the precomputed count-only grid. The ONLY surface
+ * that represents a genuine SINGLE bucket is the `#864` raw UNCLUSTERED leaf:
+ * supercluster never emits a 1-point cluster (`getClusters` needs point_count>1;
+ * `_cluster` needs a merged neighbour, independent of `clusterMinPoints`), so a
+ * single isolated bucket is always painted unclustered and its click is handled
+ * by the `unclustered-point` map handler — which opens a `ClusterListPopover`
+ * and (post-#1302) threads a `{kind:'cell'}` context. Picking a species there
+ * fetches that cell's per-sighting rows from `GET /api/observations/cell` (B1)
+ * and renders them, including the server-truncation banner.
  *
- * DETERMINISM: reaching a genuine SINGLE aggregated bucket at a specific
- * low-zoom coordinate depends on real MapLibre/supercluster clustering, which
- * is fragile under `retries:0` / `fullyParallel` and never materializes in a
- * WebGL-less headless run. So this spec follows the same probe-and-skip
- * discipline as `sightings-log.spec.ts` and `map-adaptive-grid.spec.ts`: it
- * STUBS `/api/observations/cell` deterministically, then drives the live UI to
- * a single-bucket cell popover; if clustering does not produce one (no WebGL /
- * sparse seed), it skips. The hard mapping/truncation/0-row coverage lives in
- * the unit + RTL specs (use-sightings-rows / SightingsLog / client). The
- * orchestrator's live Playwright pass exercises the full visual path.
+ * DETERMINISM: this spec drives the REACHABLE single-bucket path directly. It
+ * does NOT rely on real canvas hit-testing to land a click on a painted SDF
+ * symbol (which never works in a WebGL-less headless run). Instead it overrides
+ * the live maplibre instance's `queryRenderedFeatures` (exposed as `__birdMap`
+ * in dev/test) to return ONE bucket feature, then `fire`s the `unclustered-point`
+ * click — the same call path a real canvas click takes. Every step after that
+ * (popover → species pick → cell fetch → log render) is real DOM + the stubbed
+ * B1 endpoint, so the rows / banner / `since` round-trip assertions are
+ * deterministic. The ONLY residual nondeterminism is whether maplibre fires
+ * `load` at all (it does not without a GPU); that single condition is guarded
+ * and `log()`d — it never silently swallows the core assertions below it.
  */
 
 const SILHOUETTES = [
@@ -51,6 +61,34 @@ const speciesMetaFixture: SpeciesMeta = {
   familyCode: 'tyrannidae',
   familyName: 'Tyrant Flycatchers',
   taxonOrder: 4400,
+};
+
+// The single isolated bucket centered at a true round(coord*m)/m grid center
+// (m=2 at the national z<6 → integer lng/lat). Its family carries the one
+// `vermfly` species so the popover row resolves to a clickable common name.
+const BUCKET_FAMILIES: AggregatedFamily[] = [
+  {
+    code: 'tyrannidae',
+    count: 7,
+    speciesCount: 1,
+    species: [{ code: 'vermfly', count: 7 }],
+    name: 'Tyrant Flycatchers',
+  },
+];
+const BUCKET_LNG = -110;
+const BUCKET_LAT = 32;
+const SINGLE_BUCKET_RESPONSE = {
+  mode: 'aggregated' as const,
+  buckets: [
+    {
+      lat: BUCKET_LAT,
+      lng: BUCKET_LNG,
+      count: 7,
+      speciesCount: 1,
+      families: BUCKET_FAMILIES,
+    },
+  ],
+  meta: { freshestObservationAt: new Date(Date.now() - 5 * 60 * 1000).toISOString() },
 };
 
 /** Two cell rows out of a (claimed) larger set → truncated banner "latest 2 of 137". */
@@ -101,10 +139,21 @@ test.describe('Sightings Log — zoom<6 cell path (#1302)', () => {
         body: JSON.stringify(SILHOUETTES),
       });
     });
+    // ONE isolated aggregated bucket — the single-bucket case the unclustered
+    // handler owns. The bare species dictionary resolves `vermfly`'s name in the
+    // popover row.
+    await page.route('**/api/observations**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SINGLE_BUCKET_RESPONSE),
+      });
+    });
+    await apiStub.stubSpeciesDictionary();
+    await apiStub.stubSpeciesInScope();
     await apiStub.stubSpecies('vermfly', speciesMetaFixture);
-    // Deterministically stub the B1 cell endpoint regardless of which single
-    // bucket the live clustering surfaces — the test asserts the LOG renders
-    // exactly these rows + this truncation banner once a cell is selected.
+    // Deterministically stub the B1 cell endpoint: the test asserts the LOG
+    // renders exactly these rows + this truncation banner once a cell is picked.
     await page.route('**/api/observations/cell**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -124,51 +173,95 @@ test.describe('Sightings Log — zoom<6 cell path (#1302)', () => {
     await app.goto('scope=us&since=1d');
     await app.waitForAppReady();
 
-    // The adaptive-grid markers mount only after MapLibre fires `load`; in a
-    // WebGL-less headless run that never happens — tolerate via probe+skip.
-    const webglReady = await page.evaluate(() => Boolean((window as { __birdMap?: unknown }).__birdMap));
-    test.skip(!webglReady, 'WebGL unavailable — map canvas did not paint');
-
-    // Find a single-bucket adaptive-grid marker, open its CellPopover, and pick
-    // a clickable species row. A single-bucket cell is the only marker shape
-    // that threads a {kind:'cell'} context (handleGridSelectSpecies gate).
-    const gridMarker = page.locator('[data-testid=adaptive-grid-marker]').first();
-    try {
-      await gridMarker.waitFor({ state: 'visible', timeout: 8_000 });
-    } catch {
-      test.skip(true, 'No adaptive-grid markers at the national overview — sparse seed');
+    // The ONLY residual nondeterminism: the live maplibre instance (exposed as
+    // `__birdMap`) is published from the `load` handler, which never fires in a
+    // WebGL-less headless run. Everything past this point is deterministic (a
+    // direct fire of the unclustered-point handler + real DOM + the stubbed B1
+    // endpoint), so this single guard never masks the core assertions — it only
+    // tolerates the no-GPU environment, and logs exactly what it skips.
+    const webglReady = await page
+      .waitForFunction(() => Boolean((window as { __birdMap?: unknown }).__birdMap), null, {
+        timeout: 12_000,
+      })
+      .then(() => true)
+      .catch(() => false);
+    if (!webglReady) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[sightings-log-cell] SKIP: maplibre never fired `load` (no WebGL/GPU) — ' +
+          '__birdMap unavailable, so the single-bucket click cannot be driven. ' +
+          'The cell mapping/fetch/banner contract is covered deterministically by ' +
+          'the unit + RTL specs (MapCanvas / use-sightings-rows / SightingsLog / client).',
+      );
+      test.skip(true, 'WebGL unavailable — __birdMap not published');
       return;
     }
-    await gridMarker.click();
 
-    const popover = page.locator('[data-testid=cell-popover]');
-    try {
-      await popover.waitFor({ state: 'visible', timeout: 5_000 });
-    } catch {
-      test.skip(true, 'Clicked marker did not open a CellPopover (cluster, not single bucket)');
-      return;
-    }
+    // Drive the REACHABLE single-bucket path. The `unclustered-point` click is a
+    // maplibre LAYER-DELEGATED listener: maplibre stores it on
+    // `map._delegatedListeners.click` as `{ layers:['unclustered-point'],
+    // delegates:{ click } }`, where `delegates.click` is the wrapper maplibre
+    // itself calls on a real canvas click — it runs `queryRenderedFeatures(point,
+    // {layers:['unclustered-point']})` and, if a feature matches, invokes the
+    // app handler with `e.features` populated. We override `queryRenderedFeatures`
+    // to return ONE bucket feature (no subId, real familiesJson — exactly what
+    // bucketsToGeoJson writes for an unclustered bucket), then invoke that same
+    // `delegates.click` wrapper with a synthetic point/lngLat event. This is the
+    // identical call path a real canvas click takes, with no painted SDF symbol
+    // and no dependence on the bucket's on-screen pixel position — so it is fully
+    // deterministic under WebGL.
+    const drove = await page.evaluate(
+      ({ families }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const map = (window as any).__birdMap;
+        const bucketFeature = {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-110, 32] },
+          properties: {
+            count: 7,
+            speciesCount: 1,
+            familiesJson: JSON.stringify(families),
+            familyCode: 'tyrannidae',
+            silhouetteId: 'tyrannidae',
+            color: '#c3772d',
+          },
+        };
+        const orig = map.queryRenderedFeatures.bind(map);
+        map.queryRenderedFeatures = (point: unknown, opts?: { layers?: string[] }) =>
+          opts?.layers?.includes('unclustered-point') ? [bucketFeature] : orig(point, opts);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const delegated = (map._delegatedListeners?.click ?? []).find((d: any) =>
+          (d.layers ?? []).includes('unclustered-point'),
+        );
+        if (!delegated?.delegates?.click) return false;
+        delegated.delegates.click({
+          type: 'click',
+          target: map,
+          point: { x: 120, y: 120 },
+          lngLat: { lng: -110, lat: 32 },
+          originalEvent: new MouseEvent('click'),
+        });
+        return true;
+      },
+      { families: BUCKET_FAMILIES },
+    );
+    expect(drove, 'the unclustered-point delegated click wrapper must exist').toBe(true);
 
-    const speciesRow = popover.locator('[data-testid=cell-popover-row] button').first();
-    if ((await speciesRow.count()) === 0) {
-      test.skip(true, 'CellPopover has no clickable species row');
-      return;
-    }
-    await speciesRow.click();
+    // The unclustered handler opens the real-species ClusterListPopover.
+    const popover = page.getByTestId('cluster-list-popover');
+    await expect(popover).toBeVisible({ timeout: 8_000 });
 
-    // The detail surface opens (?detail=...). If the chosen bucket was a genuine
-    // single bucket, the cell fetch fires and the log renders. If clustering
-    // surfaced a multi-bucket marker instead (no cell context), the log is
-    // absent — skip, since that is a clustering-shape artifact, not a F3 bug.
-    await expect.poll(() => app.getUrlParams().get('detail'), { timeout: 5_000 }).not.toBeNull();
+    // Expand the family, then pick the species row → threads the {kind:'cell'}
+    // context built from the bucket's own center.
+    const familyToggle = popover.getByTestId('cluster-list-popover-family-tyrannidae');
+    await familyToggle.locator('button').first().click();
+    await popover.getByText(/Vermilion Flycatcher/).click();
+
+    // The detail surface opens (?detail=vermfly) and the cell fetch fires.
+    await expect.poll(() => app.getUrlParams().get('detail'), { timeout: 8_000 }).toBe('vermfly');
 
     const log = page.getByRole('region', { name: /sightings under this marker/i });
-    try {
-      await log.waitFor({ state: 'visible', timeout: 5_000 });
-    } catch {
-      test.skip(true, 'Selected marker was a multi-bucket cluster (no cell context threaded)');
-      return;
-    }
+    await expect(log).toBeVisible({ timeout: 8_000 });
 
     // Deterministic assertions once the cell log is mounted:
     // - exactly the two stubbed rows render,
@@ -177,20 +270,22 @@ test.describe('Sightings Log — zoom<6 cell path (#1302)', () => {
     // - howMany 4 > 1 → the ×4 count column,
     await expect(log.locator('.detail-fg-sighting-count').first()).toHaveText('×4');
     // - truncation banner uses meta.cellObservationCount (137) as M.
-    await expect(log.locator('.detail-fg-sightings-truncation')).toHaveText('Showing latest 2 of 137');
+    await expect(log.locator('.detail-fg-sightings-truncation')).toHaveText(
+      'Showing latest 2 of 137',
+    );
 
-    // The cell request carried the ACTIVE since-window (since=1d) and the
-    // single-bucket scope/grid params.
-    const cellReq = await page.evaluate(async () => {
-      // The route stub already fulfilled it; re-derive the last request URL from
-      // the performance entries as a lightweight check.
+    // The cell request carried the ACTIVE since-window (since=1d), the picked
+    // species, the bucket center, and the national scope ('US').
+    const cellReq = await page.evaluate(() => {
       const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
       return entries.map((e) => e.name).find((n) => n.includes('/api/observations/cell')) ?? null;
     });
-    if (cellReq) {
-      const u = new URL(cellReq);
-      expect(u.searchParams.get('since')).toBe('1d');
-      expect(u.searchParams.get('species')).toBe('vermfly');
-    }
+    expect(cellReq, 'a /api/observations/cell request must have fired').not.toBeNull();
+    const u = new URL(cellReq!);
+    expect(u.searchParams.get('since')).toBe('1d');
+    expect(u.searchParams.get('species')).toBe('vermfly');
+    expect(u.searchParams.get('scope')).toBe('US');
+    expect(Number(u.searchParams.get('lng'))).toBe(BUCKET_LNG);
+    expect(Number(u.searchParams.get('lat'))).toBe(BUCKET_LAT);
   });
 });

--- a/frontend/e2e/species/sightings-log-cell.spec.ts
+++ b/frontend/e2e/species/sightings-log-cell.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from '../fixtures.js';
+import { AppPage } from '../pages/app-page.js';
+import type { CellObservationsResponse, Observation, SpeciesMeta } from '@bird-watch/shared-types';
+
+/**
+ * #1302 (F3, epic #1299) — the zoom<6 CELL path of the Sightings Log.
+ *
+ * At zoom<6 the map renders the precomputed count-only grid. Clicking a single
+ * aggregated bucket and selecting a species in the `<CellPopover>` threads a
+ * `{kind:'cell'}` context; the log then fetches that cell's per-sighting rows
+ * from `GET /api/observations/cell` (B1) and renders them, including the
+ * server-truncation banner.
+ *
+ * DETERMINISM: reaching a genuine SINGLE aggregated bucket at a specific
+ * low-zoom coordinate depends on real MapLibre/supercluster clustering, which
+ * is fragile under `retries:0` / `fullyParallel` and never materializes in a
+ * WebGL-less headless run. So this spec follows the same probe-and-skip
+ * discipline as `sightings-log.spec.ts` and `map-adaptive-grid.spec.ts`: it
+ * STUBS `/api/observations/cell` deterministically, then drives the live UI to
+ * a single-bucket cell popover; if clustering does not produce one (no WebGL /
+ * sparse seed), it skips. The hard mapping/truncation/0-row coverage lives in
+ * the unit + RTL specs (use-sightings-rows / SightingsLog / client). The
+ * orchestrator's live Playwright pass exercises the full visual path.
+ */
+
+const SILHOUETTES = [
+  {
+    familyCode: 'tyrannidae',
+    color: '#C77A2E',
+    svgData: 'M5 13 C5 9 9 8 13 9 L17 7 L17 10 L15 11 L15 14 L13 15 L8 15 L5 13 Z',
+    source: null,
+    license: null,
+    commonName: 'Tyrant Flycatchers',
+    creator: null,
+  },
+  {
+    familyCode: '_FALLBACK',
+    color: '#555555',
+    svgData: 'M 6 12 C 6 9 8 7 11 7 C 13 7 14 8 15 9 L 18 8 L 18 10 L 16 11 L 16 14 L 14 16 L 9 16 L 6 14 Z',
+    source: null,
+    license: null,
+    commonName: 'Unknown family',
+    creator: null,
+  },
+];
+
+const speciesMetaFixture: SpeciesMeta = {
+  speciesCode: 'vermfly',
+  comName: 'Vermilion Flycatcher',
+  sciName: 'Pyrocephalus rubinus',
+  familyCode: 'tyrannidae',
+  familyName: 'Tyrant Flycatchers',
+  taxonOrder: 4400,
+};
+
+/** Two cell rows out of a (claimed) larger set → truncated banner "latest 2 of 137". */
+function cellObservations(): Observation[] {
+  return [
+    {
+      subId: 'CELL-1',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.27,
+      lng: -110.85,
+      obsDt: '2026-04-15T12:00:00Z',
+      locId: 'L99',
+      locName: 'Sweetwater Wetlands',
+      howMany: 4,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+    {
+      subId: 'CELL-2',
+      speciesCode: 'vermfly',
+      comName: 'Vermilion Flycatcher',
+      lat: 32.21,
+      lng: -110.92,
+      obsDt: '2026-04-15T08:00:00Z',
+      locId: 'L100',
+      locName: 'Patagonia Lake',
+      howMany: null,
+      isNotable: false,
+      silhouetteId: 'tyrannidae',
+      familyCode: 'tyrannidae',
+    },
+  ];
+}
+
+const CELL_RESPONSE: CellObservationsResponse = {
+  data: cellObservations(),
+  meta: { cellObservationCount: 137, truncated: true },
+};
+
+test.describe('Sightings Log — zoom<6 cell path (#1302)', () => {
+  test.beforeEach(async ({ page, apiStub }) => {
+    await page.route('**/api/silhouettes', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SILHOUETTES),
+      });
+    });
+    await apiStub.stubSpecies('vermfly', speciesMetaFixture);
+    // Deterministically stub the B1 cell endpoint regardless of which single
+    // bucket the live clustering surfaces — the test asserts the LOG renders
+    // exactly these rows + this truncation banner once a cell is selected.
+    await page.route('**/api/observations/cell**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(CELL_RESPONSE),
+      });
+    });
+  });
+
+  test('single-bucket cell → pick species → log fetches + renders cell sightings with truncation banner (1440×900)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const app = new AppPage(page);
+    // Whole-US national view cold-loads at zoom<6 (aggregated grid). A 1d window
+    // is the ACTIVE since-window — the cell request must carry it (B1 contract).
+    await app.goto('scope=us&since=1d');
+    await app.waitForAppReady();
+
+    // The adaptive-grid markers mount only after MapLibre fires `load`; in a
+    // WebGL-less headless run that never happens — tolerate via probe+skip.
+    const webglReady = await page.evaluate(() => Boolean((window as { __birdMap?: unknown }).__birdMap));
+    test.skip(!webglReady, 'WebGL unavailable — map canvas did not paint');
+
+    // Find a single-bucket adaptive-grid marker, open its CellPopover, and pick
+    // a clickable species row. A single-bucket cell is the only marker shape
+    // that threads a {kind:'cell'} context (handleGridSelectSpecies gate).
+    const gridMarker = page.locator('[data-testid=adaptive-grid-marker]').first();
+    try {
+      await gridMarker.waitFor({ state: 'visible', timeout: 8_000 });
+    } catch {
+      test.skip(true, 'No adaptive-grid markers at the national overview — sparse seed');
+      return;
+    }
+    await gridMarker.click();
+
+    const popover = page.locator('[data-testid=cell-popover]');
+    try {
+      await popover.waitFor({ state: 'visible', timeout: 5_000 });
+    } catch {
+      test.skip(true, 'Clicked marker did not open a CellPopover (cluster, not single bucket)');
+      return;
+    }
+
+    const speciesRow = popover.locator('[data-testid=cell-popover-row] button').first();
+    if ((await speciesRow.count()) === 0) {
+      test.skip(true, 'CellPopover has no clickable species row');
+      return;
+    }
+    await speciesRow.click();
+
+    // The detail surface opens (?detail=...). If the chosen bucket was a genuine
+    // single bucket, the cell fetch fires and the log renders. If clustering
+    // surfaced a multi-bucket marker instead (no cell context), the log is
+    // absent — skip, since that is a clustering-shape artifact, not a F3 bug.
+    await expect.poll(() => app.getUrlParams().get('detail'), { timeout: 5_000 }).not.toBeNull();
+
+    const log = page.getByRole('region', { name: /sightings under this marker/i });
+    try {
+      await log.waitFor({ state: 'visible', timeout: 5_000 });
+    } catch {
+      test.skip(true, 'Selected marker was a multi-bucket cluster (no cell context threaded)');
+      return;
+    }
+
+    // Deterministic assertions once the cell log is mounted:
+    // - exactly the two stubbed rows render,
+    await expect(log.locator('.detail-fg-sighting-row')).toHaveCount(2);
+    await expect(log.getByText('Sweetwater Wetlands')).toBeVisible();
+    // - howMany 4 > 1 → the ×4 count column,
+    await expect(log.locator('.detail-fg-sighting-count').first()).toHaveText('×4');
+    // - truncation banner uses meta.cellObservationCount (137) as M.
+    await expect(log.locator('.detail-fg-sightings-truncation')).toHaveText('Showing latest 2 of 137');
+
+    // The cell request carried the ACTIVE since-window (since=1d) and the
+    // single-bucket scope/grid params.
+    const cellReq = await page.evaluate(async () => {
+      // The route stub already fulfilled it; re-derive the last request URL from
+      // the performance entries as a lightweight check.
+      const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+      return entries.map((e) => e.name).find((n) => n.includes('/api/observations/cell')) ?? null;
+    });
+    if (cellReq) {
+      const u = new URL(cellReq);
+      expect(u.searchParams.get('since')).toBe('1d');
+      expect(u.searchParams.get('species')).toBe('vermfly');
+    }
+  });
+});

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -353,6 +353,78 @@ describe('ApiClient', () => {
     expect(url).not.toContain('state=');
   });
 
+  // ── #1302 (F3) — GET /api/observations/cell client method ──────────────────
+  //
+  // The low-zoom (zoom<6) sightings-log fetch. Per-species rows inside one
+  // clicked grid cell, identified by (scope, grid multiplier, lng/lat bucket).
+  // Mirrors the B1 route param names exactly (species, scope, m, lng, lat,
+  // since). The method passes NO AbortSignal (staleness is the hook's
+  // cancelled-flag job), and must NOT serialize `since` when it is undefined
+  // (exactOptionalPropertyTypes).
+  it('serializes all cell params for GET /api/observations/cell (#1302)', async () => {
+    const body = JSON.stringify({ data: [], meta: { cellObservationCount: 0, truncated: false } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getCellObservations({
+      scopeKey: 'US-AZ',
+      gridMultiplier: 2,
+      lngBucket: -110.5,
+      latBucket: 32.5,
+      speciesCode: 'vermfly',
+      since: '1d',
+    });
+    const url = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]![0];
+    expect(url).toContain('/api/observations/cell');
+    expect(url).toContain('species=vermfly');
+    expect(url).toContain('scope=US-AZ');
+    expect(url).toContain('m=2');
+    // lng/lat negatives encode the `-` literally (URLSearchParams leaves it).
+    expect(new URL(url, 'http://x').searchParams.get('lng')).toBe('-110.5');
+    expect(new URL(url, 'http://x').searchParams.get('lat')).toBe('32.5');
+    expect(url).toContain('since=1d');
+  });
+
+  it('omits since from the cell query when undefined (exactOptionalPropertyTypes) (#1302)', async () => {
+    const body = JSON.stringify({ data: [], meta: { cellObservationCount: 0, truncated: false } });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    await client.getCellObservations({
+      scopeKey: 'US',
+      gridMultiplier: 8,
+      lngBucket: -112,
+      latBucket: 31.75,
+      speciesCode: 'norcar',
+    });
+    const url = (fetch as unknown as { mock: { calls: [string, unknown][] } }).mock.calls[0]![0];
+    expect(url).not.toContain('since=');
+    // Never attaches an AbortSignal (the cell fetch is not abortable, #1302).
+    const init = (fetch as unknown as { mock: { calls: [string, RequestInit | undefined][] } }).mock.calls[0]![1];
+    expect(init?.signal ?? undefined).toBeUndefined();
+  });
+
+  it('returns the CellObservationsResponse envelope verbatim (#1302)', async () => {
+    const body = JSON.stringify({
+      data: [
+        {
+          subId: 'S1', speciesCode: 'vermfly', comName: 'Vermilion Flycatcher',
+          lat: 32.27, lng: -110.85, obsDt: '2026-04-15T10:00:00Z', locId: 'L99',
+          locName: 'Sweetwater Wetlands', howMany: 4, isNotable: false,
+          silhouetteId: 'tyrannidae', familyCode: 'tyrannidae',
+        },
+      ],
+      meta: { cellObservationCount: 137, truncated: true },
+    });
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(body, { status: 200 }));
+    const client = new ApiClient({ baseUrl: '' });
+    const res = await client.getCellObservations({
+      scopeKey: 'US-AZ', gridMultiplier: 2, lngBucket: -110.5, latBucket: 32.5, speciesCode: 'vermfly',
+    });
+    expect(res.data).toHaveLength(1);
+    expect(res.data[0]?.locId).toBe('L99');
+    expect(res.meta.cellObservationCount).toBe(137);
+    expect(res.meta.truncated).toBe(true);
+  });
+
   it('throws on non-2xx response', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
     const client = new ApiClient({ baseUrl: '' });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import type {
   Hotspot, Observation, ObservationsResponse, SpeciesMeta, ObservationFilters,
-  FamilySilhouette, StateSummary, SpeciesDictEntry,
+  FamilySilhouette, StateSummary, SpeciesDictEntry, CellObservationsResponse,
 } from '@bird-watch/shared-types';
 import { canonicalFetchBboxParam, perObsFetchBboxParam, serializeBbox, snapFetchBboxParam } from '@bird-watch/geo';
 
@@ -200,6 +200,39 @@ export class ApiClient {
     if (f.familyCode) url.searchParams.set('family', f.familyCode);
     if (f.stateCode) url.searchParams.set('state', f.stateCode);
     return this.get<SpeciesDictEntry[]>(url.pathname + url.search);
+  }
+
+  // #1302 (F3, epic #1299) — the per-species rows inside ONE clicked grid cell,
+  // backing the low-zoom (zoom<6) sightings log. The map at zoom<6 renders the
+  // precomputed grid (counts only), so the raw rows for a single species inside
+  // a single bucket must be fetched on demand. Param names mirror the B1 route
+  // (`services/read-api/src/app.ts` /api/observations/cell) exactly:
+  // species · scope · m (grid multiplier) · lng/lat bucket center · optional
+  // since-window.
+  //
+  // No AbortSignal: `get<T>` only attaches one when passed (`client.ts` `get`),
+  // and this method passes none — the fetch is intentionally NOT abortable.
+  // Staleness on a rapid species/cell change is handled entirely by the
+  // consuming hook's `cancelled` flag (use-sightings-rows.ts), NOT by
+  // AbortController. `since` is serialized ONLY when present — never as the
+  // literal string "undefined" (exactOptionalPropertyTypes: the param type's
+  // `since` is optional-but-not-undefined).
+  getCellObservations(p: {
+    scopeKey: string;
+    gridMultiplier: number;
+    lngBucket: number;
+    latBucket: number;
+    speciesCode: string;
+    since?: '1d' | '7d' | '14d';
+  }): Promise<CellObservationsResponse> {
+    const url = new URL('/api/observations/cell', 'http://x');
+    url.searchParams.set('species', p.speciesCode);
+    url.searchParams.set('scope', p.scopeKey);
+    url.searchParams.set('m', String(p.gridMultiplier));
+    url.searchParams.set('lng', String(p.lngBucket));
+    url.searchParams.set('lat', String(p.latBucket));
+    if (p.since) url.searchParams.set('since', p.since);
+    return this.get<CellObservationsResponse>(url.pathname + url.search);
   }
 
   getSilhouettes(): Promise<FamilySilhouette[]> {

--- a/frontend/src/components/SightingsLog.test.tsx
+++ b/frontend/src/components/SightingsLog.test.tsx
@@ -1,10 +1,39 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { ApiClient } from '@/api/client.js';
+import type { CellObservationsResponse, Observation } from '@bird-watch/shared-types';
 import type { SightingRow, SightingsContext } from './sightings-context.js';
 import { SightingsLog } from './SightingsLog.js';
 
 const apiClient = new ApiClient({ baseUrl: '' });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const CELL: Extract<SightingsContext, { kind: 'cell' }> = {
+  kind: 'cell',
+  lngBucket: -110.5,
+  latBucket: 32.5,
+  gridMultiplier: 2,
+  scopeKey: 'US-AZ',
+};
+
+function cellObs(over: Partial<Observation> & { subId: string; obsDt: string }): Observation {
+  return {
+    speciesCode: 'vermfly',
+    comName: 'Vermilion Flycatcher',
+    lat: 32.27,
+    lng: -110.85,
+    locId: 'L99',
+    locName: 'Sweetwater Wetlands',
+    howMany: null,
+    isNotable: false,
+    silhouetteId: 'tyrannidae',
+    familyCode: 'tyrannidae',
+    ...over,
+  };
+}
 
 function row(over: Partial<SightingRow> & { subId: string; obsDt: string }): SightingRow {
   return { speciesCode: 'vermfly', locName: null, howMany: null, isNotable: false, ...over };
@@ -22,14 +51,63 @@ describe('SightingsLog', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders nothing for a cell context (cell wired in F3)', () => {
-    const { container } = renderLog({
-      kind: 'cell',
-      lngBucket: -110.5,
-      latBucket: 32.5,
-      gridMultiplier: 2,
-      scopeKey: 'US-AZ',
+  it('shows a static loading affordance (no spinner/count animation) while the cell fetch is in flight', () => {
+    // Never-resolving fetch → stays in the loading state.
+    vi.spyOn(apiClient, 'getCellObservations').mockReturnValue(
+      new Promise<CellObservationsResponse>(() => {}),
+    );
+    const { container } = render(
+      <SightingsLog apiClient={apiClient} speciesCode="vermfly" context={CELL} since="7d" />,
+    );
+    const loading = container.querySelector('.detail-fg-sightings-loading');
+    expect(loading).not.toBeNull();
+    expect(loading?.textContent).toMatch(/loading sightings/i);
+    // No rows / no banner while loading.
+    expect(container.querySelector('.detail-fg-sighting-row')).toBeNull();
+    expect(container.querySelector('.detail-fg-sightings-truncation')).toBeNull();
+  });
+
+  it('renders the fetched cell rows + truncation banner using meta.cellObservationCount as M', async () => {
+    vi.spyOn(apiClient, 'getCellObservations').mockResolvedValue({
+      data: [
+        cellObs({ subId: 'C', obsDt: '2026-04-15T12:00:00Z', locName: 'Sweetwater Wetlands', howMany: 4 }),
+        cellObs({ subId: 'A', obsDt: '2026-04-15T08:00:00Z', locName: 'Patagonia' }),
+      ],
+      meta: { cellObservationCount: 137, truncated: true },
     });
+    const { container } = render(
+      <SightingsLog apiClient={apiClient} speciesCode="vermfly" context={CELL} since="7d" />,
+    );
+    const section = await screen.findByRole('region', { name: /sightings under this marker/i });
+    expect(section).toBeInTheDocument();
+    expect(container.querySelectorAll('.detail-fg-sighting-row')).toHaveLength(2);
+    // Banner reads "Showing latest N of M" with M = meta.cellObservationCount.
+    expect(container.querySelector('.detail-fg-sightings-truncation')?.textContent).toBe(
+      'Showing latest 2 of 137',
+    );
+    // No loading affordance once resolved.
+    expect(container.querySelector('.detail-fg-sightings-loading')).toBeNull();
+  });
+
+  it('renders NOTHING for a resolved 0-row cell fetch (no empty shell)', async () => {
+    vi.spyOn(apiClient, 'getCellObservations').mockResolvedValue({
+      data: [],
+      meta: { cellObservationCount: 0, truncated: false },
+    });
+    const { container } = render(
+      <SightingsLog apiClient={apiClient} speciesCode="vermfly" context={CELL} since="7d" />,
+    );
+    // Wait for the loading affordance to disappear, then assert no section.
+    await waitFor(() => expect(container.querySelector('.detail-fg-sightings-loading')).toBeNull());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders NOTHING on a rejected cell fetch (the panel already has the species)', async () => {
+    vi.spyOn(apiClient, 'getCellObservations').mockRejectedValue(new Error('boom'));
+    const { container } = render(
+      <SightingsLog apiClient={apiClient} speciesCode="vermfly" context={CELL} since="7d" />,
+    );
+    await waitFor(() => expect(container.querySelector('.detail-fg-sightings-loading')).toBeNull());
     expect(container.firstChild).toBeNull();
   });
 

--- a/frontend/src/components/SightingsLog.tsx
+++ b/frontend/src/components/SightingsLog.tsx
@@ -41,10 +41,25 @@ export function SightingsLog({ apiClient, speciesCode, context, since }: Sightin
     context,
     since,
   );
-  // cell pre-F3 / no context / zoom<6 cluster-list → nothing to show.
+  // No context / cell-with-no-species / zoom<6 cluster-list → nothing to show.
   if (!supported) return null;
-  // loading/error states are refined in F3 (the cell fetch); the leaf path is synchronous.
-  if (loading || error || rows.length === 0) return null;
+  // F3 (#1302) cell path: while the per-cell fetch is in flight, show a minimal
+  // STATIC loading line — no spinner and no count animation (#953: the counts
+  // are camera-coupled and must never animate). The leaf path is synchronous so
+  // `loading` is never true there.
+  if (loading) {
+    return (
+      <section className="detail-fg-sightings" aria-label="Sightings under this marker">
+        <h2 className="detail-fg-sightings-eyebrow">Sightings here</h2>
+        <p className="detail-fg-sightings-loading">Loading sightings…</p>
+      </section>
+    );
+  }
+  // On error, render nothing — the species-detail panel already has the species;
+  // a failed per-cell fetch is non-essential supplementary recency, not a
+  // panel-blocking failure. A resolved fetch with 0 rows ALSO renders nothing
+  // (omit the section rather than show an empty shell).
+  if (error || rows.length === 0) return null;
 
   const visibleRows = rows.slice(0, MAX_VISIBLE_ROWS);
   const overflow = rows.length > MAX_VISIBLE_ROWS;

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -2085,6 +2085,82 @@ describe('#860 — lone clustered bucket opens its real species (coarse pointer)
     });
     expect(screen.getByText(/Western Wood-Pewee/)).toBeInTheDocument();
   });
+
+  it('#1302 — a MULTI-bucket marker popover threads NO cell context (single-arg select)', async () => {
+    // TWO bucket leaves under one marker → the merged group spans >1 bucket.
+    // Its anchor is a supercluster centroid, not a true bucket center, so
+    // deriving a {kind:cell} from it is forbidden (epic #1299 Decisions §4):
+    // the species pick must keep the historical single-arg shape.
+    const clustered = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [LONE_BUCKET.lng, LONE_BUCKET.lat] },
+      properties: {
+        cluster: true,
+        cluster_id: 777,
+        point_count: 2,
+        sumCount: LONE_BUCKET.count * 2,
+        sumSpeciesCount: LONE_BUCKET.speciesCount,
+      },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('clusters-hit') ? [clustered] : [],
+    );
+    fakeMap.getSource.mockReturnValue({
+      getClusterLeaves: vi.fn().mockResolvedValue([
+        { type: 'Feature', properties: { familiesJson: JSON.stringify(LONE_BUCKET.families) } },
+        { type: 'Feature', properties: { familiesJson: JSON.stringify(LONE_BUCKET.families) } },
+      ]),
+      getClusterExpansionZoom: vi.fn().mockResolvedValue(11),
+    });
+    fakeMap.getZoom.mockReturnValue(4);
+
+    const onSelectSpecies = vi.fn();
+    render(
+      <MapCanvasFresh
+        observations={[]}
+        buckets={[LONE_BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+        boundsKey="US-AZ"
+        onSelectSpecies={onSelectSpecies}
+      />,
+    );
+
+    await waitFor(() => expect(bareHandlers['idle']).toBeTypeOf('function'));
+    await act(async () => { await fireAllIdleHandlers(); });
+    await act(async () => { await Promise.resolve(); });
+
+    const marker = await waitFor(() => {
+      const btn = screen
+        .queryAllByRole('button')
+        .find((b) => b.className.includes('adaptive-grid-marker'));
+      if (!btn) throw new Error('multi-bucket marker did not render');
+      return btn;
+    });
+    await act(async () => {
+      fireEvent.click(marker);
+      await Promise.resolve();
+    });
+
+    const familyToggle = await waitFor(() =>
+      screen.getByTestId('cluster-list-popover-family-tyrannidae'),
+    );
+    await act(async () => {
+      fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
+      await Promise.resolve();
+    });
+    const row = screen.getByText(/Western Wood-Pewee/);
+    await act(async () => {
+      fireEvent.click(row.closest('button.cluster-list-popover__row-button') ?? row);
+      await Promise.resolve();
+    });
+
+    expect(onSelectSpecies).toHaveBeenCalledOnce();
+    expect(onSelectSpecies).toHaveBeenCalledWith('wewp');
+    expect(onSelectSpecies.mock.calls[0]).toHaveLength(1);
+  });
 });
 
 /* ── #864: a lone UNCLUSTERED bucket silhouette is clickable at low zoom ──────
@@ -2204,6 +2280,77 @@ describe('#864 — lone unclustered bucket silhouette opens its real species', (
     expect(link).toBeInTheDocument();
     expect(link.closest('button.cluster-list-popover__row-button')).not.toBeNull();
     expect(link.closest('[role="link"]')).toBeNull();
+  });
+
+  it('#1302 — selecting a species from the lone-bucket popover threads a {kind:cell} context (bucket center + multiplier + scope)', async () => {
+    // The lone unclustered bucket IS the only reachable single-bucket surface
+    // (supercluster never emits a 1-point cluster, so the DOM CellPopover gate
+    // is dead). Picking a species here must thread the cell context that drives
+    // the zoom<6 Sightings-Log fetch — derived from the bucket's OWN geometry.
+    const onSelectSpecies = vi.fn();
+    // zoom 4 → gridMultiplierForZoom(4) === 4 (distinct from the default-8 case
+    // so the assertion is meaningful).
+    fakeMap.getZoom.mockReturnValue(4);
+    render(
+      <MapCanvas
+        observations={[]}
+        buckets={[LONE_BUCKET]}
+        mode="aggregated"
+        dictionary={DICT}
+        silhouettes={SILHOUETTES}
+        boundsKey="US-AZ"
+        onSelectSpecies={onSelectSpecies}
+      />,
+    );
+    await waitFor(() =>
+      expect(registeredHandlers['click:unclustered-point']).toBeTypeOf('function'),
+    );
+
+    const bucketFeature = {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [LONE_BUCKET.lng, LONE_BUCKET.lat] },
+      properties: {
+        count: LONE_BUCKET.count,
+        speciesCount: LONE_BUCKET.speciesCount,
+        familiesJson: JSON.stringify(LONE_BUCKET.families),
+        familyCode: 'tyrannidae',
+        silhouetteId: 'tyrannidae',
+        color: '#c3772d',
+      },
+    };
+    fakeMap.queryRenderedFeatures.mockImplementation(
+      (_: unknown, opts?: { layers?: string[] }) =>
+        opts?.layers?.includes('unclustered-point') ? [bucketFeature] : [],
+    );
+
+    const handler = registeredHandlers['click:unclustered-point'];
+    if (!handler) throw new Error('click:unclustered-point handler missing');
+    await act(async () => {
+      handler({ point: [120, 120] });
+      await Promise.resolve();
+    });
+
+    const familyToggle = await waitFor(() =>
+      screen.getByTestId('cluster-list-popover-family-tyrannidae'),
+    );
+    await act(async () => {
+      fireEvent.click(familyToggle.querySelector('button') ?? familyToggle);
+      await Promise.resolve();
+    });
+    const row = screen.getByText(/Western Wood-Pewee/);
+    await act(async () => {
+      fireEvent.click(row.closest('button.cluster-list-popover__row-button') ?? row);
+      await Promise.resolve();
+    });
+
+    expect(onSelectSpecies).toHaveBeenCalledOnce();
+    expect(onSelectSpecies).toHaveBeenCalledWith('wewp', {
+      kind: 'cell',
+      lngBucket: LONE_BUCKET.lng,
+      latBucket: LONE_BUCKET.lat,
+      gridMultiplier: 4,
+      scopeKey: 'US-AZ',
+    });
   });
 
   it('clicking an unclustered feature WITH a subId still opens the observation popover (unchanged)', async () => {
@@ -4785,26 +4932,28 @@ describe('#1301 — Sightings-Log marker-context threading', () => {
       fireEvent.click(wewpRow.querySelector('button') ?? wewpRow);
     }
 
-    it('single aggregated bucket → {kind:"cell"} whose gridMultiplier is the zoom->m single source', async () => {
+    // #1302: the AdaptiveGridMarker only renders for a supercluster CLUSTER, and
+    // supercluster NEVER emits a 1-point cluster (`getClusters` requires
+    // point_count > 1; `_cluster` requires a merged neighbour, independent of
+    // clusterMinPoints). So this marker-local ClusterListPopover ALWAYS spans ≥2
+    // buckets — its anchor is a centroid, not a true bucket center — and threads
+    // NO cell context (epic #1299 Decisions §4). A fabricated `point_count:1`
+    // cluster confirms even that degenerate (unreachable) shape threads
+    // single-arg; the GENUINE single-bucket cell context is exercised against
+    // the only REACHABLE single-bucket surface — the `#864` unclustered-point
+    // handler — in the `#864` describe block above.
+    it('a (fabricated) 1-point cluster marker threads NO cell context — single bucket is unreachable here', async () => {
       const onSelectSpecies = vi.fn();
-      // zoom 4 ⇒ gridMultiplierForZoom(4) === 4 (the read-api zoom->{2,4,8} switch).
       await openLoneBucketPopover({ pointCount: 1, zoom: 4, boundsKey: 'US-AZ', onSelectSpecies });
 
       expect(onSelectSpecies).toHaveBeenCalledTimes(1);
-      const [code, context] = onSelectSpecies.mock.calls[0];
-      expect(code).toBe('wewp');
-      expect(context).toEqual({
-        kind: 'cell',
-        lngBucket: -110.0,
-        latBucket: 46.0,
-        gridMultiplier: 4,
-        scopeKey: 'US-AZ',
-      });
+      expect(onSelectSpecies).toHaveBeenCalledWith('wewp');
+      expect(onSelectSpecies.mock.calls[0]).toHaveLength(1);
     });
 
-    it('multi-bucket aggregated cluster threads NO context (single-bucket only — Decisions §4)', async () => {
+    it('multi-bucket aggregated cluster threads NO context (Decisions §4)', async () => {
       const onSelectSpecies = vi.fn();
-      // point_count 2 ⇒ not a single bucket ⇒ no cell context (1-arg call).
+      // point_count 2 ⇒ multi-bucket ⇒ no cell context (1-arg call).
       await openLoneBucketPopover({ pointCount: 2, zoom: 3, boundsKey: 'US-AZ', onSelectSpecies });
 
       expect(onSelectSpecies).toHaveBeenCalledTimes(1);

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -463,6 +463,17 @@ export function MapCanvas({
      * #1299 Decisions §4: the multi-bucket cluster-list seam is unsupported).
      */
     sightingRows?: SightingRow[];
+    /**
+     * #1302 — the zoom<6 SINGLE-bucket Sightings-Log context. Present ONLY when
+     * this popover represents exactly ONE aggregated bucket (the lone-bucket
+     * `#864` unclustered path): its `lng/latBucket` are that bucket's own
+     * `round(coord*m)/m` Point center, so the derived cell aligns with the
+     * server's bucketing by construction. ABSENT on the multi-bucket cluster
+     * path (anchor = supercluster centroid, not a true bucket center — epic
+     * #1299 Decisions §4 forbids deriving a cell from it) and on the zoom>=6
+     * per-observation path (which threads `{kind:'leaves'}` via `sightingRows`).
+     */
+    cellContext?: SightingsContext;
   } | null>(null);
   // E1 (#1053): close the canvas-owned transient popovers on the RISING edge of
   // `detailOpen`. Opening a species detail must dismiss any open
@@ -827,6 +838,11 @@ export function MapCanvas({
   aggregatedRef.current = aggregated;
   const dictionaryRef = useRef(dictionary);
   dictionaryRef.current = dictionary;
+  // #1302: the same handler derives a single-bucket `{kind:'cell'}` scopeKey
+  // from `boundsKey`. Read it through a ref for the same reason — the handler is
+  // registered once at load, but `boundsKey` changes on every scope switch.
+  const boundsKeyRef = useRef(boundsKey);
+  boundsKeyRef.current = boundsKey;
 
   // Sprite-registration completion gate. Flips true after `Promise.all`
   // in the sprite-registration effect resolves. The symbol layer JSX is
@@ -1020,14 +1036,18 @@ export function MapCanvas({
         return;
       }
 
-      // #864: no subId ⇒ this is an aggregated BUCKET painted unclustered (a
-      // lone bucket past clusterRadius / clusterMaxZoom that #860's
-      // clusterMinPoints=1 didn't fold into a degenerate cluster). It carries
-      // its real families/species in `familiesJson` — open the SAME real-species
-      // popover the cluster path opens (mergeLeafBuckets on this one bucket →
-      // ClusterListPopover), so a click resolves names + working links instead
-      // of no-op'ing on a dead silhouette. Gated on aggregated mode + presence
-      // of familiesJson so the per-observation path is untouched.
+      // #864: no subId ⇒ this is an aggregated BUCKET painted unclustered — a
+      // genuinely ISOLATED bucket with no neighbour within clusterRadius, which
+      // supercluster always emits as a raw leaf (clusterMinPoints=1 lowers the
+      // group-clustering threshold but never folds a lone bucket into a
+      // degenerate 1-point cluster — `_cluster` requires a merged neighbour). It
+      // carries its real families/species in `familiesJson` — open the SAME
+      // real-species popover the cluster path opens (mergeLeafBuckets on this one
+      // bucket → ClusterListPopover), so a click resolves names + working links
+      // instead of no-op'ing on a dead silhouette. This is also the ONLY
+      // reachable single-bucket surface, so #1302 threads the `{kind:'cell'}`
+      // Sightings-Log context from here (below). Gated on aggregated mode +
+      // presence of familiesJson so the per-observation path is untouched.
       const familiesJson = feature.properties?.familiesJson as
         | string
         | undefined;
@@ -1053,6 +1073,33 @@ export function MapCanvas({
           ? (geom.coordinates as [number, number])
           : undefined;
 
+      // #1302: this handler ALWAYS operates on exactly ONE bucket leaf (the
+      // clicked unclustered feature), which is the only place a genuine SINGLE
+      // bucket actually renders — supercluster never emits a 1-point cluster, so
+      // the DOM adaptive-grid `CellPopover` gate is unreachable. The clicked
+      // Point IS the bucket's own `round(coord*m)/m` center, so the derived cell
+      // aligns with the server's bucketing by construction (epic #1299 Decisions
+      // §4). Thread a `{kind:'cell'}` context so the per-sighting log fetches
+      // this cell's rows. `gridMultiplier` reads the FLOORED integer zoom (never
+      // a raw float); `scopeKey` mirrors the server's base ('US' national, else
+      // the `US-XX` state code MapCanvas already holds as `boundsKey`).
+      const cellContext: SightingsContext | undefined = center
+        ? {
+            kind: 'cell',
+            lngBucket: center[0],
+            latBucket: center[1],
+            gridMultiplier: gridMultiplierForZoom(Math.floor(map.getZoom())),
+            // 'US' is the server's NATIONAL_SCOPE_KEY base; the read-api cell
+            // route treats an absent/`US` scope as national (no clip) and a
+            // `US-XX` code as a state clip. `boundsKey` is 'us' (national) or a
+            // `US-XX` state code, so map the former to the server's 'US'.
+            scopeKey:
+              boundsKeyRef.current && boundsKeyRef.current !== 'us'
+                ? boundsKeyRef.current
+                : 'US',
+          }
+        : undefined;
+
       setClusterList({
         families: merged.families,
         speciesByFamily: merged.speciesByFamily,
@@ -1064,6 +1111,7 @@ export function MapCanvas({
         // anchorEl for .focus() on dismiss — positioning is sheet-style CSS).
         anchorEl: map.getCanvas(),
         ...(center ? { drillCenter: center } : {}),
+        ...(cellContext ? { cellContext } : {}),
       });
     });
 
@@ -2270,53 +2318,25 @@ export function MapCanvas({
   );
 
   /**
-   * #1301 — the per-family `<CellPopover>` species-select seam (inside an
-   * `<AdaptiveGridMarker>`, via `<GroupMarkerLayer>`). Builds a `{kind:'cell'}`
-   * Sightings-Log context ONLY for a genuine SINGLE aggregated bucket: its
-   * marker anchor IS a true `round(coord*m)/m` bucket center, so the derived
-   * cell aligns with the server's bucketing by construction. A multi-bucket
-   * cluster (anchor = supercluster centroid) or a zoom>=6 per-observation marker
-   * threads NO context — epic #1299 Decisions §4 forbids deriving a cell from a
-   * non-bucket center. INERT in F2 (`useSightingsRows` is `supported:false` for
-   * `cell`); wired now so F3 (#1302) adds the fetch without re-threading.
-   *
-   * `gridMultiplier` reads `gridMultiplierForZoom(Math.floor(map.getZoom()))` —
-   * the SINGLE frontend copy of the read-api zoom->{2,4,8} switch, fed the
-   * FLOORED integer zoom (never a raw float). `scopeKey` mirrors the server's
-   * `resolveScopeKey` base ('US' national, else the state code) off the
-   * scope-change `boundsKey` MapCanvas already holds.
+   * The per-family `<CellPopover>` species-select seam (inside an
+   * `<AdaptiveGridMarker>`, via `<GroupMarkerLayer>`). A `<CellPopover>` only
+   * renders inside a DOM adaptive-grid `'cell'` shape, which only exists for a
+   * supercluster CLUSTER — and supercluster never emits a 1-point cluster
+   * (`getClusters` requires `point_count > 1`; `_cluster` requires a merged
+   * neighbour with `numPoints > numPointsOrigin`, independent of
+   * `clusterMinPoints`). So a `CellPopover` ALWAYS represents ≥2 buckets, whose
+   * marker anchor is a supercluster centroid — NOT a true `round(coord*m)/m`
+   * bucket center. Epic #1299 Decisions §4 forbids deriving a cell from a
+   * non-bucket center, so this seam threads NO Sightings-Log context (single-arg
+   * call). The genuine SINGLE bucket — the only place a per-sighting cell log is
+   * reachable — renders as a RAW UNCLUSTERED leaf and is handled by the `#864`
+   * unclustered-point path above, which threads the `{kind:'cell'}` context.
    */
   const handleGridSelectSpecies = useCallback(
-    (speciesCode: string, group: DeconflictGroup) => {
-      if (!onSelectSpecies) return;
-      let context: SightingsContext | undefined;
-      const map = mapRef.current?.getMap();
-      const { anchor, memberIds } = group;
-      if (
-        aggregated &&
-        map &&
-        memberIds.length === 1 &&
-        // A genuine SINGLE bucket carries exactly one supercluster leaf. (The
-        // #859 sumCount overwrite makes `anchor.point_count` the summed obs count,
-        // so it cannot gate this — `bucketCount` preserves the raw leaf count.)
-        anchor.bucketCount === 1 &&
-        anchor.longitude !== undefined &&
-        anchor.latitude !== undefined
-      ) {
-        context = {
-          kind: 'cell',
-          lngBucket: anchor.longitude,
-          latBucket: anchor.latitude,
-          gridMultiplier: gridMultiplierForZoom(Math.floor(map.getZoom())),
-          scopeKey: boundsKey && boundsKey !== 'us' ? boundsKey : 'US',
-        };
-      }
-      // Call with the 2nd arg ONLY when a single-bucket cell context was built,
-      // so the per-observation / multi-bucket path keeps its single-arg shape.
-      if (context) onSelectSpecies(speciesCode, context);
-      else onSelectSpecies(speciesCode);
+    (speciesCode: string) => {
+      onSelectSpecies?.(speciesCode);
     },
-    [onSelectSpecies, aggregated, boundsKey],
+    [onSelectSpecies],
   );
 
   /**
@@ -2538,17 +2558,27 @@ export function MapCanvas({
           // `count`/`speciesCount`/`familiesJson` but NEVER a `subId`, so every
           // interaction path keys on `subId` (the reconciler's clustered + the
           // unclustered-silhouette input passes, and the canvas unclustered-point
-          // click handler) DROPS that lone bucket — it still canvas-paints a
-          // dominant-family silhouette, so the user gets a marker that does
-          // nothing on click. That is the "dead cell at low zoom" #859 set out to
-          // kill, reintroduced via a different mechanism (reachable at national
-          // zoom in sparse states — MT/WY/NV). Forcing clusterMinPoints=1 makes
-          // EVERY bucket a (degenerate) 1-point cluster, so even a lone one flows
-          // through the existing clustered/reconciler + bucket-popover path
-          // (getClusterLeaves → mergeLeafBuckets → grid/pill → real-species
-          // popover). Gated on `aggregated`: per-observation mode keeps maplibre's
-          // default (2), so real Observation rows — which legitimately use `subId`
-          // + the unclustered silhouette layer — are completely unchanged.
+          // click handler) DROPPED that lone bucket — it still canvas-painted a
+          // dominant-family silhouette, so the user got a marker that did nothing
+          // on click. That is the "dead cell at low zoom" #859 set out to kill,
+          // reintroduced via a different mechanism (reachable at national zoom in
+          // sparse states — MT/WY/NV).
+          //
+          // clusterMinPoints=1 lowers the threshold at which a GROUP of buckets
+          // becomes a cluster from 2 to 1 — it does NOT turn a truly isolated
+          // bucket into a degenerate 1-point cluster. supercluster only emits a
+          // cluster when `_cluster` merges a neighbour (`numPoints >
+          // numPointsOrigin`), so a bucket with NO neighbour within clusterRadius
+          // STILL renders as a raw unclustered leaf at every zoom, regardless of
+          // clusterMinPoints. That genuinely-isolated single bucket is handled by
+          // the `#864` unclustered-point click handler above (mergeLeafBuckets on
+          // the one leaf → ClusterListPopover → real-species popover, and the
+          // #1302 `{kind:'cell'}` Sightings-Log context). clusterMinPoints=1 only
+          // helps the case where ≥2 buckets fall within clusterRadius but the
+          // default-2 floor would otherwise have left a 1-neighbour group
+          // unclustered. Gated on `aggregated`: per-observation mode keeps
+          // maplibre's default (2), so real Observation rows — which legitimately
+          // use `subId` + the unclustered silhouette layer — are unchanged.
           clusterMinPoints={aggregated ? 1 : 2}
           // maplibre warns that a GeoJSON source's `maxzoom` must EXCEED
           // `clusterMaxZoom`. With the deliberate max-zoom cap (CLUSTER_MAX_ZOOM
@@ -2660,15 +2690,20 @@ export function MapCanvas({
           onDismiss={() => setClusterList(null)}
           onSelectSpecies={(code) => {
             if (onSelectSpecies) {
-              // #1301 — zoom>=6 stuck-cluster seam: thread the cluster's leaves
-              // for the chosen species as a `{kind:'leaves'}` context. At zoom<6
-              // (aggregated) `sightingRows` is absent, so NO context is threaded
-              // (the multi-bucket cluster-list seam is unsupported — epic #1299
-              // Decisions §4); the log then renders nothing.
+              // Thread the Sightings-Log context that matches the popover's zoom
+              // band:
+              //   - #1301 zoom>=6: each leaf is a real sighting, so `sightingRows`
+              //     is present → a `{kind:'leaves'}` context filtered by `code`.
+              //   - #1302 zoom<6 SINGLE bucket: the lone-bucket `#864` path
+              //     stashed a `{kind:'cell'}` context keyed to this bucket's own
+              //     center → fetch this cell's per-sighting rows for `code`.
+              //   - zoom<6 MULTI-bucket: neither is present, so NO context is
+              //     threaded (epic #1299 Decisions §4 — a centroid is not a true
+              //     bucket center); the log renders nothing.
               const rows = clusterList.sightingRows;
               const context: SightingsContext | undefined = rows
                 ? { kind: 'leaves', rows: rows.filter((r) => r.speciesCode === code) }
-                : undefined;
+                : clusterList.cellContext;
               if (context) onSelectSpecies(code, context);
               else onSelectSpecies(code);
             }

--- a/frontend/src/data/use-sightings-rows.test.tsx
+++ b/frontend/src/data/use-sightings-rows.test.tsx
@@ -1,10 +1,34 @@
-import { describe, it, expect } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { ApiClient } from '@/api/client.js';
+import type { CellObservationsResponse, Observation } from '@bird-watch/shared-types';
 import type { SightingRow, SightingsContext } from '@/components/sightings-context.js';
 import { useSightingsRows } from './use-sightings-rows.js';
 
 const apiClient = new ApiClient({ baseUrl: '' });
+
+function obs(over: Partial<Observation> & { subId: string; speciesCode: string; obsDt: string }): Observation {
+  return {
+    comName: 'Vermilion Flycatcher',
+    lat: 32.27,
+    lng: -110.85,
+    locId: 'L99',
+    locName: 'Sweetwater Wetlands',
+    howMany: null,
+    isNotable: false,
+    silhouetteId: 'tyrannidae',
+    familyCode: 'tyrannidae',
+    ...over,
+  };
+}
+
+const CELL: Extract<SightingsContext, { kind: 'cell' }> = {
+  kind: 'cell',
+  lngBucket: -110.5,
+  latBucket: 32.5,
+  gridMultiplier: 2,
+  scopeKey: 'US-AZ',
+};
 
 function row(over: Partial<SightingRow> & { subId: string; speciesCode: string; obsDt: string }): SightingRow {
   return { locName: null, howMany: null, isNotable: false, ...over };
@@ -56,7 +80,7 @@ describe('useSightingsRows — leaves branch', () => {
   });
 });
 
-describe('useSightingsRows — unsupported branches (cell wired in F3)', () => {
+describe('useSightingsRows — unsupported branches', () => {
   it('returns supported:false for a null context', () => {
     const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', null));
     expect(result.current).toEqual({
@@ -69,17 +93,138 @@ describe('useSightingsRows — unsupported branches (cell wired in F3)', () => {
     });
   });
 
-  it('returns supported:false for a cell context (no fetch in F2)', () => {
-    const context: SightingsContext = {
-      kind: 'cell',
+  it('returns supported:false for a cell context with an empty speciesCode (no fetch)', () => {
+    const fetchSpy = vi.spyOn(apiClient, 'getCellObservations');
+    const { result } = renderHook(() => useSightingsRows(apiClient, '', CELL, '7d'));
+    expect(result.current.supported).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('useSightingsRows — cell branch (#1302)', () => {
+  function cellResponse(over: Partial<CellObservationsResponse> = {}): CellObservationsResponse {
+    return {
+      data: [
+        obs({ subId: 'C', speciesCode: 'vermfly', obsDt: '2026-04-15T12:00:00Z', howMany: 4 }),
+        obs({ subId: 'A', speciesCode: 'vermfly', obsDt: '2026-04-15T08:00:00Z' }),
+      ],
+      meta: { cellObservationCount: 2, truncated: false },
+      ...over,
+    };
+  }
+
+  it('starts loading, then maps the fetched Observation[] to SightingRow[] with total + truncated', async () => {
+    const fetchSpy = vi
+      .spyOn(apiClient, 'getCellObservations')
+      .mockResolvedValue(cellResponse({ meta: { cellObservationCount: 137, truncated: true } }));
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', CELL, '7d'));
+
+    // First commit: supported + loading, no rows yet.
+    expect(result.current.supported).toBe(true);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.rows).toEqual([]);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.rows.map((r) => r.subId)).toEqual(['C', 'A']);
+    // Full Observation → SightingRow projection (subId/speciesCode/obsDt/locName/howMany/isNotable).
+    expect(result.current.rows[0]).toEqual({
+      subId: 'C',
+      speciesCode: 'vermfly',
+      obsDt: '2026-04-15T12:00:00Z',
+      locName: 'Sweetwater Wetlands',
+      howMany: 4,
+      isNotable: false,
+    });
+    // M is meta.cellObservationCount (the truncation-banner denominator), NOT rows.length.
+    expect(result.current.total).toBe(137);
+    expect(result.current.truncated).toBe(true);
+    fetchSpy.mockRestore();
+  });
+
+  it('carries the ACTIVE since-window through to the client call (1d → since=1d)', async () => {
+    const fetchSpy = vi.spyOn(apiClient, 'getCellObservations').mockResolvedValue(cellResponse());
+    renderHook(() => useSightingsRows(apiClient, 'vermfly', CELL, '1d'));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    expect(fetchSpy).toHaveBeenCalledWith({
+      scopeKey: 'US-AZ',
+      gridMultiplier: 2,
       lngBucket: -110.5,
       latBucket: 32.5,
-      gridMultiplier: 2,
-      scopeKey: 'US-AZ',
-    };
-    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', context, '7d'));
-    expect(result.current.supported).toBe(false);
+      speciesCode: 'vermfly',
+      since: '1d',
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it('omits since from the client arg when the active window is undefined (exactOptionalPropertyTypes)', async () => {
+    const fetchSpy = vi.spyOn(apiClient, 'getCellObservations').mockResolvedValue(cellResponse());
+    renderHook(() => useSightingsRows(apiClient, 'vermfly', CELL));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const arg = fetchSpy.mock.calls[0]![0];
+    expect('since' in arg).toBe(false);
+    fetchSpy.mockRestore();
+  });
+
+  it('renders nothing for a resolved 0-row cell fetch (supported, not loading, empty rows)', async () => {
+    const fetchSpy = vi
+      .spyOn(apiClient, 'getCellObservations')
+      .mockResolvedValue({ data: [], meta: { cellObservationCount: 0, truncated: false } });
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', CELL, '7d'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.supported).toBe(true);
     expect(result.current.rows).toEqual([]);
     expect(result.current.total).toBe(0);
+    expect(result.current.error).toBeNull();
+    fetchSpy.mockRestore();
+  });
+
+  it('surfaces a rejected cell fetch as error (loading cleared)', async () => {
+    const boom = new Error('cell fetch failed');
+    const fetchSpy = vi.spyOn(apiClient, 'getCellObservations').mockRejectedValue(boom);
+    const { result } = renderHook(() => useSightingsRows(apiClient, 'vermfly', CELL, '7d'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(boom);
+    expect(result.current.rows).toEqual([]);
+    fetchSpy.mockRestore();
+  });
+
+  it('drops a stale resolution after the selected species changes (cancelled-flag guard)', async () => {
+    // First species resolves LATE; second species resolves first. The stale
+    // (first) resolution must NEVER overwrite the second species' state.
+    let resolveFirst!: (r: CellObservationsResponse) => void;
+    const firstPromise = new Promise<CellObservationsResponse>((res) => {
+      resolveFirst = res;
+    });
+    const fetchSpy = vi
+      .spyOn(apiClient, 'getCellObservations')
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce(
+        cellResponse({
+          data: [obs({ subId: 'SECOND', speciesCode: 'norcar', obsDt: '2026-04-16T09:00:00Z' })],
+          meta: { cellObservationCount: 1, truncated: false },
+        }),
+      );
+
+    const { result, rerender } = renderHook(
+      ({ code }: { code: string }) => useSightingsRows(apiClient, code, CELL, '7d'),
+      { initialProps: { code: 'vermfly' } },
+    );
+
+    // Re-render with a NEW species BEFORE the first fetch resolves — this
+    // supersedes the first effect (its cleanup sets cancelled = true).
+    rerender({ code: 'norcar' });
+    await waitFor(() => expect(result.current.rows.map((r) => r.subId)).toEqual(['SECOND']));
+
+    // Now resolve the FIRST (stale) fetch — it must be dropped, leaving the
+    // second species' rows intact.
+    resolveFirst(cellResponse());
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(result.current.rows.map((r) => r.subId)).toEqual(['SECOND']);
+    expect(result.current.total).toBe(1);
+    fetchSpy.mockRestore();
   });
 });

--- a/frontend/src/data/use-sightings-rows.ts
+++ b/frontend/src/data/use-sightings-rows.ts
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ApiClient } from '@/api/client.js';
+import type { Observation } from '@bird-watch/shared-types';
 import type { Since } from '@/state/url-state.js';
 import type { SightingRow, SightingsContext } from '@/components/sightings-context.js';
 
@@ -10,7 +11,7 @@ export interface SightingsRowsState {
   truncated: boolean;
   loading: boolean;
   error: Error | null;
-  /** `false` for a null / cell context — the cell fetch is wired in F3 (#1302). */
+  /** `false` for a null context (or a cell context with no species yet). */
   supported: boolean;
 }
 
@@ -24,16 +25,54 @@ const UNSUPPORTED: SightingsRowsState = {
 };
 
 /**
- * The Sightings-Log data hook (epic #1299, F2 #1301).
+ * Project a FULL `Observation` (the F3 zoom<6 cell path) down to the narrow
+ * `SightingRow` the log renders.
  *
- * F2 implements ONLY the `leaves` branch — the rows are already on the client
- * (cached cluster leaves at zoom>=6), so this filters by species + sorts
- * newest-first with no fetch. A `null` or `cell` context is `supported: false`
- * (the cell fetch lands in F3, which replaces the cell arm). `apiClient` and
- * `since` are unused this PR but stay in the signature so F3 adds the fetch
- * WITHOUT a signature change. The hook does NOT apply the visible-row cap —
- * `total` is the full pre-cap count; the cap lives in `<SightingsLog>` so it
- * bounds both the leaf path and the F3 cell path identically.
+ * Distinct from F2's `leafToSightingRow` (which reads stamped maplibre-feature
+ * `properties` defensively) and from `observationToSightingRow` in
+ * `sightings-context.ts` (the single-Observation popover seam): the cell fetch
+ * yields `Observation[]` straight off the wire (B1, `locId` present), so this
+ * is a direct field pick — no widening, no defensive narrowing. Keeping it here
+ * (not in `sightings-context.ts`) co-locates it with the only consumer (the
+ * cell branch below) and keeps the hook's `rows` type uniform across both arms.
+ */
+function observationToSightingRow(o: Observation): SightingRow {
+  return {
+    subId: o.subId,
+    speciesCode: o.speciesCode,
+    obsDt: o.obsDt,
+    locName: o.locName,
+    howMany: o.howMany,
+    isNotable: o.isNotable,
+  };
+}
+
+/**
+ * The Sightings-Log data hook (epic #1299; F2 #1301 leaf path, F3 #1302 cell
+ * path).
+ *
+ *  - `leaves` (zoom>=6): rows are already on the client (cached cluster leaves /
+ *    the clicked observation), so this filters by species + sorts newest-first
+ *    with NO fetch — a pure `useMemo`.
+ *  - `cell` (zoom<6 single bucket): the map renders the precomputed count-only
+ *    grid, so the per-species rows for the clicked bucket are fetched on demand
+ *    from `GET /api/observations/cell` (B1). The fetched `Observation[]` is
+ *    projected to `SightingRow[]`; `total` is `meta.cellObservationCount` (the
+ *    truncation-banner denominator M, NOT `rows.length`), and `truncated` is the
+ *    server's row-brake flag.
+ *  - `null` / `cell` with no species → `supported: false` (component renders
+ *    nothing).
+ *
+ * The hook does NOT apply the visible-row cap — `total` is the full pre-cap
+ * count; the cap lives in `<SightingsLog>` so it bounds the leaf and cell paths
+ * identically.
+ *
+ * STALENESS: the cell fetch is NOT abortable (the client passes no AbortSignal).
+ * A rapid species/cell/window change is guarded by a plain `cancelled` boolean
+ * closed over by the effect cleanup (the same pattern as `use-species-detail.ts`
+ * / `useBirdData`): a resolution that arrives after the inputs changed is
+ * dropped before it can call `setState`, so a superseded fetch never paints
+ * stale rows.
  */
 export function useSightingsRows(
   apiClient: ApiClient,
@@ -41,16 +80,88 @@ export function useSightingsRows(
   context: SightingsContext | null,
   since?: Since,
 ): SightingsRowsState {
-  // F2: not yet consumed — F3 forwards both to the cell fetch.
-  void apiClient;
-  void since;
-  return useMemo<SightingsRowsState>(() => {
+  // Leaf / unsupported result — synchronous, recomputed only when the inputs
+  // that feed it change. A `cell` context routes through the fetch effect below
+  // (this memo returns null for it so the effect-driven state wins).
+  const syncState = useMemo<SightingsRowsState | null>(() => {
     if (context && context.kind === 'leaves') {
       const rows = context.rows
         .filter((r) => r.speciesCode === speciesCode)
         .sort((a, b) => b.obsDt.localeCompare(a.obsDt));
       return { rows, total: rows.length, truncated: false, loading: false, error: null, supported: true };
     }
-    return UNSUPPORTED;
+    if (context === null) return UNSUPPORTED;
+    // A cell context with no selected species yet can never resolve to rows —
+    // short-circuit to unsupported so the effect issues no doomed fetch.
+    if (context.kind === 'cell' && speciesCode === '') return UNSUPPORTED;
+    return null; // cell with a real species — handled by the fetch effect.
   }, [context, speciesCode]);
+
+  const isCellFetch = syncState === null;
+
+  const [cellState, setCellState] = useState<SightingsRowsState>({
+    ...UNSUPPORTED,
+    supported: true,
+    loading: true,
+  });
+
+  // The cell branch is keyed on the exact PRIMITIVES a single fetch depends on
+  // (not the `context` object) so a referentially-new-but-value-equal context
+  // never re-fetches, while a real change to any field cancels the prior fetch
+  // and re-runs.
+  const cell = context?.kind === 'cell' ? context : null;
+  const lngBucket = cell?.lngBucket;
+  const latBucket = cell?.latBucket;
+  const gridMultiplier = cell?.gridMultiplier;
+  const scopeKey = cell?.scopeKey;
+
+  useEffect(() => {
+    if (
+      !isCellFetch ||
+      lngBucket === undefined ||
+      latBucket === undefined ||
+      gridMultiplier === undefined ||
+      scopeKey === undefined
+    ) {
+      return;
+    }
+    let cancelled = false;
+    setCellState({ ...UNSUPPORTED, supported: true, loading: true });
+
+    // exactOptionalPropertyTypes: build the base arg, then assign `since` only
+    // when defined — never spread a possibly-undefined value into the optional
+    // key.
+    const arg: Parameters<ApiClient['getCellObservations']>[0] = {
+      scopeKey,
+      gridMultiplier,
+      lngBucket,
+      latBucket,
+      speciesCode,
+    };
+    if (since !== undefined) arg.since = since;
+
+    apiClient
+      .getCellObservations(arg)
+      .then((res) => {
+        if (cancelled) return;
+        setCellState({
+          rows: res.data.map(observationToSightingRow),
+          total: res.meta.cellObservationCount,
+          truncated: res.meta.truncated,
+          loading: false,
+          error: null,
+          supported: true,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setCellState({ ...UNSUPPORTED, supported: true, loading: false, error: err as Error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, isCellFetch, speciesCode, since, lngBucket, latBucket, gridMultiplier, scopeKey]);
+
+  return syncState ?? cellState;
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1748,6 +1748,14 @@ body {
   font-size: var(--type-xs);
   color: var(--color-text-muted);
 }
+/* #1302 (F3) — static "Loading sightings…" line shown while the zoom<6 per-cell
+   fetch is in flight. Deliberately a plain text line: no spinner, no count
+   animation (#953 — the sightings counts are camera-coupled). */
+.detail-fg-sightings-loading {
+  margin: var(--space-sm) 0 0;
+  font-size: var(--type-sm);
+  color: var(--color-text-muted);
+}
 .species-detail-loading { color: var(--color-text-muted); font-size: var(--type-sm); margin: 8px 0 0 0; }
 .species-detail-error {
   margin-top: 8px;


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant U as User
    participant Map as MapCanvas (zoom under 6)
    participant Pop as ClusterListPopover
    participant Hook as useSightingsRows
    participant API as GET /api/observations/cell
    participant Log as SightingsLog (Rail)
    U->>Map: click an isolated single bucket (unclustered-point)
    Map->>Pop: open popover, attach cell context (bucket center + multiplier + scope)
    U->>Pop: expand family, pick species
    Pop->>Hook: thread {kind cell} context
    Hook->>API: fetch the cell's observations (species + cell + since)
    API-->>Hook: CellObservationsResponse (data + meta)
    Hook->>Log: SightingRow array (time, location, count, notable)
    Log-->>U: "Sightings under this marker" rows in the detail Rail
```

## Summary

- **Why:** epic #1299 — complete the Sightings Log by wiring the **zoom < 6 cell path** (F2 #1301 shipped the desktop Rail + zoom ≥ 6 leaf path; B1 #1300 shipped `GET /api/observations/cell`). Selecting a species from a single aggregated grid bucket fetches that cell's per-sighting rows and renders them in the detail Rail.
- **What:** `getCellObservations()` (client), the `useSightingsRows` cell branch (cancelled-flag stale-guard, F3's own `observationToSightingRow`, 0-row → renders nothing, `truncated` → "latest N of M" banner, static rows #953), and the "Loading sightings…" affordance.
- **Dead-code fix — caught by live verification (`59480ec`).** The first commit (`56b36f1`) threaded the cell context through `handleGridSelectSpecies`, gated `anchor.bucketCount === 1`. That gate is **unreachable**: a `CellPopover` only renders inside a DOM adaptive-grid `'cell'`, which only exists for a supercluster *cluster* — and maplibre's supercluster never emits a 1-point cluster (independent of `clusterMinPoints`; the old comment claiming otherwise was wrong, and the repo's own `MapCanvas.test.tsx:2090` already documented it). A genuine single bucket renders as a raw `unclustered-point` leaf whose click is handled by the `#864` path → `ClusterListPopover`, which threaded `undefined`. **So the cell log never rendered for a single bucket.** The fix builds `{kind:'cell'}` in the **reachable** single-bucket `#864`/`ClusterListPopover` seam (bucket-center geometry + `gridMultiplierForZoom` + scope), removes the dead `bucketCount === 1` branch, corrects the false `clusterMinPoints` comments, and makes the e2e deterministic (no probe-and-skip). Multi-bucket popovers still thread `undefined` (the documented non-goal).

## Screenshots

**Desktop Rail — zoom < 6 cell log visible (≥ 1200px).** Clicking the isolated single bucket → `ClusterListPopover` → American Robin renders the cell's sighting: `Jun 30, 2026, 8:25 AM · Lone Butte, ND · ×4` (`×4` since `howMany > 1`), fetched from `GET /api/observations/cell`.

| Viewport | Light | Dark |
|---|---|---|
| **1440 × 900** | <img width="420" alt="1440 light" src="https://github.com/user-attachments/assets/7655121c-3194-4c19-993c-bdf32485e70c" /> | <img width="420" alt="1440 dark" src="https://github.com/user-attachments/assets/e1c9e3bf-1600-408a-be73-bbc60438afea" /> |
| **1920 × 1080** | <img width="420" alt="1920 light" src="https://github.com/user-attachments/assets/8b1580c4-34a5-4cf0-a354-7ac198441406" /> | <img width="420" alt="1920 dark" src="https://github.com/user-attachments/assets/b6f03444-e8e5-40ea-9a53-968937ce550a" /> |

**Tablet / mobile — detail Sheet *without* the log (≤ 1199px) — correct pre-M4 state; M4 (#1303) adds the mobile log.**

| Viewport | Light | Dark |
|---|---|---|
| **1024 × 768** | <img width="420" alt="1024 light" src="https://github.com/user-attachments/assets/cf36d1c6-84d4-41b0-a659-a5d2bff477ea" /> | <img width="420" alt="1024 dark" src="https://github.com/user-attachments/assets/21ee134b-2765-43fc-8638-0b49938910e4" /> |
| **768 × 1024** | <img width="300" alt="768 light" src="https://github.com/user-attachments/assets/e02aca6f-1ca7-4c1a-9c94-2ad5da646234" /> | <img width="300" alt="768 dark" src="https://github.com/user-attachments/assets/fd79754a-ab49-4525-8c13-b17917924b37" /> |
| **390 × 844** | <img width="220" alt="390 light" src="https://github.com/user-attachments/assets/03d880f1-2d1c-4bbf-b8aa-c70bf280df0d" /> | <img width="220" alt="390 dark" src="https://github.com/user-attachments/assets/f4f35a61-feef-4a40-b6eb-dc61837b8acd" /> |


- [x] Every new/renamed `className` has a matching CSS rule (orphan-classname green locally + CI).
- [x] Multi-viewport QA: ≥10 `user-attachments` URLs (5 viewports × 2 themes).

## Test plan

- [x] `npm test -w @bird-watch/frontend` — **1853 pass** (unit/RTL: single-bucket builds `{kind:'cell'}` with the correct bucket center / multiplier / scope; multi-bucket threads `undefined`).
- [x] Deterministic e2e `frontend/e2e/species/sightings-log-cell.spec.ts` — 3/3 (`--repeat-each=3`).
- [x] `npm run build` (tsc -b + vite) + orphan-classname — green; knip shows no new findings in changed files.
- [x] **Playwright MCP live UI verification (orchestrator-driven)** — 5 viewports × 2 themes (above). To make a real single bucket exist at zoom < 6 (the dev seed co-locates all obs in cities, so no isolated bucket otherwise), I seeded one isolated observation (American Robin, rural ND) and refreshed the precompute grid; clicked the `unclustered-point` → `ClusterListPopover` → American Robin → the Rail's "Sightings under this marker" region fetched `GET /api/observations/cell` and rendered **"Jun 30, 2026, 8:25 AM · Lone Butte, ND · ×4"** (`×4` since `howMany > 1`). Tablet + mobile render the Sheet **without** the log (correct pre-M4 — M4 #1303 adds the mobile log). **Zero console errors and zero warnings** at every viewport.

## Plan reference

Implements #1302; part of epic #1299 (Sightings Log). Build order: B1 #1300 ∥ F2 #1301 → **F3 (this)** → M4 #1303 → D5 #1304. (D5 merged; a tiny follow-up will correct its "single-bucket `CellPopover` seam" wording to the single-bucket `ClusterListPopover`/unclustered-point seam this PR establishes.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
